### PR TITLE
decrease component update check frequency

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -52,5 +52,5 @@ gardener-updates:
         component_descriptor: ~
         update_component_deps: ~
         cronjob:
-          interval: '1m'
+          interval: '2.5m'
         version: ~


### PR DESCRIPTION
Reduce frequency with which Concourse checks for updates in order to avoid hitting GitHub rate limits.