### PR TITLE
 Reenable multi-zone support for GCP (has been fixed from 1.8.5 and 1.9)

### DIFF
--- a/pkg/apis/garden/validation/validation.go
+++ b/pkg/apis/garden/validation/validation.go
@@ -866,13 +866,6 @@ func validateCloud(cloud garden.Cloud, fldPath *field.Path) field.ErrorList {
 			return allErrs
 		}
 
-		// Disable multi-zone deployments due to an issue with PVCs and volume bindings over multiple zones by the default class
-		// https://github.com/kubernetes/kubernetes/issues/50115
-		// TODO: remove the following block and uncomment below blocks once the issue is fixed.
-		if zoneCount != 1 {
-			allErrs = append(allErrs, field.Forbidden(gcpPath.Child("zones"), "cannot specify more than once zone currently"))
-		}
-
 		allErrs = append(allErrs, validateK8SNetworks(gcp.Networks.K8SNetworks, gcpPath.Child("networks"))...)
 
 		if len(gcp.Networks.Workers) != zoneCount {

--- a/pkg/apis/garden/validation/validation_test.go
+++ b/pkg/apis/garden/validation/validation_test.go
@@ -2528,19 +2528,6 @@ var _ = Describe("validation", func() {
 				}))
 			})
 
-			It("should forbid specifying more than one zone", func() {
-				shoot.Spec.Cloud.GCP.Zones = []string{"zone1", "zone2"}
-				shoot.Spec.Cloud.GCP.Networks.Workers = []garden.CIDR{"10.250.0.0/16", "10.250.0.0/16"}
-
-				errorList := ValidateShoot(shoot)
-
-				Expect(len(errorList)).To(Equal(1))
-				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal(fmt.Sprintf("spec.cloud.%s.zones", fldPath)),
-				}))
-			})
-
 			It("should forbid updating networks and zones", func() {
 				newShoot := prepareShootForUpdate(shoot)
 				cidr := garden.CIDR("255.255.255.255/32")

--- a/pkg/operation/cloudbotanist/gcpbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/gcpbotanist/controlplane.go
@@ -30,9 +30,8 @@ func (b *GCPBotanist) GenerateCloudProviderConfig() (string, error) {
 	return `[Global]
 project-id = ` + b.Project + `
 network-name = ` + networkName + `
-multizone = false
+multizone = true
 token-url = nil
-local-zone = ` + string(b.Shoot.Info.Spec.Cloud.GCP.Zones[0]) + `
 node-tags = ` + b.Shoot.SeedNamespace, nil
 }
 


### PR DESCRIPTION
K8S pull request that fixes the issue:
https://github.com/kubernetes/kubernetes/pull/52322

Now at a multi-zone setup not all zones of a region are seen as available when e.g. creating PV(C)s, but only the ones where nodes are running.

See also Changelog of K8S 1.8.5:
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.8.md#other-notable-changes-5

closes #64