### PR TITLE
Add CIDR overlap verification.

### DIFF
--- a/pkg/apis/garden/validation/validation_test.go
+++ b/pkg/apis/garden/validation/validation_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	. "github.com/gardener/gardener/pkg/utils/validation/gomega"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -1980,7 +1981,7 @@ var _ = Describe("validation", func() {
 
 			errorList := ValidateSeed(seed)
 
-			assertErrorList(errorList, Fields{
+			Expect(errorList).To(ConsistOfFields(Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("spec.networks.pods"),
 				"Detail": Equal(`must not be a subset of "spec.networks.nodes" ("10.0.0.0/8")`),
@@ -1992,7 +1993,7 @@ var _ = Describe("validation", func() {
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("spec.networks.services"),
 				"Detail": Equal(`must not be a subset of "spec.networks.pods" ("10.0.1.0/24")`),
-			})
+			}))
 		})
 	})
 
@@ -2681,11 +2682,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.aws.networks.vpc.cidr"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
-					})
+					}))
 				})
 
 				It("should forbid invalid internal CIDR", func() {
@@ -2693,11 +2694,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.aws.networks.internal[0]"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
-					})
+					}))
 				})
 
 				It("should forbid invalid public CIDR", func() {
@@ -2705,11 +2706,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.aws.networks.public[0]"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
-					})
+					}))
 				})
 
 				It("should forbid invalid workers CIDR", func() {
@@ -2717,11 +2718,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.aws.networks.workers[0]"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
-					})
+					}))
 				})
 
 				It("should forbid internal CIDR which is not in VPC CIDR", func() {
@@ -2729,11 +2730,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.aws.networks.internal[0]"),
 						"Detail": Equal(`must be a subset of "spec.cloud.aws.networks.vpc.cidr" ("10.0.0.0/8")`),
-					})
+					}))
 				})
 
 				It("should forbid public CIDR which is not in VPC CIDR", func() {
@@ -2741,11 +2742,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.aws.networks.public[0]"),
 						"Detail": Equal(`must be a subset of "spec.cloud.aws.networks.vpc.cidr" ("10.0.0.0/8")`),
-					})
+					}))
 				})
 
 				It("should forbid workers CIDR which are not in VPC and Nodes CIDR", func() {
@@ -2753,7 +2754,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.aws.networks.workers[0]"),
 						"Detail": Equal(`must be a subset of "spec.cloud.aws.networks.nodes" ("10.250.0.0/16")`),
@@ -2761,7 +2762,7 @@ var _ = Describe("validation", func() {
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.aws.networks.workers[0]"),
 						"Detail": Equal(`must be a subset of "spec.cloud.aws.networks.vpc.cidr" ("10.0.0.0/8")`),
-					})
+					}))
 				})
 
 				It("should forbid Pod CIDR to overlap with VPC CIDR", func() {
@@ -2770,11 +2771,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.aws.networks.pods"),
 						"Detail": Equal(`must not be a subset of "spec.cloud.aws.networks.vpc.cidr" ("10.0.0.0/8")`),
-					})
+					}))
 				})
 
 				It("should forbid Services CIDR to overlap with VPC CIDR", func() {
@@ -2783,11 +2784,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.aws.networks.services"),
 						"Detail": Equal(`must not be a subset of "spec.cloud.aws.networks.vpc.cidr" ("10.0.0.0/8")`),
-					})
+					}))
 				})
 
 				It("should forbid VPC CIDRs to overlap with other VPC CIDRs", func() {
@@ -2799,7 +2800,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.aws.networks.public[0]"),
 						"Detail": Equal(`must not be a subset of "spec.cloud.aws.networks.internal[0]" ("10.250.0.1/32")`),
@@ -2823,7 +2824,7 @@ var _ = Describe("validation", func() {
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.aws.networks.public[0]"),
 						"Detail": Equal(`must not be a subset of "spec.cloud.aws.networks.workers[0]" ("10.250.0.1/32")`),
-					})
+					}))
 				})
 
 				It("should forbid non-specified k8s networks", func() {
@@ -2831,7 +2832,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.cloud.aws.networks.nodes"),
 					}, Fields{
@@ -2840,7 +2841,7 @@ var _ = Describe("validation", func() {
 					}, Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.cloud.aws.networks.services"),
-					})
+					}))
 				})
 
 				It("should invalid k8s networks", func() {
@@ -2848,7 +2849,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.aws.networks.nodes"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
@@ -2860,7 +2861,7 @@ var _ = Describe("validation", func() {
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.aws.networks.services"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
-					})
+					}))
 				})
 
 			})
