### PR TITLE
Use resource versions for addon_manager prune list

### DIFF
--- a/charts/seed-controlplane/charts/kube-addon-manager/templates/_prune_whitelist.tpl
+++ b/charts/seed-controlplane/charts/kube-addon-manager/templates/_prune_whitelist.tpl
@@ -1,0 +1,19 @@
+{{- define "prune.whitelist" -}}
+{{ include "initializeradmissionregistrationversion" . }}/InitializerConfiguration
+{{ include "webhookadmissionregistration" . }}/MutatingWebhookConfiguration
+{{ include "webhookadmissionregistration" . }}/ValidatingWebhookConfiguration
+{{ include "apiserviceversion" . }}/APIService
+{{ include "hpaversion" . }}/HorizontalPodAutoscaler
+core/v1/LimitRange
+core/v1/ResourceQuota
+core/v1/ServiceAccount
+extensions/v1beta1/Ingress
+extensions/v1beta1/PodSecurityPolicy
+{{ include "networkpolicyversion" . }}/NetworkPolicy
+policy/v1beta1/PodDisruptionBudget
+{{ include "rbacversion" . }}/ClusterRole
+{{ include "rbacversion" . }}/ClusterRoleBinding
+{{ include "rbacversion" . }}/Role
+{{ include "rbacversion" . }}/RoleBinding
+storage.k8s.io/v1/StorageClass
+{{- end -}}

--- a/charts/seed-controlplane/charts/kube-addon-manager/templates/kube-addon-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-addon-manager/templates/kube-addon-manager.yaml
@@ -38,7 +38,7 @@ spec:
         - name: KUBECTL_OPTS
           value: "--kubeconfig=/var/lib/kube-addon-manager/kubeconfig"
         - name: KUBECTL_EXTRA_PRUNE_WHITELIST
-          value: "admissionregistration.k8s.io/v1alpha1/InitializerConfiguration admissionregistration.k8s.io/v1beta1/MutatingWebhookConfiguration admissionregistration.k8s.io/v1beta1/ValidatingWebhookConfiguration apiregistration.k8s.io/v1/APIService autoscaling/v1/HorizontalPodAutoscaler core/v1/LimitRange core/v1/ResourceQuota core/v1/ServiceAccount extensions/v1beta1/Ingress extensions/v1beta1/PodSecurityPolicy networking.k8s.io/v1/NetworkPolicy policy/v1beta1/PodDisruptionBudget rbac.authorization.k8s.io/v1/ClusterRole rbac.authorization.k8s.io/v1/ClusterRoleBinding rbac.authorization.k8s.io/v1/Role rbac.authorization.k8s.io/v1/RoleBinding storage.k8s.io/v1/StorageClass"
+          value: "{{ include "prune.whitelist" .Values.shootAPIServer | replace "\n" " " }}"
           # addon-manager executes kubectl apply -f /etc/kubernetes/addons/, but because there are hidden ../data files,
           # it applies every single file 2 times.
         - name: ADDON_PATH

--- a/charts/seed-controlplane/charts/kube-addon-manager/values.yaml
+++ b/charts/seed-controlplane/charts/kube-addon-manager/values.yaml
@@ -6,3 +6,7 @@ optionalAddonsContent: {}
 podAnnotations: {}
 images:
   kube-addon-manager: image-repository:image-tag
+shootAPIServer:
+  Capabilities:
+    KubeVersion:
+      GitVersion: v1.9

--- a/pkg/operation/hybridbotanist/addon_manager.go
+++ b/pkg/operation/hybridbotanist/addon_manager.go
@@ -58,6 +58,14 @@ func (b *HybridBotanist) DeployKubeAddonManager() error {
 			"checksum/secret-kube-addon-manager": b.CheckSums[name],
 		},
 		"replicas": replicas,
+		// we need to add capabilities for Shoot's API server.
+		"shootAPIServer": map[string]interface{}{
+			"Capabilities": map[string]interface{}{
+				"KubeVersion": map[string]interface{}{
+					"GitVersion": b.Shoot.Info.Spec.Kubernetes.Version,
+				},
+			},
+		},
 	}
 
 	values, err := b.Botanist.InjectImages(defaultValues, b.K8sSeedClient.Version(), map[string]string{"kube-addon-manager": "kube-addon-manager"})


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes K8S `1.9` where `APIService` is `v1beta1`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
