### PR TITLE
Enable IPVS mode in kube-proxy

### DIFF
--- a/charts/shoot-core/charts/kube-proxy/templates/_proxy_mode.tpl
+++ b/charts/shoot-core/charts/kube-proxy/templates/_proxy_mode.tpl
@@ -1,0 +1,7 @@
+{{- define "kube-proxy.mode" -}}
+{{- if .Values.enableIPVS -}}
+ipvs
+{{- else -}}
+iptables
+{{- end -}}
+{{- end -}}

--- a/charts/shoot-core/charts/kube-proxy/templates/componentconfig.yaml
+++ b/charts/shoot-core/charts/kube-proxy/templates/componentconfig.yaml
@@ -13,7 +13,10 @@ data:
     kind: KubeProxyConfiguration
     clientConnection:
       kubeconfig: /var/lib/kube-proxy/kubeconfig
+{{- if not .Values.enableIPVS }}
     clusterCIDR: {{ .Values.global.podNetwork }}
+{{- end }}
+    mode: {{ include "kube-proxy.mode" . }}
     conntrack:
       maxPerCore: 524288
     {{- if .Values.featureGates }}

--- a/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -30,6 +30,19 @@ spec:
         app: kubernetes
         role: proxy
     spec:
+{{- if .Values.enableIPVS }}
+      # Temporary fix until https://github.com/kubernetes/kubernetes/issues/70113
+      # is fixed in 1.13, 1.12 and 1.11
+      initContainers:
+      - name: disable-ipv6
+        image: {{ index .Values.images "alpine"}}
+        command:
+        - /sbin/sysctl
+        - -w
+        - net.ipv6.conf.all.disable_ipv6=1
+        securityContext:
+          privileged: true
+{{- end }}
       priorityClassName: system-cluster-critical
       tolerations:
       - effect: NoSchedule
@@ -70,6 +83,8 @@ spec:
           readOnly: true
         - name: systembussocket
           mountPath: /var/run/dbus/system_bus_socket
+        - name: kernel-modules
+          mountPath: /lib/modules
       volumes:
       - name: kubeconfig
         secret:
@@ -83,3 +98,6 @@ spec:
       - name: systembussocket
         hostPath:
           path: /var/run/dbus/system_bus_socket
+      - name: kernel-modules
+        hostPath:
+          path: /lib/modules

--- a/charts/shoot-core/charts/kube-proxy/templates/psp/kube-proxy-psp.yaml
+++ b/charts/shoot-core/charts/kube-proxy/templates/psp/kube-proxy-psp.yaml
@@ -14,6 +14,7 @@ spec:
   allowedHostPaths:
   - pathPrefix: /usr/share/ca-certificates
   - pathPrefix: /var/run/dbus/system_bus_socket
+  - pathPrefix: /lib/modules
   runAsUser:
     rule: 'RunAsAny'
   seLinux:

--- a/charts/shoot-core/charts/kube-proxy/values.yaml
+++ b/charts/shoot-core/charts/kube-proxy/values.yaml
@@ -6,4 +6,7 @@ featureGates: {}
   # RotateKubeletServerCertificate: false
 images:
   hyperkube: image-repository
+  alpine: image-repository
 podAnnotations: {}
+
+enableIPVS: false

--- a/example/90-shoot-alicloud.yaml
+++ b/example/90-shoot-alicloud.yaml
@@ -80,6 +80,7 @@ spec:
   # kubeProxy:
   #   featureGates:
   #     SomeKubernetesFeature: true
+  #   mode: IPVS
   # kubelet:
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-aws.yaml
+++ b/example/90-shoot-aws.yaml
@@ -84,6 +84,7 @@ spec:
   # kubeProxy:
   #   featureGates:
   #     SomeKubernetesFeature: true
+  #   mode: IPVS
   # kubelet:
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-azure.yaml
+++ b/example/90-shoot-azure.yaml
@@ -83,6 +83,7 @@ spec:
   # kubeProxy:
   #   featureGates:
   #     SomeKubernetesFeature: true
