### PR TITLE
Make `Shoot.spec.cloud.secretBindingRef` immutable

### DIFF
--- a/pkg/apis/garden/validation/validation.go
+++ b/pkg/apis/garden/validation/validation.go
@@ -1353,6 +1353,7 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *garden.ShootSpec, deletionTimesta
 		return allErrs
 	}
 
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.SecretBindingRef, oldSpec.Cloud.SecretBindingRef, fldPath.Child("cloud", "secretBindingRef"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.Profile, oldSpec.Cloud.Profile, fldPath.Child("cloud", "profile"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.Region, oldSpec.Cloud.Region, fldPath.Child("cloud", "region"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.Seed, oldSpec.Cloud.Seed, fldPath.Child("cloud", "seed"))...)

--- a/pkg/apis/garden/validation/validation_test.go
+++ b/pkg/apis/garden/validation/validation_test.go
@@ -2569,19 +2569,24 @@ var _ = Describe("validation", func() {
 
 			errorList := ValidateShootUpdate(newShoot, shoot)
 
-			Expect(len(errorList)).To(Equal(3))
-			Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("spec.cloud.profile"),
-			}))
-			Expect(*errorList[1]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("spec.cloud.region"),
-			}))
-			Expect(*errorList[2]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("spec.cloud.seed"),
-			}))
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.cloud.profile"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.cloud.region"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.cloud.secretBindingRef"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.cloud.seed"),
+				}))),
+			)
 		})
 
 		Context("AWS specific validation", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Make `Shoot.spec.cloud.secretBindingRef` immutable - don't allow tinkering with the binding, secret credentials still can be altered by modifying the secret content itself.

```noteworthy user
The shoot's secret binding reference field (`.spec.cloud.secretBindingRef`) is now immutable. Rotating the cloud provider credentials is still possible by modifying the referenced secret's data.
```
