### PR TITLE
Fix network overlapping for local provider

### DIFF
--- a/example/50-seed-local.yaml
+++ b/example/50-seed-local.yaml
@@ -13,6 +13,6 @@ spec:
     namespace: garden
   ingressDomain: <minikube-ip>.nip.io
   networks: # Seed and Shoot networks must be disjunct
-    nodes: 192.168.99.100/24
+    nodes: 192.168.99.100/25
     pods: 172.17.0.0/16
     services: 10.96.0.0/13

--- a/example/90-shoot-local.yaml
+++ b/example/90-shoot-local.yaml
@@ -13,7 +13,7 @@ spec:
     local:
       endpoint: localhost:3777 # endpoint service pointing to gardener-local-provider
       networks:
-        workers: ['192.168.99.100/24']
+        workers: ['192.168.99.200/25']
   kubernetes:
     version: 1.12.1
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.

--- a/hack/templates/resources/50-seed.yaml.tpl
+++ b/hack/templates/resources/50-seed.yaml.tpl
@@ -55,6 +55,6 @@ spec:
     namespace: ${value("spec.secretRef.namespace", "garden")}
   ingressDomain: ${value("spec.ingressDomain", "dev." + cloud + ".seed.example.com") if cloud != "local" else "<minikube-ip>.nip.io"}
   networks: # Seed and Shoot networks must be disjunct
-    nodes: ${value("spec.networks.nodes", "10.240.0.0/16") if cloud != "local" else "192.168.99.100/24"}
+    nodes: ${value("spec.networks.nodes", "10.240.0.0/16") if cloud != "local" else "192.168.99.100/25"}
     pods: ${value("spec.networks.pods", "10.241.128.0/17") if cloud != "local" else "172.17.0.0/16"}
     services: ${value("spec.networks.services", "10.241.0.0/17") if cloud != "local" else "10.96.0.0/13"}

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -202,7 +202,7 @@ spec:
     local:
       endpoint: ${value("spec.cloud.local.endpoint", "localhost:3777")} # endpoint service pointing to gardener-local-provider
       networks:
-        workers: ${value("spec.cloud.local.networks.workers", ["192.168.99.100/24"])}
+        workers: ${value("spec.cloud.local.networks.workers", ["192.168.99.200/25"])}
     % endif
   kubernetes:
     version: ${value("spec.kubernetes.version", kubernetesVersion)}<% kubeAPIServer=value("spec.kubernetes.kubeAPIServer", {}) %><% cloudControllerManager=value("spec.kubernetes.cloudControllerManager", {}) %><% kubeControllerManager=value("spec.kubernetes.kubeControllerManager", {}) %><% kubeScheduler=value("spec.kubernetes.kubeScheduler", {}) %><% kubeProxy=value("spec.kubernetes.kubeProxy", {}) %><% kubelet=value("spec.kubernetes.kubelet", {}) %>


### PR DESCRIPTION
**What this PR does / why we need it**:
For the local provider the node networks of the shoot and seed were overlapping. Because of this reason it was not possible to apply the shoot spec:
```
$ k apply -f dev/90-shoot-local.yaml
Error from server (Forbidden): error when creating "dev/90-shoot-local.yaml": shoots.garden.sapcloud.io "local" is forbidden: no adequate seed cluster found for this cloud profile and region
```
See #570 for more details.

Thanks to @vpnachev and @KristianZH for the fix.

**Which issue(s) this PR fixes**:
Fixes #570 .

**Special notes for your reviewer**:
@mvladev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
