### PR TITLE
Refine network policies

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/network-policy.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/network-policy.yaml
@@ -2,88 +2,59 @@
 apiVersion: {{ include "networkpolicyversion" . }}
 kind: NetworkPolicy
 metadata:
-  name: kube-apiserver-deny-blacklist
-  namespace:  {{ .Release.Namespace }}
+  name: kube-apiserver-default
+  namespace: {{ .Release.Namespace }}
 spec:
-  podSelector:
-    matchLabels:
-      app: kubernetes
-      role: apiserver
-  policyTypes:
-  - Egress
   egress:
+  # Allow cluster internal DNS lookups (kube-dns/coredns).
+  # This rule does not have a podSelector as we cannot know in general how the
+  # DNS pod in the seed cluster is labelled.
+  - ports:
+    - port: 8053
+      protocol: UDP
+    - port: 8053
+      protocol: TCP
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          role: kube-system
+  # Allow connection to shoot's etcd instances.
+  - ports:
+    - port: {{ required ".etcdServicePort is required" .Values.etcdServicePort }}
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          app: etcd-statefulset
+  # Allow connection to gardener external admission controller.
+  - ports:
+    - port: 2730
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          role: garden
+      podSelector:
+        matchLabels:
+          app: gardener
+          role: external-admission-controller
+  # Allow connection to everywhere else other than the seed networks and the
+  # cloud's metadata service.
   - to:
     - ipBlock:
-        # Allow all except seed networks
         cidr: 0.0.0.0/0
         except:
         - {{ .Values.seedNetworks.pod }}
         - {{ .Values.seedNetworks.node }}
         - {{ .Values.seedNetworks.service }}
         - 169.254.169.254/32
----
-apiVersion: {{ include "networkpolicyversion" . }}
-kind: NetworkPolicy
-metadata:
-  name: kube-apiserver-allow-etcd
-  namespace: {{ .Release.Namespace }}
-spec:
   podSelector:
     matchLabels:
       app: kubernetes
       role: apiserver
   policyTypes:
   - Egress
-  egress:
-  - ports:
-    - port: {{ required ".etcdServicePort is required" .Values.etcdServicePort }}
-      protocol: TCP
-  - to:
-    - podSelector:
-        matchLabels:
-          app: etcd-statefulset
----
-apiVersion: {{ include "networkpolicyversion" . }}
-kind: NetworkPolicy
-metadata:
-  name: kube-apiserver-allow-dns
-  namespace: {{ .Release.Namespace }}
-spec:
-  podSelector:
-    matchLabels:
-      app: kubernetes
-      role: apiserver
-  policyTypes:
-  - Egress
-  egress:
-  - ports:
-    - port: 53
-      protocol: UDP
-    - port: 53
-      protocol: TCP  
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          role: kube-system
----
-apiVersion: {{ include "networkpolicyversion" . }}
-kind: NetworkPolicy
-metadata:
-  name: kube-apiserver-allow-gardener-admission-controller
-  namespace: {{ .Release.Namespace }}
-spec:
-  podSelector:
-    matchLabels:
-      app: kubernetes
-      role: apiserver
-  policyTypes:
-  - Egress
-  egress:
-  - ports:
-    - port: 2730
-      protocol: TCP
-  - to:
-    - podSelector:
-        matchLabels:
-          app: gardener
-          role: external-admission-controller

--- a/pkg/client/kubernetes/base/networkpolicies.go
+++ b/pkg/client/kubernetes/base/networkpolicies.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetesbase
+
+// DeleteNetworkPolicy deletes an NetworkPolicy object.
+func (c *Client) DeleteNetworkPolicy(namespace, name string) error {
+	return c.clientset.NetworkingV1().NetworkPolicies(namespace).Delete(name, &defaultDeleteOptions)
+}

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -155,6 +155,9 @@ type Client interface {
 	// Ingresses
 	DeleteIngress(namespace, name string) error
 
+	// NetworkPolicies
+	DeleteNetworkPolicy(namespace, name string) error
+
 	// Arbitrary manifests
 	Apply([]byte) error
 

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -170,17 +170,19 @@ func BootstrapCluster(seed *Seed, k8sGardenClient kubernetes.Client, secrets map
 		return err
 	}
 
-	body := fmt.Sprintf(`[{"op": "add", "path": "/metadata/labels", "value": %s}]`, `{"role":"kube-system"}`)
-	if _, err := k8sSeedClient.PatchNamespace("kube-system", []byte(body)); err != nil {
-		return err
-	}
-
 	gardenNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: common.GardenNamespace,
 		},
 	}
 	if _, err := k8sSeedClient.CreateNamespace(gardenNamespace, false); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	if _, err := k8sSeedClient.PatchNamespace(common.GardenNamespace, []byte(fmt.Sprintf(`[{"op": "add", "path": "/metadata/labels", "value": {"role":"%s"}}]`, common.GardenNamespace))); err != nil {
+		return err
+	}
+	if _, err := k8sSeedClient.PatchNamespace(metav1.NamespaceSystem, []byte(fmt.Sprintf(`[{"op": "add", "path": "/metadata/labels", "value": {"role":"%s"}}]`, metav1.NamespaceSystem))); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**: The network policies have been refined and merged into one.

**Special notes for your reviewer**:
/cc @marwinski 
/cc @alban
/cc @schu

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The network policies isolating the shoot's kube-apiserver have been refined and do now restrict even more connection that are not needed/desired.
```
