### PR TITLE
Guide for running Gardener on Minikube

### DIFF
--- a/charts/gardener/templates/apiservice-v1beta1-garden-sapcloud-io.yaml
+++ b/charts/gardener/templates/apiservice-v1beta1-garden-sapcloud-io.yaml
@@ -10,7 +10,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
+  insecureSkipTLSVerify: {{ .Values.apiserver.insecureSkipTLSVerify }}
+  {{- if not .Values.apiserver.insecureSkipTLSVerify }}
   caBundle: {{ required ".Values.apiserver.caBundle is required" (b64enc .Values.apiserver.caBundle) }}
+  {{- end }}
   group: garden.sapcloud.io
   version: v1beta1
   groupPriorityMinimum: {{ required ".Values.apiserver.groupPriorityMinimum is required" .Values.apiserver.groupPriorityMinimum }}

--- a/charts/gardener/templates/deployment-apiserver.yaml
+++ b/charts/gardener/templates/deployment-apiserver.yaml
@@ -27,6 +27,9 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+        {{- if .Values.apiserver.etcd.useSidecar }}
+        sidecar: etcd
+        {{- end }}
     spec:
       serviceAccountName: {{ required ".Values.apiserver.serviceAccountName is required" .Values.apiserver.serviceAccountName }}
       containers:
@@ -66,7 +69,7 @@ spec:
           mountPath: /etc/garden/audit
       {{- if .Values.apiserver.etcd.useSidecar }}
       - name: etcd
-        image: quay.io/coreos/etcd:v3.2
+        image: quay.io/coreos/etcd:v3.1.12
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/etcd