+  #   mode: IPVS
   # kubelet:
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-gcp.yaml
+++ b/example/90-shoot-gcp.yaml
@@ -82,6 +82,7 @@ spec:
   # kubeProxy:
   #   featureGates:
   #     SomeKubernetesFeature: true
+  #   mode: IPVS
   # kubelet:
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-local.yaml
+++ b/example/90-shoot-local.yaml
@@ -70,6 +70,7 @@ spec:
   # kubeProxy:
   #   featureGates:
   #     SomeKubernetesFeature: true
+  #   mode: IPVS
   # kubelet:
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-openstack.yaml
+++ b/example/90-shoot-openstack.yaml
@@ -81,6 +81,7 @@ spec:
   # kubeProxy:
   #   featureGates:
   #     SomeKubernetesFeature: true
+  #   mode: IPVS
   # kubelet:
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -280,6 +280,7 @@ spec:
   # kubeProxy:
   #   featureGates:
   #     SomeKubernetesFeature: true
+  #   mode: IPVS
   % endif
     % if kubelet != {}:
     kubelet: ${yaml.dump(kubelet, width=10000)}

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -1377,7 +1377,27 @@ type KubeSchedulerConfig struct {
 // KubeProxyConfig contains configuration settings for the kube-proxy.
 type KubeProxyConfig struct {
 	KubernetesConfig
+	// Mode specifies which proxy mode to use.
+	// defaults to IPTables.
+	Mode *ProxyMode
 }
+
+// ProxyMode available in Linux platform: 'userspace' (older, going to be EOL), 'iptables'
+// (newer, faster), 'ipvs'(newest, better in performance and scalability).
+//
+// As of now only 'iptables' and 'ipvs' is supported by Gardener.
+//
+// In Linux platform, if the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are
+// insufficient, this always falls back to the userspace proxy. IPVS mode will be enabled when proxy mode is set to 'ipvs',
+// and the fall back path is firstly iptables and then userspace.
+type ProxyMode string
+
+const (
+	// ProxyModeIPTables uses iptables as proxy implementation.
+	ProxyModeIPTables ProxyMode = "IPTables"
+	// ProxyModeIPVS uses ipvs as proxy implementation.
+	ProxyModeIPVS ProxyMode = "IPVS"
+)
 
 // KubeletConfig contains configuration settings for the kubelet.
 type KubeletConfig struct {

--- a/pkg/apis/garden/v1beta1/defaults.go
+++ b/pkg/apis/garden/v1beta1/defaults.go
@@ -30,6 +30,7 @@ func SetDefaults_Shoot(obj *Shoot) {
 		cloud              = obj.Spec.Cloud
 		defaultPodCIDR     = DefaultPodNetworkCIDR
 		defaultServiceCIDR = DefaultServiceNetworkCIDR
+		defaultProxyMode   = ProxyModeIPTables
 	)
 
 	if cloud.AWS != nil {
@@ -117,6 +118,12 @@ func SetDefaults_Shoot(obj *Shoot) {
 	trueVar := true
 	if obj.Spec.Kubernetes.AllowPrivilegedContainers == nil {
 		obj.Spec.Kubernetes.AllowPrivilegedContainers = &trueVar
+	}
+
+	if obj.Spec.Kubernetes.KubeProxy != nil {
+		if obj.Spec.Kubernetes.KubeProxy.Mode == nil {
+			obj.Spec.Kubernetes.KubeProxy.Mode = &defaultProxyMode
+		}
 	}
 
 	if obj.Spec.Maintenance == nil {

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -1425,7 +1425,28 @@ type KubeSchedulerConfig struct {
 // KubeProxyConfig contains configuration settings for the kube-proxy.
 type KubeProxyConfig struct {
 	KubernetesConfig `json:",inline"`
+	// Mode specifies which proxy mode to use.
+	// defaults to IPTables.
+	// +optional
+	Mode *ProxyMode `json:"mode,omitempty"`
 }
+
+// ProxyMode available in Linux platform: 'userspace' (older, going to be EOL), 'iptables'
+// (newer, faster), 'ipvs'(newest, better in performance and scalability).
+//
+// As of now only 'iptables' and 'ipvs' is supported by Gardener.
+//
+// In Linux platform, if the iptables proxy is selected, regardless of how, but the system's kernel or iptables versions are
+// insufficient, this always falls back to the userspace proxy. IPVS mode will be enabled when proxy mode is set to 'ipvs',
+// and the fall back path is firstly iptables and then userspace.
+type ProxyMode string
+
+const (
+	// ProxyModeIPTables uses iptables as proxy implementation.
+	ProxyModeIPTables ProxyMode = "IPTables"
+	// ProxyModeIPVS uses ipvs as proxy implementation.
+	ProxyModeIPVS ProxyMode = "IPVS"
+)
 
 // KubeletConfig contains configuration settings for the kubelet.
 type KubeletConfig struct {

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -3092,6 +3092,7 @@ func autoConvert_v1beta1_KubeProxyConfig_To_garden_KubeProxyConfig(in *KubeProxy
 	if err := Convert_v1beta1_KubernetesConfig_To_garden_KubernetesConfig(&in.KubernetesConfig, &out.KubernetesConfig, s); err != nil {
 		return err
 	}
+	out.Mode = (*garden.ProxyMode)(unsafe.Pointer(in.Mode))
 	return nil
 }
 
@@ -3104,6 +3105,7 @@ func autoConvert_garden_KubeProxyConfig_To_v1beta1_KubeProxyConfig(in *garden.Ku
 	if err := Convert_garden_KubernetesConfig_To_v1beta1_KubernetesConfig(&in.KubernetesConfig, &out.KubernetesConfig, s); err != nil {
 		return err
 	}
+	out.Mode = (*ProxyMode)(unsafe.Pointer(in.Mode))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -1703,6 +1703,11 @@ func (in *KubeLego) DeepCopy() *KubeLego {
 func (in *KubeProxyConfig) DeepCopyInto(out *KubeProxyConfig) {
 	*out = *in
 	in.KubernetesConfig.DeepCopyInto(&out.KubernetesConfig)
+	if in.Mode != nil {
+		in, out := &in.Mode, &out.Mode
+		*out = new(ProxyMode)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/garden/validation/validation_test.go
+++ b/pkg/apis/garden/validation/validation_test.go
@@ -4908,6 +4908,62 @@ var _ = Describe("validation", func() {
 			})
 		})
 
+		Context("KubeProxy validation", func() {
+			BeforeEach(func() {
+				shoot.Spec.Kubernetes.KubeProxy = &garden.KubeProxyConfig{}
+			})
+
+			It("should succeed when using IPTables mode", func() {
+				m := garden.ProxyModeIPTables
+				shoot.Spec.Kubernetes.KubeProxy.Mode = &m
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(BeEmpty())
+
+			})
+
+			It("should succeed when using IPVS mode", func() {
+				m := garden.ProxyModeIPVS
+				shoot.Spec.Kubernetes.KubeProxy.Mode = &m
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(BeEmpty())
+
+			})
+
+			It("should fail when using nil proxy mode", func() {
+				shoot.Spec.Kubernetes.KubeProxy.Mode = nil
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.kubernetes.kubeProxy.mode"),
+				}))))
+			})
+
+			It("should fail when using empty proxy mode", func() {
+				m := garden.ProxyMode("")
+				shoot.Spec.Kubernetes.KubeProxy.Mode = &m
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeNotSupported),
+					"Field": Equal("spec.kubernetes.kubeProxy.mode"),
+				}))))
+			})
+
+			It("should fail when using unknown proxy mode", func() {
+				m := garden.ProxyMode("fooMode")
+				shoot.Spec.Kubernetes.KubeProxy.Mode = &m
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeNotSupported),
+					"Field": Equal("spec.kubernetes.kubeProxy.mode"),
+				}))))
+			})
+		})
+
 		Context("AuditConfig validation", func() {
 			It("should forbid empty name", func() {
 				shoot.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name = ""

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -1684,6 +1684,11 @@ func (in *KubeLego) DeepCopy() *KubeLego {
 func (in *KubeProxyConfig) DeepCopyInto(out *KubeProxyConfig) {
 	*out = *in
 	in.KubernetesConfig.DeepCopyInto(&out.KubernetesConfig)
+	if in.Mode != nil {
+		in, out := &in.Mode, &out.Mode
+		*out = new(ProxyMode)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/client/machine/clientset/versioned/typed/machine/v1alpha1/fake/fake_machine.go
+++ b/pkg/client/machine/clientset/versioned/typed/machine/v1alpha1/fake/fake_machine.go
@@ -100,6 +100,18 @@ func (c *FakeMachines) Update(machine *v1alpha1.Machine) (result *v1alpha1.Machi
 	return obj.(*v1alpha1.Machine), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeMachines) UpdateStatus(machine *v1alpha1.Machine) (*v1alpha1.Machine, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(machinesResource, "status", c.ns, machine), &v1alpha1.Machine{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.Machine), err
+}
+
 // Delete takes name of the machine and deletes it. Returns an error if one occurs.
 func (c *FakeMachines) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.

--- a/pkg/client/machine/clientset/versioned/typed/machine/v1alpha1/machine.go
+++ b/pkg/client/machine/clientset/versioned/typed/machine/v1alpha1/machine.go
@@ -39,6 +39,7 @@ type MachinesGetter interface {
 type MachineInterface interface {
 	Create(*v1alpha1.Machine) (*v1alpha1.Machine, error)
 	Update(*v1alpha1.Machine) (*v1alpha1.Machine, error)
+	UpdateStatus(*v1alpha1.Machine) (*v1alpha1.Machine, error)
 	Delete(name string, options *v1.DeleteOptions) error
 	DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error
 	Get(name string, options v1.GetOptions) (*v1alpha1.Machine, error)
@@ -126,6 +127,22 @@ func (c *machines) Update(machine *v1alpha1.Machine) (result *v1alpha1.Machine, 
 		Namespace(c.ns).
 		Resource("machines").
 		Name(machine.Name).
+		Body(machine).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+
+func (c *machines) UpdateStatus(machine *v1alpha1.Machine) (result *v1alpha1.Machine, err error) {
+	result = &v1alpha1.Machine{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("machines").
+		Name(machine.Name).
+		SubResource("status").
 		Body(machine).
 		Do().
 		Into(result)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3631,6 +3631,12 @@ func schema_pkg_apis_garden_v1beta1_KubeProxyConfig(ref common.ReferenceCallback
 							},
 						},
 					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/operation/hybridbotanist/addons.go
+++ b/pkg/operation/hybridbotanist/addons.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/secrets"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,6 +66,7 @@ func (b *HybridBotanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart
 			"podAnnotations": map[string]interface{}{
 				"checksum/secret-kube-proxy": b.CheckSums["kube-proxy"],
 			},
+			"enableIPVS": b.Shoot.IPVSEnabled(),
 		}
 		metricsServerConfig = map[string]interface{}{
 			"tls": map[string]interface{}{
@@ -108,7 +108,7 @@ func (b *HybridBotanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart
 		return nil, err
 	}
 
-	kubeProxy, err := b.Botanist.InjectImages(kubeProxyConfig, b.ShootVersion(), b.ShootVersion(), common.HyperkubeImageName)
+	kubeProxy, err := b.Botanist.InjectImages(kubeProxyConfig, b.ShootVersion(), b.ShootVersion(), common.HyperkubeImageName, common.AlpineImageName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -238,6 +238,13 @@ func (s *Shoot) ComputeAPIServerURL(runsInSeed, useInternalClusterDomain bool) s
 	return *(s.ExternalClusterDomain)
 }
 
+// IPVSEnabled returns true if IPVS is enabled for the shoot.
+func (s *Shoot) IPVSEnabled() bool {
+	return s.Info.Spec.Kubernetes.KubeProxy != nil &&
+		s.Info.Spec.Kubernetes.KubeProxy.Mode != nil &&
+		*s.Info.Spec.Kubernetes.KubeProxy.Mode == gardenv1beta1.ProxyModeIPVS
+}
+
 // ComputeTechnicalID determines the technical id of that Shoot which is later used for the name of the
 // namespace and for tagging all the resources created in the infrastructure.
 func ComputeTechnicalID(projectName string, shoot *gardenv1beta1.Shoot) string {

--- a/pkg/operation/shoot/shoot_suite_test.go
+++ b/pkg/operation/shoot/shoot_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestCommon(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Shoot Suite")
+}

--- a/pkg/operation/shoot/shoot_test.go
+++ b/pkg/operation/shoot/shoot_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot_test
+
+import (
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	. "github.com/gardener/gardener/pkg/operation/shoot"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("shoot", func() {
+
+	var shoot *Shoot
+
+	BeforeEach(func() {
+		shoot = &Shoot{
+			Info: &gardenv1beta1.Shoot{},
+		}
+	})
+
+	Describe("#IPVSEnabled", func() {
+
+		It("should return false when KubeProxy is null", func() {
+			shoot.Info.Spec.Kubernetes.KubeProxy = nil
+
+			Expect(shoot.IPVSEnabled()).To(BeFalse())
+		})
+
+		It("should return false when KubeProxy.Mode is null", func() {
+			shoot.Info.Spec.Kubernetes.KubeProxy = &gardenv1beta1.KubeProxyConfig{}
+			Expect(shoot.IPVSEnabled()).To(BeFalse())
+		})
+
+		It("should return false when KubeProxy.Mode is not IPVS", func() {
+			mode := gardenv1beta1.ProxyModeIPTables
+			shoot.Info.Spec.Kubernetes.KubeProxy = &gardenv1beta1.KubeProxyConfig{
+				Mode: &mode,
+			}
+			Expect(shoot.IPVSEnabled()).To(BeFalse())
+		})
+
+		It("should return true when KubeProxy.Mode is IPVS", func() {
+			mode := gardenv1beta1.ProxyModeIPVS
+			shoot.Info.Spec.Kubernetes.KubeProxy = &gardenv1beta1.KubeProxyConfig{
+				Mode: &mode,
+			}
+			Expect(shoot.IPVSEnabled()).To(BeTrue())
+		})
+
+	})
+
+})


### PR DESCRIPTION
**What this PR does / why we need it**: IPVS offers better performance than `iptables`

**Which issue(s) this PR fixes**:
Fixes #247 

**Special notes for your reviewer**:  
`IPVS` works, but when switching from `iptables` to `IPVS` it complains about an IPv6 address (See kubernetes/kubernetes#70113) which it doesn't know for.

```
﻿﻿....
I1105 12:43:56.030870       1 proxier.go:1657] Opened local port "nodePort for kube-system/addons-monocular-api:monocular-api" (:30122/tcp)
I1105 12:43:56.032516       1 proxier.go:1657] Opened local port "nodePort for kube-system/addons-monocular-ui:monocular-ui" (:31147/tcp)
E1105 12:43:56.730688       1 proxier.go:1591] Failed to unbind service addr fe80::48a:39ff:feb1:21ba from dummy interface kube-ipvs0: error unbind address: fe80::48a:39ff:feb1:21ba from interface: kube-ipvs0, err: cannot assign requested address
E1105 12:43:57.630347       1 proxier.go:1591] Failed to unbind service addr fe80::48a:39ff:feb1:21ba from dummy interface kube-ipvs0: error unbind address: fe80::48a:39ff:feb1:21ba from interface: kube-ipvs0, err: cannot assign requested address
``` 

I'll suggest to keep this PR open for now.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
`IPVS` mode in `kube-proxy` can now be enabled via the Shoot's `spec.kubernetes.kubeProxy.mode` field. Recommended versions of Kubernetes which can be used with this configuration are: 
- `~1.11.6`
- `~1.12.4`
- `~1.13.1`
- `^1.14`
```