@@ -3163,11 +3164,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.azure.networks.vnet.cidr"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
-					})
+					}))
 				})
 
 				It("should forbid invalid workers CIDR", func() {
@@ -3175,11 +3176,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.azure.networks.workers"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
-					})
+					}))
 				})
 
 				It("should forbid workers which are not in VNet anmd Nodes CIDR", func() {
@@ -3189,7 +3190,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.azure.networks.workers"),
 						"Detail": Equal(`must be a subset of "spec.cloud.azure.networks.nodes" ("10.250.0.0/16")`),
@@ -3197,7 +3198,7 @@ var _ = Describe("validation", func() {
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.azure.networks.workers"),
 						"Detail": Equal(`must be a subset of "spec.cloud.azure.networks.vnet.cidr" ("10.0.0.0/8")`),
-					})
+					}))
 				})
 
 				It("should forbid Pod CIDR to overlap with VNet CIDR", func() {
@@ -3206,11 +3207,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.azure.networks.pods"),
 						"Detail": Equal(`must not be a subset of "spec.cloud.azure.networks.vnet.cidr" ("10.0.0.0/8")`),
-					})
+					}))
 				})
 
 				It("should forbid Services CIDR to overlap with VNet CIDR", func() {
@@ -3219,11 +3220,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.azure.networks.services"),
 						"Detail": Equal(`must not be a subset of "spec.cloud.azure.networks.vnet.cidr" ("10.0.0.0/8")`),
-					})
+					}))
 				})
 
 				It("should forbid non-specified k8s networks", func() {
@@ -3231,7 +3232,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.cloud.azure.networks.nodes"),
 					}, Fields{
@@ -3240,7 +3241,7 @@ var _ = Describe("validation", func() {
 					}, Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.cloud.azure.networks.services"),
-					})
+					}))
 				})
 
 				It("should forbid non-specified k8s networks", func() {
@@ -3248,7 +3249,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.cloud.azure.networks.nodes"),
 					}, Fields{
@@ -3257,7 +3258,7 @@ var _ = Describe("validation", func() {
 					}, Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.cloud.azure.networks.services"),
-					})
+					}))
 				})
 
 				It("should invalid k8s networks", func() {
@@ -3265,7 +3266,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.azure.networks.nodes"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
@@ -3277,7 +3278,7 @@ var _ = Describe("validation", func() {
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.azure.networks.services"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
-					})
+					}))
 				})
 			})
 
@@ -3550,11 +3551,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.gcp.networks.workers[0]"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
-					})
+					}))
 				})
 
 				It("should forbid workers CIDR which are not in Nodes CIDR", func() {
@@ -3562,11 +3563,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.gcp.networks.workers[0]"),
 						"Detail": Equal(`must be a subset of "spec.cloud.gcp.networks.nodes" ("10.250.0.0/16")`),
-					})
+					}))
 				})
 
 				It("should forbid non-specified k8s networks", func() {
@@ -3574,7 +3575,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.cloud.gcp.networks.nodes"),
 					}, Fields{
@@ -3583,7 +3584,7 @@ var _ = Describe("validation", func() {
 					}, Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.cloud.gcp.networks.services"),
-					})
+					}))
 				})
 
 				It("should invalid k8s networks", func() {
@@ -3591,7 +3592,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.gcp.networks.nodes"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
@@ -3603,7 +3604,7 @@ var _ = Describe("validation", func() {
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.gcp.networks.services"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
-					})
+					}))
 				})
 			})
 
