### PR TITLE
Fix fluentd volume mount path

### DIFF
--- a/.ci/set_dependency_version
+++ b/.ci/set_dependency_version
@@ -92,7 +92,7 @@ if name == 'autoscaler':
 elif name == 'vpn':
     names = ['vpn-seed', 'vpn-shoot']
 elif name == 'logging':
-    names = ['fluentd-es', 'elasticsearch-oss', 'curator-es']
+    names = ['fluentd-es', 'curator-es']
 else:
     names = [name]
 

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
@@ -218,7 +218,7 @@ data:
         Name                parser
         Match               kubernetes.*lb-readvertiser*lb-readvertiser*
         Key_Name            log
-        Parser              geacParser
+        Parser              lbReadvertiserParser
         Reserve_Data        True
 
     [FILTER]
@@ -239,8 +239,7 @@ data:
         Name                parser
         Match               kubernetes.kube-addon-manager*kube-addon-manager*
         Key_Name            log
-        Parser              addonmanagerSeverityParser
-        Parser.             addonmanagerParser
+        Parser              addonmanagerParser
         Reserve_Data        True
 
     [FILTER]
@@ -253,10 +252,10 @@ data:
         tls.verify          Off
 
     [FILTER]
-        Name    lua
-        Match   *
-        script  modify_severity.lua
-        call    cb_modify
+        Name                lua
+        Match               *
+        script              modify_severity.lua
+        call                cb_modify
 
   output-fluentd.conf: |
     [OUTPUT]
@@ -363,6 +362,13 @@ data:
         Time_Format %Y-%m-%dT%H:%M:%S.%L
 
     [PARSER]
+        Name        lbReadvertiserParser
+        Format      regex
+        Regex       ^time="(?<time>\d{4}-\d{2}-\d{2}T[^"]*)"\s+level=(?<severity>\w+)\smsg="(?<log>.*)"
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S%Z
+
+    [PARSER]
         Name        grafanaParser
         Format      regex
         Regex       ^t=(?<time>\d{4}-\d{2}-\d{2}T[^ ]*)\s+lvl=(?<severity>\w+)\smsg="(?<log>.*)"\s+logger=(?<source>.*)
@@ -370,14 +376,9 @@ data:
         Time_Format %Y-%m-%dT%H:%M:%S%z
 
     [PARSER]
-        Name        addonmanagerSeverityParser
-        Format      regex
-        Regex       ^(?<severity>.[^:]*):\s==\s(?<log>.*)
-
-    [PARSER]
         Name        addonmanagerParser
         Format      regex
-        Regex       ^(?<log>.*)
+        Regex       ^(?<severity>.[^:]*):\s(?<log>.*)
 
   modify_severity.lua: |-
     function cb_modify(tag, timestamp, record)

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-configmap.yaml
@@ -51,7 +51,7 @@ data:
         queued_chunks_limit_size 4096
         # The number of threads of output plugins, which is used to write chunks in parallel
         flush_thread_count 32
-        # he size limitation of this buffer plugin instance
+        # the size limitation of this buffer plugin instance
         total_limit_size 6GB
         @include /etc/fluent/config.d/buffer.options
         path /gardener/fluentd-buffers/kubernetes.shoot.buffer
@@ -141,13 +141,13 @@ data:
 
   default.template: |-
     {
-      "index_patterns" : ["logstash-*"],
-      "settings" : {
-        "index" :{
-          "number_of_shards" : "3",
-          "number_of_replicas" : "0",
+      "index_patterns": ["logstash-*"],
+      "settings": {
+        "index": {
+          "number_of_shards": "3",
+          "number_of_replicas": "0",
           "refresh_interval": "60s",
-          "translog":{
+          "translog": {
             "durability": "async"
           }
         }

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-statefulset.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-statefulset.yaml
@@ -74,7 +74,7 @@ spec:
         volumeMounts:
         - mountPath: /etc/fluent/config.d
           name: config-volume
-        - mountPath: /gardener/flentd-buffers
+        - mountPath: /gardener/fluentd-buffers
           name: fluentd
       volumes:
       - configMap:


### PR DESCRIPTION
**What this PR does / why we need it**:
- The fluentd buffer plugin is configured to write to `/gardener/fluentd-buffers/...` ([link](https://github.com/gardener/gardener/blob/master/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-configmap.yaml#L57)). The mountPath in fluentd is wrong (with a typo) - `/gardener/flentd-buffers`. The PR fixes the mountPath so the buffer plugin can write to the volume and not to the pod fs.
- Improve fluent-bit parsers as suggested by @KristianZH .
- Remove `elasticsearch` version increment as we already refer directly to the oss one.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
