### PR TITLE
Smooth kubelet update via docker image preload

### DIFF
--- a/charts/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -47,7 +47,7 @@ spec:
         operator: Exists
       containers:
       - name: cloud-controller-manager
-        image: {{ index .Values.images "hyperkube" }}:v{{ .Values.kubernetesVersion }}
+        image: {{ index .Values.images "hyperkube" }}
         imagePullPolicy: IfNotPresent
         command:
         - /hyperkube

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
@@ -33,7 +33,7 @@ spec:
         operator: Exists
       containers:
       - name: kube-apiserver
-        image: {{ index .Values.images "hyperkube" }}:v{{ .Values.kubernetesVersion }}
+        image: {{ index .Values.images "hyperkube" }}
         imagePullPolicy: IfNotPresent
         command:
         - /hyperkube

--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -47,7 +47,7 @@ spec:
         operator: Exists
       containers:
       - name: kube-controller-manager
-        image: {{ index .Values.images "hyperkube" }}:v{{ .Values.kubernetesVersion }}
+        image: {{ index .Values.images "hyperkube" }}
         imagePullPolicy: IfNotPresent
         command:
         - /hyperkube

--- a/charts/seed-controlplane/charts/kube-scheduler/templates/kube-scheduler.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/templates/kube-scheduler.yaml
@@ -48,7 +48,7 @@ spec:
         operator: Exists
       containers:
       - name: kube-scheduler
-        image: {{ index .Values.images "hyperkube" }}:v{{ .Values.kubernetesVersion }}
+        image: {{ index .Values.images "hyperkube" }}
         imagePullPolicy: IfNotPresent
         command:
         - /hyperkube

--- a/charts/shoot-cloud-config/charts/downloader/templates/cloud-config/_download-cloud-config.sh
+++ b/charts/shoot-cloud-config/charts/downloader/templates/cloud-config/_download-cloud-config.sh
@@ -33,6 +33,12 @@ if ! BOOTSTRAP_TOKEN="$(kubectl --namespace=kube-system get secret "$SECRET_NAME
   exit 1
 fi
 
+IMAGES="$(kubectl --namespace=kube-system get secret "$SECRET_NAME" -o jsonpath='{.data.images}')";
+if [[ "$IMAGES" != "" ]]; then
+  echo "Preloading docker images"
+  echo "$IMAGES" | base64 -d | docker run -i {{ index .Values.images "ruby" }} ruby -e 'require "json"; puts JSON::load(STDIN.read).values.compact' | xargs docker pull
+fi
+
 base64 -d <<< $CLOUD_CONFIG > "$PATH_CLOUDCONFIG"
 if [ ! -f "$PATH_CLOUDCONFIG" ]; then
   echo "No cloud config file found at location $PATH_CLOUDCONFIG"

--- a/charts/shoot-cloud-config/charts/original/templates/cloud-config-secret.yaml
+++ b/charts/shoot-cloud-config/charts/original/templates/cloud-config-secret.yaml
@@ -10,4 +10,5 @@ metadata:
 data:
   bootstrapToken: {{ b64enc $.Values.kubernetes.kubelet.bootstrapToken }}
   cloudconfig: {{ include "cloud-config.user-data" (set $.Values "worker" $value) | b64enc }}
+  images: {{ $.Values.images | toJson | b64enc }}
 {{- end }}

--- a/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet.service
+++ b/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet.service
@@ -15,7 +15,7 @@
     Restart=always
     RestartSec=10
     EnvironmentFile=/etc/environment
-    ExecStartPre=/bin/docker run --rm -v /opt/bin:/opt/bin:rw {{ required "images.hyperkube is required" .images.hyperkube }}:v{{ required "kubernetes.version is required" .kubernetes.version }} cp /hyperkube /opt/bin/
+    ExecStartPre=/bin/docker run --rm -v /opt/bin:/opt/bin:rw {{ required "images.hyperkube is required" .images.hyperkube }} cp /hyperkube /opt/bin/
 {{- if .kubernetes.kubelet.hostnameOverride }}
     ExecStartPre=/bin/sh -c 'hostnamectl set-hostname $(echo $HOSTNAME | cut -d '.' -f 1)'
 {{- end }}

