### PR TITLE
HPA configuration adaption for Kubernetes 1.12

### DIFF
--- a/charts/_versions.tpl
+++ b/charts/_versions.tpl
@@ -23,6 +23,16 @@ kubeproxy.config.k8s.io/v1alpha1
 apiserver.k8s.io/v1alpha1
 {{- end -}}
 
+
+{{- define "auditkubernetesversion" -}}
+{{- if semverCompare ">= 1.12" .Capabilities.KubeVersion.GitVersion -}}
+audit.k8s.io/v1
+{{- else -}}
+audit.k8s.io/v1beta1
+{{- end -}}
+{{- end -}}
+
+
 {{- define "rbacversion" -}}
 rbac.authorization.k8s.io/v1
 {{- end -}}

--- a/charts/_versions.tpl
+++ b/charts/_versions.tpl
@@ -23,7 +23,6 @@ kubeproxy.config.k8s.io/v1alpha1
 apiserver.k8s.io/v1alpha1
 {{- end -}}
 
-
 {{- define "auditkubernetesversion" -}}
 {{- if semverCompare ">= 1.12" .Capabilities.KubeVersion.GitVersion -}}
 audit.k8s.io/v1
@@ -31,7 +30,6 @@ audit.k8s.io/v1
 audit.k8s.io/v1beta1
 {{- end -}}
 {{- end -}}
-
 
 {{- define "rbacversion" -}}
 rbac.authorization.k8s.io/v1

--- a/charts/gardener/templates/configmap-apiserver-audit.yaml
+++ b/charts/gardener/templates/configmap-apiserver-audit.yaml
@@ -12,7 +12,7 @@ metadata:
 data:
   audit-policy.yaml: |-
     ---
-    apiVersion: audit.k8s.io/v1beta1
+    apiVersion: {{ include "auditkubernetesversion" .}}
     kind: Policy
     rules:
     - level: None

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/audit-policy.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/audit-policy.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   audit-policy.yaml: |-
     ---
-    apiVersion: audit.k8s.io/v1beta1
+    apiVersion: {{ include "auditkubernetesversion" .}}
     kind: Policy
     rules:
     - level: None

--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -72,10 +72,12 @@ spec:
         - --concurrent-deployment-syncs=10
         - --concurrent-replicaset-syncs=10
         {{- include "kube-controller-manager.featureGates" . | trimSuffix "," | indent 8 }}
+        {{- if semverCompare "< 1.12" .Values.kubernetesVersion }}
         - --horizontal-pod-autoscaler-downscale-delay={{ .Values.horizontalPodAutoscaler.downscaleDelay }}
+        - --horizontal-pod-autoscaler-upscale-delay={{ .Values.horizontalPodAutoscaler.upscaleDelay }}
+        {{- end}}
         - --horizontal-pod-autoscaler-sync-period={{ .Values.horizontalPodAutoscaler.syncPeriod }}
         - --horizontal-pod-autoscaler-tolerance={{ .Values.horizontalPodAutoscaler.tolerance }}
-        - --horizontal-pod-autoscaler-upscale-delay={{ .Values.horizontalPodAutoscaler.upscaleDelay }}
         - --kubeconfig=/var/lib/kube-controller-manager/kubeconfig
         - --leader-elect=true
         - --pod-eviction-timeout=2m0s
@@ -83,6 +85,9 @@ spec:
         - --service-account-private-key-file=/srv/kubernetes/service-account-key/id_rsa
         - --service-cluster-ip-range={{ .Values.serviceNetwork }}
         {{- if semverCompare ">= 1.12" .Values.kubernetesVersion }}
+        - --horizontal-pod-autoscaler-downscale-stabilization={{ .Values.horizontalPodAutoscaler.downscaleStabilization }}
+        - --horizontal-pod-autoscaler-initial-readiness-delay={{ .Values.horizontalPodAutoscaler.readinessDelay }}
+        - --horizontal-pod-autoscaler-cpu-initialization-period={{ .Values.horizontalPodAutoscaler.cpuInitializationPeriod }}
         - --authentication-kubeconfig=/var/lib/kube-controller-manager/kubeconfig
         - --authorization-kubeconfig=/var/lib/kube-controller-manager/kubeconfig
         - --tls-cert-file=/var/lib/kube-controller-manager-server/kube-controller-manager-server.crt