--- a/charts/gardener/vagrant-local-values.yaml
+++ b/charts/gardener/vagrant-local-values.yaml
@@ -1,0 +1,72 @@
+# Vagrant specific values which override values.yaml
+
+# Gardener API server configuration values
+apiserver:
+  image:
+    tag: 0.2.0-f15944037e1784bada87bd4bff51b5a334b3b066
+  etcd:
+    useSidecar: true
+  # Don't care about certificates for local development scenario
+  insecureSkipTLSVerify: true
+  caBundle: ""
+  tls:
+    crt: |
+      -----BEGIN CERTIFICATE-----
+      MIIDkjCCAnqgAwIBAgIBAjANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwptaW5p
+      a3ViZUNBMB4XDTE4MDMxMzA3MjUwMFoXDTE5MDMxMzA3MjUwMFowLDEXMBUGA1UE
+      ChMOc3lzdGVtOm1hc3RlcnMxETAPBgNVBAMTCG1pbmlrdWJlMIIBIjANBgkqhkiG
+      9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2b8eW1Aq0elVVIDNyXJC/qbSnVMqyQhFmI1+
+      0ZHH+nuDHtXHHB0QigvD83f6IVolsbC7HAGVsqACX2sgDACx7yHsQzWFogTM+/xj
+      f9Z3hdnYEQkaKeJKfmYThH+cbPHdoToVqHVoUIIWrlts8s76Q3QQBfq8kj/pJ60P
+      eAnFZpjkf/UbmFlevnl53+YA/Ikk4m6CkEtway0WzPlCtmNOMprSxUb3FkVILOco
+      bjf1l+PqlAwoy7mxtaG9BDLIENnI8UbOpC+mJPaVnXsV7JQE/LQMcQN1xL2KsFi7
+      9/kDNVbXLlgaQWgy8LZ0+0/k7OpWy57AUiuOF42wYGwG+SbpQwIDAQABo4HVMIHS
+      MA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw
+      DAYDVR0TAQH/BAIwADCBkgYDVR0RBIGKMIGHggptaW5pa3ViZUNBgiRrdWJlcm5l
+      dGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWyCFmt1YmVybmV0ZXMuZGVmYXVs
+      dC5zdmOCEmt1YmVybmV0ZXMuZGVmYXVsdIIKa3ViZXJuZXRlc4IJbG9jYWxob3N0
+      hwTAqGNkhwQKYAABhwQKAAABMA0GCSqGSIb3DQEBCwUAA4IBAQA75Pt0rzjMtxME
+      4h6GBzeba/QUCFfKtR4gNxV1EcKQwJz2UcVr20yGgGUGyJLyTS7t56ktlWVF2NWD
+      7W3M0DNjSY6ELlgGHnU273WiQN8sHrmON/9AqhtElfQ2IbqL3uIMJwn2g3t/5rBn
+      SS1r2Y7xLcsJ4tneFa+ARTlx9JlPBjYx7nMZ/Vd6yP6U7BButQGUf/p6F1+vTslM
+      bMmq4RmmV4FvzPWNEfFejOV/6Hjm3TrFds2Z3fpGIVQGAmEiT4tb1bHW8AorJ5CR
+      fhzQ4+MoUBFMOo3BBnKPmospcGL9NAh81nBbqmzKbzXRi7AlBc+fh/nhDpZMcMqr
+      QaZeuq/C
+      -----END CERTIFICATE-----
+    key: |
+      -----BEGIN RSA PRIVATE KEY-----
+      MIIEowIBAAKCAQEA2b8eW1Aq0elVVIDNyXJC/qbSnVMqyQhFmI1+0ZHH+nuDHtXH
+      HB0QigvD83f6IVolsbC7HAGVsqACX2sgDACx7yHsQzWFogTM+/xjf9Z3hdnYEQka
+      KeJKfmYThH+cbPHdoToVqHVoUIIWrlts8s76Q3QQBfq8kj/pJ60PeAnFZpjkf/Ub
+      mFlevnl53+YA/Ikk4m6CkEtway0WzPlCtmNOMprSxUb3FkVILOcobjf1l+PqlAwo
+      y7mxtaG9BDLIENnI8UbOpC+mJPaVnXsV7JQE/LQMcQN1xL2KsFi79/kDNVbXLlga
+      QWgy8LZ0+0/k7OpWy57AUiuOF42wYGwG+SbpQwIDAQABAoIBAEqR9Sd4cPGqYxqp
+      cdBHXUIwh3hxfvmR56Oy8Xd74Wya1/C7bZDnMz7TgKvkrri1UqtjxvB0anvd6HId
+      EcCKjGVEzNDHh5hQ5JJ3gOvK2uvwCtrqrxcg9DoNYynBOiTlP+1zIu+qJatMoc/c
+      Z5dP4s0u9j3V/LZpRMPdtKp7TiswF3ku2jfwNAmSKpMBurVxh7Rx41Ddzk4v6pBn
+      MJRiI2RSYoMXbyIz/jFRpJghuqC/EePpaV7iFoYJsjIpBdsnHLd5cn6d/lp2x1qb
+      5U2OjO+HuEoHiIn7BRRXl6zIzluZTRHN5jZf5tiu36NEcE9K8x5Jfytz98CXxNCk
+      Q5E8iiECgYEA7dWGvy/r2GobY9xXGMMlc+vxbhrjf4PYnidH9KwItbFoeXd5GZ4k
+      mBIVuxMDO0YxIfI0B1seW9smRyRBLNQbV1A1EYbjfqwROnqAFtH/6yzjomwwp2iM
+      dwIyfIp8mA4hrcalQrb4V1bodEKecH3J9Si9i24yf9uMnJnuzVuiH4UCgYEA6mDP
+      3iH0qk6jqXWdzowDUaFhY3L5oUnmR3XP9BLPH6mZkKzozc0i60PWJnsd4k3BWoGB
+      HBkyMzkPSB1ou3JAKAHQhMRqQWHAVWrwaZ7v9eGlWLUHJ2b20yydAjHwucKEli86
+      HnA5aeXACbsQlkpoNnYRvBDJQAEnYsrnBroIbCcCgYAFfK+nKYvfalNHcoXv5FCw
+      4/il+ajWAEy3GWDnnDB3QKiQZNk+Zg+iEoi90Cp665umlNfuc4O3ys6PRZ7bUelv
+      kkInLV2CRqX/G2RpIl8tJdP6o1RcCGV1OW/Av9EwEONmBvc5Gs+P9ElYpVDSd5R5
+      O39kAB7aJE6SLlr8EekjoQKBgQC1nvnVl5iB1NiMO6Fi6iq0Ogs+xlzc+GgjHg9c
+      gqrQTVu7udHZkMorZ3Dudt9Me5aGrO5AuOGmweOurWN4ReujVOyhxZbVPYuOZYUR
+      Q+GNNyMrH3UAupAwSlUM22hAepTF0KkH500GW8w5fiU3YUdqVIofox5go8RCkRr/
+      om9eZwKBgFqf+3EqR9mgaMZCmon08DzQXxTPITnCtlh1RMqjDPV4rr2ebootARg2
+      grZ3BVGluAD/h4gEpteIxwsp+C1sZXMO7GAXwbOuQ+04pnskIoVbtK8Tp6Z4CFBs
+      Y0TqA2hEv0a0xSaTn4l9lvVNylPBF4tVOh9MDQo90FYJSS/3O/pg
+      -----END RSA PRIVATE KEY-----
+
+# Gardener controller manager configuration values
+controller:
+  image:
+    tag: 0.2.0-f15944037e1784bada87bd4bff51b5a334b3b066
+  internalDomain:
+    provider: unmanaged
+    hostedZoneID: ABCDEFGHIJ
+    domain: nip.io