--- a/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: {{ index .Values.images "hyperkube" }}:{{ .Capabilities.KubeVersion }}
+        image: {{ index .Values.images "hyperkube" }}
         imagePullPolicy: IfNotPresent
         command:
         - /hyperkube

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -180,7 +180,7 @@ func (b *Botanist) DeployMachineControllerManager() error {
 		}
 	)
 
-	values, err := b.InjectImages(defaultValues, b.K8sSeedClient.Version(), map[string]string{name: name})
+	values, err := b.InjectImages(defaultValues, b.SeedVersion(), b.ShootVersion(), common.MachineControllerManagerImageName)
 	if err != nil {
 		return err
 	}
@@ -229,7 +229,7 @@ func (b *Botanist) DeployClusterAutoscaler() error {
 		"workerPools": workerPools,
 	}
 
-	values, err := b.InjectImages(defaultValues, b.K8sSeedClient.Version(), map[string]string{name: name})
+	values, err := b.InjectImages(defaultValues, b.SeedVersion(), b.ShootVersion(), common.ClusterAutoscalerImageName)
 	if err != nil {
 		return err
 	}
@@ -312,28 +312,28 @@ func (b *Botanist) DeploySeedMonitoring() error {
 		}
 	)
 
-	alertManager, err := b.InjectImages(alertManagerConfig, b.K8sSeedClient.Version(), map[string]string{"alertmanager": "alertmanager", "configmap-reloader": "configmap-reloader"})
+	alertManager, err := b.InjectImages(alertManagerConfig, b.SeedVersion(), b.ShootVersion(), common.AlertManagerImageName, common.ConfigMapReloaderImageName)
 	if err != nil {
 		return err
 	}
-	grafana, err := b.InjectImages(grafanaConfig, b.K8sSeedClient.Version(), map[string]string{"grafana": "grafana", "busybox": "busybox"})
+	grafana, err := b.InjectImages(grafanaConfig, b.SeedVersion(), b.ShootVersion(), common.GrafanaImageName, common.BusyboxImageName)
 	if err != nil {
 		return err
 	}
-	prometheus, err := b.InjectImages(prometheusConfig, b.K8sSeedClient.Version(), map[string]string{
-		"prometheus":         "prometheus",
-		"configmap-reloader": "configmap-reloader",
-		"vpn-seed":           "vpn-seed",
-		"blackbox-exporter":  "blackbox-exporter",
-	})
+	prometheus, err := b.InjectImages(prometheusConfig, b.SeedVersion(), b.ShootVersion(),
+		common.PrometheusImageName,
+		common.ConfigMapReloaderImageName,
+		common.VPNSeedImageName,
+		common.BlackboxExporterImageName,
+	)
 	if err != nil {
 		return err
 	}
-	kubeStateMetricsSeed, err := b.InjectImages(kubeStateMetricsSeedConfig, b.K8sSeedClient.Version(), map[string]string{"kube-state-metrics": "kube-state-metrics"})
+	kubeStateMetricsSeed, err := b.InjectImages(kubeStateMetricsSeedConfig, b.SeedVersion(), b.ShootVersion(), common.KubeStateMetricsImageName)
 	if err != nil {
 		return err
 	}
-	kubeStateMetricsShoot, err := b.InjectImages(kubeStateMetricsShootConfig, b.K8sSeedClient.Version(), map[string]string{"kube-state-metrics": "kube-state-metrics"})
+	kubeStateMetricsShoot, err := b.InjectImages(kubeStateMetricsShootConfig, b.SeedVersion(), b.ShootVersion(), common.KubeStateMetricsImageName)
 	if err != nil {
 		return err
 	}

--- a/pkg/operation/cloudbotanist/awsbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/awsbotanist/controlplane.go
@@ -214,7 +214,7 @@ func (b *AWSBotanist) DeployCloudSpecificControlPlane() error {
 		}
 	)
 
