### PR TITLE
Reserve some CPU for kubelet

### DIFF
--- a/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet-config-file
+++ b/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet-config-file
@@ -64,6 +64,7 @@ imageGCLowThresholdPercent: 40
 kubeAPIBurst: 25
 kubeAPIQPS: 25
 kubeReserved:
+  cpu: 80m
   memory: 1Gi
 hairpinMode: promiscuous-bridge
 hostNetworkSources:

--- a/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet.flags
+++ b/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet.flags
@@ -35,7 +35,7 @@
 --image-gc-high-threshold=50 \
 --image-gc-low-threshold=40 \
 --kubeconfig=/var/lib/kubelet/kubeconfig-real \
---kube-reserved=memory="1Gi" \
+--kube-reserved=cpu="80m",memory="1Gi" \
 --network-plugin=cni \
 --node-labels="kubernetes.io/role=node,node-role.kubernetes.io/node=,worker.garden.sapcloud.io/group={{ required "workers.name is required" .worker.name }}" \
 --read-only-port=0 \


### PR DESCRIPTION
**What this PR does / why we need it**: We should reserve some CPU for the kubelet on every shoot worker node.

**Special notes for your reviewer**:
/cc @mvladev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
The kubelet does now reserve `80m` CPU on every shoot worker node for itself.
```
