### PR TITLE
Feature/kubernetes 1.12

### DIFF
--- a/charts/_versions.tpl
+++ b/charts/_versions.tpl
@@ -23,6 +23,16 @@ kubeproxy.config.k8s.io/v1alpha1
 apiserver.k8s.io/v1alpha1
 {{- end -}}
 
+
+{{- define "auditkubernetesversion" -}}
+{{- if semverCompare ">= 1.12" .Capabilities.KubeVersion.GitVersion -}}
+audit.k8s.io/v1
+{{- else -}}
+audit.k8s.io/v1beta1
+{{- end -}}
+{{- end -}}
+
+
 {{- define "rbacversion" -}}
 rbac.authorization.k8s.io/v1
 {{- end -}}

--- a/charts/gardener/templates/configmap-apiserver-audit.yaml
+++ b/charts/gardener/templates/configmap-apiserver-audit.yaml
@@ -12,7 +12,7 @@ metadata:
 data:
   audit-policy.yaml: |-
     ---
-    apiVersion: audit.k8s.io/v1beta1
+    apiVersion: {{ include "auditkubernetesversion" .}}
     kind: Policy
     rules:
     - level: None

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/audit-policy.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/audit-policy.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   audit-policy.yaml: |-
     ---
-    apiVersion: audit.k8s.io/v1beta1
+    apiVersion: {{ include "auditkubernetesversion" .}}
     kind: Policy
     rules:
     - level: None

--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -72,10 +72,12 @@ spec:
         - --concurrent-deployment-syncs=10
         - --concurrent-replicaset-syncs=10
         {{- include "kube-controller-manager.featureGates" . | trimSuffix "," | indent 8 }}
+        {{- if semverCompare "< 1.12" .Values.kubernetesVersion }}
         - --horizontal-pod-autoscaler-downscale-delay={{ .Values.horizontalPodAutoscaler.downscaleDelay }}
+        - --horizontal-pod-autoscaler-upscale-delay={{ .Values.horizontalPodAutoscaler.upscaleDelay }}
+        {{- end}}
         - --horizontal-pod-autoscaler-sync-period={{ .Values.horizontalPodAutoscaler.syncPeriod }}
         - --horizontal-pod-autoscaler-tolerance={{ .Values.horizontalPodAutoscaler.tolerance }}
-        - --horizontal-pod-autoscaler-upscale-delay={{ .Values.horizontalPodAutoscaler.upscaleDelay }}
         - --kubeconfig=/var/lib/kube-controller-manager/kubeconfig
         - --leader-elect=true
         - --pod-eviction-timeout=2m0s
@@ -83,6 +85,9 @@ spec:
         - --service-account-private-key-file=/srv/kubernetes/service-account-key/id_rsa
         - --service-cluster-ip-range={{ .Values.serviceNetwork }}
         {{- if semverCompare ">= 1.12" .Values.kubernetesVersion }}
+        - --horizontal-pod-autoscaler-downscale-stabilization={{ .Values.horizontalPodAutoscaler.downscaleStabilization }}
+        - --horizontal-pod-autoscaler-initial-readiness-delay={{ .Values.horizontalPodAutoscaler.readinessDelay }}
+        - --horizontal-pod-autoscaler-cpu-initialization-period={{ .Values.horizontalPodAutoscaler.cpuInitializationPeriod }}
         - --authentication-kubeconfig=/var/lib/kube-controller-manager/kubeconfig
         - --authorization-kubeconfig=/var/lib/kube-controller-manager/kubeconfig
         - --tls-cert-file=/var/lib/kube-controller-manager-server/kube-controller-manager-server.crt

--- a/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
@@ -24,3 +24,6 @@ horizontalPodAutoscaler:
   syncPeriod: 30s
   tolerance: 0.1
   upscaleDelay: 1m
+  downscaleStabilization: 5m0s
+  readinessDelay: 30s
+  cpuInitializationPeriod: 5m0s


### PR DESCRIPTION
**What this PR does / why we need it**:
- [x] 🔧  The audit.k8s.io api group has been upgraded from v1beta1 to v1.
- [x] 🔧  Adapt HPA configuration options for 1.12 (see #399):
  - [x] `--horizontal-pod-autoscaler-downscale-delay` does not exist any longer in 1.12, hence, we should validate that it can only be used with versions <1.12
  - [x] `--horizontal-pod-autoscaler-downscale-stabilization` new flag in 1.12, defaults to `5m0s`: The period for which autoscaler will look backwards and not scale down below any recommendation it made during that period. -> we should validate that it can only be used with versions >=1.12
  - [x] `--horizontal-pod-autoscaler-upscale-delay` does not exist any longer in 1.12, hence, we should validate that it can only be used with versions <1.12
  - [x] `--horizontal-pod-autoscaler-initial-readiness-delay ` new flag in 1.12, defaults to `30s`:  The period after pod start during which readiness changes will be treated as initial readiness. -> we should validate that it can only be used with versions >=1.12
  - [x] `--horizontal-pod-autoscaler-cpu-initialization-period`, new flag in 1.12, defaults to `5m0s`: The period after pod start when CPU samples might be skipped. -> we should validate that it can only be used with versions >=1.12


**Which issue(s) this PR fixes**:
Fixes #400 