-	values, err := b.InjectImages(defaultValues, b.K8sSeedClient.Version(), map[string]string{name: name})
+	values, err := b.InjectImages(defaultValues, b.SeedVersion(), b.ShootVersion(), common.AWSLBReadvertiserImageName)
 	if err != nil {
 		return err
 	}

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -251,6 +251,108 @@ const (
 
 	// BackupNamespacePrefix is a constant for backup namespace created for shoot's backup infrastructure related resources.
 	BackupNamespacePrefix = "backup"
+
+	// KubeAddonManagerImageName is the name of the KubeAddonManager image.
+	KubeAddonManagerImageName = "kube-addon-manager"
+
+	// CalicoNodeImageName is the name of the CalicoNode image.
+	CalicoNodeImageName = "calico-node"
+
+	// CalicoCNIImageName is the name of the CalicoCNI image.
+	CalicoCNIImageName = "calico-cni"
+
+	// CalicoTyphaImageName is the name of the CalicoTypha image.
+	CalicoTyphaImageName = "calico-typha"
+
+	// CoreDNSImageName is the name of the CoreDNS image.
+	CoreDNSImageName = "coredns"
+
+	// HyperkubeImageName is the name of the Hyperkube image.
+	HyperkubeImageName = "hyperkube"
+
+	// MetricsServerImageName is the name of the MetricsServer image.
+	MetricsServerImageName = "metrics-server"
+
+	// VPNShootImageName is the name of the VPNShoot image.
+	VPNShootImageName = "vpn-shoot"
+
+	// VPNSeedImageName is the name of the VPNSeed image.
+	VPNSeedImageName = "vpn-seed"
+
+	// NodeExporterImageName is the name of the NodeExporter image.
+	NodeExporterImageName = "node-exporter"
+
+	// HelmTillerImageName is the name of the HelmTiller image.
+	HelmTillerImageName = "helm-tiller"
+
+	// KubeLegoImageName is the name of the KubeLego image.
+	KubeLegoImageName = "kube-lego"
+
+	// Kube2IAMImageName is the name of the Kube2IAM image.
+	Kube2IAMImageName = "kube2iam"
+
+	// KubernetesDashboardImageName is the name of the KubernetesDashboard image.
+	KubernetesDashboardImageName = "kubernetes-dashboard"
+
+	// MonocularAPIImageName is the name of the MonocularAPI image.
+	MonocularAPIImageName = "monocular-api"
+
+	// MonocularUIImageName is the name of the MonocularUI image.
+	MonocularUIImageName = "monocular-ui"
+
+	// BusyboxImageName is the name of the Busybox image.
+	BusyboxImageName = "busybox"
+
+	// NginxIngressControllerImageName is the name of the NginxIngressController image.
+	NginxIngressControllerImageName = "nginx-ingress-controller"
+
+	// IngressDefaultBackendImageName is the name of the IngressDefaultBackend image.
+	IngressDefaultBackendImageName = "ingress-default-backend"
+
+	// MachineControllerManagerImageName is the name of the MachineControllerManager image.
+	MachineControllerManagerImageName = "machine-controller-manager"
+
+	// ClusterAutoscalerImageName is the name of the ClusterAutoscaler image.
+	ClusterAutoscalerImageName = "cluster-autoscaler"
+
+	// AlertManagerImageName is the name of the AlertManager image.
+	AlertManagerImageName = "alertmanager"
+
+	// ConfigMapReloaderImageName is the name of the ConfigMapReloader image.
+	ConfigMapReloaderImageName = "configmap-reloader"
+
+	// GrafanaImageName is the name of the Grafana image.
+	GrafanaImageName = "grafana"
+
+	// PrometheusImageName is the name of the Prometheus image.
+	PrometheusImageName = "prometheus"
+
+	// BlackboxExporterImageName is the name of the BlackboxExporter image.
+	BlackboxExporterImageName = "blackbox-exporter"
+
+	// KubeStateMetricsImageName is the name of the KubeStateMetrics image.
+	KubeStateMetricsImageName = "kube-state-metrics"
+
+	// ETCDImageName is the name of the ETCD image.
+	ETCDImageName = "etcd"
+
+	// ETCDBackupRestoreImageName is the name of the ETCDBackupRestore image.
+	ETCDBackupRestoreImageName = "etcd-backup-restore"
+
+	// RubyImageName is the name of the Ruby image.
+	RubyImageName = "ruby"
+
+	// AWSLBReadvertiserImageName is the name of the AWSLBReadvertiser image.
+	AWSLBReadvertiserImageName = "aws-lb-readvertiser"
+
+	// PauseContainerImageName is the name of the PauseContainer image.
+	PauseContainerImageName = "pause-container"
+
+	// GardenerExternalAdmissionControllerImageName is the name of the GardenerExternalAdmissionController image.
+	GardenerExternalAdmissionControllerImageName = "gardener-external-admission-controller"
+
+	// TerraformerImageName is the name of the Terraformer image.
+	TerraformerImageName = "terraformer"
 )
 
 // CloudConfigUserDataConfig is a struct containing cloud-specific configuration required to

