### PR TITLE
Adjust shoot's Prometheus resources based on node count.

### DIFF
--- a/charts/seed-monitoring/charts/prometheus/templates/_resource.tpl
+++ b/charts/seed-monitoring/charts/prometheus/templates/_resource.tpl
@@ -1,0 +1,12 @@
+{{/*
+resource.quantity returns resource quantity based on number of objects (such as nodes, pods etc..),
+resource per object, object weight and base resource quantity.
+*/}}
+{{- define "resource.quantity" -}}
+{{- range $resourceKey, $resourceValue := $.resources }}
+{{ $resourceKey }}:
+{{- range $_, $r := $resourceValue }}
+  {{ $r.name }}: {{ printf "%d%s" ( add $r.base ( mul ( div $.objectCount $r.weight ) $r.perObject $r.weight ) ) $r.unit }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
@@ -98,12 +98,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 3
         resources:
-          requests:
-            cpu: 50m
-            memory: 1200Mi
-          limits:
-            cpu: 500m
-            memory: 2400Mi
+{{- include "resource.quantity" .Values | indent 10 }}
         volumeMounts:
         - mountPath: /srv/kubernetes/prometheus-kubelet
           name: prometheus-kubelet

--- a/charts/seed-monitoring/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/prometheus/values.yaml
@@ -152,3 +152,32 @@ rules:
   optional:
     cluster-autoscaler:
       enabled: true
+
+# object can be any object you want to scale Prometheus on:
+# - number of Pods
+# - number of Nodes
+# - total Foos
+objectCount: 4
+resources:
+  requests:
+  - name: cpu
+    base: 200
+    perObject: 6
+    weight: 5
+    unit: m
+  - name: memory
+    base: 300
+    perObject: 35
+    weight: 5
+    unit: Mi
+  limits:
+  - name: cpu
+    base: 350
+    perObject: 12
+    weight: 5
+    unit: m
+  - name: memory
+    base: 700
+    perObject: 60
+    weight: 5
+    unit: Mi

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -281,6 +281,7 @@ func (b *Botanist) DeploySeedMonitoring() error {
 			"namespace": map[string]interface{}{
 				"uid": b.SeedNamespaceObject.UID,
 			},
+			"objectCount": b.Shoot.GetNodeCount(),
 			"podAnnotations": map[string]interface{}{
 				"checksum/secret-prometheus":                b.CheckSums["prometheus"],
 				"checksum/secret-kube-apiserver-basic-auth": b.CheckSums["kube-apiserver-basic-auth"],


### PR DESCRIPTION
**What this PR does / why we need it**:

The memory consumption of Shoot Prometheus can vary based on the Shoot's size. With this PR we make the resource calculations dynamically

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

For K8S shoot cluster with

3 nodes:

```yaml
limits:
  cpu: 350m
  memory: 700Mi
requests:
  cpu: 200m
  memory: 300Mi
```

50 nodes:

```yaml
limits:
  cpu: 950m
  memory: 3700Mi
requests:
  cpu: 500m
  memory: 2050Mi
```

100 nodes:

```yaml
limits:
  cpu: 1550m
  memory: 6700Mi
requests:
  cpu: 800m
  memory: 3800Mi
```


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The shoot's Prometheus does now scale vertically based on the node count.
```

/cc

@vlerenc @dkistner @wyb1 
