### PR TITLE
Add readinessProbe for kibana

### DIFF
--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-deployment.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-deployment.yaml
@@ -12,7 +12,7 @@ spec:
     matchLabels:
       app: kibana-logging
       role: logging
-  replicas: {{ .Values.kibanaReplicas }}
+  replicas: {{ .Values.kibana.replicaCount }}
   template:
     metadata:
       annotations:
@@ -38,9 +38,20 @@ spec:
         - name: ELASTICSEARCH_URL
           value: http://elasticsearch-logging:{{ .Values.global.elasticsearchPorts.db }}
         ports:
-        - containerPort: {{ .Values.kibanaPort }}
+        - containerPort: {{ .Values.kibana.service.internalPort }}
           name: ui
           protocol: TCP
+{{- if .Values.kibana.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /api/status
+            port: {{ .Values.kibana.service.internalPort }}
+          initialDelaySeconds: {{ .Values.kibana.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.kibana.readinessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.kibana.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.kibana.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.kibana.readinessProbe.failureThreshold }}
+{{- end }}
       - image: {{ index .Values.global.images "kibana-oss" }}
         name: auto-create-objects
         command:

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-ingress.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-ingress.yaml
@@ -19,5 +19,5 @@ spec:
       paths:
       - backend:
           serviceName: kibana-logging
-          servicePort: {{ .Values.kibanaPort }}
+          servicePort: {{ .Values.kibana.service.internalPort }}
         path: /

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-objects-registration-config.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-objects-registration-config.yaml
@@ -10,7 +10,7 @@ data:
   register: |-
     #/bin/sh
 
-    KIBANA_HOST=http://127.0.0.1:{{ .Values.kibanaPort }}
+    KIBANA_HOST=http://127.0.0.1:{{ .Values.kibana.service.internalPort }}
 
     until curl -sS ${KIBANA_HOST}/ > /dev/null; do
       echo "Waiting for Kibana..."

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-service.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/kibana/kibana-service.yaml
@@ -8,7 +8,7 @@ metadata:
     role: logging
 spec:
   ports:
-  - port: {{ .Values.kibanaPort }}
+  - port: {{ .Values.kibana.service.internalPort }}
     protocol: TCP
     targetPort: ui
   selector:

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/values.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/values.yaml
@@ -7,16 +7,12 @@ global:
   elasticsearchPorts:
     db: 9200
     transport: 9300
-kibanaPort: 5601
 
 ingress:
   enabled: true
   host: k.seed-1.example.com
   # admin : admin base64 encoded
   basicAuthSecret: YWRtaW46JGFwcjEkSWRSaVM5c3MkR3U1MHMxaGUwL2Z6Tzh2elE4S1BEMQ==
-
-
-kibanaReplicas: 1
 
 curator:
   objectCount: 1
@@ -51,3 +47,15 @@ elasticsearch:
         perObject: 89
         weight: 5
         unit: Mi
+
+kibana:
+  replicaCount: 1
+  service:
+    internalPort: 5601
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    failureThreshold: 10

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -73,8 +73,6 @@ global:
 
 elastic-kibana-curator:
   enabled: true
-  kibanaReplicas: 1
-  kibanaPort: 5601
   curator:
     objectCount: 1
   elasticsearch:

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -17,6 +17,7 @@ package seed
 import (
 	"fmt"
 	"path/filepath"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/apis/garden"
@@ -323,7 +324,9 @@ func BootstrapCluster(seed *Seed, secrets map[string]*corev1.Secret, imageVector
 				"basicAuthSecret": basicAuth,
 				"host":            kibanaHost,
 			},
-			"kibanaReplicas": replicas,
+			"kibana": map[string]interface{}{
+				"replicaCount": replicas,
+			},
 			"curator": map[string]interface{}{
 				"objectCount":       nodeCount,
 				"baseDiskThreshold": 2 * 1073741824,


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `readinessProbe` for kibana. Fixes the cases when kibana container is started, a traffic is routed to the container but kibana application is still starting (and is unable to server requests - around 5-10 seconds). 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
