### PR TITLE
Drop noisy metrics from Shoot's Prometheus

### DIFF
--- a/charts/seed-monitoring/charts/prometheus/templates/_helpers.tpl
+++ b/charts/seed-monitoring/charts/prometheus/templates/_helpers.tpl
@@ -1,29 +1,46 @@
-{{- define "prometheus.service-endpoints.relabel-config" }}
-      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
-        action: keep
-        regex: true
-      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
-        action: replace
-        target_label: __scheme__
-        regex: (https?)
-      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
-        action: replace
-        target_label: __metrics_path__
-        regex: (.+)
-      - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
-        action: replace
-        target_label: __address__
-        regex: ([^:]+)(?::\d+)?;(\d+)
-        replacement: $1:$2
-      - action: labelmap
-        regex: __meta_kubernetes_service_label_(.+)
-      - source_labels: [__meta_kubernetes_service_name]
-        action: replace
-        target_label: job
-      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_name]
-        action: replace
-        target_label: job
-        regex: (.+)
-      - source_labels: [__meta_kubernetes_pod_name]
-        target_label: pod
-{{- end}}
+{{- define "prometheus.service-endpoints.relabel-config" -}}
+- source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+  action: keep
+  regex: true
+- source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+  action: replace
+  target_label: __scheme__
+  regex: (https?)
+- source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+  action: replace
+  target_label: __metrics_path__
+  regex: (.+)
+- source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+  action: replace
+  target_label: __address__
+  regex: ([^:]+)(?::\d+)?;(\d+)
+  replacement: $1:$2
+- action: labelmap
+  regex: __meta_kubernetes_service_label_(.+)
+- source_labels: [__meta_kubernetes_service_name]
+  action: replace
+  target_label: job
+- source_labels: [__meta_kubernetes_service_annotation_prometheus_io_name]
+  action: replace
+  target_label: job
+  regex: (.+)
+- source_labels: [__meta_kubernetes_pod_name]
+  target_label: pod
+{{- end -}}
+
+{{/*
+Drops metrics which produce lots of time-series without much gain.
+*/}}
+{{- define "prometheus.drop-metrics.metric-relabel-config" -}}
+- source_labels: [ __name__ ]
+  regex: ^rest_client_request_latency_seconds.+$
+  action: drop
+{{- end -}}
+
+
+{{- define "prometheus.tls-config.kube-cert-auth" -}}
+ca_file: /etc/prometheus/seed/ca.crt
+cert_file: /etc/prometheus/seed/prometheus.crt
+key_file: /etc/prometheus/seed/prometheus.key
+{{- end -}}
+

