### PR TITLE
Add alerts for pvs

### DIFF
--- a/charts/seed-bootstrap/templates/prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/config.yaml
@@ -57,3 +57,30 @@ data:
         replacement: '${1}'
       - regex: ^id$
         action: labeldrop
+
+    - job_name: kubelet
+      honor_labels: false
+      scheme: https
+
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_node_address_InternalIP]
+        target_label: instance
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics
+      - target_label: type
+        replacement: seed
+
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.kubelet | indent 6 }}

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -14,6 +14,9 @@ allowedMetrics:
   - container_memory_working_set_bytes
   - container_network_receive_bytes_total
   - container_network_transmit_bytes_total
+  kubelet:
+  - kubelet_volume_stats_available_bytes
+  - kubelet_volume_stats_capacity_bytes
 
   # object can be any object you want to scale Prometheus on:
   # - number of Pods

--- a/charts/seed-monitoring/charts/prometheus/rules/kube-kubelet.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/kube-kubelet.rules.yaml
@@ -82,3 +82,30 @@ groups:
       description: '{{ $labels.node }} is using {{ $value }}% of the available file/socket
         descriptors.'
       summary: '{{ $labels.job }} has too many open file descriptors'
+  - alert: KubePersistentVolumeUsageCritical
+    expr: |
+      100 * kubelet_volume_stats_available_bytes /
+      kubelet_volume_stats_capacity_bytes < 3
+    for: 1m
+    labels:
+      service: kube-kubelet
+      severity: critical
+      type: seed
+    annotations:
+      description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} is only {{ printf "%0.2f" $value }}% free.
+      summary: PersistentVolume almost full.
+  - alert: KubePersistentVolumeFullInFourDays
+    expr: |
+      100 * (kubelet_volume_stats_available_bytes /
+      kubelet_volume_stats_capacity_bytes) < 15
+      and predict_linear(kubelet_volume_stats_available_bytes[6h], 4 * 24 * 3600) < 0
+    for: 5m
+    labels:
+      service: kube-kubelet
+      severity: critical
+      type: seed
+    annotations:
+      description: Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} is expected to
+        fill up within four days.
+        Currently {{ printf "%0.2f" $value }}% is available.
+      summary: PersistentVolume will be full in four days.


### PR DESCRIPTION
**What this PR does / why we need it**:
Added alerts for full persistent volumes.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The shoot's AlertManager does now contain alerts for persistent volumes whose capacity is filled up entirely.
```
