### PR TITLE
Worker pool validation for cluster autoscaling

### DIFF
--- a/pkg/apis/garden/validation/validation.go
+++ b/pkg/apis/garden/validation/validation.go
@@ -1263,6 +1263,9 @@ func validateWorker(worker garden.Worker, autoScalingEnabled bool, fldPath *fiel
 	if !autoScalingEnabled && worker.AutoScalerMin != worker.AutoScalerMax {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("autoScalerMin/autoScalerMax"), "maximum value must be equal to minimum value if cluster autoscaler addon is disabled"))
 	}
+	if autoScalingEnabled && worker.AutoScalerMax != 0 && worker.AutoScalerMin == 0 {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("autoScalerMin"), "minimum value must be larger than 0 if autoscaling is enabled and maximum is not equals zero"))
+	}
 
 	return allErrs
 }

--- a/pkg/apis/garden/validation/validation_test.go
+++ b/pkg/apis/garden/validation/validation_test.go
@@ -1631,6 +1631,18 @@ var _ = Describe("validation", func() {
 				AutoScalerMin: 1,
 				AutoScalerMax: 2,
 			}
+			workerAutoScalingInvalid = garden.Worker{
+				Name:          "cpu-worker",
+				MachineType:   "large",
+				AutoScalerMin: 0,
+				AutoScalerMax: 2,
+			}
+			workerAutoScalingHibernated = garden.Worker{
+				Name:          "cpu-worker",
+				MachineType:   "large",
+				AutoScalerMin: 0,
+				AutoScalerMax: 0,
+			}
 		)
 
 		BeforeEach(func() {
@@ -2075,6 +2087,38 @@ var _ = Describe("validation", func() {
 				}))
 			})
 
+			It("should enforce workers min > 0 if autoscaler is enabled and max > 0", func() {
+				shoot.Spec.Cloud.AWS.Workers = []garden.AWSWorker{
+					{
+						Worker:     workerAutoScalingInvalid,
+						VolumeSize: "20Gi",
+						VolumeType: "default",
+					},
+				}
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(len(errorList)).To(Equal(1))
+				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal(fmt.Sprintf("spec.cloud.%s.workers[0].autoScalerMin", fldPath)),
+				}))
+			})
+
+			It("should allow workers min=0 if autoscaler is enabled and max=0", func() {
+				shoot.Spec.Cloud.AWS.Workers = []garden.AWSWorker{
+					{
+						Worker:     workerAutoScalingHibernated,
+						VolumeSize: "20Gi",
+						VolumeType: "default",
+					},
+				}
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(len(errorList)).To(Equal(0))
+			})
+
 			It("should enforce workers min=max if autoscaler is disabled", func() {
 				shoot.Spec.Cloud.AWS.Workers = []garden.AWSWorker{
 					{
@@ -2407,6 +2451,38 @@ var _ = Describe("validation", func() {
 				}))
 			})
 
+			It("should enforce workers min > 0 if autoscaler is enabled and max > 0", func() {
+				shoot.Spec.Cloud.Azure.Workers = []garden.AzureWorker{
+					{
+						Worker:     workerAutoScalingInvalid,
+						VolumeSize: "40Gi",
+						VolumeType: "default",
+					},
+				}
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(len(errorList)).To(Equal(1))
+				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal(fmt.Sprintf("spec.cloud.%s.workers[0].autoScalerMin", fldPath)),
+				}))
+			})
+
+			It("should allow workers min=0 if autoscaler is enabled and max=0", func() {
+				shoot.Spec.Cloud.Azure.Workers = []garden.AzureWorker{
+					{
+						Worker:     workerAutoScalingHibernated,
+						VolumeSize: "40Gi",
+						VolumeType: "default",
+					},
+				}
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(len(errorList)).To(Equal(0))
+			})
+
 			It("should enforce workers min=max if autoscaler is disabled", func() {
 				shoot.Spec.Cloud.Azure.Workers = []garden.AzureWorker{
 					{
@@ -2707,6 +2783,38 @@ var _ = Describe("validation", func() {
 				}))
 			})
 
+			It("should enforce workers min > 0 if autoscaler is enabled and max > 0", func() {
+				shoot.Spec.Cloud.GCP.Workers = []garden.GCPWorker{
+					{
+						Worker:     workerAutoScalingInvalid,
+						VolumeSize: "20Gi",
+						VolumeType: "default",
+					},
+				}
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(len(errorList)).To(Equal(1))
+				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal(fmt.Sprintf("spec.cloud.%s.workers[0].autoScalerMin", fldPath)),
+				}))
+			})
+
+			It("should allow workers min=0 if autoscaler is enabled and max=0", func() {
+				shoot.Spec.Cloud.GCP.Workers = []garden.GCPWorker{
+					{
+						Worker:     workerAutoScalingHibernated,
+						VolumeSize: "20Gi",
+						VolumeType: "default",
+					},
+				}
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(len(errorList)).To(Equal(0))
+			})
+
 			It("should enforce workers min=max if autoscaler is disabled", func() {
 				shoot.Spec.Cloud.GCP.Workers = []garden.GCPWorker{
 					{
@@ -3003,6 +3111,34 @@ var _ = Describe("validation", func() {
 					"Type":  Equal(field.ErrorTypeForbidden),
 					"Field": Equal(fmt.Sprintf("spec.cloud.%s.workers[0].autoScalerMax", fldPath)),
 				}))
+			})
+
+			It("should enforce workers min > 0 if autoscaler is enabled and max > 0", func() {
+				shoot.Spec.Cloud.OpenStack.Workers = []garden.OpenStackWorker{
+					{
+						Worker: workerAutoScalingInvalid,
+					},
+				}
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(len(errorList)).To(Equal(1))
+				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal(fmt.Sprintf("spec.cloud.%s.workers[0].autoScalerMin", fldPath)),
+				}))
+			})
+
+			It("should allow workers min=0 if autoscaler is enabled and max=0", func() {
+				shoot.Spec.Cloud.OpenStack.Workers = []garden.OpenStackWorker{
+					{
+						Worker: workerAutoScalingHibernated,
+					},
+				}
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(len(errorList)).To(Equal(0))
 			})
 
 			It("should enforce workers min=max if autoscaler is disabled", func() {

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -252,9 +252,21 @@ func (b *Botanist) DeployClusterAutoscaler() error {
 	)
 
 	for _, worker := range b.MachineDeployments {
+		// Skip worker pools for which min=max=0.
+		if worker.Minimum == 0 && worker.Maximum == 0 {
+			continue
+		}
+
+		// Cluster Autoscaler requires min>=1. We ensure that in the API server validation part, however,
+		// for backwards compatibility, we treat existing worker pools whose minimum equals 0 as min=1.
+		min := worker.Minimum
+		if worker.Minimum == 0 {
+			min = 1
+		}
+
 		workerPools = append(workerPools, map[string]interface{}{
 			"name": worker.Name,
-			"min":  worker.Minimum,
+			"min":  min,
 			"max":  worker.Maximum,
 		})
 	}


### PR DESCRIPTION
1. We should skip worker pools in the cluster autoscaler configuration
   for which `min=max=0`.

2. The cluster autoscaler is not yet able to handle `min=0` correctly.
   Consequently, we validate that `min>0` if `max>0` and autoscaling is
   enabled. For backwards compatibility (it might exist Shoot clusters
   which have worker pools with `min=0` configured) we treat the minimum
   to be equal to 1.