### PR TITLE
Limit fluent-bit-coredns cycle

### DIFF
--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-daemonset.yaml
@@ -25,7 +25,7 @@ spec:
           - /fluent-bit/etc/fluent-bit.conf
         env:
         - name: FLUENTD_HOST
-          value: fluentd-es.{{ .Release.Namespace }}.svc
+          value: fluentd-es
         - name: FLUENTD_PORT
           value: "{{ .Values.fluentd.ports.forward }}"
         resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the fluent-bit sends the logs messages to fluentd service with the following config:
```yaml
env:
  - name: FLUENTD_HOST
    value: fluentd-es.{{ .Release.Namespace }}.svc
```
After the template rendering, the service that fluent-bit tries to reach is for example `fluentd-es.garden.svc`. On the other hand the `/etc/resolve.conf` of a pod looks like:
```
$ cat /etc/resolv.conf
nameserver {ip}
search {namespace}.svc.cluster.local svc.cluster.local cluster.local {aws-region}.compute.internal
options ndots:{n}
```
With the current fluentd-host config (fluentd-es.garden.svc), the fluent-bit executes the following tries to resolve the fluentd dns:
```
fluentd-es.garden.svc.garden.svc.cluster.local (unsuccessful)
fluentd-es.garden.svc.svc.cluster.local (unsuccessful)
fluentd-es.garden.svc.cluster.local (successful)
```

Each of these unsuccessful lookup tries will generate an error log in coredns:
```
10.243.131.2:45250 - [19/Dec/2018:14:00:27 +0000] 23564 "A IN fluentd-es.garden.svc.garden.svc.cluster.local. udp 72 false 512" NXDOMAIN qr,rd,ra 165 0.00006218s
[...]
10.243.131.2:60044 - [19/Dec/2018:14:00:27 +0000] 55161 "AAAA IN es-test-fluentd-es.garden.svc.svc.cluster.local. udp 65 false 512" NXDOMAIN qr,rd,ra 158 0.000081116s
[...]
10.243.131.2:58021 - [19/Dec/2018:14:00:27 +0000] 12419 "AAAA IN es-test-fluentd-es.garden.svc.cluster.local. udp 61 false 512" NOERROR qr,rd,ra 154 0.101586129s
```
Each dns lookup from fluent-bit generates 3 logs entries in coredns. And these coredns logs entries are flushed by fluent-bit, and this again generates 3 log entries and this all ends with a huge log size of coredns:
![coredns diagram](https://i.imgur.com/Y0HKE35.png)

In the diagram we have elasticsearch log sizes for a short period of time (several hours). We see that coredns pods are generating a huge amount of logs (5 X 350,000 = 1,750,000) because of this cycle between coredns and fluent-bit.
The fix limits fluent-bit to cause only one success log in coredns:
```
10.243.134.240:52900 - [19/Dec/2018:19:49:43 +0000] 61898 "AAAA IN es-test-fluentd-es.garden.svc.cluster.local. udp 61 false 512" NOERROR qr,rd,ra 154 0.000099446s
```
We will also try to propose a separate PR that disables coredns to log success messages (NOERROR). 

/cc @vpnachev @vlvasilev @KristianZH 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
