### PR TITLE
Register Shoot as Seed only for gardener namespace

### DIFF
--- a/pkg/client/kubernetes/base/secrets.go
+++ b/pkg/client/kubernetes/base/secrets.go
@@ -37,6 +37,16 @@ func (c *Client) CreateSecret(namespace, name string, secretType corev1.SecretTy
 	return secret, err
 }
 
+// CreateSecretObject creates a new Secret object.
+func (c *Client) CreateSecretObject(secret *corev1.Secret, updateIfExists bool) (*corev1.Secret, error) {
+
+	secret, err := c.clientset.CoreV1().Secrets(secret.Namespace).Create(secret)
+	if err != nil && apierrors.IsAlreadyExists(err) && updateIfExists {
+		return c.UpdateSecretObject(secret)
+	}
+	return secret, err
+}
+
 // UpdateSecret updates an already existing Secret object.
 func (c *Client) UpdateSecret(namespace, name string, secretType corev1.SecretType, data map[string][]byte) (*corev1.Secret, error) {
 	return c.clientset.CoreV1().Secrets(namespace).Update(&corev1.Secret{

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -62,6 +62,7 @@ type Client interface {
 
 	// Secrets
 	CreateSecret(string, string, corev1.SecretType, map[string][]byte, bool) (*corev1.Secret, error)
+	CreateSecretObject(*corev1.Secret, bool) (*corev1.Secret, error)
 	UpdateSecret(string, string, corev1.SecretType, map[string][]byte) (*corev1.Secret, error)
 	UpdateSecretObject(*corev1.Secret) (*corev1.Secret, error)
 	ListSecrets(string, metav1.ListOptions) (*corev1.SecretList, error)

--- a/pkg/controller/shoot/shoot_control_delete.go
+++ b/pkg/controller/shoot/shoot_control_delete.go
@@ -130,11 +130,6 @@ func (c *defaultControl) deleteShoot(o *operation.Operation) *gardenv1beta1.Last
 		return e
 	}
 
-	// Unregister the Shoot as Seed if it was annotated properly.
-	if err := botanist.UnregisterAsSeed(); err != nil {
-		o.Logger.Errorf("Could not unregister '%s' as Seed: '%s'", o.Shoot.Info.Name, err.Error())
-	}
-
 	o.Logger.Infof("Successfully deleted Shoot cluster '%s'", o.Shoot.Info.Name)
 	return nil
 }

--- a/pkg/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controller/shoot/shoot_control_reconcile.go
@@ -87,21 +87,23 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 		return e
 	}
 
-	// Register the Shoot as Seed cluster if it was annotated properly.
-	registerAsSeed := false
-	if val, ok := o.Shoot.Info.Annotations[common.ShootUseAsSeed]; ok {
-		useAsSeed, err := strconv.ParseBool(val)
-		if err == nil && useAsSeed {
-			registerAsSeed = true
+	// Register the Shoot as Seed cluster if it was annotated properly and in the Gardener namespace
+	if o.Shoot.Info.Namespace == common.GardenNamespace {
+		registerAsSeed := false
+		if val, ok := o.Shoot.Info.Annotations[common.ShootUseAsSeed]; ok {
+			useAsSeed, err := strconv.ParseBool(val)
+			if err == nil && useAsSeed {
+				registerAsSeed = true
+			}
 		}
-	}
-	if registerAsSeed {
-		if err := botanist.RegisterAsSeed(); err != nil {
-			o.Logger.Errorf("Could not register '%s' as Seed: '%s'", o.Shoot.Info.Name, err.Error())
-		}
-	} else {
-		if err := botanist.UnregisterAsSeed(); err != nil {
-			o.Logger.Errorf("Could not unregister '%s' as Seed: '%s'", o.Shoot.Info.Name, err.Error())
+		if registerAsSeed {
+			if err := botanist.RegisterAsSeed(); err != nil {
+				o.Logger.Errorf("Could not register '%s' as Seed: '%s'", o.Shoot.Info.Name, err.Error())
+			}
+		} else {
+			if err := botanist.UnregisterAsSeed(); err != nil {
+				o.Logger.Errorf("Could not unregister '%s' as Seed: '%s'", o.Shoot.Info.Name, err.Error())
+			}
 		}
 	}
 


### PR DESCRIPTION
Seed and Secrets for them are automatically created / deleted only if the shoot cluster is in the gardener namespace.

Additionally both resources have `OwnerReferences` set to the Shoot cluster.

Deletion is done automatically by the GC.