### PR TITLE
Increasing memory and CPU limits for core/critical components

### DIFF
--- a/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
@@ -88,7 +88,7 @@ spec:
             cpu: 200m
             memory: 500Mi
           limits:
-            cpu: 750m
+            cpu: 1000m
             memory: 2560Mi
         volumeMounts:
         - name: etcd-{{ .Values.role }}
@@ -129,8 +129,8 @@ spec:
             cpu: 100m
             memory: 128Mi
           limits:
-            cpu: 300m
-            memory: 1Gi
+            cpu: 500m
+            memory: 1.5Gi
         env:
         - name: STORAGE_CONTAINER
           value: {{ .Values.backup.storageContainer }}

--- a/charts/shoot-addons/charts/nginx-ingress/values.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/values.yaml
@@ -75,8 +75,8 @@ controller:
       cpu: 100m
       memory: 100Mi
     limits:
-      cpu: 200m
-      memory: 512Mi
+      cpu: 2000m
+      memory: 800Mi
 
   service:
     annotations:

--- a/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet-config-file
+++ b/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet-config-file
@@ -34,13 +34,13 @@ eventBurst: 50
 evictionHard:
   imagefs.available: 5%
   imagefs.inodesFree: 5%
-  memory.available: 100Mi
+  memory.available: {{ .worker.evictionHardMemoryAvailable }}
   nodefs.available: 5%
   nodefs.inodesFree: 5%
 evictionSoft:
   imagefs.available: 10%
   imagefs.inodesFree: 10%
-  memory.available: 200Mi
+  memory.available: {{ .worker.evictionSoftMemoryAvailable }}
   nodefs.available: 10%
   nodefs.inodesFree: 10%
 evictionSoftGracePeriod:

--- a/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet.flags
+++ b/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet.flags
@@ -19,8 +19,8 @@
 --enable-debugging-handlers=true \
 --event-burst=25 \
 --event-qps=25 \
---eviction-hard="memory.available<100Mi,nodefs.available<5%,nodefs.inodesFree<5%,imagefs.available<5%,imagefs.inodesFree<5%" \
---eviction-soft="memory.available<200Mi,nodefs.available<10%,nodefs.inodesFree<10%,imagefs.available<10%,imagefs.inodesFree<10%" \
+--eviction-hard="memory.available<{{ .worker.evictionHardMemoryAvailable }},nodefs.available<5%,nodefs.inodesFree<5%,imagefs.available<5%,imagefs.inodesFree<5%" \
+--eviction-soft="memory.available<{{ .worker.evictionSoftMemoryAvailable }},nodefs.available<10%,nodefs.inodesFree<10%,imagefs.available<10%,imagefs.inodesFree<10%" \
 --eviction-soft-grace-period="memory.available=1m30s,nodefs.available=1m30s,nodefs.inodesFree=1m30s,imagefs.available=1m30s,imagefs.inodesFree=1m30s" \
 --eviction-max-pod-grace-period="90" \
 --eviction-pressure-transition-period="4m" \

--- a/charts/shoot-cloud-config/charts/original/values.yaml
+++ b/charts/shoot-cloud-config/charts/original/values.yaml
@@ -22,5 +22,9 @@
 # workers:
 # - name: cpu-worker
 #   secretName: cloud-config-cpu-worker-ab234
+#   evictionSoftMemoryAvailable: 200Mi
+#   evictionHardMemoryAvailable: 100Mi
 # - name: cpu-worker2
 #   secretName: cloud-config-cpu-worker2-4av4a
+#   evictionSoftMemoryAvailable: 200Mi
+#   evictionHardMemoryAvailable: 100Mi

--- a/charts/shoot-core/charts/calico/templates/calico.yaml
+++ b/charts/shoot-core/charts/calico/templates/calico.yaml
@@ -187,7 +187,7 @@ spec:
               cpu: 100m
               memory: 100Mi
             limits:
-              cpu: 300m
+              cpu: 500m
               memory: 700Mi
           livenessProbe:
             httpGet:

--- a/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -54,7 +54,7 @@ spec:
             cpu: 20m
             memory: 64Mi
           limits:
-            cpu: 100m
+            cpu: 900m
             memory: 200Mi
         volumeMounts:
         - name: kubeconfig

