### PR TITLE
added ability to restrict addons-nginx-ingress with loadBalancerSourc…

### DIFF
--- a/example/90-shoot-aws.yaml
+++ b/example/90-shoot-aws.yaml
@@ -73,6 +73,7 @@ spec:
       enabled: true
     nginx-ingress:
       enabled: true
+      loadBalancerSourceRanges: []
     kube-lego:
       enabled: true
       email: john.doe@example.com

--- a/example/90-shoot-azure.yaml
+++ b/example/90-shoot-azure.yaml
@@ -48,6 +48,7 @@ spec:
       enabled: true
     nginx-ingress:
       enabled: true
+      loadBalancerSourceRanges: []
     kube-lego:
       enabled: true
       email: john.doe@example.com

--- a/example/90-shoot-gcp.yaml
+++ b/example/90-shoot-gcp.yaml
@@ -46,6 +46,7 @@ spec:
       enabled: true
     nginx-ingress:
       enabled: true
+      loadBalancerSourceRanges: []
     kube-lego:
       enabled: true
       email: john.doe@example.com

--- a/example/90-shoot-local.yaml
+++ b/example/90-shoot-local.yaml
@@ -34,6 +34,7 @@ spec:
       enabled: true
     nginx-ingress:
       enabled: true
+      loadBalancerSourceRanges: []
     kube-lego:
       enabled: true
       email: john.doe@example.com

--- a/example/90-shoot-openstack.yaml
+++ b/example/90-shoot-openstack.yaml
@@ -46,6 +46,7 @@ spec:
       enabled: true
     nginx-ingress:
       enabled: true
+      loadBalancerSourceRanges: []
     kube-lego:
       enabled: true
       email: john.doe@example.com

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -223,6 +223,7 @@ spec:
       enabled: ${value("spec.addons.cluster-autoscaler.enabled", "true")}
     nginx-ingress:
       enabled: ${value("spec.addons.nginx-ingress.enabled", "true")}
