### PR TITLE
Enable tcp fast fail + strengthen timeouts

### DIFF
--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -87,10 +87,10 @@ func newClientSet(config *rest.Config, clientConfig clientcmd.ClientConfig) (Cli
 	// Fix zombie tcp connections on un-ACK-nowledged data
 	config.Dial = newFailFastDial(
 		(&net.Dialer{
-			Timeout:   10 * time.Second,
-			KeepAlive: 10 * time.Second,
+			Timeout:   20 * time.Second,
+			KeepAlive: 20 * time.Second,
 		}).DialContext,
-		7*time.Second,
+		20*time.Second,
 	).DialContext
 
 	clientset, err := kubernetes.NewForConfig(config)

--- a/pkg/client/kubernetes/dial.go
+++ b/pkg/client/kubernetes/dial.go
@@ -1,0 +1,49 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"github.com/sirupsen/logrus"
+	"net"
+	"time"
+)
+
+var errUnsupported = errors.New("tcp fast fail is unsupported on this platform")
+
+type dialFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+type failFastDial struct {
+	dialFunc dialFunc
+	timeout  time.Duration
+}
+
+func newFailFastDial(dial dialFunc, timeout time.Duration) *failFastDial {
+	return &failFastDial{dial, timeout}
+}
+
+func (f *failFastDial) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	conn, err := f.dialFunc(ctx, network, address)
+	if err != nil {
+		return nil, err
+	}
+
+	if tcp, ok := conn.(*net.TCPConn); ok {
+		tcpErr := ff(tcp, f.timeout)
+		switch tcpErr {
+		case nil:
+			logrus.Debugf("Enabled fast failing tcp connection %s:%s. "+
+				"Connections will be terminated after %v of unacknowledged transmissions",
+				network, address, f.timeout)
+		case errUnsupported:
+			logrus.Warn("Fast failing tcp connections are not enabled on this platform. " +
+				"It may take a long time (> 15min) for dead connections to really be considered dead")
+		default:
+			conn.Close()
+			return nil, err
+		}
+	} else {
+		logrus.Debugf("Connection is no TCP connection, skipping fail fast")
+	}
+
+	return conn, err
+}

--- a/pkg/client/kubernetes/dial_darwin.go
+++ b/pkg/client/kubernetes/dial_darwin.go
@@ -1,0 +1,16 @@
+package kubernetes
+
+import (
+	"golang.org/x/sys/unix"
+	"net"
+	"time"
+)
+
+func ff(tcp *net.TCPConn, timeout time.Duration) error {
+	fd, err := tcp.File()
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+	return unix.SetsockoptInt(int(fd.Fd()), unix.IPPROTO_TCP, unix.TCP_RXT_CONNDROPTIME, int(timeout/time.Second))
+}

--- a/pkg/client/kubernetes/dial_linux.go
+++ b/pkg/client/kubernetes/dial_linux.go
@@ -1,0 +1,20 @@
+package kubernetes
+
+import (
+	"net"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const tcpUserTimeout = 0x12
+
+func ff(tcp *net.TCPConn, timeout time.Duration) error {
+	fd, err := tcp.File()
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+
+	return unix.SetsockoptInt(int(fd.Fd()), unix.IPPROTO_TCP, tcpUserTimeout, int(timeout/time.Millisecond))
+}

--- a/pkg/client/kubernetes/dial_other.go
+++ b/pkg/client/kubernetes/dial_other.go
@@ -1,0 +1,12 @@
+// +build !linux,!darwin
+
+package kubernetes
+
+import (
+	"net"
+	"time"
+)
+
+func ff(tcp *net.TCPConn, timeout time.Duration) error {
+	return errUnsupported
+}


### PR DESCRIPTION
set options to cleanup tcp sockets if they receive too many un-acked
packages
set more aggressive timeouts to force earlier connection renewal

**What this PR does / why we need it**:
fixes the timeouts on gcp shoot initialization

**Which issue(s) this PR fixes**:
Fixes #288

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Fix GCP timeout issues
```
