### PR TITLE
Set the delta snapshot memory limit to 100MB

### DIFF
--- a/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
@@ -117,6 +117,7 @@ spec:
         - --endpoints=https://etcd-{{ .Values.role }}-0:2379
         - --etcd-connection-timeout=300
         - --delta-snapshot-period-seconds=300
+        - --delta-snapshot-memory-limit=104857600 #100MB
         - --garbage-collection-period-seconds=43200
         - --snapstore-temp-directory=/var/etcd/data/temp
         image: {{ index .Values.images "etcd-backup-restore" }}


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
With etcd-backup-restore version 0.4.1 we introduced parameter `delta-snapshot-memory-limit` to trigger delta snapshot before schedule in case of this memory limit is crossed. Default value is 10MB, But since for seed clusters average observed value of delta snapshot ~45MB, and to be on safer side, this PR set it to 100MB
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
