### PR TITLE
Execute Terraform, Kube2IAM only in maintenance

### DIFF
--- a/pkg/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controller/shoot/shoot_control_reconcile.go
@@ -19,6 +19,7 @@ import (
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
+	controllerutils "github.com/gardener/gardener/pkg/controller/utils"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/operation/botanist"
@@ -54,11 +55,14 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 	}
 
 	var (
-		defaultTimeout  = 30 * time.Second
-		defaultInterval = 5 * time.Second
-		managedDNS      = o.Shoot.Info.Spec.DNS.Provider != gardenv1beta1.DNSUnmanaged
-		isCloud         = o.Shoot.Info.Spec.Cloud.Local == nil
-		loggingEnabled  = features.ControllerFeatureGate.Enabled(features.Logging)
+		defaultTimeout                  = 30 * time.Second
+		defaultInterval                 = 5 * time.Second
+		managedDNS                      = o.Shoot.Info.Spec.DNS.Provider != gardenv1beta1.DNSUnmanaged
+		isCloud                         = o.Shoot.Info.Spec.Cloud.Local == nil
+		loggingEnabled                  = features.ControllerFeatureGate.Enabled(features.Logging)
+		creationPhase                   = operationType == gardenv1beta1.ShootLastOperationTypeCreate
+		requireInfrastructureDeployment = creationPhase || controllerutils.HasTask(o.Shoot.Info.Annotations, common.ShootTaskDeployInfrastructure)
+		requireKube2IAMDeployment       = creationPhase || controllerutils.HasTask(o.Shoot.Info.Annotations, common.ShootTaskDeployKube2IAMResource)
 
 		g               = flow.NewGraph("Shoot cluster reconciliation")
 		deployNamespace = g.Add(flow.Task{
@@ -102,7 +106,7 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 		})
 		deployInfrastructure = g.Add(flow.Task{
 			Name:         "Deploying Shoot infrastructure",
-			Fn:           flow.SimpleTaskFn(shootCloudBotanist.DeployInfrastructure),
+			Fn:           flow.SimpleTaskFn(shootCloudBotanist.DeployInfrastructure).DoIf(requireInfrastructureDeployment),
 			Dependencies: flow.NewTaskIDs(deploySecrets, deployCloudProviderSecret),
 		})
 		deployBackupInfrastructure = g.Add(flow.Task{
@@ -181,7 +185,7 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying Kube2IAM resources",
-			Fn:           flow.SimpleTaskFn(shootCloudBotanist.DeployKube2IAMResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.SimpleTaskFn(shootCloudBotanist.DeployKube2IAMResources).DoIf(requireKube2IAMDeployment).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployInfrastructure),
 		})
 		_ = g.Add(flow.Task{
@@ -297,7 +301,18 @@ func (c *defaultControl) updateShootStatusReconcileStart(o *operation.Operation,
 }
 
 func (c *defaultControl) updateShootStatusReconcileSuccess(o *operation.Operation, operationType gardenv1beta1.ShootLastOperationType) error {
-	newShoot, err := kutil.TryUpdateShootStatus(c.k8sGardenClient.GardenClientset(), retry.DefaultRetry, o.Shoot.Info.ObjectMeta,
+	// Remove task list from Shoot annotations since reconciliation was successful.
+	newShoot, err := kutil.TryUpdateShootAnnotations(c.k8sGardenClient.GardenClientset(), retry.DefaultRetry, o.Shoot.Info.ObjectMeta,
+		func(shoot *gardenv1beta1.Shoot) (*gardenv1beta1.Shoot, error) {
+			controllerutils.RemoveAllTasks(shoot.Annotations)
+			return shoot, nil
+		})
+
+	if err != nil {
+		return err
+	}
+
+	newShoot, err = kutil.TryUpdateShootStatus(c.k8sGardenClient.GardenClientset(), retry.DefaultRetry, newShoot.ObjectMeta,
 		func(shoot *gardenv1beta1.Shoot) (*gardenv1beta1.Shoot, error) {
 			shoot.Status.RetryCycleStartTime = nil
 			shoot.Status.Seed = o.Seed.Info.Name
@@ -311,6 +326,7 @@ func (c *defaultControl) updateShootStatusReconcileSuccess(o *operation.Operatio
 			}
 			return shoot, nil
 		})
+
 	if err == nil {
 		o.Shoot.Info = newShoot
 	}

--- a/pkg/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controller/shoot/shoot_maintenance_control.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
 	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/externalversions/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	controllerutils "github.com/gardener/gardener/pkg/controller/utils"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/common"
@@ -214,7 +215,11 @@ func (c *defaultMaintenanceControl) Maintain(shootObj *gardenv1beta1.Shoot, key 
 			return nil, fmt.Errorf("auto update section of Shoot %s/%s changed mid-air", s.Namespace, s.Name)
 		}
 
-		delete(shoot.Annotations, common.ShootOperation)
+		delete(s.Annotations, common.ShootOperation)
+
+		controllerutils.AddTasks(s.Annotations, common.ShootTaskDeployInfrastructure, common.ShootTaskDeployKube2IAMResource)
+		s.Annotations[common.ShootOperation] = common.ShootOperationReconcile
+
 		if updateMachineImage != nil {
 			updateMachineImage(&s.Spec.Cloud)
 		}

--- a/pkg/controller/utils/miscelleneous_test.go
+++ b/pkg/controller/utils/miscelleneous_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gardener/gardener/pkg/controller/utils"
+	"github.com/gardener/gardener/pkg/operation/common"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}
+
+var _ = Describe("controller", func() {
+	Describe("utils", func() {
+		DescribeTable("#AddTask",
+			func(existingTasks map[string]string, tasks []string, expectedTasks []string) {
+				utils.AddTasks(existingTasks, tasks...)
+				shootTasks := existingTasks[common.ShootTasks]
+				Expect(strings.Split(shootTasks, ",")).To(Equal(expectedTasks))
+			},
+			Entry("task to absent annotation", map[string]string{},
+				[]string{common.ShootTaskDeployInfrastructure}, []string{common.ShootTaskDeployInfrastructure}),
+			Entry("tasks to empty list", map[string]string{},
+				[]string{common.ShootTaskDeployInfrastructure, common.ShootTaskDeployKube2IAMResource}, []string{common.ShootTaskDeployInfrastructure, common.ShootTaskDeployKube2IAMResource}),
+			Entry("task to empty list", map[string]string{common.ShootTaskDeployInfrastructure: ""},
+				[]string{common.ShootTaskDeployInfrastructure}, []string{common.ShootTaskDeployInfrastructure}),
+			Entry("task to empty list twice", map[string]string{},
+				[]string{common.ShootTaskDeployInfrastructure, common.ShootTaskDeployInfrastructure}, []string{common.ShootTaskDeployInfrastructure}),
+			Entry("tasks to filled list", map[string]string{common.ShootTasks: common.ShootTaskDeployInfrastructure},
+				[]string{common.ShootTaskDeployKube2IAMResource}, []string{common.ShootTaskDeployInfrastructure, common.ShootTaskDeployKube2IAMResource}),
+			Entry("tasks already in list", map[string]string{common.ShootTasks: common.ShootTaskDeployInfrastructure},
+				[]string{common.ShootTaskDeployKube2IAMResource, common.ShootTaskDeployInfrastructure}, []string{common.ShootTaskDeployInfrastructure, common.ShootTaskDeployKube2IAMResource}),
+		)
+
+		DescribeTable("#HasTask",
+			func(existingTasks map[string]string, task string, expectedResult bool) {
+				result := utils.HasTask(existingTasks, task)
+				Expect(result).To(Equal(expectedResult))
+			},
+			Entry("absent task annotation", map[string]string{}, common.ShootTaskDeployInfrastructure, false),
+			Entry("empty task list", map[string]string{common.ShootTasks: ""}, common.ShootTaskDeployInfrastructure, false),
+			Entry("task not in list", map[string]string{common.ShootTasks: common.ShootTaskDeployKube2IAMResource + "," + "dummyTask"}, common.ShootTaskDeployInfrastructure, false),
+			Entry("task in list", map[string]string{common.ShootTasks: common.ShootTaskDeployKube2IAMResource + "," + common.ShootTaskDeployInfrastructure}, common.ShootTaskDeployKube2IAMResource, true),
+		)
+	})
+})

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -310,6 +310,15 @@ const (
 	// possible.
 	ShootOperationMaintain = "maintain"
 
+	// ShootTasks is a constant for an annotation on a Shoot which states that certain tasks should be done.
+	ShootTasks = "shoot.garden.sapcloud.io/tasks"
+
+	// ShootTaskDeployInfrastructure is a name for a Shoot's infrastructure deployment task.
+	ShootTaskDeployInfrastructure = "deployInfrastructure"
+
+	// ShootTaskDeployKube2IAMResource is a name for a Shoot's Kube2IAM Resource deployment task.
+	ShootTaskDeployKube2IAMResource = "deployKube2IAMResource"
+
 	// ShootOperationRetry is a constant for an annotation on a Shoot indicating that a failed Shoot reconciliation shall be retried.
 	ShootOperationRetry = "retry"
 

--- a/pkg/utils/kubernetes/shoot.go
+++ b/pkg/utils/kubernetes/shoot.go
@@ -125,3 +125,15 @@ func TryUpdateShootConditions(g garden.Interface, backoff wait.Backoff, meta met
 		return equality.Semantic.DeepEqual(cur.Status.Conditions, updated.Status.Conditions)
 	})
 }
+
+// TryUpdateShootAnnotations tries to update the annotations of the shoot matching the given <meta>.
+// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
+// The transformation function is applied to the current state of the Shoot object. If the transformation
+// yields a semantically equal Shoot (regarding conditions), no update is done and the operation returns normally.
+func TryUpdateShootAnnotations(g garden.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardenv1beta1.Shoot) (*gardenv1beta1.Shoot, error)) (*gardenv1beta1.Shoot, error) {
+	return tryUpdateShoot(g, backoff, meta, transform, func(g garden.Interface, shoot *gardenv1beta1.Shoot) (*gardenv1beta1.Shoot, error) {
+		return g.GardenV1beta1().Shoots(shoot.Namespace).Update(shoot)
+	}, func(cur, updated *gardenv1beta1.Shoot) bool {
+		return equality.Semantic.DeepEqual(cur.Annotations, updated.Annotations)
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the frequency of infrastructure / cloud provider calls imposed by Gardener. Whereas the `Terraform infrastructure` and the `kube2iam jobs` were triggered during reconciliation, it is now only done if the Shoot is either in `creation` phase of in `maintenance` mode.

**Which issue(s) this PR fixes**:
Fixes #510

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
The infrastructure and kube2iam jobs are now only executed during shoot creation and within maintenance time window. This is to reduce the number of cloud API calls for the respective infrastructure providers. In order to perform an on-demand maintenance operation out of the time window annotate the shoot with `shoot.garden.sapcloud.io/operation=maintain`.
```
