### PR TITLE
Add separated parsers for logs

### DIFF
--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
@@ -15,7 +15,6 @@ data:
 
     @INCLUDE input-kubernetes.conf
     @INCLUDE input-systemd.conf
-    @INCLUDE input-kernel.conf
     @INCLUDE filter-kubernetes.conf
     @INCLUDE output-fluentd.conf
 
@@ -62,10 +61,202 @@ data:
         K8S-Logging.Parser  On
         tls.verify          Off
 
-  input-kernel.conf: |
-    [INPUT]
-        Name            kmsg
-        Tag             kernel
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.kube-apiserver*kube-apiserver*
+        Key_Name            log
+        Parser              kubeapiserverParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.kube-controller-manager*kube-controller-manager*
+        Key_Name            log
+        Parser              kubeapiserverParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.cloud-controller-manager*cloud-controller-manager*
+        Key_Name            log
+        Parser              kubeapiserverParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.kube-scheduler*cloud-kube-scheduler*
+        Key_Name            log
+        Parser              kubeapiserverParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.etcd*etcd*
+        Key_Name            log
+        Parser              etcdeventsParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.etcd*backup-restore*
+        Key_Name            log
+        Parser              geacParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.kube-scheduler*kube-scheduler*
+        Key_Name            log
+        Parser              kubeapiserverParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.kube-proxy*kube-proxy*
+        Key_Name            log
+        Parser              kubeapiserverParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.cluster-autoscaler*cluster-autoscaler*
+        Key_Name            log
+        Parser              kubeapiserverParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.calico-node*calico-node*
+        Key_Name            log
+        Parser              caliconodeParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.alertmanager*alertmanager*
+        Key_Name            log
+        Parser              alermanagerParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.elasticsearch*elasticsearch*
+        Key_Name            log
+        Parser              elasticsearchParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.addons-nginx-ingress-controller*nginx-ingress-controller*
+        Key_Name            log
+        Parser              kubeapiserverParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.metrics-server*metrics-server*
+        Key_Name            log
+        Parser              kubeapiserverParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.kube-state-metrics*kube-state-metrics*
+        Key_Name            log
+        Parser              kubeapiserverParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.machine-controller-manager*machine-controller-manager*
+        Key_Name            log
+        Parser              kubeapiserverParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.vpn-shoot*vpn-shoot*
+        Key_Name            log
+        Parser              vpnshootParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.addons-kubernetes-dashboard*kubernetes-dashboard*
+        Key_Name            log
+        Parser              kubernetesdashboardParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.coredns*coredns*
+        Key_Name            log
+        Parser              corednsParser 
+        Parser              kubeapiserverParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.node-exporter*node-exporter*
+        Key_Name            log
+        Parser              nodeexporterParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.*curator*
+        Key_Name            log
+        Parser              curatorParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.gardener-external-admission-controller*gardener-external-admission-controller*
+        Key_Name            log
+        Parser              geacParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.prometheus*prometheus*
+        Key_Name            log
+        Parser              alermanagerParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.*lb-readvertiser*lb-readvertiser*
+        Key_Name            log
+        Parser              geacParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.daily-curator*curator*
+        Key_Name            log
+        Parser              curatorParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.grafana*grafana*
+        Key_Name            log
+        Parser              grafanaParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name                parser
+        Match               kubernetes.var.log.containers.kube-addon-manager*kube-addon-manager*
+        Key_Name            log
+        Parser              addonmanagerSeverityParser
+        Parser.             addonmanagerParser
+        Reserve_Data        True
+
+    [FILTER]
+        Name    lua
+        Match   *
+        script  modify_severity.lua
+        call    cb_modify
 
   output-fluentd.conf: |
     [OUTPUT]
@@ -92,3 +283,128 @@ data:
         Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
         Time_Key    time
         Time_Format %b %d %H:%M:%S
