### PR TITLE
Fixes links in documentation

### DIFF
--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -1,17 +1,17 @@
 # Configuration
 
-In order to establish different configuration settings for the same cloud environment, one has to define [`CloudProfiles`](../../example/cloudprofile-aws.yaml). These profiles define configuration and constraints for allowed values in the Shoot manifest as well.
+In order to establish different configuration settings for the same cloud environment, one has to define [`CloudProfiles`](../../example/30-cloudprofile-aws.yaml). These profiles define configuration and constraints for allowed values in the Shoot manifest as well.
 
-Seed clusters have their [own resource](../../example/seed-aws-dev.yaml) as well. These resources contain metadata about the respective Seed cluster and a reference to a secret holding the credentials (see below).
+Seed clusters have their [own resource](../../example/50-seed-aws.yaml) as well. These resources contain metadata about the respective Seed cluster and a reference to a secret holding the credentials (see below).
 
 The Gardener requires some secrets in order to work properly. These secrets are:
-* *Seed cluster secrets*, contain the credentials of the cloud provider account in which the Seed cluster is deployed, and a Kubeconfig which can be used to authenticate against the Seed cluster's kube-apiserver, please see [this](../../example/secret-seed-aws-dev.yaml) for an example.
+* *Seed cluster secrets*, contain the credentials of the cloud provider account in which the Seed cluster is deployed, and a Kubeconfig which can be used to authenticate against the Seed cluster's kube-apiserver, please see [this](../../example/40-secret-seed-aws.yaml) for an example.
 
-* *Internal domain secrets* (optional), contain the DNS provider credentials (with appropriate privileges) which will be used to create/delete internal DNS records for the Shoot clusters (e.g., `example.com`), please see [this](../../example/secret-internal-domain.yaml) for an example.
+* *Internal domain secrets* (optional), contain the DNS provider credentials (with appropriate privileges) which will be used to create/delete internal DNS records for the Shoot clusters (e.g., `example.com`), please see [this](../../example/10-secret-internal-domain.yaml) for an example.
   * These secrets are used in order to establish a stable endpoint for Shoot clusters which is used internally by all control plane components.
   * It is forbidden to change the internal domain secret if there are existing Shoot clusters.
 
-* *Default domain secrets* (optional), contain the DNS provider credentials (with appropriate privileges) which will be used to create/delete DNS records for the default domain (e.g., `example.com`), please see [this](../../example/secret-default-domain.yaml) for an example.
+* *Default domain secrets* (optional), contain the DNS provider credentials (with appropriate privileges) which will be used to create/delete DNS records for the default domain (e.g., `example.com`), please see [this](../../example/10-secret-default-domain.yaml) for an example.
   * These secrets are used in order to allow not specifying a hosted zone when creating a Shoot cluster in the `.spec.dns.hostedZoneID` field (useful when a user does not have an own domain/hosted zone but want us to manage it). In this case, based on the provided `.spec.dns.domain` value, the Gardener tries to find an appropriate secret holding the credentials for the hosted zone of this domain. It will use them to manage the relevant DNS records. Currently, we have implemented AWS Route53 and Google CloudDNS as DNS providers. For Google CloudDNS you need to provide a service account with the `DNS Administrator` role. For AWS you need to provide a user being assigned to this IAM policy document:
     ```bash
     {
@@ -31,20 +31,20 @@ The Gardener requires some secrets in order to work properly. These secrets are:
     }
     ```
 
