### PR TITLE
Fix shoot health label / add shoot status label

### DIFF
--- a/pkg/controller/shoot/shoot_care_control.go
+++ b/pkg/controller/shoot/shoot_care_control.go
@@ -169,7 +169,14 @@ func (c *defaultCareControl) Care(shootObj *gardenv1beta1.Shoot, key string) err
 	}
 
 	// Mark Shoot as healthy/unhealthy
-	kutil.TryUpdateShootLabels(c.k8sGardenClient.GardenClientset(), retry.DefaultBackoff, shoot.ObjectMeta, shootHealthyLabelTransform(shootIsHealthy(shoot, conditionAPIServerAvailable, conditionControlPlaneHealthy, conditionEveryNodeReady, conditionSystemComponentsHealthy)))
+	kutil.TryUpdateShootLabels(
+		c.k8sGardenClient.GardenClientset(),
+		retry.DefaultBackoff, shoot.ObjectMeta,
+		StatusLabelTransform(
+			ComputeStatus(
+				shoot.Status.LastOperation,
+				shoot.Status.LastError,
+				conditionAPIServerAvailable, conditionControlPlaneHealthy, conditionEveryNodeReady, conditionSystemComponentsHealthy)))
 	return nil // We do not want to run in the exponential backoff for the condition checks.
 }
 

--- a/pkg/controller/shoot/shoot_control_delete.go
+++ b/pkg/controller/shoot/shoot_control_delete.go
@@ -390,7 +390,7 @@ func (c *defaultControl) updateShootStatusDeleteError(o *operation.Operation, la
 	}
 	o.Logger.Error(description)
 
-	newShootAfterLabel, err := kubernetes.TryUpdateShootLabels(c.k8sGardenClient.GardenClientset(), retry.DefaultRetry, o.Shoot.Info.ObjectMeta, shootHealthyLabelTransform(false))
+	newShootAfterLabel, err := kubernetes.TryUpdateShootLabels(c.k8sGardenClient.GardenClientset(), retry.DefaultRetry, o.Shoot.Info.ObjectMeta, StatusLabelTransform(StatusUnhealthy))
 	if err == nil {
 		o.Shoot.Info = newShootAfterLabel
 	}

--- a/pkg/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controller/shoot/shoot_control_reconcile.go
@@ -379,7 +379,7 @@ func (c *defaultControl) updateShootStatusReconcileError(o *operation.Operation,
 		o.Shoot.Info = newShoot
 	}
 
-	newShootAfterLabel, err := kutil.TryUpdateShootLabels(c.k8sGardenClient.GardenClientset(), retry.DefaultRetry, o.Shoot.Info.ObjectMeta, shootHealthyLabelTransform(false))
+	newShootAfterLabel, err := kutil.TryUpdateShootLabels(c.k8sGardenClient.GardenClientset(), retry.DefaultRetry, o.Shoot.Info.ObjectMeta, StatusLabelTransform(StatusUnhealthy))
 	if err == nil {
 		o.Shoot.Info = newShootAfterLabel
 	}

