### PR TITLE
Add alertmanager for Seed clusters

### DIFF
--- a/charts/seed-bootstrap/charts/cert-manager/templates/deployment.yaml
+++ b/charts/seed-bootstrap/charts/cert-manager/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: {{ template "cert-manager.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ index .Values.images "cert-manager" }}"
+          image: "{{ index .Values.global.images "cert-manager" }}"
           args:
         {{- if .Values.clusterResourceNamespace }}
           - --cluster-resource-namespace={{ .Values.clusterResourceNamespace }}

--- a/charts/seed-bootstrap/charts/cert-manager/values.yaml
+++ b/charts/seed-bootstrap/charts/cert-manager/values.yaml
@@ -80,8 +80,9 @@ createNamespaceResource: false
 
 name: cert-manager
 
-images:
-  cert-manager: image-repository:image-tag
+global:
+  images:
+    cert-manager: image-repository:image-tag
 
 clusterissuer:
   name: issuer

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/curator-cronjob.yml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/curator-cronjob.yml
@@ -23,7 +23,7 @@ spec:
             role: logging
         spec:
           containers:
-          - image: {{ index .Values.images "curator-es" }}
+          - image: {{ index .Values.global.images "curator-es" }}
             name: curator
             command: ["/bin/sh","-c"]
             args: ["extra-deleter --disk_threshold={{ include "curator.disk_threshold" .Values.curator }}; curator --config /etc/config/config.yml /etc/config/action_file.yml"]
@@ -68,7 +68,7 @@ spec:
             role: logging
         spec:
           containers:
-          - image: {{ index .Values.images "curator-es" }}
+          - image: {{ index .Values.global.images "curator-es" }}
             name: curator
             args:
             - --config

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/es-statefulset.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/es-statefulset.yaml
@@ -26,14 +26,14 @@ spec:
       # If your OS already sets up this number to a higher value, feel free
       # to remove this init container.
       initContainers:
-      - image: {{ index .Values.images "alpine" }}
+      - image: {{ index .Values.global.images "alpine" }}
         command: ["sh", "-c", "if [ $(sysctl -n vm.max_map_count) -lt 262144 ]; then sysctl -w vm.max_map_count=262144; fi"]
         name: elasticsearch-logging-init
         securityContext:
           privileged: true
       containers:
       - name: elasticsearch-logging
-        image: {{ index .Values.images "elasticsearch-oss" }}
+        image: {{ index .Values.global.images "elasticsearch-oss" }}
         imagePullPolicy: IfNotPresent
         env:
         - name: ES_JAVA_OPTS

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-deployment.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: kibana-logging
-        image: {{ index .Values.images "kibana-oss" }}
+        image: {{ index .Values.global.images "kibana-oss" }}
         resources:
           # need more cpu upon initialization, therefore burstable class
           limits:
@@ -40,7 +40,7 @@ spec:
         - containerPort: {{ .Values.kibanaPort }}
           name: ui
           protocol: TCP
-      - image: {{ index .Values.images "kibana-oss" }}
+      - image: {{ index .Values.global.images "kibana-oss" }}
         name: auto-register-index
         command:
         - /bin/sh

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/values.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/values.yaml
@@ -1,4 +1,9 @@
 global:
+  images:
+    alpine: image-repository:image-tag
+    curator-es: image-repository:image-tag
+    elasticsearch-oss: image-repository:image-tag
+    kibana-oss: image-repository:image-tag
   elasticsearchPorts:
     db: 9200
     transport: 9300
@@ -45,9 +50,3 @@ elasticsearch:
         perObject: 89
         weight: 5
         unit: Mi
-
-images:
-  elasticsearch-oss: image-repository:image-tag
-  curator-es: image-repository:image-tag
-  kibana-oss: image-repository:image-tag
-  alpine: image-repository:image-tag

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-daemonset.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: {{ index .Values.images "fluent-bit" }}
+        image: {{ index .Values.global.images "fluent-bit" }}
         command:
           - /fluent-bit/bin/fluent-bit
           - -c

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-statefulset.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-statefulset.yaml
@@ -39,7 +39,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       containers:
       - name: fluentd-es
-        image: {{ index .Values.images "fluentd-es" }}
+        image: {{ index .Values.global.images "fluentd-es" }}
         imagePullPolicy: IfNotPresent
         env:
         - name: FLUENTD_ARGS

--- a/charts/seed-bootstrap/charts/fluentd-es/values.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/values.yaml
@@ -2,9 +2,10 @@ global:
   elasticsearchPorts:
     db: 9200
     transport: 9300
-images:
-  fluentd-es: image-repository:image-tag
-  fluent-bit: image-repository:image-tag
+  images:
+    fluentd-es: image-repository:image-tag
+    fluent-bit: image-repository:image-tag
+
 fluentd:
   ports:
     forward: 24224

--- a/charts/seed-bootstrap/templates/alertmanager/_config.tpl
+++ b/charts/seed-bootstrap/templates/alertmanager/_config.tpl
@@ -6,7 +6,7 @@ templates:
 # The root route on which each incoming alert enters.
 route:
   # The labels by which incoming alerts are grouped together.
-  group_by: ['type']
+  group_by: ['type', 'cluster']
 
   # When a new group of alerts is created by an incoming alert, wait at
   # least 'group_wait' to send the initial notification.
@@ -38,27 +38,27 @@ inhibit_rules:
     severity: critical
   target_match:
     severity: warning
-  equal: ['alertname', 'service']
+  equal: ['alertname', 'service', 'cluster']
 # Stop all alerts for type=shoot if no there are VPN problems.
 - source_match:
     service: vpn
   target_match_re:
     type: shoot
     severity: ^(critical|warning)$
-  equal: ['type']
+  equal: ['type', 'cluster']
 # Stop warning and critical alerts, when there is a blocker -
 # no workers, no etcd main etc.
 - source_match:
     severity: blocker
   target_match_re:
     severity: ^(critical|warning)$
-  equal: ['type']
+  equal: ['type', 'cluster']
 
 receivers:
 - name: dev-null
 - name: email-kubernetes-ops
-{{- if .Values.emailConfigs }}
+{{- if $.emailConfigs }}
   email_configs:
-{{ toYaml .Values.emailConfigs | indent 2 }}
+{{ toYaml $.emailConfigs | indent 2 }}
 {{- end }}
 {{- end -}}

--- a/charts/seed-bootstrap/templates/alertmanager/alertmanager.yaml
+++ b/charts/seed-bootstrap/templates/alertmanager/alertmanager.yaml
@@ -1,0 +1,136 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-client
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: alertmanager
+    role: monitoring
+spec:
+  ports:
+  - port: 9093
+    name: metrics
+  type: ClusterIP
+  selector:
+    component: alertmanager
+    role: monitoring
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: alertmanager
+    role: monitoring
+spec:
+  ports:
+  - port: 9093
+    name: cluster
+  type: ClusterIP
+  # This is important! Without it the mech won't work.
+  clusterIP: None
+  selector:
+    component: alertmanager
+    role: monitoring
+---
+apiVersion: {{ include "statefulsetversion" . }}
+kind: StatefulSet
+metadata:
+  name: alertmanager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    garden.sapcloud.io/role: monitoring
+    component: alertmanager
+    role: monitoring
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      component: alertmanager
+      role: monitoring
+  serviceName: alertmanager
+  template:
+    metadata:
+      labels:
+        garden.sapcloud.io/role: monitoring
+        component: alertmanager
+        role: monitoring
+    spec:
+      containers:
+      - name: alertmanager
+        image: {{ index .Values.global.images "alertmanager" }}
+        imagePullPolicy: IfNotPresent
+        args:
+        - --config.file=/etc/alertmanager/config/alertmanager.yaml
+        - --web.listen-address=:9093
+        - --storage.path=/var/alertmanager/data
+        - --log.level=info
+        ports:
+        - containerPort: 9093
+          name: web
+          protocol: TCP
+        - containerPort: 6783
+          name: cluster
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /api/v1/status
+            port: web
+            scheme: HTTP
+          failureThreshold: 10
+        readinessProbe:
+          httpGet:
+            path: /api/v1/status
+            port: web
+            scheme: HTTP
+          periodSeconds: 5
+          timeoutSeconds: 3
+          initialDelaySeconds: 3
+          failureThreshold: 10
+        resources:
+          requests:
+            cpu: 5m
+            memory: 20Mi
+          limits:
+            cpu: 100m
+            memory: 60Mi
+        volumeMounts:
+        - mountPath: /etc/alertmanager/config
+          name: config
+          readOnly: true
+        - mountPath: /var/alertmanager/data
+          name: alertmanager-db
+          subPath: alertmanager-
+      - name: alertmanager-config-reloader
+        image: {{ index .Values.global.images "configmap-reloader" }}
+        imagePullPolicy: IfNotPresent
+        args:
+        - -webhook-url=http://localhost:9093/-/reload
+        - -volume-dir=/etc/alertmanager/config
+        resources:
+          requests:
+            cpu: 5m
+            memory: 10Mi
+          limits:
+            cpu: 10m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/alertmanager/config
+          name: config
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: config
+        secret:
+          secretName: alertmanager-config
+  volumeClaimTemplates:
+  - metadata:
+      name: alertmanager-db
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi

--- a/charts/seed-bootstrap/templates/alertmanager/config.yaml
+++ b/charts/seed-bootstrap/templates/alertmanager/config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-config
+  namespace: {{ .Release.Namespace }}
+data:
+  alertmanager.yaml: {{ include "config" .Values.alertmanager | b64enc }}

--- a/charts/seed-bootstrap/templates/gardener-external-admission-controller.yaml
+++ b/charts/seed-bootstrap/templates/gardener-external-admission-controller.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: gardener-external-admission-controller
-        image: {{ index .Values.images "gardener-external-admission-controller" }}
+        image: {{ index .Values.global.images "gardener-external-admission-controller" }}
         imagePullPolicy: IfNotPresent
         args:
         - -secure-port=2730

--- a/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: prometheus
       containers:
       - name: prometheus
-        image: {{ index .Values.images "prometheus" }}
+        image: {{ index .Values.global.images "prometheus" }}
         imagePullPolicy: IfNotPresent
         args:
         - --config.file=/etc/prometheus/config/prometheus.yaml
@@ -70,7 +70,7 @@ spec:
           name: prometheus-db
           subPath: prometheus-
       - name: prometheus-config-reloader
-        image: {{ index .Values.images "configmap-reloader" }}
+        image: {{ index .Values.global.images "configmap-reloader" }}
         imagePullPolicy: IfNotPresent
         args:
         - -webhook-url=http://localhost:9090/-/reload

--- a/charts/seed-bootstrap/templates/reserve-excess-capacity/deployment.yaml
+++ b/charts/seed-bootstrap/templates/reserve-excess-capacity/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: pause-container
-        image: {{ index .Values.images "pause-container" }}
+        image: {{ index .Values.global.images "pause-container" }}
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -51,15 +51,22 @@ reserveExcessCapacity: true
 replicas:
   reserve-excess-capacity: 0
 
-images:
-  pause-container: image-repository:image-tag
-  prometheus: image-repository:image-tag
-  gardener-external-admission-controller: image-repository:image-tag
-  cert-manager: image-repository:image-tag
-
 prometheusPort: 9090
 
 global:
+  images:
+    alertmanager: image-repository:image-tag
+    alpine: image-repository:image-tag
+    cert-manager: image-repository:image-tag
+    configmap-reloader: image-repository:image-tag
+    curator-es: image-repository:image-tag
+    elasticsearch-oss: image-repository:image-tag
+    fluentd-es: image-repository:image-tag
+    gardener-external-admission-controller: image-repository:image-tag
+    kibana-oss: image-repository:image-tag
+    pause-container: image-repository:image-tag
+    prometheus: image-repository:image-tag
+
   elasticsearchPorts:
     db: 9200
     transport: 9300
@@ -74,16 +81,14 @@ elastic-kibana-curator:
     elasticsearchReplicas: 1
     elasticsearchVolumeSizeGB: 30
     objectCount: 1
-  images:
-    elasticsearch-oss: image-repository:image-tag
-    curator-es: image-repository:image-tag
-    kibana-oss: image-repository:image-tag
-    alpine: image-repository:image-tag
 
 fluentd-es:
   enabled: true
   images:
-    fluentd-es: image-repository:image-tag
+
+
+alertmanager:
+  emailConfigs: []
 
 cert-manager:
   enabled: true

--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -28,7 +28,9 @@ data:
       - kubernetes_sd_configs:
         - role: endpoints
           namespaces:
-            names: [{{ .Release.Namespace }}]
+            names:
+            - {{ .Release.Namespace }}
+            - garden
         scheme: http
         relabel_configs:
         - source_labels: [ __meta_kubernetes_service_label_component ]

--- a/pkg/utils/imagevector/imagevector.go
+++ b/pkg/utils/imagevector/imagevector.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	yaml "gopkg.in/yaml.v2"
-	"strings"
 )
 
 // ReadImageVector reads the image.yaml in the chart directory, unmarshals it
@@ -77,6 +77,25 @@ func (v ImageVector) FindImage(name, k8sVersionRuntime, k8sVersionTarget string)
 	}
 
 	return nil, fmt.Errorf("could not find image %q for Kubernetes runtime version %q in the image vector", name, k8sVersionRuntime)
