### PR TITLE
Only sync shoot credentials to Garden cluster after controller deployment

### DIFF
--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -695,10 +695,6 @@ func (b *Botanist) DeploySecrets() error {
 		return err
 	}
 
-	if err := b.syncShootCredentialsToGarden(); err != nil {
-		return err
-	}
-
 	for name, secret := range b.Secrets {
 		b.CheckSums[name] = computeSecretCheckSum(secret.Data)
 	}
@@ -842,7 +838,9 @@ func (b *Botanist) generateShootSecrets(existingSecretsMap map[string]*corev1.Se
 	return nil
 }
 
-func (b *Botanist) syncShootCredentialsToGarden() error {
+// SyncShootCredentialsToGarden copies the kubeconfig generated for the user as well as the SSH keypair to
+// the project namespace in the Garden cluster.
+func (b *Botanist) SyncShootCredentialsToGarden() error {
 	for key, value := range map[string]string{"kubeconfig": "kubecfg", "ssh-keypair": "ssh-keypair"} {
 		secretObj := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:
So far the shoot credentials (kubeconfig and ssh-keypair) have been synced to the project namespace in the Garden cluster at a quite early stage (before the Kubernetes control plane itself has been deployed).
Moreover, due to the fact that the kube-apiserver is now be deployed independently of any cloud/infrastructure preparations the cluster is in the most cases reachable before the kube-controller-manager/cloud-controller-manager get deployed. This may lead to the situation in which the infrastructure cannot be created (maybe due to misconfiguration/some other issue) - hence, the cluster is reachable but no controllers are online.
We have seen cases in which users started creating pods/namespaces/some other Kubernetes resources as soon as the cluster was available. When they tried to delete the cluster afterwards the deletion process got stuck because their created resources could not be cleaned up anymore (due to offline controllers).

**Special notes for your reviewer**:
/cc @vpnachev @gardener/dashboard-maintainers 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
The shoot access credentials are now only synced to the project namespace in the Garden cluster if the shoot's kube-apiserver as well as the kube-controller-manager/cloud-controller-manager were successfully deployed.
```
