### PR TITLE
Add validation for shoot backup schedule

### DIFF
--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -1411,12 +1411,12 @@ const (
 	DefaultPodNetworkCIDR = CIDR("100.96.0.0/11")
 	// DefaultServiceNetworkCIDR is a constant for the default service network CIDR of a Shoot cluster.
 	DefaultServiceNetworkCIDR = CIDR("100.64.0.0/13")
-	// DefaultETCDBackupSchedule is a constant for the default schedule to take backups of a Shoot cluster (5 minutes).
+	// DefaultETCDBackupSchedule is a constant for the default schedule to take backups of a Shoot cluster.
 	DefaultETCDBackupSchedule = "0 */24 * * *"
 	// DefaultETCDBackupMaximum is a constant for the default number of etcd backups to keep for a Shoot cluster.
 	DefaultETCDBackupMaximum = 7
-	// MinimumETCDFullBackupTimeInterval is the time interval between consecutive full backups.
-	MinimumETCDFullBackupTimeInterval = 24 * time.Hour
+	// MinimumETCDFullBackupTimeInterval is the minimum time interval between consecutive full backups.
+	MinimumETCDFullBackupTimeInterval = 1 * time.Hour
 )
 
 ////////////////////////

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -1456,11 +1456,11 @@ const (
 	DefaultPodNetworkCIDR = CIDR("100.96.0.0/11")
 	// DefaultServiceNetworkCIDR is a constant for the default service network CIDR of a Shoot cluster.
 	DefaultServiceNetworkCIDR = CIDR("100.64.0.0/13")
-	// DefaultETCDBackupSchedule is a constant for the default schedule to take backups of a Shoot cluster (5 minutes).
+	// DefaultETCDBackupSchedule is a constant for the default schedule to take backups of a Shoot cluster.
 	DefaultETCDBackupSchedule = "0 */24 * * *"
 	// DefaultETCDBackupMaximum is a constant for the default number of etcd backups to keep for a Shoot cluster.
 	DefaultETCDBackupMaximum = 7
-	// MinimumETCDFullBackupTimeInterval is the time interval between consecutive full backups.
+	// MinimumETCDFullBackupTimeInterval is the minimum time interval between consecutive full backups.
 	MinimumETCDFullBackupTimeInterval = 24 * time.Hour
 )
 

--- a/pkg/controller/shoot/shoot.go
+++ b/pkg/controller/shoot/shoot.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/pkg/apis/componentconfig"
-	garden "github.com/gardener/gardener/pkg/apis/garden"
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/externalversions"
 	gardenlisters "github.com/gardener/gardener/pkg/client/garden/listers/garden/v1beta1"
@@ -225,24 +224,6 @@ func (c *Controller) Run(ctx context.Context, shootWorkers, shootCareWorkers, sh
 			needsSpecUpdate   = false
 			needsStatusUpdate = false
 		)
-
-		// Check if the backup defaults are valid. If not, update the shoots with the default backup schedule.
-		schedule, err := cron.ParseStandard(shoot.Spec.Backup.Schedule)
-		if err != nil {
-			logger.Logger.Errorf("Failed to parse the schedule for shoot [%v]: %v ", shoot.ObjectMeta.Name, err.Error())
-			return
-		}
-
-		var (
-			nextScheduleTime              = schedule.Next(time.Now())
-			scheduleTimeAfterNextSchedule = schedule.Next(nextScheduleTime)
-			granularity                   = scheduleTimeAfterNextSchedule.Sub(nextScheduleTime)
-		)
-
-		if shoot.DeletionTimestamp == nil && granularity < garden.MinimumETCDFullBackupTimeInterval {
-			newShoot.Spec.Backup.Schedule = garden.DefaultETCDBackupSchedule
-			needsSpecUpdate = true
-		}
 
 		// Check if the status indicates that an operation is processing and mark it as "aborted".
 		if shoot.Status.LastOperation != nil && shoot.Status.LastOperation.State == gardenv1beta1.ShootLastOperationStateProcessing {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, gardener overrides the backup schedule value if it is less than the minimum (daily), this leads to issues for users who later find the value they set changed. Furthermore, an optimum value for backups would be to set the minimum to once / hour. 

cc @swapnilgm 

**Which issue(s) this PR fixes**:
Fixes #550 

**Release note**:

```improvement operator
Added validation for shoot backup schedules. 
```
