### PR TITLE
Seed and cloud controller

### DIFF
--- a/pkg/client/kubernetes/base/cloudprofile.go
+++ b/pkg/client/kubernetes/base/cloudprofile.go
@@ -18,7 +18,7 @@ import (
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 )
 
-// UpdateCloudProfile update an existing CloudProfile resource.
+// UpdateCloudProfile updates an existing CloudProfile resource.
 func (c *Client) UpdateCloudProfile(cloudProfile *gardenv1beta1.CloudProfile) (*gardenv1beta1.CloudProfile, error) {
 	return c.GardenClientset.GardenV1beta1().CloudProfiles().Update(cloudProfile)
 }

--- a/pkg/client/kubernetes/base/cloudprofile.go
+++ b/pkg/client/kubernetes/base/cloudprofile.go
@@ -1,0 +1,24 @@
+// Copyright 2018 The Gardener Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetesbase
+
+import (
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+)
+
+// UpdateCloudProfile update an existing CloudProfile resource.
+func (c *Client) UpdateCloudProfile(cloudProfile *gardenv1beta1.CloudProfile) (*gardenv1beta1.CloudProfile, error) {
+	return c.GardenClientset.GardenV1beta1().CloudProfiles().Update(cloudProfile)
+}

--- a/pkg/client/kubernetes/base/seeds.go
+++ b/pkg/client/kubernetes/base/seeds.go
@@ -44,7 +44,7 @@ func (c *Client) UpdateSeedStatus(seed *gardenv1beta1.Seed) (*gardenv1beta1.Seed
 	return c.GardenClientset.GardenV1beta1().Seeds().UpdateStatus(seed)
 }
 
-// ListSeeds return a list of Seed resources.
+// ListSeeds returns a list of Seed resources.
 func (c *Client) ListSeeds() (*gardenv1beta1.SeedList, error) {
 	return c.GardenClientset.GardenV1beta1().Seeds().List(metav1.ListOptions{})
 }

--- a/pkg/client/kubernetes/base/seeds.go
+++ b/pkg/client/kubernetes/base/seeds.go
@@ -44,6 +44,11 @@ func (c *Client) UpdateSeedStatus(seed *gardenv1beta1.Seed) (*gardenv1beta1.Seed
 	return c.GardenClientset.GardenV1beta1().Seeds().UpdateStatus(seed)
 }
 
