### PR TITLE
Adapt HPA upscale/downscale delays

### DIFF
--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -76,6 +76,8 @@ spec:
         - --concurrent-deployment-syncs=10
         - --concurrent-replicaset-syncs=10
         {{- include "kube-controller-manager.featureGates" . | trimSuffix "," | indent 8 }}
+        - --horizontal-pod-autoscaler-downscale-delay=15m
+        - --horizontal-pod-autoscaler-upscale-delay=1m
         - --kubeconfig=/var/lib/kube-controller-manager/kubeconfig
         - --leader-elect=true
         - --pod-eviction-timeout=2m0s


### PR DESCRIPTION
**What this PR does / why we need it**: We are using the default delays for the HPA (`5m` for downscale, `3m` for upscale). We have seen that this might result in an oscillating behaviour in some cases (depending on the load, of course). With this PR we can hopefully reduce this oscillation.

**Release note**:
```improvement user
The delays for the horizontal pod autoscaler have been modified in the following way to achieve a less oscillating behaviour: Downscale: `5m` -> `15m` and Upscale: `3m` -> `1m`.
```
