### PR TITLE
Etcd connection timeout increased and frequency decreased.

### DIFF
--- a/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
@@ -113,6 +113,7 @@ spec:
         - --insecure-transport=false
         - --insecure-skip-tls-verify=false
         - --endpoints=https://etcd-{{ .Values.role }}-0:2379
+        - --etcd-connection-timeout=300
         image: {{ index .Values.images "etcd-backup-restore" }}
         imagePullPolicy: IfNotPresent
         ports:

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -15,6 +15,8 @@
 package garden
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1113,9 +1115,11 @@ const (
 	// DefaultServiceNetworkCIDR is a constant for the default service network CIDR of a Shoot cluster.
 	DefaultServiceNetworkCIDR = CIDR("100.64.0.0/13")
 	// DefaultETCDBackupSchedule is a constant for the default schedule to take backups of a Shoot cluster (5 minutes).
-	DefaultETCDBackupSchedule = "*/5 * * * *"
+	DefaultETCDBackupSchedule = "0 */24 * * *"
 	// DefaultETCDBackupMaximum is a constant for the default number of etcd backups to keep for a Shoot cluster.
 	DefaultETCDBackupMaximum = 7
+	// MinimumETCDFullBackupTimeInterval is the time interval between consecutive full backups.
+	MinimumETCDFullBackupTimeInterval = 24 * time.Hour
 )
 
 ////////////////////////

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -15,6 +15,8 @@
 package v1beta1
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1092,9 +1094,11 @@ const (
 	// DefaultServiceNetworkCIDR is a constant for the default service network CIDR of a Shoot cluster.
 	DefaultServiceNetworkCIDR = CIDR("100.64.0.0/13")
 	// DefaultETCDBackupSchedule is a constant for the default schedule to take backups of a Shoot cluster (5 minutes).
-	DefaultETCDBackupSchedule = "*/5 * * * *"
+	DefaultETCDBackupSchedule = "0 */24 * * *"
 	// DefaultETCDBackupMaximum is a constant for the default number of etcd backups to keep for a Shoot cluster.
 	DefaultETCDBackupMaximum = 7
+	// MinimumETCDFullBackupTimeInterval is the time interval between consecutive full backups.
+	MinimumETCDFullBackupTimeInterval = 24 * time.Hour
 )
 
 ////////////////////////


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the etcd-connection-timeout is the default value of 30 seconds. It will result in partial failed snapshots of large etcd data directories. It has been changed to 300 seconds. The data directory is backed up every 5 minutes. It has been made to backup once a day and keep the delta backups for the period in between.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.
NONE
Format of block header: <category> <target_group>
Possible values:
- category:       improvement
- target_group:  operator
-->
```improvement operator

```
