### PR TITLE
Fixed an issue with project quota check

### DIFF
--- a/plugin/pkg/shoot/quotavalidator/admission.go
+++ b/plugin/pkg/shoot/quotavalidator/admission.go
@@ -311,7 +311,11 @@ func (q *QuotaValidator) findShootsReferQuota(quota garden.Quota, shoot garden.S
 		secretBindings   []garden.SecretBinding
 	)
 
-	allSecretBindings, err := q.secretBindingLister.SecretBindings(v1.NamespaceAll).List(labels.Everything())
+	namespace := v1.NamespaceAll
+	if quota.Spec.Scope == garden.QuotaScopeProject {
+		namespace = shoot.Namespace
+	}
+	allSecretBindings, err := q.secretBindingLister.SecretBindings(namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The quota check treated the default project quota like a global quota. So the check if the quota was exceeded wasn't restricted to the current project but done for all projects. This resulted in incorrect quota exceeded errors.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement user
An issue has been fixed causing that no more trial clusters could be created although the quota was not exceeded.
```
