### PR TITLE
Fixing the default etcd db size

### DIFF
--- a/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
@@ -32,7 +32,8 @@ data:
                       --listen-client-urls=https://0.0.0.0:2379 \
                       --initial-cluster-state=new \
                       --initial-cluster-token=new \
-                      --snapshot-count=75000
+                      --snapshot-count=75000 \
+                      --quota-backend-bytes=8589934592 
             ;;
       esac;
     done


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing the default etcd db size (2GB) .
**Which issue(s) this PR fixes**:
Fixes #
https://github.com/gardener/gardener/issues/369 
Introduced parameter `--quota-backend-bytes` in the configmap to 8GB which is the maximum limit.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Increasing the default etcd DB size to 8GB. 
```
