### PR TITLE
Bump golang to v1.11.1

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -23,9 +23,9 @@ gardener:
             tag_as_latest: true
     steps:
       check:
-        image: 'golang:1.10.2'
+        image: 'golang:1.11.1'
       test:
-        image: 'golang:1.10.2'
+        image: 'golang:1.11.1'
   variants:
     head-update:
       traits:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.10.3 AS builder
+FROM golang:1.11.1 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -12,7 +12,7 @@ This setup is based on [minikube](https://github.com/kubernetes/minikube), a Kub
 
 ## Installing Golang environment
 
-Install the latest version of Golang (at least `v1.10.x` is required). For Mac OS you could use [Homebrew](https://brew.sh/):
+Install the Golang `v1.11`. For Mac OS you could use [Homebrew](https://brew.sh/):
 
 ```bash
 $ brew install golang

--- a/pkg/client/kubernetes/base/base.go
+++ b/pkg/client/kubernetes/base/base.go
@@ -57,11 +57,11 @@ func NewForConfig(config *rest.Config) (*Client, error) {
 			Jobs:                      {"apis", "batch", "v1"},
 			Namespaces:                {"api", "v1"},
 			PersistentVolumeClaims:    {"api", "v1"},
-			Pods:                   {"api", "v1"},
-			ReplicaSets:            {"apis", "apps", "v1"},
-			ReplicationControllers: {"api", "v1"},
-			Services:               {"api", "v1"},
-			StatefulSets:           {"apis", "apps", "v1"},
+			Pods:                      {"api", "v1"},
+			ReplicaSets:               {"apis", "apps", "v1"},
+			ReplicationControllers:    {"api", "v1"},
+			Services:                  {"api", "v1"},
+			StatefulSets:              {"apis", "apps", "v1"},
 		},
 	}
 

--- a/pkg/utils/secrets/certificates.go
+++ b/pkg/utils/secrets/certificates.go
@@ -178,11 +178,11 @@ func (s *CertificateSecretConfig) generateCertificateTemplate() *x509.Certificat
 
 		template = &x509.Certificate{
 			BasicConstraintsValid: true,
-			IsCA:         isCA,
-			SerialNumber: serialNumber,
-			NotBefore:    now,
-			NotAfter:     now.AddDate(10, 0, 0), // + 10 years
-			KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+			IsCA:                  isCA,
+			SerialNumber:          serialNumber,
+			NotBefore:             now,
+			NotAfter:              now.AddDate(10, 0, 0), // + 10 years
+			KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 			Subject: pkix.Name{
 				CommonName:   s.CommonName,
 				Organization: s.Organization,


### PR DESCRIPTION
**What this PR does / why we need it**:
We should keep up-to-date with the latest versions.

**Special notes for your reviewer**:
New formatting rules applied on the way.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The version of golang has been upgraded to v1.11.1.
```