--- a/pkg/controller/shoot/shoot_suite_test.go
+++ b/pkg/controller/shoot/shoot_suite_test.go
@@ -14,6 +14,10 @@
 package shoot_test
 
 import (
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/gardener/pkg/controller/shoot"
+	"github.com/gardener/gardener/pkg/operation/common"
+	. "github.com/onsi/ginkgo/extensions/table"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -24,3 +28,115 @@ func TestShoot(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controller Shoot Suite")
 }
+
+var _ = Describe("Shoot Utils", func() {
+	Context("Status", func() {
+		DescribeTable("#OrWorse",
+			func(s1, s2, expected shoot.Status) {
+				Expect(s1.OrWorse(s2)).To(Equal(expected))
+				Expect(s2.OrWorse(s1)).To(Equal(expected), "not reflexive")
+			},
+			Entry("healthy - healthy", shoot.StatusHealthy, shoot.StatusHealthy, shoot.StatusHealthy),
+			Entry("healthy - progressing", shoot.StatusHealthy, shoot.StatusProgressing, shoot.StatusProgressing),
+			Entry("healthy - unhealthy", shoot.StatusHealthy, shoot.StatusUnhealthy, shoot.StatusUnhealthy),
+			Entry("progressing - progressing", shoot.StatusProgressing, shoot.StatusProgressing, shoot.StatusProgressing),
+			Entry("progressing - unhealthy", shoot.StatusProgressing, shoot.StatusUnhealthy, shoot.StatusUnhealthy),
+			Entry("unhealthy - unhealthy", shoot.StatusUnhealthy, shoot.StatusUnhealthy, shoot.StatusUnhealthy),
+		)
+
+		DescribeTable("#ConditionStatusToStatus",
+			func(status gardenv1beta1.ConditionStatus, expected shoot.Status) {
+				Expect(shoot.ConditionStatusToStatus(status)).To(Equal(expected))
+			},
+			Entry("ConditionTrue", gardenv1beta1.ConditionTrue, shoot.StatusHealthy),
+			Entry("ConditionProgressing", gardenv1beta1.ConditionProgressing, shoot.StatusProgressing),
+			Entry("ConditionUnknown", gardenv1beta1.ConditionUnknown, shoot.StatusUnhealthy),
+			Entry("ConditionFalse", gardenv1beta1.ConditionFalse, shoot.StatusUnhealthy),
+		)
+
+		DescribeTable("#ComputeConditionStatus",
+			func(conditions []*gardenv1beta1.Condition, expected shoot.Status) {
+				Expect(shoot.ComputeConditionStatus(conditions...)).To(Equal(expected))
+			},
+			Entry("no conditions", nil, shoot.StatusHealthy),
+			Entry("true condition", []*gardenv1beta1.Condition{
+				{Status: gardenv1beta1.ConditionTrue},
+			}, shoot.StatusHealthy),
+			Entry("progressing condition", []*gardenv1beta1.Condition{
+				{Status: gardenv1beta1.ConditionTrue},
+				{Status: gardenv1beta1.ConditionProgressing},
+			}, shoot.StatusProgressing),
+			Entry("unknown condition", []*gardenv1beta1.Condition{
+				{Status: gardenv1beta1.ConditionTrue},
+				{Status: gardenv1beta1.ConditionProgressing},
+				{Status: gardenv1beta1.ConditionUnknown},
+			}, shoot.StatusUnhealthy),
+			Entry("false condition", []*gardenv1beta1.Condition{
+				{Status: gardenv1beta1.ConditionTrue},
+				{Status: gardenv1beta1.ConditionProgressing},
+				{Status: gardenv1beta1.ConditionUnknown},
+				{Status: gardenv1beta1.ConditionFalse},
+			}, shoot.StatusUnhealthy),
+		)
+
+		DescribeTable("#BoolToStatus",
+			func(b bool, expected shoot.Status) {
+				Expect(shoot.BoolToStatus(b)).To(Equal(expected))
+			},
+			Entry("true", true, shoot.StatusHealthy),
+			Entry("false", false, shoot.StatusUnhealthy),
+		)
+
+		DescribeTable("#ComputeStatus",
+			func(lastOperation *gardenv1beta1.LastOperation, lastError *gardenv1beta1.LastError, conditions []*gardenv1beta1.Condition, expected shoot.Status) {
+				Expect(shoot.ComputeStatus(lastOperation, lastError, conditions...)).To(Equal(expected))
+			},
+			Entry("lastOperation is nil",
+				nil, nil, nil, shoot.StatusHealthy),
+			Entry("lastOperation.Type is ShootLastOperationTypeCreate",
+				&gardenv1beta1.LastOperation{Type: gardenv1beta1.ShootLastOperationTypeCreate}, nil, nil, shoot.StatusHealthy),
+			Entry("lastOperation.Type is ShootLastOperationTypeDelete",
+				&gardenv1beta1.LastOperation{Type: gardenv1beta1.ShootLastOperationTypeDelete}, nil, nil, shoot.StatusHealthy),
+			Entry("lastOperation.Type is ShootLastOperationTypeCreate and lastError is set",
+				&gardenv1beta1.LastOperation{Type: gardenv1beta1.ShootLastOperationTypeCreate}, &gardenv1beta1.LastError{}, nil, shoot.StatusUnhealthy),
+			Entry("lastOperation.Type is ShootLastOperationTypeDelete and lastError is set",
+				&gardenv1beta1.LastOperation{Type: gardenv1beta1.ShootLastOperationTypeDelete}, &gardenv1beta1.LastError{}, nil, shoot.StatusUnhealthy),
+			Entry("lastOperation.State is ShootLastOperationStateProcessing with healthy conditions",
+				&gardenv1beta1.LastOperation{State: gardenv1beta1.ShootLastOperationStateProcessing}, nil, nil, shoot.StatusHealthy),
+			Entry("lastOperation.State is ShootLastOperationStateProcessing with unhealthy conditions",
+				&gardenv1beta1.LastOperation{State: gardenv1beta1.ShootLastOperationStateProcessing}, nil, []*gardenv1beta1.Condition{{Status: gardenv1beta1.ConditionFalse}}, shoot.StatusUnhealthy),
+			Entry("lastOperation.State is ShootLastOperationStateProcessing with healthy conditions but lastError set",
+				&gardenv1beta1.LastOperation{State: gardenv1beta1.ShootLastOperationStateProcessing}, &gardenv1beta1.LastError{}, nil, shoot.StatusUnhealthy),
+			Entry("lastOperation.State is neither ShootLastOperationStateProcessing nor ShootLastOperationStateSucceeded with healthy conditions",
+				&gardenv1beta1.LastOperation{State: gardenv1beta1.ShootLastOperationStateError}, nil, nil, shoot.StatusUnhealthy),
+			Entry("lastOperation.State is ShootLastOperationStateSucceeded with healthy conditions",
+				&gardenv1beta1.LastOperation{State: gardenv1beta1.ShootLastOperationStateSucceeded}, nil, nil, shoot.StatusHealthy),
+			Entry("lastOperation.State is ShootLastOperationStateSucceeded with unhealthy conditions",
+				&gardenv1beta1.LastOperation{State: gardenv1beta1.ShootLastOperationStateSucceeded}, nil, []*gardenv1beta1.Condition{{Status: gardenv1beta1.ConditionFalse}}, shoot.StatusUnhealthy),
+		)
+
+		DescribeTable("#StatusLabelTransform",
+			func(status shoot.Status, expectedLabels map[string]string) {
+				original := &gardenv1beta1.Shoot{}
+
+				modified, err := shoot.StatusLabelTransform(status)(original.DeepCopy())
+				Expect(err).NotTo(HaveOccurred())
+				modifiedWithoutLabels := modified.DeepCopy()
+				modifiedWithoutLabels.Labels = nil
+				Expect(modifiedWithoutLabels).To(Equal(original), "not only labels were modified")
+				Expect(modified.Labels).To(Equal(expectedLabels))
+			},
+			Entry("StatusHealthy", shoot.StatusHealthy, map[string]string{
+				common.ShootStatus: string(shoot.StatusHealthy),
+			}),
+			Entry("StatusProgressing", shoot.StatusProgressing, map[string]string{
+				common.ShootStatus:    string(shoot.StatusProgressing),
+				common.ShootUnhealthy: "true",
+			}),
+			Entry("StatusUnhealthy", shoot.StatusUnhealthy, map[string]string{
+				common.ShootStatus:    string(shoot.StatusUnhealthy),
+				common.ShootUnhealthy: "true",
+			}),
+		)
+	})
+})

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -299,8 +299,13 @@ const (
 	// Garden cluster once successfully created.
 	ShootUseAsSeed = "shoot.garden.sapcloud.io/use-as-seed"
 
+	// ShootStatus is a constant for a label on a Shoot resource indicating that the Shoot's health.
+	// Shoot Care controller and can be used to easily identify Shoot clusters with certain states.
+	ShootStatus = "shoot.garden.sapcloud.io/status"
+
 	// ShootUnhealthy is a constant for a label on a Shoot resource indicating that the Shoot is unhealthy. It is set and unset by the
 	// Shoot Care controller and can be used to easily identify Shoot clusters with issues.
+	// Deprecated: Use ShootStatus instead
 	ShootUnhealthy = "shoot.garden.sapcloud.io/unhealthy"
 
 	// ShootOperation is a constant for an annotation on a Shoot in a failed state indicating that an operation shall be performed.

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -1,0 +1,13 @@
+package kubernetes
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// SetMetaDataLabel sets the key value pair in the labels section of the given ObjectMeta.
+// If the given ObjectMeta did not yet have labels, they are initialized.
+func SetMetaDataLabel(meta *metav1.ObjectMeta, key, value string) {
+	if meta.Labels == nil {
+		meta.Labels = make(map[string]string)
+	}
+
+	meta.Labels[key] = value
+}

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -50,6 +50,22 @@ var _ = Describe("kubernetes", func() {
 		})
 	})
 
