### PR TITLE
Increase conntrack tables size

### DIFF
--- a/charts/shoot-cloud-config/charts/original/templates/config/_99-k8s-general.conf
+++ b/charts/shoot-cloud-config/charts/original/templates/config/_99-k8s-general.conf
@@ -2,61 +2,61 @@
 - path: /etc/sysctl.d/99-k8s-general.conf
   permissions: 0644
   content: |
-    {{/* # A higher vm.max_map_count is great for elasticsearch, mongo, or other mmap users */ -}}
-    {{/* # See https://github.com/kubernetes/kops/issues/1340 */ -}}
+    # A higher vm.max_map_count is great for elasticsearch, mongo, or other mmap users
+    # See https://github.com/kubernetes/kops/issues/1340
     vm.max_map_count = 135217728
-    {{/* # See https://github.com/kubernetes/kubernetes/pull/38001 */ -}}
+    # See https://github.com/kubernetes/kubernetes/pull/38001
     kernel.softlockup_panic = 1
     kernel.softlockup_all_cpu_backtrace = 1
-    {{/* # See https://github.com/kubernetes/kube-deploy/issues/261 */ -}}
-    {{/* # Increase the number of connections */ -}}
+    # See https://github.com/kubernetes/kube-deploy/issues/261
+    # Increase the number of connections
     net.core.somaxconn = 32768
-    {{/* # Increase number of incoming connections backlog */ -}}
+    # Increase number of incoming connections backlog
     net.core.netdev_max_backlog = 5000
-    {{/* # Maximum Socket Receive Buffer */ -}}
+    # Maximum Socket Receive Buffer
     net.core.rmem_max = 16777216
-    {{/* # Default Socket Send Buffer */ -}}
+    # Default Socket Send Buffer
     net.core.wmem_max = 16777216
-    {{/* # Increase the maximum total buffer-space allocatable */ -}}
+    # Increase the maximum total buffer-space allocatable
     net.ipv4.tcp_wmem = 4096 12582912 16777216
     net.ipv4.tcp_rmem = 4096 12582912 16777216
-    {{/* # Mitigate broken TCP connections */ -}}
-    {{/* # https://github.com/kubernetes/kubernetes/issues/41916#issuecomment-312428731 */ -}}
+    # Mitigate broken TCP connections
+    # https://github.com/kubernetes/kubernetes/issues/41916#issuecomment-312428731
     net.ipv4.tcp_retries2 = 8
-    {{/* # Increase the number of outstanding syn requests allowed */ -}}
+    # Increase the number of outstanding syn requests allowed
     net.ipv4.tcp_max_syn_backlog = 8096
-    {{/* # For persistent HTTP connections */ -}}
+    # For persistent HTTP connections
     net.ipv4.tcp_slow_start_after_idle = 0
-    {{/* # Increase the tcp-time-wait buckets pool size to prevent simple DOS attacks */ -}}
+    # Increase the tcp-time-wait buckets pool size to prevent simple DOS attacks
     net.ipv4.tcp_tw_reuse = 1
-    {{/* # Allowed local port range. */ -}}
+    # Allowed local port range.
     net.ipv4.ip_local_port_range = 10240 65535
-    {{/* # Max number of packets that can be queued on interface input */ -}}
-    {{/* # If kernel is receiving packets faster than can be processed */ -}}
-    {{/* # this queue increases */ -}}
+    # Max number of packets that can be queued on interface input
+    # If kernel is receiving packets faster than can be processed
+    # this queue increases
     net.core.netdev_max_backlog = 16384
-    {{/* # Increase size of file handles and inode cache */ -}}
+    # Increase size of file handles and inode cache
     fs.file-max = 20000000
-    {{/* # Max number of inotify instances and watches for a user */ -}}
-    {{/* # Since dockerd runs as a single user, the default instances value of 128 per user is too low */ -}}
-    {{/* # e.g. uses of inotify: nginx ingress controller, kubectl logs -f */ -}}
+    # Max number of inotify instances and watches for a user
+    # Since dockerd runs as a single user, the default instances value of 128 per user is too low
+    # e.g. uses of inotify: nginx ingress controller, kubectl logs -f
     fs.inotify.max_user_instances = 8192
     fs.inotify.max_user_watches = 524288
-    {{/* # HANA requirement */ -}}
-    {{/* # See https://www.sap.com/developer/tutorials/hxe-ua-install-using-docker.html */ -}}
+    # HANA requirement
+    # See https://www.sap.com/developer/tutorials/hxe-ua-install-using-docker.html
     fs.aio-max-nr = 262144
     vm.memory_failure_early_kill = 1
-    {{/* # A common problem on Linux systems is running out of space in the conntrack table, */ -}}
-    {{/* # which can cause poor iptables performance. */ -}}
-    {{/* # This can happen if you run a lot of workloads on a given host, */ -}}
-    {{/* # or if your workloads create a lot of TCP connections or bidirectional UDP streams. */ -}}
+    # A common problem on Linux systems is running out of space in the conntrack table,
+    # which can cause poor iptables performance.
+    # This can happen if you run a lot of workloads on a given host,
+    # or if your workloads create a lot of TCP connections or bidirectional UDP streams.
     net.netfilter.nf_conntrack_max = 1048576
 {{- if eq .cloudProvider.name "aws"}}
-    {{/* # AWS specific settings */ -}}
-    {{/* # See https://github.com/kubernetes/kubernetes/issues/23395 */ -}}
+    # AWS specific settings
+    # See https://github.com/kubernetes/kubernetes/issues/23395
     net.ipv4.neigh.default.gc_thresh1 = 0
 {{- else if eq .cloudProvider.name "gce"}}
-    {{/* # GCE specific settings */ -}}
+    # GCE specific settings
     net.ipv4.ip_forward = 1
 {{- end}}
 {{- end}}

--- a/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -35,7 +35,7 @@ spec:
         - /hyperkube
         - proxy
         - --cluster-cidr={{ .Values.global.podNetwork }}
-        - --conntrack-max-per-core=131072
+        - --conntrack-max-per-core=524288
         - --kubeconfig=/var/lib/kube-proxy/kubeconfig
         {{- include "kube-proxy.featureGates" . | trimSuffix "," | indent 8 }}
         - --v=2


### PR DESCRIPTION
`kube-proxy` automatically sets `net.netfilter.nf_conntrack_max` based on the number of CPU cores.
With 2 cores it will be `1048576`.

The fallback value in `99_k8s-general.conf` is kept in case `kube-proxy` removes this functionality in the future.