### PR TITLE
Allow connection to Gardner Admission Controller

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/network-policy.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/network-policy.yaml
@@ -65,3 +65,25 @@ spec:
     - namespaceSelector:
         matchLabels:
           role: kube-system
+---
+apiVersion: {{ include "networkpolicyversion" . }}
+kind: NetworkPolicy
+metadata:
+  name: kube-apiserver-allow-gardener-admission-controller
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes
+      role: apiserver
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - port: 2730
+      protocol: TCP
+  - to:
+    - podSelector:
+        matchLabels:
+          app: gardener
+          role: external-admission-controller


### PR DESCRIPTION
Backport of #464

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
A network policy has been added allowing the kube-apiserver of a Shoot to connect to the Gardener external admission controller.
```
