### PR TITLE
Scale kube-controller-manager vertically.

### DIFF
--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -117,10 +117,8 @@ spec:
           timeoutSeconds: 15
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
-        {{- if .Values.resources }}
         resources:
-{{ toYaml .Values.resources | indent 10 }}
-        {{- end }}
+{{- include "util-templates.resource-quantity" .Values | indent 10 }}
         volumeMounts:
         - name: ca
           mountPath: /srv/kubernetes/ca

--- a/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
@@ -12,13 +12,6 @@ featureGates: {}
   # RotateKubeletServerCertificate: false
 images:
   hyperkube: image-repository
-resources:
-  requests:
-    cpu: 200m
-    memory: 128Mi
-  limits:
-    cpu: 500m
-    memory: 512Mi
 horizontalPodAutoscaler:
   downscaleDelay: 15m
   syncPeriod: 30s
@@ -27,3 +20,29 @@ horizontalPodAutoscaler:
   downscaleStabilization: 5m0s
   readinessDelay: 30s
   cpuInitializationPeriod: 5m0s
+
+
+objectCount: 4
+resources:
+  requests:
+    cpu:
+      base: 40
+      perObject: 4
+      weight: 5
+      unit: m
+    memory:
+      base: 128
+      perObject: 28
+      weight: 5
+      unit: Mi
+  limits:
+    cpu:
+      base: 200
+      perObject: 7
+      weight: 5
+      unit: m
+    memory:
+      base: 256
+      perObject: 50
+      weight: 5
+      unit: Mi

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -394,19 +394,11 @@ func (b *HybridBotanist) DeployKubeControllerManager() error {
 			"checksum/secret-cloudprovider":                  b.CheckSums[common.CloudProviderSecretName],
 			"checksum/configmap-cloud-provider-config":       b.CheckSums[common.CloudProviderConfigName],
 		},
+		"objectCount": b.Shoot.GetNodeCount(),
 	}
 	cloudSpecificValues, err := b.ShootCloudBotanist.GenerateKubeControllerManagerConfig()
 	if err != nil {
 		return err
-	}
-
-	if b.ShootedSeed != nil {
-		defaultValues["resources"] = map[string]interface{}{
-			"limits": map[string]interface{}{
-				"cpu":    "750m",
-				"memory": "1.5Gi",
-			},
-		}
 	}
 
 	// If a shoot is hibernated we only want to scale down the KCM if no nodes exist anymore. The node-lifecycle-controller


### PR DESCRIPTION
**What this PR does / why we need it**:

Scale kube-controller-manager's resource `limits` and `requests`based on the amount of Shoot nodes.

Example:

1-4 Nodes:

```yaml
limits:
  cpu: 200m
  memory: 256Mi
requests:
  cpu: 40m
  memory: 128Mi
```

17-19 Nodes:

```yaml
limits:
  cpu: 305m
  memory: 1006Mi
requests:
  cpu: 100m
  memory: 548Mi
```

50 Nodes:

```yaml
limits:
  cpu: 550m
  memory: 2756Mi
requests:
  cpu: 240m
  memory: 1528Mi
```

128 Nodes:

```yaml
limits:
  cpu: 1075m
  memory: 6506Mi
requests:
  cpu: 540m
  memory: 3628Mi
```

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```

/cc @KristianZH @vpnachev 