### PR TITLE
Add DeletionConfirmation admission controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ start-api:
 	@go run cmd/gardener-apiserver/main.go \
 			--authentication-kubeconfig ~/.kube/config \
 			--authorization-kubeconfig ~/.kube/config \
-			--enable-admission-plugins=ResourceReferenceManager,ShootSeedManager,ShootDNSHostedZone,ShootValidator,ShootQuotaValidator \
+			--enable-admission-plugins=DeletionConfirmation \
 			--etcd-servers=http://$(shell minikube ip):32379 \
 			--kubeconfig ~/.kube/config \
 			--tls-cert-file ~/.minikube/apiserver.crt \

--- a/hack/delete-shoot
+++ b/hack/delete-shoot
@@ -17,6 +17,7 @@
 NAME="$1"
 NAMESPACE="${2:-$(id -u -n)}"
 
+kubectl --namespace "$NAMESPACE" patch shoot "$NAME" --type=merge -p "{\"metadata\": {\"annotations\": {\"confirmation.garden.sapcloud.io/deletion\": \"true\"}}}"
 kubectl --namespace "$NAMESPACE" delete shoot "$NAME"
 deletionTimestamp="$(kubectl --namespace "$NAMESPACE" get shoot "$NAME" -o jsonpath --template={.metadata.deletionTimestamp})"
 kubectl --namespace "$NAMESPACE" patch shoot "$NAME" --type=merge -p "{\"metadata\": {\"annotations\": {\"confirmation.garden.sapcloud.io/deletionTimestamp\": \"$deletionTimestamp\"}}}"

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -40,7 +40,12 @@ const (
 
 	// ConfirmationDeletionTimestamp is an annotation on a Shoot resource whose value must be set equal to the Shoot's
 	// '.metadata.deletionTimestamp' value to trigger the deletion process of the Shoot cluster.
+	// DEPRECATED: Use ConfirmationDeletion instead.
 	ConfirmationDeletionTimestamp = "confirmation.garden.sapcloud.io/deletionTimestamp"
+
+	// ConfirmationDeletion is an annotation on a Shoot resource whose value must be set to true
+	// to trigger the deletion process of the Shoot cluster.
+	ConfirmationDeletion = "confirmation.garden.sapcloud.io/deletion"
 
 	// ControllerManagerInternalConfigMapName is the name of the internal config map in which the Gardener controller
 	// manager stores its configuration.

--- a/plugin/pkg/global/deletionconfirmation/admission.go
+++ b/plugin/pkg/global/deletionconfirmation/admission.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deletionconfirmation
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/gardener/gardener/pkg/apis/garden"
+	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
+	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/internalversion"
+	gardenlisters "github.com/gardener/gardener/pkg/client/garden/listers/garden/internalversion"
+	"github.com/gardener/gardener/pkg/operation/common"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const (
+	// PluginName is the name of this admission plugin.
+	PluginName = "DeletionConfirmation"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, NewFactory)
+}
+
+// NewFactory creates a new PluginFactory.
+func NewFactory(config io.Reader) (admission.Interface, error) {
+	return New()
+}
+
+// WaitFunc is a function that waits for true.
+type WaitFunc func() bool
+
+// DeletionConfirmation contains an admission handler and listers.
+type DeletionConfirmation struct {
+	*admission.Handler
+	shootLister gardenlisters.ShootLister
+	waitFunc    WaitFunc
+}
+
+var _ = admissioninitializer.WantsInternalGardenInformerFactory(&DeletionConfirmation{})
+
+// New creates a new DeletionConfirmation admission plugin.
+func New() (*DeletionConfirmation, error) {
+	h := admission.NewHandler(admission.Delete)
+	return &DeletionConfirmation{
+		Handler:  h,
+		waitFunc: h.WaitForReady,
+	}, nil
+}
+
+// SetInternalGardenInformerFactory gets Lister from SharedInformerFactory.
+func (d *DeletionConfirmation) SetInternalGardenInformerFactory(f gardeninformers.SharedInformerFactory) {
+	d.shootLister = f.Garden().InternalVersion().Shoots().Lister()
+}
+
+// SetWaitFunc sets the wait function
+func (d *DeletionConfirmation) SetWaitFunc(w WaitFunc) {
+	d.waitFunc = w
+}
+
+// ValidateInitialization checks whether the plugin was correctly initialized.
+func (d *DeletionConfirmation) ValidateInitialization() error {
+	if d.shootLister == nil {
+		return errors.New("missing shoot lister")
+	}
+	return nil
+}
+
+// Admit makes admissions decisions based on deletion confirmation annotation.
+func (d *DeletionConfirmation) Admit(a admission.Attributes) error {
+	// Ignore all kinds other than Shoot.
+	// TODO: in future the Kinds should be configurable
+	// https://v1-9.docs.kubernetes.io/docs/admin/admission-controllers/#imagepolicywebhook
+	if a.GetKind().GroupKind() != garden.Kind("Shoot") {
+		return nil
+	}
+
+	// Wait until the caches have been synced
+	if !d.waitFunc() {
+		return admission.NewForbidden(a, errors.New("not yet ready to handle request"))
+	}
+
+	shoot, err := d.shootLister.Shoots(a.GetNamespace()).Get(a.GetName())
+	if err != nil {
+		return err
+	}
+
+	annotations := shoot.GetAnnotations()
+
+	if annotations == nil {
+		return admission.NewForbidden(a, annotationRequiredError())
+	}
+	if present, _ := strconv.ParseBool(annotations[common.ConfirmationDeletion]); !present {
+		return admission.NewForbidden(a, annotationRequiredError())
+	}
+	return nil
+}
+
+func annotationRequiredError() error {
+	return fmt.Errorf("must have a %q annotation to delete", common.ConfirmationDeletion)
+}

