### PR TITLE
Hotfix 0.12.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -12,7 +12,7 @@ images:
 - name: gardener-external-admission-controller
   sourceRepository: github.com/gardener/gardener
   repository: eu.gcr.io/gardener-project/gardener/external-admission-controller
-  tag: "v2"
+  tag: "v3"
 
 # Seed controlplane
 - name: etcd

--- a/charts/seed-controlplane/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/cluster-autoscaler/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 300Mi
+            memory: 400Mi
           requests:
             cpu: 100m
             memory: 300Mi

--- a/charts/seed-controlplane/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/cluster-autoscaler/templates/deployment.yaml
@@ -51,8 +51,8 @@ spec:
           value: "/var/lib/cluster-autoscaler/kubeconfig"
         resources:
           limits:
-            cpu: 100m
-            memory: 400Mi
+            cpu: 150m
+            memory: 500Mi
           requests:
             cpu: 100m
             memory: 300Mi

--- a/charts/seed-controlplane/charts/kube-addon-manager/templates/kube-addon-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-addon-manager/templates/kube-addon-manager.yaml
@@ -17,7 +17,12 @@ spec:
     metadata:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        checksum/secret-cloud-config: {{ include (print $.Template.BasePath "/cloud-config.yaml") . | sha256sum }}
+        # The cloud-config secret is excluded from this list on purpose as it contains the bootstrap token which is refreshed every 60 minutes.
+        # In order to not restarting the kube-addon-manager unnecessarily we exclude the checksum of this secret. If the content of the secret
+        # changes it will get re-mounted automatically into the running kube-addon-manager pod (after ~60s). Hence, we can be sure that the
+        # running kube-addon-manager will definitely see the changes and apply them (although it is a little later than if we would restart it
+        # explicitly).
+        # We should again include the checksum when the secret does no longer contain the bootstrap token.
         checksum/secret-storageclasses: {{ include (print $.Template.BasePath "/storageclasses.yaml") . | sha256sum }}
         checksum/secret-core-addons: {{ include (print $.Template.BasePath "/core-addons.yaml") . | sha256sum }}
         checksum/secret-optional-addons: {{ include (print $.Template.BasePath "/optional-addons.yaml") . | sha256sum }}

