### PR TITLE
Update etcd and backup-restore configuration

### DIFF
--- a/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
@@ -9,12 +9,6 @@ metadata:
 data:
   bootstrap.sh: |-
     #!/bin/sh
-    if [ ! -d /var/etcd/data/new.etcd ]; then
-        mkdir /var/etcd/data/new.etcd
-    fi
-    if [ -d /var/etcd/data/member ]; then
-        mv /var/etcd/data/member /var/etcd/data/new.etcd/member
-    fi
     while true;
     do
       wget http://localhost:8080/initialization/status -S -O status;
@@ -23,7 +17,7 @@ data:
       "New")
             wget http://localhost:8080/initialization/start -S -O - ;;
       "Progress")
-            sleep 1;
+            sleep 5;
             continue;;
       "Failed")
             continue;;
@@ -76,3 +70,10 @@ data:
       # Raise alarms when backend size exceeds the given quota. 0 means use the
       # default quota.
       quota-backend-bytes: 8589934592
+
+      # Accept etcd V2 client requests
+      enable-v2: false
+
+      # keep one day of history
+      auto-compaction-mode: periodic
+      auto-compaction-retention: "24"

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
@@ -106,7 +106,6 @@ spec:
         - etcdbrctl
         - server
         - --schedule={{ .Values.backup.schedule }}
-        - --max-backups={{ .Values.backup.maxBackups }}
         - --data-dir=/var/etcd/data/new.etcd
         - --storage-provider={{ .Values.backup.storageProvider }}
         - --store-prefix=etcd-{{ .Values.role }}
@@ -118,6 +117,8 @@ spec:
         - --endpoints=https://etcd-{{ .Values.role }}-0:2379
         - --etcd-connection-timeout=300
         - --delta-snapshot-period-seconds=300
+        - --garbage-collection-period-seconds=43200
+        - --snapstore-temp-directory=/var/etcd/data/temp
         image: {{ index .Values.images "etcd-backup-restore" }}
         imagePullPolicy: IfNotPresent
         ports:


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
This PR update the etcd and backubr-restore command configuration as per changes in the https://github.com/gardener/etcd-backup-restore/releases/tag/0.4.0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```action operator
:warning: The migration steps for the etcd data directory have been removed. Upgrading from Gardener versions prior to 0.13.0 is not supported.
```
``` noteworthy operator
The etcd as well as its backup/restore configuration has been updated - rolling out this change results in restarts of the etcd pods.
```

cc: @georgekuruvillak @shreyas-s-rao 