### PR TITLE
Bumped Openstack and GCP CoreOS image to verion 1745.7.0

### DIFF
--- a/example/30-cloudprofile-aws.yaml
+++ b/example/30-cloudprofile-aws.yaml
@@ -15,7 +15,7 @@ spec:
       - name: unmanaged
       kubernetes:
         versions:
-        - 1.11.0
+        - 1.11.1
         - 1.10.5
         - 1.9.8
         - 1.8.14
@@ -23,9 +23,9 @@ spec:
       - name: CoreOS
         regions:
         - name: eu-west-1
-          ami: ami-32d1474b
+          ami: ami-1ed8d467
         - name: us-east-1
-          ami: ami-e582d29f
+          ami: ami-f6ecac89
       machineTypes:
       - name: m4.large
         cpu: "2"

--- a/example/30-cloudprofile-azure.yaml
+++ b/example/30-cloudprofile-azure.yaml
@@ -15,7 +15,7 @@ spec:
       - name: unmanaged
       kubernetes:
         versions:
-        - 1.11.0
+        - 1.11.1
         - 1.10.5
         - 1.9.8
         - 1.8.14
@@ -24,7 +24,7 @@ spec:
         publisher: CoreOS
         offer: CoreOS
         sku: Stable
-        version: 1632.3.0
+        version: 1745.7.0
       machineTypes:
       - name: Standard_DS2_v2
         cpu: "2"

--- a/example/30-cloudprofile-gcp.yaml
+++ b/example/30-cloudprofile-gcp.yaml
@@ -15,13 +15,13 @@ spec:
       - name: unmanaged
       kubernetes:
         versions:
-        - 1.11.0
+        - 1.11.1
         - 1.10.5
         - 1.9.8
         - 1.8.14
       machineImages:
       - name: CoreOS
-        image: projects/coreos-cloud/global/images/coreos-stable-1576-5-0-v20180105
+        image: projects/coreos-cloud/global/images/coreos-stable-1745-7-0-v20180614
       machineTypes:
       - name: n1-standard-2
         cpu: "2"

--- a/example/30-cloudprofile-openstack.yaml
+++ b/example/30-cloudprofile-openstack.yaml
@@ -17,7 +17,7 @@ spec:
       - name: MY-FLOATING-POOL
       kubernetes:
         versions:
-        - 1.11.0
+        - 1.11.1
         - 1.10.5
         - 1.9.8
         - 1.8.14
@@ -25,7 +25,7 @@ spec:
       - name: haproxy
       machineImages:
       - name: CoreOS
-        image: coreos-1576.5.0
+        image: coreos-1745.7.0
       machineTypes:
       - name: medium_2_4
         cpu: "2"

--- a/hack/templates/resources/30-cloudprofile.yaml.tpl
+++ b/hack/templates/resources/30-cloudprofile.yaml.tpl
@@ -67,7 +67,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % if kubernetesVersions != []:
         ${yaml.dump(kubernetesVersions, width=10000)}
         % else:
-        - 1.11.0
+        - 1.11.1
         - 1.10.5
         - 1.9.8
         - 1.8.14
@@ -79,9 +79,9 @@ spec:<% caBundle=value("spec.caBundle", "") %>
       - name: CoreOS
         regions:
         - name: eu-west-1
-          ami: ami-32d1474b
+          ami: ami-1ed8d467
         - name: us-east-1
-          ami: ami-e582d29f
+          ami: ami-f6ecac89
       % endif
       machineTypes:<% machineTypes=value("spec.aws.constraints.machineTypes", []) %>
       % if machineTypes != []:
@@ -164,7 +164,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % if kubernetesVersions != []:
         ${yaml.dump(kubernetesVersions, width=10000)}
         % else:
-        - 1.11.0
+        - 1.11.1
         - 1.10.5
         - 1.9.8
         - 1.8.14
@@ -177,7 +177,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         publisher: CoreOS
         offer: CoreOS
         sku: Stable
-        version: 1632.3.0
+        version: 1745.7.0
       % endif
       machineTypes:<% machineTypes=value("spec.azure.constraints.machineTypes", []) %>
         % if machineTypes != []:
@@ -259,7 +259,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % if kubernetesVersions != []:
         ${yaml.dump(kubernetesVersions, width=10000)}
         % else:
-        - 1.11.0
+        - 1.11.1
         - 1.10.5
         - 1.9.8
         - 1.8.14
@@ -269,7 +269,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
       ${yaml.dump(machineImages, width=10000)}
       % else:
       - name: CoreOS
-        image: projects/coreos-cloud/global/images/coreos-stable-1576-5-0-v20180105
+        image: projects/coreos-cloud/global/images/coreos-stable-1745-7-0-v20180614
       % endif
       machineTypes:<% machineTypes=value("spec.gcp.constraints.machineTypes", []) %>
       % if machineTypes != []:
@@ -346,7 +346,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % if kubernetesVersions != []:
         ${yaml.dump(kubernetesVersions, width=10000)}
         % else:
-        - 1.11.0
+        - 1.11.1
         - 1.10.5
         - 1.9.8
         - 1.8.14
@@ -362,7 +362,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
       ${yaml.dump(machineImages, width=10000)}
       % else:
       - name: CoreOS
-        image: coreos-1576.5.0
+        image: coreos-1745.7.0
       % endif
       machineTypes:<% machineTypes=value("spec.openstack.constraints.machineTypes", []) %>
       % if machineTypes != []:


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated the CoreOS images in the cloudprofile template for the local dev setup to CoreOS v1745.7.0.

