### PR TITLE
Add network policy to restrict traffic from kube-apiserver

### DIFF
--- a/charts/_versions.tpl
+++ b/charts/_versions.tpl
@@ -54,3 +54,7 @@ apiregistration.k8s.io/v1
 apiregistration.k8s.io/v1beta1
 {{- end -}}
 {{- end -}}
+
+{{- define "networkpolicyversion" -}}
+networking.k8s.io/v1
+{{- end -}}

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
@@ -81,7 +81,7 @@ spec:
         - --requestheader-username-headers=X-Remote-User
         {{- include "kube-apiserver.runtimeConfig" . | trimSuffix "," | indent 8 }}
         - --secure-port={{ required ".securePort is required" .Values.securePort }}
-        - --service-cluster-ip-range={{ .Values.serviceNetwork }}
+        - --service-cluster-ip-range={{ .Values.shootNetworks.service }}
         - --service-account-key-file=/srv/kubernetes/service-account-key/id_rsa
         - --tls-cert-file=/srv/kubernetes/apiserver/kube-apiserver.crt
         - --tls-private-key-file=/srv/kubernetes/apiserver/kube-apiserver.key

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/network-policy.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/network-policy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: networking.k8s.io/v1
+apiVersion: {{ include "networkpolicyversion" . }}
 kind: NetworkPolicy
 metadata:
   name: kube-apiserver-deny-blacklist
@@ -23,7 +23,7 @@ spec:
         # Cloud provider metadata service ip
         - 169.254.169.254/32
 ---
-apiVersion: networking.k8s.io/v1
+apiVersion: {{ include "networkpolicyversion" . }}
 kind: NetworkPolicy
 metadata:
   name: kube-apiserver-allow-etcd
@@ -44,7 +44,7 @@ spec:
         matchLabels:
           app: etcd-statefulset
 ---
-apiVersion: networking.k8s.io/v1
+apiVersion: {{ include "networkpolicyversion" . }}
 kind: NetworkPolicy
 metadata:
   name: kube-apiserver-allow-dns

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/network-policy.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/network-policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: kube-apiserver-deny-seed
+  name: kube-apiserver-deny-blacklist
   namespace:  {{ .Release.Namespace }}
 spec:
   podSelector:
@@ -17,9 +17,11 @@ spec:
         # Allow all except seed networks
         cidr: 0.0.0.0/0
         except:
