### PR TITLE
Skip explicit AWS load balancer/security group deletion if infrastructure already deleted

### DIFF
--- a/pkg/operation/cloudbotanist/awsbotanist/infrastructure.go
+++ b/pkg/operation/cloudbotanist/awsbotanist/infrastructure.go
@@ -63,12 +63,17 @@ func (b *AWSBotanist) DestroyInfrastructure() error {
 		return err
 	}
 
+	canSkipTerraform, err := tf.ConfigExists()
+	if err != nil {
+		return err
+	}
+
 	var (
 		g = flow.NewGraph("AWS infrastructure destruction")
 
 		destroyKubernetesLoadBalancersAndSecurityGroups = g.Add(flow.Task{
 			Name: "Destroying Kubernetes load balancers and security groups",
-			Fn:   flow.TaskFn(b.destroyKubernetesLoadBalancersAndSecurityGroups).RetryUntilTimeout(10*time.Second, 5*time.Minute),
+			Fn:   flow.TaskFn(b.destroyKubernetesLoadBalancersAndSecurityGroups).RetryUntilTimeout(10*time.Second, 5*time.Minute).DoIf(!canSkipTerraform),
 		})
 
 		_ = g.Add(flow.Task{

--- a/pkg/operation/terraformer/config.go
+++ b/pkg/operation/terraformer/config.go
@@ -65,39 +65,42 @@ func (t *Terraformer) DefineConfig(chartName string, values map[string]interface
 // prepare checks whether all required ConfigMaps and Secrets exist. It returns the number of
 // existing ConfigMaps/Secrets, or the error in case something unexpected happens.
 func (t *Terraformer) prepare() (int, error) {
-	// Check whether the required ConfigMaps and the Secret exist
-	numberOfExistingResources := 3
+	numberOfExistingResources := 0
 
-	_, err := t.k8sClient.GetConfigMap(t.namespace, t.stateName)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return -1, err
-		}
-		numberOfExistingResources--
+	if _, err := t.k8sClient.GetConfigMap(t.namespace, t.stateName); err == nil {
+		numberOfExistingResources++
+	} else if err != nil && !apierrors.IsNotFound(err) {
+		return -1, err
 	}
-	_, err = t.k8sClient.GetSecret(t.namespace, t.variablesName)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return -1, err
-		}
-		numberOfExistingResources--
+
+	if _, err := t.k8sClient.GetSecret(t.namespace, t.variablesName); err == nil {
+		numberOfExistingResources++
+	} else if err != nil && !apierrors.IsNotFound(err) {
+		return -1, err
 	}
-	_, err = t.k8sClient.GetConfigMap(t.namespace, t.configName)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return -1, err
-		}
-		numberOfExistingResources--
+
+	if _, err := t.k8sClient.GetConfigMap(t.namespace, t.configName); err == nil {
+		numberOfExistingResources++
+	} else if err != nil && !apierrors.IsNotFound(err) {
+		return -1, err
 	}
+
 	if t.variablesEnvironment == nil {
-		return -1, errors.New("no Terraform variable environment provided")
+		return -1, errors.New("no Terraform variables environment provided")
 	}
 
 	// Clean up possible existing job/pod artifacts from previous runs
 	if err := t.EnsureCleanedUp(); err != nil {
 		return -1, err
 	}
+
 	return numberOfExistingResources, nil
+}
+
+// ConfigExists returns true if all three Terraform configuration secrets/configmaps exist, and false otherwise.
+func (t *Terraformer) ConfigExists() (bool, error) {
+	numberOfExistingResources, err := t.prepare()
+	return numberOfExistingResources == numberOfConfigResources, err
 }
 
 // cleanupConfiguration deletes the two ConfigMaps which store the Terraform configuration and state. It also deletes

--- a/pkg/operation/terraformer/terraformer.go
+++ b/pkg/operation/terraformer/terraformer.go
@@ -113,7 +113,7 @@ func (t *Terraformer) execute(scriptName string) error {
 		if numberOfExistingResources == 0 {
 			t.logger.Debug("All ConfigMaps/Secrets do not exist, can not execute the Terraform Job.")
 			return true, nil
-		} else if numberOfExistingResources == 3 {
+		} else if numberOfExistingResources == numberOfConfigResources {
 			t.logger.Debug("All ConfigMaps/Secrets exist, will execute the Terraform Job.")
 			execute = true
 			return true, nil

--- a/pkg/operation/terraformer/types.go
+++ b/pkg/operation/terraformer/types.go
@@ -56,3 +56,5 @@ type Terraformer struct {
 }
 
 var chartPath = filepath.Join(common.ChartPath, "seed-terraformer", "charts")
+
+const numberOfConfigResources = 3


### PR DESCRIPTION
**What this PR does / why we need it**: If the infrastructure has already been deleted we do not need to explicitly delete AWS load balancers and security groups.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
The explicit AWS load balancer and security group deletion is skipped if the infrastructure has already been deleted.
```
