### PR TITLE
Change etcd-bootstrap configmap to create data directory inside the mount directory of PV.

### DIFF
--- a/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
@@ -9,6 +9,10 @@ metadata:
 data:
   bootstrap.sh: |-
     #!/bin/sh
+    if [ -d /var/etcd/data/member ]; then
+        mkdir /var/etcd/data/new.etcd
+        mv /var/etcd/data/member /var/etcd/data/new.etcd/member
+    fi
     while true;
     do
       wget http://localhost:8080/initialization/status -S -O status;
@@ -22,18 +26,51 @@ data:
       "Failed")
             continue;;
       "Successful")
-            exec etcd --data-dir=/var/etcd/data \
-                      --name=etcd-{{.Values.role}} \
-                      --cert-file=/var/etcd/ssl/server/tls.crt \
-                      --key-file=/var/etcd/ssl/server/tls.key \
-                      --trusted-ca-file=/var/etcd/ssl/ca/ca.crt \
-                      --client-cert-auth \
-                      --advertise-client-urls=https://0.0.0.0:2379 \
-                      --listen-client-urls=https://0.0.0.0:2379 \
-                      --initial-cluster-state=new \
-                      --initial-cluster-token=new \
-                      --snapshot-count=75000 \
-                      --quota-backend-bytes=8589934592 
+            exec etcd --config-file /bootstrap/etcd.conf.yml
             ;;
       esac;
     done
+  etcd.conf.yml: |-
+      # This is the configuration file for the etcd server.
+
+      # Human-readable name for this member.
+      name: etcd-{{.Values.role}}
+
+      client-transport-security:
+        # Path to the client server TLS cert file.
+        cert-file: /var/etcd/ssl/server/tls.crt
+
+        # Path to the client server TLS key file.
+        key-file: /var/etcd/ssl/server/tls.key
+
+        # Enable client cert authentication.
+        client-cert-auth: true
+
+        # Path to the client server TLS trusted CA cert file.
+        trusted-ca-file: /var/etcd/ssl/ca/ca.crt
+
+        # Client TLS using generated certificates
+        auto-tls: false
+
+      # Path to the data directory.
+      data-dir: /var/etcd/data/new.etcd
+
+      # List of this member's client URLs to advertise to the public.
+      # The URLs needed to be a comma-separated list.
+      advertise-client-urls: https://0.0.0.0:2379
+
+      # List of comma separated URLs to listen on for client traffic.
+      listen-client-urls: https://0.0.0.0:2379
+
+      # Initial cluster token for the etcd cluster during bootstrap.
+      initial-cluster-token: 'new'
+
+      # Initial cluster state ('new' or 'existing').
+      initial-cluster-state: 'new'
+
+      # Number of committed transactions to trigger a snapshot to disk.
+      snapshot-count: 75000  
+
+      # Raise alarms when backend size exceeds the given quota. 0 means use the
+      # default quota.
+      quota-backend-bytes: 8589934592

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
@@ -105,7 +105,7 @@ spec:
         - server
         - --schedule={{ .Values.backup.schedule }}
         - --max-backups={{ .Values.backup.maxBackups }}
-        - --data-dir=/var/etcd/data
+        - --data-dir=/var/etcd/data/new.etcd
         - --storage-provider={{ .Values.backup.storageProvider }}
         - --store-prefix=etcd-{{ .Values.role }}
         - --cert=/var/etcd/ssl/client/tls.crt


### PR DESCRIPTION


**What this PR does / why we need it**:
This PR adds changes to create a data directory in mount directory for etcd and use config file for etcd instead of growing flag list. It will help solve issues that should arise because of mount point directly being the data directory of etcd.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
