### PR TITLE
Create new.etcd directory if not present, else etcd data validation fails.

### DIFF
--- a/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
@@ -9,8 +9,10 @@ metadata:
 data:
   bootstrap.sh: |-
     #!/bin/sh
-    if [ -d /var/etcd/data/member ]; then
+    if [ ! -d /var/etcd/data/new.etcd ]; then
         mkdir /var/etcd/data/new.etcd
+    fi
+    if [ -d /var/etcd/data/member ]; then
         mv /var/etcd/data/member /var/etcd/data/new.etcd/member
     fi
     while true;


### PR DESCRIPTION
**What this PR does / why we need it**:
This fix creates the `new.etcd` data directory, in case it is not already present. If this is not done, data directory validation fails for new clusters.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
