### PR TITLE
Add support for setting K8S log level in controller manager

### DIFF
--- a/cmd/gardener-controller-manager/app/gardener_controller_manager.go
+++ b/cmd/gardener-controller-manager/app/gardener_controller_manager.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
+	"flag"
 )
 
 // Options has all the context and parameters needed to run a Gardener controller manager.
@@ -245,6 +246,9 @@ func NewGardener(config *componentconfig.ControllerManagerConfiguration) (*Garde
 	logger := logger.NewLogger(config.LogLevel)
 	logger.Info("Starting Gardener controller manager...")
 	logger.Infof("Feature Gates: %s", gardenerfeatures.ControllerFeatureGate.String())
+	if err := flag.Lookup("v").Value.Set(fmt.Sprintf("%d", config.KubernetesLogLevel)); err != nil {
+		return nil, err
+	}
 	// Prepare a Kubernetes client object for the Garden cluster which contains all the Clientsets
 	// that can be used to access the Kubernetes API.
 	var (

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -36,6 +36,7 @@ leaderElection:
   retryPeriod: 2s
   resourceLock: configmaps
 logLevel: info
+kubernetesLogLevel: 0
 metrics:
   interval: 30s
 server:

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -16,6 +16,7 @@ package componentconfig
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/golang/glog"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -36,6 +37,8 @@ type ControllerManagerConfiguration struct {
 	LeaderElection LeaderElectionConfiguration
 	// LogLevel is the level/severity for the logs. Must be one of [info,debug,error].
 	LogLevel string
+	// KubernetesLogLevel is the log level used for Kubernetes' glog functions.
+	KubernetesLogLevel glog.Level
 	// Metrics defines the metrics configuration.
 	Metrics MetricsConfiguration
 	// Server defines the configuration of the HTTP server.

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -16,6 +16,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/golang/glog"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -36,6 +37,8 @@ type ControllerManagerConfiguration struct {
 	LeaderElection LeaderElectionConfiguration `json:"leaderElection"`
 	// LogLevel is the level/severity for the logs. Must be one of [info,debug,error].
 	LogLevel string `json:"logLevel"`
+	// KubernetesLogLevel is the log level used for Kubernetes' glog functions.
+	KubernetesLogLevel glog.Level `json:"kubernetesLogLevel"`
 	// Metrics defines the metrics configuration.
 	Metrics MetricsConfiguration `json:"metrics"`
 	// Server defines the configuration of the HTTP server.

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -24,6 +24,7 @@ import (
 	unsafe "unsafe"
 
 	componentconfig "github.com/gardener/gardener/pkg/apis/componentconfig"
+	glog "github.com/golang/glog"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -156,6 +157,7 @@ func autoConvert_v1alpha1_ControllerManagerConfiguration_To_componentconfig_Cont
 		return err
 	}
 	out.LogLevel = in.LogLevel
+	out.KubernetesLogLevel = glog.Level(in.KubernetesLogLevel)
 	if err := Convert_v1alpha1_MetricsConfiguration_To_componentconfig_MetricsConfiguration(&in.Metrics, &out.Metrics, s); err != nil {
 		return err
 	}
@@ -183,6 +185,7 @@ func autoConvert_componentconfig_ControllerManagerConfiguration_To_v1alpha1_Cont
 		return err
 	}
 	out.LogLevel = in.LogLevel
+	out.KubernetesLogLevel = glog.Level(in.KubernetesLogLevel)
 	if err := Convert_componentconfig_MetricsConfiguration_To_v1alpha1_MetricsConfiguration(&in.Metrics, &out.Metrics, s); err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for setting K8S log level in controller manager

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Add support for setting K8S log level in controller manager
```