--- a/pkg/apis/garden/v1beta1/helper/helpers.go
+++ b/pkg/apis/garden/v1beta1/helper/helpers.go
@@ -135,6 +135,32 @@ func GetShootCloudProviderWorkers(cloudProvider gardenv1beta1.CloudProvider, sho
 	return workers
 }
 
+// GetMachineTypesFromCloudProfile retrieves list of machine types from cloud profile
+func GetMachineTypesFromCloudProfile(cloudProvider gardenv1beta1.CloudProvider, profile *gardenv1beta1.CloudProfile) []gardenv1beta1.MachineType {
+	var (
+		machineTypes []gardenv1beta1.MachineType
+	)
+
+	switch cloudProvider {
+	case gardenv1beta1.CloudProviderAWS:
+		return profile.Spec.AWS.Constraints.MachineTypes
+	case gardenv1beta1.CloudProviderAzure:
+		return profile.Spec.Azure.Constraints.MachineTypes
+	case gardenv1beta1.CloudProviderGCP:
+		return profile.Spec.GCP.Constraints.MachineTypes
+	case gardenv1beta1.CloudProviderOpenStack:
+		for _, openStackMachineType := range profile.Spec.OpenStack.Constraints.MachineTypes {
+			machineTypes = append(machineTypes, openStackMachineType.MachineType)
+		}
+	case gardenv1beta1.CloudProviderLocal:
+		machineTypes = append(machineTypes, gardenv1beta1.MachineType{
+			Name: "local",
+		})
+	}
+
+	return machineTypes
+}
+
 // DetermineCloudProviderInShoot takes a Shoot cloud object and returns the cloud provider this profile is used for.
 // If it is not able to determine it, an error will be returned.
 func DetermineCloudProviderInShoot(cloudObj gardenv1beta1.Cloud) (gardenv1beta1.CloudProvider, error) {

--- a/pkg/operation/cloudbotanist/awsbotanist/cloud_config.go
+++ b/pkg/operation/cloudbotanist/awsbotanist/cloud_config.go
@@ -20,7 +20,5 @@ import (
 
 // GenerateCloudConfigUserDataConfig generates values which are required to render the chart shoot-cloud-config properly.
 func (b *AWSBotanist) GenerateCloudConfigUserDataConfig() *common.CloudConfigUserDataConfig {
-	return &common.CloudConfigUserDataConfig{
-		WorkerNames: b.Shoot.GetWorkerNames(),
-	}
+	return &common.CloudConfigUserDataConfig{}
 }

--- a/pkg/operation/cloudbotanist/azurebotanist/cloud_config.go
+++ b/pkg/operation/cloudbotanist/azurebotanist/cloud_config.go
@@ -22,6 +22,5 @@ import (
 func (b *AzureBotanist) GenerateCloudConfigUserDataConfig() *common.CloudConfigUserDataConfig {
 	return &common.CloudConfigUserDataConfig{
 		ProvisionCloudProviderConfig: true,
-		WorkerNames:                  b.Shoot.GetWorkerNames(),
 	}
 }

--- a/pkg/operation/cloudbotanist/gcpbotanist/cloud_config.go
+++ b/pkg/operation/cloudbotanist/gcpbotanist/cloud_config.go
@@ -19,7 +19,6 @@ import "github.com/gardener/gardener/pkg/operation/common"
 // GenerateCloudConfigUserDataConfig generates values which are required to render the chart shoot-cloud-config properly.
 func (b *GCPBotanist) GenerateCloudConfigUserDataConfig() *common.CloudConfigUserDataConfig {
 	return &common.CloudConfigUserDataConfig{
-		WorkerNames:      b.Shoot.GetWorkerNames(),
 		HostnameOverride: true,
 	}
 }

--- a/pkg/operation/cloudbotanist/localbotanist/cloud_config.go
+++ b/pkg/operation/cloudbotanist/localbotanist/cloud_config.go
@@ -20,7 +20,5 @@ import (
 
 // GenerateCloudConfigUserDataConfig generates values which are required to render the chart shoot-cloud-config properly.
 func (b *LocalBotanist) GenerateCloudConfigUserDataConfig() *common.CloudConfigUserDataConfig {
-	return &common.CloudConfigUserDataConfig{
-		WorkerNames: b.Shoot.GetWorkerNames(),
-	}
+	return &common.CloudConfigUserDataConfig{}
 }

--- a/pkg/operation/cloudbotanist/openstackbotanist/cloud_config.go
+++ b/pkg/operation/cloudbotanist/openstackbotanist/cloud_config.go
@@ -22,7 +22,6 @@ import (
 func (b *OpenStackBotanist) GenerateCloudConfigUserDataConfig() *common.CloudConfigUserDataConfig {
 	return &common.CloudConfigUserDataConfig{
 		ProvisionCloudProviderConfig: true,
-		WorkerNames:                  b.Shoot.GetWorkerNames(),
 		HostnameOverride:             true,
 	}
 }

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -549,6 +549,5 @@ var (
 type CloudConfigUserDataConfig struct {
 	ProvisionCloudProviderConfig bool
 	KubeletParameters            []string
-	WorkerNames                  []string
 	HostnameOverride             bool
 }

--- a/pkg/operation/hybridbotanist/cloud_config.go
+++ b/pkg/operation/hybridbotanist/cloud_config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	bootstraptokenapi "k8s.io/client-go/tools/bootstrap/token/api"
 	bootstraptokenutil "k8s.io/client-go/tools/bootstrap/token/util"
@@ -55,12 +56,33 @@ func (b *HybridBotanist) generateCloudConfigChart() (*chartrenderer.RenderedChar
 		cloudProvider["config"] = cloudProviderConfig
 	}
 
+	machineTypes := b.Shoot.GetMachineTypesFromCloudProfile()
+	memoryThreshold, _ := resource.ParseQuantity("8Gi")
+
 	workers := []map[string]interface{}{}
-	for _, workerName := range userDataConfig.WorkerNames {
-		workers = append(workers, map[string]interface{}{
-			"name":       workerName,
-			"secretName": b.Shoot.ComputeCloudConfigSecretName(workerName),
-		})
+
+	for _, worker := range b.Shoot.GetWorkers() {
+		newWorker := map[string]interface{}{
+			"name":                        worker.Name,
+			"secretName":                  b.Shoot.ComputeCloudConfigSecretName(worker.Name),
+			"evictionHardMemoryAvailable": "100Mi",
+			"evictionSoftMemoryAvailable": "200Mi",
+		}
+		for _, machtype := range machineTypes {
+			if machtype.Name == worker.MachineType {
+				// Found a match, no need for further comparisons
+				// Break the loop after replacing default values
+				if machtype.Memory.Cmp(memoryThreshold) > 0 {
+					newWorker["evictionHardMemoryAvailable"] = "1Gi"
+					newWorker["evictionSoftMemoryAvailable"] = "1.5Gi"
+				} else {
+					newWorker["evictionHardMemoryAvailable"] = "5%"
+					newWorker["evictionSoftMemoryAvailable"] = "10%"
+				}
+				break
+			}
+		}
+		workers = append(workers, newWorker)
 	}
 
 	config := map[string]interface{}{

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -103,6 +103,11 @@ func (s *Shoot) GetWorkers() []gardenv1beta1.Worker {
 	return helper.GetShootCloudProviderWorkers(s.CloudProvider, s.Info)
 }
 
+// GetMachineTypesFromCloudProfile returns a list of machine types in the cloud profile.
+func (s *Shoot) GetMachineTypesFromCloudProfile() []gardenv1beta1.MachineType {
+	return helper.GetMachineTypesFromCloudProfile(s.CloudProvider, s.CloudProfile)
+}
+
 // GetWorkerNames returns a list of names of the worker groups in the Shoot manifest.
 func (s *Shoot) GetWorkerNames() []string {
 	workerNames := []string{}


### PR DESCRIPTION
Increasing memory and CPU limits for kube-proxy, ingress-controller, calico and etcd based on observations from performance tests.

**What this PR does / why we need it**:
For network heavy workloads, the limits assigned to kube-proxy, ingress controller weren't enough. Thus need to be increased.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The "requests" values are kept the same, and might be changed as part of another PR.
Idea is to launch pods so that they consume/reserve less resources to begin with. The limits are increased so that those critical components can grow if necessary.

**Release note**:
```noteworthy user
The resource limits for kube-proxy, calico, etcd and nginx-ingress have been increased. Also, the eviction thresholds for available memory on the nodes is now optimized for the used machine type.
```