-* *Alerting SMTP secrets* (optional), contain the SMTP credentials which will be used by the [Alertmanager](https://prometheus.io/docs/alerting/alertmanager/) to send emails on alerts, please see [this](../../example/secret-alerting-smtp.yaml) for an example.
+* *Alerting SMTP secrets* (optional), contain the SMTP credentials which will be used by the [Alertmanager](https://prometheus.io/docs/alerting/alertmanager/) to send emails on alerts, please see [this](../../example/10-secret-alerting-smtp.yaml) for an example.
   * These secrets are used by the Alertmanager which is deployed next to the Kubernetes control plane of a Shoot cluster in Seed clusters. In case there have been alerting SMTP secrets configured, the Gardener will inject the credentials in the configuration of the Alertmanager. It will use them to send mails to the stated email address in case anything is wrong with the Shoot clusters.
 
-* *Cloud provider secrets*, contains the credentials of the cloud provider account in which Shoot clusters can be deployed, please see [this](../../example/secret-core-aws.yaml) for an example.
+* *Cloud provider secrets*, contains the credentials of the cloud provider account in which Shoot clusters can be deployed, please see [this](../../example/70-secret-cloudprovider-aws.yaml) for an example.
   * For each Shoot cluster, the Gardener needs to create infrastructure (networks, security groups, technical users, ...) and worker nodes in the desired cloud provider account.
 
 The described secrets are expected to be stored in the so-called **Garden namespace**. In case the Gardener runs inside a Kubernetes cluster, the Garden namespace is the namespace the Gardener is deployed in (default, can be overwritten). In case it runs outside (local development), the Garden namespace must be specified via a command line flag (see below).
 The secrets are determined based on labels with key `garden.sapcloud.io/role`. Please take a look on the above linked examples.
 
-The Seed cluster which is used to deploy the control plane of a Shoot cluster can be specified by the user in the Shoot manifest (see [here](../../example/shoot-azure.yaml#L10)). If it is not specified, the Gardener will try to find an adequate Seed cluster (one deployed in the same region at the same cloud provider) automatically.
+The Seed cluster which is used to deploy the control plane of a Shoot cluster can be specified by the user in the Shoot manifest (see [here](../../example/90-shoot-azure.yaml#L10)). If it is not specified, the Gardener will try to find an adequate Seed cluster (one deployed in the same region at the same cloud provider) automatically.
 
-The cloud provider secrets can be stored in any namespace. With [`SecretBindings`](../../example/secretbinding-core-aws.yaml) one can reference a secret in the same or in another namespace. These binding objects can also be used to reference `Quotas` for the specific secret.
+The cloud provider secrets can be stored in any namespace. With [`SecretBindings`](../../example/80-secretbinding-cloudprovider-aws.yaml) one can reference a secret in the same or in another namespace. These binding objects can also be used to reference `Quotas` for the specific secret.
 
 ## Configuration file for Gardener controller manager
 The Gardener controller manager does only support one command line flag which should be a path to a valid configuration file.
 
-Please take a look at [this](../../example/componentconfig-gardener-controller-manager.yaml) example configuration.
+Please take a look at [this](../../example/20-componentconfig-gardener-controller-manager.yaml) example configuration.

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -8,4 +8,4 @@ $ helm install charts/gardener --name gardener --wait
 
 You can configure the Helm chart by modifying the [allowed configuration values](../../charts/gardener/values.yaml). Please note that all resources and deployments need to be created in the `garden` namespace (not overrideable).
 
-:warning: The Seed Kubernetes clusters need to have a `nginx-ingress-conroller` deployed to make the Gardener work properly. Moreover, there should exist a DNS record `*.ingress.<SEED-CLUSTER-DOMAIN>` where `<SEED-CLUSTER-DOMAIN>` is the value of the `domain` field of [a Seed cluster resource](../../example/seed-aws-dev.yaml).
+:warning: The Seed Kubernetes clusters need to have a `nginx-ingress-conroller` deployed to make the Gardener work properly. Moreover, there should exist a DNS record `*.ingress.<SEED-CLUSTER-DOMAIN>` where `<SEED-CLUSTER-DOMAIN>` is the value of the `domain` field of [a Seed cluster resource](../../example/50-seed-aws.yaml).

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -187,7 +187,7 @@ kubectl is now configured to use the cluster.
 
 The Gardener exposes the API servers of Shoot clusters via Kubernetes services of type `LoadBalancer`. In order to establish stable endpoints (robust against changes of the load balancer address), it creates DNS records pointing to these load balancer addresses. They are used internally and by all cluster components to communicate.
 You need to have control over a domain (or subdomain) for which these records will be created.
-Please provide an *internal domain secret* (see [this](../../example/secret-internal-domain.yaml) for an example) which contains credentials with the proper privileges. Further information can be found [here](../deployment/configuration.md).
+Please provide an *internal domain secret* (see [this](../../example/10-secret-internal-domain.yaml) for an example) which contains credentials with the proper privileges. Further information can be found [here](../deployment/configuration.md).
 
 ```bash
 $ make dev-setup
@@ -356,6 +356,6 @@ Currently, there are some limitations in the local Shoot setup which need to be 
 
 ## Additional information
 
-In order to ensure that a specific Seed cluster will be chosen, add the `.spec.cloud.seed` field (see [here](../../example/shoot-azure.yaml#L10) for an example Shoot manifest).
+In order to ensure that a specific Seed cluster will be chosen, add the `.spec.cloud.seed` field (see [here](../../example/90-shoot-azure.yaml#L10) for an example Shoot manifest).
 
 Please take a look at the [example manifests folder](../../example) to see which resource objects you need to install into your Garden cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes all docs to match latest shoot creation flow.

**Which issue(s) this PR fixes**:
Fixes #292 

**Special notes for your reviewer**:
This PR does not fix
**document** : https://github.com/gardener/gardener/blob/master/docs/development/process.md
**wrong link** :https://github.com/gardener/gardener/blob/master/docs/development/compare

From my understanding we should either: 
 - Create the `compare` file and it should use [github's rest api for pull requests](https://developer.github.com/v3/pulls/#create-a-pull-request) 
 - Just provide a link to [creating a pull request documentation](https://help.github.com/articles/creating-a-pull-request-from-a-fork/) 


**Release note**:
NONE