+// ListSeeds return a list of Seed resources.
+func (c *Client) ListSeeds() (*gardenv1beta1.SeedList, error) {
+	return c.GardenClientset.GardenV1beta1().Seeds().List(metav1.ListOptions{})
+}
+
 // DeleteSeed deletes an existing Seed resource.
 func (c *Client) DeleteSeed(name string) error {
 	return c.GardenClientset.GardenV1beta1().Seeds().Delete(name, &defaultDeleteOptions)

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -58,7 +58,11 @@ type Client interface {
 	GetSeed(string) (*gardenv1beta1.Seed, error)
 	UpdateSeed(*gardenv1beta1.Seed) (*gardenv1beta1.Seed, error)
 	UpdateSeedStatus(*gardenv1beta1.Seed) (*gardenv1beta1.Seed, error)
+	ListSeeds() (*gardenv1beta1.SeedList, error)
 	DeleteSeed(string) error
+
+	// Cloud Profiles
+	UpdateCloudProfile(*gardenv1beta1.CloudProfile) (*gardenv1beta1.CloudProfile, error)
 
 	// Namespaces
 	CreateNamespace(string, bool) (*corev1.Namespace, error)

--- a/pkg/controller/cloudprofile/cloudprofile.go
+++ b/pkg/controller/cloudprofile/cloudprofile.go
@@ -1,0 +1,126 @@
+// Copyright 2018 The Gardener Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudprofile
+
+import (
+	"sync"
+	"time"
+
+	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/externalversions"
+	gardenlisters "github.com/gardener/gardener/pkg/client/garden/listers/garden/v1beta1"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	controllerutils "github.com/gardener/gardener/pkg/controller/utils"
+	"github.com/gardener/gardener/pkg/logger"
+
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// Controller controlls CloudProfiles.
+type Controller struct {
+	k8sGardenClient    kubernetes.Client
+	k8sGardenInformers gardeninformers.SharedInformerFactory
+
+	control ControlInterface
+
+	cloudProfileLister gardenlisters.CloudProfileLister
+	cloudProfileQueue  workqueue.RateLimitingInterface
+	cloudprofileSynced cache.InformerSynced
+
+	seedLister  gardenlisters.SeedLister
+	shootLister gardenlisters.ShootLister
+
+	workerCh               chan int
+	numberOfRunningWorkers int
+}
+
+// NewCloudProfileController takes a Kubernetes client <k8sGardenClient> and a <k8sGardenInformers> for the Garden clusters.
+// It creates and return a new Garden controller to control CloudProfiles.
+func NewCloudProfileController(k8sGardenClient kubernetes.Client, k8sGardenInformers gardeninformers.SharedInformerFactory) *Controller {
+	var (
+		gardenv1beta1Informer = k8sGardenInformers.Garden().V1beta1()
+		cloudProfileInformer  = gardenv1beta1Informer.CloudProfiles()
+		seedLister            = gardenv1beta1Informer.Seeds().Lister()
+		shootLister           = gardenv1beta1Informer.Shoots().Lister()
+	)
+
+	cloudProfileController := &Controller{
+		k8sGardenClient:    k8sGardenClient,
+		k8sGardenInformers: k8sGardenInformers,
+		cloudProfileLister: cloudProfileInformer.Lister(),
+		cloudProfileQueue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cloudprofile"),
+		seedLister:         seedLister,
+		shootLister:        shootLister,
+		control:            NewDefaultControl(k8sGardenClient, seedLister, shootLister),
+		workerCh:           make(chan int),
+	}
+
+	cloudProfileInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    cloudProfileController.cloudProfileAdd,
+		UpdateFunc: cloudProfileController.cloudProfileUpdate,
+		DeleteFunc: cloudProfileController.cloudProfileDelete,
+	})
+	cloudProfileController.cloudprofileSynced = cloudProfileInformer.Informer().HasSynced
+
+	return cloudProfileController
+}
+
+// Run runs the Controller until the given stop channel can be read from.
+func (c *Controller) Run(workers int, stopCh <-chan struct{}) {
+	var waitGroup sync.WaitGroup
+
+	// Check if informers cache has been populated
+	if !cache.WaitForCacheSync(stopCh, c.cloudprofileSynced) {
+		logger.Logger.Error("Time out waiting for caches to sync")
+		return
+	}
+
+	go func() {
+		for {
+			select {
+			case res := <-c.workerCh:
+				c.numberOfRunningWorkers += res
+				logger.Logger.Debugf("Current number of running CloudProfile workers is %d", c.numberOfRunningWorkers)
+			}
+		}
+	}()
+
+	logger.Logger.Info("CloudProfile controller initialized.")
+
+	// Start the workers
+	for i := 0; i < workers; i++ {
+		controllerutils.CreateWorker(c.cloudProfileQueue, "cloudprofile", c.reconcileCloudProfileKey, stopCh, &waitGroup, c.workerCh)
+	}
+
+	<-stopCh
+	c.cloudProfileQueue.ShutDown()
+
+	for {
+		if c.cloudProfileQueue.Len() == 0 && c.numberOfRunningWorkers == 0 {
+			logger.Logger.Info("No running CloudProfile worker and no items left in the queues. Terminating CloudProfile controller...")
+			break
+		}
+		logger.Logger.Infof("Waiting for %d CloudProfile worker(s) to finish (%d item(s) left in the queues)...", c.numberOfRunningWorkers, c.cloudProfileQueue.Len())
+		time.Sleep(5 * time.Second)
+	}
+
+	waitGroup.Wait()
+}
+
+// RunningWorkers returns the number of running workers.
+func (c *Controller) RunningWorkers() int {
+	return c.numberOfRunningWorkers
+}

--- a/pkg/controller/cloudprofile/cloudprofile.go
+++ b/pkg/controller/cloudprofile/cloudprofile.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
-// Controller controlls CloudProfiles.
+// Controller controls CloudProfiles.
 type Controller struct {
 	k8sGardenClient    kubernetes.Client
 	k8sGardenInformers gardeninformers.SharedInformerFactory

--- a/pkg/controller/cloudprofile/cloudprofile_control.go
+++ b/pkg/controller/cloudprofile/cloudprofile_control.go
@@ -1,0 +1,189 @@
+// Copyright 2018 The Gardener Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudprofile
+
+import (
+	"fmt"
+	"time"
+
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	gardenlisters "github.com/gardener/gardener/pkg/client/garden/listers/garden/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+)
+
+func (c *Controller) cloudProfileAdd(obj interface{}) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		return
+	}
+	c.cloudProfileQueue.Add(key)
+}
+
+func (c *Controller) cloudProfileUpdate(oldObj, newObj interface{}) {
+	c.cloudProfileAdd(newObj)
+}
+
+func (c *Controller) cloudProfileDelete(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		return
+	}
+	c.cloudProfileQueue.Add(key)
+}
+
+func (c *Controller) reconcileCloudProfileKey(key string) error {
+	// Get the cloudprofile to the key from cache
+	_, cloudProfileName, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+
+	cloudProfile, err := c.cloudProfileLister.Get(cloudProfileName)
+	if apierrors.IsNotFound(err) {
+		logger.Logger.Debugf("[CLOUDPROFILE RECONCILE] %s - skipping because CloudProfile has been deleted", key)
+		return nil
+	}
+	if err != nil {
+		logger.Logger.Infof("[CLOUDPROFILE RECONCILE] %s - unable to retrieve object from store: %v", key, err)
+		return err
+	}
+
+	err = c.control.ReconcileCloudProfile(cloudProfile, key)
+	if err != nil {
+		c.cloudProfileQueue.AddAfter(key, 15*time.Second)
+	}
+	return nil
+}
+
+// ControlInterface implements the control logic for reconciling CloudProfiles. It is implemented as an interface to allow
+// for extensions that provide different semantics. Currently, there is only one implementation.
+type ControlInterface interface {
+	// ReconcileCloudProfile implements the control logic for CloudProfile creation, update, and deletion.
+	// If an implementation returns a non-nil error, the invocation will be retried using a rate-limited strategy.
+	// Implementors should sink any errors that they do not wish to trigger a retry, and they may feel free to
+	// exit exceptionally at any point provided they wish the update to be re-run at a later point in time.
+	ReconcileCloudProfile(cloudprofile *gardenv1beta1.CloudProfile, key string) error
+}
+
+// NewDefaultControl returns a new instance of the default implementation ControlInterface that
+// implements the documented semantics for CloudProfiles.
+func NewDefaultControl(k8sGardenClient kubernetes.Client, seedLister gardenlisters.SeedLister, shootLister gardenlisters.ShootLister) ControlInterface {
+	return &defaultControl{k8sGardenClient, seedLister, shootLister}
+
+}
+
+type defaultControl struct {
+	k8sGardenClient kubernetes.Client
+	seedLister      gardenlisters.SeedLister
+	shootLister     gardenlisters.ShootLister
+}
+
+func (c *defaultControl) ReconcileCloudProfile(obj *gardenv1beta1.CloudProfile, key string) error {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return err
+	}
+
+	var (
+		cloudProfile       = obj.DeepCopy()
+		cloudProfileLogger = logger.NewCloudProfileLogger(logger.Logger, cloudProfile.Name)
+	)
+
+	// The deletionTimestamp labels the CloudProfile as intended to get deleted. Before deletion, it has to be ensured that
+	// no Shoots and Seed s are assigned to the CloudProfile anymore. If this is the case then the controlller will remove
+	// the Finalizers from the CloudProfile and deletion will be triggered.
+	if cloudProfile.DeletionTimestamp != nil {
+		associatedShoots, err := c.determineAssociations("shoot", cloudProfile.Name)
+		if err != nil {
+			logger.Logger.Error(err)
+			return nil
+		}
+		associatedSeed, err := c.determineAssociations("seed", cloudProfile.Name)
+		if err != nil {
+			logger.Logger.Error(err)
+			return nil
+		}
+		if len(associatedShoots) == 0 && len(associatedSeed) == 0 {
+			cloudProfileLogger.Infof("No Shoots and Seeds are attached to CloudProfile. Deletion accepted.")
+
+			finalizers := sets.NewString(cloudProfile.Finalizers...)
+			finalizers.Delete(gardenv1beta1.GardenerName)
+			cloudProfile.Finalizers = finalizers.UnsortedList()
+
+			_, err := c.k8sGardenClient.UpdateCloudProfile(cloudProfile)
+			if err != nil {
+				logger.Logger.Error(err)
+				return nil
+			}
+			return nil
+		}
+		message := "Can't delete CloudProfile, because Shoot(s) and/or Seed(s) are still attached."
+		if len(associatedShoots) != 0 {
+			message += fmt.Sprintf(" Shoots: %+v", associatedShoots)
+		}
+		if len(associatedSeed) != 0 {
+			message += fmt.Sprintf(" Seeds: %+v", associatedSeed)
+		}
+		cloudProfileLogger.Info(message)
+		return nil
+	}
+	cloudProfileLogger.Infof("[CLOUDPROFILE RECONCILE] %s", key)
+	return nil
+}
+
+func (c *defaultControl) determineAssociations(resourceType, cloudProfile string) ([]string, error) {
+	var associatedResources []string
+
+	if resourceType == "shoot" {
+		shoots, err := c.shootLister.List(labels.Everything())
+		if err != nil {
+			return nil, err
+		}
+		for _, shoot := range shoots {
+			if shoot.Spec.Cloud.Profile == "" {
+				continue
+			}
+			if shoot.Spec.Cloud.Profile == cloudProfile {
+				associatedResources = append(associatedResources, fmt.Sprintf("%s/%s", shoot.Namespace, shoot.Name))
+			}
+		}
+		return associatedResources, nil
+	}
+
+	if resourceType == "seed" {
+		seeds, err := c.seedLister.List(labels.Everything())
+		if err != nil {
+			return nil, err
+		}
+		for _, seed := range seeds {
+			if seed.Spec.Cloud.Profile == "" {
+				continue
+			}
+			if seed.Spec.Cloud.Profile == cloudProfile {
+				associatedResources = append(associatedResources, seed.Name)
+			}
+		}
+		return associatedResources, nil
+	}
+
+	return nil, fmt.Errorf("Could not determine CloudProfile associations, due to unknown resource type %s", resourceType)
+}

