### PR TITLE
Fix k8s version in local_setup.md

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -185,14 +185,13 @@ The commands below will configure your `minikube` with the absolute minimum reso
 
 #### Start `minikube`
 
-First, start `minikube` with at least Kubernetes v1.9.x, e.g. via `minikube --kubernetes-version=v1.9.0`.
-Default cpu and memory settings of minikube machine are not sufficient to host the control plane of a shoot cluster, thus use at least 4 CPUs and 8192MB memory.
+First, start `minikube` with at least Kubernetes v1.11.x. Default cpu and memory settings of minikube machine are not sufficient to host the control plane of a shoot cluster, thus use at least 4 CPUs and 8192MB memory.
 
 ```bash
-$ minikube start --cpus=4 --memory=8192 --kubernetes-version=v1.9.0 --extra-config=apiserver.admission-control=MutatingAdmissionWebhook,ValidatingAdmissionWebhook
-Starting local Kubernetes v1.9.0 cluster...
+$ minikube start --cpus=4 --memory=8192 --kubernetes-version=v1.11.0
+Starting local Kubernetes v1.11.0 cluster...
 [...]
-kubectl is now configured to use the cluster.
+Kubectl is now configured to use the cluster.
 ```
 
 #### Prepare the Gardener


### PR DESCRIPTION
**What this PR does / why we need it**:
I follow the steps in [local_setup.md](https://github.com/gardener/gardener/blob/master/docs/development/local_setup.md). After the fix that @rfranzke provided for #563, now the seed fails with the following reason:
```bash
$ k describe seed local
[...]
Status:
 Conditions:
   Last Transition Time:  2018-11-29T10:25:19Z
   Last Update Time:      2018-11-29T11:01:30Z
   Message:               Could not construct the API path for apiVersion scheduling.k8s.io/v1alpha1 and kind PriorityClass: (timed out waiting for the condition)
   Reason:                BootstrappingFailed
   Status:                False
   Type:                  Available
```

The seed requires the PodPriority feature gate to be enabled either by specifying `--feature-gates` or by using a Kubrenetes version in which it is enabled by default [(from 1.11.0)](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
First, I tried to specify `--feature-gates`with:
```bash
$ minikube start --cpus=4 --memory=8192 --kubernetes-version=v1.9.0 \
  --feature-gates=PodPriority=true \
  --extra-config=apiserver.admission-control=MutatingAdmissionWebhook,ValidatingAdmissionWebhook
```

And this resulted in (several times):
```bash
$ make start-api
Found Minikube ...
I1129 18:55:24.773061   16017 plugins.go:84] Registered admission plugin "ResourceReferenceManager"
I1129 18:55:24.773448   16017 plugins.go:84] Registered admission plugin "DeletionConfirmation"
I1129 18:55:24.773469   16017 plugins.go:84] Registered admission plugin "ShootQuotaValidator"
I1129 18:55:24.773501   16017 plugins.go:84] Registered admission plugin "ShootSeedManager"
I1129 18:55:24.773601   16017 plugins.go:84] Registered admission plugin "ShootDNSHostedZone"
I1129 18:55:24.773638   16017 plugins.go:84] Registered admission plugin "ShootValidator"
I1129 18:55:25.279719   16017 plugins.go:158] Loaded 7 mutating admission controller(s) successfully in the following order: MutatingAdmissionWebhook,NamespaceLifecycle,ResourceReferenceManager,ShootDNSHostedZone,ShootQuotaValidator,ShootSeedManager,ShootValidator.
I1129 18:55:25.279739   16017 plugins.go:161] Loaded 2 validating admission controller(s) successfully in the following order: DeletionConfirmation,ValidatingAdmissionWebhook.
F1129 18:55:45.283329   16017 storage_decorator.go:57] Unable to create storage backend: config (&{ /registry/garden.sapcloud.io [http://192.168.99.100:32379]    true false 0 0xc00060c000 <nil> 5m0s 1m0s}), err (dial tcp 192.168.99.100:32379: connect: connection refused)
exit status 255
make: *** [start-api] Error 1
```

However I tried with `v1.11.0` (where `PodPriority` is enabled by default):
```bash
$ minikube start --cpus=4 --memory=8192 --kubernetes-version=v1.11.0
Starting local Kubernetes v1.11.0 cluster...
[...]
Kubectl is now configured to use the cluster.
```

And it passed:
```bash
$ k describe seed local
[...]
Status:
  Conditions:
    Last Transition Time:  2018-11-29T15:49:46Z
    Last Update Time:      2018-11-29T15:49:46Z
    Message:               all checks passed
    Reason:                Passed
    Status:                True
    Type:                  Available
Events:                    <none>
```

**Which issue(s) this PR fixes**:
A step in [local_setup.md](https://github.com/gardener/gardener/blob/master/docs/development/local_setup.md) file which is used for local development.

**Special notes for your reviewer**:
However I am not sure if it is okay to state `at least Kubernetes v1.11.x`. If you have any ideas to make it work with `v.1.9.0` and I can try to apply them.

**Release note**: "NONE"
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
