### PR TITLE
Reconcile scheduler to prevent concurrent reconciliations of seeds and shoots

### DIFF
--- a/pkg/controller/shoot/seed_control.go
+++ b/pkg/controller/shoot/seed_control.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot
+
+import (
+	"github.com/gardener/gardener/pkg/logger"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+)
+
+func (c *Controller) seedAdd(obj interface{}) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		return
+	}
+	c.seedQueue.Add(key)
+}
+
+func (c *Controller) seedUpdate(oldObj, newObj interface{}) {
+	c.seedAdd(newObj)
+}
+
+func (c *Controller) seedDelete(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		return
+	}
+	c.seedQueue.Add(key)
+}
+
+func (c *Controller) reconcileSeedKey(key string) error {
+	_, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+
+	seed, err := c.seedLister.Get(name)
+	seedID := newID("", seed.Name)
+
+	if apierrors.IsNotFound(err) {
+		logger.Logger.Debugf("[SHOOT SEED RECONCILE] %s - skipping because Seed has been deleted", key)
+		c.scheduler.UnmarkStatic(seedID)
+		return nil
+	}
+	if err != nil {
+		logger.Logger.Infof("[SHOOT SEED RECONCILE] %s - unable to retrieve object from store: %v", key, err)
+		return err
+	}
+
+	if !seedIsShoot(seed) {
+		c.scheduler.MarkStatic(seedID)
+	} else {
+		c.scheduler.UnmarkStatic(seedID)
+	}
+
+	return nil
+}

--- a/pkg/controller/shoot/shoot_control_types.go
+++ b/pkg/controller/shoot/shoot_control_types.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot
+
+import (
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/utils/reconcilescheduler"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+type id struct {
+	namespace string
+	name      string
+}
+
+func (i id) String() string {
+	return fmt.Sprintf("%s/%s", i.namespace, i.name)
+}
+
+func (i id) GetName() string {
+	return i.name
+}
+
+func (i id) GetNamespace() string {
+	return i.namespace
+}
+
+func newID(namespace, name string) id {
+	return id{namespace, name}
+}
+
+func newIDFromString(key string) (id, error) {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return id{}, err
+	}
+	return newID(namespace, name), nil
+}
+
+type shootElement struct {
+	seed  id
+	shoot id
+}
+
+func (e *shootElement) String() string {
+	return e.shoot.String()
+}
+
+func (e *shootElement) GetID() reconcilescheduler.ID {
+	return e.shoot
+}
+
+func (e *shootElement) GetParentID() reconcilescheduler.ID {
+	return e.seed
+}

--- a/pkg/controller/shoot/shoot_utils.go
+++ b/pkg/controller/shoot/shoot_utils.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/operation/common"
 )
 
@@ -57,4 +58,14 @@ func computeLabelsWithShootHealthiness(healthy bool) func(map[string]string) map
 func mustIgnoreShoot(annotations map[string]string, respectSyncPeriodOverwrite *bool) bool {
 	_, ignore := annotations[common.ShootIgnore]
 	return respectSyncPeriodOverwrite != nil && ignore && *respectSyncPeriodOverwrite
+}
+
+func seedIsShoot(seed *gardenv1beta1.Seed) bool {
+	hasOwnerReference, _ := seedHasShootOwnerReference(seed.ObjectMeta)
+	return hasOwnerReference
+}
+
+func shootIsSeed(shoot *gardenv1beta1.Shoot) bool {
+	shootedSeed, err := helper.ReadShootedSeed(shoot)
+	return err == nil && shootedSeed != nil
 }

