### PR TITLE
Use init container for Calico install-cni

### DIFF
--- a/charts/shoot-core/charts/calico/templates/calico.yaml
+++ b/charts/shoot-core/charts/calico/templates/calico.yaml
@@ -70,6 +70,41 @@ spec:
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
+      initContainers:
+      # This container installs the Calico CNI binaries
+      # and CNI network config file on each node.
+      - name: install-cni
+        image: {{ index .Values.images "calico-cni" }}
+        command: ["/install-cni.sh"]
+        env:
+          # Name of the CNI config file to create.
+          - name: CNI_CONF_NAME
+            value: "10-calico.conflist"
+          # The CNI network config to install on each node.
+          - name: CNI_NETWORK_CONFIG
+            valueFrom:
+              configMapKeyRef:
+                name: calico-config
+                key: cni_network_config
+          # Set the hostname based on the k8s node name.
+          - name: KUBERNETES_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          # CNI MTU Config variable
+          - name: CNI_MTU
+            valueFrom:
+              configMapKeyRef:
+                name: calico-config
+                key: veth_mtu
+          # Prevents the container from sleeping forever.
+          - name: SLEEP
+            value: "false"
+        volumeMounts:
+          - mountPath: /host/opt/cni/bin
+            name: cni-bin-dir
+          - mountPath: /host/etc/cni/net.d
+            name: cni-net-dir
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each
@@ -179,37 +214,6 @@ spec:
             - mountPath: /var/lib/calico
               name: var-lib-calico
               readOnly: false
-        # This container installs the Calico CNI binaries
-        # and CNI network config file on each node.
-        - name: install-cni
-          image: {{ index .Values.images "calico-cni" }}
-          command: ["/install-cni.sh"]
-          env:
-            # Name of the CNI config file to create.
-            - name: CNI_CONF_NAME
-              value: "10-calico.conflist"
-            # The CNI network config to install on each node.
-            - name: CNI_NETWORK_CONFIG
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: cni_network_config
-            # Set the hostname based on the k8s node name.
-            - name: KUBERNETES_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            # CNI MTU Config variable
-            - name: CNI_MTU
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: veth_mtu
-          volumeMounts:
-            - mountPath: /host/opt/cni/bin
-              name: cni-bin-dir
-            - mountPath: /host/etc/cni/net.d
-              name: cni-net-dir
       volumes:
         # Used by calico/node.
         - name: lib-modules


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows to run only 1 container:

```bash
addons-kubernetes-dashboard-789b6fcb7f-vj7tz                      1/1     Running   0          19m
addons-monocular-api-7dcb47f496-c4rgp                             1/1     Running   3          19m
addons-monocular-ui-58fcd596d9-ng6f5                              1/1     Running   0          19m
addons-nginx-ingress-controller-65c7dbf9-fhdzp                    1/1     Running   0          19m
addons-nginx-ingress-nginx-ingress-k8s-backend-6584cc89bc-7b9kb   1/1     Running   0          19m
calico-node-qs8wc                                                 1/1     Running   0          78s
calico-node-z2znq                                                 1/1     Running   0          78s
coredns-996685c97-6q2c2                                           1/1     Running   0          19m
kube-proxy-hxlpg                                                  1/1     Running   0          18m
kube-proxy-rw76v                                                  1/1     Running   0          18m
metrics-server-685c9dd8cc-9fg7q                                   1/1     Running   0          19m
node-exporter-88mmr                                               1/1     Running   0          18m
node-exporter-tr5tg                                               1/1     Running   0          18m
tiller-deploy-777d98d9bc-hfx27                                    1/1     Running   0          19m
vpn-shoot-5fc99d674f-wkx9f                                        1/1     Running   0          19m
```

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Calico now starts only one container. CNI installation happens via an init container.
```