@@ -3865,11 +3866,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.alicloud.networks.vpc.cidr"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
-					})
+					}))
 				})
 
 				It("should forbid invalid workers CIDR", func() {
@@ -3877,11 +3878,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.alicloud.networks.workers[0]"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
-					})
+					}))
 				})
 
 				It("should forbid workers CIDR which are not in Nodes CIDR", func() {
@@ -3889,7 +3890,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.alicloud.networks.workers[0]"),
 						"Detail": Equal(`must be a subset of "spec.cloud.alicloud.networks.nodes" ("10.250.0.0/16")`),
@@ -3897,7 +3898,7 @@ var _ = Describe("validation", func() {
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.alicloud.networks.workers[0]"),
 						"Detail": Equal(`must be a subset of "spec.cloud.alicloud.networks.vpc.cidr" ("10.0.0.0/8")`),
-					})
+					}))
 				})
 
 				It("should forbid Node which are not in VPC CIDR", func() {
@@ -3907,7 +3908,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.alicloud.networks.nodes"),
 						"Detail": Equal(`must be a subset of "spec.cloud.alicloud.networks.vpc.cidr" ("10.0.0.0/8")`),
@@ -3915,7 +3916,7 @@ var _ = Describe("validation", func() {
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.alicloud.networks.workers[0]"),
 						"Detail": Equal(`must be a subset of "spec.cloud.alicloud.networks.vpc.cidr" ("10.0.0.0/8")`),
-					})
+					}))
 				})
 
 				It("should forbid Pod CIDR to overlap with VPC CIDR", func() {
@@ -3924,11 +3925,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.alicloud.networks.pods"),
 						"Detail": Equal(`must not be a subset of "spec.cloud.alicloud.networks.vpc.cidr" ("10.0.0.0/8")`),
-					})
+					}))
 				})
 
 				It("should forbid Services CIDR to overlap with VPC CIDR", func() {
@@ -3937,11 +3938,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.alicloud.networks.services"),
 						"Detail": Equal(`must not be a subset of "spec.cloud.alicloud.networks.vpc.cidr" ("10.0.0.0/8")`),
-					})
+					}))
 				})
 
 				It("should forbid non-specified k8s networks", func() {
@@ -3949,7 +3950,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.cloud.alicloud.networks.nodes"),
 					}, Fields{
@@ -3958,7 +3959,7 @@ var _ = Describe("validation", func() {
 					}, Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.cloud.alicloud.networks.services"),
-					})
+					}))
 				})
 
 				It("should forbid non-specified k8s networks", func() {
@@ -3966,7 +3967,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.cloud.alicloud.networks.nodes"),
 					}, Fields{
@@ -3975,7 +3976,7 @@ var _ = Describe("validation", func() {
 					}, Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.cloud.alicloud.networks.services"),
-					})
+					}))
 				})
 
 				It("should invalid k8s networks", func() {
@@ -3983,7 +3984,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.alicloud.networks.nodes"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
@@ -3995,7 +3996,7 @@ var _ = Describe("validation", func() {
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.alicloud.networks.services"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
-					})
+					}))
 				})
 			})
 