--- a/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
@@ -24,3 +24,6 @@ horizontalPodAutoscaler:
   syncPeriod: 30s
   tolerance: 0.1
   upscaleDelay: 1m
+  downscaleStabilization: 5m0s
+  readinessDelay: 30s
+  cpuInitializationPeriod: 5m0s

--- a/example/90-shoot-alicloud.yaml
+++ b/example/90-shoot-alicloud.yaml
@@ -40,6 +40,11 @@ spec:
   #     groupsClaim: groups-claim
   #     groupsPrefix: groups-prefix
   #     issuerURL: https://identity.example.com
+  #     usernameClaim: username-claim
+  #     usernamePrefix: username-prefix
+  #-#-# only usable with Kubernetes >= 1.10
+  #     signingAlgs: RS256,some-other-algorithm
+  #-#-# only usable with Kubernetes >= 1.11
   #     requiredClaims:
   #       key: value
   #     signingAlgs: RS256,some-other-algorithm
@@ -59,10 +64,15 @@ spec:
   #   featureGates:
   #     SomeKubernetesFeature: true
   #   horizontalPodAutoscaler:
-  #     downscaleDelay: 15m0s
   #     syncPeriod: 30s
   #     tolerance: 0.1
+  #-#-# only usable with Kubernetes < 1.12
+  #     downscaleDelay: 15m0s
   #     upscaleDelay: 1m0s
+  #-#-# only usable with Kubernetes >= 1.12
+  #     downscaleStabilization: 5m0s
+  #     initialReadinessDelay: 30s
+  #     cpuInitializationPeriod: 5m0s
   # kubeScheduler:
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-aws.yaml
+++ b/example/90-shoot-aws.yaml
@@ -44,6 +44,11 @@ spec:
   #     groupsClaim: groups-claim
   #     groupsPrefix: groups-prefix
   #     issuerURL: https://identity.example.com
+  #     usernameClaim: username-claim
+  #     usernamePrefix: username-prefix
+  #-#-# only usable with Kubernetes >= 1.10
+  #     signingAlgs: RS256,some-other-algorithm
+  #-#-# only usable with Kubernetes >= 1.11
   #     requiredClaims:
   #       key: value
   #     signingAlgs: RS256,some-other-algorithm
@@ -63,10 +68,15 @@ spec:
   #   featureGates:
   #     SomeKubernetesFeature: true
   #   horizontalPodAutoscaler:
-  #     downscaleDelay: 15m0s
   #     syncPeriod: 30s
   #     tolerance: 0.1
+  #-#-# only usable with Kubernetes < 1.12
+  #     downscaleDelay: 15m0s
   #     upscaleDelay: 1m0s
+  #-#-# only usable with Kubernetes >= 1.12
+  #     downscaleStabilization: 5m0s
+  #     initialReadinessDelay: 30s
+  #     cpuInitializationPeriod: 5m0s
   # kubeScheduler:
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-azure.yaml
+++ b/example/90-shoot-azure.yaml
@@ -43,6 +43,11 @@ spec:
   #     groupsClaim: groups-claim
   #     groupsPrefix: groups-prefix
   #     issuerURL: https://identity.example.com
+  #     usernameClaim: username-claim
+  #     usernamePrefix: username-prefix
+  #-#-# only usable with Kubernetes >= 1.10
+  #     signingAlgs: RS256,some-other-algorithm
+  #-#-# only usable with Kubernetes >= 1.11
   #     requiredClaims:
   #       key: value
   #     signingAlgs: RS256,some-other-algorithm
@@ -62,10 +67,15 @@ spec:
   #   featureGates:
   #     SomeKubernetesFeature: true
   #   horizontalPodAutoscaler:
-  #     downscaleDelay: 15m0s
   #     syncPeriod: 30s
   #     tolerance: 0.1
+  #-#-# only usable with Kubernetes < 1.12
+  #     downscaleDelay: 15m0s
   #     upscaleDelay: 1m0s
+  #-#-# only usable with Kubernetes >= 1.12
+  #     downscaleStabilization: 5m0s
+  #     initialReadinessDelay: 30s
+  #     cpuInitializationPeriod: 5m0s
   # kubeScheduler:
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-gcp.yaml
+++ b/example/90-shoot-gcp.yaml
@@ -41,6 +41,11 @@ spec:
   #     groupsClaim: groups-claim
   #     groupsPrefix: groups-prefix
   #     issuerURL: https://identity.example.com
