### PR TITLE
Skip explicit AWS LB deletion if state is empty

### DIFF
--- a/pkg/operation/cloudbotanist/awsbotanist/infrastructure.go
+++ b/pkg/operation/cloudbotanist/awsbotanist/infrastructure.go
@@ -157,6 +157,10 @@ func (b *AWSBotanist) destroyKubernetesLoadBalancersAndSecurityGroups() error {
 	vpcIDKey := "vpc_id"
 	stateVariables, err := t.GetStateOutputVariables(vpcIDKey)
 	if err != nil {
+		if terraformer.IsVariablesNotFoundError(err) {
+			b.Logger.Infof("Skipping explicit AWS load balancer and security group deletion because not all variables have been found in the Terraform state.")
+			return nil
+		}
 		return err
 	}
 	vpcID := stateVariables[vpcIDKey]


### PR DESCRIPTION
**What this PR does / why we need it**: When the Terraform job destructs the infrastructure it updates the state configmap after it is done. However, the state configmap will not contain any output variables anymore which are needed for the explicit load balancer and security group deletion. If the gardener-controller-manager goes down during the run of a Terraform destruction job it can't delete the empty state configmap, hence, when it comes up again it will fail to delete the AWS LBs/SecGrps:

```
\"Destroying Shoot infrastructure\" failed: flow \"AWS infrastructure destruction\"
      failed: 1 error occurred:\n\t* task \"Destroying Kubernetes load balancers and
      security groups\" failed: timed out after 5m1.863959048s, last error: could
      not find all requested variables\n\n\n\n"
```

/cc @afritzler @dguendisch 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
