### PR TITLE
Increase the KCM memory limit for seed

### DIFF
--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -310,7 +310,7 @@ func (b *HybridBotanist) DeployKubeControllerManager() error {
 		defaultValues["resources"] = map[string]interface{}{
 			"limits": map[string]interface{}{
 				"cpu":    "750m",
-				"memory": "1Gi",
+				"memory": "1.5Gi",
 			},
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
This PR increase the memory limit from 1 GiB to 1.5GiB for Kube-controller-manager when shoot is acting as seed. On production seed cluster, we have observed the KCM is getting OOMKilled multiple times. Though currently frequency is low. But for safety concern, we are increasing limit.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: action operator
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The memory limit for the kube-controller-manager deployment of shooted seeds has been increased from `1Gi` to `1.5Gi`.
```