+      loadBalancerSourceRanges: ${value("spec.addons.nginx-ingress.loadBalancerSourceRanges", [])}
     kube-lego:
       enabled: ${value("spec.addons.kube-lego.enabled", "true")}
       email: ${value("spec.addons.kube-lego.email", "john.doe@example.com")}

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -891,6 +891,9 @@ type ClusterAutoscaler struct {
 // NginxIngress describes configuration values for the nginx-ingress addon.
 type NginxIngress struct {
 	Addon
+	// LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress
+	// +optional
+	LoadBalancerSourceRanges []string
 }
 
 // Monocular describes configuration values for the monocular addon.

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -870,6 +870,9 @@ type ClusterAutoscaler struct {
 // NginxIngress describes configuration values for the nginx-ingress addon.
 type NginxIngress struct {
 	Addon `json:",inline"`
+	// LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress
+	// +optional
+	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty"`
 }
 
 // Monocular describes configuration values for the monocular addon.

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -1954,6 +1954,7 @@ func autoConvert_v1beta1_NginxIngress_To_garden_NginxIngress(in *NginxIngress, o
 	if err := Convert_v1beta1_Addon_To_garden_Addon(&in.Addon, &out.Addon, s); err != nil {
 		return err
 	}
+	out.LoadBalancerSourceRanges = *(*[]string)(unsafe.Pointer(&in.LoadBalancerSourceRanges))
 	return nil
 }
 
@@ -1966,6 +1967,7 @@ func autoConvert_garden_NginxIngress_To_v1beta1_NginxIngress(in *garden.NginxIng
 	if err := Convert_garden_Addon_To_v1beta1_Addon(&in.Addon, &out.Addon, s); err != nil {
 		return err
 	}
+	out.LoadBalancerSourceRanges = *(*[]string)(unsafe.Pointer(&in.LoadBalancerSourceRanges))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -298,7 +298,7 @@ func (in *Addons) DeepCopyInto(out *Addons) {
 	if in.NginxIngress != nil {
 		in, out := &in.NginxIngress, &out.NginxIngress
 		*out = new(NginxIngress)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Monocular != nil {
 		in, out := &in.Monocular, &out.Monocular
@@ -1602,6 +1602,11 @@ func (in *Monocular) DeepCopy() *Monocular {
 func (in *NginxIngress) DeepCopyInto(out *NginxIngress) {
 	*out = *in
 	out.Addon = in.Addon
+	if in.LoadBalancerSourceRanges != nil {
+		in, out := &in.LoadBalancerSourceRanges, &out.LoadBalancerSourceRanges
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -298,7 +298,7 @@ func (in *Addons) DeepCopyInto(out *Addons) {
 	if in.NginxIngress != nil {
 		in, out := &in.NginxIngress, &out.NginxIngress
 		*out = new(NginxIngress)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Monocular != nil {
 		in, out := &in.Monocular, &out.Monocular
@@ -1607,6 +1607,11 @@ func (in *Monocular) DeepCopy() *Monocular {
 func (in *NginxIngress) DeepCopyInto(out *NginxIngress) {
 	*out = *in
 	out.Addon = in.Addon
+	if in.LoadBalancerSourceRanges != nil {
+		in, out := &in.LoadBalancerSourceRanges, &out.LoadBalancerSourceRanges
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2970,6 +2970,20 @@ func schema_pkg_apis_garden_v1beta1_NginxIngress(ref common.ReferenceCallback) c
 							Format:      "",
 						},
 					},
+					"loadBalancerSourceRanges": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"enabled"},
 			},

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -40,12 +40,6 @@ func (b *Botanist) DestroyIngressDNSRecord() error {
 	return b.DestroyDNSRecord("ingress", false)
 }
 
-// GenerateNginxIngressConfig generates the values which are required to render the chart of
-// the nginx-ingress-controller properly.
-func (b *Botanist) GenerateNginxIngressConfig() (map[string]interface{}, error) {
-	return common.GenerateAddonConfig(nil, b.Shoot.NginxIngressEnabled()), nil
-}
-
 // GenerateKubernetesDashboardConfig generates the values which are required to render the chart of
 // the kubernetes-dashboard properly.
 func (b *Botanist) GenerateKubernetesDashboardConfig() (map[string]interface{}, error) {

--- a/pkg/operation/cloudbotanist/localbotanist/addons.go
+++ b/pkg/operation/cloudbotanist/localbotanist/addons.go
@@ -52,5 +52,5 @@ func (b *LocalBotanist) GenerateAdmissionControlConfig() (map[string]interface{}
 
 // GenerateNginxIngressConfig generates values which are required to render the chart nginx-ingress properly.
 func (b *LocalBotanist) GenerateNginxIngressConfig() (map[string]interface{}, error) {
-	return common.GenerateAddonConfig(nil, b.Shoot.Info.Spec.Addons.NginxIngress.Enabled), nil
+	return common.GenerateAddonConfig(nil, b.Shoot.NginxIngressEnabled()), nil
 }

--- a/pkg/operation/hybridbotanist/addons.go
+++ b/pkg/operation/hybridbotanist/addons.go
@@ -145,6 +145,13 @@ func (b *HybridBotanist) generateOptionalAddonsChart() (*chartrenderer.RenderedC
 	if err != nil {
 		return nil, err
 	}
+	if b.Shoot.NginxIngressEnabled() {
+		nginxIngressConfig["controller"] =  map[string]interface{}{
+			"service": map[string]interface{}{
+				"loadBalancerSourceRanges": b.Shoot.Info.Spec.Addons.NginxIngress.LoadBalancerSourceRanges,
+			},
+		}
+	}
 
 	heapster, err := b.Botanist.InjectImages(heapsterConfig, b.K8sShootClient.Version(), map[string]string{"heapster": "heapster", "heapster-nanny": "addon-resizer"})
 	if err != nil {


### PR DESCRIPTION
…eRanges regarding issue-269

**What this PR does / why we need it**:
This PR adds the ability to pass list of source ranges to the addon chart that deploy addons-nginx-ingress-controller so that it will be possible to restrict access to the exposed services in shoot clusters.

**Which issue(s) this PR fixes**:
Fixes #269

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement user
Ability to configure loadBalancerSourceRanges for the service resource in .spec.addons.nginx-ingress
```
