### PR TITLE
Remove label initializers for cloud independent persistent volumes

### DIFF
--- a/pkg/controller/shoot/shoot_care_control.go
+++ b/pkg/controller/shoot/shoot_care_control.go
@@ -31,8 +31,11 @@ import (
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )
+
+const pvLabelInitializerName = "pvlabel.kubernetes.io"
 
 func (c *Controller) shootCareAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
@@ -154,7 +157,9 @@ func (c *defaultCareControl) Care(shootObj *gardenv1beta1.Shoot, key string) err
 	}
 
 	// Trigger garbage collection
-	garbageCollection(botanist)
+	go garbageCollection(botanist)
+
+	go mitigatePvLabels(botanist)
 
 	// Trigger health check
 	conditionControlPlaneHealthy, conditionEveryNodeReady, conditionSystemComponentsHealthy = healthCheck(botanist, cloudBotanist, conditionControlPlaneHealthy, conditionEveryNodeReady, conditionSystemComponentsHealthy)
@@ -173,6 +178,36 @@ func (c *defaultCareControl) Care(shootObj *gardenv1beta1.Shoot, key string) err
 	c.labelShoot(shoot, healthy)
 
 	return nil
+}
+
+func isCloudSpecificPersistentVolume(pv *corev1.PersistentVolume) bool {
+	volumeSource := pv.Spec.PersistentVolumeSource
+	return volumeSource.AWSElasticBlockStore != nil ||
+		volumeSource.GCEPersistentDisk != nil ||
+		volumeSource.AzureDisk != nil ||
+		volumeSource.AzureFile != nil ||
+		volumeSource.VsphereVolume != nil ||
+		volumeSource.PhotonPersistentDisk != nil
+}
+
+func mitigatePvLabels(botanist *botanistpkg.Botanist) {
+	pvs, err := botanist.K8sShootClient.Clientset().CoreV1().PersistentVolumes().List(metav1.ListOptions{IncludeUninitialized: true})
+	if err != nil {
+		botanist.Logger.Warn("Could not fetch persistent volumes, skipping PV label mitigation")
+		return
+	}
+	for _, pv := range pvs.Items {
+		if common.HasInitializer(pv.Initializers, pvLabelInitializerName) && !isCloudSpecificPersistentVolume(&pv) {
+			pv.Initializers = common.RemoveInitializer(pv.Initializers, pvLabelInitializerName)
+			_, err := botanist.K8sShootClient.Clientset().CoreV1().PersistentVolumes().Update(&pv)
+			if err != nil {
+				botanist.Logger.Warnf("Could not remove PV label initializer from %q", pv.Name)
+				continue
+			}
+
+			botanist.Logger.Infof("Removed PV initializer from %q", pv.Name)
+		}
+	}
 }
 
 func (c *defaultCareControl) updateShootStatus(shoot *gardenv1beta1.Shoot, conditions ...gardenv1beta1.Condition) (*gardenv1beta1.Shoot, error) {

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -348,3 +348,30 @@ func MergeOwnerReferences(references []metav1.OwnerReference, newReferences ...m
 
 	return references
 }
+
+// HasInitializer checks whether the passed name is part of the pending initializers
+func HasInitializer(initializers *metav1.Initializers, name string) bool {
+	if initializers == nil {
+		return false
+	}
+	for _, initializer := range initializers.Pending {
+		if initializer.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// RemoveInitializer removes the passed initializer name from the pending initializers
+func RemoveInitializer(initializers *metav1.Initializers, name string) *metav1.Initializers {
+	if initializers == nil {
+		return nil
+	}
+	var updatedInitializers []metav1.Initializer
+	for _, initializer := range initializers.Pending {
+		if initializer.Name != name {
+			updatedInitializers = append(updatedInitializers, initializer)
+		}
+	}
+	return &metav1.Initializers{Pending: updatedInitializers, Result: initializers.Result}
+}

--- a/pkg/operation/common/utils_test.go
+++ b/pkg/operation/common/utils_test.go
@@ -238,4 +238,28 @@ var _ = Describe("common", func() {
 			Expect(result).To(ConsistOf(newReferences))
 		})
 	})
+
+	DescribeTable("#HasInitializer",
+		func(initializers *metav1.Initializers, name string, expected bool) {
+			Expect(HasInitializer(initializers, name)).To(Equal(expected))
+		},
+		Entry("nil initializers", nil, "foo", false),
+		Entry("no matching initializer", &metav1.Initializers{Pending: []metav1.Initializer{{Name: "bar"}}}, "foo", false),
+		Entry("matching initializer", &metav1.Initializers{Pending: []metav1.Initializer{{Name: "foo"}}}, "foo", true),
+	)
+
+	DescribeTable("#RemoveInitializer",
+		func(initializers *metav1.Initializers, name string, expected *metav1.Initializers) {
+			Expect(RemoveInitializer(initializers, name)).To(Equal(expected))
+		},
+		Entry("nil initializers", nil, "foo", nil),
+		Entry("no matching initializer",
+			&metav1.Initializers{Pending: []metav1.Initializer{{Name: "bar"}}},
+			"foo",
+			&metav1.Initializers{Pending: []metav1.Initializer{{Name: "bar"}}}),
+		Entry("matching initializer",
+			&metav1.Initializers{Pending: []metav1.Initializer{{Name: "bar"}, {Name: "foo"}}},
+			"foo",
+			&metav1.Initializers{Pending: []metav1.Initializer{{Name: "bar"}}}),
+	)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes PV label initializers for cloud independent persistent volumes. This is necessary since the K8s Cloud Controller Manager crashes by accessing cloud specific properties of a persistent volume that are nil, causing a runtime panic (see https://github.com/kubernetes/kubernetes/issues/68996).

**Special notes for your reviewer**:

**Release note**:
```noteworthy user
NONE
```
