### PR TITLE
Set dialer and client timeout settings for kubernetes client-go

### DIFF
--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -29,6 +29,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"net"
+	"time"
 )
 
 // NewClientFromFile creates a new Client struct for a given kubeconfig. The kubeconfig will be
@@ -82,6 +84,11 @@ func NewClientFromSecretObject(secret *corev1.Secret) (Client, error) {
 }
 
 func newClientSet(config *rest.Config, clientConfig clientcmd.ClientConfig) (Client, error) {
+	config.Dial = (&net.Dialer{
+		Timeout: 5 * time.Second,
+	}).DialContext
+	config.Timeout = 10 * time.Second
+
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err

--- a/vendor/k8s.io/client-go/transport/cache.go
+++ b/vendor/k8s.io/client-go/transport/cache.go
@@ -91,9 +91,8 @@ func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
 	// Cache a single transport for these options
 	c.transports[key] = utilnet.SetTransportDefaults(&http.Transport{
 		Proxy:               http.ProxyFromEnvironment,
-		TLSHandshakeTimeout: 10 * time.Second,
+		TLSHandshakeTimeout: 5 * time.Second,
 		TLSClientConfig:     tlsConfig,
-		MaxIdleConnsPerHost: idleConnsPerHost,
 		DialContext:         dial,
 	})
 	return c.transports[key], nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Set dialer and client timeout settings for kubernetes client-go

**Which issue(s) this PR fixes**:
Fixes #288 

**Special notes for your reviewer**:
This is just a temporary fix for now.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Set proper timeouts for Kubernetes clientset
```
