### PR TITLE
fix logging chart feature gates

### DIFF
--- a/charts/seed-bootstrap/requirements.yaml
+++ b/charts/seed-bootstrap/requirements.yaml
@@ -1,0 +1,11 @@
+dependencies:
+- name: elastic-kibana-curator
+  repository: http://localhost:10191
+  version: 0.1.0
+  # needed for the logging feature gate
+  condition: elastic-kibana-curator.enabled
+- name: fluentd-es
+  repository: http://localhost:10191
+  version: 0.1.0
+  # needed for the logging feature gate
+  condition: fluentd-es.enabled


### PR DESCRIPTION
Enable logging chart only when the feature gates are enabled.

**What this PR does / why we need it**: https://github.com/gardener/gardener/blob/68b8b1d8c19cbb53984e1d609abba37c120f67a7/pkg/operation/seed/seed.go#L280 and
https://github.com/gardener/gardener/blob/68b8b1d8c19cbb53984e1d609abba37c120f67a7/pkg/operation/seed/seed.go#L295
requires this chart to have `requirements.yaml` to disable sub-charts.

/cc @vlpanov @vlvasilev @vpnachev 

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
