### PR TITLE
Fix timedOut not exporting its cause

### DIFF
--- a/pkg/utils/retry_test.go
+++ b/pkg/utils/retry_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	errwrap "github.com/pkg/errors"
 )
 
 var (
@@ -60,14 +61,12 @@ var _ = Describe("utils", func() {
 		})
 
 		It("should fail due to a timeout containing the last error", func() {
-
 			err := Retry(0*time.Second, 0*time.Second, func() (ok, severe bool, err error) {
 				return false, false, testErr
 			})
 
-			Expect(err).To(BeAssignableToTypeOf(&TimedOut{}))
-			timedOut := err.(*TimedOut)
-			Expect(timedOut.LastError).To(Equal(testErr))
+			Expect(err).To(HaveOccurred())
+			Expect(errwrap.Cause(err)).To(Equal(testErr))
 		})
 
 		It("should fail due to a timeout containing no last error", func() {
@@ -75,9 +74,8 @@ var _ = Describe("utils", func() {
 				return false, false, nil
 			})
 
-			Expect(err).To(BeAssignableToTypeOf(&TimedOut{}))
-			timedOut := err.(*TimedOut)
-			Expect(timedOut.LastError).To(BeNil())
+			Expect(err).To(HaveOccurred())
+			Expect(errwrap.Cause(err)).To(Equal(err))
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix timedOut not exporting its cause.
This fixes the correct code not being displayed when an error was wrapped inside a timed out block.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Fixed an issue that prevented a correct error code mapping for errors returned by the machine-controller-manager.
```