--- a/pkg/operation/hybridbotanist/addon_manager.go
+++ b/pkg/operation/hybridbotanist/addon_manager.go
@@ -68,7 +68,7 @@ func (b *HybridBotanist) DeployKubeAddonManager() error {
 		},
 	}
 
-	values, err := b.Botanist.InjectImages(defaultValues, b.K8sSeedClient.Version(), map[string]string{"kube-addon-manager": "kube-addon-manager"})
+	values, err := b.Botanist.InjectImages(defaultValues, b.SeedVersion(), b.ShootVersion(), common.KubeAddonManagerImageName)
 	if err != nil {
 		return err
 	}

--- a/pkg/operation/hybridbotanist/addons.go
+++ b/pkg/operation/hybridbotanist/addons.go
@@ -86,27 +86,27 @@ func (b *HybridBotanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart
 		vpnShootConfig["diffieHellmanKey"] = openvpnDiffieHellmanSecret.Data["dh2048.pem"]
 	}
 
-	calico, err := b.Botanist.InjectImages(calicoConfig, b.K8sShootClient.Version(), map[string]string{"calico-node": "calico-node", "calico-cni": "calico-cni", "calico-typha": "calico-typha"})
+	calico, err := b.Botanist.InjectImages(calicoConfig, b.ShootVersion(), b.ShootVersion(), common.CalicoNodeImageName, common.CalicoCNIImageName, common.CalicoTyphaImageName)
 	if err != nil {
 		return nil, err
 	}
-	coreDNS, err := b.Botanist.InjectImages(coreDNSConfig, b.K8sShootClient.Version(), map[string]string{"coredns": "coredns"})
+	coreDNS, err := b.Botanist.InjectImages(coreDNSConfig, b.ShootVersion(), b.ShootVersion(), common.CoreDNSImageName)
 	if err != nil {
 		return nil, err
 	}
-	kubeProxy, err := b.Botanist.InjectImages(kubeProxyConfig, b.K8sShootClient.Version(), map[string]string{"hyperkube": "hyperkube"})
+	kubeProxy, err := b.Botanist.InjectImages(kubeProxyConfig, b.ShootVersion(), b.ShootVersion(), common.HyperkubeImageName)
 	if err != nil {
 		return nil, err
 	}
-	metricsServer, err := b.Botanist.InjectImages(metricsServerConfig, b.K8sShootClient.Version(), map[string]string{"metrics-server": "metrics-server"})
+	metricsServer, err := b.Botanist.InjectImages(metricsServerConfig, b.ShootVersion(), b.ShootVersion(), common.MetricsServerImageName)
 	if err != nil {
 		return nil, err
 	}
-	vpnShoot, err := b.Botanist.InjectImages(vpnShootConfig, b.K8sShootClient.Version(), map[string]string{"vpn-shoot": "vpn-shoot"})
+	vpnShoot, err := b.Botanist.InjectImages(vpnShootConfig, b.ShootVersion(), b.ShootVersion(), common.VPNShootImageName)
 	if err != nil {
 		return nil, err
 	}
-	nodeExporter, err := b.Botanist.InjectImages(nodeExporterConfig, b.K8sShootClient.Version(), map[string]string{"node-exporter": "node-exporter"})
+	nodeExporter, err := b.Botanist.InjectImages(nodeExporterConfig, b.ShootVersion(), b.ShootVersion(), common.NodeExporterImageName)
 	if err != nil {
 		return nil, err
 	}
@@ -183,27 +183,27 @@ func (b *HybridBotanist) generateOptionalAddonsChart() (*chartrenderer.RenderedC
 		}
 	}
 
-	helmTiller, err := b.Botanist.InjectImages(helmTillerConfig, b.K8sShootClient.Version(), map[string]string{"helm-tiller": "helm-tiller"})
+	helmTiller, err := b.Botanist.InjectImages(helmTillerConfig, b.ShootVersion(), b.ShootVersion(), common.HelmTillerImageName)
 	if err != nil {
 		return nil, err
 	}
