### PR TITLE
Enable on-demand shoot reconciliation trigger

### DIFF
--- a/hack/shoot-operation
+++ b/hack/shoot-operation
@@ -14,4 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-$(dirname $0)/shoot-operation $1 $2 retry
+NAME="$1"
+NAMESPACE="${2:-$(id -u -n)}"
+OPERATION="${3:-reconcile}"
+
+kubectl --namespace "$NAMESPACE" annotate shoot "$NAME" shoot.garden.sapcloud.io/operation="$OPERATION" --overwrite

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -308,6 +309,9 @@ const (
 
 	// ShootOperationRetry is a constant for an annotation on a Shoot indicating that a failed Shoot reconciliation shall be retried.
 	ShootOperationRetry = "retry"
+
+	// ShootOperationReconcile is a constant for an annotation on a Shoot indicating that a Shoot reconciliation shall be triggered.
+	ShootOperationReconcile = "reconcile"
 
 	// ShootSyncPeriod is a constant for an annotation on a Shoot which may be used to overwrite the global Shoot controller sync period.
 	// The value must be a duration. It can also be used to disable the reconciliation at all by setting it to 0m. Disabling the reconciliation


### PR DESCRIPTION
**What this PR does / why we need it**: Users can trigger a shoot reconciliation on-demand without the necessity of changing the shoot specification by annotating the shoot with `shoot.garden.sapcloud.io/operation=reconcile`.

**Which issue(s) this PR fixes**:
Fixes #512 

**Special notes for your reviewer**:
/cc @gardener/dashboard-maintainers FYI

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
Users can now trigger an on-demand shoot reconciliation without the necessity of changing the shoot specification by annotating the shoot with `shoot.garden.sapcloud.io/operation=reconcile`.
```