@@ -4281,11 +4282,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.openstack.networks.workers[0]"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
-					})
+					}))
 				})
 
 				It("should forbid workers CIDR which are not in Nodes CIDR", func() {
@@ -4293,11 +4294,11 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.openstack.networks.workers[0]"),
 						"Detail": Equal(`must be a subset of "spec.cloud.openstack.networks.nodes" ("10.250.0.0/16")`),
-					})
+					}))
 				})
 
 				It("should forbid non-specified k8s networks", func() {
@@ -4305,7 +4306,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.cloud.openstack.networks.nodes"),
 					}, Fields{
@@ -4314,7 +4315,7 @@ var _ = Describe("validation", func() {
 					}, Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.cloud.openstack.networks.services"),
-					})
+					}))
 				})
 
 				It("should forbid non-specified k8s networks", func() {
@@ -4322,7 +4323,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.cloud.openstack.networks.nodes"),
 					}, Fields{
@@ -4331,7 +4332,7 @@ var _ = Describe("validation", func() {
 					}, Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.cloud.openstack.networks.services"),
-					})
+					}))
 				})
 
 				It("should invalid k8s networks", func() {
@@ -4339,7 +4340,7 @@ var _ = Describe("validation", func() {
 
 					errorList := ValidateShoot(shoot)
 
-					assertErrorList(errorList, Fields{
+					Expect(errorList).To(ConsistOfFields(Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.openstack.networks.nodes"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
@@ -4351,7 +4352,7 @@ var _ = Describe("validation", func() {
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.cloud.openstack.networks.services"),
 						"Detail": Equal("invalid CIDR address: invalid-cidr"),
-					})
+					}))
 				})
 			})
 
@@ -5261,11 +5262,4 @@ func prepareProjectForUpdate(project *garden.Project) *garden.Project {
 	p := project.DeepCopy()
 	p.ResourceVersion = "1"
 	return p
-}
-
-func assertErrorList(ee field.ErrorList, ff ...Fields) {
-	ExpectWithOffset(1, ee).To(HaveLen(len(ff)))
-	for i, f := range ff {
-		ExpectWithOffset(1, *ee[i]).To(MatchFields(IgnoreExtras, f))
-	}
 }

--- a/pkg/utils/validation/cidr/cidr.go
+++ b/pkg/utils/validation/cidr/cidr.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cidr
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/gardener/gardener/pkg/apis/garden"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// CIDR contains CIDR and Path information
+type CIDR interface {
+	// GetCIDR returns the provided CIDR
+	GetCIDR() garden.CIDR
+	// GetFieldPath returns the fieldpath
+	GetFieldPath() *field.Path
+	// GetIPNet optionaly returns the IPNet of the CIDR
+	GetIPNet() *net.IPNet
+	// Parse checks if CIDR parses
+	Parse() bool
+	// ValidateNotSubset returns errors if subsets is a subset.
+	ValidateNotSubset(subsets ...CIDR) field.ErrorList
+	// ValidateParse returns errors CIDR can't be parsed.
+	ValidateParse() field.ErrorList
+	// ValidateSubset returns errors if subsets is not a subset.
+	ValidateSubset(subsets ...CIDR) field.ErrorList
+}
+
+type cidrPath struct {
+	cidr       garden.CIDR
+	fieldPath  *field.Path
+	net        *net.IPNet
+	ParseError error
+}
+
+// NewCIDR creates a new instance of cidrPath
+func NewCIDR(c garden.CIDR, f *field.Path) CIDR {
+	_, ipnet, err := net.ParseCIDR(string(c))
+	return &cidrPath{c, f, ipnet, err}
+}
+
+func (c *cidrPath) ValidateSubset(subsets ...CIDR) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if c.ParseError != nil {
+		return allErrs
+	}
+	for _, subset := range subsets {
+		if subset == nil || c == subset || !subset.Parse() {
+			continue
+		}
+		if !c.net.Contains(subset.GetIPNet().IP) {
+			allErrs = append(allErrs, field.Invalid(subset.GetFieldPath(), subset.GetCIDR(), fmt.Sprintf("must be a subset of %q (%q)", c.fieldPath.String(), c.cidr)))
+		}
+	}
+	return allErrs
+}
+
+func (c *cidrPath) ValidateNotSubset(subsets ...CIDR) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if c.ParseError != nil {
+		return allErrs
+	}
+	for _, subset := range subsets {
+		if subset == nil || c == subset || !subset.Parse() {
+			continue
+		}
+		if c.net.Contains(subset.GetIPNet().IP) {
+			allErrs = append(allErrs, field.Invalid(subset.GetFieldPath(), subset.GetCIDR(), fmt.Sprintf("must not be a subset of %q (%q)", c.fieldPath.String(), c.cidr)))
+		}
+	}
+	return allErrs
+}
+
+func (c *cidrPath) ValidateParse() field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if c.ParseError != nil {
+		allErrs = append(allErrs, field.Invalid(c.fieldPath, c.cidr, c.ParseError.Error()))
+	}
+
+	return allErrs
+}
+
+func (c *cidrPath) Parse() (success bool) {
+	return c.ParseError == nil
+}
+
+func (c *cidrPath) GetIPNet() *net.IPNet {
+	return c.net
+}
+
+func (c *cidrPath) GetFieldPath() *field.Path {
+	return c.fieldPath
+}
+
+func (c *cidrPath) GetCIDR() garden.CIDR {
+	return c.cidr
+}

--- a/pkg/utils/validation/cidr/cidr_suite_test.go
+++ b/pkg/utils/validation/cidr/cidr_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cidr_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCIDR(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CIDR Suite")
+}

