### PR TITLE
Add custom column printing for Seed and Shoot

### DIFF
--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -324,6 +324,7 @@ const (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Seed holds certain properties about a Seed cluster.
+// +k8s:openapi-gen=x-kubernetes-print-columns:custom-columns=NAME:.metadata.name,DOMAIN:.spec.ingressDomain,CLOUDPROFILE:.spec.cloud.profile,REGION:.spec.cloud.profile,READY:.status.conditions[?(@.type == 'Available')].status
 type Seed struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.
@@ -482,6 +483,7 @@ type SecretBindingList struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// +k8s:openapi-gen=x-kubernetes-print-columns:custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,SEED:.spec.cloud.seed,DOMAIN:.spec.dns.domain,VERSION:.spec.kubernetes.version,CONTROL:.status.conditions[?(@.type == 'ControlPlaneHealthy')].status,NODES:.status.conditions[?(@.type == 'EveryNodeReady')].status,SYSTEM:.status.conditions[?(@.type == 'SystemComponentsHealthy')].status,LATEST:.status.lastOperation.state
 type Shoot struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2910,6 +2910,11 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 					},
 				},
+				VendorExtensible: spec.VendorExtensible{
+					Extensions: spec.Extensions{
+						"x-kubernetes-print-columns": "custom-columns=NAME:.metadata.name,DOMAIN:.spec.ingressDomain,CLOUDPROFILE:.spec.cloud.profile,REGION:.spec.cloud.profile,READY:.status.conditions[?(@.type == 'Available')].status",
+					},
+				},
 			},
 			Dependencies: []string{
 				"github.com/gardener/gardener/pkg/apis/garden/v1beta1.SeedSpec", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.SeedStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
@@ -3127,6 +3132,11 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref:         ref("github.com/gardener/gardener/pkg/apis/garden/v1beta1.ShootStatus"),
 							},
 						},
+					},
+				},
+				VendorExtensible: spec.VendorExtensible{
+					Extensions: spec.Extensions{
+						"x-kubernetes-print-columns": "custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,SEED:.spec.cloud.seed,DOMAIN:.spec.dns.domain,VERSION:.spec.kubernetes.version,CONTROL:.status.conditions[?(@.type == 'ControlPlaneHealthy')].status,NODES:.status.conditions[?(@.type == 'EveryNodeReady')].status,SYSTEM:.status.conditions[?(@.type == 'SystemComponentsHealthy')].status,LATEST:.status.lastOperation.state",
 					},
 				},
 			},


### PR DESCRIPTION
*Seeds*

Before

```bash
kubectl get seeds --use-openapi-print-columns=false
NAME      AGE
vagrant   1m
```

After:

```bash
kubectl get seeds
NAME      DOMAIN                  CLOUDPROFILE   REGION    READY
vagrant   192.168.99.100.nip.io   vagrant        vagrant   True
```

*Shoots*

Before

```bash
kubectl get shoots --namespace garden --use-openapi-print-columns=false
NAME           AGE
vagrant-test   1m
```

After

```bash
kubectl get shoots --namespace garden
NAMESPACE   NAME           SEED      DOMAIN                  VERSION   CONTROL   NODES  SYSTEM  LATEST
garden      vagrant-test   vagrant   192.168.99.100.nip.io   1.10.0    True      True   True    Succeeded
```