### PR TITLE
Increase scrape_timeout for kube-controller-manager

### DIFF
--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -217,6 +217,7 @@ data:
 
     - job_name: kube-controller-manager
       honor_labels: false
+      scrape_timeout: 15s
       kubernetes_sd_configs:
       - role: endpoints
         namespaces:


### PR DESCRIPTION
After v1.11, the amount of metrics generated by `kube-controller-manager` increased several times. See
https://github.com/kubernetes/kubernetes/pull/68530

We drop all those metrics, but it takes extra time for Prometheus to scrape this endpoint, resulting in a timeout.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
