### PR TITLE
Prevent unnecessary restarts of kube-addon-manager

### DIFF
--- a/charts/seed-controlplane/charts/kube-addon-manager/templates/kube-addon-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-addon-manager/templates/kube-addon-manager.yaml
@@ -17,7 +17,12 @@ spec:
     metadata:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        checksum/secret-cloud-config: {{ include (print $.Template.BasePath "/cloud-config.yaml") . | sha256sum }}
+        # The cloud-config secret is excluded from this list on purpose as it contains the bootstrap token which is refreshed every 60 minutes.
+        # In order to not restarting the kube-addon-manager unnecessarily we exclude the checksum of this secret. If the content of the secret
+        # changes it will get re-mounted automatically into the running kube-addon-manager pod (after ~60s). Hence, we can be sure that the
+        # running kube-addon-manager will definitely see the changes and apply them (although it is a little later than if we would restart it
+        # explicitly).
+        # We should again include the checksum when the secret does no longer contain the bootstrap token.
         checksum/secret-storageclasses: {{ include (print $.Template.BasePath "/storageclasses.yaml") . | sha256sum }}
         checksum/secret-core-addons: {{ include (print $.Template.BasePath "/core-addons.yaml") . | sha256sum }}
         checksum/secret-optional-addons: {{ include (print $.Template.BasePath "/optional-addons.yaml") . | sha256sum }}


### PR DESCRIPTION
**What this PR does / why we need it**: The cloud-config secret is now excluded from the checksum annotations of the kube-addon-manager on purpose as it contains the bootstrap token which is refreshed every 60 minutes. In order to prevent unneeded restarts of the kube-addon-manager we exclude the checksum of this secret. If the content of the secret changes it will get re-mounted automatically into the running kube-addon-manager pod (after ~60s). Hence, we can be sure that the running kube-addon-manager will definitely see the changes and apply them (although it is a little later than if we would restart it explicitly).

:warning: We should again include the checksum when the secret does no longer contain the bootstrap token.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
An issue causing unnecessary restarts of the kube-addon-manager pods has been fixed.
```