### PR TITLE
White list of all Prometheus metrics.

### DIFF
--- a/charts/seed-bootstrap/templates/prometheus/_resource.tpl
+++ b/charts/seed-bootstrap/templates/prometheus/_resource.tpl
@@ -10,3 +10,9 @@ resource per object, object weight and base resource quantity.
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "prometheus.keep-metrics.metric-relabel-config" -}}
+- source_labels: [ __name__ ]
+  regex: ^({{ . | join "|" }})$
+  action: keep
+{{- end -}}

--- a/charts/seed-bootstrap/templates/prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/config.yaml
@@ -40,11 +40,10 @@ data:
       # Drop metrics that are useless and high-volume
       # Use topk(20, count by (__name__, job)({__name__=~".+"})) to find offending time-series
       metric_relabel_configs:
-      - source_labels: [ __name__ ]
-        regex: ^container_({{ .Values.prometheus.cadvisorAllowedMetrics | join "|" }})$
-        action: keep
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.cAdvisor | indent 6 }}
       - source_labels: [ container_name ]
-        regex: ^POD$
+        # The system container POD is used for networking
+        regex: ^POD$;^({{ without .Values.allowedMetrics.cAdvisor "container_network_receive_bytes_total" "container_network_transmit_bytes_total" | join "|" }})$
         action: drop
         # drop terraform pods
       - source_labels: [ pod_name ]

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -2,18 +2,27 @@ cloudProvider: aws
 
 prometheus:
   port: 9090
-  cadvisorAllowedMetrics:
-  # container metrics without the container_
-  - last_seen
-  - fs_usage_bytes
-  - fs_inodes_total
-  - fs_limit_bytes
-  - network_receive_bytes_total
-  - network_transmit_bytes_total
-  - cpu_cfs_periods_total
-  - cpu_usage_seconds_total
-  - memory_usage_bytes
-  - memory_working_set_bytes
+
+allowedMetrics:
+  cAdvisor:
+  - container_cpu_cfs_periods_total
+  - container_cpu_usage_seconds_total
+  - container_fs_inodes_total
+  - container_fs_limit_bytes
+  - container_fs_usage_bytes
+  - container_last_seen
+  - container_memory_cache
+  - container_memory_failcnt
+  - container_memory_failures_total
+  - container_memory_rss
+  - container_memory_usage_bytes
+  - container_memory_working_set_bytes
+  - container_network_receive_bytes_total
+  - container_network_transmit_bytes_total
+  - container_spec_cpu_shares
+  - container_spec_memory_limit_bytes
+  - machine_cpu_cores
+  - machine_memory_bytes
 
   # object can be any object you want to scale Prometheus on:
   # - number of Pods

--- a/charts/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -6,10 +6,6 @@ metadata:
   labels:
     app: kubernetes
     role: cloud-controller-manager
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "10253"
-    prometheus.io/name: cloud-controller-manager
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -6,10 +6,6 @@ metadata:
   labels:
     app: kubernetes
     role: controller-manager
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "10252"
-    prometheus.io/name: kube-controller-manager
 spec:
   type: ClusterIP
   clusterIP: None

--- a/charts/seed-controlplane/charts/kube-scheduler/templates/kube-scheduler.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/templates/kube-scheduler.yaml
@@ -6,17 +6,13 @@ metadata:
   labels:
     app: kubernetes
     role: scheduler
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "10251"
-    prometheus.io/name: kube-scheduler
 spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - name: metrics
-      port: 10251
-      protocol: TCP
+  - name: metrics
+    port: 10251
+    protocol: TCP
   selector:
     app: kubernetes
     role: scheduler

--- a/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
@@ -6,10 +6,6 @@ metadata:
   labels:
     component: alertmanager
     role: monitoring
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9093"
-    prometheus.io/name: alertmanager
 spec:
   ports:
   - port: 9093

--- a/charts/seed-monitoring/charts/prometheus/templates/_helpers.tpl
+++ b/charts/seed-monitoring/charts/prometheus/templates/_helpers.tpl
@@ -37,6 +37,11 @@ Drops metrics which produce lots of time-series without much gain.
   action: drop
 {{- end -}}
 
+{{- define "prometheus.keep-metrics.metric-relabel-config" -}}
+- source_labels: [ __name__ ]
+  regex: ^({{ . | join "|" }})$
+  action: keep
+{{- end -}}
 
 {{- define "prometheus.tls-config.kube-cert-auth" -}}
 ca_file: /etc/prometheus/seed/ca.crt

