### PR TITLE
Vertical scaling of elasticsearch

### DIFF
--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/_resource.tpl
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/_resource.tpl
@@ -1,0 +1,3 @@
+{{- define "curator.disk_threshold" -}}
+{{- printf "%d" ( add $.base_disk_threshold ( mul $.base_disk_threshold ( sub $.objectCount 1 ) ) ) -}}
+{{- end -}}

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/curator-cronjob.yml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/curator-cronjob.yml
@@ -26,7 +26,7 @@ spec:
           - image: {{ index .Values.images "curator-es" }}
             name: curator
             command: ["/bin/sh","-c"]
-            args: ["extra-deleter --disk_threshold=1073741824; curator --config /etc/config/config.yml /etc/config/action_file.yml"]
+            args: ["extra-deleter --disk_threshold={{ include "curator.disk_threshold" .Values.curator }}; curator --config /etc/config/config.yml /etc/config/action_file.yml"]
             volumeMounts:
             - name: config
               mountPath: /etc/config

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/_resource.tpl
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/_resource.tpl
@@ -1,0 +1,5 @@
+{{- define "jvm.memory" -}}
+{{- $r := $.resources.requests.memory -}}
+{{- $base := $.jvmHeapBase -}}
+{{ printf "%d%s" ( add $base ( mul ( div $.objectCount $r.weight ) 79 $r.weight ) ) "m" }}
+{{- end -}}

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/es-statefulset.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/es-statefulset.yaml
@@ -14,7 +14,7 @@ spec:
     matchLabels:
       app: elasticsearch-logging
       role: logging
-  replicas: {{ .Values.elasticsearchReplicas }}
+  replicas: {{ .Values.elasticsearch.elasticsearchReplicas }}
   template:
     metadata:
       labels:
@@ -35,14 +35,12 @@ spec:
       - name: elasticsearch-logging
         image: {{ index .Values.images "elasticsearch-oss" }}
         imagePullPolicy: IfNotPresent
+        env:
+        - name: ES_JAVA_OPTS
+          value: "-Xms{{ include "jvm.memory" .Values.elasticsearch }} -Xmx{{ include "jvm.memory" .Values.elasticsearch }}"
         resources:
           # need more cpu upon initialization, therefore burstable class
-          limits:
-            cpu: 600m
-            memory: 1792Mi
-          requests:
-            cpu: 200m
-            memory: 1792Mi
+{{- include "util-templates.resource-quantity" .Values.elasticsearch | indent 10 }}
         ports:
         - containerPort: {{ .Values.global.elasticsearchPorts.db }}
           name: http
@@ -73,4 +71,4 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: {{ .Values.elasticsearchVolumeSizeGB }}Gi
+          storage: {{ .Values.elasticsearch.elasticsearchVolumeSizeGB }}Gi

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/values.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/values.yaml
@@ -10,10 +10,41 @@ ingress:
   # admin : admin base64 encoded
   basicAuthSecret: YWRtaW46JGFwcjEkSWRSaVM5c3MkR3U1MHMxaGUwL2Z6Tzh2elE4S1BEMQ==
 
-elasticsearchReplicas: 1
+
 kibanaReplicas: 1
 
-elasticsearchVolumeSizeGB: 30
+curator:
+  objectCount: 1
+  base_disk_threshold: 1073741824
+
+elasticsearch:
+  elasticsearchReplicas: 1
+  elasticsearchVolumeSizeGB: 30
+  objectCount: 1
+  jvmHeapBase: 1280
+  resources:
+    requests:
+      cpu:
+        base: 200
+        perObject: 1
+        weight: 5
+        unit: m
+      memory:
+        base: 1792
+        perObject: 84
+        weight: 5
+        unit: Mi
+    limits:
+      cpu:
+        base: 1800
+        perObject: 1
+        weight: 5
+        unit: m
+      memory:
+        base: 1900
+        perObject: 89
+        weight: 5
+        unit: Mi
 
 images:
   elasticsearch-oss: image-repository:image-tag

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -66,10 +66,14 @@ global:
 
 elastic-kibana-curator:
   enabled: true
-  elasticsearchReplicas: 1
   kibanaReplicas: 1
   kibanaPort: 5601
-  elasticsearchVolumeSizeGB: 30
+  curator:
+    objectCount: 1
+  elasticsearch:
+    elasticsearchReplicas: 1
+    elasticsearchVolumeSizeGB: 30
+    objectCount: 1
   images:
     elasticsearch-oss: image-repository:image-tag
     curator-es: image-repository:image-tag

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -444,8 +444,10 @@ func (b *Botanist) DeploySeedLogging() error {
 			"basicAuthSecret": basicAuth,
 			"host":            kibanaHost,
 		},
-		"elasticsearchReplicas": b.Shoot.GetReplicas(1),
-		"kibanaReplicas":        b.Shoot.GetReplicas(1),
+		"elasticsearch": map[string]interface{}{
+			"elasticsearchReplicas": b.Shoot.GetReplicas(1),
+		},
+		"kibanaReplicas": b.Shoot.GetReplicas(1),
 	}
 
 	elasticKibanaCurator, err := b.InjectImages(kibanaConfig, b.K8sSeedClient.Version(), b.K8sSeedClient.Version(),

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -308,8 +308,15 @@ func BootstrapCluster(seed *Seed, k8sGardenClient kubernetes.Client, secrets map
 				"basicAuthSecret": basicAuth,
 				"host":            kibanaHost,
 			},
-			"kibanaReplicas":        replicas,
-			"elasticsearchReplicas": replicas,
+			"kibanaReplicas": replicas,
+			"curator": map[string]interface{}{
+				"objectCount": nodeCount,
+			},
+			"elasticsearch": map[string]interface{}{
+				"elasticsearchReplicas":     replicas,
+				"objectCount":               nodeCount,
+				"elasticsearchVolumeSizeGB": 100,
+			},
 			"images": map[string]interface{}{
 				"elasticsearch-oss": elasticsearchVersion.String(),
 				"curator-es":        curatorEsVersion.String(),


### PR DESCRIPTION
**What this PR does / why we need it**:
This is vertical scaling of central elasticsearch cluster, which is in the "garden" namespace in the seed.
The scaling is based on the number of nodes of the seed.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
``` noteworthy operator.
The ElasticSearch cluster in the seed's `garden` namespace is now scaling vertically based on the number of the nodes of the seed cluster.
The minimal required free storage for the ElasticSearch cluster is  based on the number of the nodes of the seed cluster. 
The storage of the central ElasticSearch cluster has been increased to `100Gi`.
```
``` action operator
⚠️ If you had enabled the `Logging` feature gate previously then please delete the persistent volumes related to the central ElasticSearch cluster before before upgrading Gardener: `kubectl -n garden delete sts elasticsearch-logging`
```
