### PR TITLE
Replace MAINTAINERS.md by CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# gardener maintainers
+*   @rfranzke @mvladev @dkistner

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,0 @@
-Maintainers of this repository with their focus areas:
-
-* Rafael Franzke <rafael.franzke@sap.com> @rfranzke
-* Martin Vladev <martin.vladev@sap.com> @mvladev
-* Dominic Kistner <dominic.kistner@sap.com> @dkistner


### PR DESCRIPTION
This enables use of the Github codeowners feature
https://help.github.com/articles/about-codeowners/