### PR TITLE
Fix metadata service access restrictions

### DIFF
--- a/charts/seed-controlplane/charts/cloud-metadata-service/templates/network-policy-role.yaml
+++ b/charts/seed-controlplane/charts/cloud-metadata-service/templates/network-policy-role.yaml
@@ -12,4 +12,5 @@ spec:
         values:
         - controller-manager
         - cloud-controller-manager
+        - apiserver
 {{include "egress" . | indent 2}}

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/network-policy.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/network-policy.yaml
@@ -20,6 +20,7 @@ spec:
         - {{ .Values.seedNetworks.pod }}
         - {{ .Values.seedNetworks.node }}
         - {{ .Values.seedNetworks.service }}
+        - 169.254.169.254/32
 ---
 apiVersion: {{ include "networkpolicyversion" . }}
 kind: NetworkPolicy


### PR DESCRIPTION
A Shoot's Kube-Apiserver must not be selected by the Networkpolicy
`cloud-metadata-service-deny-blacklist-role` since its intersection with
`kube-apiserver-deny-blacklist` invalidates the intended access
restriction to the cloud metadata service.

**What this PR does / why we need it**:
#381 was supposed to deny connections from all Pods but Cloud-, Kube-Controller-Manager to the cloud metadata service. The introduced Networkpolicy `cloud-metadata-service-deny-blacklist-role` overlaps with `kube-apiserver-deny-blacklist` which invalidates this restriction. This PR excludes the Shoot Kube-Apiserver from `cloud-metadata-service-deny-blacklist-role` and adds the connection restriction to the cloud metadata service to `kube-apiserver-deny-blacklist`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The network policies in the seed cluster have been refined.
```
