### PR TITLE
Supports multiple seeds per region and cloud in SeedManager admission plugins

### DIFF
--- a/pkg/apis/garden/helper/helpers.go
+++ b/pkg/apis/garden/helper/helpers.go
@@ -98,6 +98,28 @@ func DetermineCloudProviderInShoot(cloudObj garden.Cloud) (garden.CloudProvider,
 	return cloud, nil
 }
 
+// GetK8SNetworks returns the Kubernetes network CIDRs for the Shoot cluster.
+func GetK8SNetworks(shoot *garden.Shoot) (garden.K8SNetworks, error) {
+	cloudProvider, err := DetermineCloudProviderInShoot(shoot.Spec.Cloud)
+	if err != nil {
+		return garden.K8SNetworks{}, err
+	}
+
+	switch cloudProvider {
+	case garden.CloudProviderAWS:
+		return shoot.Spec.Cloud.AWS.Networks.K8SNetworks, nil
+	case garden.CloudProviderAzure:
+		return shoot.Spec.Cloud.Azure.Networks.K8SNetworks, nil
+	case garden.CloudProviderGCP:
+		return shoot.Spec.Cloud.GCP.Networks.K8SNetworks, nil
+	case garden.CloudProviderOpenStack:
+		return shoot.Spec.Cloud.OpenStack.Networks.K8SNetworks, nil
+	case garden.CloudProviderLocal:
+		return shoot.Spec.Cloud.Local.Networks.K8SNetworks, nil
+	}
+	return garden.K8SNetworks{}, nil
+}
+
 // GetCondition returns the condition with the given <conditionType> out of the list of <conditions>.
 // In case the required type could not be found, it returns nil.
 func GetCondition(conditions []garden.Condition, conditionType garden.ConditionType) *garden.Condition {

--- a/plugin/pkg/utils/admission_test.go
+++ b/plugin/pkg/utils/admission_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	"github.com/gardener/gardener/pkg/apis/garden"
+	. "github.com/gardener/gardener/plugin/pkg/utils"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+var _ = Describe("utils", func() {
+	Describe("#ValidateNetworkDisjointedness", func() {
+		var (
+			seedPodsCIDR     = garden.CIDR("10.241.128.0/17")
+			seedServicesCIDR = garden.CIDR("10.241.0.0/17")
+			seedNodesCIDR    = garden.CIDR("10.240.0.0/16")
+
+			seedNetworks = garden.SeedNetworks{
+				Pods:     seedPodsCIDR,
+				Services: seedServicesCIDR,
+				Nodes:    seedNodesCIDR,
+			}
+		)
+
+		It("should pass the validation", func() {
+			var (
+				podsCIDR     = garden.CIDR("10.242.128.0/17")
+				servicesCIDR = garden.CIDR("10.242.0.0/17")
+				nodesCIDR    = garden.CIDR("10.241.0.0/16")
+
+				validK8sNetworks = garden.K8SNetworks{
+					Pods:     &podsCIDR,
+					Services: &servicesCIDR,
+					Nodes:    &nodesCIDR,
+				}
+			)
+
+			errorList := ValidateNetworkDisjointedness(seedNetworks, validK8sNetworks, field.NewPath(""))
+
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should fail due to disjointedness", func() {
+			var (
+				podsCIDR     = seedPodsCIDR
+				servicesCIDR = seedServicesCIDR
+				nodesCIDR    = seedNodesCIDR
+
+				validK8sNetworks = garden.K8SNetworks{
+					Pods:     &podsCIDR,
+					Services: &servicesCIDR,
+					Nodes:    &nodesCIDR,
+				}
+			)
+
+			errorList := ValidateNetworkDisjointedness(seedNetworks, validK8sNetworks, field.NewPath(""))
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].nodes"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].services"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].pods"),
+			}))))
+		})
+
+		It("should fail due to missing fields", func() {
+			var (
+				validK8sNetworks = garden.K8SNetworks{
+					Pods:     nil,
+					Services: nil,
+					Nodes:    nil,
+				}
+			)
+
+			errorList := ValidateNetworkDisjointedness(seedNetworks, validK8sNetworks, field.NewPath(""))
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("[].nodes"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("[].services"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("[].pods"),
+			}))))
+		})
+	})
+})

--- a/plugin/pkg/utils/networks.go
+++ b/plugin/pkg/utils/networks.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"net"
+
+	"github.com/gardener/gardener/pkg/apis/garden"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateNetworkDisjointedness validates that the given <seedNetworks> and <k8sNetworks> are disjoint.
+func ValidateNetworkDisjointedness(seedNetworks garden.SeedNetworks, k8sNetworks garden.K8SNetworks, fldPath *field.Path) field.ErrorList {
+	var (
+		allErrs = field.ErrorList{}
+
+		pathNodes    = fldPath.Child("nodes")
+		pathServices = fldPath.Child("services")
+		pathPods     = fldPath.Child("pods")
+	)
+
+	if nodes := k8sNetworks.Nodes; nodes != nil {
+		if networksIntersect(seedNetworks.Nodes, *nodes) {
+			allErrs = append(allErrs, field.Invalid(pathNodes, *nodes, "shoot node network intersects with seed node network"))
+		}
+	} else {
+		allErrs = append(allErrs, field.Required(pathNodes, "nodes is required"))
+	}
+
+	if services := k8sNetworks.Services; services != nil {
+		if networksIntersect(seedNetworks.Services, *services) {
+			allErrs = append(allErrs, field.Invalid(pathServices, *services, "shoot service network intersects with seed node network"))
+		}
+	} else {
+		allErrs = append(allErrs, field.Required(pathServices, "services is required"))
+	}
+
+	if pods := k8sNetworks.Pods; pods != nil {
+		if networksIntersect(seedNetworks.Pods, *pods) {
+			allErrs = append(allErrs, field.Invalid(pathPods, *pods, "shoot pod network intersects with seed node network"))
+		}
+	} else {
+		allErrs = append(allErrs, field.Required(pathPods, "pods is required"))
+	}
+
+	return allErrs
+}
+
+func networksIntersect(cidr1, cidr2 garden.CIDR) bool {
+	_, net1, err1 := net.ParseCIDR(string(cidr1))
+	_, net2, err2 := net.ParseCIDR(string(cidr2))
+	return err1 != nil || err2 != nil || net2.Contains(net1.IP) || net1.Contains(net2.IP)
+}

--- a/plugin/pkg/utils/utils_suite_test.go
+++ b/plugin/pkg/utils/utils_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestSeedManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Admission Utils Suite")
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Gardener does now have better support for multiple seed clusters in the same cloud and region. Previously, Gardener assigned shoots to the first matching seed (if there were multiple). Now Gardener identifies all candidate seed clusters in a first step, and then assigns shoots to the best one out of those in a second step. Right now, "the best candidate" is the seed managing the smallest number of shoots in this cloud and region.

**Special notes for your reviewer**:
The long-term architecture for this "scheduling problem" is described in #356: We envision moving the logic of the SeedManager admission plugin into a dedicated gardener-scheduler binary to align with the Kubernetes architecture. Having this we can even add more intelligence to the scheduling phase and even allow policies for determining the best candidate.
This PR is meant to enable immediate support of multiple seeds per region and cloud with minimal implementation effort compared to how it works today.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
Gardener does now have better support for multiple seed clusters in the same cloud and region. Previously, Gardener assigned shoots to the first matching seed (if there were multiple). Now Gardener identifies all candidate seed clusters in a first step, and then assigns shoots to the best out of those in a second step.
```
