### PR TITLE
Remove legacy ClusterRoleBinding for system:nodes

### DIFF
--- a/charts/shoot-core/charts/kube-apiserver-kubelet/templates/kube-apiserver-kubelet-rbac.yaml
+++ b/charts/shoot-core/charts/kube-apiserver-kubelet/templates/kube-apiserver-kubelet-rbac.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: {{ template "rbacversion" . }}
 kind: ClusterRole
 metadata:
@@ -18,7 +19,6 @@ rules:
   - '*'
   verbs:
   - '*'
-
 ---
 apiVersion: {{ template "rbacversion" . }}
 kind: ClusterRoleBinding
@@ -33,20 +33,3 @@ roleRef:
 subjects:
 - kind: User
   name: system:kube-apiserver:kubelet
-
----
-
-apiVersion: {{include "rbacversion" .}}
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    addonmanager.kubernetes.io/mode: Reconcile
-  name: system:node
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:node
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:nodes


### PR DESCRIPTION
**What this PR does / why we need it**: We can now safely remove the ClusterRoleBinding we created at a time where we had no node-specific certificates for the kubelet (before TLS bootstrapping every kubelet had the same certificate).

**Special notes for your reviewer**:
I tested the creation/reconciliation of clusters in all Kubernetes versions.
We successfully ran the conformance tests and the related e2e tests of Kubernetes.
/cc @rolpat 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Gardener does no longer create a `ClusterRoleBinding` that allows every node to read every secret, pod, etc. Instead, due to the "node authorizer" plugin, every node is restricted to only read those secrets/pods/... that are assigned or related to its node.
```
