### PR TITLE
Slow down HPA down-scale to once in 24 hours

### DIFF
--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -76,8 +76,8 @@ spec:
         - --concurrent-deployment-syncs=10
         - --concurrent-replicaset-syncs=10
         {{- include "kube-controller-manager.featureGates" . | trimSuffix "," | indent 8 }}
-        - --horizontal-pod-autoscaler-downscale-delay=15m
-        - --horizontal-pod-autoscaler-upscale-delay=1m
+        - --horizontal-pod-autoscaler-downscale-delay={{ .Values.horizontalPodAutoscaler.downscaleDelay }}
+        - --horizontal-pod-autoscaler-upscale-delay={{ .Values.horizontalPodAutoscaler.upscaleDelay }}
         - --kubeconfig=/var/lib/kube-controller-manager/kubeconfig
         - --leader-elect=true
         - --pod-eviction-timeout=2m0s

--- a/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
@@ -19,3 +19,6 @@ resources:
   limits:
     cpu: 500m
     memory: 512Mi
+horizontalPodAutoscaler:
+  downscaleDelay: 15m
+  upscaleDelay: 1m

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -310,6 +310,10 @@ func (b *HybridBotanist) DeployKubeControllerManager() error {
 				"memory": "1Gi",
 			},
 		}
+		defaultValues["horizontalPodAutoscaler"] = map[string]interface{}{
+			"downscaleDelay": "24h",
+			"upscaleDelay":   "1m",
+		}
 	}
 
 	controllerManagerConfig := b.Shoot.Info.Spec.Kubernetes.KubeControllerManager


### PR DESCRIPTION
**What this PR does / why we need it**: As a follow up for [PR#389](https://github.com/gardener/gardener/pull/389), using HPA for kube-apiserver can cause HPA to thrash kube-apiserver replicas in some cases.

For example, if the HPA specifies desired CPU utilisation as 60% and the actual utilisation is around 40%, then a slight change in utilisation can cause the HPA to thrash between replicas 2 and 3.

Since scaling down of kube-apiserver can be disruptive to work-loads, this PR increases the downscale-delay to 24h.

**Release note**:
```noteworthy operator
The horizontal pod autoscaler downscale delay for shooted Seed clusters has been increased to `24h`.
```
