### PR TITLE
Fix alertmanager's storage path

### DIFF
--- a/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
@@ -65,7 +65,7 @@ spec:
         - --config.file=/etc/alertmanager/config/alertmanager.yaml
         - --web.listen-address=:9093
         - --web.external-url=https://{{ .Values.ingress.host }}
-        - --storage.path=/etc/alertmanager/data
+        - --storage.path=/var/alertmanager/data
         - --log.level=info
         env:
         - name: ALERTMANAGER_NAMESPACE


### PR DESCRIPTION
**What this PR does / why we need it**: Alertmanager did not store the persistent data in the correct path.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**: N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
