### PR TITLE
Fix dashboard's label selectors

### DIFF
--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment.yaml
@@ -1,4 +1,8 @@
-apiVersion: {{ include "deploymentversion" . }}
+{{/*
+Temporary fix due to https://github.com/gardener/gardener/commit/a2dc6bb0a8980689f90b96a0391e454b9bbd3a5e
+TODO (mvladev): revert this to dynamic version after several gardener releases
+*/}}
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "kubernetes-dashboard.fullname" . }}
@@ -18,10 +22,7 @@ spec:
   selector:
     matchLabels:
       app: {{ template "kubernetes-dashboard.name" . }}
-      heritage: "{{ .Release.Service }}"
       release: "{{ .Release.Name }}"
-      chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-      kubernetes.io/cluster-service: "true"
   strategy:
     rollingUpdate:
       maxSurge: 0


### PR DESCRIPTION
**What this PR does / why we need it**: 
Dashboard creation is broken due to missmatch of selectors.

In `apps.v1` Deployment's `spec.labelSelector` is immutable.

As a temporary fix the `apiVersion` for the Dashboard's Deployment is now set to `extensions/v1beta1` where it can be modified.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

Picking correct labels for selection should be done with care as we might not be able to change them in the future.

If versions are needed in `Deployments` then `matchExpressions` with `operator` `Exists` should be used:

```yaml
spec:
  selector:
    matchExpressions:
    - {key: app, operator: In, values: [nginx] }
    - {key: version, operator: Exists }
  template:
    metadata:
      labels:
        app: nginx
        version: v1
```

this allows for updates to the labels of the `Pod`:

```yaml
spec:
  selector:
    matchExpressions:
    - {key: app, operator: In, values: [nginx] }
    - {key: version, operator: Exists }
  template:
    metadata:
      labels:
        app: nginx
        version: v2
```

/cc @gardener/gardener-maintainers

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
