### PR TITLE
External admission controller taking over the responsibility to add i…

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -11,6 +11,8 @@ echo "enriching creating component descriptor from ${BASE_DEFINITION_PATH}"
 eval "$(jq -r ".images |
   map(if (.name == \"hyperkube\") then
     \"--generic-dependencies '{\\\"name\\\": \\\"\" + .name + \"\\\", \\\"version\\\": \\\"\" + .tag + \"\\\"}'\"
+  elif (.repository | startswith(\"eu.gcr.io/gardener-project/gardener/external-admission-controller\")) then
+  \"--container-image-dependencies '{\\\"name\\\": \\\"\" + .name + \"\\\", \\\"image_reference\\\": \\\"\" + .repository + \":\" + .tag + \"\\\", \\\"version\\\": \\\"\" + .tag + \"\\\"}'\"
   elif (.repository | startswith(\"eu.gcr.io/gardener-project/gardener\")) then
     \"--component-dependencies '{\\\"name\\\": \\\"\" + .sourceRepository + \"\\\", \\\"version\\\": \\\"\" + .tag + \"\\\"}'\"
   else

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,3 +31,13 @@ WORKDIR /
 
 ENTRYPOINT ["/gardener-controller-manager"]
 
+############# external-admission-controller #############
+FROM alpine:3.7 AS external-admission-controller
+
+RUN apk add --update bash curl
+
+COPY --from=builder /go/bin/gardener-external-admission-controller /gardener-external-admission-controller
+
+WORKDIR /
+
+ENTRYPOINT ["/gardener-external-admission-controller"]

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -4,6 +4,16 @@
 # the respective tag can be used. The syntax must be as described in the
 # Masterminds/semver package: https://github.com/Masterminds/semver#hyphen-range-comparisons.
 images:
+# Seed bootstrap
+- name: pause-container
+  sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
+  repository: gcr.io/google_containers/pause-amd64
+  tag: "3.1"
+- name: gardener-external-admission-controller
+  sourceRepository: github.com/gardener/gardener
+  repository: eu.gcr.io/gardener-project/gardener/external-admission-controller
+  tag: "v1"
+
 # Seed controlplane
 - name: etcd
   sourceRepository: github.com/coreos/etcd
@@ -140,9 +150,3 @@ images:
   sourceRepository: github.com/docker-library/ruby
   repository: ruby
   tag: "2.5.1-alpine"
-
-# Seed bootstrap
-- name: pause-container
-  sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
-  repository: gcr.io/google_containers/pause-amd64
-  tag: "3.1"

--- a/charts/seed-bootstrap/templates/gardener-external-admission-controller.yaml
+++ b/charts/seed-bootstrap/templates/gardener-external-admission-controller.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gardener-external-admission-controller-tls
+  namespace: garden
+type: kubernetes.io/tls
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVSRENDQXl5Z0F3SUJBZ0lVYlBtK3NXanI1TXhhSlREemxudGNqZ1FOSGIwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1NERUxNQWtHQTFVRUJoTUNWVk14Q3pBSkJnTlZCQWdUQWtOQk1SWXdGQVlEVlFRSEV3MVRZVzRnUm5KaApibU5wYzJOdk1SUXdFZ1lEVlFRREV3dGxlR0Z0Y0d4bExtNWxkREFnRncweE9EQTVNall4TURVM01EQmFHQTh5Ck1URTRNRGt3TWpFd05UY3dNRm93UlRFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ1RBa05CTVJZd0ZBWUQKVlFRSEV3MVRZVzRnUm5KaGJtTnBjMk52TVJFd0R3WURWUVFERXdobllYSmtaVzVsY2pDQ0FTSXdEUVlKS29aSQpodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQUxzUEJidzQxbnJkVkpwaTFQV2ZXVEZkYktnRmlrR2w5N2FUCnJZQUN0bUVYdWlhMzdja2k2SGVwR0R3SlNwc3ZUcWsrbFZJdHgxaERlMTlRQkxheHpBSTJqNjZIUmt6aWY3czQKL3NlaWg2OHR5RnJ1QXdsbXpoekEzbThWZ1hISm9QSVdEeEZ3YVJCR1paMmVTZzJ5Uk1nU0xIeTB6K1loaG5CWApwd0FQd05OdU5pNEJDZm4zZ3pFeXdzNGd6amozMSsxNkNDQzBGdzcyT3ZNdW1aRlhhOTZnYUEyNUNrdDRPWXJlCmdmaU0wNnNtek1zQlRPRnNaMzhjN1FqMWlBbUtESytObWkxMVB4UittcGkrYXQza2thakY3SS9GcTdWT05reEsKV1lHVWIxS2NqQm9BOVR2U3BvRkx3cnFOTENjUGtld3E0c2pSN0xQMzU2OWdweSt1Y0ZNQ0F3RUFBYU9DQVNVdwpnZ0VoTUE0R0ExVWREd0VCL3dRRUF3SUZvREFUQmdOVkhTVUVEREFLQmdnckJnRUZCUWNEQVRBTUJnTlZIUk1CCkFmOEVBakFBTUIwR0ExVWREZ1FXQkJSRVQvL3dYUUVyNGhJUzE4V3E5WGpKekNyaEd6QWZCZ05WSFNNRUdEQVcKZ0JUV2FCWnpyblBwZVBTQ092Nm9udkFJcFk3UGx6Q0Jxd1lEVlIwUkJJR2pNSUdnZ2labllYSmtaVzVsY2kxbAplSFJsY201aGJDMWhaRzFwYzNOcGIyNHRZMjl1ZEhKdmJHeGxjb0l0WjJGeVpHVnVaWEl0WlhoMFpYSnVZV3d0CllXUnRhWE56YVc5dUxXTnZiblJ5YjJ4c1pYSXVaMkZ5WkdWdWdqRm5ZWEprWlc1bGNpMWxlSFJsY201aGJDMWgKWkcxcGMzTnBiMjR0WTI5dWRISnZiR3hsY2k1bllYSmtaVzR1YzNaamdoUm9iM04wTG1SdlkydGxjaTVwYm5SbApjbTVoYkRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWtqQ05zaTdwcjZiYmFncUcwUVFyZllPeEhpZWlwYmdMCnYzK3Zuc012V2xHSWJweGM4c2RxdVpxYkpob2NFOGUzbGF4NnNCeW5WZG9Geld6VlhhRDhaWHNmU092V0w2ZXUKWnZuZklFN2laUVkxUERldlIyN2dvTE0xY2ZPQTJJM0FxalI4eng0ZUVJQnlNenBTeElseWJLaHRtcTJtOTNuVwpick1nVUFuR2pvbEtmTEt6QnZaUU85RVFRbXhETy9kTG5UQ3JyaHg2cU00NWk5b0lrOWszMDZOQmtoU3FtelpNCmFvUDg4OGtkTDhWQ1BxYUNoVVZvUHg2R3JpSnZiNnROcm01cWFzTEZWOU1ONE5rUGlJZ1lpSlVKdGZBUEpiOWoKMlhibDNKU0lHWElrWW1NZDJTVE5sM0FXa3pmWGM5TVlqVTgxK3czKzFiM2lzM1Q3MjRzMVBnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBdXc4RnZEaldldDFVbW1MVTlaOVpNVjFzcUFXS1FhWDN0cE90Z0FLMllSZTZKcmZ0CnlTTG9kNmtZUEFsS215OU9xVDZWVWkzSFdFTjdYMUFFdHJITUFqYVByb2RHVE9KL3V6ait4NktIcnkzSVd1NEQKQ1diT0hNRGVieFdCY2NtZzhoWVBFWEJwRUVabG5aNUtEYkpFeUJJc2ZMVFA1aUdHY0ZlbkFBL0EwMjQyTGdFSgorZmVETVRMQ3ppRE9PUGZYN1hvSUlMUVhEdlk2OHk2WmtWZHIzcUJvRGJrS1MzZzVpdDZCK0l6VHF5Yk15d0ZNCjRXeG5meHp0Q1BXSUNZb01yNDJhTFhVL0ZINmFtTDVxM2VTUnFNWHNqOFdydFU0MlRFcFpnWlJ2VXB5TUdnRDEKTzlLbWdVdkN1bzBzSncrUjdDcml5Tkhzcy9mbnIyQ25MNjV3VXdJREFRQUJBb0lCQUdSNzFHUGcwRzVkMk9XNgpNNVhpVEtKMUFqcGNCNEh1YXR2OEJwYWVYbVJYdjVxdThTQThEVTdDV2c5ZUdtSzBqZmZpYzRvYXAxd2xtKzkrClo1blFkcnUxbllkdWlYZ2hyK1hkM3hkVW1yaWl5bDcyUGxGZGxWaml6bG96M2o1R3hwdGsrQ0V4Rm04MHNiOXkKMldyMEdYaTBNb3VuQVlzbzlUUUNFZWE1ajZiRFFPSi82b25uaEVjQlpGa1J3TVVjSExkLzVlcXRWMnlyYUhPVQo1OVVKUFltV0llYkhrWDNuSnVhS043Szh2RXllZWRyM1RoNkpVbnN3OU43aldrdWUwZ1FQNFF3UEtFckdYMjVvCjRQSlVXRGxDU1B4ZHE5VGZMRjhzZVNZcDNCSGFJQzVnMFp5c3FXckV6aEdJZjhzOXlhK1IzRlprVlA2V0p3YUoKL0FnQTBNa0NnWUVBelFWTEo0QjRCZXNZYW1KMnZOTVRMaDdCYStwM3VzU3VIZTk5blk2U0NLM09VbStYOC9HKwpMbFBDTGViMWpMN1V1RlBlazM5bkplU0FRT1IwakZFRkJKa20rSmdZU2pkd3lMUVVvTkRYOWdaTFRqNVFKSElvCnQzMUVmNGJ1RDViSTAxWGlCdTM3NkRRUEx1YUtncGxFM1kwNUJDdVEvQ1FsMkFyRy9JT3pLRzBDZ1lFQTZaSloKQy9KRjdyelEwM1JMaTF3ZzBPY29KYzlZd1hmcmlWa2pjQmk1U0g5aEVIRGQ1dk05OStPc3BBVjFaZUJMZlFPNwprVGowUFlrTU5JbjA5eWxnSVdFYWtZY3EwcWh1WVJUc1dEQnorSmQxYXRvSUFnaWIrb01oR250TzFBM0hFWm5JCjl3aWxqTGhja3ZlM3NpL3dhS21rbUE0Z2w2YkJJTTV4Qno5eUE3OENnWUVBd2ExcGhPU1kvY1pNcDF0akhoZ3MKTzFwMGtKVE1ESlQyZzNNVjhMeVplamR1L0hOTlVmY2lHVE9vOGFJSWY3QmExZEx0SmR1cVBxS3hBaHlQZVdxawpXZWF3YVJHTmlMYjlCYTBRKzZhdkRVeCs0V2grWHgrMUZUbnlkcUtweS9JK3YxNlhpc0pSUWRmRUxDTS80QVlZCmgwOTgrRktMd1pZSVppSXdQcVhQbnJVQ2dZQlI2RFk5MERuaDNHakduak9YclRqOHlQTDFQMTc2aVZrWmt4NncKUXB0RzV4UmN0WmU3VTNWWnBvZDJCVXdENjhITkZ6QUJYeDJYTHFZUERvbk8ycjJSTndJZ0lteEw3ekMxN3FacQp6cUw4ZS9CN0JmWms4Q3Z5ajJWZWFmdGN0WEFucGV3cFpPalpEaFc0bkJIWTlLS3pzVG04OE1kUkp2TDIxQzRpCndvYnk5UUtCZ0QyS1pkZ3ZCVXZrYURjU3krMDkyUCtGY3RvOHQ0SkdKQk8yOS9aVmdXa284T25BRER1aTJiSnUKcGZFeWRNQjJHQmhNU3IyZncxRU5YKzBDc2ZZNnZiNFprbHBScG1RMmYrczZtRTFUWVFhTC9xWDJjVzhxWDUrOQo4OXh0aS81aWNZYzhUb1VhOEZTeU53UCtiYU9tR3doVnNZRUExOGFqVzA5Q3BLWEdlRUhuCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
+---
+apiVersion: {{ include "deploymentversion" . }}
+kind: Deployment
+metadata:
+  name: gardener-external-admission-controller
+  namespace: garden
+  labels:
+    app: gardener
+    role: external-admission-controller
+spec:
+  revisionHistoryLimit: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gardener
+      role: external-admission-controller
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+      labels:
+        app: gardener
+        role: external-admission-controller
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: gardener-external-admission-controller
+        image: {{ index .Values.images "gardener-external-admission-controller" }}
+        imagePullPolicy: IfNotPresent
+        args:
+        - -secure-port=2730
+        - -tls-cert-file=/srv/gardener-external-admission-controller/tls.crt
+        - -tls-private-key-file=/srv/gardener-external-admission-controller/tls.key
+        env:
+        resources:
+          requests:
+            cpu: 20m
+            memory: 50Mi
+          limits:
+            cpu: 100m
+            memory: 100Mi
+        volumeMounts:
+        - mountPath: /srv/gardener-external-admission-controller
+          name: gardener-external-admission-controller-tls
+          readOnly: true
+      volumes:
+      - name: gardener-external-admission-controller-tls
+        secret:
+          secretName: gardener-external-admission-controller-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gardener-external-admission-controller
+  namespace: garden
+  labels:
+    app: gardener
+    role: external-admission-controller
+spec:
+  type: ClusterIP
+  selector:
+    app: gardener
+    role: external-admission-controller
+  ports:
+  - name: web
+    port: 443
+    protocol: TCP
+    targetPort: 2730

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -52,3 +52,4 @@ replicas:
 images:
   pause-container: image-repository:image-tag
   prometheus: image-repository:image-tag
+  gardener-external-admission-controller: image-repository:image-tag

--- a/charts/shoot-core/charts/cloud-controller-manager/templates/initializerconfiguration.yaml
+++ b/charts/shoot-core/charts/cloud-controller-manager/templates/initializerconfiguration.yaml
@@ -1,16 +1,17 @@
----
-apiVersion: {{ include "initializeradmissionregistrationversion" . }}
-kind: InitializerConfiguration
-metadata:
-  name: pvlabel.kubernetes.io
-  labels:
-    addonmanager.kubernetes.io/mode: Reconcile
-initializers:
-- name: pvlabel.kubernetes.io
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - "*"
-    resources:
-    - persistentvolumes
+# Temporarily disabled due to https://github.com/kubernetes/kubernetes/issues/68996
+# ---
+# apiVersion: {{ include "initializeradmissionregistrationversion" . }}
+# kind: InitializerConfiguration
+# metadata:
+#   name: pvlabel.kubernetes.io
+#   labels:
+#     addonmanager.kubernetes.io/mode: Reconcile
+# initializers:
+# - name: pvlabel.kubernetes.io
+#   rules:
+#   - apiGroups:
+#     - ""
+#     apiVersions:
+#     - "*"
+#     resources:
+#     - persistentvolumes

--- a/charts/shoot-core/charts/cloud-controller-manager/templates/webhook-gardener-add-initializer.yaml
+++ b/charts/shoot-core/charts/cloud-controller-manager/templates/webhook-gardener-add-initializer.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: persistent-volume-binder-initializer
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - initialize
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: persistent-volume-binder-initializer
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: persistent-volume-binder-initializer
+subjects:
+- kind: ServiceAccount
+  name: persistent-volume-binder
+  namespace: kube-system
+---
+apiVersion: {{ include "webhookadmissionregistration" . }}
+kind: MutatingWebhookConfiguration
+metadata:
+  name: add-initializers-only-for-cloud-pvs
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+webhooks:
+- name: add-initializers-only-for-cloud-pvs.gardener.cloud
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - persistentvolumes
+  failurePolicy: Fail
+  clientConfig:
+    url: https://gardener-external-admission-controller.garden/webhooks/mutate-pv-initializers
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVUy94QmlSMW5Ob2EyK2NseVJRenBQYVJTcmtJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1NERUxNQWtHQTFVRUJoTUNWVk14Q3pBSkJnTlZCQWdUQWtOQk1SWXdGQVlEVlFRSEV3MVRZVzRnUm5KaApibU5wYzJOdk1SUXdFZ1lEVlFRREV3dGxlR0Z0Y0d4bExtNWxkREFlRncweE9EQTVNall4TURJMU1EQmFGdzB5Ck16QTVNalV4TURJMU1EQmFNRWd4Q3pBSkJnTlZCQVlUQWxWVE1Rc3dDUVlEVlFRSUV3SkRRVEVXTUJRR0ExVUUKQnhNTlUyRnVJRVp5WVc1amFYTmpiekVVTUJJR0ExVUVBeE1MWlhoaGJYQnNaUzV1WlhRd2dnRWlNQTBHQ1NxRwpTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDM0F2TXZRM01FQndXak5tZjRFR0RyZ1p6dGY3dldBRXZBCmltNUZRYmpQSkdqME1ZZThBRHJwTHh3Y0RGZzQzWXdnVjcvVTVOaGl0a3lpREU3SUh1QnNoa2VkaWFCK3JadkIKaldqQ3EzVytpOVEvN3dUMWY5VVRwOG52RC9WYVBGc0tkNnhNeklPSjlKdGU2NCtyTkRTUzBkcDRVb1grZEdvKwo3NUNXZzNXc1BuU0J6ZEpUYk5uSVJtZ2pRdCsrZWg0VXdvaHIrUTNyZmUvckwxcm5mVUNkbEdSUDl6ZEdhMUFmCmtVMkVNTjBmQWZRUXVwcEdBM1hiaHJMT0Q4MzFFYzVKV2JudTNuTUNLUWlxa0cwZXZDZW9EYk1iMEtuOHRUNGcKM3BOWXF4NWZ4WlBwdm5FZHdtYlY2TytSdDNpQ256TWFmakk3WUlWV3lFdjdtMGVTaURCakFnTUJBQUdqUWpCQQpNQTRHQTFVZER3RUIvd1FFQXdJQkJqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01CMEdBMVVkRGdRV0JCVFdhQlp6CnJuUHBlUFNDT3Y2b252QUlwWTdQbHpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQXRoQzdkdTNUeW82WDRPZXEKdjNZMjd5cTlQSkJzVkhKZk5udnJDanp1dDVtOHVBc1hoY1o5OEE3YmxOUlFKSHV3S0JrWFkzams1dEJObnhRKwpyWis3U3U1Ty8rYUFTQXJNT2gwR21XUXhMaE5yaEFtVmEyU3l4bGZvdk9RRHNKYjhza1JKbHcwbUtUK0w4VG1pClBsV2h4RGR5WjhOQ3ZlOFZGdVgxcEZZUjd6YkFPak1CcmNvSjNTdllDVWYwYWY4VFRybkx3b0lrUW9YTS9SbC8KZENjVlc0OHRrR29xdjVBWWpTSWpiUnpXa2s3R0dHRXV4TC9VWThZNmI5bWg3TjVRa3YvVXVBaXdUeDBYbXBPbQpQdmo0VXZmejcwT0NRRnQ3VW5md3VDc1JIVit3aXVlNVRFa2dZWmk3endTM0kzMzNOY3NZWXlGR2tEMGNNUmt4CjRJWU1yUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K

--- a/cmd/gardener-external-admission-controller/main.go
+++ b/cmd/gardener-external-admission-controller/main.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// IMPORTANT: This is only a temporary component that will be removed as soon as https://github.com/kubernetes/kubernetes/issues/68996 is fixed.
+// It mutates PersistentVolumes and removes the initializer for all non-cloud volumes.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	gardenerlogger "github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/operation/common"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+const pvLabelInitializerName = "pvlabel.kubernetes.io"
+
+var (
+	logger = gardenerlogger.NewLogger("info")
+)
+
+func main() {
+	stopCh := make(chan struct{})
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	go func() {
+		<-c
+		close(stopCh)
+		<-c
+		os.Exit(1)
+	}()
+
+	var (
+		bindAddress = flag.String("bind-address", "0.0.0.0", "address to bind to")
+		port        = flag.Int("secure-port", 2730, "serverport")
+		serverCert  = flag.String("tls-cert-file", "server.crt", "path to server certificate")
+		serverKey   = flag.String("tls-private-key-file", "server.key", "path to client certificate")
+	)
+
+	flag.Parse()
+
+	serve(*bindAddress, *port, *serverCert, *serverKey, stopCh)
+}
+
+func serve(bindAddress string, port int, certPath, keyPath string, stopCh <-chan struct{}) {
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	admissionregistrationv1beta1.AddToScheme(scheme)
+	deserializer := serializer.NewCodecFactory(scheme).UniversalDeserializer()
+
+	mux := http.NewServeMux()
+
+	pvInitializerHandler := &pvInitializerHandler{deserializer}
+	mux.HandleFunc("/webhooks/mutate-pv-initializers", pvInitializerHandler.mutate)
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf("%s:%d", bindAddress, port),
+		Handler: mux,
+	}
+
+	go func() {
+		logger.Infof("Starting Gardener external admission controller...")
+		if err := srv.ListenAndServeTLS(certPath, keyPath); err != http.ErrServerClosed {
+			logger.Errorf("Could not start HTTPS server: %v", err)
+		}
+	}()
+
+	<-stopCh
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		logger.Errorf("Error when shutting down HTTPS server: %v", err)
+	}
+	logger.Info("HTTPS servers stopped.")
+}
+
+type pvInitializerHandler struct {
+	codecs runtime.Decoder
+}
+
+func (p *pvInitializerHandler) mutate(w http.ResponseWriter, r *http.Request) {
+	var (
+		body           []byte
+		receivedReview = admissionv1beta1.AdmissionReview{}
+	)
+
+	// Read HTTP request body into variable.
+	if r.Body != nil {
+		if data, err := ioutil.ReadAll(r.Body); err == nil {
+			body = data
+		}
+	}
+
+	// Verify that the correct content-type header has been sent.
+	if contentType := r.Header.Get("Content-Type"); contentType != "application/json" {
+		err := fmt.Errorf("contentType=%s, expect %s", contentType, "application/json")
+		logger.Errorf(err.Error())
+		respond(w, &admissionv1beta1.AdmissionResponse{Result: &metav1.Status{Message: err.Error()}})
+		return
+	}
+
+	// Deserialize HTTP request body into admissionv1beta1.AdmissionReview object.
+	if _, _, err := p.codecs.Decode(body, nil, &receivedReview); err != nil {
+		logger.Errorf(err.Error())
+		respond(w, &admissionv1beta1.AdmissionResponse{Result: &metav1.Status{Message: err.Error()}})
+		return
+	}
+
+	// If the request field is empty then do not admit (invalid body).
+	if receivedReview.Request == nil {
+		err := fmt.Errorf("invalid request body (missing admission request)")
+		logger.Errorf(err.Error())
+		respond(w, &admissionv1beta1.AdmissionResponse{Result: &metav1.Status{Message: err.Error()}})
+		return
+	}
+	// If the request does not indicate the correct operation (CREATE,UPDATE) we allow the review without further doing.
+	if receivedReview.Request.Operation != admissionv1beta1.Create && receivedReview.Request.Operation != admissionv1beta1.Update {
+		respond(w, &admissionv1beta1.AdmissionResponse{})
+		return
+	}
+
+	// Check that resource is a persistentvolume
+	persistentVolumeResource := metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"}
+	if receivedReview.Request.Resource != persistentVolumeResource {
+		err := fmt.Errorf("invalid object (no persistentvolume)")
+		logger.Errorf(err.Error())
+		respond(w, &admissionv1beta1.AdmissionResponse{Result: &metav1.Status{Message: err.Error()}})
+		return
+	}
+
+	// At this point all validation steps have been passed, let's mutate our object.
+	pv := &corev1.PersistentVolume{}
+	if err := json.Unmarshal(receivedReview.Request.Object.Raw, pv); err != nil {
+		logger.Errorf(err.Error())
+		respond(w, &admissionv1beta1.AdmissionResponse{Result: &metav1.Status{Message: err.Error()}})
+		return
+	}
+
+	patch := "[]"
+	if isCloudSpecificPersistentVolume(pv) {
+		switch {
+		case pv.Initializers == nil:
+			patch = fmt.Sprintf(`[{"op": "add", "path": "/metadata/initializers", "value": {"pending": [{"name": "%s"}]}}]`, pvLabelInitializerName)
+		case !common.HasInitializer(pv.Initializers, pvLabelInitializerName):
+			patch = fmt.Sprintf(`[{"op": "add", "path": "/metadata/initializers/pending/%d", "value": {"name": "%s"}}]`, len(pv.Initializers.Pending), pvLabelInitializerName)
+		}
+		logger.Infof("Added initializer '%s' for PersistentVolume '%s'", pvLabelInitializerName, pv.Name)
+	} else {
+		logger.Infof("Skipped PersistentVolume '%s' as it is not cloud specific", pv.Name)
+	}
+
+	respond(w, &admissionv1beta1.AdmissionResponse{
+		UID:     receivedReview.Request.UID,
+		Allowed: true,
+		Patch:   []byte(patch),
+		PatchType: func() *admissionv1beta1.PatchType {
+			pt := admissionv1beta1.PatchTypeJSONPatch
+			return &pt
+		}(),
+	})
+}
+
+func respond(w http.ResponseWriter, response *admissionv1beta1.AdmissionResponse) {
+	responseObj := admissionv1beta1.AdmissionReview{}
+	if response != nil {
+		responseObj.Response = response
+	}
+
+	jsonResponse, err := json.Marshal(responseObj)
+	if err != nil {
+		logger.Error(err)
+	}
+	if _, err := w.Write(jsonResponse); err != nil {
+		logger.Error(err)
+	}
+}
+
+func isCloudSpecificPersistentVolume(pv *corev1.PersistentVolume) bool {
+	volumeSource := pv.Spec.PersistentVolumeSource
+	return volumeSource.AWSElasticBlockStore != nil ||
+		volumeSource.GCEPersistentDisk != nil ||
+		volumeSource.AzureDisk != nil ||
+		volumeSource.AzureFile != nil ||
+		volumeSource.VsphereVolume != nil ||
+		volumeSource.PhotonPersistentDisk != nil
+}

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 	"strings"
 
+	"time"
+
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	gardenlisters "github.com/gardener/gardener/pkg/client/garden/listers/garden/v1beta1"
@@ -36,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	"time"
 )
 
 var json = jsoniter.ConfigFastest
@@ -366,20 +367,6 @@ func HasInitializer(initializers *metav1.Initializers, name string) bool {
 		}
 	}
 	return false
-}
-
-// RemoveInitializer removes the passed initializer name from the pending initializers.
-func RemoveInitializer(initializers *metav1.Initializers, name string) *metav1.Initializers {
-	if initializers == nil {
-		return nil
-	}
-	var updatedInitializers []metav1.Initializer
-	for _, initializer := range initializers.Pending {
-		if initializer.Name != name {
-			updatedInitializers = append(updatedInitializers, initializer)
-		}
-	}
-	return &metav1.Initializers{Pending: updatedInitializers, Result: initializers.Result}
 }
 
 // ReadLeaderElectionRecord returns the leader election record for a given lock type and a namespace/name combination.

--- a/pkg/operation/common/utils_test.go
+++ b/pkg/operation/common/utils_test.go
@@ -26,7 +26,6 @@ import (
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	. "github.com/onsi/ginkgo/extensions/table"
-	"time"
 )
 
 var _ = Describe("common", func() {
@@ -247,32 +246,5 @@ var _ = Describe("common", func() {
 		Entry("nil initializers", nil, "foo", false),
 		Entry("no matching initializer", &metav1.Initializers{Pending: []metav1.Initializer{{Name: "bar"}}}, "foo", false),
 		Entry("matching initializer", &metav1.Initializers{Pending: []metav1.Initializer{{Name: "foo"}}}, "foo", true),
-	)
-
-	DescribeTable("#RemoveInitializer",
-		func(initializers *metav1.Initializers, name string, expected *metav1.Initializers) {
-			Expect(RemoveInitializer(initializers, name)).To(Equal(expected))
-		},
-		Entry("nil initializers", nil, "foo", nil),
-		Entry("no matching initializer",
-			&metav1.Initializers{Pending: []metav1.Initializer{{Name: "bar"}}},
-			"foo",
-			&metav1.Initializers{Pending: []metav1.Initializer{{Name: "bar"}}}),
-		Entry("matching initializer",
-			&metav1.Initializers{Pending: []metav1.Initializer{{Name: "bar"}, {Name: "foo"}}},
-			"foo",
-			&metav1.Initializers{Pending: []metav1.Initializer{{Name: "bar"}}}),
-	)
-
-	DescribeTable("#ShouldObjectBeRemoved",
-		func(obj metav1.Object, gracePeriod time.Duration, expected bool) {
-			Expect(ShouldObjectBeRemoved(obj, gracePeriod)).To(Equal(expected))
-		},
-		Entry("nil timestamp",
-			&metav1.ObjectMeta{}, 0*time.Second, false),
-		Entry("due timestamp",
-			&metav1.ObjectMeta{DeletionTimestamp: &metav1.Time{Time: time.Now().Add(-10 * time.Second)}}, 0*time.Second, true),
-		Entry("due timestamp but grace period",
-			&metav1.ObjectMeta{DeletionTimestamp: &metav1.Time{Time: time.Now().Add(-10 * time.Second)}}, 20*time.Second, false),
 	)
 })

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -124,6 +124,10 @@ func BootstrapCluster(seed *Seed, k8sGardenClient kubernetes.Client, secrets map
 	if err != nil {
 		return err
 	}
+	gardenerExternalAdmissionController, err := imageVector.FindImage("gardener-external-admission-controller", k8sGardenClient.Version())
+	if err != nil {
+		return err
+	}
 
 	nodes, err := k8sSeedClient.ListNodes(metav1.ListOptions{})
 	if err != nil {
@@ -140,9 +144,10 @@ func BootstrapCluster(seed *Seed, k8sGardenClient kubernetes.Client, secrets map
 	return common.ApplyChart(k8sSeedClient, chartRenderer, filepath.Join("charts", chartName), chartName, common.GardenNamespace, nil, map[string]interface{}{
 		"cloudProvider": seed.CloudProvider,
 		"images": map[string]interface{}{
-			"prometheus":         prometheusVersion.String(),
-			"configmap-reloader": configMapReloader.String(),
-			"pause-container":    pauseContainer.String(),
+			"prometheus":                             prometheusVersion.String(),
+			"configmap-reloader":                     configMapReloader.String(),
+			"pause-container":                        pauseContainer.String(),
+			"gardener-external-admission-controller": gardenerExternalAdmissionController.String(),
 		},
 		"reserveExcessCapacity": seed.reserveExcessCapacity,
 		"replicas": map[string]interface{}{


### PR DESCRIPTION
**What this PR does / why we need it**: To mitigate the Kubernetes cloud-controller-manager bug mentioned in the release notes we do now deploy an external admission controller into the `garden` namespace in the Seeds which takes over the responsibility to add `initializers` to `PersistentVolume`s that are cloud-specific. Non cloud-specific volumes are ignored. The standard initializer configuration is disabled until the bug is fixed upstream in Kubernetes.

**Release note**:
```noteworthy user
Initializers for cloud-specific `PersistentVolume`s are now added by Gardener instead of the Kubernetes initializer admission plugin (to temporarily mitigate a runtime panic that would otherwise happen in the Kubernetes cloud-controller-manager (see https://github.com/kubernetes/kubernetes/issues/68996 for more details)).
```
