### PR TITLE
Rectify condition order for health checks

### DIFF
--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -845,7 +845,7 @@ func (b *Botanist) HealthChecks(initializeShootClients func() error, thresholdMa
 	}()
 	wg.Wait()
 
-	return apiserverAvailability, controlPlane, systemComponents, nodes
+	return apiserverAvailability, controlPlane, nodes, systemComponents
 }
 
 // MonitoringHealthChecks performs the monitoring releated health checks.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aligns the order of conditions returned by the health check.

```improvement operator
NONE
```
