### PR TITLE
Seed admission

### DIFF
--- a/charts/gardener/templates/deployment-apiserver.yaml
+++ b/charts/gardener/templates/deployment-apiserver.yaml
@@ -32,7 +32,7 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - /garden-apiserver
-        - --admission-control=ShootSeedFinder,ShootDNSHostedZone,ShootValidator,ShootQuotaValidator
+        - --admission-control=ShootSeedFinder,ShootSeedProtector,ShootDNSHostedZone,ShootValidator,ShootQuotaValidator
         - --audit-log-path=/var/lib/audit.log
         - --audit-policy-file=/etc/garden/audit/audit-policy.yaml
         - --audit-log-maxsize=100

--- a/cmd/garden-apiserver/app/garden_apiserver.go
+++ b/cmd/garden-apiserver/app/garden_apiserver.go
@@ -29,6 +29,7 @@ import (
 	shootdnshostedzone "github.com/gardener/gardener/plugin/pkg/shoot/dnshostedzone"
 	shootquotavalidator "github.com/gardener/gardener/plugin/pkg/shoot/quotavalidator"
 	shootseedfinder "github.com/gardener/gardener/plugin/pkg/shoot/seedfinder"
+	shootseedprotector "github.com/gardener/gardener/plugin/pkg/shoot/seedprotector"
 	shootvalidator "github.com/gardener/gardener/plugin/pkg/shoot/validator"
 	"github.com/spf13/cobra"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -135,6 +136,7 @@ func (o Options) config() (*apiserver.Config, gardeninformers.SharedInformerFact
 	// Admission plugin registration
 	shootquotavalidator.Register(o.Admission.Plugins)
 	shootseedfinder.Register(o.Admission.Plugins)
+	shootseedprotector.Register(o.Admission.Plugins)
 	shootdnshostedzone.Register(o.Admission.Plugins)
 	shootvalidator.Register(o.Admission.Plugins)
 

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -299,6 +299,8 @@ type SeedSpec struct {
 	SecretRef CrossReference
 	// Networks defines the pod, service and worker network of the Seed cluster.
 	Networks K8SNetworks
+	// Visible labels the Seed cluster as selectable for the seedfinder admisson controller.
+	Visible *bool
 }
 
 // SeedStatus holds the most recently observed status of the Seed cluster.

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -301,6 +301,8 @@ type SeedSpec struct {
 	Networks K8SNetworks
 	// Visible labels the Seed cluster as selectable for the seedfinder admisson controller.
 	Visible *bool
+	// Protected prevent that the Seed Cluster can be used for regular Shoot cluster control planes.
+	Protected *bool
 }
 
 // SeedStatus holds the most recently observed status of the Seed cluster.

--- a/pkg/apis/garden/v1beta1/defaults.go
+++ b/pkg/apis/garden/v1beta1/defaults.go
@@ -89,3 +89,11 @@ func SetDefaults_Shoot(obj *Shoot) {
 		obj.Spec.Kubernetes.AllowPrivilegedContainers = &trueVar
 	}
 }
+
+// SetDefaults_Seed sets default values for Seed objects.
+func SetDefaults_Seed(obj *Seed) {
+	trueVar := true
+	if obj.Spec.Visible == nil {
+		obj.Spec.Visible = &trueVar
+	}
+}

--- a/pkg/apis/garden/v1beta1/defaults.go
+++ b/pkg/apis/garden/v1beta1/defaults.go
@@ -96,4 +96,8 @@ func SetDefaults_Seed(obj *Seed) {
 	if obj.Spec.Visible == nil {
 		obj.Spec.Visible = &trueVar
 	}
+	falseVar := false
+	if obj.Spec.Protected == nil {
+		obj.Spec.Protected = &falseVar
+	}
 }

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -301,6 +301,8 @@ type SeedSpec struct {
 	Networks K8SNetworks `json:"networks"`
 	// Visible labels the Seed cluster as selectable for the seedfinder admisson controller.
 	Visible *bool `json:"visible"`
+	// Protected prevent that the Seed Cluster can be used for regular Shoot cluster control planes.
+	Protected *bool `json:"protected"`
 }
 
 // SeedStatus holds the most recently observed status of the Seed cluster.

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -299,6 +299,8 @@ type SeedSpec struct {
 	SecretRef CrossReference `json:"secretRef"`
 	// Networks defines the pod, service and worker network of the Seed cluster.
 	Networks K8SNetworks `json:"networks"`
+	// Visible labels the Seed cluster as selectable for the seedfinder admisson controller.
+	Visible *bool `json:"visible"`
 }
 
 // SeedStatus holds the most recently observed status of the Seed cluster.

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -2254,6 +2254,7 @@ func autoConvert_v1beta1_SeedSpec_To_garden_SeedSpec(in *SeedSpec, out *garden.S
 		return err
 	}
 	out.Visible = (*bool)(unsafe.Pointer(in.Visible))
+	out.Protected = (*bool)(unsafe.Pointer(in.Protected))
 	return nil
 }
 
