### PR TITLE
`seedCloudBotanist` should be used instead of the `shootCloudBotanist`

### DIFF
--- a/pkg/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controller/shoot/shoot_control_reconcile.go
@@ -152,7 +152,7 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 		})
 		deployCloudSpecificControlPlane = g.Add(flow.Task{
 			Name:         "Deploying cloud-specific control plane components",
-			Fn:           flow.TaskFn(shootCloudBotanist.DeployCloudSpecificControlPlane).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(seedCloudBotanist.DeployCloudSpecificControlPlane).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady),
 		})
 		initializeShootClients = g.Add(flow.Task{


### PR DESCRIPTION
`seedCloudBotanist` should be used instead of the `shootCloudBotanist` for the call to `DeployCloudSpecificControlPlane`. 