### PR TITLE
Generate default domain for Shoots

### DIFF
--- a/plugin/pkg/shoot/dnshostedzone/admission_test.go
+++ b/plugin/pkg/shoot/dnshostedzone/admission_test.go
@@ -15,6 +15,8 @@
 package dnshostedzone_test
 
 import (
+	"fmt"
+
 	"github.com/gardener/gardener/pkg/apis/garden"
 	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/internalversion"
 	"github.com/gardener/gardener/pkg/operation/cloudbotanist/awsbotanist"
@@ -43,6 +45,7 @@ var _ = Describe("quotavalidator", func() {
 			referencedSecretName    = "my-dns-secret"
 			secretBindingName       = "my-secret-binding"
 			namespace               = "my-namespace"
+			shootName               = "shoot"
 
 			cloudProviderSecret = corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -71,7 +74,7 @@ var _ = Describe("quotavalidator", func() {
 
 			shootBase = garden.Shoot{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "shoot",
+					Name:      shootName,
 					Namespace: namespace,
 				},
 				Spec: garden.ShootSpec{
@@ -119,21 +122,69 @@ var _ = Describe("quotavalidator", func() {
 		})
 
 		It("should do nothing because the shoot specifies the 'unmanaged' dns provider", func() {
+			shootBefore := shoot.DeepCopy()
 			attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
 
 			err := admissionHandler.Admit(attrs)
 
 			Expect(err).NotTo(HaveOccurred())
+			Expect(shoot).To(Equal(*shootBefore))
 		})
 
-		It("should reject because no domain was configured for the shoot", func() {
-			shoot.Spec.DNS.Domain = nil
-			shoot.Spec.DNS.Provider = garden.DNSAWSRoute53
-			attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
+		Context("domain has not been set", func() {
+			BeforeEach(func() {
+				shoot.Spec.DNS.Domain = nil
+				shoot.Spec.DNS.Provider = garden.DNSAWSRoute53
+			})
 
-			err := admissionHandler.Admit(attrs)
+			It("shoud pass because a default domain was generated fot the shoot", func() {
+				projectName := "my-project"
+				kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&defaultDomainSecret)
 
-			Expect(err).To(MatchError(apierrors.NewBadRequest("shoot domain field .spec.dns.domain must be set if provider != unmanaged")))
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&garden.Project{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: projectName,
+					},
+					Spec: garden.ProjectSpec{
+						Namespace: &namespace,
+					},
+				})
+
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
+
+				err := admissionHandler.Admit(attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(*shoot.Spec.DNS.Domain).To(Equal(fmt.Sprintf("%s.%s.%s", shootName, projectName, domain)))
+				Expect(*shoot.Spec.DNS.HostedZoneID).To(Equal(hostedZoneID))
+			})
+
+			It("should reject because no domain was configured for the shoot and project is missing", func() {
+				kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&defaultDomainSecret)
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
+
+				err := admissionHandler.Admit(attrs)
+
+				Expect(err).To(MatchError(apierrors.NewBadRequest("shoot domain field .spec.dns.domain must be set if provider != unmanaged")))
+			})
+
+			It("should reject because no domain was configured for the shoot and default domain secret is missing", func() {
+				projectName := "my-project"
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&garden.Project{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: projectName,
+					},
+					Spec: garden.ProjectSpec{
+						Namespace: &namespace,
+					},
+				})
+
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
+
+				err := admissionHandler.Admit(attrs)
+
+				Expect(err).To(MatchError(apierrors.NewBadRequest("shoot domain field .spec.dns.domain must be set if provider != unmanaged")))
+			})
 		})
 
 		Context("hosted zone id has been specified", func() {

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -151,19 +151,9 @@ func (v *ValidateShoot) Admit(a admission.Attributes) error {
 		return apierrors.NewBadRequest(fmt.Sprintf("could not find referenced seed: %+v", err.Error()))
 	}
 
-	var project *garden.Project
-	projectList, err := v.projectLister.List(labels.Everything())
+	project, err := admissionutils.GetProject(shoot, v.projectLister)
 	if err != nil {
 		return apierrors.NewBadRequest(fmt.Sprintf("could not find referenced project: %+v", err.Error()))
-	}
-	for _, p := range projectList {
-		if p.Spec.Namespace != nil && *p.Spec.Namespace == shoot.Namespace {
-			project = p
-			break
-		}
-	}
-	if project == nil {
-		return apierrors.NewBadRequest("could not find referenced project")
 	}
 
 	switch a.GetOperation() {

--- a/plugin/pkg/utils/miscellaneous.go
+++ b/plugin/pkg/utils/miscellaneous.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/apis/garden"
+	gardenlisters "github.com/gardener/gardener/pkg/client/garden/listers/garden/internalversion"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// GetProject returns the Project resource the passed Shoot is assigned to.
+func GetProject(shoot *garden.Shoot, projectLister gardenlisters.ProjectLister) (*garden.Project, error) {
+	projects, err := projectLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	for _, project := range projects {
+		if project.Spec.Namespace != nil && *project.Spec.Namespace == shoot.Namespace {
+			return project, nil
+		}
+	}
+	return nil, fmt.Errorf("no project for shoot namespace %q", shoot.Namespace)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
In case the Shoot manifest does not have any domain configured in
`.spec.dns.domain` and `spec.dns.provider` field is not unmanaged,
the ShootDNSHostedZone admission plugin generates
a domain for it by applying the following pattern:
\<shootName\>.\<projectName\>.\<managed-domain\>

**Which issue(s) this PR fixes**:
Fixes #544 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Gardener does now generate a default domain name for newly created shoots that do not specify `.spec.dns.domain` but set `.spec.dns.provider!=unmanaged`. The domain will have the following scheme: `<shootName>.<projectName>.<managed-domain>`. This does only work if [default domains](https://github.com/gardener/gardener/blob/master/example/10-secret-default-domain.yaml) were registered in the system beforehand.
```