+  #     usernameClaim: username-claim
+  #     usernamePrefix: username-prefix
+  #-#-# only usable with Kubernetes >= 1.10
+  #     signingAlgs: RS256,some-other-algorithm
+  #-#-# only usable with Kubernetes >= 1.11
   #     requiredClaims:
   #       key: value
   #     signingAlgs: RS256,some-other-algorithm
@@ -60,10 +65,15 @@ spec:
   #   featureGates:
   #     SomeKubernetesFeature: true
   #   horizontalPodAutoscaler:
-  #     downscaleDelay: 15m0s
   #     syncPeriod: 30s
   #     tolerance: 0.1
+  #-#-# only usable with Kubernetes < 1.12
+  #     downscaleDelay: 15m0s
   #     upscaleDelay: 1m0s
+  #-#-# only usable with Kubernetes >= 1.12
+  #     downscaleStabilization: 5m0s
+  #     initialReadinessDelay: 30s
+  #     cpuInitializationPeriod: 5m0s
   # kubeScheduler:
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-local.yaml
+++ b/example/90-shoot-local.yaml
@@ -30,6 +30,11 @@ spec:
   #     groupsClaim: groups-claim
   #     groupsPrefix: groups-prefix
   #     issuerURL: https://identity.example.com
+  #     usernameClaim: username-claim
+  #     usernamePrefix: username-prefix
+  #-#-# only usable with Kubernetes >= 1.10
+  #     signingAlgs: RS256,some-other-algorithm
+  #-#-# only usable with Kubernetes >= 1.11
   #     requiredClaims:
   #       key: value
   #     signingAlgs: RS256,some-other-algorithm
@@ -49,10 +54,15 @@ spec:
   #   featureGates:
   #     SomeKubernetesFeature: true
   #   horizontalPodAutoscaler:
-  #     downscaleDelay: 15m0s
   #     syncPeriod: 30s
   #     tolerance: 0.1
+  #-#-# only usable with Kubernetes < 1.12
+  #     downscaleDelay: 15m0s
   #     upscaleDelay: 1m0s
+  #-#-# only usable with Kubernetes >= 1.12
+  #     downscaleStabilization: 5m0s
+  #     initialReadinessDelay: 30s
+  #     cpuInitializationPeriod: 5m0s
   # kubeScheduler:
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-openstack.yaml
+++ b/example/90-shoot-openstack.yaml
@@ -41,6 +41,11 @@ spec:
   #     groupsClaim: groups-claim
   #     groupsPrefix: groups-prefix
   #     issuerURL: https://identity.example.com
+  #     usernameClaim: username-claim
+  #     usernamePrefix: username-prefix
+  #-#-# only usable with Kubernetes >= 1.10
+  #     signingAlgs: RS256,some-other-algorithm
+  #-#-# only usable with Kubernetes >= 1.11
   #     requiredClaims:
   #       key: value
   #     signingAlgs: RS256,some-other-algorithm
@@ -60,10 +65,15 @@ spec:
   #   featureGates:
   #     SomeKubernetesFeature: true
   #   horizontalPodAutoscaler:
-  #     downscaleDelay: 15m0s
   #     syncPeriod: 30s
   #     tolerance: 0.1
+  #-#-# only usable with Kubernetes < 1.12
+  #     downscaleDelay: 15m0s
   #     upscaleDelay: 1m0s
+  #-#-# only usable with Kubernetes >= 1.12
+  #     downscaleStabilization: 5m0s
+  #     initialReadinessDelay: 30s
+  #     cpuInitializationPeriod: 5m0s
   # kubeScheduler:
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -223,6 +223,11 @@ spec:
   #     groupsClaim: groups-claim
   #     groupsPrefix: groups-prefix
   #     issuerURL: https://identity.example.com
+  #     usernameClaim: username-claim
+  #     usernamePrefix: username-prefix
+  #-#-# only usable with Kubernetes >= 1.10
+  #     signingAlgs: RS256,some-other-algorithm
+  #-#-# only usable with Kubernetes >= 1.11
   #     requiredClaims:
   #       key: value
   #     signingAlgs: RS256,some-other-algorithm
