### PR TITLE
Configure prometheus to scrape CCM and KCM using https

### DIFF
--- a/charts/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -67,6 +67,10 @@ spec:
         {{- include "cloud-controller-manager.featureGates" . | trimSuffix "," | indent 8 }}
         - --kubeconfig=/var/lib/cloud-controller-manager/kubeconfig
         - --leader-elect=true
+        {{- if semverCompare ">= 1.13" .Values.kubernetesVersion }}
+        - --secure-port=10253
+        - --port=0
+        {{- end}}
         {{- if semverCompare ">= 1.12" .Values.kubernetesVersion }}
         - --authentication-kubeconfig=/var/lib/cloud-controller-manager/kubeconfig
         - --authorization-kubeconfig=/var/lib/cloud-controller-manager/kubeconfig

--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -86,6 +86,10 @@ spec:
         - --root-ca-file=/srv/kubernetes/ca/ca.crt
         - --service-account-private-key-file=/srv/kubernetes/service-account-key/id_rsa
         - --service-cluster-ip-range={{ .Values.serviceNetwork }}
+        {{- if semverCompare ">= 1.13" .Values.kubernetesVersion }}
+        - --secure-port=10252
+        - --port=0
+        {{- end}}
         {{- if semverCompare ">= 1.12" .Values.kubernetesVersion }}
         - --horizontal-pod-autoscaler-downscale-stabilization={{ .Values.horizontalPodAutoscaler.downscaleStabilization }}
         - --horizontal-pod-autoscaler-initial-readiness-delay={{ .Values.horizontalPodAutoscaler.readinessDelay }}

--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -31,7 +31,6 @@ data:
             names:
             - {{ .Release.Namespace }}
             - garden
-        scheme: http
         relabel_configs:
         - source_labels: [ __meta_kubernetes_service_label_component ]
           action: keep
@@ -188,7 +187,6 @@ data:
         replacement: kube-system
 
     - job_name: kube-state-metrics
-      scheme: http
       honor_labels: false
       # Service is used, because we only care about metric from one kube-state-metrics instance
       # and not multiple in HA setup
@@ -230,6 +228,13 @@ data:
 {{ include "prometheus.drop-metrics.metric-relabel-config" . | indent 6 }}
 
     - job_name: kube-controller-manager
+      {{- if semverCompare ">= 1.13" .Values.kubernetesVersion }}
+      scheme: https
+      tls_config:
+        insecure_skip_verify: true
+        cert_file: /etc/prometheus/seed/prometheus.crt
+        key_file: /etc/prometheus/seed/prometheus.key
+      {{- end }}
       honor_labels: false
       scrape_timeout: 15s
       kubernetes_sd_configs:
@@ -271,6 +276,13 @@ data:
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.kubeScheduler | indent 6 }}
 
     - job_name: cloud-controller-manager
+      {{- if semverCompare ">= 1.13" .Values.kubernetesVersion }}
+      scheme: https
+      tls_config:
+        insecure_skip_verify: true
+        cert_file: /etc/prometheus/seed/prometheus.crt
+        key_file: /etc/prometheus/seed/prometheus.key
+      {{- end }}
       honor_labels: false
       kubernetes_sd_configs:
       - role: endpoints
@@ -445,10 +457,8 @@ data:
       params:
         module:
         - http_apiserver
-      scrape_interval: 30s
       scrape_timeout: 10s
       metrics_path: /probe
-      scheme: http
       static_configs:
       - targets:
         - {{ .Values.shoot.apiserver }}/healthz

--- a/charts/seed-monitoring/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/prometheus/values.yaml
@@ -16,6 +16,8 @@ ingress:
   # admin : admin base64 encoded
   basicAuthSecret: YWRtaW46JGFwcjEkSWRSaVM5c3MkR3U1MHMxaGUwL2Z6Tzh2elE4S1BEMQ==
 
+kubernetesVersion: 1.10.0
+
 namespace:
   uid: 100c3bb5-48b9-4f88-96ef-48ed557d4212
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -288,6 +288,7 @@ func (b *Botanist) DeploySeedMonitoring() error {
 			"replicas": b.Shoot.GetReplicas(1),
 		}
 		prometheusConfig = map[string]interface{}{
+			"kubernetesVersion": b.Shoot.Info.Spec.Kubernetes.Version,
 			"networks": map[string]interface{}{
 				"pods":     b.Shoot.GetPodNetwork(),
 				"services": b.Shoot.GetServiceNetwork(),


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables Prometheus to scrape CCM and KCM via https. 
**Which issue(s) this PR fixes**:
Fixes #476 

**Special notes for your reviewer**:
CCM and KCM need to be version 1.13+
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
