### PR TITLE
Introduce logrotate

### DIFF
--- a/charts/shoot-cloud-config/charts/original/templates/_cloud-config.tpl
+++ b/charts/shoot-cloud-config/charts/original/templates/_cloud-config.tpl
@@ -9,13 +9,15 @@ coreos:
     mask: true
   - name: locksmithd.service
     mask: true
-{{ include "docker" . | indent 2 }}
+{{ include "logrotate" . | indent 2 }}
 {{ include "docker-monitor" . | indent 2 }}
 {{ include "kubelet" . | indent 2 }}
 {{ include "kubelet-monitor" . | indent 2 }}
 {{ include "update-ca-certs" . | indent 2 }}
 {{ include "systemd-sysctl" . | indent 2 }}
 write_files:
+{{ include "logrotate-config" . }}
+{{ include "journald-config" . }}
 {{ include "kubelet-binary" . }}
 {{ include "root-certs" . }}
 {{ include "kernel-config" . }}

--- a/charts/shoot-cloud-config/charts/original/templates/docker/_docker.service
+++ b/charts/shoot-cloud-config/charts/original/templates/docker/_docker.service
@@ -1,9 +1,0 @@
-{{- define "docker" -}}
-{{/* enable docker log rotation */ -}}
-- name: docker.service
-  drop-ins:
-  - name: 10-docker-opts.conf
-    content: |
-      [Service]
-      Environment="DOCKER_OPTS=--log-opt max-size=60m --log-opt max-file=3"
-{{- end}}

--- a/charts/shoot-cloud-config/charts/original/templates/journald/_journald-config
+++ b/charts/shoot-cloud-config/charts/original/templates/journald/_journald-config
@@ -1,0 +1,14 @@
+{{- define "journald-config" -}}
+- path: /etc/systemd/journald.conf
+  permissions: 0644
+  content: |
+    # Configure log rotation for all journal logs, which is where kubelet and
+    # container runtime  are configured to write their log entries. 
+    # Journal config will:
+    # * stores individual Journal files for 24 hours before rotating to a new Journal file
+    # * keep only 14 old Journal files, and will discard older ones
+
+    [Journal]
+    MaxFileSec=24h
+    MaxRetentionSec=14day
+{{- end -}}

--- a/charts/shoot-cloud-config/charts/original/templates/logrotate/_logrotate-config
+++ b/charts/shoot-cloud-config/charts/original/templates/logrotate/_logrotate-config
@@ -1,0 +1,6 @@
+{{- define "logrotate-config" -}}
+- path: /etc/logrotate.d/docker.conf
+  permissions: 0644
+  content: |
+{{ include "docker-config" . | indent 4 }}
+{{- end -}}

--- a/charts/shoot-cloud-config/charts/original/templates/logrotate/_logrotate.service
+++ b/charts/shoot-cloud-config/charts/original/templates/logrotate/_logrotate.service
@@ -1,0 +1,13 @@
+{{ define "logrotate" -}}
+- name: logrotate.service
+  enable: true
+  content: |
+    [Unit]
+    Description=Rotate and Compress System Logs
+
+    [Service]
+    ExecStart=/usr/sbin/logrotate /usr/share/logrotate/logrotate.conf
+
+    [Install]
+    WantedBy=multi-user.target
+{{- end}}

--- a/charts/shoot-cloud-config/charts/original/templates/logrotate/docker.conf
+++ b/charts/shoot-cloud-config/charts/original/templates/logrotate/docker.conf
@@ -1,0 +1,25 @@
+{{- define "docker-config" -}}
+# Configure log rotation for all logs in /var/lib/docker/containers/*/*.log, which is where docker containers
+# are configured to write their log files. Whenever logrotate is ran, this
+# config will:
+# * rotate the log file if its size is > 200Mb OR if one day has elapsed
+# * save rotated logs into a gzipped timestamped backup
+# * log file timestamp (controlled by 'dateformat') includes seconds too. This
+#   ensures that logrotate can generate unique logfiles during each rotation
+#   (otherwise it skips rotation if 'maxsize' is reached multiple times in a
+#   day).
+# * keep only 14 old (rotated) logs, and will discard older logs.
+
+/var/lib/docker/containers/*/*.log {
+    rotate 14
+    copytruncate
+    missingok
+    notifempty
+    compress
+    maxsize 200M
+    daily
+    dateext
+    dateformat -%Y%m%d-%s
+    create 0644 root root
+}
+{{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Enables [logrotate](https://linux.die.net/man/8/logrotate) for container log rotation. 
- Configures [journal](https://www.freedesktop.org/software/systemd/man/journald.conf.html) to rotate the system components that do not run in container and log in journal - kubelet, the container runtime (docker). 

**Which issue(s) this PR fixes**:
Fixes #653 and #662.

**Special notes for your reviewer**:
See:
- https://kubernetes.io/docs/concepts/cluster-administration/logging/#logging-at-the-node-level
- https://docs.docker.com/config/containers/logging/json-file/

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement
- target_group:  operator
-->
```noteworthy operator
All shoot worker machines are now configured with log rotation for user containers and system components. Log files are kept for a maximum of 14 days.
```
