### PR TITLE
Improve assumptions on node count

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -272,6 +272,11 @@ func (b *Botanist) DeploySeedMonitoring() error {
 		prometheusHost   = b.ComputePrometheusIngressFQDN()
 	)
 
+	nodeCount, err := b.GetNodeCountForVerticalScaling()
+	if err != nil {
+		return err
+	}
+
 	var (
 		alertManagerConfig = map[string]interface{}{
 			"ingress": map[string]interface{}{
@@ -300,7 +305,7 @@ func (b *Botanist) DeploySeedMonitoring() error {
 			"namespace": map[string]interface{}{
 				"uid": b.SeedNamespaceObject.UID,
 			},
-			"objectCount": b.Shoot.GetNodeCount(),
+			"objectCount": nodeCount,
 			"podAnnotations": map[string]interface{}{
 				"checksum/secret-prometheus":                b.CheckSums["prometheus"],
 				"checksum/secret-kube-apiserver-basic-auth": b.CheckSums["kube-apiserver-basic-auth"],

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -112,15 +112,6 @@ func (s *Shoot) GetWorkerNames() []string {
 	return workerNames
 }
 
-// GetNodeCount returns the sum of all 'autoScalerMax' fields of all worker groups of the Shoot.
-func (s *Shoot) GetNodeCount() int {
-	nodeCount := 0
-	for _, worker := range s.GetWorkers() {
-		nodeCount += worker.AutoScalerMax
-	}
-	return nodeCount
-}
-
 // GetK8SNetworks returns the Kubernetes network CIDRs for the Shoot cluster.
 func (s *Shoot) GetK8SNetworks() *gardenv1beta1.K8SNetworks {
 	switch s.CloudProvider {

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -117,3 +117,11 @@ func TestEmail(email string) bool {
 	match, _ := regexp.MatchString(`^[^@]+@(?:[a-zA-Z-0-9]+\.)+[a-zA-Z]{2,}$`, email)
 	return match
 }
+
+// MaxInt returns the maximum value of the two given integers.
+func MaxInt(i1, i2 int) int {
+	if i1 > i2 {
+		return i1
+	}
+	return i2
+}

--- a/pkg/utils/miscellaneous_test.go
+++ b/pkg/utils/miscellaneous_test.go
@@ -15,6 +15,7 @@ package utils_test
 
 import (
 	. "github.com/gardener/gardener/pkg/utils"
+	. "github.com/onsi/ginkgo/extensions/table"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -57,4 +58,13 @@ var _ = Describe("utils", func() {
 			}))
 		})
 	})
+
+	DescribeTable("#MaxInt",
+		func(i1, i2, expected int) {
+			Expect(MaxInt(i1, i2)).To(Equal(expected))
+		},
+		Entry("first value greater", 1, 0, 1),
+		Entry("second value greater", 0, 1, 1),
+		Entry("both values equal", 1, 1, 1),
+	)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This improves the assumptions on node count we currently have for vertical scaling of some of our helm templates (for now, in the future we should use VPAs anyways once they're more stable).

**Release note**:
```improvement operator
NONE
```