--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -5,16 +5,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   prometheus.yaml: |
-    # All services in the {{ .Release.Namespace }} and shoot's kube-system that are annotated with
+    # All services in the {{ .Release.Namespace }} and that are annotated with
     # * `prometheus.io/scrape`: Only scrape services that have a value of `true`
     # * `prometheus.io/scheme`: If the metrics endpoint is secured then you will need to set this to `https` & most likely set the `tls_config` of the scrape config.
     # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
     # * `prometheus.io/port`: If the metrics are exposed on a different port to the service then set this appropriately. Use this when multiple ports are avaible by the pod.
     # * `prometheus.io/name`: job name label to be applied to all metrics from that service.
-    # exceptions are:
-    # * kube-apiserver
-    # * kubelet (both in seed and shoot)
-    # * kube-state-metrics (both in seed and shoot)
+    # take note that there is a limit of 500 samples per target
 
     global:
       evaluation_interval: 30s
@@ -34,37 +31,42 @@ data:
             names: [{{ .Release.Namespace }}]
         scheme: http
         relabel_configs:
-        - source_labels: [__meta_kubernetes_service_label_component]
+        - source_labels: [ __meta_kubernetes_service_label_component ]
           action: keep
           regex: alertmanager
-        - source_labels: [__meta_kubernetes_service_label_role]
+        - source_labels: [ __meta_kubernetes_service_label_role ]
           action: keep
           regex: monitoring
-        - source_labels: [__meta_kubernetes_endpoint_port_name]
+        - source_labels: [ __meta_kubernetes_endpoint_port_name ]
           action: keep
           regex: metrics
     scrape_configs:
-    - job_name: 'kube-etcd3'
+    - job_name: kube-etcd3
       scheme: https
       tls_config:
-        ca_file: /srv/kubernetes/etcd/ca/ca.crt
+        # This is needed because the etcd's certificates are not are generated
+        # for a specific pod IP
+        insecure_skip_verify: true
         cert_file: /srv/kubernetes/etcd/client/tls.crt
         key_file: /srv/kubernetes/etcd/client/tls.key
       kubernetes_sd_configs:
-      - role: service
+      - role: endpoints
         namespaces:
           names: [{{ .Release.Namespace }}]
       relabel_configs:
-      - source_labels: [__meta_kubernetes_service_label_app]
+      - source_labels:
+        - __meta_kubernetes_service_label_app
+        - __meta_kubernetes_endpoint_port_name
         action: keep
-        regex: etcd-statefulset
-      - source_labels: [__meta_kubernetes_service_label_role]
+        regex: etcd-statefulset;client
+      - source_labels: [ __meta_kubernetes_service_label_role ]
         target_label: role
-      - source_labels: [__meta_kubernetes_service_port_name]
-        action: keep
-        regex: client
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.kubeETCD3 | indent 6 }}
 
-    - job_name: 'kube-apiserver'
+    - job_name: kube-apiserver
       scheme: https
       kubernetes_sd_configs:
       - role: endpoints
@@ -77,21 +79,19 @@ data:
         cert_file: /etc/prometheus/seed/prometheus.crt
         key_file: /etc/prometheus/seed/prometheus.key
       relabel_configs:
-      - source_labels: [__meta_kubernetes_service_name]
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
         action: keep
-        regex: kube-apiserver
-      - source_labels: [__meta_kubernetes_endpoint_port_name]
-        action: keep
-        regex: kube-apiserver
-      - source_labels: [__meta_kubernetes_pod_name]
+        regex: kube-apiserver;kube-apiserver
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [ __meta_kubernetes_pod_name ]
         target_label: pod
       metric_relabel_configs:
-      - source_labels: [ __name__ ]
-        regex: ^apiserver_admission_.+$
-        action: drop
-{{ include "prometheus.drop-metrics.metric-relabel-config" . | indent 6 }}
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.kubeAPIServer | indent 6 }}
 
-    - job_name: 'kube-kubelet'
+    - job_name: kube-kubelet
       honor_labels: false
       scheme: https
       tls_config:
