### PR TITLE
Change maxUnavailable parameter in machineDeployment to 0.

### DIFF
--- a/charts/seed-machines/charts/machines/values.yaml
+++ b/charts/seed-machines/charts/machines/values.yaml
@@ -4,7 +4,7 @@ machineDeployments:
   minReadySeconds: 200
   rollingUpdate:
     maxSurge: 1
-    maxUnavailable: 1
+    maxUnavailable: 0
   labels: {}
   class:
     kind: AWSMachineClass

--- a/pkg/operation/hybridbotanist/machines.go
+++ b/pkg/operation/hybridbotanist/machines.go
@@ -214,7 +214,7 @@ func (b *HybridBotanist) generateMachineDeploymentConfig(existingMachineDeployme
 			"minReadySeconds": 500,
 			"rollingUpdate": map[string]interface{}{
 				"maxSurge":       1,
-				"maxUnavailable": 1,
+				"maxUnavailable": 0,
 			},
 			"labels": map[string]interface{}{
 				"name": deployment.Name,


### PR DESCRIPTION
Reason: During rolling update, the number of available replicas should not go below the desired number of replicas