--- a/cmd/gardener-external-admission-controller/main.go
+++ b/cmd/gardener-external-admission-controller/main.go
@@ -164,7 +164,7 @@ func (p *pvInitializerHandler) mutate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	patch := "[]"
-	if isCloudSpecificPersistentVolume(pv) {
+	if pv.DeletionTimestamp == nil && isCloudSpecificPersistentVolume(pv) {
 		switch {
 		case pv.Initializers == nil:
 			patch = fmt.Sprintf(`[{"op": "add", "path": "/metadata/initializers", "value": {"pending": [{"name": "%s"}]}}]`, pvLabelInitializerName)
@@ -173,7 +173,7 @@ func (p *pvInitializerHandler) mutate(w http.ResponseWriter, r *http.Request) {
 		}
 		logger.Infof("Added initializer '%s' for PersistentVolume '%s'", pvLabelInitializerName, pv.Name)
 	} else {
-		logger.Infof("Skipped PersistentVolume '%s' as it is not cloud specific", pv.Name)
+		logger.Infof("Skipped PersistentVolume '%s' as it is marked for deletion or not cloud specific", pv.Name)
 	}
 
 	respond(w, &admissionv1beta1.AdmissionResponse{

--- a/pkg/client/kubernetes/base/apiservices.go
+++ b/pkg/client/kubernetes/base/apiservices.go
@@ -19,16 +19,16 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
-	apiregistrationclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1"
+	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+	apiregistrationclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1"
 )
 
 func (c *Client) apiServices() apiregistrationclientset.APIServiceInterface {
-	return c.apiregistrationClientset.ApiregistrationV1().APIServices()
+	return c.apiregistrationClientset.ApiregistrationV1beta1().APIServices()
 }
 
 // ListAPIServices will list all the APIServices for the given <listOptions>.
-func (c *Client) ListAPIServices(opts metav1.ListOptions) (*apiregistrationv1.APIServiceList, error) {
+func (c *Client) ListAPIServices(opts metav1.ListOptions) (*apiregistrationv1beta1.APIServiceList, error) {
 	return c.apiServices().List(opts)
 }
 

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	apiregistrationclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 )
 
@@ -132,7 +132,7 @@ type Client interface {
 	DeleteCRDForcefully(name string) error
 
 	// APIServices
-	ListAPIServices(metav1.ListOptions) (*apiregistrationv1.APIServiceList, error)
+	ListAPIServices(metav1.ListOptions) (*apiregistrationv1beta1.APIServiceList, error)
 	DeleteAPIService(name string) error
 	DeleteAPIServiceForcefully(name string) error
 

--- a/pkg/controller/shoot/shoot.go
+++ b/pkg/controller/shoot/shoot.go
@@ -317,7 +317,7 @@ func (c *Controller) CollectMetrics(ch chan<- prometheus.Metric) {
 
 func (c *Controller) getShootQueue(obj interface{}) workqueue.RateLimitingInterface {
 	if shoot, ok := obj.(*gardenv1beta1.Shoot); ok {
-		if shootUsedAsSeed, _, _ := helper.IsUsedAsSeed(shoot); shootUsedAsSeed {
+		if shootedSeed, err := helper.ReadShootedSeed(shoot); err == nil && shootedSeed != nil {
 			return c.shootSeedQueue
 		}
 	}

--- a/pkg/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controller/shoot/shoot_control_reconcile.go
@@ -215,8 +215,8 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 
 	// Register the Shoot as Seed cluster if it was annotated properly and in the garden namespace
 	if o.Shoot.Info.Namespace == common.GardenNamespace {
-		if shootUsedAsSeed, protected, visible := helper.IsUsedAsSeed(o.Shoot.Info); shootUsedAsSeed {
-			if err := botanist.RegisterAsSeed(protected, visible); err != nil {
+		if o.ShootedSeed != nil {
+			if err := botanist.RegisterAsSeed(o.ShootedSeed.Protected, o.ShootedSeed.Visible); err != nil {
 				o.Logger.Errorf("Could not register Shoot %q as Seed: %+v", o.Shoot.Info.Name, err)
 			}
 		} else {

--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -163,7 +163,7 @@ func (b *Botanist) ForceDeleteCustomAPIServices() error {
 }
 
 func (b *Botanist) waitForAPIGroupCleanedUp(apiGroupPath []string, resource string) error {
-	if err := wait.PollImmediate(5*time.Second, 10*time.Minute, func() (bool, error) {
+	if err := wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
 		return b.K8sShootClient.CheckResourceCleanup(b.Logger, exceptions, resource, apiGroupPath)
 	}); err != nil {
 		return fmt.Errorf("Error while waiting for cleanup of '%s' resources: '%s'", resource, err.Error())

--- a/pkg/operation/cloudbotanist/awsbotanist/infrastructure.go
+++ b/pkg/operation/cloudbotanist/awsbotanist/infrastructure.go
@@ -63,12 +63,17 @@ func (b *AWSBotanist) DestroyInfrastructure() error {
 		return err
 	}
 
+	canSkipTerraform, err := tf.ConfigExists()
+	if err != nil {
+		return err
+	}
+
 	var (
 		g = flow.NewGraph("AWS infrastructure destruction")
 
 		destroyKubernetesLoadBalancersAndSecurityGroups = g.Add(flow.Task{
 			Name: "Destroying Kubernetes load balancers and security groups",
-			Fn:   flow.TaskFn(b.destroyKubernetesLoadBalancersAndSecurityGroups).RetryUntilTimeout(10*time.Second, 5*time.Minute),
+			Fn:   flow.TaskFn(b.destroyKubernetesLoadBalancersAndSecurityGroups).RetryUntilTimeout(10*time.Second, 5*time.Minute).DoIf(!canSkipTerraform),
 		})
 
 		_ = g.Add(flow.Task{

--- a/pkg/operation/hybridbotanist/addons.go
+++ b/pkg/operation/hybridbotanist/addons.go
@@ -18,7 +18,6 @@ import (
 	"path/filepath"
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
-	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
@@ -168,7 +167,7 @@ func (b *HybridBotanist) generateOptionalAddonsChart() (*chartrenderer.RenderedC
 			},
 		})
 
-		if shootUsedAsSeed, _, _ := helper.IsUsedAsSeed(b.Shoot.Info); shootUsedAsSeed {
+		if b.ShootedSeed != nil {
 			nginxIngressConfig = utils.MergeMaps(nginxIngressConfig, map[string]interface{}{
 				"controller": map[string]interface{}{
 					"resources": map[string]interface{}{

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -19,7 +19,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
@@ -207,10 +206,14 @@ func (b *HybridBotanist) DeployKubeAPIServer() error {
 		return err
 	}
 
-	if shootUsedAsSeed, _, _ := helper.IsUsedAsSeed(b.Shoot.Info); shootUsedAsSeed {
-		defaultValues["replicas"] = 3
-		defaultValues["minReplicas"] = 3
-		defaultValues["maxReplicas"] = 3
+	if b.ShootedSeed != nil {
+		var (
+			apiServer  = b.ShootedSeed.APIServer
+			autoscaler = apiServer.Autoscaler
+		)
+		defaultValues["replicas"] = *apiServer.Replicas
+		defaultValues["minReplicas"] = *autoscaler.MinReplicas
+		defaultValues["maxReplicas"] = autoscaler.MaxReplicas
 		defaultValues["apiServerResources"] = map[string]interface{}{
 			"limits": map[string]interface{}{
 				"cpu":    "1500m",
@@ -303,7 +306,7 @@ func (b *HybridBotanist) DeployKubeControllerManager() error {
 		return err
 	}
 
-	if shootUsedAsSeed, _, _ := helper.IsUsedAsSeed(b.Shoot.Info); shootUsedAsSeed {
+	if b.ShootedSeed != nil {
 		defaultValues["resources"] = map[string]interface{}{
 			"limits": map[string]interface{}{
 				"cpu":    "750m",
@@ -348,7 +351,7 @@ func (b *HybridBotanist) DeployCloudControllerManager() error {
 		return err
 	}
 
-	if shootUsedAsSeed, _, _ := helper.IsUsedAsSeed(b.Shoot.Info); shootUsedAsSeed {
+	if b.ShootedSeed != nil {
 		defaultValues["resources"] = map[string]interface{}{
 			"limits": map[string]interface{}{
 				"cpu":    "500m",
@@ -384,7 +387,7 @@ func (b *HybridBotanist) DeployKubeScheduler() error {
 		return err
 	}
 
-	if shootUsedAsSeed, _, _ := helper.IsUsedAsSeed(b.Shoot.Info); shootUsedAsSeed {
+	if b.ShootedSeed != nil {
 		defaultValues["resources"] = map[string]interface{}{
 			"limits": map[string]interface{}{
 				"cpu":    "300m",

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/externalversions/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -99,6 +100,13 @@ func newOperation(
 			return nil, err
 		}
 		operation.Shoot = shootObj
+
+		shootedSeed, err := helper.ReadShootedSeed(shoot)
+		if err != nil {
+			logger.Warnf("Cannot use shoot %s/%s as shooted seed: %+v", shoot.Namespace, shoot.Name, err)
+		} else {
+			operation.ShootedSeed = shootedSeed
+		}
 	}
 
 	return operation, nil

--- a/pkg/operation/terraformer/config.go
+++ b/pkg/operation/terraformer/config.go
@@ -65,39 +65,42 @@ func (t *Terraformer) DefineConfig(chartName string, values map[string]interface
 // prepare checks whether all required ConfigMaps and Secrets exist. It returns the number of
 // existing ConfigMaps/Secrets, or the error in case something unexpected happens.
 func (t *Terraformer) prepare() (int, error) {
-	// Check whether the required ConfigMaps and the Secret exist
-	numberOfExistingResources := 3
+	numberOfExistingResources := 0
 
-	_, err := t.k8sClient.GetConfigMap(t.namespace, t.stateName)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return -1, err
-		}
-		numberOfExistingResources--
+	if _, err := t.k8sClient.GetConfigMap(t.namespace, t.stateName); err == nil {
+		numberOfExistingResources++
+	} else if err != nil && !apierrors.IsNotFound(err) {
+		return -1, err
 	}
-	_, err = t.k8sClient.GetSecret(t.namespace, t.variablesName)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return -1, err
-		}
-		numberOfExistingResources--
+
+	if _, err := t.k8sClient.GetSecret(t.namespace, t.variablesName); err == nil {
+		numberOfExistingResources++
+	} else if err != nil && !apierrors.IsNotFound(err) {
+		return -1, err
 	}
-	_, err = t.k8sClient.GetConfigMap(t.namespace, t.configName)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return -1, err
-		}
-		numberOfExistingResources--
+
+	if _, err := t.k8sClient.GetConfigMap(t.namespace, t.configName); err == nil {
+		numberOfExistingResources++
+	} else if err != nil && !apierrors.IsNotFound(err) {
+		return -1, err
 	}
+
 	if t.variablesEnvironment == nil {
-		return -1, errors.New("no Terraform variable environment provided")
+		return -1, errors.New("no Terraform variables environment provided")
 	}
 
 	// Clean up possible existing job/pod artifacts from previous runs
 	if err := t.EnsureCleanedUp(); err != nil {
 		return -1, err
 	}
+
 	return numberOfExistingResources, nil
+}
+
+// ConfigExists returns true if all three Terraform configuration secrets/configmaps exist, and false otherwise.
+func (t *Terraformer) ConfigExists() (bool, error) {
+	numberOfExistingResources, err := t.prepare()
+	return numberOfExistingResources == numberOfConfigResources, err
 }
 
 // cleanupConfiguration deletes the two ConfigMaps which store the Terraform configuration and state. It also deletes

--- a/pkg/operation/terraformer/terraformer.go
+++ b/pkg/operation/terraformer/terraformer.go
@@ -113,7 +113,7 @@ func (t *Terraformer) execute(scriptName string) error {
 		if numberOfExistingResources == 0 {
 			t.logger.Debug("All ConfigMaps/Secrets do not exist, can not execute the Terraform Job.")
 			return true, nil
-		} else if numberOfExistingResources == 3 {
+		} else if numberOfExistingResources == numberOfConfigResources {
 			t.logger.Debug("All ConfigMaps/Secrets exist, will execute the Terraform Job.")
 			execute = true
 			return true, nil

--- a/pkg/operation/terraformer/types.go
+++ b/pkg/operation/terraformer/types.go
@@ -56,3 +56,5 @@ type Terraformer struct {
 }
 
 var chartPath = filepath.Join(common.ChartPath, "seed-terraformer", "charts")
+
+const numberOfConfigResources = 3

--- a/pkg/operation/types.go
+++ b/pkg/operation/types.go
@@ -16,6 +16,7 @@ package operation
 
 import (
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/externalversions/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -38,6 +39,7 @@ type Operation struct {
 	Garden               *garden.Garden
 	Seed                 *seed.Seed
 	Shoot                *shoot.Shoot
+	ShootedSeed          *helper.ShootedSeed
 	K8sGardenClient      kubernetes.Client
 	K8sGardenInformers   gardeninformers.Interface
 	K8sSeedClient        kubernetes.Client


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
An issue has been resolved which caused a failure during deletion for Shoot cluster running Kubernetes 1.9.x. The error occurred because in Kubernetes 1.9.x APIServices are only available of version v1beta1. As a consequence, Gardener now uses APIServices v1beta1 instead of v1.
```
```improvement operator
The explicit AWS load balancer and security group deletion is skipped if the infrastructure has already been deleted.
```
```improvement operator
An issue causing unnecessary restarts of the kube-addon-manager pods has been fixed.
```
```improvement user
When deleting a Shoot then Gardener does only wait for the controllers to be active if both deployments for kube-controller-manager and cloud-controller-manager exist.
```
