### PR TITLE
Scale shoot's control plane according to the number of maximum nodes

### DIFF
--- a/charts/_versions.tpl
+++ b/charts/_versions.tpl
@@ -66,3 +66,7 @@ scheduling.k8s.io/v1beta1
 scheduling.k8s.io/v1alpha1
 {{- end -}}
 {{- end -}}
+
+{{- define "hpaversion" -}}
+autoscaling/v2beta1
+{{- end -}}

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hpa.yaml
@@ -1,0 +1,17 @@
+apiVersion: {{ include "hpaversion" . }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: kube-apiserver
+  namespace: {{.Release.Namespace}}
+spec:
+  maxReplicas: {{.Values.maxReplicas}}
+  minReplicas: {{.Values.minReplicas}}
+  scaleTargetRef:
+    apiVersion: {{ include "deploymentversion" . }}
+    kind: Deployment
+    name: kube-apiserver
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: {{.Values.targetAverageUtilization}}

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -50,3 +50,7 @@ apiServerResources:
   limits:
     cpu: 1500m
     memory: 2500Mi
+
+maxReplicas: 1
+minReplicas: 1
+targetAverageUtilization: 60

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -132,6 +132,9 @@ const (
 	// KubeAPIServerDeploymentName is the name of the kube-apiserver deployment.
 	KubeAPIServerDeploymentName = "kube-apiserver"
 
+	// EnableHPANodeCount is the number of nodes in shoot cluster after which HPA is deployed to autoscale kube-apiserver.
+	EnableHPANodeCount = 5
+
 	// KubeControllerManagerDeploymentName is the name of the kube-controller-manager deployment.
 	KubeControllerManagerDeploymentName = "kube-controller-manager"
 


### PR DESCRIPTION
**What this PR does / why we need it**: Currently the shoot's api server is not able to handle load in case it increases. We need to scale the api server as the load increases

**Which issue(s) this PR fixes**:
One part of #255 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
NONE
-->
```improvement user
The kube-apiserver of a Shoot cluster does now get a `HorizontalPodAutoscaler`. It is configured to scale automatically up to maximum number of 4 replicas in case the cluster is large. The scale decision will be made based on its CPU consumption.
```
