### PR TITLE
kube-apiserver's liveliness port can be configurable

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
@@ -91,7 +91,7 @@ spec:
           httpGet:
             scheme: HTTPS
             path: /healthz
-            port: 443
+            port: {{ required ".securePort is required" .Values.securePort }}
             httpHeaders:
             - name: Authorization
               value: Basic {{ .Values.livenessProbeCredentials }}


### PR DESCRIPTION
This was breaking the vagrant provider