### PR TITLE
Add NoExists and NoSchedule tolerations to system components

### DIFF
--- a/charts/shoot-core/charts/coredns/templates/coredns-deployment.yaml
+++ b/charts/shoot-core/charts/coredns/templates/coredns-deployment.yaml
@@ -30,8 +30,8 @@ spec:
         runAsUser: 65534
       serviceAccountName: coredns
       tolerations:
-      - key: "CriticalAddonsOnly"
-        operator: "Exists"
+      - key: CriticalAddonsOnly
+        operator: Exists
       containers:
       - name: coredns
         image: {{ index .Values.images "coredns" }}

--- a/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -32,7 +32,11 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       tolerations:
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
         operator: Exists
       hostNetwork: true
       serviceAccountName: kube-proxy

--- a/charts/shoot-core/charts/metrics-server/templates/deployment.yaml
+++ b/charts/shoot-core/charts/metrics-server/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
       priorityClassName: system-cluster-critical
       securityContext:
         runAsUser: 65534

--- a/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -51,7 +51,11 @@ spec:
         component: node-exporter
     spec:
       tolerations:
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
         operator: Exists
       hostNetwork: true
       hostPID: true

--- a/charts/shoot-core/charts/vpn-shoot/templates/deployment.yaml
+++ b/charts/shoot-core/charts/vpn-shoot/templates/deployment.yaml
@@ -29,13 +29,10 @@ spec:
         garden.sapcloud.io/role: system-component
         app: vpn-shoot
     spec:
-      # not used
       automountServiceAccountToken: false
       serviceAccountName: vpn-shoot
       priorityClassName: system-cluster-critical
       tolerations:
-      - effect: NoExecute
-        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
       containers:


### PR DESCRIPTION
**What this PR does / why we need it**: Add missing tolerations to system components deployed by Gardener.

**Which issue(s) this PR fixes**:
Fixes #656 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
All system components deployed by Gardener do now tolerate the `NoSchedule`, `CriticalAddonsOnly`, and `NoExecute` taints on nodes.
```
