### PR TITLE
Enable traffic to AWS worker network node ports from everywhere

### DIFF
--- a/charts/seed-terraformer/charts/aws-infra/templates/_main.tf
+++ b/charts/seed-terraformer/charts/aws-infra/templates/_main.tf
@@ -92,6 +92,24 @@ resource "aws_security_group_rule" "nodes_self" {
   security_group_id = "${aws_security_group.nodes.id}"
 }
 
+resource "aws_security_group_rule" "nodes_tcp_all" {
+  type              = "ingress"
+  from_port         = 30000
+  to_port           = 32767
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.nodes.id}"
+}
+
+resource "aws_security_group_rule" "nodes_udp_all" {
+  type              = "ingress"
+  from_port         = 30000
+  to_port           = 32767
+  protocol          = "udp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.nodes.id}"
+}
+
 resource "aws_security_group_rule" "nodes_ssh_bastion" {
   type                     = "ingress"
   from_port                = 22


### PR DESCRIPTION
**What this PR does / why we need it**: In order to enable NLBs on AWS we have to allow traffic from every client IP to the worker network. The reason for this is that NLBs (in contrast to ELBs) preserve the client IPs of the callers.

**Which issue(s) this PR tackles**:
More details: #242

**Special notes for your reviewer**:
/cc @vlerenc @mvladev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
AWS shoot clusters can now use network load balancers out of the box. This requires to allow TCP/UDP traffic to the ports 30000-32767 in the worker subnet from all client IPs. As the worker subnet is private and not accessible from the outside without proper routes (by default) this is not of any concern. In case you have created additional routes to the worker subnet please double check which subnets might now have access.
```
