### PR TITLE
Block Metadata service access by default for Shoots

### DIFF
--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager-networkpolicy.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager-networkpolicy.yaml
@@ -1,0 +1,16 @@
+apiVersion: {{ include "networkpolicyversion" . }}
+kind: NetworkPolicy
+metadata:
+  name: kube-controller-manager-allow-metadata-service
+  namespace:  {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes
+      role: controller-manager
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 169.254.169.254/32

--- a/charts/shoot-addons/charts/kube2iam/templates/networkpolicy.yaml
+++ b/charts/shoot-addons/charts/kube2iam/templates/networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: {{ include "networkpolicyversion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "name" . }}
+      release: {{ .Release.Name }}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 169.254.169.254/32

--- a/charts/shoot-core/charts/calico/templates/calico.yaml
+++ b/charts/shoot-core/charts/calico/templates/calico.yaml
@@ -454,3 +454,20 @@ spec:
     kind: NetworkPolicy
     plural: networkpolicies
     singular: networkpolicy
+
+---
+
+apiVersion: crd.projectcalico.org/v1
+kind: GlobalNetworkPolicy
+metadata:
+  name: block-metadata-service
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  egress:
+  - action: Allow
+    destination:
+      notNets:
+      - 169.254.169.254/32
+  types:
+  - Egress


### PR DESCRIPTION
**What this PR does / why we need it**: adds a new `GlobalNetworkPolicy` which blocks access from Shoot pods to the metadata service of cloud providers (169.254.169.254/32).

Cluster administrators who want allow pods to talk to the metadata service must allow it via Kubernetes network policy

```yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: allow-foo
  namespace: foo
spec:
  podSelector:
    matchLabels:
      app: foo
  policyTypes:
  - Egress
  egress:
  - to:
    - ipBlock:
        cidr: 169.254.169.254/32
```

**Which issue(s) this PR fixes**:
Fixes #276 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Access to cloud provider's metadata service from Shoot pods is disabled by default. A Kubernetes network policy must be created to enable it.
```
