### PR TITLE
Increease AWS ELB healthy threshold to 2

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver-service/templates/kube-apiserver-service.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver-service/templates/kube-apiserver-service.yaml
@@ -10,7 +10,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout: "5"
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval: "30"
-    service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold: "1"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold: "2"
     service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold: "2"
     service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
   {{end -}}


### PR DESCRIPTION
AWS doesn't like to have one as value:

```
validation error(s) found.\n- minimum field value of 2, HealthCheck.HealthyThreshold
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**: It seems that the only indication when you reconcile a working LB to one with broken configuration is the events of said load balancer

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
