### PR TITLE
Calico v3.2.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -75,15 +75,15 @@ images:
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
   repository: quay.io/calico/node
-  tag: v3.1.3
+  tag: v3.2.1
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
   repository: quay.io/calico/cni
-  tag: v3.1.3
+  tag: v3.2.1
 - name: calico-typha
   sourceRepository: github.com/projectcalico/typha
   repository: quay.io/calico/typha
-  tag: v0.7.4
+  tag: v3.2.1
 - name: vpn-shoot
   sourceRepository: github.com/gardener/vpn
   repository: eu.gcr.io/gardener-project/gardener/vpn-shoot

--- a/charts/shoot-core/charts/calico/templates/calico.yaml
+++ b/charts/shoot-core/charts/calico/templates/calico.yaml
@@ -42,9 +42,11 @@ spec:
         checksum/configmap-calico: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
     spec:
       priorityClassName: system-cluster-critical
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       hostNetwork: true
       tolerations:
-        # Make sure calico/node gets scheduled on all nodes.
+        # Make sure calico-node gets scheduled on all nodes.
         - effect: NoSchedule
           operator: Exists
         # Mark the pod as a critical add-on for rescheduling.
@@ -83,7 +85,10 @@ spec:
               value: "false"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
-              value: "1440"
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
             # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
               value: "true"
@@ -95,6 +100,12 @@ spec:
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "Always"
+            # Choose the backend to use.
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
             {{- if ne .Values.cloudProvider "azure"}}
             # Enable IP-in-IP within Felix.
             - name: FELIX_IPINIPENABLED
@@ -102,8 +113,6 @@ spec:
             {{- else }}
             - name: FELIX_IPINIPENABLED
               value: "false"
-            - name: CALICO_NETWORKING_BACKEND
-              value: "none"
             {{- end }}
             # Typha support: controlled by the ConfigMap.
             - name: FELIX_TYPHAK8SSERVICENAME
@@ -134,13 +143,16 @@ spec:
             httpGet:
               path: /liveness
               port: 9099
+              host: localhost
             periodSeconds: 10
             initialDelaySeconds: 10
             failureThreshold: 6
           readinessProbe:
-            httpGet:
-              path: /readiness
-              port: 9099
+            exec:
+              command:
+              - /bin/calico-node
+              - -bird-ready
+              - -felix-ready
             periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules
@@ -172,6 +184,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # CNI MTU Config variable
+            - name: CNI_MTU
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: veth_mtu
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir
@@ -240,7 +258,7 @@ spec:
   # (when using the Kubernetes datastore).  Use one replica for every 100-200 nodes.  In
   # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
   replicas: 0
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 2
   template:
     metadata:
       labels:
@@ -252,7 +270,10 @@ spec:
         # if it ever gets evicted.
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       tolerations:
+      # Mark the pod as a critical add-on for rescheduling.
       - key: CriticalAddonsOnly
         operator: Exists
       # Since Calico can't network a pod until Typha is up, we need to run Typha itself
@@ -291,15 +312,19 @@ spec:
           #- name: TYPHA_PROMETHEUSMETRICSPORT
           #  value: "9093"
         livenessProbe:
-          httpGet:
-            path: /liveness
-            port: 9098
+          exec:
+            command:
+            - calico-typha
+            - check
+            - liveness
           periodSeconds: 30
           initialDelaySeconds: 30
         readinessProbe:
-          httpGet:
-            path: /readiness
-            port: 9098
+          exec:
+            command:
+            - calico-typha
+            - check
+            - readiness
           periodSeconds: 10
 
 # Create all the CustomResourceDefinitions needed for

--- a/charts/shoot-core/charts/calico/templates/calico.yaml
+++ b/charts/shoot-core/charts/calico/templates/calico.yaml
@@ -130,6 +130,9 @@ spec:
               value: "autodetect"
             - name: FELIX_HEALTHENABLED
               value: "true"
+            # Limit NAT port range: https://github.com/projectcalico/felix/pull/1838
+            - name: FELIX_NATPORTRANGE
+              value: "32768:65535"
           securityContext:
             privileged: true
           resources:

--- a/charts/shoot-core/charts/calico/templates/config.yaml
+++ b/charts/shoot-core/charts/calico/templates/config.yaml
@@ -13,7 +13,7 @@ data:
   # essential.
   typha_service_name: "none"
   # Configure the Calico backend to use.
-  calico_backend: {{- if ne .Values.cloudProvider "azure" }}"bird"{{ else }}"none"{{ end }}
+  calico_backend: {{ if ne .Values.cloudProvider "azure" }}"bird"{{ else }}"none"{{ end }}
 
   # Configure the MTU to use
   veth_mtu: "1440"

--- a/charts/shoot-core/charts/calico/templates/config.yaml
+++ b/charts/shoot-core/charts/calico/templates/config.yaml
@@ -12,6 +12,11 @@ data:
   # below.  We recommend using Typha if you have more than 50 nodes. Above 100 nodes it is
   # essential.
   typha_service_name: "none"
+  # Configure the Calico backend to use.
+  calico_backend: {{- if ne .Values.cloudProvider "azure" }}"bird"{{ else }}"none"{{ end }}
+
+  # Configure the MTU to use
+  veth_mtu: "1440"
   # The CNI network configuration to install on each node.
   cni_network_config: |-
     {
@@ -23,7 +28,7 @@ data:
           "log_level": "info",
           "datastore_type": "kubernetes",
           "nodename": "__KUBERNETES_NODE_NAME__",
-          "mtu": 1500,
+          "mtu": __CNI_MTU__,
           "ipam": {
             "type": "host-local",
             "subnet": "usePodCidr"

--- a/charts/shoot-core/charts/calico/templates/rbac.yaml
+++ b/charts/shoot-core/charts/calico/templates/rbac.yaml
@@ -1,5 +1,5 @@
-# Calico Version v3.1.0
-# https://docs.projectcalico.org/v3.1/releases#v3.1.0
+# Calico Version v3.2.1
+# https://docs.projectcalico.org/v3.2/releases#v3.2.1
 kind: ClusterRole
 apiVersion: {{ include "rbacversion" . }}
 metadata:
@@ -10,6 +10,7 @@ rules:
 - apiGroups: [""]
   resources:
   - namespaces
+  - serviceaccounts
   verbs:
   - get
   - list


### PR DESCRIPTION
I bumped the images and merged in the template changes from the official calico manifests trying to minimise whitespace and ordering changes.

**Which issue(s) this PR fixes**:
Fixes #376
Fixes #159 

**Special notes for your reviewer**:
The mtu is now configured centrally in the configmap. See https://github.com/projectcalico/calico/pull/1770.
This will change the CNI MTU from `1500` to `1440` (see diff). Not sure if it was different on purpose.

This change is not tested as I don't have access to a gardner dev setup and don't have the time to set one up right now.

**Release note**:
```improvement user
The version of calico has been upgraded to `v3.2.1`.
```