### PR TITLE
kube-dns now uses .spec.DNS.Domain as domain

### DIFF
--- a/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet.flags
+++ b/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet.flags
@@ -10,7 +10,7 @@
 --cloud-config=/var/lib/kubelet/cloudprovider.conf \
 {{- end }}
 --cluster-dns="{{ required "kubernetes.clusterDNS is required" .kubernetes.clusterDNS }}" \
---cluster-domain=cluster.local \
+--cluster-domain={{ required "kubernetes.domain is required" .kubernetes.domain }} \
 {{- if eq .kubernetes.kubelet.networkPlugin "cni" -}}
 --cni-bin-dir=/opt/cni/bin/ \
 --cni-conf-dir=/etc/cni/net.d/ \

--- a/charts/shoot-core/charts/kube-dns/templates/kube-dns-deployment.yaml
+++ b/charts/shoot-core/charts/kube-dns/templates/kube-dns-deployment.yaml
@@ -77,7 +77,7 @@ spec:
           initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
-        - --domain=cluster.local.
+        - --domain={{ required ".Values.domain is required" .Values.domain }}.
         - --dns-port=10053
         - --config-dir=/kube-dns-config
         - --v=2
@@ -117,7 +117,7 @@ spec:
         - -k
         - --cache-size=1000
         - --log-facility=-
-        - --server=/cluster.local/127.0.0.1#10053
+        - --server=/{{ required ".Values.domain is required" .Values.domain }}/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053
         - --server=/in6.arpa/127.0.0.1#10053
         ports:
@@ -148,8 +148,8 @@ spec:
         args:
         - --v=2
         - --logtostderr
-        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.cluster.local,5,A
-        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.cluster.local,5,A
+        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.{{ required ".Values.domain is required" .Values.domain }},5,A
+        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.{{ required ".Values.domain is required" .Values.domain }},5,A
         ports:
         - containerPort: 10054
           name: metrics

--- a/charts/shoot-core/charts/kube-dns/values.yaml
+++ b/charts/shoot-core/charts/kube-dns/values.yaml
@@ -1,4 +1,5 @@
 clusterDNS: 100.64.0.10
+domain: cluster.local
 images:
   kube-dns: image-repository:image-tag
   kube-dns-dnsmasq: image-repository:image-tag

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -543,12 +543,13 @@ func (b *Botanist) generateSecrets() ([]interface{}, error) {
 	apiServerCertDNSNames := []string{
 		fmt.Sprintf("kube-apiserver.%s", b.Shoot.SeedNamespace),
 		fmt.Sprintf("kube-apiserver.%s.svc", b.Shoot.SeedNamespace),
-		fmt.Sprintf("kube-apiserver.%s.svc.cluster.local", b.Shoot.SeedNamespace),
+		// TODO: Determine Seed cluster's domain that is configured for kubelet and kube-dns/coredns
+		// fmt.Sprintf("kube-apiserver.%s.svc.%s", b.Shoot.SeedNamespace, seed-kube-domain),
 		"kube-apiserver",
 		"kubernetes",
 		"kubernetes.default",
 		"kubernetes.default.svc",
-		"kubernetes.default.svc.cluster.local",
+		fmt.Sprintf("kubernetes.default.svc.%s", *b.Shoot.Info.Spec.DNS.Domain),
 		b.Shoot.InternalClusterDomain,
 	}
 	if b.Shoot.ExternalClusterDomain != nil {

--- a/pkg/operation/hybridbotanist/addon_manager.go
+++ b/pkg/operation/hybridbotanist/addon_manager.go
@@ -110,6 +110,7 @@ func (b *HybridBotanist) generateCloudConfigChart() (*chartrenderer.RenderedChar
 		"kubernetes": map[string]interface{}{
 			"caCert":     string(kubeletSecret.Data["ca.crt"]),
 			"clusterDNS": common.ComputeClusterIP(serviceNetwork, 10),
+			"domain":     *b.Shoot.Info.Spec.DNS.Domain,
 			"kubelet": map[string]interface{}{
 				"kubeconfig":    string(kubeletSecret.Data["kubeconfig"]),
 				"networkPlugin": userDataConfig.NetworkPlugin,
@@ -151,6 +152,7 @@ func (b *HybridBotanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart
 
 		kubeDNSConfig = map[string]interface{}{
 			"clusterDNS": common.ComputeClusterIP(b.Shoot.GetServiceNetwork(), 10),
+			"domain":     *b.Shoot.Info.Spec.DNS.Domain,
 		}
 		kubeProxyConfig = map[string]interface{}{
 			"kubeconfig": kubeProxySecret.Data["kubeconfig"],


### PR DESCRIPTION
This will allow end-users to expose their kube-dns and use dnsmasq to connect
multiple clusters easily.

closes #90 