### PR TITLE
[ci:component:github.com/gardener/machine-controller-manager:0.10.0->0.11.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -29,7 +29,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "0.10.0"
+  tag: "0.11.0"
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler

--- a/charts/seed-controlplane/charts/machine-controller-manager/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/machine-controller-manager/templates/deployment.yaml
@@ -36,12 +36,18 @@ spec:
         command:
         - ./machine-controller-manager
         - --control-kubeconfig=inClusterConfig
-        - --machine-health-timeout=10
-        - --machine-drain-timeout=5
-        - --machine-set-scale-timeout=40
         - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
         - --namespace={{ .Release.Namespace }}
         - --port={{ .Values.metricsPort }}
+        - --machine-creation-timeout=20m
+        - --machine-drain-timeout=5m
+        - --machine-health-timeout=10m
+        - --machine-safety-apiserver-statuscheck-timeout=30s
+        - --machine-safety-apiserver-statuscheck-period=1m
+        - --machine-safety-orphan-vms-period=30m
+        - --machine-safety-overshooting-period=1m
+        - --safety-up=2
+        - --safety-down=1
         - --v=2
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
*Release Notes*:
``` noteworthy user github.com/gardener/machine-controller-manager #183 @prashanth26
Timeouts for creation and health check is split into two configurable knobs instead of a single one
```

``` improvement operator github.com/gardener/machine-controller-manager #173 @prashanth26
Updates vendor dependecies to support K8s version 1.10
```

``` improvement operator github.com/gardener/machine-controller-manager #159 @zanetworker
Restructure documentation so they are easier to consume.
```

``` improvement operator github.com/gardener/machine-controller-manager #180 @prashanth26
(Un)Freezing of machine controller based on APIServer availability
```