### PR TITLE
Add "spec.cloud.seed" field selector to Shoot resource

### DIFF
--- a/pkg/apis/garden/field_constants.go
+++ b/pkg/apis/garden/field_constants.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package garden
+
+// Field path constants that are specific to the internal API
+// representation.
+const (
+
+	// ShootSeedName is the field selector path for finding
+	// the Seed cluster of a Shoot.
+	ShootSeedName = "spec.cloud.seed"
+)

--- a/pkg/apis/garden/v1beta1/conversions.go
+++ b/pkg/apis/garden/v1beta1/conversions.go
@@ -15,9 +15,16 @@
 package v1beta1
 
 import (
+	"fmt"
+
 	"github.com/gardener/gardener/pkg/apis/garden"
 	"k8s.io/apimachinery/pkg/conversion"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 )
+
+func init() {
+	localSchemeBuilder.Register(addConversionFuncs)
+}
 
 func Convert_v1beta1_Worker_To_garden_Worker(in *Worker, out *garden.Worker, s conversion.Scope) error {
 	autoConvert_v1beta1_Worker_To_garden_Worker(in, out, s)
@@ -39,4 +46,21 @@ func Convert_garden_Worker_To_v1beta1_Worker(in *garden.Worker, out *Worker, s c
 	out.MaxSurge = &in.MaxSurge
 	out.MaxUnavailable = &in.MaxUnavailable
 	return nil
+}
+
+func addConversionFuncs(scheme *runtime.Scheme) error {
+
+	// Add field conversion funcs.
+	return scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Shoot"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name",
+				"metadata.namespace",
+				garden.ShootSeedName:
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		},
+	)
 }

--- a/pkg/registry/garden/shoot/storage/storage.go
+++ b/pkg/registry/garden/shoot/storage/storage.go
@@ -52,6 +52,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
 		NewFunc:                  func() runtime.Object { return &garden.Shoot{} },
 		NewListFunc:              func() runtime.Object { return &garden.ShootList{} },
+		PredicateFunc:            shoot.MatchShoot,
 		DefaultQualifiedResource: garden.Resource("shoots"),
 		EnableGarbageCollection:  true,
 
@@ -61,7 +62,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 
 		TableConvertor: newTableConvertor(),
 	}
-	options := &generic.StoreOptions{RESTOptions: optsGetter}
+	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: shoot.GetAttrs, TriggerFunc: shoot.SeedTriggerFunc}
 	if err := store.CompleteWithOptions(options); err != nil {
 		panic(err)
 	}

--- a/pkg/registry/garden/shoot/strategy.go
+++ b/pkg/registry/garden/shoot/strategy.go
@@ -152,7 +152,7 @@ func ToSelectableFields(shoot *garden.Shoot) fields.Set {
 	// field here or the number of object-meta related fields changes, this should
 	// be adjusted.
 	shootSpecificFieldsSet := make(fields.Set, 3)
-	shootSpecificFieldsSet[garden.ShootSeedName] = getShootName(shoot)
+	shootSpecificFieldsSet[garden.ShootSeedName] = getSeedName(shoot)
 	return generic.AddObjectMetaFieldsSet(shootSpecificFieldsSet, &shoot.ObjectMeta, true)
 }
 
@@ -169,7 +169,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
 func SeedTriggerFunc(obj runtime.Object) []storage.MatchValue {
 	shoot := obj.(*garden.Shoot)
 
-	result := storage.MatchValue{IndexName: garden.ShootSeedName, Value: getShootName(shoot)}
+	result := storage.MatchValue{IndexName: garden.ShootSeedName, Value: getSeedName(shoot)}
 	return []storage.MatchValue{result}
 }
 
@@ -183,7 +183,7 @@ func MatchShoot(label labels.Selector, field fields.Selector) storage.SelectionP
 	}
 }
 
