### PR TITLE
Schedule etcds and kube-apiservers of Shoots with priority

### DIFF
--- a/charts/seed-bootstrap/templates/priorityclass-shoot-controlplane.yaml
+++ b/charts/seed-bootstrap/templates/priorityclass-shoot-controlplane.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: {{ include "priorityclassversion" . }}
+kind: PriorityClass
+metadata:
+  name: gardener-shoot-controlplane
+value: 100
+globalDefault: false
+description: "This class is used to ensure priority scheduling for the etcd's and kube-apiserver pods of Shoot control planes."

--- a/charts/seed-bootstrap/templates/reserve-excess-capacity/deployment.yaml
+++ b/charts/seed-bootstrap/templates/reserve-excess-capacity/deployment.yaml
@@ -32,5 +32,5 @@ spec:
           limits:
             cpu: 500m
             memory: 1200Mi
-      priorityClassName: reserve-excess-capacity
+      priorityClassName: gardener-reserve-excess-capacity
 {{- end }}

--- a/charts/seed-bootstrap/templates/reserve-excess-capacity/priorityclass.yaml
+++ b/charts/seed-bootstrap/templates/reserve-excess-capacity/priorityclass.yaml
@@ -2,8 +2,7 @@
 apiVersion: {{ include "priorityclassversion" . }}
 kind: PriorityClass
 metadata:
-  name: reserve-excess-capacity
-  namespace: {{ .Release.Namespace }}
+  name: gardener-reserve-excess-capacity
 value: -5
 globalDefault: false
 description: "This class is used to reserve excess resource capacity on a cluster"

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
@@ -46,6 +46,7 @@ spec:
         app: etcd-statefulset
         role: {{ .Values.role }}
     spec:
+      priorityClassName: gardener-shoot-controlplane
       containers:
       - name: etcd
         image: {{ index .Values.images "etcd" }}

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
@@ -27,6 +27,7 @@ spec:
         app: kubernetes
         role: apiserver
     spec:
+      priorityClassName: gardener-shoot-controlplane
       tolerations:
       - effect: NoExecute
         operator: Exists


### PR DESCRIPTION
**What this PR does / why we need it**: We should schedule the most critical components of a Shoot's control plane with priority in the Seeds. With this PR we give the etcds and kube-apiserver pods of Shoots a priority of `100`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
Gardener does now schedule the etcd and kube-apiserver pods of the Shoot control planes with priority in the Seeds. Rolling out this change will result in rescheduling all existing etcd and kube-apiserver pods.
```