--- a/pkg/controller/utils/miscelleneous.go
+++ b/pkg/controller/utils/miscelleneous.go
@@ -16,11 +16,17 @@ package utils
 
 import (
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ComputeOperationType checksthe <lastOperation> and determines whether is it is Create operation or reconcile operation
-func ComputeOperationType(lastOperation *gardenv1beta1.LastOperation) gardenv1beta1.ShootLastOperationType {
-	if lastOperation == nil || (lastOperation.Type == gardenv1beta1.ShootLastOperationTypeCreate && lastOperation.State != gardenv1beta1.ShootLastOperationStateSucceeded) {
+func ComputeOperationType(meta metav1.ObjectMeta, lastOperation *gardenv1beta1.LastOperation) gardenv1beta1.ShootLastOperationType {
+	switch {
+	case meta.DeletionTimestamp != nil:
+		return gardenv1beta1.ShootLastOperationTypeDelete
+	case lastOperation == nil:
+		return gardenv1beta1.ShootLastOperationTypeCreate
+	case (lastOperation.Type == gardenv1beta1.ShootLastOperationTypeCreate && lastOperation.State != gardenv1beta1.ShootLastOperationStateSucceeded):
 		return gardenv1beta1.ShootLastOperationTypeCreate
 	}
 	return gardenv1beta1.ShootLastOperationTypeReconcile

--- a/pkg/utils/reconcilescheduler/reason.go
+++ b/pkg/utils/reconcilescheduler/reason.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconcilescheduler
+
+import (
+	"fmt"
+)
+
+const (
+	// CodeActivated is a reason code indicating that an element has been activated.
+	CodeActivated = iota
+	// CodeAlreadyActive is a reason code indicating that an element is active already.
+	CodeAlreadyActive = iota
+
+	// CodeChildActive is a reason code indicating that an element's child is currently active.
+	CodeChildActive = iota
+
+	// CodeParentPending is a reason code indicating that the element's parent has precedence.
+	CodeParentPending = iota
+	// CodeParentActive is a reason code indicating that the element's parent is currently active.
+	CodeParentActive = iota
+	// CodeParentNotReconciled is a reason code indicating that the element's parent has not yet been reconciled.
+	CodeParentNotReconciled = iota
+	// CodeParentUnknown is a reason code indicating that the element's parent is not (yet) known.
+	CodeParentUnknown = iota
+
+	// CodeOther is a reason code for unspecified reasons.
+	CodeOther = iota
+)
+
+// Reason is a structure type that contains a reason code as well as a message. It is returned to users' requests
+// in order to explain the made decision.
+type Reason struct {
+	code    int
+	message string
+}
+
+// NewReason creates a new reason structure with the given <code> and the message.
+func NewReason(code int, msgFmt string, args ...interface{}) *Reason {
+	return &Reason{
+		code:    code,
+		message: fmt.Sprintf(msgFmt, args...),
+	}
+}
+
+// String returns the string representation of Reason.
+func (r *Reason) String() string {
+	return r.message
+}
+
+// Code returns the code of the Reason.
+func (r *Reason) Code() int {
+	return r.code
+}
+
+// Message returns the message of the Reason.
+func (r *Reason) Message() string {
+	return r.message
+}

--- a/pkg/utils/reconcilescheduler/reason_test.go
+++ b/pkg/utils/reconcilescheduler/reason_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconcilescheduler_test
+
+import (
+	"fmt"
+
+	. "github.com/gardener/gardener/pkg/utils/reconcilescheduler"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("reconcilescheduler", func() {
+	Context("Reason", func() {
+		DescribeTable("#NewReason",
+			func(code int, msgFmt string, args ...interface{}) {
+				reason := NewReason(code, msgFmt, args...)
+
+				Expect(reason.Code()).To(Equal(code))
+				Expect(reason.Message()).To(Equal(fmt.Sprintf(msgFmt, args...)))
+			},
+
+			Entry("code with unformatted message", CodeOther, "some nice message"),
+			Entry("code with unformatted message", CodeParentUnknown, "some %s format", "foo"),
+		)
+
+		var (
+			code    = CodeParentActive
+			message = "must wait for parent"
+			reason  = NewReason(code, message)
+		)
+
+		Describe("#String", func() {
+			It("should return the correct string representation", func() {
+				Expect(reason.String()).To(Equal(message))
+			})
+		})
+
+		Describe("#Code", func() {
+			It("should return the correct code", func() {
+				Expect(reason.Code()).To(Equal(code))
+			})
+		})
+
+		Describe("#Message", func() {
+			It("should return the correct message", func() {
+				Expect(reason.Message()).To(Equal(message))
+			})
+		})
+	})
+})

--- a/pkg/utils/reconcilescheduler/reconcilescheduler_suite_test.go
+++ b/pkg/utils/reconcilescheduler/reconcilescheduler_suite_test.go
@@ -1,0 +1,13 @@
+package reconcilescheduler_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestScheduler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Scheduler Suite")
+}

--- a/pkg/utils/reconcilescheduler/state.go
+++ b/pkg/utils/reconcilescheduler/state.go
@@ -1,0 +1,260 @@
+package reconcilescheduler
+
+import (
+	"io/ioutil"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// ID describes the interface for an unique identifier of an object.
+type ID interface {
+	// String returns the string representation of the id.
+	String() string
+}
+
+// Element describes the interface for getting the id an its parent.
+type Element interface {
+	// GetID returns the ID of the element.
+	GetID() ID
+	// GetParent returns the ID of the element's parent.
+	GetParentID() ID
+}
+
+// Interface describes the interface for interacting with the reconcile scheduler.
+// It holds an internal state of elements and answers "may I schedule this element now" questions.
+type Interface interface {
+	// TestAndActivate decides whether the given Element is allowed to be activated (with respected to whether it has
+	// been modified and/or inhibitChildren).
+	TestAndActivate(Element, bool, bool) (bool, *Reason)
+	// Done marks the given ID as "done" (meaning that a reconciliation has been executed successful).
+	Done(ID) bool
+	// Delete deletes the given ID from the internal state.
+	Delete(ID)
+
+	// MarkStatic marks an identifier as "static" (meaning that it has no parent represented by another ID).
+	MarkStatic(ID)
+	// UnmarkStatic unmarks an identifer as "static".
+	UnmarkStatic(ID)
+
+	// Reset resets the internal state of the scheduler.
+	Reset()
+}
+
+type entry struct {
+	id     ID
+	parent ID
+
+	active          bool
+	inhibitChildren bool
+
+	lastScheduleTime time.Time
+}
+
+type state struct {
+	lock   sync.Mutex
+	logger logrus.FieldLogger
+
+	staticParents map[ID]struct{}
+	entries       map[ID]*entry
+}
+
+var (
+	_        Interface = &state{}
+	zeroTime time.Time
+)
+
+// New returns a new reconcile scheduler interface.
+func New(logger logrus.FieldLogger) Interface {
+	s := &state{
+		staticParents: map[ID]struct{}{},
+		entries:       map[ID]*entry{},
+	}
+
+	if logger == nil {
+		l := logrus.New()
+		l.Out = ioutil.Discard
+		s.logger = l
+	} else {
+		s.logger = logger
+	}
+
+	return s
+}
+
+// TestAndActivate decides whether the given Element is allowed to be activated (with respected to whether it has
+// been modified and/or it wants to inhibit children although they might have a higher priority).
+func (s *state) TestAndActivate(element Element, modified, inhibitChildren bool) (bool, *Reason) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.logger.Debugf("TEST %q (modified=%t, inhibitChildren=%t)", element.GetID(), modified, inhibitChildren)
+
+	entry := s.getEntry(element)
+
+	// If the element is already active then it cannot be activated again.
+	if entry.active {
+		return false, NewReason(CodeAlreadyActive, "element has already been marked as 'active'")
+	}
+
+	var (
+		elementID   = element.GetID()
+		parentID    = element.GetParentID()
+		parentEntry = s.entries[parentID]
+	)
+
+	// We want to ensure that parents are schedule first. Hence, when the object has not been
+	// modified then we check whether the parent has already been reconciled.
+	if !modified {
+		var (
+			checkedIDs = sets.NewString(elementID.String())
+			currentID  = parentID
+		)
+
+		// IDentify the first parent of the entry to later check whether we are in a cycle or not,
+		// and whether the parent needs to be scheduled first.
+		for p := s.entries[currentID]; p != nil && !checkedIDs.Has(currentID.String()); {
+			checkedIDs.Insert(currentID.String())
+			currentID = p.parent
+			p = s.entries[currentID]
+		}
+
+		// If a parent is missing then we cannot decide yet whether the given element may be scheduled.
+		if !s.parentKnown(currentID) {
+			return false, NewReason(CodeParentUnknown, "required parent (%q) not yet known", currentID)
+		}
+
+		// If we have not found a cycle then we check whether the first parent has been scheduled already.
+		if currentID != elementID {
+			// Check whether first parent has already been scheduled previously. If not then we deny as we
+			// want that parents are scheduled first.
+			if !alreadyScheduled(parentEntry) {
+				return false, NewReason(CodeParentNotReconciled, "parent (%q) not yet scheduled", parentEntry.id)
+			}
+		} else {
+			s.logger.Debugf("cycle found for %s", elementID)
+		}
+	}
+
+	// Check that neither the parent nor any of the children is currently active. If a child has been found
+	// to be active it is possible to prohibit further child schedules in order to prevent that a parent
+	// starves (based on the set <inhibitChildren> argument).
+	for _, e := range s.entries {
+		if isMyChild(elementID, e) && e.active {
+			entry.inhibitChildren = inhibitChildren
+			return false, NewReason(CodeChildActive, "child (%s) active", e.id)
+		}
+	}
+
+	if parentEntry != nil {
+		if parentEntry.active {
+			return false, NewReason(CodeParentActive, "parent (%q) active", parentEntry.id)
+		}
+		if parentEntry.inhibitChildren {
+			return false, NewReason(CodeParentPending, "parent (%q) requested to be scheduled before any other children", parentEntry.id)
+		}
+	}
+
+	// All checks have been passed - the element can be activated. Its entry is no longer marked for
+	// inhibiting children (if it actually was marked at all) as it is now activated and allowed to
+	// be scheduled.
+	entry.lastScheduleTime = time.Now()
+	entry.active = true
+	entry.inhibitChildren = false
+
+	return true, NewReason(CodeActivated, "activated %q", element.GetID())
+}
+
+// Done marks the given id as "done" (meaning that a reconciliation has been executed successful).
+// It returns false if the no entry with the given id is known or if the respective entry is not
+// active. Otherwise, true is returned.
+func (s *state) Done(id ID) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.logger.Debugf("DONE %q", id)
+
+	entry := s.entries[id]
+	if entry == nil || !entry.active {
+		return false
+	}
+
+	entry.active = false
+	return true
+}
+
+// Delete deletes the given id from the internal state.
+func (s *state) Delete(id ID) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.logger.Debugf("DELETE %q", id)
+
+	delete(s.entries, id)
+}
+
+// Reset resets the internal state of the scheduler.
+func (s *state) Reset() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.logger.Debugf("RESET")
+
+	s.entries = map[ID]*entry{}
+}
+
+// MarkStatic marks an identifier as "static" (meaning that it has no parent represented by another ID).
+func (s *state) MarkStatic(id ID) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.logger.Debugf("DECLARE STATIC PARENT %q", id)
+
+	s.staticParents[id] = struct{}{}
+}
+
+// UnmarkStatic unmarks an identifer as "static".
+func (s *state) UnmarkStatic(id ID) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.logger.Debugf("DELETE STATIC PARENT %q", id)
+
+	delete(s.staticParents, id)
+}
+
+// parentKnown checks whether the given parent is valid. It returns true if the parent
+// was either found in the state map or if has been declared as "static". It returns
+// false if the parent is not (yet) known.
+func (s *state) parentKnown(parent ID) bool {
+	_, isStatic := s.staticParents[parent]
+	return s.entries[parent] != nil || isStatic
+}
+
+// getEntry returns the entry that has been stored for the given element in the state map.
+// It also updates the parent in case it has changed.
+// If the given element is not yet known to the state map then it gets added and returned.
+func (s *state) getEntry(element Element) *entry {
+	id := element.GetID()
+
+	// id has been found in the state map - refresh parent in case it has changed
+	if entry := s.entries[id]; entry != nil {
+		entry.parent = element.GetParentID()
+		return entry
+	}
+
+	// id has not been found in the state map - add and return it
+	entry := &entry{
+		id:               id,
+		parent:           element.GetParentID(),
+		active:           false,
+		inhibitChildren:  false,
+		lastScheduleTime: zeroTime,
+	}
+	s.entries[id] = entry
+	return entry
+}
+
+func alreadyScheduled(entry *entry) bool {
+	return entry == nil || entry.lastScheduleTime != zeroTime
+}
+
+func isMyChild(me ID, entry *entry) bool {
+	return entry.parent == me
+}