@@ -106,7 +106,7 @@ data:
         tls_config:
 {{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
       relabel_configs:
-      - source_labels: [__meta_kubernetes_node_address_InternalIP]
+      - source_labels: [ __meta_kubernetes_node_address_InternalIP ]
         target_label: instance
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
@@ -114,26 +114,9 @@ data:
         replacement: shoot
       # get system services
       metric_relabel_configs:
-      - source_labels: [id]
-        action: replace
-        regex: '^/system\.slice/(.+)\.service$'
-        target_label: systemd_service_name
-        replacement: '${1}'
-      # We want to keep only metrics in kube-system namespace
-      - source_labels: [namespace]
-        action: keep
-        regex: kube-system
-      # Drop metrics that are useless and high-volume
-      # Use topk(20, count by (__name__, job)({__name__=~".+"})) to find offending time-series
-      - source_labels: [ __name__ ]
-        regex: ^rest_client_request_latency_seconds.+$
-        action: drop
-      - source_labels: [ __name__ ]
-        regex: ^(etcd|reflector)_.+
-        action: drop
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.kubelet | indent 6 }}
 
-    # As of K8S v1.7.3 cAdvisor metrics are located at <kubelet-address>/metrics/cadvisor
-    - job_name: 'cadvisor'
+    - job_name: cadvisor
       honor_labels: false
       scheme: https
       metrics_path: /metrics/cadvisor
@@ -149,7 +132,7 @@ data:
         tls_config:
 {{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
       relabel_configs:
-      - source_labels: [__meta_kubernetes_node_address_InternalIP]
+      - source_labels: [ __meta_kubernetes_node_address_InternalIP ]
         target_label: instance
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
@@ -157,16 +140,14 @@ data:
         replacement: shoot
       metric_relabel_configs:
       # We want to keep only metrics in kube-system namespace
-      - source_labels: [namespace]
+      - source_labels: [ namespace ]
         action: keep
-        regex: kube-system
-      # Drop metrics that are useless and high-volume
-      # Use topk(20, count by (__name__, job)({__name__=~".+"})) to find offending time-series
-      - source_labels: [ __name__ ]
-        regex: ^container_({{ .Values.cadvisorAllowedMetrics | join "|" }})$
-        action: keep
+        # systemd containers don't have namespaces
+        regex: (^$|^kube-system$)
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.cAdvisor | indent 6 }}
       - source_labels: [ container_name ]
-        regex: ^POD$
+        # The system container POD is used for networking
+        regex: ^POD$;^({{ without .Values.allowedMetrics.cAdvisor "container_network_receive_bytes_total" "container_network_transmit_bytes_total" | join "|" }})$
         action: drop
       # get system services
       - source_labels: [ id ]
@@ -179,7 +160,7 @@ data:
 
     # We fetch kubelet metrics from seed's kube-system Prometheus and filter
     # the metrics in shoot's namespace
-    - job_name: 'kube-kubelet-seed'
+    - job_name: kube-kubelet-seed
       metrics_path: /federate
       params:
         'match[]':
@@ -192,7 +173,7 @@ data:
       - target_label: namespace
         replacement: kube-system
 
-    - job_name: 'kube-state-metrics'
+    - job_name: kube-state-metrics
       scheme: http
       honor_labels: false
       # Service is used, because we only care about metric from one kube-state-metrics instance
@@ -202,12 +183,12 @@ data:
         namespaces:
           names: [{{ .Release.Namespace }}]
       relabel_configs:
-      - source_labels: [__meta_kubernetes_service_label_component]
+      - source_labels: [ __meta_kubernetes_service_label_component ]
         action: keep
         regex: kube-state-metrics
-      - source_labels: [__meta_kubernetes_service_port_name]
+      - source_labels: [ __meta_kubernetes_service_port_name ]
         action: keep
-      - source_labels: [__meta_kubernetes_service_label_type]
+      - source_labels: [ __meta_kubernetes_service_label_type ]
         regex: (.+)
         target_label: type
         replacement: ${1}
@@ -217,6 +198,10 @@ data:
       # we make the shoot's pods in the shoot's namepsace to apear in as its in the kube-system
       - target_label: namespace
         replacement: kube-system
+      - source_labels: [ pod ]
+        regex: ^.+\.tf-pod.+$
+        action: drop
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.kubeStateMetrics | indent 6 }}
 
     - job_name: 'annotated-seed-service-endpoints'
       honor_labels: false