+
+    [PARSER]
+        Name        kubeapiserverParser
+        Format      regex
+        Regex       ^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<log>.*)$
+        Time_Key    time
+        Time_Format %m%d %H:%M:%S.%L
+
+    [PARSER]
+        Name        etcdeventsParser
+        Format      regex
+        Regex       ^(?<time>\d{4}-\d{2}-\d{2}\s+[^ ]*)\s+(?<severity>\w+)\s+\|\s+(?<source>[^ :]*):\s+(?<log>.*)
+        Time_Key    time
+        Time_Format %Y-%m-%d %H:%M:%S.%L
+
+
+    [PARSER]
+        Name        caliconodeParser
+        Format      regex
+        Regex       ^(?<time>\d{4}-\d{2}-\d{2}\s+[^ ]*)\s+\[(?<severity>\w*)\]\[(?<pid>\d+)\]\s+(?<source>[^:]*):\s+(?<log>.*)
+        Time_Key    time
+        Time_Format %Y-%m-%d %H:%M:%S.%L
+
+    [PARSER]
+        Name        alermanagerParser
+        Format      regex
+        Regex       ^level=(?<severity>\w+)\s+ts=(?<time>\d{4}-\d{2}-\d{2}[Tt].*[zZ])\s+caller=(?<source>[^\s]*+)\s+(?<log>.*)
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L
+
+    [PARSER]
+        Name        elasticsearchParser
+        Format      regex
+        Regex       ^\[(?<time>.*?)\]\[(?<severity>[^\s]*)\s+\]\[(?<source>.*?)\].*?\]\s+(?<log>.*)
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L
+
+    [PARSER]
+        Name        vpnshootParser
+        Format      regex
+        Regex       ^(?<time>[^0-9]*\d{1,2}\s+[^\s]+\s+\d{4})\s+(?<log>.*)
+        Time_Key    time
+        Time_Format %a %b%t%d %H:%M:%S %Y
+
+    [PARSER]
+        Name        kubernetesdashboardParser
+        Format      regex
+        Regex       ^(?<time>\d{4}\/\d{2}\/\d{2}\s+[^\s]*)\s+(?<log>.*)
+        Time_Key    time
+        Time_Format %Y/%m/%d %H:%M:%S
+
+    [PARSER]
+        Name        corednsParser
+        Format      regex
+        Regex       ^(?<time>\d{4}-\d{2}-\d{2}[Tt].*[zZ])\s+\[(?<severity>\w*[^\]])\]\s+(?<log>.*)
+        Time_Key    time
+        Time_Format  %Y-%m-%dT%H:%M:%S.%L
+
+    [PARSER]
+        Name        nodeexporterParser
+        Format      regex
+        Regex       ^time="(?<time>\d{4}-\d{2}-\d{2}T[^"]*)"\s+level=(?<severity>\w+)\smsg="(?<log>.*)"\s+source="(?<source>.*)"
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L
+
+    [PARSER]
+        Name        curatorParser
+        Format      regex
+        Regex       ^(?<time>\d{4}-\d{2}-\d{2}\s+[^\s]+)\s+(?<severity>\w+)\s+(?<log>.*)
+        Time_Key    time
+        Time_Format %Y-%m-%d %H:%M:%S.%L
+
+    [PARSER]
+        Name        geacParser
+        Format      regex
+        Regex       ^time="(?<time>\d{4}-\d{2}-\d{2}T[^"]*)"\s+level=(?<severity>\w+)\smsg="(?<log>.*)"
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L
+
+    [PARSER]
+        Name        grafanaParser
+        Format      regex
+        Regex       ^t=(?<time>\d{4}-\d{2}-\d{2}T[^ ]*)\s+lvl=(?<severity>\w+)\smsg="(?<log>.*)"\s+logger=(?<source>.*)
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S%z
+
+    [PARSER]
+        Name        addonmanagerSeverityParser
+        Format      regex
+        Regex       ^(?<severity>.[^:]*):\s==\s(?<log>.*)
+
+    [PARSER]
+        Name        addonmanagerParser
+        Format      regex
+        Regex       ^(?<log>.*)
+
+  modify_severity.lua: |-
+    function cb_modify(tag, timestamp, record)
+
+        local modified = false
+
+        for key, val in pairs(record) do
+          if key == "severity" then 
+            if val:upper() == "I" or val:upper() == "INFO" then
+                record[key] = "INF"
+                modified = true
+            elseif val:upper() == "W" or val:upper() == "WARN" or val:upper() == "WARNING" then
+                record[key] = "WARN"
+                modified = true
+            elseif val:upper() == "E" or val:upper() == "ERR" or val:upper() == "ERROR" then
+                record[key] = "ERR"
+                modified = true
+            elseif val:upper() == "D" or val:upper() == "DBG" or val:upper() == "DEBUG" then
+                record[key] = "DBG"
+                modified = true
+            end
+          end
+        end
+   
+        if modified then
+            return 1, timestamp, record
+        end
+
+        return 0, 0, 0
+    end


