### PR TITLE
Changing the eviction thresholds for kubelet.

### DIFF
--- a/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet-config-file
+++ b/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet-config-file
@@ -34,13 +34,13 @@ eventBurst: 50
 evictionHard:
   imagefs.available: 5%
   imagefs.inodesFree: 5%
-  memory.available: 100Mi
+  memory.available: {{ .worker.evictionHard }}
   nodefs.available: 5%
   nodefs.inodesFree: 5%
 evictionSoft:
   imagefs.available: 10%
   imagefs.inodesFree: 10%
-  memory.available: 200Mi
+  memory.available: {{ .worker.evictionSoft }}
   nodefs.available: 10%
   nodefs.inodesFree: 10%
 evictionSoftGracePeriod:

--- a/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet.flags
+++ b/charts/shoot-cloud-config/charts/original/templates/kubelet/_kubelet.flags
@@ -19,8 +19,8 @@
 --enable-debugging-handlers=true \
 --event-burst=25 \
 --event-qps=25 \
---eviction-hard="memory.available<100Mi,nodefs.available<5%,nodefs.inodesFree<5%,imagefs.available<5%,imagefs.inodesFree<5%" \
---eviction-soft="memory.available<200Mi,nodefs.available<10%,nodefs.inodesFree<10%,imagefs.available<10%,imagefs.inodesFree<10%" \
+--eviction-hard="memory.available<{{ .worker.evictionHard }},nodefs.available<5%,nodefs.inodesFree<5%,imagefs.available<5%,imagefs.inodesFree<5%" \
+--eviction-soft="memory.available<{{ .worker.evictionSoft }},nodefs.available<10%,nodefs.inodesFree<10%,imagefs.available<10%,imagefs.inodesFree<10%" \
 --eviction-soft-grace-period="memory.available=1m30s,nodefs.available=1m30s,nodefs.inodesFree=1m30s,imagefs.available=1m30s,imagefs.inodesFree=1m30s" \
 --eviction-max-pod-grace-period="90" \
 --eviction-pressure-transition-period="4m" \

--- a/pkg/apis/garden/v1beta1/helper/helpers.go
+++ b/pkg/apis/garden/v1beta1/helper/helpers.go
@@ -135,6 +135,32 @@ func GetShootCloudProviderWorkers(cloudProvider gardenv1beta1.CloudProvider, sho
 	return workers
 }
 
+// GetMachineTypesFromCloudProfile retrieves list of machine types from cloud profile
+func GetMachineTypesFromCloudProfile(cloudProvider gardenv1beta1.CloudProvider, profile *gardenv1beta1.CloudProfile) []gardenv1beta1.MachineType {
+	var (
+		machineTypes []gardenv1beta1.MachineType
+	)
+
+	switch cloudProvider {
+	case gardenv1beta1.CloudProviderAWS:
+		return profile.Spec.AWS.Constraints.MachineTypes
+	case gardenv1beta1.CloudProviderAzure:
+		return profile.Spec.Azure.Constraints.MachineTypes
+	case gardenv1beta1.CloudProviderGCP:
+		return profile.Spec.GCP.Constraints.MachineTypes
+	case gardenv1beta1.CloudProviderOpenStack:
+		for _, openStackMachineType := range profile.Spec.OpenStack.Constraints.MachineTypes {
+			machineTypes = append(machineTypes, openStackMachineType.MachineType)
+		}
+	case gardenv1beta1.CloudProviderLocal:
+		machineTypes = append(machineTypes, gardenv1beta1.MachineType{
+			Name: "local",
+		})
+	}
+
+	return machineTypes
+}
+
 // DetermineCloudProviderInShoot takes a Shoot cloud object and returns the cloud provider this profile is used for.
 // If it is not able to determine it, an error will be returned.
 func DetermineCloudProviderInShoot(cloudObj gardenv1beta1.Cloud) (gardenv1beta1.CloudProvider, error) {

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -103,6 +103,11 @@ func (s *Shoot) GetWorkers() []gardenv1beta1.Worker {
 	return helper.GetShootCloudProviderWorkers(s.CloudProvider, s.Info)
 }
 
+// GetMachineTypesFromCloudProfile returns a list of machine types in the cloud profile.
+func (s *Shoot) GetMachineTypesFromCloudProfile() []gardenv1beta1.MachineType {
+	return helper.GetMachineTypesFromCloudProfile(s.CloudProvider, s.CloudProfile)
+}
+
 // GetWorkerNames returns a list of names of the worker groups in the Shoot manifest.
 func (s *Shoot) GetWorkerNames() []string {
 	workerNames := []string{}


### PR DESCRIPTION
**What this PR does / why we need it**:
The current/default soft and hard eviction thresholds are low. Increasing it to 1.5GB and 1GB respectively for machines that have memory more than 8GB, and to 10% and 5% respectively for machines that have memory less than 8GB

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!-- NONE
-->
```improvement operator

```
