### PR TITLE
Fix cAdvsitor relabel rules

### DIFF
--- a/charts/seed-bootstrap/templates/prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/config.yaml
@@ -38,25 +38,31 @@ data:
         replacement: seed
 
       metric_relabel_configs:
-{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.cAdvisor | indent 6 }}
-      - source_labels:
-        - container_name
-        - __name__
-        # The system container POD is used for networking
-        regex: ^POD$;^({{ without .Values.allowedMetrics.cAdvisor "container_network_receive_bytes_total" "container_network_transmit_bytes_total" | join "|" }})$
-        action: drop
-      # drop terraform pods
-      - source_labels: [ pod_name ]
-        regex: ^.+\.tf-pod.+$
-        action: drop
       # get system services
       - source_labels: [ id ]
         action: replace
         regex: ^/system\.slice/(.+)\.service$
         target_label: systemd_service_name
         replacement: '${1}'
-      - regex: ^id$
-        action: labeldrop
+      - source_labels: [ id ]
+        action: replace
+        regex: ^/system\.slice/(.+)\.service$
+        target_label: container_name
+        replacement: '${1}'
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.cAdvisor | indent 6 }}
+      - source_labels:
+        - container_name
+        - __name__
+        # The system container POD is used for networking
+        regex: POD;({{ without .Values.allowedMetrics.cAdvisor "container_network_receive_bytes_total" "container_network_transmit_bytes_total" | join "|" }})
+        action: drop
+      - source_labels: [ container_name ]
+        regex: ^$
+        action: drop
+      # drop terraform pods
+      - source_labels: [ pod_name ]
+        regex: ^.+\.tf-pod.+$
+        action: drop
 
     - job_name: kubelet
       honor_labels: false

--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -143,24 +143,32 @@ data:
       - target_label: type
         replacement: shoot
       metric_relabel_configs:
-      # We want to keep only metrics in kube-system namespace
-      - source_labels: [ namespace ]
-        action: keep
-        # systemd containers don't have namespaces
-        regex: (^$|^kube-system$)
-{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.cAdvisor | indent 6 }}
-      - source_labels:
-        - container_name
-        - __name__
-        # The system container POD is used for networking
-        regex: ^POD$;^({{ without .Values.allowedMetrics.cAdvisor "container_network_receive_bytes_total" "container_network_transmit_bytes_total" | join "|" }})$
-        action: drop
       # get system services
       - source_labels: [ id ]
         action: replace
         regex: ^/system\.slice/(.+)\.service$
         target_label: systemd_service_name
         replacement: '${1}'
+      - source_labels: [ id ]
+        action: replace
+        regex: ^/system\.slice/(.+)\.service$
+        target_label: container_name
+        replacement: '${1}'
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.cAdvisor | indent 6 }}
+      # We want to keep only metrics in kube-system namespace
+      - source_labels: [ namespace ]
+        action: keep
+        # systemd containers don't have namespaces
+        regex: (^$|^kube-system$)
+      - source_labels:
+        - container_name
+        - __name__
+        # The system container POD is used for networking
+        regex: POD;({{ without .Values.allowedMetrics.cAdvisor "container_network_receive_bytes_total" "container_network_transmit_bytes_total" | join "|" }})
+        action: drop
+      - source_labels: [ container_name ]
+        regex: ^$
+        action: drop
       - regex: ^id$
         action: labeldrop
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Metrics for the "POD" system container are now correctly dropped.
- Combined (cpu, memory, network) metrics for the entire Pod are now correctly dropped.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
It turns out that when using `regex` and multiple source labels , the regex `^` and `$`  don't behave as expected, because the source labels are concatenated and they match nothing. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```

/cc @dkistner @wyb1 
