### PR TITLE
Audit log no events by default

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/_helpers.tpl
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/_helpers.tpl
@@ -86,32 +86,5 @@ apiVersion: {{ include "kube-apiserver.auditversion" . }}
 kind: Policy
 rules:
 - level: None
-  userGroups:
-  - system:nodes
-- level: None
-  users:
-  - gardener
-  - kubelet
-  - system:kube-controller-manager
-  - system:kube-scheduler
-  - system:kube-addon-manager
-  - system:kube-aggregator
-  - system:kube-proxy
-  - system:apiserver
-  - garden.sapcloud.io:monitoring
-  - garden.sapcloud.io:monitoring:prometheus
-  - garden.sapcloud.io:monitoring:kube-state-metrics
-- level: None
-  nonResourceURLs:
-  - /healthz*
-  - /version
-  - /swagger*
-- level: None
-  resources:
-  - group: ""
-    resources: ["events"]
-- level: None
-  verbs: ["get"]
-- level: Metadata
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
The `kube-apiserver` of the shoot cluster will not produce audit events by default.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```action user
By default kube-apiserver of the shoot clusters will no longer produce audit events. To enable auditing, please provide a custom audit policy.
```
