### PR TITLE
Change http2-max-streams-per-connection flag in kube-apiserver

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
@@ -61,6 +61,9 @@ spec:
         - --client-ca-file=/srv/kubernetes/ca/ca.crt
         - --enable-aggregator-routing=true
         - --enable-bootstrap-token-auth=true
+        {{- if semverCompare ">= 1.9.7" .Values.kubernetesVersion }}
+        - --http2-max-streams-per-connection=1000
+        {{- end }}
         {{- if .Values.endpointReconcilerType }}
         - --endpoint-reconciler-type={{ .Values.endpointReconcilerType }}
         {{- end }}


### PR DESCRIPTION
Changed value of http2-max-streams-per-connection to 1000, to support more watchers. Default value is 0. This means to use the default in golang's HTTP/2 code (which
is currently 250)

**What this PR does / why we need it**:
Currently we support 110 pods per node. Kubelet monitors/watches each resources (secrets/ configMaps) consumed by each pod on the node. Keeping the value to 1000 which should be able to support ~10 consumed resources per pod.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
