### PR TITLE
Add TCPKeepAliveConnection configuration flag to disable TCP connecti…

### DIFF
--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -2,6 +2,7 @@
 apiVersion: componentconfig.sapcloud.io/v1alpha1
 kind: ControllerManagerConfiguration
 clientConnection:
+  disableTCPKeepAlive: false
   acceptContentTypes: application/json
   contentType: application/json
   qps: 100

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -62,6 +62,8 @@ type ClientConnectionConfiguration struct {
 	QPS float32
 	// Burst allows extra queries to accumulate when a client is exceeding its rate.
 	Burst int32
+	// Disable TCP connection reuse for Kubernetes clients (client-go)
+	DisableTCPKeepAlive bool
 }
 
 // ControllerManagerControllerConfiguration defines the configuration of the controllers.

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -63,6 +63,8 @@ type ClientConnectionConfiguration struct {
 	QPS float32 `json:"qps"`
 	// Burst allows extra queries to accumulate when a client is exceeding its rate.
 	Burst int32 `json:"burst"`
+	// Disable TCP connection reuse for Kubernetes clients (client-go)
+	DisableTCPKeepAlive bool `json:"disableTCPKeepAlive"`
 }
 
 // ControllerManagerControllerConfiguration defines the configuration of the controllers.

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -100,6 +100,7 @@ func autoConvert_v1alpha1_ClientConnectionConfiguration_To_componentconfig_Clien
 	out.ContentType = in.ContentType
 	out.QPS = in.QPS
 	out.Burst = in.Burst
+	out.DisableTCPKeepAlive = in.DisableTCPKeepAlive
 	return nil
 }
 
@@ -114,6 +115,7 @@ func autoConvert_componentconfig_ClientConnectionConfiguration_To_v1alpha1_Clien
 	out.ContentType = in.ContentType
 	out.QPS = in.QPS
 	out.Burst = in.Burst
+	out.DisableTCPKeepAlive = in.DisableTCPKeepAlive
 	return nil
 }
 


### PR DESCRIPTION
…on reuse in the Kubernetes clientset

**Which issue(s) this PR fixes**:
Fixes #288 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Added disableTCPKeepAlive config flag to disable TCP connection reuse in Kubernetes clientset
```