-func getShootName(shoot *garden.Shoot) string {
+func getSeedName(shoot *garden.Shoot) string {
 	if shoot.Spec.Cloud.Seed == nil {
 		return ""
 	}

--- a/pkg/registry/garden/shoot/strategy.go
+++ b/pkg/registry/garden/shoot/strategy.go
@@ -16,18 +16,22 @@ package shoot
 
 import (
 	"context"
-
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/apiserver/pkg/storage/names"
+	"fmt"
 
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/garden"
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/garden/validation"
 	"github.com/gardener/gardener/pkg/operation/common"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/apiserver/pkg/storage/names"
 )
 
 type shootStrategy struct {
@@ -138,4 +142,50 @@ func (shootStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtim
 
 func (shootStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	return validation.ValidateShootStatusUpdate(obj.(*garden.Shoot).Status, old.(*garden.Shoot).Status)
+}
+
+// ToSelectableFields returns a field set that represents the object
+// TODO: fields are not labels, and the validation rules for them do not apply.
+func ToSelectableFields(shoot *garden.Shoot) fields.Set {
+	// The purpose of allocation with a given number of elements is to reduce
+	// amount of allocations needed to create the fields.Set. If you add any
+	// field here or the number of object-meta related fields changes, this should
+	// be adjusted.
+	shootSpecificFieldsSet := make(fields.Set, 3)
+	shootSpecificFieldsSet[garden.ShootSeedName] = getShootName(shoot)
+	return generic.AddObjectMetaFieldsSet(shootSpecificFieldsSet, &shoot.ObjectMeta, true)
+}
+
+// GetAttrs returns labels and fields of a given object for filtering purposes.
+func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, bool, error) {
+	shoot, ok := obj.(*garden.Shoot)
+	if !ok {
+		return nil, nil, false, fmt.Errorf("not a shoot")
+	}
+	return labels.Set(shoot.ObjectMeta.Labels), ToSelectableFields(shoot), shoot.Initializers != nil, nil
+}
+
+// SeedTriggerFunc matches correct seed when watching.
+func SeedTriggerFunc(obj runtime.Object) []storage.MatchValue {
+	shoot := obj.(*garden.Shoot)
+
+	result := storage.MatchValue{IndexName: garden.ShootSeedName, Value: getShootName(shoot)}
+	return []storage.MatchValue{result}
+}
+
+// MatchShoot returns a generic matcher for a given label and field selector.
+func MatchShoot(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+	return storage.SelectionPredicate{
+		Label:       label,
+		Field:       field,
+		GetAttrs:    GetAttrs,
+		IndexFields: []string{garden.ShootSeedName},
+	}
+}
+
+func getShootName(shoot *garden.Shoot) string {
+	if shoot.Spec.Cloud.Seed == nil {
+		return ""
+	}
+	return *shoot.Spec.Cloud.Seed
 }

--- a/pkg/registry/garden/shoot/strategy_test.go
+++ b/pkg/registry/garden/shoot/strategy_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot_test
+
+import (
+	"testing"
+
+	"github.com/gardener/gardener/pkg/apis/garden"
+	strategy "github.com/gardener/gardener/pkg/registry/garden/shoot"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apiserver/pkg/storage"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestHealth(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Shoot Suite")
+}
+
+var _ = Describe("ToSelectableFields", func() {
+	It("should return correct fields", func() {
+		result := strategy.ToSelectableFields(newShoot("foo"))
+
+		Expect(result).To(HaveLen(3))
+		Expect(result.Has(garden.ShootSeedName)).To(BeTrue())
+		Expect(result.Get(garden.ShootSeedName)).To(Equal("foo"))
+	})
+})
+
+var _ = Describe("GetAttrs", func() {
+	It("should return error when object is not Shoot", func() {
+		_, _, _, err := strategy.GetAttrs(&garden.Seed{})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return correct result", func() {
+		ls, fs, uninitialized, err := strategy.GetAttrs(newShoot("foo"))
+
+		Expect(ls).To(HaveLen(1))
+		Expect(ls.Get("foo")).To(Equal("bar"))
+
+		Expect(fs.Get(garden.ShootSeedName)).To(Equal("foo"))
+
+		Expect(uninitialized).To(BeFalse())
+
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("SeedTriggerFunc", func() {
+	It("should return correct matching values", func() {
+		expected := []storage.MatchValue{{IndexName: garden.ShootSeedName, Value: "foo"}}
+
+		mv := strategy.SeedTriggerFunc(newShoot("foo"))
+
+		Expect(mv).To(Equal(expected))
+
+	})
+})
+
+var _ = Describe("MatchShoot", func() {
+	It("should return correct predicate", func() {
+		ls, _ := labels.Parse("app=test")
+		fs := fields.OneTermEqualSelector(garden.ShootSeedName, "foo")
+
+		result := strategy.MatchShoot(ls, fs)
+
+		Expect(result.Label).To(Equal(ls))
+		Expect(result.Field).To(Equal(fs))
+		Expect(result.IndexFields).To(ConsistOf(garden.ShootSeedName))
+
+	})
+})
+
+func newShoot(seedName string) *garden.Shoot {
+	return &garden.Shoot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-namespace",
+			Labels:    map[string]string{"foo": "bar"},
+		},
+		Spec: garden.ShootSpec{
+			Cloud: garden.Cloud{
+				Seed: &seedName,
+			},
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This enables an efficient query to quickly find all Shoot clusters for a particular Seed.

For example, the command bellow finds all Shoots which are bound to a Seed called "foo":

```
kubectl get shoots --field-selector spec.cloud.seed=foo --all-namespaces
```

The same approach can be used in various listers and the generated go-lang client.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
This is a prerequisite for the inversion of control with `gardenlet` as it should be able to only watch and list `Shoot` resources which are bound to it. Other resources in the dependency graph of a `Shoot`are not a concern of this PR as they can be individually watched and synchronized. 

**Release note**:
```noteworthy user
Added a new field selector `spec.cloud.seed` to `Shoot`s so that end-users can query for all shoot clusters on a particular Seed, e.g. `kubectl -n garden-my-project get shoot --field-selector .spec.cloud.seed=aws-eu1`.
```