@@ -2274,6 +2275,7 @@ func autoConvert_garden_SeedSpec_To_v1beta1_SeedSpec(in *garden.SeedSpec, out *S
 		return err
 	}
 	out.Visible = (*bool)(unsafe.Pointer(in.Visible))
+	out.Protected = (*bool)(unsafe.Pointer(in.Protected))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -2253,6 +2253,7 @@ func autoConvert_v1beta1_SeedSpec_To_garden_SeedSpec(in *SeedSpec, out *garden.S
 	if err := Convert_v1beta1_K8SNetworks_To_garden_K8SNetworks(&in.Networks, &out.Networks, s); err != nil {
 		return err
 	}
+	out.Visible = (*bool)(unsafe.Pointer(in.Visible))
 	return nil
 }
 
@@ -2272,6 +2273,7 @@ func autoConvert_garden_SeedSpec_To_v1beta1_SeedSpec(in *garden.SeedSpec, out *S
 	if err := Convert_garden_K8SNetworks_To_v1beta1_K8SNetworks(&in.Networks, &out.Networks, s); err != nil {
 		return err
 	}
+	out.Visible = (*bool)(unsafe.Pointer(in.Visible))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -1853,7 +1853,7 @@ func (in *Seed) DeepCopyInto(out *Seed) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	out.Spec = in.Spec
+	in.Spec.DeepCopyInto(&out.Spec)
 	in.Status.DeepCopyInto(&out.Status)
 	return
 }
@@ -1933,6 +1933,15 @@ func (in *SeedSpec) DeepCopyInto(out *SeedSpec) {
 	out.Cloud = in.Cloud
 	out.SecretRef = in.SecretRef
 	out.Networks = in.Networks
+	if in.Visible != nil {
+		in, out := &in.Visible, &out.Visible
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -1942,6 +1942,15 @@ func (in *SeedSpec) DeepCopyInto(out *SeedSpec) {
 			**out = **in
 		}
 	}
+	if in.Protected != nil {
+		in, out := &in.Protected, &out.Protected
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.defaults.go
@@ -12,9 +12,22 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&Seed{}, func(obj interface{}) { SetObjectDefaults_Seed(obj.(*Seed)) })
+	scheme.AddTypeDefaultingFunc(&SeedList{}, func(obj interface{}) { SetObjectDefaults_SeedList(obj.(*SeedList)) })
 	scheme.AddTypeDefaultingFunc(&Shoot{}, func(obj interface{}) { SetObjectDefaults_Shoot(obj.(*Shoot)) })
 	scheme.AddTypeDefaultingFunc(&ShootList{}, func(obj interface{}) { SetObjectDefaults_ShootList(obj.(*ShootList)) })
 	return nil
+}
+
+func SetObjectDefaults_Seed(in *Seed) {
+	SetDefaults_Seed(in)
+}
+
+func SetObjectDefaults_SeedList(in *SeedList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_Seed(a)
+	}
 }
 
 func SetObjectDefaults_Shoot(in *Shoot) {

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -1853,7 +1853,7 @@ func (in *Seed) DeepCopyInto(out *Seed) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	out.Spec = in.Spec
+	in.Spec.DeepCopyInto(&out.Spec)
 	in.Status.DeepCopyInto(&out.Status)
 	return
 }
