### PR TITLE
Force-delete pods stuck in Terminating state

### DIFF
--- a/pkg/client/kubernetes/base/pods.go
+++ b/pkg/client/kubernetes/base/pods.go
@@ -108,6 +108,22 @@ func (c *Client) DeletePod(namespace, name string) error {
 	return c.clientset.CoreV1().Pods(namespace).Delete(name, &defaultDeleteOptions)
 }
 
+// DeletePodForcefully will forcefully delete a Pod with the given <name> in the given <namespace>.
+func (c *Client) DeletePodForcefully(namespace, name string) error {
+	var (
+		zero               int64
+		backgroundDeletion = metav1.DeletePropagationBackground
+
+		// forceful pod deletion options
+		forceDeleteOptions = metav1.DeleteOptions{
+			GracePeriodSeconds: &zero,
+			PropagationPolicy:  &backgroundDeletion,
+		}
+	)
+
+	return c.clientset.CoreV1().Pods(namespace).Delete(name, &forceDeleteOptions)
+}
+
 func (c *Client) setupForwardPodPort(namespace, name string, local, remote int) (*portforward.PortForwarder, chan struct{}, error) {
 	var (
 		stopChan  = make(chan struct{}, 1)

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -112,6 +112,7 @@ type Client interface {
 	ForwardPodPort(string, string, int, int) (chan struct{}, error)
 	CheckForwardPodPort(string, string, int, int) (bool, error)
 	DeletePod(string, string) error
+	DeletePodForcefully(string, string) error
 
 	// Nodes
 	ListNodes(metav1.ListOptions) (*corev1.NodeList, error)

--- a/pkg/operation/botanist/garbage_collection.go
+++ b/pkg/operation/botanist/garbage_collection.go
@@ -16,8 +16,10 @@ package botanist
 
 import (
 	"strings"
+	"time"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -27,7 +29,15 @@ import (
 // PerformGarbageCollectionSeed performs garbage collection in the Shoot namespace in the Seed cluster,
 // i.e., it deletes old machine sets which have a desired=actual=0 replica count.
 func (b *Botanist) PerformGarbageCollectionSeed() error {
-	if err := b.deleteEvictedPods(b.K8sSeedClient, b.Shoot.SeedNamespace); err != nil {
+	podList, err := b.K8sSeedClient.ListPods(b.Shoot.SeedNamespace, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	if err := b.deleteEvictedPods(b.K8sSeedClient, podList); err != nil {
+		return err
+	}
+	if err := b.deleteStuckTerminatingPods(b.K8sSeedClient, podList); err != nil {
 		return err
 	}
 
@@ -67,28 +77,49 @@ func (b *Botanist) PerformGarbageCollectionSeed() error {
 // PerformGarbageCollectionShoot performs garbage collection in the kube-system namespace in the Shoot
 // cluster, i.e., it deletes evicted pods (mitigation for https://github.com/kubernetes/kubernetes/issues/55051).
 func (b *Botanist) PerformGarbageCollectionShoot() error {
-	return b.deleteEvictedPods(b.K8sShootClient, metav1.NamespaceSystem)
-}
-
-// deleteEvictedPods determine pods in state 'Evicted' in a given namespace and delete them.
-func (b *Botanist) deleteEvictedPods(client kubernetes.Client, namespace string) error {
-	podList, err := client.ListPods(namespace, metav1.ListOptions{})
+	podList, err := b.K8sShootClient.ListPods(metav1.NamespaceSystem, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
+
+	if err := b.deleteEvictedPods(b.K8sShootClient, podList); err != nil {
+		return err
+	}
+	return b.deleteStuckTerminatingPods(b.K8sShootClient, podList)
+}
+
+// deleteEvictedPods determines pods in state 'Evicted' in a given namespace and deletes them.
+func (b *Botanist) deleteEvictedPods(client kubernetes.Client, podList *corev1.PodList) error {
 	for _, pod := range podList.Items {
-		var (
-			name   = pod.ObjectMeta.Name
-			reason = pod.Status.Reason
-		)
-		if reason != "" && strings.Contains(reason, "Evicted") {
-			b.Logger.Debugf("Deleting pod %s as its reason is %s.", name, reason)
-			err := client.DeletePod(namespace, name)
-			if apierrors.IsNotFound(err) {
-				continue
-			}
-			if err != nil {
+		if strings.Contains(pod.Status.Reason, "Evicted") {
+			b.Logger.Debugf("Deleting pod %s as its reason is %s.", pod.Name, pod.Status.Reason)
+			if err := client.DeletePod(pod.Namespace, pod.Name); err != nil && !apierrors.IsNotFound(err) {
 				return err
+			}
+		}
+	}
+	return nil
+}
+
+// deleteStuckTerminatingPods determines stuck pods in state 'Terminating' in a given namespace and deletes them.
+func (b *Botanist) deleteStuckTerminatingPods(client kubernetes.Client, podList *corev1.PodList) error {
+	var (
+		now                 = metav1.Now()
+		gardenerGracePeriod = time.Minute
+	)
+
+	for _, pod := range podList.Items {
+		if pod.DeletionTimestamp != nil {
+			podDeletionGracePeriod := gardenerGracePeriod
+			if pod.DeletionGracePeriodSeconds != nil {
+				podDeletionGracePeriod += time.Duration(*pod.DeletionGracePeriodSeconds) * time.Second
+			}
+			podMaximumAliveTime := pod.DeletionTimestamp.Add(podDeletionGracePeriod)
+
+			if now.After(podMaximumAliveTime) {
+				if err := client.DeletePodForcefully(pod.Namespace, pod.Name); err != nil {
+					return nil
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: We are sometimes seeing pods stuck in Terminating state which cannot be deleted automatically. In these cases an operator needs to manually delete the pods which is effort. In order to support our minimal-ops goal Gardener does now identify these pods in the Seeds and the Shoots and deletes them itself.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy user
Gardener does now delete pods stuck in terminating state longer than their deletion grace period allows.
```
