### PR TITLE
Added missng google-clouddns secret data to internal/default domain h…

### DIFF
--- a/charts/gardener/charts/utils-common/templates/_secret-default-domain.yaml
+++ b/charts/gardener/charts/utils-common/templates/_secret-default-domain.yaml
@@ -34,6 +34,8 @@ data:
   username:       {{ ( required ".controller.defaultDomains[].credentials.username is required" $domain.credentials.username) | b64enc }}
   userDomainName: {{ ( required ".controller.defaultDomains[].credentials.userDomainName is required" $domain.credentials.userDomainName) | b64enc }}
   password: {{ ( required ".controller.defaultDomains[].credentials.password is required" $domain.credentials.password) | b64enc }}
+{{- else if eq $domain.provider "google-clouddns" }}
+  serviceaccount.json: {{ ( required ".controller.defaultDomains[].credentials['serviceaccount.json'] is required" (index $domain.credentials "serviceaccount.json") ) | b64enc }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/gardener/charts/utils-common/templates/_secret_internal-domain.yaml
+++ b/charts/gardener/charts/utils-common/templates/_secret_internal-domain.yaml
@@ -33,6 +33,8 @@ data:
   username: {{ ( required ".controller.internalDomain.credentials.username is required" .Values.global.controller.internalDomain.credentials.username) | b64enc }}
   userDomainName: {{ ( required ".controller.internalDomain.credentials.userDomainName is required" .Values.global.controller.internalDomain.credentials.userDomainName) | b64enc }}
   password: {{ ( required ".controller.internalDomain.credentials.password is required" .Values.global.controller.internalDomain.credentials.password) | b64enc }}
+{{- else if eq .Values.global.controller.internalDomain.provider "google-clouddns" }}
+  serviceaccount.json: {{ ( required ".controller.defaultDomains[].credentials['serviceaccount.json'] is required" (index .Values.global.controller.internalDomain.credentials "serviceaccount.json") ) | b64enc }}
 {{- end }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added missing secret data for Google CloudDNS for internal/default domain handling.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
