### PR TITLE
Fix quota check for shoots with multiple worker groups

### DIFF
--- a/plugin/pkg/shoot/quotavalidator/admission.go
+++ b/plugin/pkg/shoot/quotavalidator/admission.go
@@ -405,15 +405,15 @@ func (q *QuotaValidator) getShootResources(shoot garden.Shoot) (v1.ResourceList,
 		}
 
 		// For now we always use the max. amount of resources for quota calculation
-		resources[garden.QuotaMetricCPU] = multiplyQuantity(machineType.CPU, worker.AutoScalerMax)
-		resources[garden.QuotaMetricGPU] = multiplyQuantity(machineType.GPU, worker.AutoScalerMax)
-		resources[garden.QuotaMetricMemory] = multiplyQuantity(machineType.Memory, worker.AutoScalerMax)
+		resources[garden.QuotaMetricCPU] = sumQuantity(resources[garden.QuotaMetricCPU], multiplyQuantity(machineType.CPU, worker.AutoScalerMax))
+		resources[garden.QuotaMetricGPU] = sumQuantity(resources[garden.QuotaMetricGPU], multiplyQuantity(machineType.GPU, worker.AutoScalerMax))
+		resources[garden.QuotaMetricMemory] = sumQuantity(resources[garden.QuotaMetricMemory], multiplyQuantity(machineType.Memory, worker.AutoScalerMax))
 
 		switch volumeType.Class {
 		case garden.VolumeClassStandard:
-			resources[garden.QuotaMetricStorageStandard] = multiplyQuantity(worker.VolumeSize, worker.AutoScalerMax)
+			resources[garden.QuotaMetricStorageStandard] = sumQuantity(resources[garden.QuotaMetricStorageStandard], multiplyQuantity(worker.VolumeSize, worker.AutoScalerMax))
 		case garden.VolumeClassPremium:
-			resources[garden.QuotaMetricStoragePremium] = multiplyQuantity(worker.VolumeSize, worker.AutoScalerMax)
+			resources[garden.QuotaMetricStoragePremium] = sumQuantity(resources[garden.QuotaMetricStoragePremium], multiplyQuantity(worker.VolumeSize, worker.AutoScalerMax))
 		default:
 			return nil, fmt.Errorf("Unknown volumeType class %s", volumeType.Class)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the resource calculation for the quota check, if trial clusters have more than one worker group.
It allowed the creation of too big trial clusters.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```noteworthy operator
An issue has been fixed that allowed the creation of trial clusters above the project quota.
```
