### PR TITLE
Add metrics-server deployment to deletion whitelist

### DIFF
--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -41,7 +41,8 @@ var exceptions = map[string]map[string]bool{
 		fmt.Sprintf("%s/kube-proxy", metav1.NamespaceSystem):  true,
 	},
 	kubernetesbase.Deployments: {
-		fmt.Sprintf("%s/coredns", metav1.NamespaceSystem): true,
+		fmt.Sprintf("%s/coredns", metav1.NamespaceSystem):        true,
+		fmt.Sprintf("%s/metrics-server", metav1.NamespaceSystem): true,
 	},
 	kubernetesbase.Namespaces: {
 		metav1.NamespacePublic:  true,


### PR DESCRIPTION
**What this PR does / why we need it**: We have switched from Heapster to the Kubernetes metrics-server (which is an aggregated API server), but we have not put it to the deletion whitelist. When a Shoot gets deleted that has namespaces containing workload with high deletion grace periods (therefore, taking more time to terminate) Gardener has already deleted the metrics-server in the Shoot's `kube-system` namespace. However, the Kubernetes namespace controller requires to discover all APIs to be able to recursively clean up all resources/objects in the namespace:

```
E0926 06:47:03.328874       1 namespace_controller.go:148] unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently unable to handle the request
```

We have to keep the metrics-server in order to give the namespace controller enough time to clean up properly.

**Release note**:
```improvement user
The metrics-server deployment in Shoot cluster has been added to the deletion whitelist, i.e. Gardener won't delete it when deleting a Shoot. This is due to the fact that the Kubernetes namespace controller requires to discover all APIs (including aggregated APIs) in order to recursively clean up all object in the namespace.
```