-	kubeLego, err := b.Botanist.InjectImages(kubeLegoConfig, b.K8sShootClient.Version(), map[string]string{"kube-lego": "kube-lego"})
+	kubeLego, err := b.Botanist.InjectImages(kubeLegoConfig, b.ShootVersion(), b.ShootVersion(), common.KubeLegoImageName)
 	if err != nil {
 		return nil, err
 	}
-	kube2IAM, err := b.Botanist.InjectImages(kube2IAMConfig, b.K8sShootClient.Version(), map[string]string{"kube2iam": "kube2iam"})
+	kube2IAM, err := b.Botanist.InjectImages(kube2IAMConfig, b.ShootVersion(), b.ShootVersion(), common.Kube2IAMImageName)
 	if err != nil {
 		return nil, err
 	}
-	kubernetesDashboard, err := b.Botanist.InjectImages(kubernetesDashboardConfig, b.K8sShootClient.Version(), map[string]string{"kubernetes-dashboard": "kubernetes-dashboard"})
+	kubernetesDashboard, err := b.Botanist.InjectImages(kubernetesDashboardConfig, b.ShootVersion(), b.ShootVersion(), common.KubernetesDashboardImageName)
 	if err != nil {
 		return nil, err
 	}
-	monocular, err := b.Botanist.InjectImages(monocularConfig, b.K8sShootClient.Version(), map[string]string{"monocular-api": "monocular-api", "monocular-ui": "monocular-ui", "busybox": "busybox"})
+	monocular, err := b.Botanist.InjectImages(monocularConfig, b.ShootVersion(), b.ShootVersion(), common.MonocularAPIImageName, common.MonocularUIImageName, common.BusyboxImageName)
 	if err != nil {
 		return nil, err
 	}
