### PR TITLE
Fix Prometheus scrape of etcd and kubelet

### DIFF
--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-config
-  namespace: {{.Release.Namespace}}
+  namespace: {{ .Release.Namespace }}
 data:
   prometheus.yaml: |
-    # All services in the {{.Release.Namespace}} and shoot's kube-system that are annotated with
+    # All services in the {{ .Release.Namespace }} and shoot's kube-system that are annotated with
     # * `prometheus.io/scrape`: Only scrape services that have a value of `true`
     # * `prometheus.io/scheme`: If the metrics endpoint is secured then you will need to set this to `https` & most likely set the `tls_config` of the scrape config.
     # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
@@ -31,7 +31,7 @@ data:
       - kubernetes_sd_configs:
         - role: endpoints
           namespaces:
-            names: [{{.Release.Namespace}}]
+            names: [{{ .Release.Namespace }}]
         scheme: http
         relabel_configs:
         - source_labels: [__meta_kubernetes_service_label_component]
@@ -47,13 +47,13 @@ data:
     - job_name: 'kube-etcd3'
       scheme: https
       tls_config:
-        ca_file: /etc/prometheus/seed/ca.crt
-        cert_file: /etc/prometheus/seed/prometheus.crt
-        key_file: /etc/prometheus/seed/prometheus.key
+        ca_file: /srv/kubernetes/etcd/ca/ca.crt
+        cert_file: /srv/kubernetes/etcd/client/tls.crt
+        key_file: /srv/kubernetes/etcd/client/tls.key
       kubernetes_sd_configs:
       - role: service
         namespaces:
-          names: [{{.Release.Namespace}}]
+          names: [{{ .Release.Namespace }}]
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_label_app]
         action: keep
@@ -69,7 +69,7 @@ data:
       kubernetes_sd_configs:
       - role: endpoints
         namespaces:
-          names: [{{.Release.Namespace}}]
+          names: [{{ .Release.Namespace }}]
       tls_config:
         # This is needed because the api server's certificates are not are generated
         # for a specific pod IP
@@ -98,8 +98,8 @@ data:
         # This is needed because the kubelets' certificates are not are generated
         # for a specific pod IP
         insecure_skip_verify: true
-        cert_file: /etc/prometheus/seed/prometheus.crt
-        key_file: /etc/prometheus/seed/prometheus.key
+        cert_file: /srv/kubernetes/prometheus-kubelet/prometheus-kubelet.crt
+        key_file: /srv/kubernetes/prometheus-kubelet/prometheus-kubelet.key
       kubernetes_sd_configs:
       - role: node
         api_server: kube-apiserver
@@ -141,8 +141,8 @@ data:
         # This is needed because the kubelets' certificates are not are generated
         # for a specific pod IP
         insecure_skip_verify: true
-        cert_file: /etc/prometheus/seed/prometheus.crt
-        key_file: /etc/prometheus/seed/prometheus.key
+        cert_file: /srv/kubernetes/prometheus-kubelet/prometheus-kubelet.crt
+        key_file: /srv/kubernetes/prometheus-kubelet/prometheus-kubelet.key
       kubernetes_sd_configs:
       - role: node
         api_server: kube-apiserver
@@ -200,7 +200,7 @@ data:
       kubernetes_sd_configs:
       - role: service
         namespaces:
-          names: [{{.Release.Namespace}}]
+          names: [{{ .Release.Namespace }}]
       relabel_configs:
       - source_labels: [__meta_kubernetes_service_label_component]
         action: keep
@@ -223,7 +223,7 @@ data:
       kubernetes_sd_configs:
       - role: endpoints
         namespaces:
-          names: [{{.Release.Namespace}}]
+          names: [{{ .Release.Namespace }}]
       relabel_configs:
 {{ include "prometheus.service-endpoints.relabel-config" . | indent 6 }}
       metric_relabel_configs:

--- a/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
@@ -107,6 +107,12 @@ spec:
             cpu: 200m
             memory: 2400Mi
         volumeMounts:
+        - mountPath: /srv/kubernetes/prometheus-kubelet
+          name: prometheus-kubelet
+        - mountPath: /srv/kubernetes/etcd/ca
+          name: ca-etcd
+        - mountPath: /srv/kubernetes/etcd/client
+          name: etcd-client-tls
         - mountPath: /etc/prometheus/config
           name: config
           readOnly: true
@@ -226,12 +232,21 @@ spec:
         secret:
           defaultMode: 420
           secretName: ca
+      - name: ca-etcd
+        secret:
+          secretName: ca-etcd
+      - name: etcd-client-tls
+        secret:
+          secretName: etcd-client-tls
       - name: kube-apiserver-basic-auth
         secret:
           secretName: kube-apiserver-basic-auth
       - name: prometheus-kubeconfig
         secret:
           secretName: prometheus
+      - name: prometheus-kubelet
+        secret:
+          secretName: prometheus-kubelet
       - name: blackbox-exporter-config-prometheus
         configMap:
           name: blackbox-exporter-config-prometheus

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -330,6 +330,21 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 			APIServerURL:       b.computeAPIServerURL(true, false),
 		},
 
+		// Secret definition for prometheus to kubelets communication
+		&secrets.ControlPlaneSecretConfig{
+			CertificateSecretConfig: &secrets.CertificateSecretConfig{
+				Name: "prometheus-kubelet",
+
+				CommonName:   fmt.Sprintf("%s:monitoring:prometheus", garden.GroupName),
+				Organization: []string{fmt.Sprintf("%s:monitoring", garden.GroupName)},
+				DNSNames:     nil,
+				IPAddresses:  nil,
+
+				CertType:  secrets.ClientCert,
+				SigningCA: certificateAuthorities[caKubelet],
+			},
+		},
+
 		// Secret definition for kubecfg
 		&secrets.ControlPlaneSecretConfig{
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{


### PR DESCRIPTION
Prometheus now uses the client cert for `etcd` scraping and a dedicated certificate for `kubelet` authentication.

**What this PR does / why we need it**: Prometheus can't scrape both endpoints due to incorrect authentication certificates

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
An issue where the Shoot-specific Prometheus instance did use invalid certificates for scraping etcd and the kubelet has been resolved.
```