-        - {{ .Values.seedNetworks.pod}}
-        - {{ .Values.seedNetworks.node}}
-        - {{ .Values.seedNetworks.service}}
+        - {{ .Values.seedNetworks.pod }}
+        - {{ .Values.seedNetworks.node }}
+        - {{ .Values.seedNetworks.service }}
+        # Cloud provider metadata service ip
+        - 169.254.169.254/32
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/network-policy.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/network-policy.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-apiserver-deny-seed
+  namespace:  {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes
+      role: apiserver
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        # Allow all except seed networks
+        cidr: 0.0.0.0/0
+        except:
+        - {{ .Values.seedNetworks.pod}}
+        - {{ .Values.seedNetworks.node}}
+        - {{ .Values.seedNetworks.service}}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-apiserver-allow-etcd
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes
+      role: apiserver
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - port: {{ required ".etcdServicePort is required" .Values.etcdServicePort }}
+      protocol: TCP
+  - to:
+    - podSelector:
+        matchLabels:
+          app: etcd-statefulset
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kube-apiserver-allow-dns
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes
+      role: apiserver
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP  
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          role: kube-system

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -4,9 +4,12 @@ kubernetesVersion: 1.8.5
 advertiseAddress: 127.0.0.1
 securePort: 443
 probeCredentials: base64(user:pass)
-serviceNetwork: 10.0.0.0/24
-podNetwork: 192.168.0.0/16
-nodeNetwork: 172.16.0.0/20
+shootNetworks:
+  service: 10.0.0.0/24
+seedNetworks:
+  service: 172.16.0.0/20
+  pod: 10.0.0.0/24 
+  node: 192.168.0.0/16
 environment: []
 additionalParameters: []
 podAnnotations: {}

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -5,11 +5,11 @@ advertiseAddress: 127.0.0.1
 securePort: 443
 probeCredentials: base64(user:pass)
 shootNetworks:
-  service: 10.0.0.0/24
+  service: 10.0.1.0/24
 seedNetworks:
-  service: 172.16.0.0/20
-  pod: 10.0.0.0/24 
-  node: 192.168.0.0/16
+  service: 10.0.0.0/24
+  pod: 192.168.0.0/1
+  node: 172.16.0.0/20
 environment: []
 additionalParameters: []
 podAnnotations: {}

--- a/pkg/client/kubernetes/base/namespaces.go
+++ b/pkg/client/kubernetes/base/namespaces.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // CreateNamespace creates a new Namespace object.
@@ -42,6 +43,11 @@ func (c *Client) GetNamespace(name string) (*corev1.Namespace, error) {
 // ListNamespaces returns a list of namespaces. The selection can be restricted by passing a <selector>.
 func (c *Client) ListNamespaces(selector metav1.ListOptions) (*corev1.NamespaceList, error) {
 	return c.clientset.CoreV1().Namespaces().List(selector)
+}
+
+// PatchNamespace patches a Namespace object.
+func (c *Client) PatchNamespace(name string, body []byte) (*corev1.Namespace, error) {
+	return c.Clientset().CoreV1().Namespaces().Patch(name, types.JSONPatchType, body)
 }
 
 // DeleteNamespace deletes a namespace.

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -65,6 +65,7 @@ type Client interface {
 	UpdateNamespace(*corev1.Namespace) (*corev1.Namespace, error)
 	GetNamespace(string) (*corev1.Namespace, error)
 	ListNamespaces(metav1.ListOptions) (*corev1.NamespaceList, error)
+	PatchNamespace(name string, body []byte) (*corev1.Namespace, error)
 	DeleteNamespace(string) error
 
 	// Secrets

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -124,11 +124,16 @@ func (b *HybridBotanist) DeployKubeAPIServer() error {
 		"advertiseAddress":      loadBalancerIP,
 		"cloudProvider":         b.ShootCloudBotanist.GetCloudProviderName(),
 		"kubernetesVersion":     b.Shoot.Info.Spec.Kubernetes.Version,
-		"podNetwork":            b.Shoot.GetPodNetwork(),
-		"serviceNetwork":        b.Shoot.GetServiceNetwork(),
-		"nodeNetwork":           b.Shoot.GetNodeNetwork(),
-		"securePort":            443,
-		"probeCredentials":      utils.EncodeBase64([]byte(fmt.Sprintf("%s:%s", b.Secrets["kubecfg"].Data["username"], b.Secrets["kubecfg"].Data["password"]))),
+		"shootNetworks": map[string]interface{}{
+			"service": b.Shoot.GetServiceNetwork(),
+		},
+		"seedNetworks": map[string]interface{}{
+			"service": b.Seed.Info.Spec.Networks.Services,
+			"pod":     b.Seed.Info.Spec.Networks.Pods,
+			"node":    b.Seed.Info.Spec.Networks.Nodes,
+		},
+		"securePort":       443,
+		"probeCredentials": utils.EncodeBase64([]byte(fmt.Sprintf("%s:%s", b.Secrets["kubecfg"].Data["username"], b.Secrets["kubecfg"].Data["password"]))),
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-ca":                        b.CheckSums["ca"],
 			"checksum/secret-kube-apiserver":            b.CheckSums[common.KubeAPIServerDeploymentName],

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -98,6 +98,11 @@ func BootstrapCluster(seed *Seed, k8sGardenClient kubernetes.Client, secrets map
 		return err
 	}
 
+	body := fmt.Sprintf(`[{"op": "add", "path": "/metadata/labels", "value": %s}]`, "{\"role\":\"kube-system\"}")
+	if _, err := k8sSeedClient.PatchNamespace("kube-system", []byte(body)); err != nil {
+		return err
+	}
+
 	gardenNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: common.GardenNamespace,


### PR DESCRIPTION
This PR restricts the outgoing network from kube-apiserver
+ Adds labels "role:kube-system " to kube-system namespace in seed.
+ Outgoing to seeds pod, node, service networks is blocked.
+ Allow outgoing traffic to etcd only on port 2379
+ Allow outgoing traffic to port 53 on kube-system namespace
    - Since k8s 1.10 or below doesn't allow to choose specific pods in different namesapce in networkpolicy, so we were not able to harden it for only kube-dns pod.

TODO: Add network policy for other control-plane components as well.

For: https://github.com/gardener/gardener/issues/265

Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>