@@ -250,10 +255,15 @@ spec:
   #   featureGates:
   #     SomeKubernetesFeature: true
   #   horizontalPodAutoscaler:
-  #     downscaleDelay: 15m0s
   #     syncPeriod: 30s
   #     tolerance: 0.1
+  #-#-# only usable with Kubernetes < 1.12
+  #     downscaleDelay: 15m0s
   #     upscaleDelay: 1m0s
+  #-#-# only usable with Kubernetes >= 1.12
+  #     downscaleStabilization: 5m0s
+  #     initialReadinessDelay: 30s
+  #     cpuInitializationPeriod: 5m0s
   % endif
     % if kubeScheduler != {}:
     kubeScheduler: ${yaml.dump(kubeScheduler, width=10000)}

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -1269,18 +1269,27 @@ type KubeControllerManagerConfig struct {
 // HorizontalPodAutoscalerConfig contains horizontal pod autoscaler configuration settings for the kube-controller-manager.
 // Note: Descriptions were taken from the Kubernetes documentation.
 type HorizontalPodAutoscalerConfig struct {
-	// The period since last downscale, before another downscale can be performed in horizontal pod autoscaler.
+	// DownscaleDelay is the period since last downscale, before another downscale can be performed in horizontal pod autoscaler.
 	// +optional
 	DownscaleDelay *metav1.Duration
-	// The period for syncing the number of pods in horizontal pod autoscaler.
+	// SyncPeriod is the period for syncing the number of pods in horizontal pod autoscaler.
 	// +optional
 	SyncPeriod *metav1.Duration
-	// The minimum change (from 1.0) in the desired-to-actual metrics ratio for the horizontal pod autoscaler to consider scaling.
+	// Tolerance is the minimum change (from 1.0) in the desired-to-actual metrics ratio for the horizontal pod autoscaler to consider scaling.
 	// +optional
 	Tolerance *float64
-	// The period since last upscale, before another upscale can be performed in horizontal pod autoscaler.
+	// UpscaleDelay is the period since last upscale, before another upscale can be performed in horizontal pod autoscaler.
 	// +optional
 	UpscaleDelay *metav1.Duration
+	// DownscaleStabilization is the period for which autoscaler will look backwards and not scale down below any recommendation it made during that period.
+	// +optional
+	DownscaleStabilization *metav1.Duration
+	// InitialReadinessDelay is the  period after pod start during which readiness changes will be treated as initial readiness.
+	// +optional
+	InitialReadinessDelay *metav1.Duration
+	// CPUInitializationPeriod is the period after pod start when CPU samples might be skipped.
+	// +optional
+	CPUInitializationPeriod *metav1.Duration
 }
 
 // KubeSchedulerConfig contains configuration settings for the kube-scheduler.

--- a/pkg/apis/garden/v1beta1/defaults.go
+++ b/pkg/apis/garden/v1beta1/defaults.go
@@ -130,8 +130,6 @@ func SetDefaults_Shoot(obj *Shoot) {
 		obj.Spec.Kubernetes.AllowPrivilegedContainers = &trueVar
 	}
 
-	setDefaults_ShootKubeControllerManager(&obj.Spec.Kubernetes)
-
 	if obj.Spec.Maintenance == nil {
 		begin, end := utils.ComputeRandomTimeWindow()
 		obj.Spec.Maintenance = &Maintenance{
@@ -162,34 +160,6 @@ func SetDefaults_Shoot(obj *Shoot) {
 	if obj.Spec.DNS.Provider == DNSUnmanaged && obj.Spec.DNS.Domain == nil {
 		defaultDomain := DefaultDomain
 		obj.Spec.DNS.Domain = &defaultDomain
-	}
-}
-
-func setDefaults_ShootKubeControllerManager(kubernetes *Kubernetes) {
-	kcm := kubernetes.KubeControllerManager
-	if kcm == nil {
-		kcm = &KubeControllerManagerConfig{}
-		kubernetes.KubeControllerManager = kcm
-	}
-
-	hpa := kcm.HorizontalPodAutoscalerConfig
-	if hpa == nil {
-		hpa = &HorizontalPodAutoscalerConfig{}
-		kcm.HorizontalPodAutoscalerConfig = hpa
-	}
-
-	if hpa.DownscaleDelay == nil {
-		hpa.DownscaleDelay = &GardenerDuration{Duration: DefaultHPADownscaleDelay}
-	}
-	if hpa.SyncPeriod == nil {
-		hpa.SyncPeriod = &GardenerDuration{Duration: DefaultHPASyncPeriod}
-	}
-	if hpa.Tolerance == nil {
-		defaultTolerance := DefaultHPATolerance
-		hpa.Tolerance = &defaultTolerance
-	}
-	if hpa.UpscaleDelay == nil {
-		hpa.UpscaleDelay = &GardenerDuration{Duration: DefaultHPAUpscaleDelay}
 	}
 }
 

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -1309,6 +1309,15 @@ type HorizontalPodAutoscalerConfig struct {
 	// The period since last upscale, before another upscale can be performed in horizontal pod autoscaler.
 	// +optional
 	UpscaleDelay *GardenerDuration `json:"upscaleDelay,omitempty"`
+	// The configurable window at which the controller will choose the highest recommendation for autoscaling.
+	// +optional
+	DownscaleStabilization *GardenerDuration `json:"downscaleStabilization,omitempty"`
+	// The configurable period at which the horizontal pod autoscaler considers a Pod “not yet ready” given that it’s unready and it has  transitioned to unready during that time.
+	// +optional
+	InitialReadinessDelay *GardenerDuration `json:"initialReadinessDelay,omitempty"`
+	// The period after which a ready pod transition is considered to be the first.
+	// +optional
+	CPUInitializationPeriod *GardenerDuration `json:"cpuInitializationPeriod,omitempty"`
 }
 
 const (
@@ -1318,8 +1327,14 @@ const (
 	DefaultHPASyncPeriod = 30 * time.Second
 	// DefaultHPATolerance is a constant for the default HPA tolerance for a Shoot cluster.
 	DefaultHPATolerance = 0.1
-	// DefaultHPAUpscaleDelay is a constant for the default HPA upscale delay for a Shoot cluster.
+	// DefaultHPAUpscaleDelay is for the default HPA upscale delay for a Shoot cluster.
 	DefaultHPAUpscaleDelay = 1 * time.Minute
+	// DefaultDownscaleStabilization is the default HPA downscale stabilization window for a Shoot cluster
+	DefaultDownscaleStabilization = 5 * time.Minute
+	// DefaultInitialReadinessDelay is for the default HPA  ReadinessDelay value in the Shoot cluster
+	DefaultInitialReadinessDelay = 30 * time.Second
+	// DefaultCPUInitializationPeriod is the for the default value of the CPUInitializationPeriod in the Shoot cluster
+	DefaultCPUInitializationPeriod = 5 * time.Minute
 )
 
 // KubeSchedulerConfig contains configuration settings for the kube-scheduler.

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -2804,6 +2804,9 @@ func autoConvert_v1beta1_HorizontalPodAutoscalerConfig_To_garden_HorizontalPodAu
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
 	out.Tolerance = (*float64)(unsafe.Pointer(in.Tolerance))
 	out.UpscaleDelay = (*v1.Duration)(unsafe.Pointer(in.UpscaleDelay))
+	out.DownscaleStabilization = (*v1.Duration)(unsafe.Pointer(in.DownscaleStabilization))
+	out.InitialReadinessDelay = (*v1.Duration)(unsafe.Pointer(in.InitialReadinessDelay))
+	out.CPUInitializationPeriod = (*v1.Duration)(unsafe.Pointer(in.CPUInitializationPeriod))
 	return nil
 }
 
@@ -2817,6 +2820,9 @@ func autoConvert_garden_HorizontalPodAutoscalerConfig_To_v1beta1_HorizontalPodAu
 	out.SyncPeriod = (*GardenerDuration)(unsafe.Pointer(in.SyncPeriod))
 	out.Tolerance = (*float64)(unsafe.Pointer(in.Tolerance))
 	out.UpscaleDelay = (*GardenerDuration)(unsafe.Pointer(in.UpscaleDelay))
+	out.DownscaleStabilization = (*GardenerDuration)(unsafe.Pointer(in.DownscaleStabilization))
+	out.InitialReadinessDelay = (*GardenerDuration)(unsafe.Pointer(in.InitialReadinessDelay))
+	out.CPUInitializationPeriod = (*GardenerDuration)(unsafe.Pointer(in.CPUInitializationPeriod))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -1434,6 +1434,21 @@ func (in *HorizontalPodAutoscalerConfig) DeepCopyInto(out *HorizontalPodAutoscal
 		*out = new(GardenerDuration)
 		**out = **in
 	}
+	if in.DownscaleStabilization != nil {
+		in, out := &in.DownscaleStabilization, &out.DownscaleStabilization
+		*out = new(GardenerDuration)
+		**out = **in
+	}
+	if in.InitialReadinessDelay != nil {
+		in, out := &in.InitialReadinessDelay, &out.InitialReadinessDelay
+		*out = new(GardenerDuration)
+		**out = **in
+	}
+	if in.CPUInitializationPeriod != nil {
+		in, out := &in.CPUInitializationPeriod, &out.CPUInitializationPeriod
+		*out = new(GardenerDuration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/garden/validation/validation.go
+++ b/pkg/apis/garden/validation/validation.go
@@ -1546,27 +1546,61 @@ func validateKubernetes(kubernetes garden.Kubernetes, fldPath *field.Path) field
 		}
 	}
 
-	allErrs = append(allErrs, validateKubeControllerManager(kubernetes.KubeControllerManager, fldPath.Child("kubeControllerManager"))...)
+	allErrs = append(allErrs, validateKubeControllerManager(kubernetes.Version, kubernetes.KubeControllerManager, fldPath.Child("kubeControllerManager"))...)
 
 	return allErrs
 }
 
-func validateKubeControllerManager(kcm *garden.KubeControllerManagerConfig, fldPath *field.Path) field.ErrorList {
+func validateKubeControllerManager(kubernetesVersion string, kcm *garden.KubeControllerManagerConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+
+	k8sVersionLessThan112, err := utils.CompareVersions(kubernetesVersion, "<", "1.12")
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath, kubernetesVersion, err.Error()))
+	}
 	if kcm != nil {
 		if hpa := kcm.HorizontalPodAutoscalerConfig; hpa != nil {
 			fldPath = fldPath.Child("horizontalPodAutoscaler")
-			if hpa.DownscaleDelay != nil && hpa.DownscaleDelay.Duration < 0 {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("downscaleDelay"), *hpa.DownscaleDelay, "downscale delay must not be negative"))
-			}
+
 			if hpa.SyncPeriod != nil && hpa.SyncPeriod.Duration < 1*time.Second {
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("syncPeriod"), *hpa.SyncPeriod, "syncPeriod must not be less than a second"))
 			}
 			if hpa.Tolerance != nil && *hpa.Tolerance <= 0 {
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("tolerance"), *hpa.Tolerance, "tolerance of must be greater than 0"))
 			}