--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -26,14 +26,12 @@ data:
         seed_profile: {{ .Values.seed.profile }}
     rule_files:
     - /etc/prometheus/rules/*.yml
-
     alerting:
       alertmanagers:
       - kubernetes_sd_configs:
         - role: endpoints
           namespaces:
             names: [{{.Release.Namespace}}]
-
         scheme: http
         relabel_configs:
         - source_labels: [__meta_kubernetes_service_label_component]
@@ -45,7 +43,6 @@ data:
         - source_labels: [__meta_kubernetes_endpoint_port_name]
           action: keep
           regex: metrics
-
     scrape_configs:
     - job_name: 'kube-etcd3'
       scheme: https
@@ -69,19 +66,16 @@ data:
 
     - job_name: 'kube-apiserver'
       scheme: https
-
       kubernetes_sd_configs:
       - role: endpoints
         namespaces:
           names: [{{.Release.Namespace}}]
-
       tls_config:
         # This is needed because the api server's certificates are not are generated
         # for a specific pod IP
         insecure_skip_verify: true
         cert_file: /etc/prometheus/seed/prometheus.crt
         key_file: /etc/prometheus/seed/prometheus.key
-
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_name]
         action: keep
@@ -91,26 +85,26 @@ data:
         regex: kube-apiserver
       - source_labels: [__meta_kubernetes_pod_name]
         target_label: pod
+      metric_relabel_configs:
+      - source_labels: [ __name__ ]
+        regex: ^apiserver_admission_.+$
+        action: drop
+{{ include "prometheus.drop-metrics.metric-relabel-config" . | indent 6 }}
 
     - job_name: 'kube-kubelet'
       honor_labels: false
       scheme: https
-
       tls_config:
         # This is needed because the kubelets' certificates are not are generated
         # for a specific pod IP
         insecure_skip_verify: true
         cert_file: /etc/prometheus/seed/prometheus.crt
         key_file: /etc/prometheus/seed/prometheus.key
-
       kubernetes_sd_configs:
       - role: node
         api_server: kube-apiserver
         tls_config:
-          ca_file: /etc/prometheus/seed/ca.crt
-          cert_file: /etc/prometheus/seed/prometheus.crt
-          key_file: /etc/prometheus/seed/prometheus.key
-
+{{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
       relabel_configs:
       - source_labels: [__meta_kubernetes_node_address_InternalIP]
         target_label: instance
@@ -118,7 +112,6 @@ data:
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: type
         replacement: shoot
-
       # get system services
       metric_relabel_configs:
       - source_labels: [id]
@@ -133,7 +126,7 @@ data:
       # Drop metrics that are useless and high-volume
       # Use topk(20, count by (__name__, job)({__name__=~".+"})) to find offending time-series
       - source_labels: [ __name__ ]
-        regex: rest_client_request_latency_seconds_bucket
+        regex: ^rest_client_request_latency_seconds.+$
         action: drop
       - source_labels: [ __name__ ]
         regex: ^(etcd|reflector)_.+
@@ -144,22 +137,17 @@ data:
       honor_labels: false
       scheme: https
       metrics_path: /metrics/cadvisor
-
       tls_config:
         # This is needed because the kubelets' certificates are not are generated
         # for a specific pod IP
         insecure_skip_verify: true
         cert_file: /etc/prometheus/seed/prometheus.crt
         key_file: /etc/prometheus/seed/prometheus.key
-
       kubernetes_sd_configs:
       - role: node
         api_server: kube-apiserver
         tls_config:
-          ca_file: /etc/prometheus/seed/ca.crt
-          cert_file: /etc/prometheus/seed/prometheus.crt
-          key_file: /etc/prometheus/seed/prometheus.key
-
+{{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
       relabel_configs:
       - source_labels: [__meta_kubernetes_node_address_InternalIP]
         target_label: instance
@@ -167,7 +155,6 @@ data:
         regex: __meta_kubernetes_node_label_(.+)
       - target_label: type
         replacement: shoot
-
       metric_relabel_configs:
       # We want to keep only metrics in kube-system namespace
       - source_labels: [namespace]
@@ -208,14 +195,12 @@ data:
     - job_name: 'kube-state-metrics'
       scheme: http
       honor_labels: false
-
       # Service is used, because we only care about metric from one kube-state-metrics instance
       # and not multiple in HA setup
       kubernetes_sd_configs:
       - role: service
         namespaces:
           names: [{{.Release.Namespace}}]
-
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_label_component]
         action: keep
@@ -235,36 +220,36 @@ data:
 
     - job_name: 'annotated-seed-service-endpoints'
       honor_labels: false
-
       kubernetes_sd_configs:
       - role: endpoints
         namespaces:
           names: [{{.Release.Namespace}}]
-
       relabel_configs:
-{{- include "prometheus.service-endpoints.relabel-config" . }}
+{{ include "prometheus.service-endpoints.relabel-config" . | indent 6 }}
+      metric_relabel_configs:
+{{ include "prometheus.drop-metrics.metric-relabel-config" . | indent 6 }}
 
     - job_name: 'annotated-shoot-service-endpoints'
       honor_labels: false
-
       kubernetes_sd_configs:
       - role: endpoints
         namespaces:
           names: [kube-system]
         api_server: kube-apiserver
         tls_config:
-          ca_file: /etc/prometheus/seed/ca.crt
-          cert_file: /etc/prometheus/seed/prometheus.crt
-          key_file: /etc/prometheus/seed/prometheus.key
-
+{{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
       relabel_configs:
-{{- include "prometheus.service-endpoints.relabel-config" . }}
+      - source_labels: [__meta_kubernetes_service_label_addonmanager_kubernetes_io_mode]
+        regex: (.+)
+        action: keep
+{{ include "prometheus.service-endpoints.relabel-config" . | indent 6 }}
+      metric_relabel_configs:
+{{ include "prometheus.drop-metrics.metric-relabel-config" . | indent 6 }}
 
     - job_name: 'vpn-connection'
       honor_labels: false
       scrape_interval: 15s
       scrape_timeout: 5s
-
       metrics_path: /probe
       params:
         module:

--- a/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
@@ -82,21 +82,20 @@ spec:
         securityContext:
           runAsUser: 0
         livenessProbe:
-          failureThreshold: 10
           httpGet:
             path: /-/healthy
             port: {{ .Values.port }}
             scheme: HTTP
-          initialDelaySeconds: 300
+          failureThreshold: 60
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 3
         readinessProbe:
-          failureThreshold: 6
           httpGet:
             path: /-/ready
             port: {{ .Values.port }}
             scheme: HTTP
+          failureThreshold: 120
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 3


### PR DESCRIPTION
**What this PR does / why we need it**: Reduces metrics which create huge amounts of time-series such as `apiserver_admission_.+` and `rest_client_request_latency_seconds` which records every single `url` which is called.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
