### PR TITLE
local development setup documentation now uses correct namespace

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -312,14 +312,14 @@ At this point three processes should run in an individual terminal, the Gardener
 Now, you can create a Shoot cluster by running
 
 ```bash
-$ kubectl apply -f dev/shoot-local.yaml
+$ kubectl apply -f dev/90-shoot-local.yaml
 shoot "local" created
 ```
 
 When the Shoot API server is created you can download the `kubeconfig` for it and access it:
 
 ```bash
-$ kubectl --namespace shoot-dev-local get secret kubecfg -o jsonpath="{.data.kubeconfig}" | base64 --decode > dev/shoot-kubeconfig
+$ kubectl --namespace shoot--dev--local get secret kubecfg -o jsonpath="{.data.kubeconfig}" | base64 --decode > dev/shoot-kubeconfig
 
 # Depending on your Internet speed, it can take some time, before your node reports a READY status.
 $ kubectl --kubeconfig dev/shoot-kubeconfig get nodes


### PR DESCRIPTION
**What this PR does / why we need it**: fixes documentation to match latest shoot creation flow

**Which issue(s) this PR fixes**:
Fixes #290 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
