### PR TITLE
Fix CoreDNS PTR Records resolution

### DIFF
--- a/charts/shoot-core/charts/coredns/templates/coredns-configmap.yaml
+++ b/charts/shoot-core/charts/coredns/templates/coredns-configmap.yaml
@@ -12,7 +12,7 @@ data:
     {{- if .port }}:{{ .port }} {{ end -}}
     { {{ $domain:=$.Values.service.domain}}
       {{- range .plugins }}
-        {{ if eq .name "kubernetes"}}{{ .name }} {{if $domain}}{{$domain}}{{ end }}{{else}}{{ .name }}{{ if .parameters }} {{ .parameters }}{{ end }}{{end}}{{ if .configBlock }} {
+        {{ if eq .name "kubernetes"}}{{ .name }}{{if $domain}} {{$domain.clusterDomain}} {{$domain.additionalDomains}}{{ end }}{{else}}{{ .name }}{{ if .parameters }} {{ .parameters }}{{ end }}{{end}}{{ if .configBlock }} {
 {{ .configBlock | indent 12 }}
         }{{ end }}
       {{- end }}

--- a/charts/shoot-core/charts/coredns/values.yaml
+++ b/charts/shoot-core/charts/coredns/values.yaml
@@ -4,7 +4,9 @@
 service:
   type: "ClusterIP"
   clusterDNS: 100.64.0.10
-  domain: cluster.local in-addr.arpa ip6.arpa
+  domain:
+    clusterDomain: cluster.local
+    additionalDomains: in-addr.arpa ip6.arpa
   port: 53
   targetPort: 8053
   annotations: {}

--- a/pkg/operation/hybridbotanist/addons.go
+++ b/pkg/operation/hybridbotanist/addons.go
@@ -46,7 +46,9 @@ func (b *HybridBotanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart
 				"clusterDNS": common.ComputeClusterIP(b.Shoot.GetServiceNetwork(), 10),
 				// TODO: resolve conformance test issue before changing:
 				// https://github.com/kubernetes/kubernetes/blob/master/test/e2e/network/dns.go#L44
-				"domain": gardenv1beta1.DefaultDomain,
+				"domain": map[string]interface{}{
+					"clusterDomain": gardenv1beta1.DefaultDomain,
+				},
 			},
 		}
 		kubeProxyConfig = map[string]interface{}{


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently with CoreDNS it is possible to resolve A records for services
however it was not possible to do reverse lookups.

This commits fix the issue that prevented reverse-lookup configuration
to be applied (basically resolving the conflict between variables
overriden  from the go vs. direct rendering from values).

```noteworthy user
A bug in the CoreDNS configuration that prevented reverse DNS lookups has been resolved.
```