+	DescribeTable("#SetMetaDataLabel",
+		func(labels map[string]string, key, value string, expectedLabels map[string]string) {
+			original := &metav1.ObjectMeta{Labels: labels}
+			modified := original.DeepCopy()
+
+			SetMetaDataLabel(modified, key, value)
+			modifiedWithOriginalLabels := modified.DeepCopy()
+			modifiedWithOriginalLabels.Labels = labels
+			Expect(modifiedWithOriginalLabels).To(Equal(original), "not only labels were modified")
+			Expect(modified.Labels).To(Equal(expectedLabels))
+		},
+		Entry("nil labels", nil, "foo", "bar", map[string]string{"foo": "bar"}),
+		Entry("non-nil non-conflicting labels", map[string]string{"bar": "baz"}, "foo", "bar", map[string]string{"bar": "baz", "foo": "bar"}),
+		Entry("non-nil conflicting labels", map[string]string{"foo": "baz"}, "foo", "bar", map[string]string{"foo": "bar"}),
+	)
+
 	DescribeTable("#IsEmptyPatch",
 		func(patch string, expected bool) {
 			Expect(IsEmptyPatch([]byte(patch))).To(Equal(expected))


### PR DESCRIPTION
introduce shoot status label reflecting the current status of the shoot
update healthiness label to work on Progressing status
create test cases

**What this PR does / why we need it**:
This fixes / enhances the shoot status / unhealthy label.

**Special notes for your reviewer**:
cc @grolu @petersutter @holgerkoser 

```improvement user
Gardener adds a new `shoot.garden.sapcloud.io/status` label to shoots to indicate the health status of the shoot and to allow filtering. There are three possible values: `healthy`, `progressing`, `unhealthy`. See also: https://github.com/gardener/gardener/pull/552
The old label `shoot.garden.sapcloud.io/unhealthy` is deprecated and will be removed in the future. 
```