-			if hpa.UpscaleDelay != nil && hpa.UpscaleDelay.Duration < 0 {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("upscaleDelay"), *hpa.UpscaleDelay, "upscale delay must not be negative"))
+
+			if k8sVersionLessThan112 {
+				if hpa.DownscaleDelay != nil && hpa.DownscaleDelay.Duration < 0 {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("downscaleDelay"), *hpa.DownscaleDelay, "downscale delay must not be negative"))
+				}
+				if hpa.UpscaleDelay != nil && hpa.UpscaleDelay.Duration < 0 {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("upscaleDelay"), *hpa.UpscaleDelay, "upscale delay must not be negative"))
+				}
+				if hpa.DownscaleStabilization != nil {
+					allErrs = append(allErrs, field.Forbidden(fldPath.Child("downscaleStabilization"), "downscale stabilization is not supported in k8s versions < 1.12"))
+				}
+				if hpa.InitialReadinessDelay != nil {
+					allErrs = append(allErrs, field.Forbidden(fldPath.Child("initialReadinessDelay"), "initial readiness delay is not supported in k8s versions < 1.12"))
+				}
+				if hpa.CPUInitializationPeriod != nil {
+					allErrs = append(allErrs, field.Forbidden(fldPath.Child("cpuInitializationPeriod"), "cpu initialization period is not supported in k8s versions < 1.12"))
+				}
+			} else {
+				if hpa.DownscaleDelay != nil {
+					allErrs = append(allErrs, field.Forbidden(fldPath.Child("downscaleDelay"), "downscale delay is not supported in k8s versions >= 1.12"))
+				}
+				if hpa.UpscaleDelay != nil {
+					allErrs = append(allErrs, field.Forbidden(fldPath.Child("upscaleDelay"), "upscale delay is not supported in k8s versions >= 1.12"))
+				}
+				if hpa.DownscaleStabilization != nil && hpa.DownscaleStabilization.Duration < 1*time.Second {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("downscaleStabilization"), *hpa.DownscaleStabilization, "downScale stabilization must not be less than a second"))
+				}
+				if hpa.InitialReadinessDelay != nil && hpa.InitialReadinessDelay.Duration <= 0 {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("initialReadinessDelay"), *hpa.InitialReadinessDelay, "initial readiness delay be greater than 0"))
+				}
+				if hpa.CPUInitializationPeriod != nil && hpa.CPUInitializationPeriod.Duration < 1*time.Second {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("cpuInitializationPeriod"), *hpa.CPUInitializationPeriod, "cpu initialization period must not be less than a second"))
+				}
 			}
 		}
 	}

