### PR TITLE
[ci:component:github.com/gardener/autoscaler:0.2.0->0.3.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -33,7 +33,7 @@ images:
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
-  tag: "0.2.0"
+  tag: "0.3.0"
 - name: kube-addon-manager
   sourceRepository: github.com/kubernetes/kubernetes/tree/master/cluster/addons/addon-manager
   repository: k8s.gcr.io/kube-addon-manager

--- a/charts/shoot-core/charts/cluster-autoscaler/templates/clusterrole-cluster-autoscaler.yaml
+++ b/charts/shoot-core/charts/cluster-autoscaler/templates/clusterrole-cluster-autoscaler.yaml
@@ -60,7 +60,6 @@ rules:
 - apiGroups:
   - extensions
   resources:
-  - replicasets
   - daemonsets
   verbs:
   - watch
@@ -77,6 +76,7 @@ rules:
   - apps
   resources:
   - statefulsets
+  - replicasets
   verbs:
   - watch
   - list


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR upgrades the cluster auto scaler to rebase with upstream and contains bugfixes

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator github.com/gardener/autoscaler #11 @prashanth26
The autoscaler has been rebased with the upstream and now vendors 1.12
```
``` improvement user github.com/gardener/autoscaler #10 @prashanth26
Bugfix: Trying to taint more than required nodes during scale down has been fixed
```
