### PR TITLE
Stop denial logs

### DIFF
--- a/charts/shoot-core/charts/coredns/values.yaml
+++ b/charts/shoot-core/charts/coredns/values.yaml
@@ -37,7 +37,6 @@ configmap:
     - name: log
       parameters: .
       configBlock: |-
-        class denial
         class error
     - name: health
     - name: kubernetes


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the `coredns` generates a lot of logs from type `NOERROR`(around 30 000 per hour) which do not bring us any valuable information. We have established that these logs are coming with `class denial` from the `log plugin`.  This is a diagram which shows the difference before and after the fix.
![screenshot 2018-12-20 at 12 39 35](https://user-images.githubusercontent.com/16671526/50354946-ceb77780-0555-11e9-9c61-9a276a0dc6c2.png)

`Note that for busy servers logging will incur a performance hit.`

/cc @ialidzhikov  @vlvasilev  @vpnachev 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
NONE