### PR TITLE
Adjust seed's Prometheus resources based on node count.

### DIFF
--- a/charts/seed-bootstrap/templates/prometheus/_resource.tpl
+++ b/charts/seed-bootstrap/templates/prometheus/_resource.tpl
@@ -1,0 +1,12 @@
+{{/*
+resource.quantity returns resource quantity based on number of objects (such as nodes, pods etc..),
+resource per object, object weight and base resource quantity.
+*/}}
+{{- define "resource.quantity" -}}
+{{- range $resourceKey, $resourceValue := $.resources }}
+{{ $resourceKey }}:
+{{- range $_, $r := $resourceValue }}
+  {{ $r.name }}: {{ printf "%d%s" ( add $r.base ( mul ( div $.objectCount $r.weight ) $r.perObject $r.weight ) ) $r.unit }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
@@ -40,31 +40,25 @@ spec:
         securityContext:
           runAsUser: 0
         livenessProbe:
-          failureThreshold: 10
           httpGet:
             path: /-/healthy
             port: {{ .Values.prometheus.port }}
             scheme: HTTP
-          initialDelaySeconds: 300
+          failureThreshold: 60
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 3
         readinessProbe:
-          failureThreshold: 6
           httpGet:
             path: /-/ready
             port: {{ .Values.prometheus.port }}
             scheme: HTTP
-          periodSeconds: 60
+          failureThreshold: 120
+          periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 3
         resources:
-          requests:
-            cpu: 50m
-            memory: 1200Mi
-          limits:
-            cpu: 200m
-            memory: 2400Mi
+{{- include "resource.quantity" .Values.prometheus | indent 10 }}
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -15,6 +15,35 @@ prometheus:
   - memory_usage_bytes
   - memory_working_set_bytes
 
+  # object can be any object you want to scale Prometheus on:
+  # - number of Pods
+  # - number of Nodes
+  # - total Foos
+  objectCount: 4
+  resources:
+    requests:
+    - name: cpu
+      base: 100
+      perObject: 4
+      weight: 5
+      unit: m
+    - name: memory
+      base: 100
+      perObject: 18
+      weight: 5
+      unit: Mi
+    limits:
+    - name: cpu
+      base: 150
+      perObject: 8
+      weight: 5
+      unit: m
+    - name: memory
+      base: 150
+      perObject: 36
+      weight: 5
+      unit: Mi
+
 reserveExcessCapacity: true
 
 replicas:

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -125,6 +125,13 @@ func BootstrapCluster(seed *Seed, k8sGardenClient kubernetes.Client, secrets map
 		return err
 	}
 
+	nodes, err := k8sSeedClient.ListNodes(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	nodeCount := len(nodes.Items)
+
 	return common.ApplyChart(k8sSeedClient, chartrenderer.New(k8sSeedClient), filepath.Join("charts", chartName), chartName, common.GardenNamespace, nil, map[string]interface{}{
 		"cloudProvider": seed.CloudProvider,
 		"images": map[string]interface{}{
@@ -135,6 +142,9 @@ func BootstrapCluster(seed *Seed, k8sGardenClient kubernetes.Client, secrets map
 		"reserveExcessCapacity": seed.reserveExcessCapacity,
 		"replicas": map[string]interface{}{
 			"reserve-excess-capacity": DesiredExcessCapacity(numberOfAssociatedShoots),
+		},
+		"prometheus": map[string]interface{}{
+			"objectCount": nodeCount,
 		},
 	})
 }


### PR DESCRIPTION
For K8S seed cluster with 80 nodes we are looking at:

```yaml
Limits:
  cpu:     790m
  memory:  3030Mi
Requests:
  cpu:        420m
  memory:     1540Mi
```
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Continues #239 as it cannot be reopen.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Vertically scales the central Prometheus statefulset deployed in all Seed clusters based on the number of nodes.
```
