### PR TITLE
Annotate the shoot-namespace in the seed with Shoot's annotations

### DIFF
--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -341,6 +341,16 @@ const (
 	// delete)).
 	ShootIgnore = "shoot.garden.sapcloud.io/ignore"
 
+	// ShootUID is an annotation key for the shoot namespace in the seed cluster,
+	// which value will be the value of `shoot.status.uid`
+	ShootUID = "shoot.garden.sapcloud.io/uid"
+
+	// AnnotateSeedNamespacePrefix is such a prefix so that the shoot namespace in the seed cluster
+	// will be annotated with the annotations of the shoot resource starting with it.
+	// For example, if the shoot is annotated with <AnnotateSeedNamespacePrefix>key=value,
+	// then the namespace in the seed will be annotated with <AnnotateSeedNamespacePrefix>key=value, as well.
+	AnnotateSeedNamespacePrefix = "custom.shoot.sapcloud.io/"
+
 	// BackupNamespacePrefix is a constant for backup namespace created for shoot's backup infrastructure related resources.
 	BackupNamespacePrefix = "backup"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR provides a mechanism for replicating metadata(annotations) from the Garden cluster to the Seed cluster. In this way, controllers working in the seed cluster could get additional information. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The shoot's namespace in the seed cluster will now be annotated with all annotations of the shoot resource prefixed with `custom.shoot.sapcloud.io/`. The namespace is also annotated with `shoot.garden.sapcloud.io/uid=<value>`. This can be used by controllers running in the seed to extract more information about the shoot.
```
