### PR TITLE
Add Kibana dashboard

### DIFF
--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-deployment.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-deployment.yaml
@@ -16,7 +16,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/kibana-index-registration-config: {{ include (print $.Template.BasePath "/kibana/kibana-index-registration-config.yaml") . | sha256sum }}
+        checksum/kibana-objects-registration-config: {{ include (print $.Template.BasePath "/kibana/kibana-objects-registration-config.yaml") . | sha256sum }}
+        checksum/kibana-saved-objects-config: {{ include (print $.Template.BasePath "/kibana/kibana-saved-objects-config.yaml") . | sha256sum }}
       labels:
         garden.sapcloud.io/role: logging
         app: kibana-logging
@@ -41,13 +42,15 @@ spec:
           name: ui
           protocol: TCP
       - image: {{ index .Values.global.images "kibana-oss" }}
-        name: auto-register-index
+        name: auto-create-objects
         command:
         - /bin/sh
-        - /gardener/register
+        - /gardener/register/register
         volumeMounts:
         - name: register
-          mountPath: /gardener
+          mountPath: /gardener/register
+        - name: saved-objects
+          mountPath: /gardener/saved-objects
         resources:
           limits:
             cpu: 10m
@@ -58,4 +61,7 @@ spec:
       volumes:
       - name: register
         configMap:
-          name: kibana-index-registration
+          name: kibana-object-registration
+      - name: saved-objects
+        configMap:
+          name: kibana-saved-objects

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-objects-registration-config.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-objects-registration-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kibana-index-registration
+  name: kibana-object-registration
   namespace: {{ .Release.Namespace }}
   labels:
     app: kibana
@@ -12,10 +12,15 @@ data:
 
     KIBANA_HOST=http://127.0.0.1:{{ .Values.kibanaPort }}
 
-    until curl -sS $KIBANA_HOST/ > /dev/null; do
+    until curl -sS ${KIBANA_HOST}/ > /dev/null; do
       echo "Waiting for Kibana..."
       sleep 2
     done;
+
+    function get_http_status {
+      HTTP_RESPONSE="$1"
+      echo ${HTTP_RESPONSE} | tr -d '\n' | sed -e 's/.*HTTPSTATUS://'
+    }
 
     function create_index_pattern {
       while true
@@ -25,16 +30,16 @@ data:
             -H "Content-Type: application/json" \
             -H "kbn-xsrf: true" \
             --write-out "HTTPSTATUS:%{http_code}" \
-            -X POST $KIBANA_HOST/api/saved_objects/index-pattern/logstash-*?overwrite=true \
-            -d '{"attributes": {"title": "logstash-*", "timeFieldName": "@timestamp"}}')
+            -X POST ${KIBANA_HOST}/api/saved_objects/index-pattern/logstash-*?overwrite=true \
+            -d '@/gardener/saved-objects/index-pattern.json')
 
-          HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
-          HTTP_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
+          HTTP_STATUS=$(get_http_status "${HTTP_RESPONSE}")
+          HTTP_BODY=$(echo ${HTTP_RESPONSE} | sed -e 's/HTTPSTATUS\:.*//g')
 
           echo -e "Response status code: ${HTTP_STATUS}"
           echo -e "Response body: ${HTTP_BODY}"
 
-          if [ $HTTP_STATUS -eq 200 ]; then
+          if [ ${HTTP_STATUS} -eq 200 ]; then
               echo "Successfully created index pattern logstash-*."
 
               break
@@ -51,16 +56,33 @@ data:
         -H "Content-Type: application/json" \
         -H "kbn-xsrf: true" \
         --write-out "HTTPSTATUS:%{http_code}" \
-        -X POST $KIBANA_HOST/api/kibana/settings/defaultIndex \
+        -X POST ${KIBANA_HOST}/api/kibana/settings/defaultIndex \
         -d '{"value": "logstash-*"}')
 
-        HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+        HTTP_STATUS=$(get_http_status "${HTTP_RESPONSE}")
 
-        if [ $HTTP_STATUS -eq 200 ]; then
+        if [ ${HTTP_STATUS} -eq 200 ]; then
           echo "Successfully set logstash-* as default index pattern."
         else
           echo "Setting logstash-* as default index pattern failed with ${HTTP_STATUS}."
         fi
