### PR TITLE
Monitor missing components for the Shoot control plane

### DIFF
--- a/charts/seed-controlplane/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/cluster-autoscaler/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - ./cluster-autoscaler
+        - --address=:{{ .Values.metricsPort }}
         - --kubeconfig=/var/lib/cluster-autoscaler/kubeconfig
         - --cloud-provider=mcm
         {{- range $key, $pool := .Values.workerPools }}

--- a/charts/seed-controlplane/charts/cluster-autoscaler/templates/service.yaml
+++ b/charts/seed-controlplane/charts/cluster-autoscaler/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-autoscaler
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: kubernetes
+    role: cluster-autoscaler
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: {{ .Values.metricsPort }}
+    protocol: TCP
+  selector:
+    app: kubernetes
+    role: cluster-autoscaler

--- a/charts/seed-controlplane/charts/cluster-autoscaler/values.yaml
+++ b/charts/seed-controlplane/charts/cluster-autoscaler/values.yaml
@@ -11,3 +11,5 @@ workerPools:
 - name: foo
   min: 1
   max: 3
+
+metricsPort: 8085

--- a/charts/seed-controlplane/charts/machine-controller-manager/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/machine-controller-manager/templates/deployment.yaml
@@ -39,12 +39,13 @@ spec:
         - --machine-set-scale-timeout=40
         - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
         - --namespace={{ .Release.Namespace }}
+        - --port={{ .Values.metricsPort }}
         - --v=2
         livenessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 10258
+            port: {{ .Values.metricsPort }}
             scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 10

--- a/charts/seed-controlplane/charts/machine-controller-manager/templates/service.yaml
+++ b/charts/seed-controlplane/charts/machine-controller-manager/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: machine-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: kubernetes
+    role: machine-controller-manager
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: {{ .Values.metricsPort }}
+    protocol: TCP
+  selector:
+    app: kubernetes
+    role: machine-controller-manager

--- a/charts/seed-controlplane/charts/machine-controller-manager/values.yaml
+++ b/charts/seed-controlplane/charts/machine-controller-manager/values.yaml
@@ -6,3 +6,5 @@ images:
 
 namespace:
   uid: uuid-of-namespace
+
+metricsPort: 10258

--- a/charts/seed-monitoring/charts/prometheus/rules/cloud-controller-manager.rules.yml
+++ b/charts/seed-monitoring/charts/prometheus/rules/cloud-controller-manager.rules.yml
@@ -1,0 +1,15 @@
+groups:
+- name: cloud-controller-manager.rules
+  rules:
+  - alert: CloudControllerManagerDown
+    expr: absent(up{job="cloud-controller-manager"} == 1)
+    for: 7m
+    labels:
+      job: cloud-controller-manager
+      service: cloud-controller-manager
+      severity: critical
+      type: seed
+    annotations:
+      description: There is no running K8S cloud controller manager. Cloud specific resources
+        such as loadbalancers and persistent volumes are not reconcilded.
+      summary: Cloud controller manager is down

--- a/charts/seed-monitoring/charts/prometheus/rules/cluster-autoscaler.rules.yml
+++ b/charts/seed-monitoring/charts/prometheus/rules/cluster-autoscaler.rules.yml
@@ -1,0 +1,15 @@
+groups:
+- name: cluster-autoscaler.rules
+  rules:
+  - alert: ClusterAutoscallerDown
+    expr: absent(up{job="cluster-autoscaler"} == 1)
+    for: 7m
+    labels:
+      job: cluster-autoscaler
+      service: cluster-autoscaler
+      severity: critical
+      type: seed
+    annotations:
+      description: There is no running cluster autoscaler. Shoot's Nodes wont
+        be scaled dynamically, based on the load.
+      summary: Cluster autoscaler is down

--- a/charts/seed-monitoring/charts/prometheus/rules/machine-controller-manager.rules.yml
+++ b/charts/seed-monitoring/charts/prometheus/rules/machine-controller-manager.rules.yml
@@ -1,0 +1,15 @@
+groups:
+- name: machine-controller-manager.rules
+  rules:
+  - alert: MachineControllerManagerDown
+    expr: absent(up{job="machine-controller-manager"} == 1)
+    for: 5m
+    labels:
+      job: machine-controller-manager
+      service: machine-controller-manager
+      severity: critical
+      type: seed
+    annotations:
+      description: There is no running machine controller manager. No Shoot Nodes
+        can be created.
+      summary: Machine controller manager is down

--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -276,6 +276,46 @@ data:
       metric_relabel_configs:
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.cloudControllerManager | indent 6 }}
 
+    - job_name: cluster-autoscaler
+      honor_labels: false
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [{{ .Release.Namespace }}]
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+        action: keep
+        regex: cluster-autoscaler;metrics
+      # common metrics
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.clusterAutoscaler | indent 6 }}
+
+    - job_name: machine-controller-manager
+      honor_labels: false
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [{{ .Release.Namespace }}]
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+        action: keep
+        regex: machine-controller-manager;metrics
+      # common metrics
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.machineControllerManager | indent 6 }}
+
     - job_name: alertmanager
       honor_labels: false
       kubernetes_sd_configs:

--- a/charts/seed-monitoring/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/prometheus/values.yaml
@@ -55,6 +55,9 @@ allowedMetrics:
   cloudControllerManager:
   - process_max_fds
   - process_open_fds
+  clusterAutoscaler:
+  - process_max_fds
+  - process_open_fds
   kubeAPIServer:
   - apiserver_request_count
   - apiserver_request_latencies_bucket
@@ -112,6 +115,9 @@ allowedMetrics:
   - kube_statefulset_replicas
   - kube_statefulset_status_observed_generation
   - kube_statefulset_status_replicas
+  - process_max_fds
+  - process_open_fds
+  machineControllerManager:
   - process_max_fds
   - process_open_fds
   nodeExporter:


### PR DESCRIPTION
Added alets and scrape configuration for
- cluster-autoscaler
- machine-controller-manager
- cloud-controller-manager

**What this PR does / why we need it**: Improves monitoring capabilities

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
New metrics scraping and alerting rules for `cluster-autoscaler`, `machine-controller-manager` and `cloud-controller-manager` have been added.
```