@@ -224,29 +209,159 @@ data:
       - role: endpoints
         namespaces:
           names: [{{ .Release.Namespace }}]
+      sample_limit: 500
       relabel_configs:
 {{ include "prometheus.service-endpoints.relabel-config" . | indent 6 }}
       metric_relabel_configs:
 {{ include "prometheus.drop-metrics.metric-relabel-config" . | indent 6 }}
 
-    - job_name: 'annotated-shoot-service-endpoints'
+    - job_name: kube-controller-manager
       honor_labels: false
       kubernetes_sd_configs:
       - role: endpoints
         namespaces:
-          names: [kube-system]
+          names: [{{ .Release.Namespace }}]
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+        action: keep
+        regex: kube-controller-manager;metrics
+      # common metrics
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.kubeControllerManager | indent 6 }}
+
+    - job_name: kube-scheduler
+      honor_labels: false
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [{{ .Release.Namespace }}]
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+        action: keep
+        regex: kube-scheduler;metrics
+      # common metrics
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.kubeScheduler | indent 6 }}
+
+    - job_name: cloud-controller-manager
+      honor_labels: false
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [{{ .Release.Namespace }}]
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+        action: keep
+        regex: cloud-controller-manager;metrics
+      # common metrics
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.cloudControllerManager | indent 6 }}
+
+    - job_name: alertmanager
+      honor_labels: false
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [{{ .Release.Namespace }}]
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+        action: keep
+        regex: alertmanager-client;metrics
+      # common metrics
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.alertManager | indent 6 }}
+
+    - job_name: prometheus
+      honor_labels: false
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [{{ .Release.Namespace }}]
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+        action: keep
+        regex: prometheus-web;metrics
+      # common metrics
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.prometheus | indent 6 }}
+
+    - job_name: coredns
+      honor_labels: false
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [ kube-system ]
         api_server: kube-apiserver
         tls_config:
 {{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
       relabel_configs:
-      - source_labels: [__meta_kubernetes_service_label_addonmanager_kubernetes_io_mode]
-        regex: (.+)
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
         action: keep
-{{ include "prometheus.service-endpoints.relabel-config" . | indent 6 }}
+        regex: kube-dns;metrics
+      # common metrics
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
       metric_relabel_configs:
-{{ include "prometheus.drop-metrics.metric-relabel-config" . | indent 6 }}
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.coredns | indent 6 }}
 
-    - job_name: 'vpn-connection'
+    - job_name: node-exporter
+      honor_labels: false
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [ kube-system ]
+        api_server: kube-apiserver
+        tls_config:
+{{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+        action: keep
+        regex: node-exporter;metrics
+      # common metrics
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.nodeExporter | indent 6 }}
+
+    - job_name: vpn-connection
       honor_labels: false
       scrape_interval: 15s
       scrape_timeout: 5s
@@ -261,10 +376,10 @@ data:
         namespaces:
           names: [{{ .Release.Namespace }}]
       relabel_configs:
-      - source_labels: [__meta_kubernetes_pod_container_port_name]
+      - source_labels: [ __meta_kubernetes_pod_container_port_name ]
         action: keep
         regex: blackbox-export
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
-      - source_labels: [__meta_kubernetes_pod_name]
+      - source_labels: [ __meta_kubernetes_pod_name ]
         target_label: pod

--- a/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
@@ -15,13 +15,9 @@ metadata:
   labels:
     app: prometheus
     role: monitoring
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9090"
-    prometheus.io/name: prometheus
 spec:
   ports:
-  - name: web
+  - name: metrics
     port: 80
     protocol: TCP
     targetPort: {{ .Values.port }}
@@ -125,43 +121,6 @@ spec:
         # we mount the Shoot cluster's CA and certs
         - mountPath: /etc/prometheus/seed
           name: prometheus-kubeconfig
