### PR TITLE
Make shooted seeds more configurable

### DIFF
--- a/pkg/controller/shoot/shoot.go
+++ b/pkg/controller/shoot/shoot.go
@@ -317,7 +317,7 @@ func (c *Controller) CollectMetrics(ch chan<- prometheus.Metric) {
 
 func (c *Controller) getShootQueue(obj interface{}) workqueue.RateLimitingInterface {
 	if shoot, ok := obj.(*gardenv1beta1.Shoot); ok {
-		if shootUsedAsSeed, _, _ := helper.IsUsedAsSeed(shoot); shootUsedAsSeed {
+		if shootedSeed, err := helper.ReadShootedSeed(shoot); err == nil && shootedSeed != nil {
 			return c.shootSeedQueue
 		}
 	}

--- a/pkg/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controller/shoot/shoot_control_reconcile.go
@@ -215,8 +215,8 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 
 	// Register the Shoot as Seed cluster if it was annotated properly and in the garden namespace
 	if o.Shoot.Info.Namespace == common.GardenNamespace {
-		if shootUsedAsSeed, protected, visible := helper.IsUsedAsSeed(o.Shoot.Info); shootUsedAsSeed {
-			if err := botanist.RegisterAsSeed(protected, visible); err != nil {
+		if o.ShootedSeed != nil {
+			if err := botanist.RegisterAsSeed(o.ShootedSeed.Protected, o.ShootedSeed.Visible); err != nil {
 				o.Logger.Errorf("Could not register Shoot %q as Seed: %+v", o.Shoot.Info.Name, err)
 			}
 		} else {

--- a/pkg/operation/hybridbotanist/addons.go
+++ b/pkg/operation/hybridbotanist/addons.go
@@ -18,7 +18,6 @@ import (
 	"path/filepath"
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
-	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
@@ -168,7 +167,7 @@ func (b *HybridBotanist) generateOptionalAddonsChart() (*chartrenderer.RenderedC
 			},
 		})
 
-		if shootUsedAsSeed, _, _ := helper.IsUsedAsSeed(b.Shoot.Info); shootUsedAsSeed {
+		if b.ShootedSeed != nil {
 			nginxIngressConfig = utils.MergeMaps(nginxIngressConfig, map[string]interface{}{
 				"controller": map[string]interface{}{
 					"resources": map[string]interface{}{

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -19,7 +19,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
@@ -207,10 +206,14 @@ func (b *HybridBotanist) DeployKubeAPIServer() error {
 		return err
 	}
 
-	if shootUsedAsSeed, _, _ := helper.IsUsedAsSeed(b.Shoot.Info); shootUsedAsSeed {
-		defaultValues["replicas"] = 3
-		defaultValues["minReplicas"] = 3
-		defaultValues["maxReplicas"] = 3
+	if b.ShootedSeed != nil {
+		var (
+			apiServer  = b.ShootedSeed.APIServer
+			autoscaler = apiServer.Autoscaler
+		)
+		defaultValues["replicas"] = *apiServer.Replicas
+		defaultValues["minReplicas"] = *autoscaler.MinReplicas
+		defaultValues["maxReplicas"] = autoscaler.MaxReplicas
 		defaultValues["apiServerResources"] = map[string]interface{}{
 			"limits": map[string]interface{}{
 				"cpu":    "1500m",
@@ -303,7 +306,7 @@ func (b *HybridBotanist) DeployKubeControllerManager() error {
 		return err
 	}
 
-	if shootUsedAsSeed, _, _ := helper.IsUsedAsSeed(b.Shoot.Info); shootUsedAsSeed {
+	if b.ShootedSeed != nil {
 		defaultValues["resources"] = map[string]interface{}{
 			"limits": map[string]interface{}{
 				"cpu":    "750m",
@@ -348,7 +351,7 @@ func (b *HybridBotanist) DeployCloudControllerManager() error {
 		return err
 	}
 
-	if shootUsedAsSeed, _, _ := helper.IsUsedAsSeed(b.Shoot.Info); shootUsedAsSeed {
+	if b.ShootedSeed != nil {
 		defaultValues["resources"] = map[string]interface{}{
 			"limits": map[string]interface{}{
 				"cpu":    "500m",
@@ -384,7 +387,7 @@ func (b *HybridBotanist) DeployKubeScheduler() error {
 		return err
 	}
 
-	if shootUsedAsSeed, _, _ := helper.IsUsedAsSeed(b.Shoot.Info); shootUsedAsSeed {
+	if b.ShootedSeed != nil {
 		defaultValues["resources"] = map[string]interface{}{
 			"limits": map[string]interface{}{
 				"cpu":    "300m",

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/externalversions/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -99,6 +100,13 @@ func newOperation(
 			return nil, err
 		}
 		operation.Shoot = shootObj
+
+		shootedSeed, err := helper.ReadShootedSeed(shoot)
+		if err != nil {
+			logger.Warnf("Cannot use shoot %s/%s as shooted seed: %+v", shoot.Namespace, shoot.Name, err)
+		} else {
+			operation.ShootedSeed = shootedSeed
+		}
 	}
 
 	return operation, nil

--- a/pkg/operation/types.go
+++ b/pkg/operation/types.go
@@ -16,6 +16,7 @@ package operation
 
 import (
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/externalversions/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -38,6 +39,7 @@ type Operation struct {
 	Garden               *garden.Garden
 	Seed                 *seed.Seed
 	Shoot                *shoot.Shoot
+	ShootedSeed          *helper.ShootedSeed
 	K8sGardenClient      kubernetes.Client
 	K8sGardenInformers   gardeninformers.Interface
 	K8sSeedClient        kubernetes.Client


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the configuration of shooted seeds easier by (temporarily) introducing some extended parsing inside the annotation. In the future this might have to be replaced by a proper section in the shoot with role validation etc. but as of now this enables us to have more fine grained control over the scaling of API servers of our shooted seeds.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