--- a/charts/gardener/values.yaml
+++ b/charts/gardener/values.yaml
@@ -22,6 +22,7 @@ apiserver:
     #     -----BEGIN RSA PRIVATE KEY-----
     #     ...
     #     -----END RSA PRIVATE KEY-----
+  insecureSkipTLSVerify: false
   groupPriorityMinimum: 10000
   versionPriority: 20
   caBundle: |

--- a/docs/deployment/kubernetes-minikube.md
+++ b/docs/deployment/kubernetes-minikube.md
@@ -1,0 +1,48 @@
+# Deploying the Gardener into a Minikube with Vagrant Provider
+
+## Prerequisites
+
+Make sure that you have completed the following steps:
+
+- [Installing Golang environment](../development/local_setup.md#installing-golang-environment)
+- [Installing `kubectl` and `helm`](../development/local_setup.md#installing-kubectl-and-helm)
+- [Installing Minikube](../development/local_setup.md#installing-minikube)
+- [Installing iproute2](../development/local_setup.md#installing-iproute2)
+- [Installing `Vagrant`](../development/local_setup.md#installing-vagrant)
+- [Installing `Virtualbox`](../development/local_setup.md#installing-virtualbox)
+- [Get the sources](../development/local_setup.md#get-the-sources)
+
+## Running
+
+Then in a terminal execute:
+
+```bash
+# Minikube requires extra memory for this setup
+$ minikube start --cpus=3 --memory=4096 --extra-config=apiserver.Authorization.Mode=RBAC
+
+# Allow Tiller and Dashboard to run in RBAC mode
+$ kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
+
+# Start Helm's Tiller
+$ helm init
+
+# Deploy Gardener with vagrant specific configuration
+$ helm install charts/gardener \
+  --name gardener \
+  --namespace garden \
+  --values=charts/gardener/values.yaml \
+  --values=charts/gardener/vagrant-local-values.yaml
+
+# Check that everything is deployed successfuly and running without a problem
+$ kubectl -n garden get pods
+NAME                                           READY     STATUS    RESTARTS   AGE
+gardener-apiserver-d5989f856-swgbg             2/2       Running   0          32s
+gardener-controller-manager-6f7bd556d6-p98fx   1/1       Running   0          32s
+
+$ make dev-setup-vagrant
+namespace "garden-development" created
+cloudprofile "vagrant" created
+[..]
+```
+
+You can now continue with [Check Vagrant Setup](../development/local_setup.md#check-vagrant-setup)

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -289,7 +289,7 @@ shoot "vagrant" created
 When the Shoot API server is created you can download the `kubeconfig` for it and access it:
 
 ```bash
-$ kubectl --namespace shoot-development-vagrant get secret kubecfg -o jsonpath="{.data.kubeconfig}" | base64 --decode > dev/shoot-kubeconfig
+$ kubectl --namespace shoot-garden-development-vagrant get secret kubecfg -o jsonpath="{.data.kubeconfig}" | base64 --decode > dev/shoot-kubeconfig
 
 # Depending on your Internet speed, it can take some time, before your node reports a READY status.
 $ kubectl --kubeconfig dev/shoot-kubeconfig get nodes

--- a/hack/dev-setup-vagrant
+++ b/hack/dev-setup-vagrant
@@ -21,6 +21,7 @@ IP_ROUTE=$(ip route get 1)
 IP_ADDRESS=$(echo ${IP_ROUTE#*src} | awk '{print $1}')
 MINIKUBE_SEED_KUBECONFIG=${DEV_DIR}/minikube-seed-kubeconfig
 
+kubectl create namespace garden-development 2> /dev/null
 kubectl apply -f ${EXAMPLE_DIR}/cloudprofile-vagrant.yaml
 kubectl apply -f ${EXAMPLE_DIR}/secret-dev-vagrant.yaml
 kubectl apply -f ${EXAMPLE_DIR}/secretbinding-core-vagrant.yaml
@@ -93,7 +94,7 @@ spec:
         nodes: 10.250.0.0/19
         pods: 100.96.0.0/11
         services: 100.64.0.0/13
-      endpoint: localhost:3777
+      endpoint: ${IP_ADDRESS}:3777
   kubernetes:
     version: 1.9.1
   dns:


### PR DESCRIPTION
The following scenario is supported - running the Gardener control plane components in Minikube and running the vagrant-provider on the host machine for creation of Shoot clusters locally. This setup simplifies the initial deployment setup.

@vasu1124 @rolpat can you test this setup on your machines?