+    }
+
+    function create_dashboard {
+      HTTP_RESPONSE=$(curl --silent \
+         -H "Content-Type: application/json" \
+         -H "kbn-xsrf: true" \
+         --write-out "HTTPSTATUS:%{http_code}" \
+         -X POST ${KIBANA_HOST}/api/kibana/dashboards/import \
+         -d '@/gardener/saved-objects/dashboard.json')
+
+         HTTP_STATUS=$(get_http_status "${HTTP_RESPONSE}")
+
+         if [ ${HTTP_STATUS} -eq 200 ]; then
+           echo "Successfully created Kibana dashboard"
+         else
+           echo "Creating Kibana dashboard failed with status ${HTTP_STATUS}."
+         fi
     }
 
     echo "Trying to create the logstash index pattern."
@@ -68,6 +90,9 @@ data:
 
     echo "Trying to set the newly created index pattern as default."
     set_index_pattern_as_default
+
+    echo "Trying to create Kibana dashboard."
+    create_dashboard
 
     echo "Sleeping..."
     # Sleep forever

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-saved-objects-config.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-saved-objects-config.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kibana-saved-objects
+  namespace: {{ .Release.Namespace }}
+data:
+  index-pattern.json: |
+    {
+      "attributes": {
+        "title": "logstash-*",
+        "timeFieldName": "@timestamp"
+      }
+    }
+  dashboard.json: |
+    {
+      "objects": [
+        {
+          "id": "4cee8380-1264-11e9-9e23-f947fd5c80a2",
+          "type": "dashboard",
+          "attributes": {
+            "title": "Pod Logs",
+            "panelsJSON": "[{\"embeddableConfig\":{},\"gridData\":{\"x\":8,\"y\":0,\"w\":11,\"h\":19,\"i\":\"1\"},\"id\":\"f4b2b6d0-1274-11e9-b691-d5e6ef2b76df\",\"panelIndex\":\"1\",\"title\":\"Pod Names\",\"type\":\"visualization\",\"version\":\"6.5.4\"},{\"embeddableConfig\":{},\"gridData\":{\"x\":19,\"y\":0,\"w\":29,\"h\":19,\"i\":\"2\"},\"id\":\"78275cf0-1275-11e9-b691-d5e6ef2b76df\",\"panelIndex\":\"2\",\"type\":\"visualization\",\"version\":\"6.5.4\",\"title\":\"Histogram\"},{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":19,\"w\":48,\"h\":19,\"i\":\"3\"},\"id\":\"efc70290-1263-11e9-9e23-f947fd5c80a2\",\"panelIndex\":\"3\",\"type\":\"search\",\"version\":\"6.5.4\",\"title\":\"Log results\"},{\"embeddableConfig\":{},\"gridData\":{\"x\":0,\"y\":0,\"w\":8,\"h\":19,\"i\":\"4\"},\"id\":\"0d69e840-127c-11e9-b691-d5e6ef2b76df\",\"panelIndex\":\"4\",\"type\":\"visualization\",\"version\":\"6.5.4\",\"title\":\"Namespaces\"}]",
+            "optionsJSON": "{\"darkTheme\":false,\"hidePanelTitles\":false,\"useMargins\":true}",
+            "timeRestore": false,
+            "kibanaSavedObjectMeta": {
+              "searchSourceJSON": "{\"query\":{\"language\":\"lucene\",\"query\":\"\"},\"filter\":[]}"
+            }
+          }
+        },
+        {
+          "id": "0d69e840-127c-11e9-b691-d5e6ef2b76df",
+          "type": "visualization",
+          "attributes": {
+            "title": "Namespaces",
+            "visState": "{\"title\":\"Namespaces\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMetricsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":true,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"#Logs\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"kubernetes.namespace_name.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":true,\"missingBucketLabel\":\"Missing\",\"customLabel\":\"Namespaces\"}}]}",
+            "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
+            "kibanaSavedObjectMeta": {
+              "searchSourceJSON": "{\"index\":\"logstash-*\",\"query\":{\"query\":\"\",\"language\":\"lucene\"},\"filter\":[]}"
+            }
+          }
+        },
+        {
+          "id": "f4b2b6d0-1274-11e9-b691-d5e6ef2b76df",
+          "type": "visualization",
+          "attributes": {
+            "title": "Pod table",
+            "visState": "{\"title\":\"Pod table\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMetricsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":true,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"#Logs\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"kubernetes.pod_name.keyword\",\"size\":8,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":true,\"missingBucketLabel\":\"Missing\",\"customLabel\":\"Pods\"}}]}",
+            "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
+            "kibanaSavedObjectMeta": {
+              "searchSourceJSON": "{\"index\":\"logstash-*\",\"query\":{\"query\":\"\",\"language\":\"lucene\"},\"filter\":[]}"
+            }
+          }
+        },
+        {
+          "id": "78275cf0-1275-11e9-b691-d5e6ef2b76df",
+          "type": "visualization",
+          "attributes": {
+            "title": "Log histogram",
+            "visState": "{\"title\":\"Log histogram\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false,\"style\":{\"color\":\"#eee\"}},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"timeRange\":{\"from\":\"now-15m\",\"to\":\"now\",\"mode\":\"quick\"},\"useNormalizedEsInterval\":true,\"interval\":\"auto\",\"time_zone\":\"Europe/Berlin\",\"drop_partials\":false,\"customInterval\":\"2h\",\"min_doc_count\":1,\"extended_bounds\":{}}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"kubernetes.pod_name.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}",
+            "kibanaSavedObjectMeta": {
+              "searchSourceJSON": "{\"index\":\"logstash-*\",\"query\":{\"query\":\"\",\"language\":\"lucene\"},\"filter\":[]}"
+            }
+          }
+        },
+        {
+          "id": "efc70290-1263-11e9-9e23-f947fd5c80a2",
+          "type": "search",
+          "attributes": {
+            "title": "Search",
+            "columns": [
+              "kubernetes.pod_name",
+              "kubernetes.container_name",
+              "log"
+            ],
+            "sort": [
+              "@timestamp",
+              "desc"
+            ],
+            "kibanaSavedObjectMeta": {
+              "searchSourceJSON": "{\n  \"index\": \"logstash-*\",\n  \"highlightAll\": true,\n  \"version\": true,\n  \"query\": {\n    \"language\": \"lucene\",\n    \"query\": \"\"\n  },\n  \"filter\": []\n}"
+            }
+          }
+        },
+        {
+          "id": "9bdd26b0-127b-11e9-b691-d5e6ef2b76df",
+          "type": "visualization",
+          "attributes": {
+            "title": "log_msgs",
+            "visState": "{\"title\":\"log_msgs\",\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMetricsAtAllLevels\":false,\"sort\":{\"columnIndex\":null,\"direction\":null},\"showTotal\":true,\"totalFunc\":\"sum\"},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"customLabel\":\"#Logs\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"log.keyword\",\"size\":8,\"order\":\"desc\",\"orderBy\":\"1\",\"otherBucket\":true,\"otherBucketLabel\":\"- other log msgs -\",\"missingBucket\":true,\"missingBucketLabel\":\"- no log msg -\",\"customLabel\":\"Log msg\"}}]}",
+            "uiStateJSON": "{\"vis\":{\"params\":{\"sort\":{\"columnIndex\":null,\"direction\":null}}}}",
+            "kibanaSavedObjectMeta": {
+              "searchSourceJSON": "{\"index\":\"logstash-*\",\"query\":{\"query\":\"\",\"language\":\"lucene\"},\"filter\":[]}"
+            }
+          }
+        }
+      ]
+    }

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -431,7 +431,7 @@ func DeleteLoggingStack(k8sClient kubernetes.Interface, namespace string) error 
 
 	var (
 		services     = []string{"kibana-logging", "elasticsearch-logging", "fluentd-es"}
-		configmaps   = []string{"kibana-index-registration", "curator-hourly-config", "curator-daily-config", "fluent-bit-config", "fluentd-es-config"}
+		configmaps   = []string{"kibana-object-registration", "kibana-saved-objects", "curator-hourly-config", "curator-daily-config", "fluent-bit-config", "fluentd-es-config"}
 		statefulsets = []string{"elasticsearch-logging", "fluentd-es"}
 		cronjobs     = []string{"hourly-curator", "daily-curator"}
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
Creating Kibana dashboard automatically when Kibana is deployed.

*The dashboard on my test cluster looks like this*: 
<img width="1773" alt="screen shot 2019-01-09 at 9 42 33" src="https://user-images.githubusercontent.com/16671526/50889069-ba9dc200-13ff-11e9-87f8-39b90e82b135.png">


/cc @ialidzhikov @vlvasilev @dguendisch 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
