### PR TITLE
Delete logging stack if feature gate is disabled

### DIFF
--- a/pkg/client/kubernetes/base/cronjobs.go
+++ b/pkg/client/kubernetes/base/cronjobs.go
@@ -14,17 +14,7 @@
 
 package kubernetesbase
 
-import (
-	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-// ListDaemonSets returns the list of DaemonSets in the given namespace.
-func (c *Client) ListDaemonSets(namespace string, opts metav1.ListOptions) (*appsv1.DaemonSetList, error) {
-	return c.clientset.AppsV1().DaemonSets(namespace).List(opts)
-}
-
-// DeleteDaemonSet deletes a DaemonSet object.
-func (c *Client) DeleteDaemonSet(namespace, name string) error {
-	return c.Clientset().AppsV1().DaemonSets(namespace).Delete(name, &defaultDeleteOptions)
+// DeleteCronJob deletes a CronJob object.
+func (c *Client) DeleteCronJob(namespace, name string) error {
+	return c.clientset.BatchV1beta1().CronJobs(namespace).Delete(name, &defaultDeleteOptions)
 }

--- a/pkg/client/kubernetes/base/horizontalpodautoscaler.go
+++ b/pkg/client/kubernetes/base/horizontalpodautoscaler.go
@@ -14,17 +14,7 @@
 
 package kubernetesbase
 
-import (
-	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-// ListDaemonSets returns the list of DaemonSets in the given namespace.
-func (c *Client) ListDaemonSets(namespace string, opts metav1.ListOptions) (*appsv1.DaemonSetList, error) {
-	return c.clientset.AppsV1().DaemonSets(namespace).List(opts)
-}
-
-// DeleteDaemonSet deletes a DaemonSet object.
-func (c *Client) DeleteDaemonSet(namespace, name string) error {
-	return c.Clientset().AppsV1().DaemonSets(namespace).Delete(name, &defaultDeleteOptions)
+// DeleteHorizontalPodAutoscaler deletes an Ingress object.
+func (c *Client) DeleteHorizontalPodAutoscaler(namespace, name string) error {
+	return c.clientset.AutoscalingV2beta1().HorizontalPodAutoscalers(namespace).Delete(name, &defaultDeleteOptions)
 }

--- a/pkg/client/kubernetes/base/ingresses.go
+++ b/pkg/client/kubernetes/base/ingresses.go
@@ -14,17 +14,7 @@
 
 package kubernetesbase
 
-import (
-	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-// ListDaemonSets returns the list of DaemonSets in the given namespace.
-func (c *Client) ListDaemonSets(namespace string, opts metav1.ListOptions) (*appsv1.DaemonSetList, error) {
-	return c.clientset.AppsV1().DaemonSets(namespace).List(opts)
-}
-
-// DeleteDaemonSet deletes a DaemonSet object.
-func (c *Client) DeleteDaemonSet(namespace, name string) error {
-	return c.Clientset().AppsV1().DaemonSets(namespace).Delete(name, &defaultDeleteOptions)
+// DeleteIngress deletes an Ingress object.
+func (c *Client) DeleteIngress(namespace, name string) error {
+	return c.clientset.ExtensionsV1beta1().Ingresses(namespace).Delete(name, &defaultDeleteOptions)
 }

--- a/pkg/client/kubernetes/base/rbac.go
+++ b/pkg/client/kubernetes/base/rbac.go
@@ -64,6 +64,11 @@ func (c *Client) DeleteClusterRole(name string) error {
 	return c.Clientset().RbacV1().ClusterRoles().Delete(name, &defaultDeleteOptions)
 }
 
+// DeleteClusterRoleBinding deletes a ClusterRoleBinding object.
+func (c *Client) DeleteClusterRoleBinding(name string) error {
+	return c.Clientset().RbacV1().ClusterRoleBindings().Delete(name, &defaultDeleteOptions)
+}
+
 // DeleteRoleBinding deletes a RoleBindung object.
 func (c *Client) DeleteRoleBinding(namespace, name string) error {
 	return c.Clientset().RbacV1().RoleBindings(namespace).Delete(name, &defaultDeleteOptions)

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -107,10 +107,12 @@ type Client interface {
 
 	// DaemonSets
 	ListDaemonSets(string, metav1.ListOptions) (*appsv1.DaemonSetList, error)
+	DeleteDaemonSet(string, string) error
 
 	// Jobs
 	GetJob(string, string) (*batchv1.Job, error)
 	DeleteJob(string, string) error
+	DeleteCronJob(string, string) error
 
 	// ReplicaSets
 	ListReplicaSets(string, metav1.ListOptions) (*appsv1.ReplicaSetList, error)
@@ -132,6 +134,7 @@ type Client interface {
 	ListRoleBindings(string, metav1.ListOptions) (*rbacv1.RoleBindingList, error)
 	CreateOrPatchRoleBinding(metav1.ObjectMeta, func(*rbacv1.RoleBinding) *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error)
 	DeleteClusterRole(name string) error
+	DeleteClusterRoleBinding(name string) error
 	DeleteRoleBinding(namespace, name string) error
 
 	// CustomResourceDefinitions
@@ -143,6 +146,15 @@ type Client interface {
 	DeleteAPIService(name string) error
 	DeleteAPIServiceForcefully(name string) error
 
+	// ServiceAccounts
+	DeleteServiceAccount(namespace, name string) error
+
+	// HorizontalPodAutoscalers
+	DeleteHorizontalPodAutoscaler(namespace, name string) error
+
+	// Ingresses
+	DeleteIngress(namespace, name string) error
+
 	// Arbitrary manifests
 	Apply([]byte) error
 
@@ -150,7 +162,4 @@ type Client interface {
 	Curl(string) (*rest.Result, error)
 	QueryVersion() (string, error)
 	Version() string
-
-	// ServiceAccounts
-	DeleteServiceAccount(namespace, name string) error
 }

--- a/pkg/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controller/shoot/shoot_control_reconcile.go
@@ -20,7 +20,6 @@ import (
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
 	controllerutils "github.com/gardener/gardener/pkg/controller/utils"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/operation/botanist"
 	cloudbotanistpkg "github.com/gardener/gardener/pkg/operation/cloudbotanist"
@@ -65,7 +64,6 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 		defaultInterval                 = 5 * time.Second
 		managedDNS                      = o.Shoot.Info.Spec.DNS.Provider != gardenv1beta1.DNSUnmanaged
 		isCloud                         = o.Shoot.Info.Spec.Cloud.Local == nil
-		loggingEnabled                  = features.ControllerFeatureGate.Enabled(features.Logging)
 		creationPhase                   = operationType == gardenv1beta1.ShootLastOperationTypeCreate
 		requireInfrastructureDeployment = creationPhase || controllerutils.HasTask(o.Shoot.Info.Annotations, common.ShootTaskDeployInfrastructure)
 		requireKube2IAMDeployment       = creationPhase || controllerutils.HasTask(o.Shoot.Info.Annotations, common.ShootTaskDeployKube2IAMResource)
@@ -216,7 +214,7 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying shoot logging stack in Seed",
-			Fn:           flow.SimpleTaskFn(botanist.DeploySeedLogging).RetryUntilTimeout(defaultInterval, defaultTimeout).DoIf(loggingEnabled),
+			Fn:           flow.SimpleTaskFn(botanist.DeploySeedLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady, initializeShootClients, waitUntilVPNConnectionExists, reconcileMachines),
 		})
 		_ = g.Add(flow.Task{

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -436,6 +436,10 @@ func (b *Botanist) patchDeploymentCloudProviderChecksums(deploymentName string) 
 
 // DeploySeedLogging will install the Helm release "seed-bootstrap/charts/elastic-kibana-curator" in the Seed clusters.
 func (b *Botanist) DeploySeedLogging() error {
+	if !features.ControllerFeatureGate.Enabled(features.Logging) {
+		return common.DeleteLoggingStack(b.K8sSeedClient, b.Shoot.SeedNamespace)
+	}
+
 	var (
 		credentials = b.Secrets["logging-ingress-credentials"]
 		basicAuth   = utils.CreateSHA1Secret(credentials.Data["username"], credentials.Data["password"])

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -35,9 +35,12 @@ import (
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
+
 	prometheusapi "github.com/prometheus/client_golang/api"
 	prometheusclient "github.com/prometheus/client_golang/api/prometheus/v1"
+
 	"github.com/sirupsen/logrus"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"


### PR DESCRIPTION
**What this PR does / why we need it**: So far, the logging stack was not cleaned up if the feature gate has been disabled. This PR fixes this.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Gardener does now correctly clean up all logging stack related artefacts it created in case the `Logging` feature gate has been disabled.
```
