### PR TITLE
Liveliness probe added for machine-controller-manager

### DIFF
--- a/charts/seed-controlplane/charts/machine-controller-manager/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/machine-controller-manager/templates/deployment.yaml
@@ -40,6 +40,16 @@ spec:
         - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
         - --namespace={{ .Release.Namespace }}
         - --v=2
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10258
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
         resources:
           requests:
             cpu: 50m


### PR DESCRIPTION
- The basic liveliness probe for MCM already exists in the [MCM code](https://github.com/gardener/machine-controller-manager/blob/0.7.0/cmd/machine-controller-manager/app/controllermanager.go#L346)
- This PR just adds support for this endpoint to be used as liveliness prove in MCM chart of gardener
- MCM would also enhance the /healthz endpoint used by the liveliness probe to make it more effective in the next MCM release.