### PR TITLE
Switch log level of calico and node-exporter to error

### DIFF
--- a/charts/shoot-core/charts/calico/templates/config.yaml
+++ b/charts/shoot-core/charts/calico/templates/config.yaml
@@ -25,7 +25,7 @@ data:
       "plugins": [
         {
           "type": "calico",
-          "log_level": "info",
+          "log_level": "error",
           "datastore_type": "kubernetes",
           "nodename": "__KUBERNETES_NODE_NAME__",
           "mtu": __CNI_MTU__,

--- a/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -77,6 +77,7 @@ spec:
         - --collector.filesystem.ignored-fs-types=^(tmpfs|cgroup|nsfs|fuse\.lxcfs|rpc_pipefs)$
         - --collector.filesystem.ignored-mount-points=^/(rootfs/|host/)?(sys|proc|dev|host|etc|var/lib/docker)($|/)
         - --web.listen-address=:9100
+        - --log.level=error
         ports:
         - containerPort: 9100
           protocol: TCP


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduce amount of produced log entries (https://github.com/gardener/gardener/issues/671)

```improvement user
The log levels for `calico` and the `node-exporter` have been switched to `error` to reduce the number of noisy log messages.
```