### PR TITLE
remove the checking of logging sts and ds in shoot control plane

### DIFF
--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -505,7 +505,6 @@ func CheckLoggingControlPlane(
 	condition *gardenv1beta1.Condition,
 	deploymentLister kutil.DeploymentLister,
 	statefulSetLister kutil.StatefulSetLister,
-	daemonSetLister kutil.DaemonSetLister,
 ) (*gardenv1beta1.Condition, error) {
 
 	deploymentList, err := deploymentLister.Deployments(namespace).List(loggingSelector)
@@ -532,17 +531,6 @@ func CheckLoggingControlPlane(
 		return exitCondition, nil
 	}
 
-	daemonSetList, err := daemonSetLister.DaemonSets(namespace).List(loggingSelector)
-	if err != nil {
-		return nil, err
-	}
-
-	if exitCondition := checkRequiredDaemonSets(condition, common.RequiredLoggingDaemonSetNames, daemonSetList); exitCondition != nil {
-		return exitCondition, nil
-	}
-	if exitCondition := checkDaemonSets(condition, daemonSetList); exitCondition != nil {
-		return exitCondition, nil
-	}
 	return nil, nil
 }
 
@@ -551,7 +539,6 @@ func (b *Botanist) checkControlPlane(
 	condition *gardenv1beta1.Condition,
 	seedDeploymentLister kutil.DeploymentLister,
 	seedStatefulSetLister kutil.StatefulSetLister,
-	seedDaemonSetLister kutil.DaemonSetLister,
 ) (*gardenv1beta1.Condition, error) {
 
 	if exitCondition, err := CheckControlPlane(b.Shoot.Info, b.Shoot.SeedNamespace, b.Seed.CloudProvider, condition, seedDeploymentLister, seedStatefulSetLister); err != nil || exitCondition != nil {
@@ -561,7 +548,7 @@ func (b *Botanist) checkControlPlane(
 		return exitCondition, err
 	}
 	if features.ControllerFeatureGate.Enabled(features.Logging) {
-		if exitCondition, err := CheckLoggingControlPlane(b.Shoot.SeedNamespace, condition, seedDeploymentLister, seedStatefulSetLister, seedDaemonSetLister); err != nil || exitCondition != nil {
+		if exitCondition, err := CheckLoggingControlPlane(b.Shoot.SeedNamespace, condition, seedDeploymentLister, seedStatefulSetLister); err != nil || exitCondition != nil {
 			return exitCondition, nil
 		}
 	}
@@ -757,7 +744,6 @@ var (
 
 	seedDeploymentListOptions        = metav1.ListOptions{LabelSelector: controlPlaneMonitoringLoggingSelector.String()}
 	seedStatefulSetListOptions       = metav1.ListOptions{LabelSelector: controlPlaneMonitoringLoggingSelector.String()}
-	seedDaemonSetListOptions         = metav1.ListOptions{LabelSelector: loggingSelector.String()}
 	seedMachineDeploymentListOptions = metav1.ListOptions{}
 
 	shootDeploymentListOptions = metav1.ListOptions{LabelSelector: systemComponentsOptionalAddonsSelector.String()}
@@ -774,7 +760,6 @@ func (b *Botanist) HealthChecks(initializeShootClients func() error, apiserverAv
 	var (
 		seedDeploymentLister  = makeDeploymentLister(b.K8sSeedClient.Clientset(), b.Shoot.SeedNamespace, seedDeploymentListOptions)
 		seedStatefulSetLister = makeStatefulSetLister(b.K8sSeedClient.Clientset(), b.Shoot.SeedNamespace, seedStatefulSetListOptions)
-		seedDaemonSetLister   = makeDaemonSetLister(b.K8sSeedClient.Clientset(), b.Shoot.SeedNamespace, seedDaemonSetListOptions)
 	)
 
 	if err := initializeShootClients(); err != nil {
@@ -784,7 +769,7 @@ func (b *Botanist) HealthChecks(initializeShootClients func() error, apiserverAv
 		nodes = helper.UpdatedConditionUnknownErrorMessage(nodes, message)
 		systemComponents = helper.UpdatedConditionUnknownErrorMessage(systemComponents, message)
 
-		newControlPlane, err := b.checkControlPlane(controlPlane, seedDeploymentLister, seedStatefulSetLister, seedDaemonSetLister)
+		newControlPlane, err := b.checkControlPlane(controlPlane, seedDeploymentLister, seedStatefulSetLister)
 		controlPlane = newConditionOrError(controlPlane, newControlPlane, err)
 		return apiserverAvailability, controlPlane, nodes, systemComponents
 	}
@@ -806,7 +791,7 @@ func (b *Botanist) HealthChecks(initializeShootClients func() error, apiserverAv
 	}()
 	go func() {
 		defer wg.Done()
-		newControlPlane, err := b.checkControlPlane(controlPlane, seedDeploymentLister, seedStatefulSetLister, seedDaemonSetLister)
+		newControlPlane, err := b.checkControlPlane(controlPlane, seedDeploymentLister, seedStatefulSetLister)
 		controlPlane = newConditionOrError(controlPlane, newControlPlane, err)
 	}()
 	go func() {

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -531,17 +531,11 @@ var (
 	// RequiredLoggingStatefulSets is a set of the required logging stateful sets.
 	RequiredLoggingStatefulSets = sets.NewString(
 		ElasticSearchStatefulSetName,
-		FluentdEsStatefulSetName,
 	)
 
 	// RequiredLoggingDeployments is a set of the required logging deployments.
 	RequiredLoggingDeployments = sets.NewString(
 		KibanaDeploymentName,
-	)
-
-	// RequiredLoggingDaemonSetNames is a set of the required logging daemon sets.
-	RequiredLoggingDaemonSetNames = sets.NewString(
-		FluentBitDaemonSetName,
 	)
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Removing of checking for unexisting fluentd-es StatefulSet and fluent-bit DaemonSet in the shoot namespace.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The shoot care controller does now correctly check the health of the logging control plane components.
```
