### PR TITLE
Fix Retry utilities and add tests

### DIFF
--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -163,7 +163,7 @@ func (b *Botanist) ForceDeleteCustomAPIServices() error {
 }
 
 func (b *Botanist) waitForAPIGroupCleanedUp(apiGroupPath []string, resource string) error {
-	if err := wait.PollImmediate(5*time.Second, 10*time.Minute, func() (bool, error) {
+	if err := wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
 		return b.K8sShootClient.CheckResourceCleanup(b.Logger, exceptions, resource, apiGroupPath)
 	}); err != nil {
 		return fmt.Errorf("Error while waiting for cleanup of '%s' resources: '%s'", resource, err.Error())


### PR DESCRIPTION
**What this PR does / why we need it**:
Revert behavior of retry to always use the value of the function it is waiting for.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
