### PR TITLE
Remove storageclass type from OS botanist

### DIFF
--- a/pkg/operation/cloudbotanist/openstackbotanist/addons.go
+++ b/pkg/operation/cloudbotanist/openstackbotanist/addons.go
@@ -41,7 +41,6 @@ func (b *OpenStackBotanist) GenerateAdmissionControlConfig() (map[string]interfa
 				"Provisioner":    "kubernetes.io/cinder",
 				"Parameters": map[string]interface{}{
 					"availability": b.Shoot.Info.Spec.Cloud.OpenStack.Zones[0],
-					"type":         "default",
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove storageclass type from OS botanist

**Release note**:
```noteworthy user
The `type` field has been removed from the `StorageClass` deployed in OpenStack Shoots. Moreover, the `StorageClass`es deployed by Gardener are now reconciled and not only created once anymore.
```