-	nginxIngress, err := b.Botanist.InjectImages(nginxIngressConfig, b.K8sShootClient.Version(), map[string]string{"nginx-ingress-controller": "nginx-ingress-controller", "ingress-default-backend": "ingress-default-backend"})
+	nginxIngress, err := b.Botanist.InjectImages(nginxIngressConfig, b.ShootVersion(), b.ShootVersion(), common.NginxIngressControllerImageName, common.IngressDefaultBackendImageName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/hybridbotanist/cloud_config.go
+++ b/pkg/operation/hybridbotanist/cloud_config.go
@@ -55,11 +55,6 @@ func (b *HybridBotanist) generateCloudConfigChart() (*chartrenderer.RenderedChar
 		cloudProvider["config"] = cloudProviderConfig
 	}
 
-	hyperKube, err := b.ImageVector.FindImage("hyperkube", b.Shoot.Info.Spec.Kubernetes.Version)
-	if err != nil {
-		return nil, err
-	}
-
 	workers := []map[string]interface{}{}
 	for _, workerName := range userDataConfig.WorkerNames {
 		workers = append(workers, map[string]interface{}{
@@ -83,10 +78,12 @@ func (b *HybridBotanist) generateCloudConfigChart() (*chartrenderer.RenderedChar
 			},
 			"version": b.Shoot.Info.Spec.Kubernetes.Version,
 		},
-		"images": map[string]interface{}{
-			"hyperkube": hyperKube.String(),
-		},
 		"workers": workers,
+	}
+
+	config, err = b.InjectImages(config, b.ShootVersion(), b.ShootVersion(), common.HyperkubeImageName)
+	if err != nil {
+		return nil, err
 	}
 
 	kubeletConfig := b.Shoot.Info.Spec.Kubernetes.Kubelet

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -101,7 +101,7 @@ func (b *HybridBotanist) DeployETCD() error {
 		etcdConfig["backup"] = backupConfigData
 	}
 
-	etcd, err := b.Botanist.InjectImages(etcdConfig, b.K8sSeedClient.Version(), map[string]string{"etcd": "etcd", "etcd-backup-restore": "etcd-backup-restore"})
+	etcd, err := b.Botanist.InjectImages(etcdConfig, b.SeedVersion(), b.ShootVersion(), common.ETCDImageName, common.ETCDBackupRestoreImageName)
 	if err != nil {
 		return err
 	}
@@ -272,11 +272,11 @@ func (b *HybridBotanist) DeployKubeAPIServer() error {
 	}
 	defaultValues["admissionPlugins"] = admissionPlugins
 
-	values, err := b.Botanist.InjectImages(defaultValues, b.K8sSeedClient.Version(), map[string]string{
-		"hyperkube":         "hyperkube",
-		"vpn-seed":          "vpn-seed",
-		"blackbox-exporter": "blackbox-exporter",
-	})
+	values, err := b.Botanist.InjectImages(defaultValues, b.SeedVersion(), b.ShootVersion(),
+		common.HyperkubeImageName,
+		common.VPNSeedImageName,
+		common.BlackboxExporterImageName,
+	)
 	if err != nil {
 		return err
 	}
@@ -324,7 +324,7 @@ func (b *HybridBotanist) DeployKubeControllerManager() error {
 		}
 	}
 
-	values, err := b.Botanist.InjectImages(defaultValues, b.K8sSeedClient.Version(), map[string]string{"hyperkube": "hyperkube"})
+	values, err := b.Botanist.InjectImages(defaultValues, b.SeedVersion(), b.ShootVersion(), common.HyperkubeImageName)
 	if err != nil {
 		return err
 	}
@@ -365,7 +365,7 @@ func (b *HybridBotanist) DeployCloudControllerManager() error {
 		defaultValues["featureGates"] = cloudControllerManagerConfig.FeatureGates
 	}
 
-	values, err := b.Botanist.InjectImages(defaultValues, b.K8sSeedClient.Version(), map[string]string{"hyperkube": "hyperkube"})
+	values, err := b.Botanist.InjectImages(defaultValues, b.SeedVersion(), b.ShootVersion(), common.HyperkubeImageName)
 	if err != nil {
 		return err
 	}
@@ -401,7 +401,7 @@ func (b *HybridBotanist) DeployKubeScheduler() error {
 		defaultValues["featureGates"] = schedulerConfig.FeatureGates
 	}
 
-	values, err := b.Botanist.InjectImages(defaultValues, b.K8sSeedClient.Version(), map[string]string{"hyperkube": "hyperkube"})
+	values, err := b.Botanist.InjectImages(defaultValues, b.SeedVersion(), b.ShootVersion(), common.HyperkubeImageName)
 	if err != nil {
 		return err
 	}

--- a/pkg/operation/terraformer/terraformer.go
+++ b/pkg/operation/terraformer/terraformer.go
@@ -51,7 +51,7 @@ func New(logger *logrus.Entry, k8sClient kubernetes.Client, purpose, name, names
 		podSuffix = utils.ComputeSHA256Hex([]byte(time.Now().String()))[:5]
 		image     string
 	)
-	if img, _ := imageVector.FindImage("terraformer", k8sClient.Version()); img != nil {
+	if img, _ := imageVector.FindImage(common.TerraformerImageName, k8sClient.Version(), k8sClient.Version()); img != nil {
 		image = img.String()
 	}
 

--- a/pkg/utils/imagevector/types.go
+++ b/pkg/utils/imagevector/types.go
@@ -14,15 +14,22 @@
 
 package imagevector
 
-// Image contains the repository and the tag of a Docker container image. If the respective
+// ImageSource contains the repository and the tag of a Docker container image. If the respective
 // image is only valid for a specific Kubernetes version, then it must also contain the 'versions'
 // field describing for which versions it can be used.
-type Image struct {
+type ImageSource struct {
 	Name       string `json:"name" yaml:"name"`
 	Repository string `json:"repository" yaml:"repository"`
 	Tag        string `json:"tag" yaml:"tag"`
 	Versions   string `json:"versions" yaml:"versions"`
 }
 
-// ImageVector is a list of Docker container images.
-type ImageVector []*Image
+// Image is a concrete, pullable image with a nonempty tag.
+type Image struct {
+	Name       string
+	Repository string
+	Tag        string
+}
+
+// ImageVector is a list of image sources.
+type ImageVector []*ImageSource


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhance Kubelet restart by preloading Hyperkube image.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
:warning: Kubelet version updates are now smoother as the new `hyperkube` image will be preloaded in advance. Rolling out this change will result in a rolling update of all worker nodes.
```
