### PR TITLE
add a checksum for certificate-management secrets

### DIFF
--- a/charts/gardener/templates/deployment-controller-manager.yaml
+++ b/charts/gardener/templates/deployment-controller-manager.yaml
@@ -25,6 +25,7 @@ spec:
         checksum/secret-internal-domain: {{ include (print $.Template.BasePath "/secret-internal-domain.yaml") . | sha256sum }}
         checksum/secret-alerting-smtp: {{ include (print $.Template.BasePath "/secret-alerting-smtp.yaml") . | sha256sum }}
         checksum/secret-openvpn-diffie-hellman: {{ include (print $.Template.BasePath "/secret-openvpn-diffie-hellman.yaml") . | sha256sum }}
+        checksum/secret-certificatemanagement-config: {{ include (print $.Template.BasePath "/secret-certificate-management-config.yaml") . | sha256sum }}
       labels:
         app: gardener
         role: controller-manager

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -415,15 +415,6 @@ func createDNSProviderValues(configs []certmanagement.DNSProviderConfig) []inter
 	return providers
 }
 
-func deployCertificateManagementConfig(k8sSeedClient kubernetes.Client, secrets []*corev1.Secret) error {
-	for _, secret := range secrets {
-		if _, err := k8sSeedClient.CreateSecret(secret.Namespace, secret.Name, secret.Type, secret.Data, true); err != nil {
-			return fmt.Errorf("secret %s could not be copied to Seed cluster: %v", secret.Name, err)
-		}
-	}
-	return nil
-}
-
 // DesiredExcessCapacity computes the required resources (CPU and memory) required to deploy new shoot control planes
 // (on the seed) in terms of reserve-excess-capacity deployment replicas. Each deployment replica currently
 // corresponds to resources of (request/limits) 500m of CPU and 1200Mi of Memory.


### PR DESCRIPTION
**What this PR does / why we need it**:
currently the certificate-management secret is read only at the
bootstraping phase and not everytime it changes. This commit adds
a checksum to the controller-manager to detect changes in the
certificate-management

Co-authored-by: Tim Usner <tim.usner@sap.com>

**Release note**:
```improvement operator
None
```
