### PR TITLE
fix broken gardener chart

### DIFF
--- a/charts/gardener/templates/secret-internal-domain.yaml
+++ b/charts/gardener/templates/secret-internal-domain.yaml
@@ -13,7 +13,7 @@ metadata:
   annotations:
     dns.garden.sapcloud.io/provider: {{ ( required ".controller.internalDomain.provider is required" .Values.controller.internalDomain.provider ) }}
     dns.garden.sapcloud.io/domain: {{ ( required ".controller.internalDomain.domain is required" .Values.controller.internalDomain.domain ) }}
-    {{- if ne $domain.provider "alicloud-dns" }}
+    {{- if ne .Values.controller.internalDomain.provider "alicloud-dns" }}
     dns.garden.sapcloud.io/hostedZoneID: {{ ( required ".controller.internalDomain.hostedZoneID is required" .Values.controller.internalDomain.hostedZoneID ) }}
     {{- end }}
 type: Opaque


### PR DESCRIPTION
**What this PR does / why we need it**: Fixed undefined variable in the gardener chart

```
Error: parse error in "gardener/templates/secret-internal-domain.yaml": template: gardener/templates/secret-internal-domain.yaml:16: undefined variable "$domain"
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
