### PR TITLE
enhance seed_control logging for object deletion

### DIFF
--- a/pkg/controller/seed/seed_control.go
+++ b/pkg/controller/seed/seed_control.go
@@ -185,14 +185,15 @@ func (c *defaultControl) ReconcileSeed(obj *gardenv1beta1.Seed, key string) erro
 			}
 			return nil
 		}
-		seedLogger.Infof("Can't delete Seed, because the following objects are still referencing it:")
+
+		parentLogMessage := "Can't delete Seed, because the following objects are still referencing it: "
 		if len(associatedShoots) != 0 {
-			seedLogger.Infof("Shoots: %v", associatedShoots)
+			seedLogger.Infof("%s Shoots=%v", parentLogMessage, associatedShoots)
 		}
 		if len(associatedBackupInfrastructures) != 0 {
-			seedLogger.Infof("BackupInfrastructures: %v", associatedBackupInfrastructures)
+			seedLogger.Infof("%s BackupInfrastructures=%v", parentLogMessage, associatedBackupInfrastructures)
 		}
-		return errors.New("Seed still has references")
+		return errors.New("seed still has references")
 	}
 
 	seedLogger.Infof("[SEED RECONCILE] %s", key)


### PR DESCRIPTION
previously object delete logs appeared in separate lines with separate
timestamps. This commit enhances this by bundling it into the same line.

**What this PR does / why we need it**:
enhance seed_control logging for object deletion 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
NONE
