### PR TITLE
Use common label for all system component pods

### DIFF
--- a/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -31,7 +31,7 @@ metadata:
   name: node-exporter
   namespace: kube-system
   labels:
-    garden.sapcloud.io/role: monitoring
+    garden.sapcloud.io/role: system-component
     addonmanager.kubernetes.io/mode: Reconcile
     component: node-exporter
     origin: gardener
@@ -46,7 +46,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
       labels:
-        garden.sapcloud.io/role: monitoring
+        garden.sapcloud.io/role: system-component
         origin: gardener
         component: node-exporter
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**: 
Use `garden.sapcloud.io/role: system-component` label for the `node-exporter` daemon set installed inside the shoot clusters. This label is used for all other system components deployed in the shoot cluster. 
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
