### PR TITLE
use jsonpath for detecting k8s environment

### DIFF
--- a/hack/common
+++ b/hack/common
@@ -23,7 +23,7 @@ SUPPORTED_K8S_ENVS=($DOCKER_FOR_DESKTOP $MINIKUBE)
 __k8s_env=""
 k8s_env() {
     if [[ "$__k8s_env" == "" ]]; then
-        __k8s_env=$(kubectl get node -o yaml | yaml2json | jq -r .items[].metadata.name)
+        __k8s_env=$(kubectl get node -o jsonpath="{.items[*].metadata.name}")
     fi
     for supported_k8s_env in ${SUPPORTED_K8S_ENVS[@]}; do
         if [[ "$supported_k8s_env" == "$__k8s_env" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**: use `jsonpath` option for `kubectl` for detection of k8s environment.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
