### PR TITLE
Fix cluster-autoscaler memory resource limit

### DIFF
--- a/charts/seed-controlplane/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/cluster-autoscaler/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 300Mi
+            memory: 400Mi
           requests:
             cpu: 100m
             memory: 300Mi


### PR DESCRIPTION
**What this PR does / why we need it**:
By default, cluster-autoscaler is close to 300m of memory consumption.
A cluster that is a bit bigger leads to continuous OOMKilleds of the cluster-autoscaler.
This PR addresses this issue by raising the memory limit of the cluster-autoscaler from 300m to 400m.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
