### PR TITLE
Increasing resource requests and limits for kube-apiserver to avoid frequent scaling

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -73,4 +73,4 @@ apiServerResources:
 
 maxReplicas: 1
 minReplicas: 1
-targetAverageUtilization: 60
+targetAverageUtilization: 80

--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -74,6 +74,7 @@ spec:
         {{- include "kube-controller-manager.featureGates" . | trimSuffix "," | indent 8 }}
         - --horizontal-pod-autoscaler-downscale-delay={{ .Values.horizontalPodAutoscaler.downscaleDelay }}
         - --horizontal-pod-autoscaler-upscale-delay={{ .Values.horizontalPodAutoscaler.upscaleDelay }}
+        - --horizontal-pod-autoscaler-tolerance={{ .Values.horizontalPodAutoscaler.tolerance }}
         - --kubeconfig=/var/lib/kube-controller-manager/kubeconfig
         - --leader-elect=true
         - --pod-eviction-timeout=2m0s

--- a/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
@@ -22,3 +22,4 @@ resources:
 horizontalPodAutoscaler:
   downscaleDelay: 15m
   upscaleDelay: 1m
+  tolerance: 0.2

--- a/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
@@ -22,4 +22,4 @@ resources:
 horizontalPodAutoscaler:
   downscaleDelay: 15m
   upscaleDelay: 1m
-  tolerance: 0.2
+  tolerance: 0.1

--- a/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
@@ -100,7 +100,7 @@ spec:
             cpu: 50m
             memory: 1200Mi
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 2400Mi
         volumeMounts:
         - mountPath: /srv/kubernetes/prometheus-kubelet

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -316,6 +316,7 @@ func (b *HybridBotanist) DeployKubeControllerManager() error {
 		defaultValues["horizontalPodAutoscaler"] = map[string]interface{}{
 			"downscaleDelay": "24h",
 			"upscaleDelay":   "1m",
+			"tolerance":      0.2,
 		}
 	}
 

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -37,31 +37,31 @@ func getResourcesForAPIServer(nodeCount int) (string, string, string, string) {
 
 	switch {
 	case nodeCount <= 2:
-		cpuRequest = "100m"
-		memoryRequest = "512Mi"
+		cpuRequest = "800m"
+		memoryRequest = "600Mi"
 
-		cpuLimit = "400m"
-		memoryLimit = "700Mi"
+		cpuLimit = "1000m"
+		memoryLimit = "900Mi"
 	case nodeCount <= 10:
-		cpuRequest = "400m"
-		memoryRequest = "700Mi"
+		cpuRequest = "1000m"
+		memoryRequest = "800Mi"
 
-		cpuLimit = "800m"
-		memoryLimit = "1000Mi"
+		cpuLimit = "1200m"
+		memoryLimit = "1400Mi"
 	case nodeCount <= 50:
-		cpuRequest = "700m"
-		memoryRequest = "1000Mi"
+		cpuRequest = "1200m"
+		memoryRequest = "1200Mi"
 
-		cpuLimit = "1300m"
-		memoryLimit = "2000Mi"
+		cpuLimit = "1500m"
+		memoryLimit = "3000Mi"
 	case nodeCount <= 100:
-		cpuRequest = "1500m"
-		memoryRequest = "3000Mi"
+		cpuRequest = "2500m"
+		memoryRequest = "4000Mi"
 
 		cpuLimit = "3000m"
-		memoryLimit = "4000Mi"
+		memoryLimit = "4500Mi"
 	default:
-		cpuRequest = "2500m"
+		cpuRequest = "3000m"
 		memoryRequest = "4000Mi"
 
 		cpuLimit = "4000m"
@@ -184,7 +184,7 @@ func (b *HybridBotanist) DeployKubeAPIServer() error {
 			"pod":     b.Seed.Info.Spec.Networks.Pods,
 			"node":    b.Seed.Info.Spec.Networks.Nodes,
 		},
-		"maxReplicas":      4,
+		"maxReplicas":      3,
 		"securePort":       443,
 		"probeCredentials": utils.EncodeBase64([]byte(fmt.Sprintf("%s:%s", b.Secrets["kubecfg"].Data["username"], b.Secrets["kubecfg"].Data["password"]))),
 		"podAnnotations": map[string]interface{}{


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently kube-apiserver scales up when a small cluster (mostly less than 10 nodes) is booting up mainly because of the load induced by core kubernetes components coming up, and small request values applied for the CPU. Increasing this value will result in one API server in fresh clusters.
Also, increasing the `limits` and `requests` reduces need for frequent scaling.
Changed `horizontal-pod-autoscaler-tolerance` to 0.2 from default 0.1 to provide wider bandwidth to hpa, so that effect of load, fluctuating around the threshold, can be smoothened.

**Which issue(s) this PR fixes**:
Partially addresses #255 

**Special notes for your reviewer**:

**Release note**:
<!--  NONE
-->
```noteworthy user
The kube-apiservers do now get higher CPU/memory limits to avoid frequent and unneeded up-/down-scaling.
```
```noteworthy operator
The HPA tolerance flag has been changed to 0.2 for the shooted Seed clusters to provide wider bandwidth to the HPA (effect of load, fluctuating around the threshold, can be smoothened).
```