--- a/pkg/apis/garden/validation/validation_test.go
+++ b/pkg/apis/garden/validation/validation_test.go
@@ -4492,32 +4492,98 @@ var _ = Describe("validation", func() {
 			})
 		})
 
-		Context("KubeControllerManager validation", func() {
+		Context("KubeControllerManager validation < 1.12", func() {
 			It("should forbid unsupported HPA configuration", func() {
-				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.DownscaleDelay = makeDurationPointer(-1 * time.Second)
 				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.SyncPeriod = makeDurationPointer(100 * time.Millisecond)
 				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.Tolerance = makeFloat64Pointer(0)
+				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.DownscaleDelay = makeDurationPointer(-1 * time.Second)
 				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.UpscaleDelay = makeDurationPointer(-1 * time.Second)
 
 				errorList := ValidateShoot(shoot)
 
-				Expect(len(errorList)).To(Equal(4))
-				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.kubernetes.kubeControllerManager.horizontalPodAutoscaler.downscaleDelay"),
-				}))
-				Expect(*errorList[1]).To(MatchFields(IgnoreExtras, Fields{
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("spec.kubernetes.kubeControllerManager.horizontalPodAutoscaler.syncPeriod"),
-				}))
-				Expect(*errorList[2]).To(MatchFields(IgnoreExtras, Fields{
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("spec.kubernetes.kubeControllerManager.horizontalPodAutoscaler.tolerance"),
-				}))
-				Expect(*errorList[3]).To(MatchFields(IgnoreExtras, Fields{
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.kubernetes.kubeControllerManager.horizontalPodAutoscaler.downscaleDelay"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("spec.kubernetes.kubeControllerManager.horizontalPodAutoscaler.upscaleDelay"),
-				}))
+				}))))
+			})
+
+			It("should forbid unsupported HPA field configuration for versions < 1.12", func() {
+				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.DownscaleStabilization = makeDurationPointer(5 * time.Minute)
+				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.InitialReadinessDelay = makeDurationPointer(1 * time.Second)
+				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.CPUInitializationPeriod = makeDurationPointer(5 * time.Minute)
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal("spec.kubernetes.kubeControllerManager.horizontalPodAutoscaler.downscaleStabilization"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal("spec.kubernetes.kubeControllerManager.horizontalPodAutoscaler.initialReadinessDelay"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal("spec.kubernetes.kubeControllerManager.horizontalPodAutoscaler.cpuInitializationPeriod"),
+				}))))
+			})
+		})
+
+		Context("KubeControllerManager validation in versions > 1.12", func() {
+			BeforeEach(func() {
+				shoot.Spec.Kubernetes.Version = "1.12.1"
+				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.DownscaleDelay = nil
+				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.UpscaleDelay = nil
+			})
+
+			It("should forbid unsupported HPA configuration in versions > 1.12", func() {
+				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.DownscaleStabilization = makeDurationPointer(-1 * time.Second)
+				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.InitialReadinessDelay = makeDurationPointer(-1 * time.Second)
+				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.CPUInitializationPeriod = makeDurationPointer(-1 * time.Second)
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.kubernetes.kubeControllerManager.horizontalPodAutoscaler.downscaleStabilization"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.kubernetes.kubeControllerManager.horizontalPodAutoscaler.initialReadinessDelay"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.kubernetes.kubeControllerManager.horizontalPodAutoscaler.cpuInitializationPeriod"),
+				}))))
+			})
+
+			It("should fail when using configuration parameters from versions older than 1.12", func() {
+				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.UpscaleDelay = makeDurationPointer(1 * time.Minute)
+				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.DownscaleDelay = makeDurationPointer(1 * time.Second)
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal("spec.kubernetes.kubeControllerManager.horizontalPodAutoscaler.upscaleDelay"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal("spec.kubernetes.kubeControllerManager.horizontalPodAutoscaler.downscaleDelay"),
+				}))))
+			})
+
+			It("should succeed when using valid v1.12 configuration parameters", func() {
+				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.DownscaleStabilization = makeDurationPointer(5 * time.Minute)
+				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.InitialReadinessDelay = makeDurationPointer(30 * time.Second)
+				shoot.Spec.Kubernetes.KubeControllerManager.HorizontalPodAutoscalerConfig.CPUInitializationPeriod = makeDurationPointer(5 * time.Minute)
+
+				errorList := ValidateShoot(shoot)
+				Expect(len(errorList)).To(Equal(0))
 			})
 		})
 