### PR DESCRIPTION
**What this PR does / why we need it**:
Add separated parsers for logs which will extract additional field from the log message (pid, source, severity) and will make the log message more human-readable.

***Before***
```
{
  "_index": "logstash-2019.01.16",
  "_type": "fluentd",
  "_id": "NWFmMTY3NDYtZmU2Mi00YTYxLWIwNjQtNWJjZWVlODY0OWUx",
  "_version": 1,
  "_score": null,
  "_source": {
    "log": "2019-01-16 16:09:59.826 [INFO][66] health.go 150: Overall health summary=u0026health.HealthReport{Live:true, Ready:true}\n",
    "stream": "stdout",
    "kubernetes": {
      "pod_name": "calico-node-ht6nh",
      "namespace_name": "kube-system",
      "pod_id": "97208bcb-15f9-11e9-bb8c-4632b18c254a",
      "labels": {
        "controller-revision-hash": "2336478513",
        "garden.sapcloud.io/role": "system-component",
        "k8s-app": "calico-node",
        "origin": "gardener",
        "pod-template-generation": "22"
      },
      "annotations": {
        "checksum/configmap-calico": "360219df8f4ae0c5559bcbb8591d3c26ac8ad2815af23c29cc1bf7519a6f05aa",
        "kubernetes.io/psp": "gardener.privileged",
        "scheduler.alpha.kubernetes.io/critical-pod": ""
      },
      "host": "ip-10-242-14-58.eu-west-1.compute.internal",
      "container_name": "calico-node",
      "docker_id": "e4408a87f78724eacdc3f8361849644b6e85911c642e0da178cca1e16b34eaaf"
    },
    "@timestamp": "2019-01-16T16:09:59.826573004+00:00"
  },
  "fields": {
    "@timestamp": [
      "2019-01-16T16:09:59.826Z"
    ]
  },
  "highlight": {
    "kubernetes.pod_name": [
      "@kibana-highlighted-field@calico@/kibana-highlighted-field@-node-ht6nh"
    ]
  },
  "sort": [
    1547654999826
  ]
}
```

***NOW***
```
{
  "_index": "logstash-2019.01.16",
  "_type": "fluentd",
  "_id": "YmFhOGI2YmEtYzU2ZS00ODJiLWE3ODQtZDMyZjJjOWQwOTc3",
  "_version": 1,
  "_score": null,
  "_source": {
    "kubernetes": {
      "pod_name": "calico-node-z54s9",
      "pod_id": "c4ac4458-17e1-11e9-870f-0a114344f55b",
      "docker_id": "456469afbbde518be83dc2bb80daeba2008cc1335a27a3948bdf59914759742b",
      "labels": {
        "k8s-app": "calico-node",
        "garden.sapcloud.io/role": "system-component",
        "controller-revision-hash": "6454b5bffb",
        "pod-template-generation": "1",
        "origin": "gardener"
      },
      "container_name": "calico-node",
      "host": "ip-10-222-15-12.eu-west-1.compute.internal",
      "annotations": {
        "checksum/configmap-calico": "360219df8f4ae0c5559bcbb8591d3c26ac8ad2815af23c29cc1bf7519a6f05aa",
        "kubernetes.io/psp": "gardener.privileged",
        "scheduler.alpha.kubernetes.io/critical-pod": ""
      },
      "namespace_name": "kube-system"
    },
    "source": "int_dataplane.go 765",
    "log": "Finished applying updates to dataplane. msecToApply=1.325953",
    "severity": "INF",
    "stream": "stdout",
    "pid": "58",
    "@timestamp": "2019-01-16T16:06:00.543688505+00:00"
  },
  "fields": {
    "@timestamp": [
      "2019-01-16T16:06:00.543Z"
    ]
  },
  "highlight": {
    "kubernetes.namespace_name": [
      "@kibana-highlighted-field@kube@/kibana-highlighted-field@-system"
    ]
  },
  "sort": [
    1547654760543
  ]
}
```

/cc @ialidzhikov @vlvasilev

**Which issue(s) this PR fixes**:
Fixes #
**Special notes for your reviewer**:

@ialidzhikov @vlvasilev @dguendisch

**Release note**:
```
NONE
```

