### PR TITLE
set coreDNS to emits logs only for queries which were not resolved su…

### DIFF
--- a/charts/shoot-core/charts/coredns/values.yaml
+++ b/charts/shoot-core/charts/coredns/values.yaml
@@ -35,6 +35,10 @@ configmap:
     plugins:
     - name: errors
     - name: log
+      parameters: .
+      configBlock: |-
+        class denial
+        class error
     - name: health
     - name: kubernetes
       parameters: cluster.local in-addr.arpa ip6.arpa


### PR DESCRIPTION
**What this PR does / why we need it**:
Set coreDNS to log all queries which were not resolved successfully.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
The CoreDNS logs do now only contain `denial` (either NXDOMAIN or NODATA (name exists, type does not)) or `error` (SERVFAIL, NOTIMP, REFUSED, etc. - anything that indicates the remote server is not willing to resolve the request)` messages.
```
