### PR TITLE
Fix the severity of etcd and apiserver alerts

### DIFF
--- a/charts/seed-monitoring/charts/alertmanager/templates/_config.tpl
+++ b/charts/seed-monitoring/charts/alertmanager/templates/_config.tpl
@@ -39,19 +39,15 @@ inhibit_rules:
   target_match:
     severity: warning
   equal: ['alertname', 'service']
-- source_match:
-    severity: critical
-  target_match:
-    alertname: PrometheusCantScrape
-  equal: ['type', 'job']
-# Stop all alerts for type=shoot if no there are VPN problems
+# Stop all alerts for type=shoot if no there are VPN problems.
 - source_match:
     service: vpn
-  target_match:
+  target_match_re:
     type: shoot
+    severity: ^(critical|warning)$
   equal: ['type']
 # Stop warning and critical alerts, when there is a blocker -
-# no networking, no workers etc.
+# no workers, no etcd main etc.
 - source_match:
     severity: blocker
   target_match_re:

--- a/charts/seed-monitoring/charts/prometheus/rules/kube-apiserver.rules.yml
+++ b/charts/seed-monitoring/charts/prometheus/rules/kube-apiserver.rules.yml
@@ -19,7 +19,7 @@ groups:
     labels:
       job: kube-apiserver
       service: kube-apiserver
-      severity: blocker
+      severity: critical
       type: seed
     annotations:
       description: Prometheus failed to scrape API server(s), or all API servers have disappeared from service discovery.

--- a/charts/seed-monitoring/charts/prometheus/rules/kube-etcd3.rules.yml
+++ b/charts/seed-monitoring/charts/prometheus/rules/kube-etcd3.rules.yml
@@ -2,9 +2,21 @@ groups:
 - name: kube-etcd3.rules
   rules:
 
-  # alert if etcd is down
+  # alert if main etcd is down
   - alert: KubeEtcd3Down
-    expr: absent(up{job="kube-etcd3",role="main"}) or absent(up{job="kube-etcd3",role="events"})
+    expr: absent(up{job="kube-etcd3",role="main"}
+    for: 3m
+    labels:
+      service: etcd
+      severity: blocker
+      type: seed
+    annotations:
+      description: etc3 cluster {{ $labels.role }} is unavailable or cannot be scrapped
+      summary: etcd3 main cluster down
+
+  # alert if main etcd is down
+  - alert: KubeEtcd3Down
+    expr: absent(up{job="kube-etcd3",role="events"})
     for: 3m
     labels:
       service: etcd
@@ -12,7 +24,7 @@ groups:
       type: seed
     annotations:
       description: etc3 cluster {{ $labels.role }} is unavailable or cannot be scrapped
-      summary: etcd3 cluster down
+      summary: etcd3 events cluster down
 
   # etcd leader alerts
   - alert: KubeEtcd3NoLeader

--- a/charts/seed-monitoring/charts/prometheus/rules/vpn.rules.yml
+++ b/charts/seed-monitoring/charts/prometheus/rules/vpn.rules.yml
@@ -6,7 +6,7 @@ groups:
     for: 5m
     labels:
       service: vpn
-      severity: blocker
+      severity: critical
       type: shoot
     annotations:
       description: vpn-shoot deployment in Shoot cluster has 0 available pods. VPN won't work.
@@ -16,7 +16,7 @@ groups:
     for: 5m
     labels:
       service: vpn
-      severity: blocker
+      severity: critical
       type: shoot
     annotations:
       description: VPN connection for {{ $labels.pod }} is down. No resources of the Shoot cluster


### PR DESCRIPTION
- If etcd is down, then don't dispatch APIServerDown alerts.
- Split KubeEtcd3Down into `main` and `events` with different severities.