### PR TITLE
Multi client configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,12 @@ export GOBIN
 .PHONY: dev
 dev:
 	$(eval LD_FLAGS_RUN = "-w -X $(REPOSITORY)/pkg/version.Version="$(shell ./hack/get-next-version))
-	@KUBECONFIG=dev/garden-kubeconfig.yaml WATCH_NAMESPACE=$(USER) go run -ldflags $(LD_FLAGS_RUN) cmd/gardener-controller-manager/main.go --config=dev/componentconfig-gardener-controller-manager.yaml
+	@KUBECONFIG=~/.kube/config GARDENER_KUBECONFIG=~/.kube/config WATCH_NAMESPACE=$(USER) go run -ldflags $(LD_FLAGS_RUN) cmd/gardener-controller-manager/main.go --config=dev/componentconfig-gardener-controller-manager.yaml
 
 .PHONY: dev-all
 dev-all:
 	$(eval LD_FLAGS_RUN = "-w -X $(REPOSITORY)/pkg/version.Version="$(shell ./hack/get-next-version))
-	@KUBECONFIG=dev/garden-kubeconfig.yaml go run -ldflags $(LD_FLAGS_RUN) cmd/gardener-controller-manager/main.go --config=dev/componentconfig-gardener-controller-manager.yaml
+	@KUBECONFIG=~/.kube/config GARDENER_KUBECONFIG=~/.kube/config go run -ldflags $(LD_FLAGS_RUN) cmd/gardener-controller-manager/main.go --config=dev/componentconfig-gardener-controller-manager.yaml
 
 .PHONY: verify
 verify: vet fmt lint test

