### PR TITLE
increase component update check frequency

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -52,5 +52,5 @@ gardener-updates:
         component_descriptor: ~
         update_component_deps: ~
         cronjob:
-          interval: '15m'
+          interval: '1m'
         version: ~


### PR DESCRIPTION
**What this PR does / why we need it**:
Increases component update check frequency (to each 1 min). This will result in quicker component upgrade PRs after a dependet-on component has been released.