@@ -1933,6 +1933,15 @@ func (in *SeedSpec) DeepCopyInto(out *SeedSpec) {
 	out.Cloud = in.Cloud
 	out.SecretRef = in.SecretRef
 	out.Networks = in.Networks
+	if in.Visible != nil {
+		in, out := &in.Visible, &out.Visible
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -1942,6 +1942,15 @@ func (in *SeedSpec) DeepCopyInto(out *SeedSpec) {
 			**out = **in
 		}
 	}
+	if in.Protected != nil {
+		in, out := &in.Protected, &out.Protected
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/plugin/pkg/shoot/seedfinder/admission.go
+++ b/plugin/pkg/shoot/seedfinder/admission.go
@@ -105,7 +105,7 @@ func determineSeed(shoot *garden.Shoot, lister gardenlisters.SeedLister) (*garde
 
 	for _, seed := range list {
 		// We return the first matching seed cluster.
-		if seed.Spec.Cloud.Profile == shoot.Spec.Cloud.Profile && seed.Spec.Cloud.Region == shoot.Spec.Cloud.Region && verifySeedAvailability(seed) {
+		if seed.Spec.Cloud.Profile == shoot.Spec.Cloud.Profile && seed.Spec.Cloud.Region == shoot.Spec.Cloud.Region && seed.Spec.Visible != nil && *seed.Spec.Visible && verifySeedAvailability(seed) {
 			return seed, nil
 		}
 	}

--- a/plugin/pkg/shoot/seedprotector/admission.go
+++ b/plugin/pkg/shoot/seedprotector/admission.go
@@ -1,0 +1,98 @@
+// Copyright 2018 The Gardener Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seedprotector
+
+import (
+	"errors"
+	"io"
+
+	"github.com/gardener/gardener/pkg/apis/garden"
+	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
+	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/internalversion"
+	gardenlisters "github.com/gardener/gardener/pkg/client/garden/listers/garden/internalversion"
+	"github.com/gardener/gardener/pkg/operation/common"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register("ShootSeedProtector", func(config io.Reader) (admission.Interface, error) {
+		return New()
+	})
+}
+
+// Protector contains listers and admisson handler.
+type Protector struct {
+	*admission.Handler
+	seedLister gardenlisters.SeedLister
+}
+
+var _ = admissioninitializer.WantsInternalGardenInformerFactory(&Protector{})
+
+// New creates an new Protector admission plugin.
+func New() (*Protector, error) {
+	return &Protector{
+		Handler: admission.NewHandler(admission.Create),
+	}, nil
+}
+
+// SetInternalGardenInformerFactory gets Lister from SharedInformerFactory.
+func (h *Protector) SetInternalGardenInformerFactory(f gardeninformers.SharedInformerFactory) {
+	h.seedLister = f.Garden().InternalVersion().Seeds().Lister()
+}
+
+// ValidateInitialization checks whether the plugin was correctly initialized.
+func (h *Protector) ValidateInitialization() error {
+	if h.seedLister == nil {
+		return errors.New("missing seed lister")
+	}
+	return nil
+}
+
+// Admit ensures that a Shoot can't use a protected Seed cluster.
+// Protected shoots not allowed to use for regular Shoot cluster control planes.
+func (h *Protector) Admit(a admission.Attributes) error {
+	// Wait until the caches have been synced
+	if !h.WaitForReady() {
+		return admission.NewForbidden(a, errors.New("not yet ready to handle request"))
+	}
+
+	// Ignore all kinds other than Shoot
+	if a.GetKind().GroupKind() != garden.Kind("Shoot") {
+		return nil
+	}
+	shoot, ok := a.GetObject().(*garden.Shoot)
+	if !ok {
+		return apierrors.NewBadRequest("could not convert resource into Shoot object")
+	}
+
+	// If the Shoot does not specify a Seed, then the admisson controller will do nothing.
+	if shoot.Spec.Cloud.Seed == nil {
+		return nil
+	}
+
+	// Get the Seed manifest, which is refrenced by the Shoot.
+	seed, err := h.seedLister.Get(*shoot.Spec.Cloud.Seed)
+	if err != nil {
+		return admission.NewForbidden(a, err)
+	}
+
+	// Protected Seeds can be only used by shoots in garden Namespace
+	if shoot.Namespace != common.GardenNamespace && seed.Spec.Protected != nil && *seed.Spec.Protected {
+		return admission.NewForbidden(a, errors.New("forbidden to use a protected seed"))
+	}
+	return nil
+}

--- a/plugin/pkg/shoot/seedprotector/admission_test.go
+++ b/plugin/pkg/shoot/seedprotector/admission_test.go
@@ -1,0 +1,129 @@
+// Copyright 2018 The Gardener Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seedprotector_test
+
+import (
+	"github.com/gardener/gardener/pkg/apis/garden"
+	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/internalversion"
+	. "github.com/gardener/gardener/plugin/pkg/shoot/seedprotector"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("seedprotector", func() {
+	Describe("#Admit", func() {
+		var (
+			admissonHandler       *Protector
+			gardenInformerFactory gardeninformers.SharedInformerFactory
+			seed                  garden.Seed
+			shoot                 garden.Shoot
+
+			seedName = "seed-1"
+			falseVar = false
+			trueVar  = true
+
+			seedBase = garden.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: seedName,
+				},
+				Spec: garden.SeedSpec{
+					Protected: &falseVar,
+				},
+			}
+			shootBase = garden.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "shoot",
+					Namespace: "my-namespace",
+				},
+				Spec: garden.ShootSpec{
+					Cloud: garden.Cloud{
+						Seed: &seedName,
+					},
+				},
+			}
+		)
+
+		BeforeEach(func() {
+			admissonHandler, _ = New()
+			gardenInformerFactory = gardeninformers.NewSharedInformerFactory(nil, 0)
+			admissonHandler.SetInternalGardenInformerFactory(gardenInformerFactory)
+
+			seed = seedBase
+			shoot = shootBase
+		})
+
+		It("should pass because no Seed is specified in shoot.Spec.Cloud.Seed", func() {
+			shoot.Spec.Cloud.Seed = nil
+
+			gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+			attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, nil)
+			err := admissonHandler.Admit(attrs)
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should pass because the Seed specified in shoot manifest is not protected and shoot is not in garden namespace", func() {
+			gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+			attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, nil)
+			err := admissonHandler.Admit(attrs)
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should pass because shoot is not in garden namespace and seed is not protected", func() {
+			gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+			attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, nil)
+			err := admissonHandler.Admit(attrs)
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should fail because shoot is not in garden namespace and seed is protected", func() {
+			seed.Spec.Protected = &trueVar
+
+			gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+			attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, nil)
+			err := admissonHandler.Admit(attrs)
+
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsForbidden(err)).To(BeTrue())
+		})
+
+		It("should pass because shoot is in garden namespace and seed is protected", func() {
+			shoot.Namespace = "garden"
+			seed.Spec.Protected = &trueVar
+
+			gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+			attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, nil)
+			err := admissonHandler.Admit(attrs)
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should pass because shoot is in garden namespace and seed is not protected", func() {
+			shoot.Namespace = "garden"
+
+			gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+			attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, nil)
+			err := admissonHandler.Admit(attrs)
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/plugin/pkg/shoot/seedprotector/seedprotector_suite_test.go
+++ b/plugin/pkg/shoot/seedprotector/seedprotector_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2018 The Gardener Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seedprotector_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestSeedProtector(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Admission ShootSeedProtector Suite")
+}


### PR DESCRIPTION
Add ``visible`` property to ``SeedSpec``. The seedFinder admission controller assign only Seeds to Shoots ``spec.cloud.seed``, which are are labeled as ``visible==true``. By default ``SeedSpec.Visible`` is true.

Add ``protected`` property to ``SeedSpec``.  This property labels a Seed as protected and thus it can only be used by Shoots in the garden namespaces. ``SeedSpec.protected`` is ``false`` by default. Add seedProtector admission controller to take care of this.