### PR TITLE
Fix docs for local setup

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -197,20 +197,23 @@ kubectl is now configured to use the cluster.
 
 #### Prepare the Gardener
 
-The Gardener exposes the API servers of Shoot clusters via Kubernetes services of type `LoadBalancer`. In order to establish stable endpoints (robust against changes of the load balancer address), it creates DNS records pointing to these load balancer addresses. They are used internally and by all cluster components to communicate.
-You need to have control over a domain (or subdomain) for which these records will be created.
-Please provide an *internal domain secret* (see [this](../../example/10-secret-internal-domain.yaml) for an example) which contains credentials with the proper privileges. Further information can be found [here](../deployment/configuration.md).
-
 ```bash
 $ make dev-setup
 namespace "garden" created
 namespace "garden-dev" created
-secret "internal-domain-unmanaged" created
 deployment "etcd" created
 service "etcd" created
 service "gardener-apiserver" created
 endpoints "gardener-apiserver" created
 apiservice "v1beta1.garden.sapcloud.io" created
+```
+The Gardener exposes the API servers of Shoot clusters via Kubernetes services of type `LoadBalancer`. In order to establish stable endpoints (robust against changes of the load balancer address), it creates DNS records pointing to these load balancer addresses. They are used internally and by all cluster components to communicate.
+You need to have control over a domain (or subdomain) for which these records will be created.
+Please provide an *internal domain secret* (see [this](../../example/10-secret-internal-domain.yaml) for an example) which contains credentials with the proper privileges. Further information can be found [here](../deployment/configuration.md).
+
+```bash
+$ kubectl apply -f example/10-secret-internal-domain-unmanaged.yaml
+secret/internal-domain-unmanaged created
 ```
 
 #### Run the Gardener API Server and the Gardener Controller Manager


### PR DESCRIPTION
Add statement for manual daployment of internal domain secret.

**What this PR does / why we need it**:
Fix documentation
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@mvladev @Adracus 

Since PR #472 `dev-setup` script no longer deploy internal domain secret. In this way, locally run gardener controller manager fails to start with following error:
```
time="2018-10-29T16:03:17+02:00" level=info msg="Starting HTTPS server on 0.0.0.0:2719"                                                                       
panic: require exactly ONE internal domain secret, but found 0                                                                                                
                                                                                                                                                              
goroutine 250 [running]:                                                                                                                                      
github.com/gardener/gardener/pkg/controller.(*GardenControllerFactory).Run(0xc420549f60, 0xc42004c240)                                                        
        /home/homish/go/src/github.com/gardener/gardener/pkg/controller/factory.go:96 +0x19d6                                                                
github.com/gardener/gardener/cmd/gardener-controller-manager/app.(*Gardener).startControllers(0xc42011ecb0, 0xc42004c240)                                     
        /home/homeish/go/src/github.com/gardener/gardener/cmd/gardener-controller-manager/app/gardener_controller_manager.go:356 +0xce                        
created by github.com/gardener/gardener/cmd/gardener-controller-manager/app.(*Gardener).Run.func1                                                             
        /home/homeish/go/src/github.com/gardener/gardener/cmd/gardener-controller-manager/app/gardener_controller_manager.go:308 +0x50                        
exit status 2
Makefile:42: recipe for target 'start' failed                                                                                                                 
make: *** [start] Error 1                     
```
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
