### PR TITLE
Alerts for VPN issues now silence other shoot alerts

### DIFF
--- a/charts/seed-monitoring/charts/alertmanager/templates/_config.tpl
+++ b/charts/seed-monitoring/charts/alertmanager/templates/_config.tpl
@@ -33,19 +33,25 @@ route:
     receiver: email-kubernetes-ops
 
 inhibit_rules:
+# Apply inhibition if the alertname is the same.
 - source_match:
     severity: critical
   target_match:
     severity: warning
-  # Apply inhibition if the alertname is the same.
   equal: ['alertname', 'service']
 - source_match:
     severity: critical
   target_match:
     alertname: PrometheusCantScrape
   equal: ['type', 'job']
-  # Stop warning and critical alerts, when there is a blocker -
-  # no networking, no workers etc.
+# Stop all alerts for type=shoot if no there are VPN problems
+- source_match:
+    service: vpn
+  target_match:
+    type: shoot
+  equal: ['type']
+# Stop warning and critical alerts, when there is a blocker -
+# no networking, no workers etc.
 - source_match:
     severity: blocker
   target_match_re:

--- a/charts/seed-monitoring/charts/prometheus/rules/alertmanager.rules.yml
+++ b/charts/seed-monitoring/charts/prometheus/rules/alertmanager.rules.yml
@@ -31,6 +31,7 @@ groups:
     labels:
       service: alertmanager
       severity: warning
+      type: seed
     annotations:
       summary: Alertmanager configuration reload has failed
       description: Reloading Alertmanager's configuration has failed for {{ $labels.pod}}.

--- a/charts/seed-monitoring/charts/prometheus/rules/cadvisor.rules.yml
+++ b/charts/seed-monitoring/charts/prometheus/rules/cadvisor.rules.yml
@@ -1,13 +1,29 @@
 groups:
 - name: cadvisor.rules
   rules:
-  - alert: cAdvisorCantBeScrapped
+  - alert: cAdvisorSeedCantBeScrapped
     # TODO: make this rule check individual nodes
-    expr: absent(container_cpu_cfs_periods_total{type="seed"}) or absent(container_cpu_cfs_periods_total{type="shoot"})
+    expr: absent(container_cpu_cfs_periods_total{type="seed"}
     for: 7m
     labels:
+      job: kubelet
       service: kubelet
       severity: warning
+      type: seed
+    annotations:
+      description: |
+        cAdvisor for {{ $labels.type }} cluster can't be scrapped.
+        After Kubernetes 1.7.3 cAdvisor's metrics are exposed at 'kubelet-host/metrics/cadvisor'
+      summary: Kubelet's cAvisor can't be scrapped
+  - alert: cAdvisorShootCantBeScrapped
+    # TODO: make this rule check individual nodes
+    expr: absent(container_cpu_cfs_periods_total{type="shoot"})
+    for: 7m
+    labels:
+      job: kubelet
+      service: kubelet
+      severity: warning
+      type: shoot
     annotations:
       description: |
         cAdvisor for {{ $labels.type }} cluster can't be scrapped.

--- a/charts/seed-monitoring/charts/prometheus/rules/kube-kubelet.rules.yml
+++ b/charts/seed-monitoring/charts/prometheus/rules/kube-kubelet.rules.yml
@@ -3,11 +3,12 @@ groups:
   rules:
   - alert: NoWorkerNodes
     expr: absent(up{job="kube-kubelet", type="shoot"}) or count(up{job="kube-kubelet", type="shoot"} == 0)
-    for: 4m
+    for: 5m
     labels:
       job: kube-kubelet
       service: kube-kubelet
       severity: blocker
+      type: shoot
     annotations:
       description: No kubelets are available in the shoot cluster, or all Kubelets
         have disappeared from service discovery.
@@ -19,6 +20,7 @@ groups:
       job: kube-kubelet
       service: kube-kubelet
       severity: warning
+      type: shoot
     annotations:
       description: Prometheus could not scrape a {{ $labels.job }} for more than one
         hour

--- a/charts/seed-monitoring/charts/prometheus/rules/kube-pods.rules.yml
+++ b/charts/seed-monitoring/charts/prometheus/rules/kube-pods.rules.yml
@@ -5,7 +5,7 @@ groups:
     expr: kube_pod_status_phase{phase="Pending", namespace="kube-system"} == 1
     for: 10m
     labels:
-      service: k8s
+      service: kube-kubelet
       severity: warning
     annotations:
       description: Pod {{ $labels.pod }} is in state Pending for more than 10 minutes


### PR DESCRIPTION
If an alert is already present for VPN service, then silence all other alerts of `type=shoot`.

Fixes #170 

/cc @plkokanov