### PR TITLE
Update etcd-backup-restore image to 0.4.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -22,7 +22,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.4.0"
+  tag: "0.4.1"
 - name: hyperkube
   sourceRepository: github.com/kubernetes/kubernetes
   repository: k8s.gcr.io/hyperkube

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
@@ -117,6 +117,7 @@ spec:
         - --endpoints=https://etcd-{{ .Values.role }}-0:2379
         - --etcd-connection-timeout=300
         - --delta-snapshot-period-seconds=300
+        - --delta-snapshot-memory-limit=104857600 #100MB
         - --garbage-collection-period-seconds=43200
         - --snapstore-temp-directory=/var/etcd/data/temp
         image: {{ index .Values.images "etcd-backup-restore" }}


### PR DESCRIPTION
**What this PR does / why we need it**:
It introduces the fixes in etcd-backup-restore. With etcd-backup-restore version 0.4.1 we introduced parameter delta-snapshot-memory-limit to trigger delta snapshot before schedule in case of this memory limit is crossed. Default value is 10MB, But since for seed clusters average observed value of delta snapshot ~45MB, and to be on safer side, this PR set it to 100MB

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
``` improvement operator github.com/gardener/etcd-backup-restore #84 @swapnilgm
Added configurable flag `delta-snapshot-memory-limit` to restrict memory consumption due to periodic delta snapshots.
```
``` improvement operator github.com/gardener/etcd-backup-restore #80 @georgekuruvillak 
Fixed the authentication call for swift to retry authentication on token expiration by setting `AllowReauth` flag for swift authentication call to `true`.
```