### PR TITLE
Correct minikube extra-config flag

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -189,7 +189,7 @@ First, start `minikube` with at least Kubernetes v1.9.x, e.g. via `minikube --ku
 Default cpu and memory settings of minikube machine are not sufficient to host the control plane of a shoot cluster, thus use at least 4 CPUs and 8192MB memory.
 
 ```bash
-$ minikube start --cpus=4 --memory=8192 --kubernetes-version=v1.9.0 --extra-config=apiserver.Admission.PluginNames=MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+$ minikube start --cpus=4 --memory=8192 --kubernetes-version=v1.9.0 --extra-config=apiserver.admission-control=MutatingAdmissionWebhook,ValidatingAdmissionWebhook
 Starting local Kubernetes v1.9.0 cluster...
 [...]
 kubectl is now configured to use the cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
Corrects the Minikube `extra-config` flag in the local development docs (tested with minikube version: `v0.28.2`)

**Which issue(s) this PR fixes**:
-

**Special notes for your reviewer**:
-
**Release note**:
-

@rfranzke 