--- a/pkg/controller/cloudprofile/cloudprofile_control.go
+++ b/pkg/controller/cloudprofile/cloudprofile_control.go
@@ -52,7 +52,6 @@ func (c *Controller) cloudProfileDelete(obj interface{}) {
 }
 
 func (c *Controller) reconcileCloudProfileKey(key string) error {
-	// Get the cloudprofile to the key from cache
 	_, cloudProfileName, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
@@ -110,8 +109,8 @@ func (c *defaultControl) ReconcileCloudProfile(obj *gardenv1beta1.CloudProfile, 
 	)
 
 	// The deletionTimestamp labels the CloudProfile as intended to get deleted. Before deletion, it has to be ensured that
-	// no Shoots and Seed s are assigned to the CloudProfile anymore. If this is the case then the controlller will remove
-	// the Finalizers from the CloudProfile and deletion will be triggered.
+	// no Shoots and Seed  are assigned to the CloudProfile anymore. If this is the case then the controlller will remove
+	// the finalizers from the CloudProfile so that it can be garbage collected.
 	if cloudProfile.DeletionTimestamp != nil {
 		associatedShoots, err := controllerutils.DetermineShootAssociations(cloudProfile, c.shootLister)
 		if err != nil {
@@ -138,7 +137,7 @@ func (c *defaultControl) ReconcileCloudProfile(obj *gardenv1beta1.CloudProfile, 
 			}
 			return nil
 		}
-		message := "Can't delete CloudProfile, because Shoots and/or Seeds are still attached."
+		message := "Can't delete CloudProfile, because Shoots and/or Seeds are still referencing it."
 		if len(associatedShoots) != 0 {
 			message += fmt.Sprintf(" Shoots: %+v", associatedShoots)
 		}

--- a/pkg/controller/factory.go
+++ b/pkg/controller/factory.go
@@ -91,14 +91,14 @@ func (f *GardenControllerFactory) Run(stopCh <-chan struct{}) {
 	var (
 		workerCount = f.config.Controller.Reconciliation.ConcurrentSyncs
 
-		shootController       = shootcontroller.NewShootController(f.k8sGardenClient, f.k8sGardenInformers, f.config, f.identity, f.gardenNamespace, secrets, imageVector, f.recorder)
-		seedController        = seedcontroller.NewSeedController(f.k8sGardenClient, f.k8sGardenInformers, secrets, imageVector, f.recorder)
-		cloudProfileConroller = cloudprofilecontroller.NewCloudProfileController(f.k8sGardenClient, f.k8sGardenInformers)
+		shootController        = shootcontroller.NewShootController(f.k8sGardenClient, f.k8sGardenInformers, f.config, f.identity, f.gardenNamespace, secrets, imageVector, f.recorder)
+		seedController         = seedcontroller.NewSeedController(f.k8sGardenClient, f.k8sGardenInformers, secrets, imageVector, f.recorder)
+		cloudProfileController = cloudprofilecontroller.NewCloudProfileController(f.k8sGardenClient, f.k8sGardenInformers)
 	)
 
 	go shootController.Run(workerCount, stopCh)
 	go seedController.Run(workerCount, stopCh)
-	go cloudProfileConroller.Run(workerCount, stopCh)
+	go cloudProfileController.Run(workerCount, stopCh)
 
 	logger.Logger.Infof("Garden controller manager (version %s) initialized.", version.Version)
 

--- a/pkg/controller/factory.go
+++ b/pkg/controller/factory.go
@@ -22,6 +22,7 @@ import (
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/externalversions"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	cloudprofilecontroller "github.com/gardener/gardener/pkg/controller/cloudprofile"
 	seedcontroller "github.com/gardener/gardener/pkg/controller/seed"
 	shootcontroller "github.com/gardener/gardener/pkg/controller/shoot"
 	"github.com/gardener/gardener/pkg/logger"
@@ -90,12 +91,14 @@ func (f *GardenControllerFactory) Run(stopCh <-chan struct{}) {
 	var (
 		workerCount = f.config.Controller.Reconciliation.ConcurrentSyncs
 
-		shootController = shootcontroller.NewShootController(f.k8sGardenClient, f.k8sGardenInformers, f.config, f.identity, f.gardenNamespace, secrets, imageVector, f.recorder)
-		seedController  = seedcontroller.NewSeedController(f.k8sGardenClient, f.k8sGardenInformers, secrets, imageVector, f.recorder)
+		shootController       = shootcontroller.NewShootController(f.k8sGardenClient, f.k8sGardenInformers, f.config, f.identity, f.gardenNamespace, secrets, imageVector, f.recorder)
+		seedController        = seedcontroller.NewSeedController(f.k8sGardenClient, f.k8sGardenInformers, secrets, imageVector, f.recorder)
+		cloudProfileConroller = cloudprofilecontroller.NewCloudProfileController(f.k8sGardenClient, f.k8sGardenInformers)
 	)
 
 	go shootController.Run(workerCount, stopCh)
 	go seedController.Run(workerCount, stopCh)
+	go cloudProfileConroller.Run(workerCount, stopCh)
 
 	logger.Logger.Infof("Garden controller manager (version %s) initialized.", version.Version)
 

--- a/pkg/controller/seed/seed_control.go
+++ b/pkg/controller/seed/seed_control.go
@@ -130,8 +130,9 @@ func (c *defaultControl) ReconcileSeed(obj *gardenv1beta1.Seed, key string) erro
 		seedLogger  = logger.NewSeedLogger(logger.Logger, seed.Name)
 	)
 
-	// The deletionTimestamp labels a Seed as intented to get deleted. Before deletion, it has to be ensured that no Shoots
-	// are depending on the Seed anymore. When this happens the controller will remove the Finalizers from the Seed and deletion will be triggered.
+	// The deletionTimestamp labels a Seed as intented to get deleted. Before deletion,
+	// it has to be ensured that no Shoots are depending on the Seed anymore.
+	// When this happens the controller will remove the finalizers from the Seed so that it can be garbage collected.
 	if seed.DeletionTimestamp != nil {
 		associatedShoots, err := controllerutils.DetermineShootAssociations(seed, c.shootLister)
 		if err != nil {
@@ -153,7 +154,7 @@ func (c *defaultControl) ReconcileSeed(obj *gardenv1beta1.Seed, key string) erro
 			}
 			return nil
 		}
-		seedLogger.Infof("Can't delete Seed, because the following Shoots are still attached: %v", associatedShoots)
+		seedLogger.Infof("Can't delete Seed, because the following Shoots are still referencing it: %v", associatedShoots)
 		return nil
 	}
 

--- a/pkg/controller/utils/miscellaneous.go
+++ b/pkg/controller/utils/miscellaneous.go
@@ -1,0 +1,53 @@
+// Copyright 2018 The Gardener Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	gardenlisters "github.com/gardener/gardener/pkg/client/garden/listers/garden/v1beta1"
+	"github.com/gardener/gardener/pkg/logger"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// DetermineShootAssociations get a <shootLister> to determine the Shoots resources,
+// which associated to given <obj>.
+func DetermineShootAssociations(obj interface{}, shootLister gardenlisters.ShootLister) ([]string, error) {
+	var associatedShoots []string
+	shoots, err := shootLister.List(labels.Everything())
+	if err != nil {
+		logger.Logger.Info(err.Error())
+		return nil, err
+	}
+
+	for _, shoot := range shoots {
+		switch t := obj.(type) {
+		case *gardenv1beta1.CloudProfile:
+			cloudProfile := obj.(*gardenv1beta1.CloudProfile)
+			if shoot.Spec.Cloud.Profile == cloudProfile.Name {
+				associatedShoots = append(associatedShoots, fmt.Sprintf("%s/%s", shoot.Namespace, shoot.Name))
+			}
+		case *gardenv1beta1.Seed:
+			seed := obj.(*gardenv1beta1.Seed)
+			if *shoot.Spec.Cloud.Seed == seed.Name {
+				associatedShoots = append(associatedShoots, fmt.Sprintf("%s/%s", shoot.Namespace, shoot.Name))
+			}
+		default:
+			return nil, fmt.Errorf("Unable to determine Shoot associations, due to unknown type %t", t)
+		}
+	}
+	return associatedShoots, nil
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -76,3 +76,12 @@ func NewSeedLogger(logger *logrus.Logger, seed string) *logrus.Entry {
 	}
 	return logger.WithFields(fields)
 }
+
+// NewCloudProfileLogger extends an existing logrus logger and adds an additional field containing the CloudProfile name.
+// Example output: time="2017-06-08T13:00:49+02:00" level=info msg="Deletion accepted" cloudprofile=aws.
+func NewCloudProfileLogger(logger *logrus.Logger, cloudprofile string) *logrus.Entry {
+	fields := logrus.Fields{
+		"cloudprofile": cloudprofile,
+	}
+	return logger.WithFields(fields)
+}

--- a/pkg/registry/garden/cloudprofile/strategy.go
+++ b/pkg/registry/garden/cloudprofile/strategy.go
@@ -17,8 +17,10 @@ package cloudprofile
 import (
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/garden"
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/garden/validation"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage/names"
@@ -37,7 +39,13 @@ func (cloudProfileStrategy) NamespaceScoped() bool {
 }
 
 func (cloudProfileStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
-	_ = obj.(*garden.CloudProfile)
+	cloudprofile := obj.(*garden.CloudProfile)
+
+	finalizers := sets.NewString(cloudprofile.Finalizers...)
+	if !finalizers.Has(gardenv1beta1.GardenerName) {
+		finalizers.Insert(gardenv1beta1.GardenerName)
+	}
+	cloudprofile.Finalizers = finalizers.UnsortedList()
 }
 
 func (cloudProfileStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/garden/seed/strategy.go
+++ b/pkg/registry/garden/seed/strategy.go
@@ -17,9 +17,11 @@ package seed
 import (
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/garden"
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/garden/validation"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage/names"
@@ -40,6 +42,13 @@ func (seedStrategy) NamespaceScoped() bool {
 func (seedStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
 	seed := obj.(*garden.Seed)
 	seed.Status = garden.SeedStatus{}
+
+	finalizers := sets.NewString()
+	if !finalizers.Has(gardenv1beta1.GardenerName) {
+		finalizers.Insert(gardenv1beta1.GardenerName)
+	}
+	seed.Finalizers = finalizers.UnsortedList()
+
 	seed.Generation = 1
 }
 

--- a/pkg/registry/garden/shoot/strategy.go
+++ b/pkg/registry/garden/shoot/strategy.go
@@ -17,6 +17,7 @@ package shoot
 import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/storage/names"
 
@@ -42,7 +43,11 @@ func (shootStrategy) NamespaceScoped() bool {
 func (shootStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
 	shoot := obj.(*garden.Shoot)
 	shoot.Status = garden.ShootStatus{}
-	shoot.Finalizers = []string{gardenv1beta1.GardenerName}
+	finalizers := sets.NewString()
+	if !finalizers.Has(gardenv1beta1.GardenerName) {
+		finalizers.Insert(gardenv1beta1.GardenerName)
+	}
+	shoot.Finalizers = finalizers.UnsortedList()
 	shoot.Generation = 1
 }
 


### PR DESCRIPTION
Add finalizer to Seed resource. Seed controller react on Seed with ``deletionTimestamp != nil`` and removes finalizer, when the Seed has no depending resources.

Add also finalizer to CloudProfile resource. Add CloudProfile controller, which currently only react on CloudProfiles with ``deletionTimestamp != nil`` and also removes the finalizer, when the CloudProfile has no dependencies anymore.