--- a/pkg/utils/validation/cidr/cidr_test.go
+++ b/pkg/utils/validation/cidr/cidr_test.go
@@ -21,8 +21,10 @@ import (
 	. "github.com/gardener/gardener/pkg/utils/validation/cidr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	. "github.com/gardener/gardener/pkg/utils/validation/gomega"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 )
 
 var _ = Describe("cidr", func() {
@@ -129,13 +131,11 @@ var _ = Describe("cidr", func() {
 			badPath := field.NewPath("bad")
 			other := NewCIDR(badCIDR, badPath)
 
-			el := cdr.ValidateNotSubset(other)
-			Expect(el).To(HaveLen(1))
-			Expect(*el[0]).To(Equal(field.Error{
-				Type:     field.ErrorTypeInvalid,
-				Field:    badPath.String(),
-				BadValue: badCIDR,
-				Detail:   `must not be a subset of "foo" ("10.0.0.0/8")`,
+			Expect(cdr.ValidateNotSubset(other)).To(ConsistOfFields(Fields{
+				"Type":     Equal(field.ErrorTypeInvalid),
+				"Field":    Equal(badPath.String()),
+				"BadValue": Equal(badCIDR),
+				"Detail":   Equal(`must not be a subset of "foo" ("10.0.0.0/8")`),
 			}))
 		})
 	})
@@ -150,13 +150,11 @@ var _ = Describe("cidr", func() {
 		It("should return a nil FieldPath", func() {
 			cdr := NewCIDR(invalidGardenCIDR, path)
 
-			el := cdr.ValidateParse()
-			Expect(el).To(HaveLen(1))
-			Expect(*el[0]).To(Equal(field.Error{
-				Type:     field.ErrorTypeInvalid,
-				Field:    path.String(),
-				BadValue: invalidGardenCIDR,
-				Detail:   `invalid CIDR address: invalid_cidr`,
+			Expect(cdr.ValidateParse()).To(ConsistOfFields(Fields{
+				"Type":     Equal(field.ErrorTypeInvalid),
+				"Field":    Equal(path.String()),
+				"BadValue": Equal(invalidGardenCIDR),
+				"Detail":   Equal(`invalid CIDR address: invalid_cidr`),
 			}))
 		})
 	})
@@ -186,13 +184,11 @@ var _ = Describe("cidr", func() {
 			cdr := NewCIDR(validGardenCIDR, path)
 			other := NewCIDR(garden.CIDR("10.0.0.1/32"), field.NewPath("bad"))
 
-			el := other.ValidateSubset(cdr)
-			Expect(el).To(HaveLen(1))
-			Expect(*el[0]).To(Equal(field.Error{
-				Type:     field.ErrorTypeInvalid,
-				Field:    path.String(),
-				BadValue: validGardenCIDR,
-				Detail:   `must be a subset of "bad" ("10.0.0.1/32")`,
+			Expect(other.ValidateSubset(cdr)).To(ConsistOfFields(Fields{
+				"Type":     Equal(field.ErrorTypeInvalid),
+				"Field":    Equal(path.String()),
+				"BadValue": Equal(validGardenCIDR),
+				"Detail":   Equal(`must be a subset of "bad" ("10.0.0.1/32")`),
 			}))
 		})
 

--- a/pkg/utils/validation/cidr/cidr_test.go
+++ b/pkg/utils/validation/cidr/cidr_test.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cidr_test
+
+import (
+	"net"
+
+	"github.com/gardener/gardener/pkg/apis/garden"
+	. "github.com/gardener/gardener/pkg/utils/validation/cidr"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("cidr", func() {
+
+	var (
+		invalidCIDR       = "invalid_cidr"
+		validCIDR         = "10.0.0.0/8"
+		validGardenCIDR   = garden.CIDR(validCIDR)
+		invalidGardenCIDR = garden.CIDR(invalidCIDR)
+		path              = field.NewPath("foo")
+	)
+
+	Context("NewCIDR", func() {
+		It("should return a non-nil value", func() {
+			cdr := NewCIDR(validGardenCIDR, path)
+
+			Expect(cdr).ToNot(BeNil())
+		})
+
+	})
+
+	Context("GetCIDR", func() {
+		It("should return a correct address", func() {
+			cdr := NewCIDR(validGardenCIDR, path)
+
+			Expect(cdr.GetCIDR()).To(Equal(validGardenCIDR))
+		})
+	})
+
+	Context("GetIPNet", func() {
+		It("should return a correct IPNet", func() {
+			cdr := NewCIDR(validGardenCIDR, path)
+
+			_, expected, _ := net.ParseCIDR(validCIDR)
+
+			actual := cdr.GetIPNet()
+
+			Expect(actual).ToNot(BeNil())
+			Expect(actual).To(Equal(expected))
+		})
+
+		It("should return an empty IPNet", func() {
+			cdr := NewCIDR(invalidGardenCIDR, path)
+
+			Expect(cdr.GetIPNet()).To(BeNil())
+		})
+	})
+
+	Context("GetFieldPath", func() {
+		It("should return a correct FieldPath", func() {
+			cdr := NewCIDR(validGardenCIDR, path)
+
+			actual := cdr.GetFieldPath()
+
+			Expect(actual).ToNot(BeNil())
+			Expect(actual).To(Equal(path))
+		})
+
+		It("should return a nil FieldPath", func() {
+			cdr := NewCIDR(validGardenCIDR, nil)
+
+			Expect(cdr.GetFieldPath()).To(BeNil())
+		})
+	})
+
+	Context("Parse", func() {
+		It("should return a correct FieldPath", func() {
+			cdr := NewCIDR(validGardenCIDR, path)
+
+			Expect(cdr.Parse()).To(BeTrue())
+		})
+
+		It("should return a nil FieldPath", func() {
+			cdr := NewCIDR(invalidGardenCIDR, path)
+
+			Expect(cdr.Parse()).To(BeFalse())
+		})
+	})
+
+	Context("ValidateNotSubset", func() {
+		It("should not be a subset", func() {
+			cdr := NewCIDR(validGardenCIDR, path)
+			other := NewCIDR(garden.CIDR("2.2.2.2/32"), path)
+
+			Expect(cdr.ValidateNotSubset(other)).To(BeEmpty())
+		})
+
+		It("should ignore nil values", func() {
+			cdr := NewCIDR(validGardenCIDR, path)
+
+			Expect(cdr.ValidateNotSubset(nil)).To(BeEmpty())
+		})
+
+		It("should ignore when parse error", func() {
+			cdr := NewCIDR(invalidGardenCIDR, path)
+			other := NewCIDR(garden.CIDR("2.2.2.2/32"), path)
+
+			Expect(cdr.ValidateNotSubset(other)).To(BeEmpty())
+		})
+
+		It("should return a nil FieldPath", func() {
+			cdr := NewCIDR(validGardenCIDR, path)
+			badCIDR := garden.CIDR("10.0.0.1/32")
+			badPath := field.NewPath("bad")
+			other := NewCIDR(badCIDR, badPath)
+
+			el := cdr.ValidateNotSubset(other)
+			Expect(el).To(HaveLen(1))
+			Expect(*el[0]).To(Equal(field.Error{
+				Type:     field.ErrorTypeInvalid,
+				Field:    badPath.String(),
+				BadValue: badCIDR,
+				Detail:   `must not be a subset of "foo" ("10.0.0.0/8")`,
+			}))
+		})
+	})
+
+	Context("ValidateParse", func() {
+		It("should parse without errors", func() {
+			cdr := NewCIDR(validGardenCIDR, path)
+
+			Expect(cdr.ValidateParse()).To(BeEmpty())
+		})
+
+		It("should return a nil FieldPath", func() {
+			cdr := NewCIDR(invalidGardenCIDR, path)
+
+			el := cdr.ValidateParse()
+			Expect(el).To(HaveLen(1))
+			Expect(*el[0]).To(Equal(field.Error{
+				Type:     field.ErrorTypeInvalid,
+				Field:    path.String(),
+				BadValue: invalidGardenCIDR,
+				Detail:   `invalid CIDR address: invalid_cidr`,
+			}))
+		})
+	})
+
+	Context("ValidateSubset", func() {
+		It("should be a subset", func() {
+			cdr := NewCIDR(validGardenCIDR, path)
+			other := NewCIDR(garden.CIDR("10.0.0.1/32"), field.NewPath("other"))
+
+			Expect(cdr.ValidateSubset(other)).To(BeEmpty())
+		})
+
+		It("should ignore nil values", func() {
+			cdr := NewCIDR(validGardenCIDR, path)
+
+			Expect(cdr.ValidateSubset(nil)).To(BeEmpty())
+		})
+
+		It("should ignore parse errors", func() {
+			cdr := NewCIDR(invalidGardenCIDR, path)
+			other := NewCIDR(garden.CIDR("10.0.0.1/32"), field.NewPath("other"))
+
+			Expect(cdr.ValidateSubset(other)).To(BeEmpty())
+		})
+
+		It("should not be a subset", func() {
+			cdr := NewCIDR(validGardenCIDR, path)
+			other := NewCIDR(garden.CIDR("10.0.0.1/32"), field.NewPath("bad"))
+
+			el := other.ValidateSubset(cdr)
+			Expect(el).To(HaveLen(1))
+			Expect(*el[0]).To(Equal(field.Error{
+				Type:     field.ErrorTypeInvalid,
+				Field:    path.String(),
+				BadValue: validGardenCIDR,
+				Detail:   `must be a subset of "bad" ("10.0.0.1/32")`,
+			}))
+		})
+
+	})
+})

--- a/pkg/utils/validation/gomega/matchers.go
+++ b/pkg/utils/validation/gomega/matchers.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gomega
+
+import (
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+)
+
+// HaveFields succeeds if actual is a pointer and has a specific fields.
+// Ignores extra elements or fields.
+func HaveFields(fields gstruct.Fields) types.GomegaMatcher {
+	return gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, fields))
+}
+
+// ConsistOfFields succeeds if actual matches all selected fields.
+// Actual must be an array, slice or map.  For maps, ConsistOfFields matches against the map's values.
+// Actual's elements must be pointers.
+func ConsistOfFields(fields ...gstruct.Fields) types.GomegaMatcher {
+	m := []interface{}{}
+	for _, f := range fields {
+		m = append(m, HaveFields(f))
+	}
+	return gomega.ConsistOf(m...)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
At this moment we lack verification for when different CIDRs must or not overlap. Users can create `Seed` and `Shoot` resources which simply fail to be created.

On all providers `Pod`, `Nodes` and `Services` CIDRs must not overlap.
Following provider-specific verification are added:

AWS:

- `Worker`, `Public` and `Internal`, `Pods` and `Services` must not overlap.
- `Nodes` must contain all of `Worker` CIDRs.
- If VPC `cird` is provovided, then it must contain `Node`,  `Public`, `Internal` and `Workers` CIDRs.
- If VPC `cird` is provovided, then it must not contain `Pods`  and `Services` CIDRs.

Alicloud:

- `Worker`, `Pods` and `Services` must not overlap.
- `Nodes` must contain all of `Worker` CIDRs.
- If VPC `cird` is provovided, then it must contain `Node`  and `Workers` CIDRs.
- If VPC `cird` is provovided, then it must not contain `Pods`  and `Services` CIDRs.

Azure:

- `Worker`, `Pods` and `Services` must not overlap.
- `Nodes` must contain all of `Worker` CIDRs.
- If Vnet `cird` is provovided, then it must contain `Node`  and `Workers` CIDRs.
- If Vnet `cird` is provovided, then it must not contain `Pods`  and `Services` CIDRs.

GCP:

- `Worker`, `Pods` and `Services` must not overlap.
- `Nodes` must contain all of `Worker` CIDRs.

OpenStack:

- `Worker`, `Pods` and `Services` must not overlap.
- `Nodes` must contain all of `Worker` CIDRs.

**Which issue(s) this PR fixes**:
Fixes #535 

**Special notes for your reviewer**:
Please take a look at the release note as it's a backwards incompatible change (as is any verification changes).

I'll update the shoot validator in separate PR.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
``` action operator
⚠️ Strict `Seed` and `Shoot` CIDR verification rules are now enabled.
`Shoot` or `Seed` resource created previously with invalid configurations MUST be deleted, before updating to this version. Failing to do so, will cause ANY modification to said resources (including attempted deletion) to be rejected by the apiserver.
```
