### PR TITLE
Use Pod's IP for alertmanager cluster address

### DIFF
--- a/charts/seed-bootstrap/templates/alertmanager/alertmanager.yaml
+++ b/charts/seed-bootstrap/templates/alertmanager/alertmanager.yaml
@@ -64,9 +64,16 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - --config.file=/etc/alertmanager/config/alertmanager.yaml
+        - --cluster.listen-address=$(POD_IP):6783
+        - --cluster.advertise-address=$(POD_IP):6783
         - --web.listen-address=:9093
         - --storage.path=/var/alertmanager/data
         - --log.level=info
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         ports:
         - containerPort: 9093
           name: web

--- a/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
@@ -65,6 +65,8 @@ spec:
         imagePullPolicy: IfNotPresent
         args:
         - --config.file=/etc/alertmanager/config/alertmanager.yaml
+        - --cluster.listen-address=$(POD_IP):6783
+        - --cluster.advertise-address=$(POD_IP):6783
         - --web.listen-address=:9093
         - --web.external-url=https://{{ .Values.ingress.host }}
         - --storage.path=/var/alertmanager/data
@@ -74,6 +76,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         ports:
         - containerPort: 9093
           name: web


### PR DESCRIPTION
**What this PR does / why we need it**:
Alertmanager crashes when Pods's IP is not in the private IP range.

**Which issue(s) this PR fixes**:
Fixes #669 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Alertmanager now uses Pod's IP for clustering configuration.
```

/cc @eaterm