### PR TITLE
Scale down most of the control plane when shoot is hibernated

### DIFF
--- a/pkg/client/kubernetes/base/deployments.go
+++ b/pkg/client/kubernetes/base/deployments.go
@@ -17,6 +17,8 @@ package kubernetesbase
 import (
 	"sort"
 
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -42,6 +44,33 @@ func (c *Client) ListDeployments(namespace string, listOptions metav1.ListOption
 // PatchDeployment patches a Deployment object.
 func (c *Client) PatchDeployment(namespace, name string, body []byte) (*appsv1.Deployment, error) {
 	return c.Clientset().AppsV1().Deployments(namespace).Patch(name, types.JSONPatchType, body)
+}
+
+// ScaleDeployment scales a Deployment object.
+func (c *Client) ScaleDeployment(namespace, name string, replicas int32) (*appsv1.Deployment, error) {
+	old, err := c.GetDeployment(namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	new := old.DeepCopy()
+	new.Spec.Replicas = &replicas
+
+	return c.StrategicMergePatchDeployment(old, new)
+}
+
+// StrategicMergePatchDeployment performs a strategic merge patch on a Deployment object.
+func (c *Client) StrategicMergePatchDeployment(oldObj, newObj *appsv1.Deployment) (*appsv1.Deployment, error) {
+	patch, err := kutil.CreateTwoWayMergePatch(oldObj, newObj)
+	if err != nil {
+		return nil, err
+	}
+
+	if kutil.IsEmptyPatch(patch) {
+		return oldObj, nil
+	}
+
+	return c.clientset.AppsV1().Deployments(oldObj.Namespace).Patch(oldObj.Name, types.StrategicMergePatchType, patch)
 }
 
 // DeleteDeployment deletes a Deployment object.

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -97,6 +97,8 @@ type Client interface {
 	GetDeployment(string, string) (*appsv1.Deployment, error)
 	ListDeployments(string, metav1.ListOptions) (*appsv1.DeploymentList, error)
 	PatchDeployment(string, string, []byte) (*appsv1.Deployment, error)
+	StrategicMergePatchDeployment(*appsv1.Deployment, *appsv1.Deployment) (*appsv1.Deployment, error)
+	ScaleDeployment(string, string, int32) (*appsv1.Deployment, error)
 	DeleteDeployment(string, string) error
 
 	// StatefulSets

--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -28,6 +28,10 @@ import (
 // CheckConditionControlPlaneHealthy checks whether the control plane of the Shoot cluster is healthy,
 // i.e. whether all containers running in the relevant namespace in the Seed cluster are healthy.
 func (b *Botanist) CheckConditionControlPlaneHealthy(condition *gardenv1beta1.Condition) *gardenv1beta1.Condition {
+	if b.Shoot.IsHibernated {
+		return helper.ModifyCondition(condition, corev1.ConditionTrue, "ConditionNotChecked", "Shoot cluster has been hibernated.")
+	}
+
 	response, err := b.K8sShootClient.Curl("healthz")
 	if err != nil {
 		return helper.ModifyCondition(condition, corev1.ConditionFalse, "KubeAPIServerNotHealthy", fmt.Sprintf("Could not reach Shoot cluster kube-apiserver's /healthz endpoint: '%s'", err.Error()))
@@ -54,6 +58,10 @@ func (b *Botanist) CheckConditionControlPlaneHealthy(condition *gardenv1beta1.Co
 // CheckConditionEveryNodeReady checks whether every node registered at the Shoot cluster is in "Ready" state, that
 // as many nodes are registered as desired, and that every machine is running.
 func (b *Botanist) CheckConditionEveryNodeReady(condition *gardenv1beta1.Condition) *gardenv1beta1.Condition {
+	if b.Shoot.IsHibernated {
+		return helper.ModifyCondition(condition, corev1.ConditionTrue, "ConditionNotChecked", "Shoot cluster has been hibernated.")
+	}
+
 	// Check whether every Node registered to the API server is ready.
 	nodeList, err := b.K8sShootClient.ListNodes(metav1.ListOptions{})
 	if err != nil {

--- a/pkg/operation/cloudbotanist/awsbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/awsbotanist/controlplane.go
@@ -224,7 +224,8 @@ func (b *AWSBotanist) DeployCloudSpecificControlPlane() error {
 	var (
 		name          = "aws-lb-readvertiser"
 		defaultValues = map[string]interface{}{
-			"domain": b.APIServerAddress,
+			"domain":   b.APIServerAddress,
+			"replicas": b.Shoot.GetReplicas(1),
 			"podAnnotations": map[string]interface{}{
 				"checksum/secret-aws-lb-readvertiser": b.CheckSums[name],
 			},

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -150,6 +150,9 @@ const (
 	// KubeControllerManagerServerName is the name of the kube-controller-manager server.
 	KubeControllerManagerServerName = "kube-controller-manager-server"
 
+	// MachineControllerManagerDeploymentName is the name of the machine-controller-manager deployment.
+	MachineControllerManagerDeploymentName = "machine-controller-manager"
+
 	// KubeSchedulerDeploymentName is the name of the kube-scheduler deployment.
 	KubeSchedulerDeploymentName = "kube-scheduler"
 

--- a/pkg/operation/hybridbotanist/addon_manager.go
+++ b/pkg/operation/hybridbotanist/addon_manager.go
@@ -23,10 +23,7 @@ import (
 // DeployKubeAddonManager deploys the Kubernetes Addon Manager which will use labeled Kubernetes resources in order
 // to ensure that they exist in a cluster/reconcile them in case somebody changed something.
 func (b *HybridBotanist) DeployKubeAddonManager() error {
-	var (
-		name     = "kube-addon-manager"
-		replicas = 1
-	)
+	var name = "kube-addon-manager"
 
 	cloudConfig, err := b.generateCloudConfigChart()
 	if err != nil {
@@ -45,10 +42,6 @@ func (b *HybridBotanist) DeployKubeAddonManager() error {
 		return err
 	}
 
-	if b.Shoot.IsHibernated {
-		replicas = 0
-	}
-
 	defaultValues := map[string]interface{}{
 		"cloudConfigContent":    cloudConfig.Files,
 		"storageClassesContent": storageClasses.Files,
@@ -57,7 +50,7 @@ func (b *HybridBotanist) DeployKubeAddonManager() error {
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-kube-addon-manager": b.CheckSums[name],
 		},
-		"replicas": replicas,
+		"replicas": b.Shoot.GetReplicas(1),
 		// we need to add capabilities for Shoot's API server.
 		"shootAPIServer": map[string]interface{}{
 			"Capabilities": map[string]interface{}{

--- a/pkg/operation/hybridbotanist/machines.go
+++ b/pkg/operation/hybridbotanist/machines.go
@@ -122,6 +122,13 @@ func (b *HybridBotanist) ReconcileMachines() error {
 		return fmt.Errorf("The CloudBotanist failed to cleanup the orphaned machine class secrets: '%s'", err.Error())
 	}
 
+	// Scale down machine-controller-manager if shoot is hibernated.
+	if b.Shoot.IsHibernated {
+		if _, err := b.K8sSeedClient.ScaleDeployment(b.Shoot.SeedNamespace, common.MachineControllerManagerDeploymentName, 0); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -247,6 +247,14 @@ func (s *Shoot) ComputeCloudConfigSecretName(workerName string) string {
 	return fmt.Sprintf("%s-%s-%s", common.CloudConfigPrefix, workerName, utils.ComputeSHA256Hex([]byte(s.KubernetesMajorMinorVersion))[:5])
 }
 
+// GetReplicas returns the given <wokenUp> number if the shoot is not hibernated, or zero otherwise.
+func (s *Shoot) GetReplicas(wokenUp int) int {
+	if s.IsHibernated {
+		return 0
+	}
+	return wokenUp
+}
+
 // ComputeTechnicalID determines the technical id of that Shoot which is later used for the name of the
 // namespace and for tagging all the resources created in the infrastructure.
 func ComputeTechnicalID(projectName string, shoot *gardenv1beta1.Shoot) string {


### PR DESCRIPTION
**What this PR does / why we need it**: Until now we have only scaled down the monitoring stack and the kube-addon-manager when a shoot was hibernated (apart from deleting the worker machines). With this change we will also scale down all remaining components other than etcd and kube-apiserver. Please find more information why we cannot easily scale down etcd and kube-apiserver in #444 (in fact, we probably could find a way, however, we do not want to spend time investigating this one now and rather finish the left-over tasks to get started with extensibility (which might help as well)).

**Which issue(s) this PR fixes**:
Fixes #444 

**Special notes for your reviewer**: In the hibernation process we wait until all machines are gone until we scale down the machine-controller-manager. The kube-controller-manager won't be scaled down unless there are no `Node` objects anymore (otherwise its node-lifecycle-controller would not be able to delete the `Node` objects that are not backed up by a VM). See #444.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
When a shoot cluster is hibernated most of the control plane components are now scaled down to zero, effectively reducing costs.
```
