### PR TITLE
Update golang to 1.11.4

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -23,9 +23,9 @@ gardener:
             tag_as_latest: true
     steps:
       check:
-        image: 'golang:1.11.1'
+        image: 'golang:1.11.4'
       test:
-        image: 'golang:1.11.1'
+        image: 'golang:1.11.4'
   variants:
     head-update:
       traits:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.11.1 AS builder
+FROM golang:1.11.4 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
kubernetes/kubernetes will adopt soon golang 1.11.4. The patch releases contain several security fixes. For more details see [#72032](https://github.com/kubernetes/kubernetes/issues/72032) and [#72084](https://github.com/kubernetes/kubernetes/pull/72084).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Maybe it's a good idea to wait the new version to be adopted by kubernetes. For example golang 1.11.3 introduced a regression.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The golang version has been upgraded to `v1.11.4`.
```
