### PR TITLE
Remove unneeded metrics-server RBAC rules

### DIFF
--- a/charts/shoot-core/charts/metrics-server/templates/rbac.yaml
+++ b/charts/shoot-core/charts/metrics-server/templates/rbac.yaml
@@ -12,15 +12,6 @@ rules:
   - pods
   - nodes
   - nodes/stats
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "extensions"
-  resources:
-  - deployments
   verbs:
   - get
   - list


### PR DESCRIPTION
**What this PR does / why we need it**: 

Removes unneeded permissions.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

Upstream PRs:

- kubernetes/kubernetes#72337
- kubernetes-incubator/metrics-server#195


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
