### PR TITLE
Add feature gates to gardener

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ start-api:
 	@go run cmd/gardener-apiserver/main.go \
 			--authentication-kubeconfig ~/.kube/config \
 			--authorization-kubeconfig ~/.kube/config \
-			--enable-admission-plugins=DeletionConfirmation \
 			--etcd-servers=http://$(shell minikube ip):32379 \
+			--feature-gates=DeletionConfirmation=true \
 			--kubeconfig ~/.kube/config \
 			--tls-cert-file ~/.minikube/apiserver.crt \
 			--tls-private-key-file ~/.minikube/apiserver.key \

--- a/cmd/gardener-apiserver/main.go
+++ b/cmd/gardener-apiserver/main.go
@@ -20,9 +20,14 @@ import (
 	"runtime"
 
 	"github.com/gardener/gardener/cmd/gardener-apiserver/app"
+	"github.com/gardener/gardener/pkg/features"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/util/logs"
 )
+
+func init() {
+	features.RegisterAPIServerFeatureGate()
+}
 
 func main() {
 	logs.InitLogs()

--- a/cmd/gardener-controller-manager/main.go
+++ b/cmd/gardener-controller-manager/main.go
@@ -22,7 +22,12 @@ import (
 	"syscall"
 
 	"github.com/gardener/gardener/cmd/gardener-controller-manager/app"
+	"github.com/gardener/gardener/pkg/features"
 )
+
+func init() {
+	features.RegisterControllerFeatureGate()
+}
 
 func main() {
 	if err := exec.Command("which", "openvpn").Run(); err != nil {

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -218,6 +218,7 @@ In another terminal, launch the Gardener Controller Manager
 ```bash
 $ make start
 time="2018-02-20T13:24:39+02:00" level=info msg="Starting Gardener controller manager..."
+time="2018-02-20T13:24:39+02:00" level=info msg="Feature Gates: DeletionConfirmation=true
 time="2018-02-20T13:24:39+02:00" level=info msg="Gardener controller manager HTTP server started (serving on 0.0.0.0:2718)"
 time="2018-02-20T13:24:39+02:00" level=info msg="Found internal domain secret internal-domain-unmanaged for domain nip.io."
 time="2018-02-20T13:24:39+02:00" level=info msg="Successfully bootstrapped the Garden cluster."

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -36,3 +36,5 @@ metrics:
 server:
   bindAddress: 0.0.0.0
   port: 2718
+featureGates:
+  DeletionConfirmation: true

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -40,6 +40,11 @@ type ControllerManagerConfiguration struct {
 	Metrics MetricsConfiguration
 	// Server defines the configuration of the HTTP server.
 	Server ServerConfiguration
+	// FeatureGates is a map of feature names to bools that enable or disable alpha/experimental
+	// features. This field modifies piecemeal the built-in default values from
+	// "github.com/gardener/gardener/pkg/features/gardener_features.go".
+	// Default: nil
+	FeatureGates map[string]bool
 }
 
 // ClientConnectionConfiguration contains details for constructing a client.

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -40,6 +40,12 @@ type ControllerManagerConfiguration struct {
 	Metrics MetricsConfiguration `json:"metrics"`
 	// Server defines the configuration of the HTTP server.
 	Server ServerConfiguration `json:"server"`
+	// FeatureGates is a map of feature names to bools that enable or disable alpha/experimental
+	// features. This field modifies piecemeal the built-in default values from
+	// "github.com/gardener/gardener/pkg/features/gardener_features.go".
+	// Default: nil
+	// +optional
+	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 }
 
 // ClientConnectionConfiguration contains details for constructing a client.

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -160,6 +160,7 @@ func autoConvert_v1alpha1_ControllerManagerConfiguration_To_componentconfig_Cont
 	if err := Convert_v1alpha1_ServerConfiguration_To_componentconfig_ServerConfiguration(&in.Server, &out.Server, s); err != nil {
 		return err
 	}
+	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	return nil
 }
 
@@ -186,6 +187,7 @@ func autoConvert_componentconfig_ControllerManagerConfiguration_To_v1alpha1_Cont
 	if err := Convert_componentconfig_ServerConfiguration_To_v1alpha1_ServerConfiguration(&in.Server, &out.Server, s); err != nil {
 		return err
 	}
+	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	return nil
 }
 

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
@@ -101,6 +101,13 @@ func (in *ControllerManagerConfiguration) DeepCopyInto(out *ControllerManagerCon
 	out.LeaderElection = in.LeaderElection
 	out.Metrics = in.Metrics
 	out.Server = in.Server
+	if in.FeatureGates != nil {
+		in, out := &in.FeatureGates, &out.FeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/componentconfig/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/zz_generated.deepcopy.go
@@ -101,6 +101,13 @@ func (in *ControllerManagerConfiguration) DeepCopyInto(out *ControllerManagerCon
 	out.LeaderElection = in.LeaderElection
 	out.Metrics = in.Metrics
 	out.Server = in.Server
+	if in.FeatureGates != nil {
+		in, out := &in.FeatureGates, &out.FeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/features/gardener_features.go
+++ b/pkg/features/gardener_features.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package features
+
+import (
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+)
+
+const (
+	// Every feature gate should add method here following this template:
+	//
+	// // MyFeature enable Foo.
+	// // owner: @username
+	// // alpha: v5.X
+	// MyFeature utilfeature.Feature = "MyFeature"
+
+	// CoreDNS enable CoreDNS as default DNS provider.
+	// owner: @mvladev
+	// alpha: v5.0
+	CoreDNS utilfeature.Feature = "CoreDNS"
+
+	// DeletionConfirmation enables DeletionConfirmation admission controller
+	// and uses standard deletion operations for Garden resources.
+	// owner: @mvladev
+	// alpha: v5.0
+	DeletionConfirmation utilfeature.Feature = "DeletionConfirmation"
+)
+
+var (
+	// APIServerFeatureGate is a shared global FeatureGate for Gardener APIServer flags.
+	// right now the Generic API server uses this feature gate as default
+	// TODO change it once it moves to ComponentConfig
+	APIServerFeatureGate = utilfeature.DefaultFeatureGate
+
+	// ControllerFeatureGate is a shared global FeatureGate for Gardener Controller Manager flags.
+	ControllerFeatureGate = utilfeature.NewFeatureGate()
+
+	apiserverFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
+		DeletionConfirmation: {Default: false, PreRelease: utilfeature.Beta},
+	}
+
+	controllerManagerFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
+		CoreDNS:              {Default: false, PreRelease: utilfeature.Alpha},
+		DeletionConfirmation: {Default: false, PreRelease: utilfeature.Beta},
+	}
+)
+
+// RegisterAPIServerFeatureGate registers the feature gates
+// of the Gardener API Server.
+func RegisterAPIServerFeatureGate() {
+	APIServerFeatureGate.Add(apiserverFeatureGates)
+}
+
+// RegisterControllerFeatureGate registers the feature gates
+// of the Gardener Controller Manager.
+func RegisterControllerFeatureGate() {
+	ControllerFeatureGate.Add(controllerManagerFeatureGates)
+}


### PR DESCRIPTION
Feature gates are added to the APIServer and Controller Manager, allowing to toggle beta / alpha features.

Two Features are added:

- DeletionConfirmation which changes the way resources in the Gardener APIServer
are deleted.
- CoreDNS which changes the kubernetes DNS provider to CoreDNS.