-      - name: prometheus-config-reloader
-        image: {{ index .Values.images "configmap-reloader" }}
-        imagePullPolicy: IfNotPresent
-        args:
-        - -webhook-url=http://localhost:9090/-/reload
-        - -volume-dir=/etc/prometheus/config
-        - -volume-dir=/etc/prometheus/rules
-        resources:
-          requests:
-            cpu: 5m
-            memory: 10Mi
-          limits:
-            cpu: 10m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /etc/prometheus/config
-          name: config
-          readOnly: true
-        - mountPath: /etc/prometheus/rules
-          name: rules
-      - name: blackbox-exporter-config-reloader
-        image: {{ index .Values.images "configmap-reloader" }}
-        imagePullPolicy: IfNotPresent
-        args:
-        - -webhook-url=http://localhost:9115/-/reload
-        - -volume-dir=/vpn
-        resources:
-          requests:
-            cpu: 5m
-            memory: 10Mi
-          limits:
-            cpu: 10m
-            memory: 20Mi
-        volumeMounts:
-        - mountPath: /vpn
-          name: blackbox-exporter-config-prometheus
-          readOnly: true
       - image: {{ index .Values.images "vpn-seed" }}
         imagePullPolicy: IfNotPresent
         name: vpn-seed

--- a/charts/seed-monitoring/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/prometheus/values.yaml
@@ -8,8 +8,8 @@
 
 images:
   prometheus: image-repository:image-tag
-  configmap-reloader: image-repository:image-tag
   vpn-seed: image-repository:image-tag
+  blackbox-exporter: image-repository:image-tag
 
 ingress:
   host: p.seed-1.example.com
@@ -24,18 +24,122 @@ replicas: 1
 apiserverServiceIP: 100.10.10.10
 port: 9090
 
-cadvisorAllowedMetrics:
-# container metrics without the container_
-- last_seen
-- fs_usage_bytes
-- fs_inodes_total
-- fs_limit_bytes
-- network_receive_bytes_total
-- network_transmit_bytes_total
-- cpu_cfs_periods_total
-- cpu_usage_seconds_total
-- memory_usage_bytes
-- memory_working_set_bytes
+allowedMetrics:
+  alertManager:
+  - alertmanager_config_hash
+  - alertmanager_config_last_reload_successful
+  - process_max_fds
+  - process_open_fds
+  cAdvisor:
+  - container_cpu_cfs_periods_total
+  - container_cpu_usage_seconds_total
+  - container_fs_inodes_total
+  - container_fs_limit_bytes
+  - container_fs_usage_bytes
+  - container_last_seen
+  - container_memory_cache
+  - container_memory_failcnt
+  - container_memory_failures_total
+  - container_memory_rss
+  - container_memory_usage_bytes
+  - container_memory_working_set_bytes
+  - container_network_receive_bytes_total
+  - container_network_transmit_bytes_total
+  - container_spec_cpu_shares
+  - container_spec_memory_limit_bytes
+  - machine_cpu_cores
+  - machine_memory_bytes
+  coredns:
+  - process_max_fds
+  - process_open_fds
+  cloudControllerManager:
+  - process_max_fds
+  - process_open_fds
+  kubeAPIServer:
+  - apiserver_request_count
+  - apiserver_request_latencies_bucket
+  - process_max_fds
+  - process_open_fds
+  kubeControllerManager:
+  - process_max_fds
+  - process_open_fds
+  kubelet:
+  - kubelet_pod_start_latency_microseconds
+  - kubelet_running_pod_count
+  - process_max_fds
+  - process_open_fds
+  kubeETCD3:
+  - etcd_disk_backend_commit_duration_seconds_bucket
+  - etcd_disk_wal_fsync_duration_seconds_bucket
+  - etcd_server_has_leader
+  - etcd_server_leader_changes_seen_total
+  - etcd_server_proposals_failed_total
+  - process_max_fds
+  - process_open_fds
+  kubeScheduler:
+  - scheduler_binding_latency_microseconds_bucket
+  - scheduler_e2e_scheduling_latency_microseconds_bucket
+  - scheduler_scheduling_algorithm_latency_microseconds_bucket
+  - process_max_fds
+  - process_open_fds
+  kubeStateMetrics:
+  - kube_deployment_metadata_generation
+  - kube_deployment_spec_replicas
+  - kube_deployment_status_observed_generation
+  - kube_deployment_status_replicas
+  - kube_deployment_status_replicas_available
+  - kube_deployment_status_replicas_unavailable
+  - kube_deployment_status_replicas_updated
+  - kube_node_spec_unschedulable
+  - kube_node_status_allocatable_cpu_cores
+  - kube_node_status_allocatable_memory_bytes
+  - kube_node_status_capacity_pods
+  - kube_node_status_condition
+  - kube_pod_container_info
+  - kube_pod_container_resource_limits_cpu_cores
+  - kube_pod_container_resource_limits_memory_bytes
+  - kube_pod_container_resource_requests_memory_bytes
+  - kube_pod_container_status_restarts_total
+  - kube_pod_info
+  - kube_pod_labels
+  - kube_pod_status_phase
+  - kube_statefulset_metadata_generation
+  - kube_statefulset_replicas
+  - kube_statefulset_status_observed_generation
+  - kube_statefulset_status_replicas
+  - process_max_fds
+  - process_open_fds
+  nodeExporter:
+  - node_load1
+  - node_load5
+  - node_load15
+  - node_nf_conntrack_entries
+  - node_nf_conntrack_entries_limit
+  - process_max_fds
+  - process_open_fds
+  prometheus:
+  - process_max_fds
+  - process_open_fds
+  - process_resident_memory_bytes
+  - process_virtual_memory_bytes
+  - prometheus_config_last_reload_successful
+  - prometheus_engine_query_duration_seconds
+  - prometheus_rule_group_duration_seconds
+  - prometheus_rule_group_iterations_missed_total
+  - prometheus_rule_group_iterations_total
+  - prometheus_tsdb_blocks_loaded
+  - prometheus_tsdb_compactions_failed_total
+  - prometheus_tsdb_compactions_total
+  - prometheus_tsdb_compactions_triggered_total
+  - prometheus_tsdb_head_active_appenders
+  - prometheus_tsdb_head_chunks
+  - prometheus_tsdb_head_gc_duration_seconds
+  - prometheus_tsdb_head_gc_duration_seconds_count
+  - prometheus_tsdb_head_samples_appended_total
+  - prometheus_tsdb_head_series
+  - prometheus_tsdb_reloads_failures_total
+  - prometheus_tsdb_reloads_total
+  - prometheus_tsdb_wal_corruptions_total
 
 seed:
   apiserver: https://api.foo.bar