@@ -4532,7 +4598,6 @@ var _ = Describe("validation", func() {
 				"Field": Equal("spec.kubernetes.version"),
 			}))
 		})
-
 		It("should forbid removing the kubernetes version", func() {
 			newShoot := prepareShootForUpdate(shoot)
 			newShoot.Spec.Kubernetes.Version = ""

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -1415,6 +1415,21 @@ func (in *HorizontalPodAutoscalerConfig) DeepCopyInto(out *HorizontalPodAutoscal
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.DownscaleStabilization != nil {
+		in, out := &in.DownscaleStabilization, &out.DownscaleStabilization
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.InitialReadinessDelay != nil {
+		in, out := &in.InitialReadinessDelay, &out.InitialReadinessDelay
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.CPUInitializationPeriod != nil {
+		in, out := &in.CPUInitializationPeriod, &out.CPUInitializationPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2829,6 +2829,24 @@ func schema_pkg_apis_garden_v1beta1_HorizontalPodAutoscalerConfig(ref common.Ref
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/garden/v1beta1.GardenerDuration"),
 						},
 					},
+					"downscaleStabilization": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The configurable window at which the controller will choose the highest recommendation for autoscaling.",
+							Ref:         ref("github.com/gardener/gardener/pkg/apis/garden/v1beta1.GardenerDuration"),
+						},
+					},
+					"initialReadinessDelay": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The configurable period at which the horizontal pod autoscaler considers a Pod “not yet ready” given that it’s unready and it has  transitioned to unready during that time.",
+							Ref:         ref("github.com/gardener/gardener/pkg/apis/garden/v1beta1.GardenerDuration"),
+						},
+					},
+					"cpuInitializationPeriod": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The period after which a ready pod transition is considered to be the first.",
+							Ref:         ref("github.com/gardener/gardener/pkg/apis/garden/v1beta1.GardenerDuration"),
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
- [x] 🔧  The audit.k8s.io api group has been upgraded from v1beta1 to v1.
- [x] 🔧  Adapt HPA configuration options for 1.12 (see #399):
  - [x] `--horizontal-pod-autoscaler-downscale-delay` does not exist any longer in 1.12, hence, we should validate that it can only be used with versions <1.12
  - [x] `--horizontal-pod-autoscaler-downscale-stabilization` new flag in 1.12, defaults to `5m0s`: The period for which autoscaler will look backwards and not scale down below any recommendation it made during that period. -> we should validate that it can only be used with versions >=1.12
  - [x] `--horizontal-pod-autoscaler-upscale-delay` does not exist any longer in 1.12, hence, we should validate that it can only be used with versions <1.12
  - [x] `--horizontal-pod-autoscaler-initial-readiness-delay ` new flag in 1.12, defaults to `30s`:  The period after pod start during which readiness changes will be treated as initial readiness. -> we should validate that it can only be used with versions >=1.12
  - [x] `--horizontal-pod-autoscaler-cpu-initialization-period`, new flag in 1.12, defaults to `5m0s`: The period after pod start when CPU samples might be skipped. -> we should validate that it can only be used with versions >=1.12


**Which issue(s) this PR fixes**:
See #400 
