### PR TITLE
Add blackbox-exporter to apiserver and prometheus

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -45,6 +45,9 @@ images:
 - name: grafana-watcher
   repository: quay.io/coreos/grafana-watcher
   tag: v0.0.8
+- name: blackbox-exporter
+  repository: quay.io/prometheus/blackbox-exporter
+  tag: v0.11.0
 
 # Shoot core addons
 - name: calico-node

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/blackbox-exporter-config.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/blackbox-exporter-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: prometheus
+    role: monitoring
+  name: blackbox-exporter-config
+  namespace: {{ .Release.Namespace }}
+
+data:
+  blackbox.yaml: |
+    modules:
+      tcp_vpn:
+        prober: tcp
+        timeout: 2s

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         checksum/configmap-audit-policy: {{ include (print $.Template.BasePath "/audit-policy.yaml") . | sha256sum }}
         checksum/secret-oidc-cabundle: {{ include (print $.Template.BasePath "/oidc-ca-secret.yaml") . | sha256sum }}
+        checksum/configmap-blackbox-exporter: {{ include (print $.Template.BasePath "/blackbox-exporter-config.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
@@ -156,6 +157,18 @@ spec:
         volumeMounts:
         - name: vpn-ssh-keypair
           mountPath: /srv/ssh
+      - name: blackbox-exporter
+        image: {{ index .Values.images "blackbox-exporter" }}
+        args:
+        - --config.file=/vpn/blackbox.yaml
+        ports:
+        # port name must be max 15 characters long
+        - name: blackbox-export
+          containerPort: 9115
+          protocol: TCP
+        volumeMounts:
+        - name: blackbox-exporter-config
+          mountPath: /vpn
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -201,3 +214,6 @@ spec:
       - name: ssl-certs-hosts
         hostPath:
           path: /usr/share/ca-certificates
+      - name: blackbox-exporter-config
+        configMap:
+          name: blackbox-exporter-config

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -27,3 +27,4 @@ oidcConfig: {}
 images:
   hyperkube: image-repository
   vpn-seed: image-repository:image-tag
+  blackbox-exporter: image-repository:image-tag

--- a/charts/seed-monitoring/charts/prometheus/rules/kube-kubelet.rules.yml
+++ b/charts/seed-monitoring/charts/prometheus/rules/kube-kubelet.rules.yml
@@ -3,7 +3,7 @@ groups:
   rules:
   - alert: NoWorkerNodes
     expr: absent(up{job="kube-kubelet", type="shoot"}) or count(up{job="kube-kubelet", type="shoot"} == 0)
-    for: 5m
+    for: 4m
     labels:
       job: kube-kubelet
       service: kube-kubelet

--- a/charts/seed-monitoring/charts/prometheus/rules/vpn.rules.yml
+++ b/charts/seed-monitoring/charts/prometheus/rules/vpn.rules.yml
@@ -1,0 +1,24 @@
+groups:
+- name: vpn.rules
+  rules:
+  - alert: VPNShootNoPods
+    expr:  kube_deployment_status_replicas_available{deployment="vpn-shoot"} == 0
+    for: 5m
+    labels:
+      service: vpn
+      severity: blocker
+      type: shoot
+    annotations:
+      description: vpn-shoot deployment in Shoot cluster has 0 available pods. VPN won't work.
+      summary: VPN Shoot deployment no pods
+  - alert: VPNConnectionDown
+    expr: probe_success == 0
+    for: 5m
+    labels:
+      service: vpn
+      severity: blocker
+      type: shoot
+    annotations:
+      description: VPN connection for {{ $labels.pod }} is down. No resources of the Shoot cluster
+        can be accessed by this pod.
+      summary: VPN connection down

--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -139,3 +139,27 @@ data:
 
       relabel_configs:
 {{- include "prometheus.service-endpoints.relabel-config" . }}
+
+    - job_name: 'vpn-connection'
+      honor_labels: false
+      scrape_interval: 15s
+      scrape_timeout: 5s
+
+      metrics_path: /probe
+      params:
+        module:
+        - tcp_vpn
+        target:
+        - {{ .Values.apiserverServiceIP }}:443
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: [{{ .Release.Namespace }}]
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_container_port_name]
+        action: keep
+        regex: blackbox-export
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_pod_name]
+        target_label: pod

--- a/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
@@ -135,6 +135,20 @@ spec:
           readOnly: true
         - mountPath: /etc/prometheus/rules
           name: rules
+      - name: blackbox-exporter-config-reloader
+        image: {{ index .Values.images "configmap-reloader" }}
+        imagePullPolicy: IfNotPresent
+        args:
+        - -webhook-url=http://localhost:9115/-/reload
+        - -volume-dir=/vpn
+        resources:
+          limits:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /vpn
+          name: blackbox-exporter-config
+          readOnly: true
       - name: vpn-seed
         image: {{ index .Values.images "vpn-seed" }}
         imagePullPolicy: IfNotPresent
@@ -159,6 +173,18 @@ spec:
           name: vpn-ssh-keypair
         - mountPath: /srv/auth
           name: kube-apiserver-basic-auth
+      - name: blackbox-exporter
+        image: {{ index .Values.images "blackbox-exporter" }}
+        args:
+        - --config.file=/vpn/blackbox.yaml
+        ports:
+        # port name must be max 15 characters long
+        - name: blackbox-export
+          containerPort: 9115
+          protocol: TCP
+        volumeMounts:
+        - name: blackbox-exporter-config
+          mountPath: /vpn
       terminationGracePeriodSeconds: 300
       volumes:
       - name: config
@@ -183,6 +209,9 @@ spec:
       - name: prometheus-kubeconfig
         secret:
           secretName: prometheus
+      - name: blackbox-exporter-config
+        configMap:
+          name: blackbox-exporter-config
   volumeClaimTemplates:
   - metadata:
       name: prometheus-db

--- a/charts/seed-monitoring/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/prometheus/values.yaml
@@ -21,3 +21,4 @@ namespace:
 
 podAnnotations: {}
 replicas: 1
+apiserverServiceIP: 100.10.10.10

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -143,7 +143,8 @@ func (b *Botanist) DeploySeedMonitoring() error {
 				"checksum/secret-kube-apiserver-basic-auth": b.CheckSums["kube-apiserver-basic-auth"],
 				"checksum/secret-vpn-ssh-keypair":           b.CheckSums["vpn-ssh-keypair"],
 			},
-			"replicas": replicas,
+			"replicas":           replicas,
+			"apiserverServiceIP": common.ComputeClusterIP(b.Shoot.GetServiceNetwork(), 1),
 		}
 		kubeStateMetricsSeedConfig = map[string]interface{}{
 			"replicas": replicas,
@@ -161,7 +162,12 @@ func (b *Botanist) DeploySeedMonitoring() error {
 	if err != nil {
 		return err
 	}
-	prometheus, err := b.InjectImages(prometheusConfig, b.K8sSeedClient.Version(), map[string]string{"prometheus": "prometheus", "configmap-reloader": "configmap-reloader", "vpn-seed": "vpn-seed"})
+	prometheus, err := b.InjectImages(prometheusConfig, b.K8sSeedClient.Version(), map[string]string{
+		"prometheus":         "prometheus",
+		"configmap-reloader": "configmap-reloader",
+		"vpn-seed":           "vpn-seed",
+		"blackbox-exporter":  "blackbox-exporter",
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -123,7 +123,11 @@ func (b *HybridBotanist) DeployKubeAPIServer() error {
 		}
 	}
 
-	values, err := b.Botanist.InjectImages(defaultValues, b.K8sSeedClient.Version(), map[string]string{"hyperkube": "hyperkube", "vpn-seed": "vpn-seed"})
+	values, err := b.Botanist.InjectImages(defaultValues, b.K8sSeedClient.Version(), map[string]string{
+		"hyperkube":         "hyperkube",
+		"vpn-seed":          "vpn-seed",
+		"blackbox-exporter": "blackbox-exporter",
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Using `blackbox-exporter` we can test various networking resources. This adds the possibility to check if the VPN connection from the `api-server` and `prometheus` is running.