### PR TITLE
Increasing memory and CPU limits for core/critical components

### DIFF
--- a/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
@@ -88,7 +88,7 @@ spec:
             cpu: 200m
             memory: 500Mi
           limits:
-            cpu: 750m
+            cpu: 1000m
             memory: 2560Mi
         volumeMounts:
         - name: etcd-{{ .Values.role }}
@@ -129,8 +129,8 @@ spec:
             cpu: 100m
             memory: 128Mi
           limits:
-            cpu: 300m
-            memory: 1Gi
+            cpu: 500m
+            memory: 1.5Gi
         env:
         - name: STORAGE_CONTAINER
           value: {{ .Values.backup.storageContainer }}

--- a/charts/shoot-addons/charts/nginx-ingress/values.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/values.yaml
@@ -75,8 +75,8 @@ controller:
       cpu: 100m
       memory: 100Mi
     limits:
-      cpu: 200m
-      memory: 512Mi
+      cpu: 2000m
+      memory: 800Mi
 
   service:
     annotations:

--- a/charts/shoot-core/charts/calico/templates/calico.yaml
+++ b/charts/shoot-core/charts/calico/templates/calico.yaml
@@ -187,7 +187,7 @@ spec:
               cpu: 100m
               memory: 100Mi
             limits:
-              cpu: 300m
+              cpu: 500m
               memory: 700Mi
           livenessProbe:
             httpGet:

--- a/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -54,7 +54,7 @@ spec:
             cpu: 20m
             memory: 64Mi
           limits:
-            cpu: 100m
+            cpu: 900m
             memory: 200Mi
         volumeMounts:
         - name: kubeconfig


### PR DESCRIPTION
Increasing memory and CPU limits for kube-proxy, ingress-controller, calico and etcd based on observations from performance tests.

**What this PR does / why we need it**:
For network heavy workloads, the limits assigned to kube-proxy, ingress controller weren't enough. Thus need to be increased.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The "requests" values are kept the same, and might be changed as part of another PR.
Idea is to launch pods so that they consume/reserve less resources to begin with. The limits are increased so that those critical components can grow if necessary.

**Release note**:
<!--  NONE
-->
```improvement operator

```