--- a/pkg/utils/reconcilescheduler/state_test.go
+++ b/pkg/utils/reconcilescheduler/state_test.go
@@ -1,0 +1,323 @@
+package reconcilescheduler_test
+
+import (
+	"fmt"
+
+	. "github.com/gardener/gardener/pkg/utils/reconcilescheduler"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	reconcileAllowed    = true
+	reconcileNotAllowed = false
+
+	specModified = 1
+	isReserved   = 2
+)
+
+var _ = Describe("reconcilescheduler", func() {
+	Context("Interface", func() {
+		var (
+			cycleAid = newID("cycleA")
+			cycleBid = newID("cycleB")
+			cycleCid = newID("cycleC")
+			soilAid  = newID("soilA")
+			seedAid  = newID("seedA")
+			seedBid  = newID("seedB")
+			shootAid = newID("shootA")
+			shootBid = newID("shootB")
+			shootCid = newID("shootC")
+
+			cycleA = newElement(&cycleAid, &cycleCid)
+			cycleB = newElement(&cycleBid, &cycleAid)
+			cycleC = newElement(&cycleCid, &cycleBid)
+			seedA  = newElement(&seedAid, &soilAid)
+			seedB  = newElement(&seedBid, &seedAid)
+			shootA = newElement(&shootAid, &seedAid)
+			shootB = newElement(&shootBid, &seedBid)
+			shootC = newElement(&shootCid, &seedBid)
+		)
+
+		Context("#TestAndActivate", func() {
+			var (
+				scheduler = New(nil)
+				logger    *loggerType
+
+				setupSeeds = []operationTest{
+					t(seedA, reconcileAllowed),
+					d(seedA),
+					t(seedB, reconcileAllowed),
+					d(seedB),
+				}
+			)
+
+			BeforeEach(func() {
+				scheduler.Reset()
+				scheduler.MarkStatic(soilAid)
+				logger = &loggerType{}
+			})
+
+			DescribeTable("test scheduling decisions",
+				func(schedule []operationTest) {
+					for i, o := range schedule {
+						Expect(o.Execute(scheduler, logger)).To(Equal(o.Expected()), "i=%d (%s) => \n\n%s", i, o, logger.String())
+					}
+				},
+
+				Entry("cycle with three nodes", []operationTest{
+					t(cycleA, reconcileNotAllowed),
+					t(cycleB, reconcileNotAllowed),
+					t(cycleC, reconcileAllowed),
+					d(cycleC),
+					t(cycleB, reconcileAllowed),
+					t(cycleA, reconcileNotAllowed),
+					d(cycleB),
+					t(cycleA, reconcileAllowed),
+					d(cycleA),
+				}),
+
+				Entry("seeds with static parent", []operationTest{
+					t(seedA, reconcileAllowed),
+					t(seedB, reconcileNotAllowed),
+					d(seedA),
+					t(seedB, reconcileAllowed),
+				}),
+
+				Entry("shoot and seeds", []operationTest{
+					t(shootA, reconcileNotAllowed),
+					t(seedA, reconcileAllowed),
+					t(shootA, reconcileNotAllowed),
+					d(seedA),
+					t(shootA, reconcileAllowed),
+				}),
+
+				Entry("seeds with modification", append(
+					setupSeeds,
+					t(seedB, reconcileAllowed),
+					d(seedB),
+					t(seedB, reconcileAllowed, specModified),
+				)),
+
+				Entry("shoots and seeds", append(
+					setupSeeds,
+					t(shootA, reconcileAllowed),
+					t(shootB, reconcileAllowed),
+					t(shootC, reconcileAllowed),
+					d(shootA),
+					d(shootB),
+					d(shootC),
+				)),
+
+				Entry("no concurrent shoots and seeds", []operationTest{
+					t(seedA, reconcileAllowed),
+					d(seedA),
+					t(seedB, reconcileAllowed),
+					t(shootB, reconcileNotAllowed),
+					t(shootC, reconcileNotAllowed),
+					t(shootA, reconcileAllowed),
+					d(shootA),
+					d(seedB),
+					t(shootB, reconcileAllowed),
+					t(shootC, reconcileAllowed),
+					d(shootB),
+					d(shootC),
+				}),
+
+				Entry("children block waiting parent", append(
+					setupSeeds,
+					t(shootB, reconcileAllowed),
+					t(seedB, reconcileNotAllowed, specModified),
+					t(shootC, reconcileAllowed),
+					t(seedB, reconcileNotAllowed, specModified),
+					d(shootB),
+					t(seedB, reconcileNotAllowed, specModified),
+					d(shootC),
+					t(seedB, reconcileAllowed, specModified),
+				)),
+
+				Entry("waiting parent blocks further children", append(
+					setupSeeds,
+					t(shootB, reconcileAllowed),
+					t(seedB, reconcileNotAllowed, specModified, isReserved),
+					t(shootC, reconcileNotAllowed),
+					t(seedB, reconcileNotAllowed, specModified),
+					d(shootB),
+					t(seedB, reconcileAllowed, specModified),
+					t(shootC, reconcileNotAllowed),
+					d(seedB),
+					t(shootC, reconcileAllowed),
+					d(shootC),
+				)),
+
+				Entry("modified seeds at beginning", []operationTest{
+					t(seedA, reconcileAllowed),
+					d(seedA),
+					t(seedB, reconcileAllowed, specModified),
+					t(shootC, reconcileNotAllowed),
+					d(seedB),
+					t(shootC, reconcileAllowed),
+					t(seedB, reconcileNotAllowed, specModified),
+					d(shootC),
+					t(seedB, reconcileAllowed, specModified),
+				}),
+
+				Entry("no shoots before seeds", append(
+					setupSeeds,
+					t(shootA, reconcileAllowed),
+					d(shootA),
+					t(shootA, reconcileAllowed),
+				)),
+			)
+		})
+	})
+})
+
+// Helper function for tracking scheduling decisions.
+
+type loggerType struct {
+	messages []string
+}
+
+func (l *loggerType) String() string {
+	s := ""
+	for _, msg := range l.messages {
+		s = fmt.Sprintf("%s%s\n", s, msg)
+	}
+	return s
+}
+
+func (l *loggerType) Add(msgFmt string, args ...interface{}) {
+	l.messages = append(l.messages, fmt.Sprintf(msgFmt, args...))
+}
+
+// Implementation of the ID interface for test purposes.
+
+type id struct {
+	name string
+}
+
+func (i id) String() string {
+	return i.name
+}
+
+func (i id) GetID() ID {
+	return i
+}
+
+func newID(name string) id {
+	return id{name}
+}
+
+// Implementation of the Element interface for test purposes.
+
+type element struct {
+	name   *id
+	parent *id
+}
+
+func (e element) String() string {
+	return e.name.String()
+}
+
+func (e *element) GetID() ID {
+	return *e.name
+}
+func (e *element) GetParentID() ID {
+	return *e.parent
+}
+
+func newElement(id *id, parent *id) *element {
+	return &element{id, parent}
+}
+
+// Element structure for tests
+
+type operationTest interface {
+	Execute(scheduler Interface, logger *loggerType) interface{}
+	Expected() interface{}
+}
+
+// testAndActivate structure and execution
+
+type testAndActivateTest struct {
+	element         *element
+	modified        bool
+	inhibitChildren bool
+
+	expectation bool
+}
+
+func (t *testAndActivateTest) Execute(scheduler Interface, logger *loggerType) interface{} {
+	mayReconcile, reason := scheduler.TestAndActivate(t.element, t.modified, t.inhibitChildren)
+	logger.Add("%s => %s", t, reason)
+	return mayReconcile
+}
+
+func (t *testAndActivateTest) Expected() interface{} {
+	return t.expectation
+}
+
+func (t *testAndActivateTest) String() string {
+	return fmt.Sprintf("testAndActivate: %s, modified=%t, inhibitChildren=%t", t.element, t.modified, t.inhibitChildren)
+}
+
+func t(element *element, expectation bool, flags ...int) operationTest {
+	et := &testAndActivateTest{
+		element:         element,
+		modified:        false,
+		inhibitChildren: false,
+
+		expectation: expectation,
+	}
+
+	for _, flag := range flags {
+		switch flag {
+		case isReserved:
+			et.inhibitChildren = true
+		case specModified:
+			et.modified = true
+		default:
+			panic(fmt.Sprintf("invalid flag %d", flag))
+		}
+	}
+
+	return et
+}
+
+// doneTest structure and execution
+
+type doneTest struct {
+	element *element
+
+	expectation bool
+}
+
+func (d *doneTest) Execute(scheduler Interface, logger *loggerType) interface{} {
+	done := scheduler.Done(d.element.GetID())
+	logger.Add("%s => %t", d, done)
+	return done
+}
+
+func (d *doneTest) Expected() interface{} {
+	return d.expectation
+}
+
+func (d *doneTest) String() string {
+	return fmt.Sprintf("done: %s", d.element)
+}
+
+func d(element *element, expectation ...bool) operationTest {
+	d := &doneTest{
+		element:     element,
+		expectation: true,
+	}
+
+	if len(expectation) > 0 {
+		d.expectation = expectation[0]
+	}
+
+	return d
+}


### PR DESCRIPTION
**What this PR does / why we need it**: We have seen many issues that were caused by concurrent reconciliations of (shooted) seeds and shoots, e.g. if the etcd is upgraded or the kube-apiserver needs to be rolled. Shoots resulted in "error" state for quite a while until the seed has been reconciled completely.
With this PR we prevent these concurrent reconciliations under the following constraints:
- Seeds always have precedence before shoots
- Modifications to a resource always have precedence
- If a shoot is active neither its seed or any of its childs may be active at the same time
- If we detect a cycle (#233) then a random shoots of those in the cycle is reconciled first.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
Gardener does now prevent concurrent reconciliations of seeds and shoots. As a result it may take a while until a shoot gets reconciled if its seed is processing.
```
