### PR TITLE
Availability condition: Set condtion to false when Shoot apiserver clientset init failed

### DIFF
--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -765,7 +765,7 @@ func (b *Botanist) HealthChecks(initializeShootClients func() error, apiserverAv
 	if err := initializeShootClients(); err != nil {
 		message := fmt.Sprintf("Could not initialize Shoot client for health check: %+v", err)
 		b.Logger.Error(message)
-		apiserverAvailability = helper.UpdatedConditionUnknownErrorMessage(apiserverAvailability, message)
+		apiserverAvailability = helper.UpdatedCondition(apiserverAvailability, corev1.ConditionFalse, "APIServerDown", "Could not reach API server during client initialization.")
 		nodes = helper.UpdatedConditionUnknownErrorMessage(nodes, message)
 		systemComponents = helper.UpdatedConditionUnknownErrorMessage(systemComponents, message)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Before it was set to unknown, when the clientset initialisation has been failed.
During the clientset initalization the apiserver will be queried.
Then we know that the apiserver is not reachable, therefore we set the condition to false.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
