### PR TITLE
Added configurable request timeout for OpenStack

### DIFF
--- a/example/30-cloudprofile-openstack.yaml
+++ b/example/30-cloudprofile-openstack.yaml
@@ -49,3 +49,4 @@ spec:
         - europe-1c
     keystoneURL: https://url-to-keystone/v3/
   # dhcpDomain: nova.local # DHCP domain of OpenStack system (only meaningful for Kubernetes 1.10.1, see https://github.com/kubernetes/kubernetes/pull/61890 for details)
+  # requestTimeout: 180s # Kubernetes OpenStack Cloudprovider Request Timeout

--- a/hack/templates/resources/30-cloudprofile.yaml.tpl
+++ b/hack/templates/resources/30-cloudprofile.yaml.tpl
@@ -500,7 +500,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         - europe-1b
         - europe-1c
       % endif
-    keystoneURL: ${value("spec.openstack.keyStoneURL", "https://url-to-keystone/v3/")}<% dnsServers=value("spec.openstack.dnsServers", []) %><% dhcpDomain=value("spec.openstack.dhcpDomain", "") %>
+    keystoneURL: ${value("spec.openstack.keyStoneURL", "https://url-to-keystone/v3/")}<% dnsServers=value("spec.openstack.dnsServers", []) %><% dhcpDomain=value("spec.openstack.dhcpDomain", "") %><% requestTimeout=value("spec.openstack.requestTimeout", "") %>
     % if dnsServers != []:
     dnsServers: ${dnsServers}
     % endif
@@ -508,6 +508,11 @@ spec:<% caBundle=value("spec.caBundle", "") %>
     dhcpDomain: ${dhcpDomain}
     % else:
   # dhcpDomain: nova.local # DHCP domain of OpenStack system (only meaningful for Kubernetes 1.10.1, see https://github.com/kubernetes/kubernetes/pull/61890 for details)
+    % endif
+    % if requestTimeout != "":
+    requestTimeout: ${requestTimeout}
+    % else:
+  # requestTimeout: 180s # Kubernetes OpenStack Cloudprovider Request Timeout
     % endif
   % endif
   % if cloud == "local":

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -217,6 +217,9 @@ type OpenStackProfile struct {
 	// Kubernetes 1.10.1+. See https://github.com/kubernetes/kubernetes/pull/61890 for details.
 	// +optional
 	DHCPDomain *string
+	// RequestTimeout specifies the HTTP timeout against the OpenStack API.
+	// +optional
+	RequestTimeout *string
 }
 
 // OpenStackConstraints is an object containing constraints for certain values in the Shoot specification.

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -218,6 +218,9 @@ type OpenStackProfile struct {
 	// Kubernetes 1.10.1+. See https://github.com/kubernetes/kubernetes/pull/61890 for details.
 	// +optional
 	DHCPDomain *string `json:"dhcpDomain,omitempty"`
+	// RequestTimeout specifies the HTTP timeout against the OpenStack API.
+	// +optional
+	RequestTimeout *string `json:"requestTimeout,omitempty"`
 }
 
 // OpenStackConstraints is an object containing constraints for certain values in the Shoot specification.

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -3793,6 +3793,7 @@ func autoConvert_v1beta1_OpenStackProfile_To_garden_OpenStackProfile(in *OpenSta
 	out.KeyStoneURL = in.KeyStoneURL
 	out.DNSServers = *(*[]string)(unsafe.Pointer(&in.DNSServers))
 	out.DHCPDomain = (*string)(unsafe.Pointer(in.DHCPDomain))
+	out.RequestTimeout = (*string)(unsafe.Pointer(in.RequestTimeout))
 	return nil
 }
 
@@ -3808,6 +3809,7 @@ func autoConvert_garden_OpenStackProfile_To_v1beta1_OpenStackProfile(in *garden.
 	out.KeyStoneURL = in.KeyStoneURL
 	out.DNSServers = *(*[]string)(unsafe.Pointer(&in.DNSServers))
 	out.DHCPDomain = (*string)(unsafe.Pointer(in.DHCPDomain))
+	out.RequestTimeout = (*string)(unsafe.Pointer(in.RequestTimeout))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -2335,6 +2335,11 @@ func (in *OpenStackProfile) DeepCopyInto(out *OpenStackProfile) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.RequestTimeout != nil {
+		in, out := &in.RequestTimeout, &out.RequestTimeout
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/garden/validation/validation.go
+++ b/pkg/apis/garden/validation/validation.go
@@ -206,6 +206,13 @@ func ValidateCloudProfileSpec(spec *garden.CloudProfileSpec, fldPath *field.Path
 		if spec.OpenStack.DHCPDomain != nil && len(*spec.OpenStack.DHCPDomain) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("openstack", "dhcpDomain"), "must provide a dhcp domain when the key is specified"))
 		}
