### PR TITLE
Update Docker image versions

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -37,7 +37,7 @@ images:
 - name: kube-addon-manager
   sourceRepository: github.com/kubernetes/kubernetes/tree/master/cluster/addons/addon-manager
   repository: k8s.gcr.io/kube-addon-manager
-  tag: v8.7
+  tag: v8.8
 - name: vpn-seed
   sourceRepository: github.com/gardener/vpn
   repository: eu.gcr.io/gardener-project/gardener/vpn-seed
@@ -51,7 +51,7 @@ images:
 - name: alertmanager
   sourceRepository: github.com/prometheus/alertmanager
   repository: quay.io/prometheus/alertmanager
-  tag: v0.15.2
+  tag: v0.15.3
 - name: prometheus
   sourceRepository: github.com/prometheus/prometheus
   repository: quay.io/prometheus/prometheus
@@ -67,15 +67,15 @@ images:
 - name: node-exporter
   sourceRepository: github.com/prometheus/node_exporter
   repository: quay.io/prometheus/node-exporter
-  tag: v0.16.0
+  tag: v0.17.0
 - name: grafana
   sourceRepository: github.com/grafana/grafana
   repository: grafana/grafana
-  tag: "5.3.0"
+  tag: "5.4.2"
 - name: blackbox-exporter
   sourceRepository: github.com/prometheus/blackbox_exporter
   repository: quay.io/prometheus/blackbox-exporter
-  tag: v0.12.0
+  tag: v0.13.0
 - name: metrics-server
   sourceRepository: github.com/kubernetes-incubator/metrics-server
   repository: k8s.gcr.io/metrics-server-amd64
@@ -85,15 +85,15 @@ images:
 - name: calico-node
   sourceRepository: github.com/projectcalico/calico
   repository: quay.io/calico/node
-  tag: v3.2.3
+  tag: v3.4.0
 - name: calico-cni
   sourceRepository: github.com/projectcalico/cni-plugin
   repository: quay.io/calico/cni
-  tag: v3.2.3
+  tag: v3.4.0
 - name: calico-typha
   sourceRepository: github.com/projectcalico/typha
   repository: quay.io/calico/typha
-  tag: v3.2.3
+  tag: v3.4.0
 - name: vpn-shoot
   sourceRepository: github.com/gardener/vpn
   repository: eu.gcr.io/gardener-project/gardener/vpn-shoot
@@ -101,7 +101,7 @@ images:
 - name: coredns
   sourceRepository: github.com/coredns/coredns
   repository: coredns/coredns
-  tag: "1.2.2"
+  tag: "1.3.0"
 
 # Shoot optional addons
 - name: kubernetes-dashboard
@@ -119,7 +119,7 @@ images:
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-  tag: "0.20.0"
+  tag: "0.21.0"
 - name: ingress-default-backend
   sourceRepository: github.com/gardener/ingress-default-backend
   repository: eu.gcr.io/gardener-project/gardener/ingress-default-backend

--- a/charts/shoot-core/charts/calico/templates/calico.yaml
+++ b/charts/shoot-core/charts/calico/templates/calico.yaml
@@ -208,6 +208,9 @@ spec:
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true
+            - mountPath: /run/xtables.lock
+              name: xtables-lock
+              readOnly: false
             - mountPath: /var/run/calico
               name: var-run-calico
               readOnly: false
@@ -225,6 +228,10 @@ spec:
         - name: var-lib-calico
           hostPath:
             path: /var/lib/calico
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
         # Used to install CNI.
         - name: cni-bin-dir
           hostPath:
@@ -351,9 +358,27 @@ spec:
             - readiness
           periodSeconds: 10
 
+
+---
+
+# This manifest creates a Pod Disruption Budget for Typha to allow K8s Cluster Autoscaler to evict
+
+# apiVersion: {{ include "poddisruptionbudgetversion" . }}
+# kind: PodDisruptionBudget
+# metadata:
+#   name: calico-typha
+#   namespace: kube-system
+#   labels:
+#     k8s-app: calico-typha
+# spec:
+#   maxUnavailable: 1
+#   selector:
+#     matchLabels:
+#       k8s-app: calico-typha
+
+---
 # Create all the CustomResourceDefinitions needed for
 # Calico policy and networking mode.
