### PR TITLE
Make `.spec.dns.domain` required, set default

### DIFF
--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -1173,6 +1173,9 @@ const (
 	// ExternalGardenerName is the value in a Kubernetes core resources `.metadata.finalizers[]` array on which the
 	// Gardener will react when performing a delete request on a resource.
 	ExternalGardenerName = "garden.sapcloud.io/gardener"
+
+	// DefaultDomain is the default value in the Shoot's '.spec.dns.domain' when '.spec.dns.provider' is 'unmanaged'
+	DefaultDomain = "cluster.local"
 )
 
 // Condition holds the information about the state of a resource.

--- a/pkg/apis/garden/v1beta1/defaults.go
+++ b/pkg/apis/garden/v1beta1/defaults.go
@@ -117,6 +117,11 @@ func SetDefaults_Shoot(obj *Shoot) {
 			}
 		}
 	}
+
+	if obj.Spec.DNS.Provider == DNSUnmanaged && obj.Spec.DNS.Domain == nil {
+		defaultDomain := DefaultDomain
+		obj.Spec.DNS.Domain = &defaultDomain
+	}
 }
 
 // SetDefaults_Seed sets default values for Seed objects.

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -1173,6 +1173,9 @@ const (
 	// ExternalGardenerName is the value in a Kubernetes core resources `.metadata.finalizers[]` array on which the
 	// Gardener will react when performing a delete request on a resource.
 	ExternalGardenerName = "garden.sapcloud.io/gardener"
+
+	// DefaultDomain is the default value in the Shoot's '.spec.dns.domain' when '.spec.dns.provider' is 'unmanaged'
+	DefaultDomain = "cluster.local"
 )
 
 // Condition holds the information about the state of a resource.

--- a/pkg/apis/garden/validation/validation_test.go
+++ b/pkg/apis/garden/validation/validation_test.go
@@ -2922,15 +2922,38 @@ var _ = Describe("validation", func() {
 				}))
 			})
 
-			It("should forbid not specifying a domain when provider not equals 'unmanaged'", func() {
+			It("should forbid specifying no domain", func() {
 				shoot.Spec.DNS.Provider = garden.DNSAWSRoute53
 				shoot.Spec.DNS.Domain = nil
 
 				errorList := ValidateShoot(shoot)
-
 				Expect(len(errorList)).To(Equal(1))
 				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.dns.domain"),
+				}))
+			})
+
+			It("should forbid specifying empty domain", func() {
+				shoot.Spec.DNS.Provider = garden.DNSAWSRoute53
+				shoot.Spec.DNS.Domain = makeStringPointer("")
+
+				errorList := ValidateShoot(shoot)
+				Expect(len(errorList)).To(Equal(1))
+				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.dns.domain"),
+				}))
+			})
+
+			It("should forbid specifying invalid domain", func() {
+				shoot.Spec.DNS.Provider = garden.DNSAWSRoute53
+				shoot.Spec.DNS.Domain = makeStringPointer("foo/bar.baz")
+
+				errorList := ValidateShoot(shoot)
+				Expect(len(errorList)).To(Equal(1))
+				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("spec.dns.domain"),
 				}))
 			})

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -76,7 +76,7 @@ func New(k8sGardenClient kubernetes.Client, k8sGardenInformers gardeninformers.I
 
 	// Determine the external Shoot cluster domain, i.e. the domain which will be put into the Kubeconfig handed out
 	// to the user.
-	if shoot.Spec.DNS.Domain != nil {
+	if *(shoot.Spec.DNS.Domain) != gardenv1beta1.DefaultDomain {
 		extDomain := fmt.Sprintf("api.%s", *(shoot.Spec.DNS.Domain))
 		shootObj.ExternalClusterDomain = &extDomain
 	}


### PR DESCRIPTION
- defaulting `.spec.dns.domain` to cluster.local only if `.spec.dns.provider==umanaged`.
- validation: require `.spec.dns.domain` to be set in any case.
- validation: require `.spec.dns.domain` to be a valid domain name.