### PR TITLE
Enable OpenStack Swift backup container deletion

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -123,7 +123,7 @@ images:
 # Miscellaenous
 - name: terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "0.5.0"
+  tag: "0.6.0"
 - name: busybox
   repository: busybox
   tag: "1.28"

--- a/charts/seed-terraformer/charts/openstack-backup/templates/_main.tf
+++ b/charts/seed-terraformer/charts/openstack-backup/templates/_main.tf
@@ -14,8 +14,9 @@ provider "openstack" {
 //=====================================================================
 
 resource "openstack_objectstorage_container_v1" "container" {
-  region = "{{ required "openstack.region is required" .Values.openstack.region }}"
-  name   = "{{ required "container.name is required" .Values.container.name }}"
+  region        = "{{ required "openstack.region is required" .Values.openstack.region }}"
+  name          = "{{ required "container.name is required" .Values.container.name }}"
+  force_destroy = true
 }
 
 //=====================================================================

--- a/pkg/operation/cloudbotanist/openstackbotanist/infrastructure.go
+++ b/pkg/operation/cloudbotanist/openstackbotanist/infrastructure.go
@@ -98,14 +98,10 @@ func (b *OpenStackBotanist) DeployBackupInfrastructure() error {
 
 // DestroyBackupInfrastructure kicks off a Terraform job which destroys the infrastructure for backup.
 func (b *OpenStackBotanist) DestroyBackupInfrastructure() error {
-	return nil
-	//TODO: Remove this comment when backup is to be pushed on to swift container i.e.
-	// when we have next(v1.4.0) realease of https://github.com/terraform-providers/terraform-provider-openstack/releases
-	/* return terraformer.
-	NewFromOperation(b.Operation, common.TerraformerPurposeBackup).
-	SetVariablesEnvironment(b.generateTerraformBackupVariablesEnvironment()).
-	Destroy()
-	*/
+	return terraformer.
+		NewFromOperation(b.Operation, common.TerraformerPurposeBackup).
+		SetVariablesEnvironment(b.generateTerraformBackupVariablesEnvironment()).
+		Destroy()
 }
 
 // generateTerraformBackupVariablesEnvironment generates the environment containing the credentials which


### PR DESCRIPTION
* Terraformer image has been bumped to 0.6.0, featuring the OpenStack provider plugin v1.4.0