### PR TITLE
Install helm CLI tool in .ci/check script

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -28,8 +28,23 @@ if [[ "${SOURCE_PATH}" != *"src/github.com/gardener/gardener" ]]; then
   export PATH="${GOBIN}:${PATH}"
 fi
 
-# Install Golint (linting tool).
-go get -u golang.org/x/lint/golint
+# Install Golint.
+if ! which golint 1>/dev/null; then
+  echo -n "Installing golint... "
+  go get -u golang.org/x/lint/golint
+  echo "done."
+fi
+
+# Install Helm (see https://docs.helm.sh/using_helm/#from-script).
+if ! which helm 1>/dev/null; then
+  echo -n "Installing helm... "
+  install_helm_path="./get_helm.sh"
+  curl https://raw.githubusercontent.com/helm/helm/v2.9.1/scripts/get > "${install_helm_path}"
+  chmod 700 "${install_helm_path}"
+  bash "${install_helm_path}"
+  rm ./"${install_helm_path}"
+  echo "done."
+fi
 
 ###############################################################################
 


### PR DESCRIPTION
**What this PR does / why we need it**: Since #363 we have got a new check whether our Helm charts are rendering correctly, but no `helm` CLI tool was installed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