+}
+
+// FindImages returns an image map with the given <names> from the sources in the image vector.
+// The <k8sVersion> specifies the kubernetes version the image will be running on.
+// The <targetK8sVersion> specifies the kubernetes version the image shall target.
+// If multiple entries were found, the provided <k8sVersion> is compared with the constraints
+// stated in the image definition.
+// In case multiple images match the search, the first which was found is returned.
+// In case no image was found, an error is returned.
+func (v ImageVector) FindImages(names []string, k8sVersionRuntime, k8sVersionTarget string) (map[string]interface{}, error) {
+	images := map[string]interface{}{}
+	for _, imageName := range names {
+		image, err := v.FindImage(imageName, k8sVersionRuntime, k8sVersionTarget)
+		if err != nil {
+			return nil, err
+		}
+		images[imageName] = image.String()
+	}
+	return images, nil
 }
 
 // ToImage applies the given <targetK8sVersion> to the source to produce an output image.

--- a/pkg/utils/imagevector/imagevector_test.go
+++ b/pkg/utils/imagevector/imagevector_test.go
@@ -127,6 +127,46 @@ var _ = Describe("imagevector", func() {
 				Expect(image).To(Equal(imageSrc5.ToImage(k8s164)))
 			})
 		})
+
+		Describe("#FindImages", func() {
+			var (
+				k8s164 = "1.6.4"
+				k8s180 = "1.8.0"
+
+				imageSrc1 = &ImageSource{
+					Name:       "image1",
+					Repository: "repo1",
+					Tag:        "tag1",
+					Versions:   "",
+				}
+				imageSrc2 = &ImageSource{
+					Name:       "image2",
+					Repository: "repo2",
+					Tag:        "tag2",
+					Versions:   "",
+				}
+			)
+
+			It("should return an error because one or more images was not found", func() {
+				images, err := vector.FindImages([]string{"test"}, k8s164, k8s164)
+
+				Expect(err).To(HaveOccurred())
+				Expect(images).To(BeNil())
+			})
+
+			It("should return an image because it only exists once in the vector", func() {
+				vector = ImageVector{imageSrc1, imageSrc2}
+				expectMap := map[string]interface{}{
+					"image1": imageSrc1.ToImage("").String(),
+					"image2": imageSrc2.ToImage("").String(),
+				}
+
+				images, err := vector.FindImages([]string{imageSrc1.Name, imageSrc2.Name}, k8s164, k8s180)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(images).To(Equal(expectMap))
+			})
+		})
 	})
 
 	Describe("> Image", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Shoot's Prometheus now sends alerts to alertmanager in the Seed cluster. The alertmanager in the Seed's `garden` namespace uses the default smtp configuration (if provided).

Shoot's alertmanagers now only send emails to Shoot clusters annotated with `garden.sapcloud.io/operatedBy=foo@baz.buz`

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
Next steps: Move the Prometheus and Alertmanager manifest into an seperate chart and make it configurable to deploy it for Shoot clusters and for the Seed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
A new AlertManager instance is now deployed in every seed cluster. This AlertManager uses the default SMTP configuration. Prometheus in shoot clusters does now multicast alerts to the seed's AlertManager and the shoot's AlertManager. Shoot's AlertManagers now only send emails to shoot clusters annotated with `garden.sapcloud.io/operatedBy=foo@baz.buz`.
```
