### PR TITLE
Add validation for Shoot backup cron specs

### DIFF
--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -1410,12 +1410,12 @@ const (
 	DefaultPodNetworkCIDR = CIDR("100.96.0.0/11")
 	// DefaultServiceNetworkCIDR is a constant for the default service network CIDR of a Shoot cluster.
 	DefaultServiceNetworkCIDR = CIDR("100.64.0.0/13")
-	// DefaultETCDBackupSchedule is a constant for the default schedule to take backups of a Shoot cluster (5 minutes).
+	// DefaultETCDBackupSchedule is a constant for the default schedule to take backups of a Shoot cluster (24 hours).
 	DefaultETCDBackupSchedule = "0 */24 * * *"
 	// DefaultETCDBackupMaximum is a constant for the default number of etcd backups to keep for a Shoot cluster.
 	DefaultETCDBackupMaximum = 7
 	// MinimumETCDFullBackupTimeInterval is the time interval between consecutive full backups.
-	MinimumETCDFullBackupTimeInterval = 24 * time.Hour
+	MinimumETCDFullBackupTimeInterval = 1 * time.Hour
 )
 
 ////////////////////////

--- a/pkg/controller/shoot/shoot.go
+++ b/pkg/controller/shoot/shoot.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/pkg/apis/componentconfig"
-	garden "github.com/gardener/gardener/pkg/apis/garden"
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/externalversions"
 	gardenlisters "github.com/gardener/gardener/pkg/client/garden/listers/garden/v1beta1"
@@ -220,43 +219,11 @@ func (c *Controller) Run(ctx context.Context, shootWorkers, shootCareWorkers, sh
 		return
 	}
 	for _, shoot := range shoots {
-		var (
-			newShoot          = shoot.DeepCopy()
-			needsSpecUpdate   = false
-			needsStatusUpdate = false
-		)
-
-		// Check if the backup defaults are valid. If not, update the shoots with the default backup schedule.
-		schedule, err := cron.ParseStandard(shoot.Spec.Backup.Schedule)
-		if err != nil {
-			logger.Logger.Errorf("Failed to parse the schedule for shoot [%v]: %v ", shoot.ObjectMeta.Name, err.Error())
-			return
-		}
-
-		var (
-			nextScheduleTime              = schedule.Next(time.Now())
-			scheduleTimeAfterNextSchedule = schedule.Next(nextScheduleTime)
-			granularity                   = scheduleTimeAfterNextSchedule.Sub(nextScheduleTime)
-		)
-
-		if shoot.DeletionTimestamp == nil && granularity < garden.MinimumETCDFullBackupTimeInterval {
-			newShoot.Spec.Backup.Schedule = garden.DefaultETCDBackupSchedule
-			needsSpecUpdate = true
-		}
+		newShoot := shoot.DeepCopy()
 
 		// Check if the status indicates that an operation is processing and mark it as "aborted".
 		if shoot.Status.LastOperation != nil && shoot.Status.LastOperation.State == gardenv1beta1.ShootLastOperationStateProcessing {
 			newShoot.Status.LastOperation.State = gardenv1beta1.ShootLastOperationStateAborted
-			needsStatusUpdate = true
-		}
-
-		if needsSpecUpdate {
-			newShoot, err = c.k8sGardenClient.Garden().Garden().Shoots(newShoot.Namespace).Update(newShoot)
-			if err != nil {
-				panic(fmt.Sprintf("Failed to update shoot [%v]: %v ", newShoot.Name, err.Error()))
-			}
-		}
-		if needsStatusUpdate {
 			if _, err := c.k8sGardenClient.Garden().Garden().Shoots(newShoot.Namespace).UpdateStatus(newShoot); err != nil {
 				panic(fmt.Sprintf("Failed to update shoot status [%v]: %v ", newShoot.Name, err.Error()))
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Based on the discussions in #550 Shoot backups must not happen more than once an
hour. This is now validated when a Shoot is created or updated rather than set autonomously by the Shoot controller.

**Which issue(s) this PR fixes**:
Fixes #550 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
Backup schedules in the Shoot Spec are now restricted to a maximum frequency of 1h. Shoots with a Cron spec defining a higher frequency will be rejected.
```