+
+		if spec.OpenStack.RequestTimeout != nil {
+			_, err := time.ParseDuration(*spec.OpenStack.RequestTimeout)
+			if err != nil {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("openstack", "requestTimeout"), *spec.OpenStack.RequestTimeout, fmt.Sprintf("invalid duration: %v", err)))
+			}
+		}
 	}
 
 	if spec.CABundle != nil {

--- a/pkg/apis/garden/validation/validation_test.go
+++ b/pkg/apis/garden/validation/validation_test.go
@@ -1368,6 +1368,19 @@ var _ = Describe("validation", func() {
 					}))
 				})
 			})
+
+			Context("requestTimeout validation", func() {
+				It("should reject invalid durations", func() {
+					openStackCloudProfile.Spec.OpenStack.RequestTimeout = makeStringPointer("1GiB")
+
+					errorList := ValidateCloudProfile(openStackCloudProfile)
+
+					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal(fmt.Sprintf("spec.%s.requestTimeout", fldPath)),
+					}))))
+				})
+			})
 		})
 
 		Context("tests for Alicloud cloud profiles", func() {

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -2314,6 +2314,11 @@ func (in *OpenStackProfile) DeepCopyInto(out *OpenStackProfile) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.RequestTimeout != nil {
+		in, out := &in.RequestTimeout, &out.RequestTimeout
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2849,7 +2849,7 @@ func schema_pkg_apis_garden_v1beta1_Hibernation(ref common.ReferenceCallback) co
 					},
 					"schedules": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Schedule determines the hibernation schedule.",
+							Description: "Schedules determine the hibernation schedules.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -4276,6 +4276,13 @@ func schema_pkg_apis_garden_v1beta1_OpenStackProfile(ref common.ReferenceCallbac
 					"dhcpDomain": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DHCPDomain is the dhcp domain of the OpenStack system configured in nova.conf. Only meaningful for Kubernetes 1.10.1+. See https://github.com/kubernetes/kubernetes/pull/61890 for details.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"requestTimeout": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RequestTimeout specifies the HTTP timeout against the OpenStack API.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/operation/cloudbotanist/openstackbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/openstackbotanist/controlplane.go
@@ -75,10 +75,19 @@ func (b *OpenStackBotanist) GenerateCloudProviderConfig() (string, error) {
 		return "", err
 	}
 
+	if needsDHCPDomain && b.Shoot.CloudProfile.Spec.OpenStack.DHCPDomain != nil || b.Shoot.CloudProfile.Spec.OpenStack.RequestTimeout != nil {
+		cloudProviderConfig += fmt.Sprintf(`
+[Metadata]`)
+	}
+
 	if needsDHCPDomain && b.Shoot.CloudProfile.Spec.OpenStack.DHCPDomain != nil {
 		cloudProviderConfig += fmt.Sprintf(`
-[Metadata]
 dhcp-domain=%q`, *b.Shoot.CloudProfile.Spec.OpenStack.DHCPDomain)
+	}
+
+	if b.Shoot.CloudProfile.Spec.OpenStack.RequestTimeout != nil {
+		cloudProviderConfig += fmt.Sprintf(`
+request-timeout=%s`, *b.Shoot.CloudProfile.Spec.OpenStack.RequestTimeout)
 	}
 
 	return cloudProviderConfig, nil


### PR DESCRIPTION
Co-Authored-By: Axel Christ <axel.christ@sap.com>

**What this PR does / why we need it**:
Added configurable request timeout for OpenStack to CloudProfile:
```
spec:
  openstack:
    requestTimeout: 180s
```

**Release note**:
```improvement operator
The request timeout for the OpenStack Kubernetes cloud provider config is now configurable via the `CloudProfile`'s `.spec.openstack.requestTimeout` field.
```
