### PR TITLE
fix enabling pod priority feature for 1.10 clusters

### DIFF
--- a/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet.flags
+++ b/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet.flags
@@ -27,9 +27,6 @@
 {{- if (include "kubelet.featureGates" .) }}
 {{- include "kubelet.featureGates" . | trimSuffix "," }} \
 {{- end }}
-{{- if semverCompare "< 1.11" .kubernetes.version }}
---feature-gates=PodPriority=true \
-{{- end }}
 --kube-api-burst=25 \
 --kube-api-qps=25 \
 --image-gc-high-threshold=50 \
@@ -67,5 +64,8 @@
 {{ $param }} \
 {{- end }}
 --v=2
+{{- end }}
+{{- if semverCompare "< 1.11" .kubernetes.version }}
+--feature-gates=PodPriority=true \
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
currently the check for 1.10 version is not processed due to false
hierarchy. This commit fixes the hierarchy of the checks to execute 1.10
pod priority flags when needed.

Co-authored-by: tim.usner@sap.com

```improvement operator
fix enabling pod priority feature for 1.10 clusters by re-positioning the helm chart check to the right place.
```
