### PR TITLE
Create Prometheus for seed kubelet scraping

### DIFF
--- a/charts/seed-bootstrap/templates/prometheus/clusterrolebinding.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: {{include "rbacversion" .}}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: prometheus
+    role: monitoring
+  name: prometheus-seed
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: {{ .Release.Namespace }}

--- a/charts/seed-bootstrap/templates/prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/config.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: {{ .Release.Namespace }}
+data:
+  prometheus.yaml: |
+
+    global:
+      evaluation_interval: 30s
+      scrape_interval: 30s
+    rule_files:
+    - /etc/prometheus/rules/*.yml
+
+    scrape_configs:
+    - job_name: kube-kubelet-seed
+      honor_labels: false
+      scheme: https
+
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_node_address_InternalIP]
+        target_label: instance
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics
+      - target_label: type
+        replacement: seed
+      - target_label: job
+        replacement: kube-kubelet
+
+      # Here we do the actual multi-tenancy - we only get one in specific namespace
+      metric_relabel_configs:
+      # get system services
+      - source_labels: [id]
+        action: replace
+        regex: '^/system\.slice/(.+)\.service$'
+        target_label: systemd_service_name
+        replacement: '${1}'
+
+    - job_name: cadvisor-seed
+      honor_labels: false
+      scheme: https
+
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_node_address_InternalIP]
+        target_label: instance
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+      - target_label: type
+        replacement: seed
+      - target_label: job
+        replacement: kube-kubelet

--- a/charts/seed-bootstrap/templates/prometheus/rules.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/rules.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-rules
+  namespace: {{.Release.Namespace}}
+data: {}

--- a/charts/seed-bootstrap/templates/prometheus/service.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-web
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: prometheus
+    role: monitoring
+spec:
+  ports:
+  - name: web
+    port: 80
+    protocol: TCP
+    targetPort: web
+  selector:
+    app: prometheus
+    role: monitoring
+  type: ClusterIP

--- a/charts/seed-bootstrap/templates/prometheus/serviceaccount.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: prometheus
+    role: monitoring

--- a/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
@@ -1,0 +1,114 @@
+apiVersion: {{include "statefulsetversion" .}}
+kind: StatefulSet
+metadata:
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: prometheus
+    role: monitoring
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: prometheus
+      role: monitoring
+  serviceName: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+        role: monitoring
+    spec:
+      # used to talk to Seed's API server.
+      serviceAccountName: prometheus
+      containers:
+      - name: prometheus
+        image: {{ index .Values.images "prometheus" }}
+        imagePullPolicy: IfNotPresent
+        args:
+        - --config.file=/etc/prometheus/config/prometheus.yaml
+        - --storage.tsdb.path=/var/prometheus/data
+        - --storage.tsdb.no-lockfile
+        - --storage.tsdb.retention=48h
+        - --web.route-prefix=/
+        - --web.enable-lifecycle
+        # Since v2.0.0-beta.3 prometheus runs as nobody user (fsGroup 65534/runAsUser 0)
+        # data volume needs to be mounted with the same permissions,
+        # otherwise we will have Permission denied problems
+        securityContext:
+          runAsUser: 0
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /status
+            port: web
+            scheme: HTTP
+          initialDelaySeconds: 300
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        ports:
+        - containerPort: 9090
+          name: web
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /status
+            port: web
+            scheme: HTTP
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: 1400Mi
+          requests:
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /etc/prometheus/config
+          name: config
+          readOnly: true
+        - mountPath: /etc/prometheus/rules
+          name: rules
+          readOnly: true
+        - mountPath: /var/prometheus/data
+          name: prometheus-db
+          subPath: prometheus-
+      - name: prometheus-config-reloader
+        image: {{ index .Values.images "configmap-reloader" }}
+        imagePullPolicy: IfNotPresent
+        args:
+        - -webhook-url=http://localhost:9090/-/reload
+        - -volume-dir=/etc/prometheus/config
+        - -volume-dir=/etc/prometheus/rules
+        resources:
+          limits:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/prometheus/config
+          name: config
+          readOnly: true
+        - mountPath: /etc/prometheus/rules
+          name: rules
+      terminationGracePeriodSeconds: 300
+      volumes:
+      - name: config
+        configMap:
+          defaultMode: 420
+          name: prometheus-config
+      - name: rules
+        configMap:
+          defaultMode: 420
+          name: prometheus-rules
+  volumeClaimTemplates:
+  - metadata:
+      name: prometheus-db
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi

--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -76,14 +76,20 @@ data:
     - job_name: 'cadvisor-shoot'
 {{- include "prometheus.kubelet-shoot" (dict "Path" "metrics/cadvisor" "Namespace" .Release.Namespace "JobName" "cadvisor") }}
 
-    # We fetch kubelet metrics from seed's nodes and filter only the metrics in
-    # shoot's namespace
+    # We fetch kubelet metrics from seed's kube-system Prometheus and filter
+    # the metrics in shoot's namespace
     - job_name: 'kube-kubelet-seed'
-{{- include "prometheus.kubelet-seed" (dict "Path" "metrics" "Namespace" .Release.Namespace "JobName" "kube-kubelet") }}
-
-    # As of K8S v1.7.3 cAdvisor metrics are located at <kubelet-address>/metrics/cadvisor
-    - job_name: 'cadvisor-seed'
-{{- include "prometheus.kubelet-seed" (dict "Path" "metrics/cadvisor" "Namespace" .Release.Namespace "JobName" "cadvisor") }}
+      metrics_path: /federate
+      params:
+        'match[]':
+        - '{namespace="{{ .Release.Namespace }}"}'
+      static_configs:
+      - targets:
+        - prometheus-web.kube-system.svc
+      metric_relabel_configs:
+      # we make the shoot's pods in the shoot's namepsace to apear in as its in the kube-system
+      - target_label: namespace
+        replacement: kube-system
 
     - job_name: 'kube-state-metrics'
       scheme: http

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -97,8 +97,21 @@ func BootstrapCluster(seed *Seed, k8sGardenClient kubernetes.Client, secrets map
 		return err
 	}
 
+	prometheusVersion, err := imageVector.FindImage("prometheus", k8sGardenClient.Version())
+	if err != nil {
+		return err
+	}
+	configMapReloader, err := imageVector.FindImage("configmap-reloader", k8sGardenClient.Version())
+	if err != nil {
+		return err
+	}
+
 	return common.ApplyChart(k8sSeedClient, chartrenderer.New(k8sSeedClient), filepath.Join("charts", chartName), chartName, metav1.NamespaceSystem, nil, map[string]interface{}{
 		"cloudProvider": seed.CloudProvider,
+		"images": map[string]interface{}{
+			"prometheus":         prometheusVersion.String(),
+			"configmap-reloader": configMapReloader.String(),
+		},
 	})
 }
 


### PR DESCRIPTION
Added a Prometheus for the kube-system of a Seed cluster. It collects metrics from kubelets (+cadvisor) to reduce the load on the Prometheus shoot instances.
The network traffic is reduced, because the filtering is done when the Shoot Prometheus uses the /federation endpoint with filter options.

To be 100% sure that Promethus can talk to the Shoot kubelets, the API server proxy functionality is used.

fixes #60 