### PR TITLE
updated slack channel info

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ Take a look at our [landscape setup template](https://github.com/gardener/landsc
 
 ## Feedback and Support
 
-Feedback and contributions are always welcome. Please report bugs or suggestions about our Kubernetes clusters as such or the Gardener itself as [GitHub issues](https://github.com/gardener/gardener/issues) or join our [Slack workspace](https://gardener-cloud.slack.com) (find the self-service invitation link [here](https://publicslack.com/slacks/gardener-cloud/invites/new)).
+Feedback and contributions are always welcome. Please report bugs or suggestions about our Kubernetes clusters as such or the Gardener itself as [GitHub issues](https://github.com/gardener/gardener/issues) or join our [Slack channel #gardener](https://kubernetes.slack.com/messages/gardener) (Invite yourself to the Kubernetes Slack workspace [here](http://slack.k8s.io)).


### PR DESCRIPTION
**What this PR does / why we need it**:
Wrong links to slack channel

**Which issue(s) this PR fixes**:
https://kubernetes.slack.com/messages/gardener
and
http://slack.k8s.io

