### PR TITLE
Guarantee scheduling with priorities for system component pods

### DIFF
--- a/charts/shoot-addons/charts/helm-tiller/templates/helm-tiller.yaml
+++ b/charts/shoot-addons/charts/helm-tiller/templates/helm-tiller.yaml
@@ -60,6 +60,7 @@ spec:
         app: helm
         name: tiller
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: tiller
       containers:
       - env:

--- a/charts/shoot-addons/charts/kube-lego/templates/deployment.yaml
+++ b/charts/shoot-addons/charts/kube-lego/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
       # Mark the pod as a critical add-on for rescheduling.
       - key: CriticalAddonsOnly
         operator: Exists
+      priorityClassName: system-cluster-critical
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "kube-lego.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       containers:
         - name: {{ template "kube-lego.name" . }}

--- a/charts/shoot-addons/charts/kube2iam/templates/daemonset.yaml
+++ b/charts/shoot-addons/charts/kube2iam/templates/daemonset.yaml
@@ -31,6 +31,7 @@ spec:
         app: {{ template "kube2iam.name" . }}
         release: {{ .Release.Name }}
     spec:
+      priorityClassName: system-cluster-critical
       tolerations:
       # Mark the pod as a critical add-on for rescheduling.
       - key: CriticalAddonsOnly

--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      priorityClassName: system-cluster-critical
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "kubernetes-dashboard.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 10 }}

--- a/charts/shoot-addons/charts/monocular/templates/api-deployment.yaml
+++ b/charts/shoot-addons/charts/monocular/templates/api-deployment.yaml
@@ -19,8 +19,10 @@ spec:
         origin: gardener
         app: {{ template "monocular.fullname" . }}-api
       annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/config: {{ include (print $.Template.BasePath "/api-config.yaml") . | sha256sum }}
     spec:
+      priorityClassName: system-cluster-critical
       initContainers:
       - name: init-monocular
         image: {{ index .Values.images "busybox" }}

--- a/charts/shoot-addons/charts/monocular/templates/ui-deployment.yaml
+++ b/charts/shoot-addons/charts/monocular/templates/ui-deployment.yaml
@@ -19,9 +19,11 @@ spec:
         origin: gardener
         app: {{ template "monocular.fullname" . }}-ui
       annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/config: {{ include (print $.Template.BasePath "/ui-config.yaml") . | sha256sum }}
         checksum/vhost: {{ include (print $.Template.BasePath "/ui-vhost.yaml") . | sha256sum }}
     spec:
+      priorityClassName: system-cluster-critical
       containers:
       - name: {{ .Chart.Name }}
         image: {{ index .Values.images "monocular-ui" }}

--- a/charts/shoot-addons/charts/nginx-ingress/templates/controller-daemonset.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/controller-daemonset.yaml
@@ -16,6 +16,7 @@ spec:
   template:
     metadata:
       annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/config: {{ include (print $.Template.BasePath "/controller-configmap.yaml") . | sha256sum }}
     {{- if .Values.controller.podAnnotations }}
 {{ toYaml .Values.controller.podAnnotations | indent 8}}
@@ -26,6 +27,7 @@ spec:
         component: "{{ .Values.controller.name }}"
         release: {{ .Release.Name }}
     spec:
+      priorityClassName: system-cluster-critical
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
           image: {{ index .Values.images "nginx-ingress-controller" }}

--- a/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -23,6 +23,7 @@ spec:
   template:
     metadata:
       annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/config: {{ include (print $.Template.BasePath "/controller-configmap.yaml") . | sha256sum }}
       {{- if .Values.controller.podAnnotations }}
 {{ toYaml .Values.controller.podAnnotations | indent 8}}
@@ -33,6 +34,7 @@ spec:
         component: "{{ .Values.controller.name }}"
         release: {{ .Release.Name }}
     spec:
+      priorityClassName: system-cluster-critical
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.controller.name }}
           image: {{ index .Values.images "nginx-ingress-controller" }}

--- a/charts/shoot-addons/charts/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/default-backend-deployment.yaml
@@ -22,8 +22,9 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
-    {{- if .Values.defaultBackend.podAnnotations }}
       annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+{{- if .Values.defaultBackend.podAnnotations }}
 {{ toYaml .Values.defaultBackend.podAnnotations | indent 8 }}
     {{- end }}
       labels:
@@ -32,6 +33,7 @@ spec:
         component: "{{ .Values.defaultBackend.name }}"
         release: {{ .Release.Name }}
     spec:
+      priorityClassName: system-cluster-critical
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.defaultBackend.name }}
           image: {{ index .Values.images "ingress-default-backend" }}

--- a/charts/shoot-core/charts/calico/templates/calico.yaml
+++ b/charts/shoot-core/charts/calico/templates/calico.yaml
@@ -41,6 +41,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/configmap-calico: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
     spec:
+      priorityClassName: system-cluster-critical
       hostNetwork: true
       tolerations:
         # Make sure calico/node gets scheduled on all nodes.
@@ -257,6 +258,7 @@ spec:
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
       # as a host-networked pod.
       hostNetwork: true
+      priorityClassName: system-cluster-critical
       serviceAccountName: calico-node
       containers:
       - image: {{ index .Values.images "calico-typha" }}

--- a/charts/shoot-core/charts/coredns/templates/coredns-deployment.yaml
+++ b/charts/shoot-core/charts/coredns/templates/coredns-deployment.yaml
@@ -16,10 +16,13 @@ spec:
       k8s-app: kube-dns
   template:
     metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
       labels:
         k8s-app: kube-dns
       # we won't be using the checksum of the configmap since coredns provides the "reload" plugins that does the reload if config changes.
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: coredns
       tolerations:
       - key: "CriticalAddonsOnly"

--- a/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -28,6 +28,7 @@ spec:
         app: kubernetes
         role: proxy
     spec:
+      priorityClassName: system-cluster-critical
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/charts/shoot-core/charts/metrics-server/templates/deployment.yaml
+++ b/charts/shoot-core/charts/metrics-server/templates/deployment.yaml
@@ -19,11 +19,13 @@ spec:
         k8s-app: metrics-server
         origin: gardener
       annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/secret-metrics-server: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
       containers:
       - name: metrics-server

--- a/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -48,6 +48,7 @@ spec:
         operator: Exists
       hostNetwork: true
       hostPID: true
+      priorityClassName: system-cluster-critical
       containers:
       - name: node-exporter
         image: {{ index .Values.images "node-exporter" }}


### PR DESCRIPTION
**What this PR does / why we need it**: With this PR we define priority classes for our system component and our addon pods to ensure that those managed by Gardener keep running in the cluster.

**Which issue(s) this PR fixes**:
Fixes #194

**Special notes for your reviewer**: Verified functionality on all cloud providers (although the feature is not cloud-provider specific, but I had four clusters running).

**Release note**:
```noteworthy user
System component pods as well as addons managed by Gardener are now scheduled with a high priority using the [Kubernetes pod priority](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) feature. They might preempt pods created by users causing their eviction/deletion. Users should consider scaling up their cluster (either vertically or horizontally) in such cases.
```
