### PR TITLE
Correct Shoot deletion flow

### DIFF
--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -241,7 +241,8 @@ func IsFollowingNewNamingConvention(seedNamespace string) bool {
 
 // ReplaceCloudProviderConfigKey replaces a key with the new value in the given cloud provider config.
 func ReplaceCloudProviderConfigKey(cloudProviderConfig, separator, key, value string) string {
-	return regexp.MustCompile(fmt.Sprintf("%s%s(.*)\n", key, separator)).ReplaceAllString(cloudProviderConfig, fmt.Sprintf("%s%s%s\n", key, separator, value))
+	keyValueRegexp := regexp.MustCompile(fmt.Sprintf(`(\Q%s\E%s"?)([^"\n]*)("?)`, key, separator))
+	return keyValueRegexp.ReplaceAllString(cloudProviderConfig, fmt.Sprintf("${1}%s${3}", value))
 }
 
 type errorWithCode struct {


### PR DESCRIPTION
**What this PR does / why we need it**: Gardener needs to restart the components in the Seed which have information about the cloud provider secret (kube-controller-manager, cloud-controller-manager) because these components have to delete all the infrastructure resources they have created when the cluster shall be deleted.

This PR contains two improvements:

1. Gardener has already correctly refreshed the secret in the Seeds but it sometimes did accidentally restart the components although it was not necessary.
1. Gardener did neither wait nor check that the controllers are really active. We have often seen the case that Gardener did delete e.g., `Service`s whose delete event was not observed by the controllers. Now, we wait actively to be sure that the controllers are running before cleaning up the cluster.

PS: The only reason why we have to wait is that some Kubernetes objects don't have finalizers. We can remove this functionality once finalizers are implemented for at least all objects resulting in infrastructure artefacts.

**Release note**:
```improvement user
Gardener does now wait until all needed controllers are active before cleaning the Kubernetes resources when deleting a Shoot.
```
