### PR TITLE
Reduce system pod resource limits/requests

### DIFF
--- a/charts/shoot-addons/charts/kubernetes-dashboard/values.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/values.yaml
@@ -18,7 +18,7 @@ resources:
     cpu: 50m
     memory: 50Mi
   limits:
-    cpu: 200m
+    cpu: 100m
     memory: 256Mi
 
 ingress:

--- a/charts/shoot-addons/charts/nginx-ingress/values.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/values.yaml
@@ -75,7 +75,7 @@ controller:
       cpu: 100m
       memory: 100Mi
     limits:
-      cpu: 300m
+      cpu: 200m
       memory: 512Mi
 
   service:

--- a/charts/shoot-core/charts/calico/templates/calico.yaml
+++ b/charts/shoot-core/charts/calico/templates/calico.yaml
@@ -184,10 +184,10 @@ spec:
             privileged: true
           resources:
             requests:
-              cpu: 250m
+              cpu: 100m
               memory: 100Mi
             limits:
-              cpu: 500m
+              cpu: 300m
               memory: 700Mi
           livenessProbe:
             httpGet:

--- a/charts/shoot-core/charts/coredns/values.yaml
+++ b/charts/shoot-core/charts/coredns/values.yaml
@@ -19,10 +19,10 @@ deployment:
       imagePullPolicy: IfNotPresent
       resources:
         limits:
-          cpu: 200m
-          memory: 80Mi
-        requests:
           cpu: 100m
+          memory: 100Mi
+        requests:
+          cpu: 50m
           memory: 15Mi
       ports:
         dns: 8053

--- a/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -51,11 +51,11 @@ spec:
           privileged: true
         resources:
           requests:
-            cpu: 50m
+            cpu: 20m
             memory: 64Mi
           limits:
             cpu: 100m
-            memory: 256Mi
+            memory: 200Mi
         volumeMounts:
         - name: kubeconfig
           mountPath: /var/lib/kube-proxy

--- a/charts/shoot-core/charts/metrics-server/templates/deployment.yaml
+++ b/charts/shoot-core/charts/metrics-server/templates/deployment.yaml
@@ -49,6 +49,13 @@ spec:
         - --tls-cert-file=/srv/metrics-server/tls/tls.crt
         - --tls-private-key-file=/srv/metrics-server/tls/tls.key
         - --v=2
+        resources:
+          requests:
+            cpu: 20m
+            memory: 100Mi
+          limits:
+            cpu: 80m
+            memory: 400Mi
         volumeMounts:
         - name: metrics-server
           mountPath: /srv/metrics-server/tls

--- a/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -92,10 +92,10 @@ spec:
           timeoutSeconds: 5
         resources:
           requests:
-            cpu: 10m
+            cpu: 5m
             memory: 10Mi
           limits:
-            cpu: 20m
+            cpu: 15m
             memory: 50Mi
         volumeMounts:
         - name: proc

--- a/charts/shoot-core/charts/vpn-shoot/templates/deployment.yaml
+++ b/charts/shoot-core/charts/vpn-shoot/templates/deployment.yaml
@@ -56,11 +56,11 @@ spec:
             - NET_ADMIN
         resources:
           requests:
-            cpu: 100m
-            memory: 128Mi
+            cpu: 50m
+            memory: 50Mi
           limits:
-            cpu: 300m
-            memory: 512Mi
+            cpu: 100m
+            memory: 100Mi
         volumeMounts:
         - mountPath: /srv/secrets/vpn-shoot
           name: vpn-shoot


### PR DESCRIPTION
**What this PR does / why we need it**: Reduce the pod resource limits/requests of the system pods of a shoot. Mid-term/long-term solution is an entirely autoscaled system (using the vertical pod autoscaler), see #16, #255.
/cc @juergenschneider

**Special notes for your reviewer**:
Values are based on observations of a larger/busy cluster.
/cc @ggaurav10 @swapnilgm 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
The resource limits and requests for the system pods have been lowered. The mid-/long-term goal is to have vertical autoscaling in place.
```
