### PR TITLE
Update logging stack to 0.16.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -158,23 +158,23 @@ images:
 - name: fluentd-es
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluentd-es
-  tag: "0.9.0"
+  tag: "0.16.0"
 - name: fluent-bit
   sourceRepository: https://github.com/fluent/fluent-bit
   repository: fluent/fluent-bit
-  tag: "0.13.4"
+  tag: "0.14.8"
 - name: elasticsearch-oss
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/elasticsearch-oss
-  tag: "0.9.0"
+  tag: "0.16.0"
 - name: curator-es
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/curator-es
-  tag: "0.9.0"
+  tag: "0.16.0"
 - name: kibana-oss
   sourceRepository: github.com/elastic/kibana-docker
   repository: docker.elastic.co/kibana/kibana-oss
-  tag: "6.2.4"
+  tag: "6.5.4"
 
 # Certificate Management
 - name: cert-manager

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/_resource.tpl
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/_resource.tpl
@@ -1,3 +1,3 @@
 {{- define "curator.disk_threshold" -}}
-{{- printf "%d" ( add $.base_disk_threshold ( mul $.base_disk_threshold ( sub $.objectCount 1 ) ) ) -}}
+{{ printf "%d" ( div ( mul (add ( mul 13 (div $.baseDiskThreshold 1000000) ) ( mul 1000 ( sub $.objectCount 1 ) ) ) 1000000 ) 13 ) }}
 {{- end -}}

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/curator-configmap.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/curator-configmap.yaml
@@ -10,30 +10,9 @@ data:
   action_file.yml: |-
     actions:
       1:
-        action: forcemerge
-        description: >-
-          Perform a forcemerge on selected indices to 'max_num_segments' per shard
-        options:
-          max_num_segments: 1
-          timeout_override: 21600
-          delay: 120
-          continue_if_exception: True
-          ignore_empty_list: True
-        filters:
-        - filtertype: age
-          source: name
-          direction: older
-          timestring: '%Y.%m.%d'
-          unit: days
-          unit_count: 1
-          field:
-          stats_result:
-          epoch:
-          exclude: True
-      2:
         action: index_settings
         description: >-
-          Set shard replicas to 0 and remove the index from read only
+          Remove the selected indices from read only
         options:
           index_settings:
             index:
@@ -49,10 +28,7 @@ data:
           direction: older
           timestring: '%Y.%m.%d'
           unit: days
-          unit_count: 1
-          field:
-          stats_result:
-          epoch:
+          unit_count: 2
           exclude: True
   config.yml: |-
     client:
@@ -100,9 +76,6 @@ data:
           timestring: '%Y.%m.%d'
           unit: months
           unit_count: 1
-          field:
-          stats_result:
-          epoch:
           exclude: False
       2:
         action: index_settings
@@ -114,7 +87,6 @@ data:
               refresh_interval: 60s
               translog:
                 durability: async
-              number_of_replicas: 0
           ignore_unavailable: False
           preserve_existing: False
           continue_if_exception: True
@@ -126,9 +98,23 @@ data:
           timestring: '%Y.%m.%d'
           unit: days
           unit_count: 1
-          field:
-          stats_result:
-          epoch:
+          exclude: True
+      3:
+        action: replicas
+        description: >-
+          Reduce the replica count to 0 for indices younger than two days.
+        options:
+          count: 0
+          wait_for_completion: True
+          continue_if_exception: True
+          ignore_empty_list: True
+        filters:
+        - filtertype: age
+          source: name
+          direction: older
+          timestring: '%Y.%m.%d'
+          unit: days
+          unit_count: 2
           exclude: True
   config.yml: |-
     client:

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/es-statefulset.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/es-statefulset.yaml
@@ -38,6 +38,24 @@ spec:
         env:
         - name: ES_JAVA_OPTS
           value: "-Xms{{ include "jvm.memory" .Values.elasticsearch }} -Xmx{{ include "jvm.memory" .Values.elasticsearch }}"
+        - name: CLUSTER_NAME
+          value: {{ .Release.Namespace }}-elasticsearch-logging
+        - name: WRITE_QUEUE_SIZE
+          value: "500"
+        - name: INDEX_BUFFER_SIZE
+          value: "512MB"
+        - name: ALLOW_DISK_ALLOCATION
+          value: "true"
+        - name: DISK_WATERMARK_HIGHT
+          value: "200MB"
+        - name: DISK_WATERMARK_LOW
+          value: "500MB"
+        - name: DISK_WATERMARK_FLOOD_STAGE
+          value: "200MB"
+        - name: PROCESSORS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
         resources:
           # need more cpu upon initialization, therefore burstable class
 {{- include "util-templates.resource-quantity" .Values.elasticsearch | indent 10 }}

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-index-registration-config.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-index-registration-config.yaml
@@ -10,38 +10,65 @@ data:
   register: |-
     #/bin/sh
 
