### PR TITLE
Use AWS annotations for kube-apiserver health setup

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver-service/templates/kube-apiserver-service.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver-service/templates/kube-apiserver-service.yaml
@@ -6,6 +6,13 @@ metadata:
   {{if eq .Values.cloudProvider "aws" -}}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "ssl"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout: "5"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval: "30"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold: "1"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold: "2"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
   {{end -}}
   labels:
     app: kubernetes

--- a/pkg/client/aws/client.go
+++ b/pkg/client/aws/client.go
@@ -81,34 +81,6 @@ func (c *Client) GetInternetGateway(vpcID string) (string, error) {
 	return "", fmt.Errorf("no attached internet gateway found for vpc %s", vpcID)
 }
 
-// GetELB returns the AWS LoadBalancer object for the given name <loadBalancerName>.
-func (c *Client) GetELB(loadBalancerName string) (*elb.DescribeLoadBalancersOutput, error) {
-	describeLoadBalancersInput := &elb.DescribeLoadBalancersInput{
-		LoadBalancerNames: []*string{
-			aws.String(loadBalancerName),
-		},
-		PageSize: aws.Int64(1),
-	}
-	return c.ELB.DescribeLoadBalancers(describeLoadBalancersInput)
-}
-
-// UpdateELBHealthCheck updates the AWS LoadBalancer health check target protocol to SSL for a given
-// LoadBalancer <loadBalancerName>.
-func (c *Client) UpdateELBHealthCheck(loadBalancerName string, targetPort string) error {
-	configureHealthCheckInput := &elb.ConfigureHealthCheckInput{
-		HealthCheck: &elb.HealthCheck{
-			Target:             aws.String("SSL:" + targetPort),
-			Timeout:            aws.Int64(5),
-			Interval:           aws.Int64(30),
-			HealthyThreshold:   aws.Int64(2),
-			UnhealthyThreshold: aws.Int64(6),
-		},
-		LoadBalancerName: aws.String(loadBalancerName),
-	}
-	_, err := c.ELB.ConfigureHealthCheck(configureHealthCheckInput)
-	return err
-}
-
 // The following functions are only temporary needed due to https://github.com/gardener/gardener/issues/129.
 
 // ListKubernetesELBs returns the list of load balancers in the given <vpcID> tagged with <clusterName>.

--- a/pkg/client/aws/types.go
+++ b/pkg/client/aws/types.go
@@ -24,8 +24,6 @@ import (
 type ClientInterface interface {
 	GetAccountID() (string, error)
 	GetInternetGateway(string) (string, error)
-	GetELB(string) (*elb.DescribeLoadBalancersOutput, error)
-	UpdateELBHealthCheck(string, string) error
 
 	// The following functions are only temporary needed due to https://github.com/gardener/gardener/issues/129.
 	ListKubernetesELBs(vpcID, clusterName string) ([]string, error)

--- a/pkg/operation/cloudbotanist/awsbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/awsbotanist/controlplane.go
@@ -219,16 +219,5 @@ func (b *AWSBotanist) DeployCloudSpecificControlPlane() error {
 		return err
 	}
 
-	if err := b.ApplyChartSeed(filepath.Join(common.ChartPath, "seed-controlplane", "charts", name), name, b.Shoot.SeedNamespace, nil, values); err != nil {
-		return err
-	}
-
-	// Change ELB health check to SSL (avoid TLS handshake errors because of AWS ELB health checks)
-	loadBalancerName := b.APIServerAddress[:32]
-	elb, err := b.AWSClient.GetELB(loadBalancerName)
-	if err != nil {
-		return err
-	}
-	targetPort := (*elb.LoadBalancerDescriptions[0].HealthCheck.Target)[4:]
-	return b.AWSClient.UpdateELBHealthCheck(loadBalancerName, targetPort)
+	return b.ApplyChartSeed(filepath.Join(common.ChartPath, "seed-controlplane", "charts", name), name, b.Shoot.SeedNamespace, nil, values)
 }


### PR DESCRIPTION
Use the standard K8S AWS annotations on the `kube-apiserver` service.

**What this PR does / why we need it**: let the k8s cloud controller handle those settings.

**Which issue(s) this PR fixes**: n/a

**Special notes for your reviewer**:
At the moment on AWS even with `SSL` health checks we get 

```
http: TLS handshake error from SOME-NODE-IP:13724: EOF
```

this PR does **not** resolve this issue. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