----
 
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/charts/shoot-core/charts/calico/templates/rbac.yaml
+++ b/charts/shoot-core/charts/calico/templates/rbac.yaml
@@ -1,83 +1,104 @@
-# Calico Version v3.2.1
-# https://docs.projectcalico.org/v3.2/releases#v3.2.1
-kind: ClusterRole
+# Include a clusterrole for the calico-node DaemonSet,
+# and bind it to the calico-node serviceaccount.
 apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
 metadata:
   name: calico-node
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
-- apiGroups: [""]
-  resources:
-  - namespaces
-  - serviceaccounts
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups: [""]
-  resources:
-  - pods/status
-  verbs:
-  - update
-- apiGroups: [""]
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-- apiGroups: [""]
-  resources:
-  - services
-  verbs:
-  - get
-- apiGroups: [""]
-  resources:
-  - endpoints
-  verbs:
-  - get
-- apiGroups: [""]
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups: ["extensions"]
-  resources:
-  - networkpolicies
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups: ["networking.k8s.io"]
-  resources:
-  - networkpolicies
-  verbs:
-  - watch
-  - list
-- apiGroups: ["crd.projectcalico.org"]
-  resources:
-  - globalfelixconfigs
-  - felixconfigurations
-  - bgppeers
-  - globalbgpconfigs
-  - bgpconfigurations
-  - ippools
-  - globalnetworkpolicies
-  - globalnetworksets
-  - networkpolicies
-  - clusterinformations
-  - hostendpoints
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
+  # The CNI plugin needs to get pods, nodes, and namespaces.
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+      - namespaces
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - endpoints
+      - services
+    verbs:
+      # Used to discover service IPs for advertisement.
+      - watch
+      - list
+      # Used to discover Typhas.
+      - get
+  - apiGroups: [""]
+    resources:
+      - nodes/status
+    verbs:
+      # Needed for clearing NodeNetworkUnavailable flag.
+      - patch
+      # Calico stores some configuration information in node annotations.
+      - update
+  # Watch for changes to Kubernetes NetworkPolicies.
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+  # Used by Calico for policy information.
+  - apiGroups: [""]
+    resources:
+      - pods
+      - namespaces
+      - serviceaccounts
+    verbs:
+      - list
+      - watch
+  # The CNI plugin patches pods/status.
+  - apiGroups: [""]
+    resources:
+      - pods/status
+    verbs:
+      - patch
+  # Calico monitors various CRDs for config.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - globalfelixconfigs
+      - felixconfigurations
+      - bgppeers
+      - globalbgpconfigs
+      - bgpconfigurations
+      - ippools
+      - globalnetworkpolicies
+      - globalnetworksets
+      - networkpolicies
+      - clusterinformations
+      - hostendpoints
+    verbs:
+      - get
+      - list
+      - watch
+  # Calico must create and update some CRDs on startup.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - ippools
+      - felixconfigurations
+      - clusterinformations
+    verbs:
+      - create
+      - update
+  # Calico stores some configuration information on the node.
+  - apiGroups: [""]
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  # These permissions are only requried for upgrade from v2.6, and can
+  # be removed after upgrade or on fresh installations.
+  - apiGroups: ["crd.projectcalico.org"]
+    resources:
+      - bgpconfigurations
+      - bgppeers
+    verbs:
+      - create
+      - update
 
 ---
 

--- a/charts/utils-templates/templates/_versions.tpl
+++ b/charts/utils-templates/templates/_versions.tpl
@@ -78,6 +78,10 @@ admissionregistration.k8s.io/v1beta1
 admissionregistration.k8s.io/v1alpha1
 {{- end -}}
 
+{{- define "poddisruptionbudgetversion" -}}
+policy/v1beta1
+{{- end -}}
+
 {{- define "podsecuritypolicyversion" -}}
 {{- if semverCompare ">= 1.10" .Capabilities.KubeVersion.GitVersion -}}
 policy/v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**: Update some Docker image versions.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Docker image version updates:
* `k8s.gcr.io/kube-addon-manager`: `v8.7` -> `v8.8`
* `quay.io/prometheus/alertmanager`: `v0.15.2` -> `v0.15.3`
* `quay.io/prometheus/node-exporter`: `v0.16.0` -> `v0.17.0`
* `grafana/grafana`: `5.3.0` -> `5.4.2`
* `quay.io/prometheus/blackbox-exporter`: `v0.12.0` -> `v0.13.0`
* `quay.io/calico/node`: `v3.2.3` -> `v3.4.0`
* `quay.io/calico/cni`: `v3.2.3` -> `v3.4.0`
* `quay.io/calico/typha`: `v3.2.3` -> `v3.4.0`
* `coredns/coredns`: `1.2.2` -> `1.3.0`
* `quay.io/kubernetes-ingress-controller/nginx-ingress-controller`: `0.20.0` -> `0.21.0`
```
