### PR TITLE
Quota improvements

### DIFF
--- a/example/60-quota.yaml
+++ b/example/60-quota.yaml
@@ -12,7 +12,6 @@ spec:
     cpu: "200"
     gpu: "20"
     memory: 4000Gi
-    storage.basic: 8000Gi
     storage.standard: 8000Gi
     storage.premium: 2000Gi
     loadbalancer: "100"

--- a/hack/templates/resources/60-quota.yaml.tpl
+++ b/hack/templates/resources/60-quota.yaml.tpl
@@ -44,7 +44,6 @@ spec:
     cpu: "200"
     gpu: "20"
     memory: 4000Gi
-    storage.basic: 8000Gi
     storage.standard: 8000Gi
     storage.premium: 2000Gi
     loadbalancer: "100"

--- a/pkg/registry/garden/quota/storage/storage.go
+++ b/pkg/registry/garden/quota/storage/storage.go
@@ -53,6 +53,8 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		CreateStrategy: quota.Strategy,
 		UpdateStrategy: quota.Strategy,
 		DeleteStrategy: quota.Strategy,
+
+		TableConvertor: newTableConvertor(),
 	}
 	options := &generic.StoreOptions{RESTOptions: optsGetter}
 	if err := store.CompleteWithOptions(options); err != nil {
@@ -67,5 +69,5 @@ var _ rest.ShortNamesProvider = &REST{}
 
 // ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
 func (r *REST) ShortNames() []string {
-	return []string{}
+	return []string{"squota"}
 }

--- a/pkg/registry/garden/quota/storage/tableconvertor.go
+++ b/pkg/registry/garden/quota/storage/tableconvertor.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/apis/garden"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metatable "k8s.io/apimachinery/pkg/api/meta/table"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+)
+
+var swaggerMetadataDescriptions = metav1.ObjectMeta{}.SwaggerDoc()
+
+type convertor struct {
+	headers []metav1beta1.TableColumnDefinition
+}
+
+func newTableConvertor() rest.TableConvertor {
+	return &convertor{
+		headers: []metav1beta1.TableColumnDefinition{
+			{Name: "Name", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["name"]},
+			{Name: "Scope", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["scope"]},
+			{Name: "Cluster Lifetime", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["clusterLifetimeDays"]},
+			{Name: "Age", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"]},
+		},
+	}
+}
+
+// ConvertToTable converts the output to a table.
+func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+	var (
+		err   error
+		table = &metav1beta1.Table{
+			ColumnDefinitions: c.headers,
+		}
+	)
+
+	if m, err := meta.ListAccessor(obj); err == nil {
+		table.ResourceVersion = m.GetResourceVersion()
+		table.SelfLink = m.GetSelfLink()
+		table.Continue = m.GetContinue()
+	} else {
+		if m, err := meta.CommonAccessor(obj); err == nil {
+			table.ResourceVersion = m.GetResourceVersion()
+			table.SelfLink = m.GetSelfLink()
+		}
+	}
+
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {
+		var (
+			quota = obj.(*garden.Quota)
+			cells = []interface{}{}
+		)
+
+		cells = append(cells, quota.Name)
+		cells = append(cells, quota.Spec.Scope)
+		if clusterLifetimeDays := quota.Spec.ClusterLifetimeDays; clusterLifetimeDays != nil {
+			cells = append(cells, fmt.Sprintf("%d days", *clusterLifetimeDays))
+		} else {
+			cells = append(cells, "<unspecified>")
+		}
+		cells = append(cells, metatable.ConvertToHumanReadableDateType(quota.CreationTimestamp))
+
+		return cells, nil
+	})
+
+	return table, err
+}


### PR DESCRIPTION
**What this PR does / why we need it**: We are updating the outdated/non-functional `Quota` resource example manifest, adding `squota` as an alias for the `Quota` objects to allow `kubectl get squota`, and provide more information on the CLI when listing the `Quota`s.

**Special notes for your reviewer**:
/cc @mliepold

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
The Shoot `Quota` objects can now be fetched by `kubectl get squota` to avoid conflicts with Kubernetes' `core/v1/ResourceQuota` resources.
```
