### PR TITLE
Fix kube-scheduler chart to use target k8s version

### DIFF
--- a/charts/seed-controlplane/charts/kube-scheduler/templates/_helpers.tpl
+++ b/charts/seed-controlplane/charts/kube-scheduler/templates/_helpers.tpl
@@ -6,3 +6,11 @@
 - --feature-gates=PodPriority=true
 {{- end }}
 {{- end -}}
+
+{{- define "kube-scheduler.componentconfigversion" -}}
+{{ if semverCompare ">= 1.12" .Values.kubernetesVersion -}}
+kubescheduler.config.k8s.io/v1alpha1
+{{- else -}}
+componentconfig/v1alpha1
+{{- end }}
+{{- end -}}

--- a/charts/seed-controlplane/charts/kube-scheduler/templates/componentconfig.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/templates/componentconfig.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   config.yaml: |-
     ---
-    apiVersion: {{ include "schedulercomponentconfigversion" . }}
+    apiVersion: {{ include "kube-scheduler.componentconfigversion" . }}
     kind: KubeSchedulerConfiguration
     clientConnection:
       kubeconfig: /var/lib/kube-scheduler/kubeconfig


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the kube-scheduler chart to use the target shoot Kubernetes version.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