--- a/pkg/apis/componentconfig/helpers.go
+++ b/pkg/apis/componentconfig/helpers.go
@@ -27,6 +27,9 @@ func ApplyEnvironmentToConfig(config *ControllerManagerConfiguration) {
 	if kubeconfig := os.Getenv("KUBECONFIG"); kubeconfig != "" {
 		config.ClientConnection.KubeConfigFile = kubeconfig
 	}
+	if kubeconfig := os.Getenv("GARDENER_KUBECONFIG"); kubeconfig != "" {
+		config.GardenerClientConnection.KubeConfigFile = kubeconfig
+	}
 	if watchNamespace := os.Getenv("WATCH_NAMESPACE"); watchNamespace != "" {
 		config.Controller.WatchNamespace = &watchNamespace
 		config.LeaderElection.LockObjectNamespace = watchNamespace

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -103,6 +103,9 @@ type ControllerManagerConfiguration struct {
 	// ClientConnection specifies the kubeconfig file and client connection
 	// settings for the proxy server to use when communicating with the apiserver.
 	ClientConnection ClientConnectionConfiguration
+	// GardenerClientConnection specifies the kubeconfig file and client connection
+	// settings for the garden-apiserver.
+	GardenerClientConnection *ClientConnectionConfiguration
 	// Controller defines the configuration of the controllers.
 	Controller ControllerManagerControllerConfiguration
 	// Images is a list of container images which are deployed by the Gardener controller manager.

--- a/pkg/apis/componentconfig/v1alpha1/defaults.go
+++ b/pkg/apis/componentconfig/v1alpha1/defaults.go
@@ -45,6 +45,26 @@ func SetDefaults_ControllerManagerConfiguration(obj *ControllerManagerConfigurat
 		obj.ClientConnection.Burst = 100
 	}
 
+	if obj.GardenerClientConnection == nil {
+		obj.GardenerClientConnection = &obj.ClientConnection
+	} else {
+		if len(obj.GardenerClientConnection.KubeConfigFile) == 0 {
+			obj.GardenerClientConnection.KubeConfigFile = obj.ClientConnection.KubeConfigFile
+		}
+		if len(obj.GardenerClientConnection.AcceptContentTypes) == 0 {
+			obj.GardenerClientConnection.AcceptContentTypes = "application/json"
+		}
+		if len(obj.GardenerClientConnection.ContentType) == 0 {
+			obj.GardenerClientConnection.ContentType = "application/json"
+		}
+		if obj.GardenerClientConnection.QPS == 0.0 {
+			obj.GardenerClientConnection.QPS = obj.ClientConnection.QPS
+		}
+		if obj.GardenerClientConnection.Burst == 0 {
+			obj.GardenerClientConnection.Burst = obj.ClientConnection.Burst
+		}
+	}
+
 	if len(obj.LeaderElection.LockObjectNamespace) == 0 {
 		obj.LeaderElection.LockObjectNamespace = ControllerManagerDefaultLockObjectNamespace
 	}

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -103,6 +103,10 @@ type ControllerManagerConfiguration struct {
 	// ClientConnection specifies the kubeconfig file and client connection
 	// settings for the proxy server to use when communicating with the apiserver.
 	ClientConnection ClientConnectionConfiguration `json:"clientConnection"`
+	// GardenerClientConnection specifies the kubeconfig file and client connection
+	// settings for the garden-apiserver.
+	// +optional
+	GardenerClientConnection *ClientConnectionConfiguration `json:"gardenerClientConnection,omitempty"`
 	// Controller defines the configuration of the controllers.
 	Controller ControllerManagerControllerConfiguration `json:"controller"`
 	// Images is a list of container images which are deployed by the Gardener controller manager.

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -88,6 +88,7 @@ func autoConvert_v1alpha1_ControllerManagerConfiguration_To_componentconfig_Cont
 	if err := Convert_v1alpha1_ClientConnectionConfiguration_To_componentconfig_ClientConnectionConfiguration(&in.ClientConnection, &out.ClientConnection, s); err != nil {
 		return err
 	}
+	out.GardenerClientConnection = (*componentconfig.ClientConnectionConfiguration)(unsafe.Pointer(in.GardenerClientConnection))
 	if err := Convert_v1alpha1_ControllerManagerControllerConfiguration_To_componentconfig_ControllerManagerControllerConfiguration(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}
@@ -114,6 +115,7 @@ func autoConvert_componentconfig_ControllerManagerConfiguration_To_v1alpha1_Cont
 	if err := Convert_componentconfig_ClientConnectionConfiguration_To_v1alpha1_ClientConnectionConfiguration(&in.ClientConnection, &out.ClientConnection, s); err != nil {
 		return err
 	}
+	out.GardenerClientConnection = (*ClientConnectionConfiguration)(unsafe.Pointer(in.GardenerClientConnection))
 	if err := Convert_componentconfig_ControllerManagerControllerConfiguration_To_v1alpha1_ControllerManagerControllerConfiguration(&in.Controller, &out.Controller, s); err != nil {
 		return err
 	}

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
@@ -46,6 +46,15 @@ func (in *ControllerManagerConfiguration) DeepCopyInto(out *ControllerManagerCon
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	out.ClientConnection = in.ClientConnection
+	if in.GardenerClientConnection != nil {
+		in, out := &in.GardenerClientConnection, &out.GardenerClientConnection
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(ClientConnectionConfiguration)
+			**out = **in
+		}
+	}
 	in.Controller.DeepCopyInto(&out.Controller)
 	if in.Images != nil {
 		in, out := &in.Images, &out.Images

--- a/pkg/apis/componentconfig/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/zz_generated.deepcopy.go
@@ -46,6 +46,15 @@ func (in *ControllerManagerConfiguration) DeepCopyInto(out *ControllerManagerCon
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	out.ClientConnection = in.ClientConnection
+	if in.GardenerClientConnection != nil {
+		in, out := &in.GardenerClientConnection, &out.GardenerClientConnection
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(ClientConnectionConfiguration)
+			**out = **in
+		}
+	}
 	in.Controller.DeepCopyInto(&out.Controller)
 	if in.Images != nil {
 		in, out := &in.Images, &out.Images


### PR DESCRIPTION
It allows you to have multiple client configurations:

```yaml
apiVersion: componentconfig.sapcloud.io/v1alpha1
kind: ControllerManagerConfiguration
clientConnection:
  acceptContentTypes: application/vnd.kubernetes.protobuf
  contentType: application/vnd.kubernetes.protobuf
  qps: 100
  burst: 130
  kubeconfig: /Users/my-user/.kube/config
gardenerClientConnection:
  acceptContentTypes: application/json
  contentType: application/json
  qps: 100
  burst: 130
  kubeconfig: /Users/muy-user/git/go/src/github.com/gardener/gardener/dev/kubeconfig
controller:
  healthCheckPeriod: 30s
  reconciliation:
    concurrentSyncs: 20
    resyncPeriod: 10m
    retryDuration: 1440m
gardenNamespace: garden
leaderElection:
  leaderElect: true
  leaseDuration: 15s
  renewDeadline: 10s
  retryPeriod: 2s
  resourceLock: configmaps
logLevel: info
metrics:
  interval: 30s
server:
  bindAddress: 0.0.0.0
  port: 2718

```