### PR TITLE
Change delta snapshot time interval from 10 seconds to five minutes.

### DIFF
--- a/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
@@ -114,6 +114,7 @@ spec:
         - --insecure-skip-tls-verify=false
         - --endpoints=https://etcd-{{ .Values.role }}-0:2379
         - --etcd-connection-timeout=300
+        - --delta-snapshot-period-seconds=300
         image: {{ index .Values.images "etcd-backup-restore" }}
         imagePullPolicy: IfNotPresent
         ports:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the incremental snapshot update time interval from 10 seconds to 5 minutes. Currently, the backup bucket is inundated with a large number of incremental snapshots at 10 second intervals. 

**Which issue(s) this PR fixes**:
Fixes #
Reduces the incremental snapshot taken in between full snapshots.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
The incremental snapshot period for etcd has been reduced from `10s` to `5m` to reduce load on the backing blob storages.
```
