### PR TITLE
Increase alertmanager's repeat interval to 12h

### DIFF
--- a/charts/seed-monitoring/charts/alertmanager/templates/_config.tpl
+++ b/charts/seed-monitoring/charts/alertmanager/templates/_config.tpl
@@ -21,7 +21,7 @@ route:
 
   # If an alert has successfully been sent, wait 'repeat_interval' to
   # resend them.
-  repeat_interval: 3h
+  repeat_interval: 12h
 
   # Send alerts by default to nowhere
   receiver: dev-null


### PR DESCRIPTION
**What this PR does / why we need it**: reduces the amount of alerts being send and which are not silenced 

/cc @vlerenc 

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
n/a

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The repeat-send interval for the alertmanager has been increased to `12h` (this will help to reduce the amount of alerts being send).
```
