### PR TITLE
External admission controller should not react on PVs marked for deletion

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -12,7 +12,7 @@ images:
 - name: gardener-external-admission-controller
   sourceRepository: github.com/gardener/gardener
   repository: eu.gcr.io/gardener-project/gardener/external-admission-controller
-  tag: "v2"
+  tag: "v3"
 
 # Seed controlplane
 - name: etcd

--- a/cmd/gardener-external-admission-controller/main.go
+++ b/cmd/gardener-external-admission-controller/main.go
@@ -164,7 +164,7 @@ func (p *pvInitializerHandler) mutate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	patch := "[]"
-	if isCloudSpecificPersistentVolume(pv) {
+	if pv.DeletionTimestamp == nil && isCloudSpecificPersistentVolume(pv) {
 		switch {
 		case pv.Initializers == nil:
 			patch = fmt.Sprintf(`[{"op": "add", "path": "/metadata/initializers", "value": {"pending": [{"name": "%s"}]}}]`, pvLabelInitializerName)
@@ -173,7 +173,7 @@ func (p *pvInitializerHandler) mutate(w http.ResponseWriter, r *http.Request) {
 		}
 		logger.Infof("Added initializer '%s' for PersistentVolume '%s'", pvLabelInitializerName, pv.Name)
 	} else {
-		logger.Infof("Skipped PersistentVolume '%s' as it is not cloud specific", pv.Name)
+		logger.Infof("Skipped PersistentVolume '%s' as it is marked for deletion or not cloud specific", pv.Name)
 	}
 
 	respond(w, &admissionv1beta1.AdmissionResponse{


### PR DESCRIPTION
**What this PR does / why we need it**: Although the webhook is only registered for CREATE operations others misconfigured webhooks might trigger our external admission controller for existing PVs in "Terminating" state.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
