### PR TITLE
Cleanup webhooks only if shoot api server is present

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_control_delete.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_delete.go
@@ -174,7 +174,7 @@ func (c *defaultControl) deleteShoot(o *operation.Operation) *gardenv1beta1.Last
 
 		cleanupWebhooks = g.Add(flow.Task{
 			Name:         "Cleaning up non-gardener webhooks",
-			Fn:           flow.TaskFn(botanist.CleanWebhooks),
+			Fn:           flow.TaskFn(botanist.CleanWebhooks).DoIf(cleanupShootResources),
 			Dependencies: flow.NewTaskIDs(refreshKubeControllerManager, refreshCloudControllerManager, wakeUpControllers, waitUntilKubeAddonManagerDeleted),
 		})
 		waitForControllersToBeActive = g.Add(flow.Task{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a crash to the gcm where it tries to cleanup webhooks if there is no API server to cleanup from.
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