--- a/plugin/pkg/global/deletionconfirmation/admission_test.go
+++ b/plugin/pkg/global/deletionconfirmation/admission_test.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deletionconfirmation_test
+
+import (
+	. "github.com/gardener/gardener/plugin/pkg/global/deletionconfirmation"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener/pkg/apis/garden"
+	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/internalversion"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/client-go/tools/cache"
+)
+
+func ready() bool {
+	return true
+}
+
+func notReady() bool {
+	return false
+}
+
+var _ = Describe("deleteconfirmation", func() {
+
+	Describe("#Admit", func() {
+		var (
+			shoot                 garden.Shoot
+			attrs                 admission.Attributes
+			shootStore            cache.Store
+			admissionHandler      *DeletionConfirmation
+			gardenInformerFactory gardeninformers.SharedInformerFactory
+		)
+
+		BeforeEach(func() {
+			admissionHandler, _ = New()
+			gardenInformerFactory = gardeninformers.NewSharedInformerFactory(nil, 0)
+			admissionHandler.SetInternalGardenInformerFactory(gardenInformerFactory)
+			shootStore = gardenInformerFactory.Garden().InternalVersion().Shoots().Informer().GetStore()
+			admissionHandler.SetReadyFunc(ready)
+			shoot = garden.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dummy",
+					Namespace: "dummy",
+				},
+			}
+			attrs = admission.NewAttributesRecord(nil, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Namespace, garden.Resource("shoots").WithVersion("version"), "", admission.Delete, nil)
+		})
+
+		It("should do nothing because the resource is not Shoot", func() {
+			attrs = admission.NewAttributesRecord(nil, nil, garden.Kind("Foo").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("foos").WithVersion("version"), "", admission.Delete, nil)
+
+			err := admissionHandler.Admit(attrs)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should do nothing because cache is not ready", func() {
+			admissionHandler.SetWaitFunc(notReady)
+			err := admissionHandler.Admit(attrs)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not yet ready to handle request"))
+		})
+
+		It("should do nothing because the resource is already removed", func() {
+			err := admissionHandler.Admit(attrs)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal(`shoot.garden.sapcloud.io "dummy" not found`))
+		})
+
+		Context("no annotation", func() {
+			It("should reject for nil annotation field", func() {
+				shootStore.Add(&shoot)
+
+				err := admissionHandler.Admit(attrs)
+
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
+			It("should reject for false annotation value", func() {
+				shoot.Annotations = map[string]string{
+					"confirmation.garden.sapcloud.io/deletion": "false",
+				}
+				shootStore.Add(&shoot)
+
+				err := admissionHandler.Admit(attrs)
+
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
+			It("should succeed for true annotation value", func() {
+				shoot.Annotations = map[string]string{
+					"confirmation.garden.sapcloud.io/deletion": "true",
+				}
+				shootStore.Add(&shoot)
+
+				err := admissionHandler.Admit(attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+	})
+	Describe("#Register", func() {
+		It("should register the plugin", func() {
+			plugins := admission.NewPlugins()
+			Register(plugins)
+
+			registred := plugins.Registered()
+			Expect(registred).To(HaveLen(1))
+			Expect(registred).To(ContainElement("DeletionConfirmation"))
+		})
+	})
+
+	Describe("#NewFactory", func() {
+		It("should create a new PluginFactory", func() {
+			f, err := NewFactory(nil)
+
+			Expect(f).NotTo(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("#New", func() {
+		It("should only handle DELETE operations", func() {
+			dr, err := New()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dr.Handles(admission.Create)).NotTo(BeTrue())
+			Expect(dr.Handles(admission.Update)).NotTo(BeTrue())
+			Expect(dr.Handles(admission.Connect)).NotTo(BeTrue())
+			Expect(dr.Handles(admission.Delete)).To(BeTrue())
+		})
+	})
+
+	Describe("#ValidateInitialization", func() {
+		It("should return error if no ShootLister is set", func() {
+			dr, _ := New()
+
+			err := dr.ValidateInitialization()
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should not return error if ShootLister is set", func() {
+			dr, _ := New()
+			dr.SetInternalGardenInformerFactory(gardeninformers.NewSharedInformerFactory(nil, 0))
+
+			err := dr.ValidateInitialization()
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/plugin/pkg/global/deletionconfirmation/deletionrestriction_suite_test.go
+++ b/plugin/pkg/global/deletionconfirmation/deletionrestriction_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deletionconfirmation_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestDeletionConfirmation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Admission DeletionConfirmation Suite")
+}


### PR DESCRIPTION
The current way of deletion of Shoot resources is a left over from when the Gardener was working as TPR operator and external validation webhooks were not available.

`DeletionConfirmation` admission controller fixes this issue by allowing deletion of resources to happen when a Shoot resource is annotated with `confirmation.garden.sapcloud.io/deletion=true`

It is disabled by default to preserve the old behavior.