### PR TITLE
Fix GCP local zone

### DIFF
--- a/pkg/operation/cloudbotanist/gcpbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/gcpbotanist/controlplane.go
@@ -27,6 +27,7 @@ const cloudProviderConfigTemplate = `
 project-id=%q
 network-name=%q
 multizone=true
+local-zone=%q
 token-url=nil
 node-tags=%q
 `
@@ -44,6 +45,7 @@ func (b *GCPBotanist) GenerateCloudProviderConfig() (string, error) {
 		cloudProviderConfigTemplate,
 		b.Project,
 		networkName,
+		b.Shoot.Info.Spec.Cloud.GCP.Zones[0],
 		b.Shoot.SeedNamespace,
 	), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes setting the zone for GCP.
If not set, if a GCP Seed is used and the Shoot is in a different region and node wants to join, the kube-controller-manager will query for the node in the region of the Seed, resulting in the node being unable to join.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
An issue hosting GCP shoots on a different region than the seed has been fixed.
```
