### PR TITLE
Extend kube-addon-manager's prune whitelist

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -27,7 +27,7 @@ images:
 - name: kube-addon-manager
   sourceRepository: github.com/kubernetes/kubernetes/tree/master/cluster/addons/addon-manager
   repository: k8s.gcr.io/kube-addon-manager
-  tag: v8.6
+  tag: v8.7
 - name: vpn-seed
   sourceRepository: github.com/gardener/vpn
   repository: eu.gcr.io/gardener-project/gardener/vpn-seed

--- a/charts/seed-controlplane/charts/kube-addon-manager/templates/kube-addon-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-addon-manager/templates/kube-addon-manager.yaml
@@ -37,6 +37,8 @@ spec:
           value: "false"
         - name: KUBECTL_OPTS
           value: "--kubeconfig=/var/lib/kube-addon-manager/kubeconfig"
+        - name: KUBECTL_EXTRA_PRUNE_WHITELIST
+          value: "admissionregistration.k8s.io/v1alpha1/InitializerConfiguration admissionregistration.k8s.io/v1beta1/MutatingWebhookConfiguration admissionregistration.k8s.io/v1beta1/ValidatingWebhookConfiguration apiregistration.k8s.io/v1/APIService autoscaling/v1/HorizontalPodAutoscaler core/v1/LimitRange core/v1/ResourceQuota core/v1/ServiceAccount extensions/v1beta1/Ingress extensions/v1beta1/PodSecurityPolicy networking.k8s.io/v1/NetworkPolicy policy/v1beta1/PodDisruptionBudget rbac.authorization.k8s.io/v1/ClusterRole rbac.authorization.k8s.io/v1/ClusterRoleBinding rbac.authorization.k8s.io/v1/Role rbac.authorization.k8s.io/v1/RoleBinding storage.k8s.io/v1/StorageClass"
           # addon-manager executes kubectl apply -f /etc/kubernetes/addons/, but because there are hidden ../data files,
           # it applies every single file 2 times.
         - name: ADDON_PATH


### PR DESCRIPTION
**What this PR does / why we need it**: By default, the kube-addon-manager does not prune all resource. With the latest version (v8.7) it is possible to extend the prune whitelist by specifying an environment variable.

**Which issue(s) this PR fixes**:
Fixes #358 

**Release note**:
```improvement user
Resources deployed into Shoot clusters that are not needed any longer are no correctly pruned.
```
