### PR TITLE
Enhance local provider

### DIFF
--- a/hack/dev-setup-local
+++ b/hack/dev-setup-local
@@ -62,3 +62,6 @@ sed -e "s/ingressDomain: <minikube-ip>.nip.io/ingressDomain: ${MINIKUBE_IP}.nip.
 sed -e "s/domain: <minikube-ip>.nip.io/domain: ${MINIKUBE_IP}.nip.io/g" example/90-shoot-local.yaml | \
   sed -e "s/endpoint: localhost:3777/endpoint: ${IP_ADDRESS}:3777/g" | \
   sed -e "s/name: johndoe-local/name: local/g" >${DEV_DIR}/90-shoot-local.yaml
+
+# Update Vagrant images and prune the outdated ones
+(cd vagrant; vagrant box update; vagrant box prune)

--- a/pkg/operation/cloudbotanist/localbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/localbotanist/controlplane.go
@@ -14,6 +14,11 @@
 
 package localbotanist
 
+import (
+	"fmt"
+	"strings"
+)
+
 // GenerateCloudProviderConfig returns a cloud provider config for the Local cloud provider.
 // Not needed on Local.
 func (b *LocalBotanist) GenerateCloudProviderConfig() (string, error) {
@@ -40,8 +45,12 @@ func (b *LocalBotanist) GenerateKubeAPIServerServiceConfig() (map[string]interfa
 // GenerateKubeAPIServerExposeConfig defines the cloud provider specific values which configure how the kube-apiserver
 // is exposed to the public.
 func (b *LocalBotanist) GenerateKubeAPIServerExposeConfig() (map[string]interface{}, error) {
+	if !strings.HasSuffix(*b.Shoot.Info.Spec.DNS.Domain, ".nip.io") {
+		return nil, fmt.Errorf("missing `.nip.io` TLD")
+	}
 	return map[string]interface{}{
-		"securePort": 31443,
+		"advertiseAddress": strings.TrimSuffix(*b.Shoot.Info.Spec.DNS.Domain, ".nip.io"),
+		"securePort":       31443,
 	}, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `--advertise-address` for `kube-apiserver` for local provider. 
Update vagrant images when `make dev-setup-local` is called.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @mvladev 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
