### PR TITLE
Raise resource limits for Cert-Manager and Cert-Broker

### DIFF
--- a/charts/seed-bootstrap/charts/cert-manager/values.yaml
+++ b/charts/seed-bootstrap/charts/cert-manager/values.yaml
@@ -41,9 +41,9 @@ extraEnv: []
 resources:
   limits:
     cpu: 100m
-    memory: 256Mi
+    memory: 768Mi
   requests:
-    cpu: 100m
+    cpu: 50m
     memory: 128Mi
 
 podAnnotations: {}

--- a/charts/seed-controlplane/charts/cert-broker/values.yaml
+++ b/charts/seed-controlplane/charts/cert-broker/values.yaml
@@ -25,7 +25,7 @@ certmanager:
 resources:
   requests:
     memory: "64Mi"
-    cpu: "50m"
+    cpu: "20m"
   limits:
-    memory: "128Mi"
+    memory: "350Mi"
     cpu: "50m"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR raises the resource limits for the components `Cert-Manager` and `Cert-Broker` in order to avoid OOM in clusters with many `Ingresses` and `Secrets`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fixes a resource issue for Gardener's certificate management for clusters having many `Ingresses` and `Secrets`.
```