--- a/charts/shoot-core/charts/coredns/templates/coredns-service.yaml
+++ b/charts/shoot-core/charts/coredns/templates/coredns-service.yaml
@@ -3,8 +3,10 @@ kind: Service
 metadata:
   name: kube-dns
   namespace: kube-system
+{{- if .Values.service.annotations }}
   annotations:
 {{ .Values.service.annotations | toYaml | trimSuffix "\n" | indent 4  }}
+{{- end }}
   labels:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
@@ -25,3 +27,6 @@ spec:
     port: {{ .Values.service.port }}
     targetPort: {{ .Values.service.targetPort }}
     protocol: TCP
+  - name: metrics
+    port: {{ .Values.service.metricsPort }}
+    targetPort: {{ .Values.service.metricsPort }}

--- a/charts/shoot-core/charts/coredns/values.yaml
+++ b/charts/shoot-core/charts/coredns/values.yaml
@@ -1,4 +1,4 @@
-# The values here match the ones on the upstream deployment repo (https://github.com/coredns/deployment/blob/master/kubernetes/coredns.yaml.sed). 
+# The values here match the ones on the upstream deployment repo (https://github.com/coredns/deployment/blob/master/kubernetes/coredns.yaml.sed).
 # They may need to be updated in the future
 
 service:
@@ -7,14 +7,10 @@ service:
   domain: cluster.local in-addr.arpa ip6.arpa
   port: 53
   targetPort: 8053
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9153"
-    prometheus.io/name: coredns
-
+  annotations: {}
+  metricsPort: 9153
 images:
    coredns: image-repository:image-tag
-
 deployment:
   spec:
     containers:

--- a/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -6,10 +6,6 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
     component: node-exporter
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9100"
-    prometheus.io/name: node-exporter
 spec:
   type: ClusterIP
   clusterIP: None


### PR DESCRIPTION
When scraping individual targets Prometheus now stores only a collection of white-listed metrics. This reduces the samples stored and improves performance and memory utilization.

Endpoints using the `prometheus.io/*` annotations are now limited to `500` samples.

Refactoring also allowed for `cAdvisor` networking metrics to be scraped for Pods and `systemd` containers are again shown in the Grafana Dashboard.

Config reloaders for Prometheus and blackbox-exporter are dropped from the Shoot's Prometheus.

**What this PR does / why we need it**: Reduces memory and cpu usage of Prometheus.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
The Prometheus instance responsible for Shoots does now ingest only a subset of samples per scrape target.
```