-    until curl -sS http://127.0.0.1:{{ .Values.kibanaPort }}/ > /dev/null; do
-      echo Waiting for Kibana...;
-      sleep 2;
+    KIBANA_HOST=http://127.0.0.1:{{ .Values.kibanaPort }}
+
+    until curl -sS $KIBANA_HOST/ > /dev/null; do
+      echo "Waiting for Kibana..."
+      sleep 2
     done;
 
-    function register {
+    function create_index_pattern {
       while true
       do
-          RESULT=$(curl -sS -X$1 -H "Content-Type: application/json" -H "kbn-xsrf: anything" \
-            'http://127.0.0.1:{{ .Values.kibanaPort }}/api/saved_objects/index-pattern/logstash-*' \
-            -d'{"attributes":{"title":"logstash-*","timeFieldName":"@timestamp"}}')
+          # store the whole response with the status at the end
+          HTTP_RESPONSE=$(curl --silent \
+            -H "Content-Type: application/json" \
+            -H "kbn-xsrf: true" \
+            --write-out "HTTPSTATUS:%{http_code}" \
+            -X POST $KIBANA_HOST/api/saved_objects/index-pattern/logstash-*?overwrite=true \
+            -d '{"attributes": {"title": "logstash-*", "timeFieldName": "@timestamp"}}')
 
-          echo ${RESULT}
-          echo -e "\n"
+          HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+          HTTP_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
 
-          if echo ${RESULT} | grep -v -q '"error"'
-          then
+          echo -e "Response status code: ${HTTP_STATUS}"
+          echo -e "Response body: ${HTTP_BODY}"
+
+          if [ $HTTP_STATUS -eq 200 ]; then
+              echo "Successfully created index pattern logstash-*."
+
               break
           fi
-          echo Still waiting for Kibana...
+
+          echo "Still waiting for Kibana..."
           sleep 2
       done
     }
 
-    # curl doesn't care about HTTP status codes.
-    echo "Trying to create the index pattern."
-    register POST
+    function set_index_pattern_as_default {
+      # store the whole response with the status at the end
+      HTTP_RESPONSE=$(curl --silent \
+        -H "Content-Type: application/json" \
+        -H "kbn-xsrf: true" \
+        --write-out "HTTPSTATUS:%{http_code}" \
+        -X POST $KIBANA_HOST/api/kibana/settings/defaultIndex \
+        -d '{"value": "logstash-*"}')
 
-    echo Trying to update the index pattern.
-    register PUT
+        HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
 
-    echo Registred index.
-    echo Sleeping...
+        if [ $HTTP_STATUS -eq 200 ]; then
+          echo "Successfully set logstash-* as default index pattern."
+        else
+          echo "Setting logstash-* as default index pattern failed with ${HTTP_STATUS}."
+        fi
+    }
+
+    echo "Trying to create the logstash index pattern."
+    create_index_pattern
+
+    echo "Trying to set the newly created index pattern as default."
+    set_index_pattern_as_default
+
+    echo "Sleeping..."
     # Sleep forever
     while sleep 3600; do :; done

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/values.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/values.yaml
@@ -20,7 +20,8 @@ kibanaReplicas: 1
 
 curator:
   objectCount: 1
-  base_disk_threshold: 1073741824
+  # set curator threshold to 1GB
+  baseDiskThreshold: 1073741824
 
 elasticsearch:
   elasticsearchReplicas: 1
@@ -46,7 +47,7 @@ elasticsearch:
         weight: 5
         unit: m
       memory:
-        base: 1900
+        base: 2100
         perObject: 89
         weight: 5
         unit: Mi

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-configmap.yaml
@@ -16,18 +16,7 @@ data:
     </source>
 
   output.conf: |-
-    <filter kubernetes.**>
-      @type genhashvalue
-      keys time, tag
-      hash_type md5    # md5/sha1/sha256/sha512/mur128
-      base64_enc true
-      base91_enc false
-      set_key _hash
-      separator _
-      inc_time_as_key true
-      inc_tag_as_key true
-    </filter>
-
+    
     #Decide which is shoot record and which is not
     <match kubernetes.**>
       @id rewrite_tag_filter
@@ -46,27 +35,16 @@ data:
       </rule>
     </match>
 
-    # <filter **>
-    #   @type elasticsearch_genid
-    #   hash_id_key _hash    # storing generated hash id key (default is _hash)
-    # </filter>
-
+    <filter **>
+      @type elasticsearch_genid
+    </filter>
 
     <match shoot**>
       @id elasticsearch_dynamic
       @type elasticsearch_dynamic
       @log_level warn
-      include_tag_key true
       host elasticsearch-logging.${record['kubernetes']['namespace_name']}.svc
-      port 9200
-      logstash_format true
-      #use _hash field for log ID
-      id_key _hash
-      reconnect_on_error true
-      # gives time plugin to read bulk response from server
-      request_timeout 30s
-      # this is only for debug. When flush take more time than this it will produce warning
-      slow_flush_log_threshold 60
+      @include /etc/fluent/config.d/es_plugin.options
       <buffer tag, time>
         @type file
         #Limit the number of queued chunks
@@ -88,19 +66,14 @@ data:
       @id elasticsearch_static
       @type elasticsearch
       @log_level warn
-      include_tag_key true
       host elasticsearch-logging.{{ .Release.Namespace }}.svc
-      port 9200
-      logstash_format true
-      id_key _hash
-      reconnect_on_error true
-      request_timeout 30s
-      # this is only for debug. When flush take more time than this it will produce warning
-      slow_flush_log_threshold 60
+      @include /etc/fluent/config.d/es_plugin.options
+      template_name gardener
+      template_file /etc/fluent/config.d/default.template
       <buffer tag, time>
         @type file
         #Limit the number of queued chunks
-        queued_chunks_limit_size 2048
+        queued_chunks_limit_size 40
         # The number of threads of output plugins, which is used to write chunks in parallel
         flush_thread_count 8
         # he size limitation of this buffer plugin instance
@@ -117,6 +90,27 @@ data:
     <system>
       root_dir /gardener/fluentd-buffers/
     </system>
+
+  es_plugin.options: |-
+    port {{ .Values.global.elasticsearchPorts.db }}
+    logstash_format true
+    # use _hash as request id
+    id_key _hash
+    reconnect_on_error true
+    # gives enough time fluentd to read the response
+    request_timeout 30s
+    # this is only for debug. When flush take more time than this it will produce warning
+    slow_flush_log_threshold 60
+    # Do not wait ES to tell you what version is.
+    verify_es_version_at_startup false
+    # just hardcode that version number
+    default_elasticsearch_version 6
+    # we have time field from the docker runtime
+    # include_timestamp false
+    time_key time
+    # remove tag from the log content
+    include_tag_key false
+    remove_keys _hash, time
 
   buffer.options: |-
     # The max size of each chunks
@@ -144,3 +138,18 @@ data:
     retry_randomize false
     flush_mode interval
     retry_max_times 4
+
+  default.template: |-
+    {
+      "index_patterns" : ["logstash-*"],
+      "settings" : {
+        "index" :{
+          "number_of_shards" : "3",
+          "number_of_replicas" : "0",
+          "refresh_interval": "60s",
+          "translog":{
+            "durability": "async"
+          }
+        }
+      }
+    }

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-statefulset.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-statefulset.yaml
@@ -63,7 +63,7 @@ spec:
             port: {{ .Values.fluentd.ports.forward }}
           periodSeconds: 5
           timeoutSeconds: 3
-          initialDelaySeconds: 15
+          initialDelaySeconds: 240
           failureThreshold: 12
         readinessProbe:
           tcpSocket:

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -322,7 +322,8 @@ func BootstrapCluster(seed *Seed, k8sGardenClient kubernetes.Client, secrets map
 			},
 			"kibanaReplicas": replicas,
 			"curator": map[string]interface{}{
-				"objectCount": nodeCount,
+				"objectCount":       nodeCount,
+				"baseDiskThreshold": 2 * 1073741824,
 			},
 			"elasticsearch": map[string]interface{}{
 				"elasticsearchReplicas":     replicas,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the logging stack to version 0.16.0 and includes several improvements and optimizations.

**Which issue(s) this PR fixes**:
See above.

**Special notes for your reviewer**:
@vlvasilev , @mvladev , @rfranzke 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Several improvements to the EFK logging stack:
* Increase the `initialDelaySeconds` of fluentd's livenessProbe to `4m`.
* Increase the minimum required free disk space of the central ElasticSearch (in `garden` namespace).
* Update the ElasticSearch and Kibana versions from `6.2.4` to `6.5.4`.
```
