### PR TITLE
Extended validation for ControllerRegistration resources

### DIFF
--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -31,8 +31,9 @@ import (
 	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/internalversion"
 	"github.com/gardener/gardener/pkg/openapi"
 	"github.com/gardener/gardener/pkg/version"
-	deletionconfirmation "github.com/gardener/gardener/plugin/pkg/global/deletionconfirmation"
-	resourcereferencemanager "github.com/gardener/gardener/plugin/pkg/global/resourcereferencemanager"
+	controllerregistrationresources "github.com/gardener/gardener/plugin/pkg/controllerregistration/resources"
+	"github.com/gardener/gardener/plugin/pkg/global/deletionconfirmation"
+	"github.com/gardener/gardener/plugin/pkg/global/resourcereferencemanager"
 	shootdnshostedzone "github.com/gardener/gardener/plugin/pkg/shoot/dnshostedzone"
 	shootquotavalidator "github.com/gardener/gardener/plugin/pkg/shoot/quotavalidator"
 	shootseedmanager "github.com/gardener/gardener/plugin/pkg/shoot/seedmanager"
@@ -125,6 +126,7 @@ func (o *Options) complete() error {
 	shootseedmanager.Register(o.Recommended.Admission.Plugins)
 	shootdnshostedzone.Register(o.Recommended.Admission.Plugins)
 	shootvalidator.Register(o.Recommended.Admission.Plugins)
+	controllerregistrationresources.Register(o.Recommended.Admission.Plugins)
 
 	allOrderedPlugins := []string{
 		resourcereferencemanager.PluginName,
@@ -133,6 +135,7 @@ func (o *Options) complete() error {
 		shootquotavalidator.PluginName,
 		shootseedmanager.PluginName,
 		shootvalidator.PluginName,
+		controllerregistrationresources.PluginName,
 	}
 
 	recommendedPluginOrder := sets.NewString(o.Recommended.Admission.RecommendedPluginOrder...)

--- a/pkg/apis/core/validation/controllerregistration.go
+++ b/pkg/apis/core/validation/controllerregistration.go
@@ -16,6 +16,7 @@ package validation
 
 import (
 	"fmt"
+
 	"github.com/gardener/gardener/pkg/apis/core"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
@@ -55,10 +56,6 @@ func ValidateControllerRegistrationSpec(spec *core.ControllerRegistrationSpec, f
 		}
 
 		resources[resource.Kind] = resource.Type
-	}
-
-	if len(resources) == 0 {
-		allErrs = append(allErrs, field.Required(resourcesPath, "at least one resource is required"))
 	}
 
 	return allErrs

--- a/pkg/apis/core/validation/controllerregistration_test.go
+++ b/pkg/apis/core/validation/controllerregistration_test.go
@@ -51,9 +51,6 @@ var _ = Describe("validation", func() {
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
 				"Field": Equal("metadata.name"),
-			})), PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("spec.resources"),
 			}))))
 		})
 
@@ -77,6 +74,14 @@ var _ = Describe("validation", func() {
 				"Type":  Equal(field.ErrorTypeDuplicate),
 				"Field": Equal("spec.resources[1]"),
 			}))))
+		})
+
+		It("should allow specifying no resources", func() {
+			controllerRegistration.Spec.Resources = nil
+
+			errorList := ValidateControllerRegistration(controllerRegistration)
+
+			Expect(errorList).To(BeEmpty())
 		})
 
 		It("should allow valid ControllerRegistration resources", func() {

--- a/plugin/pkg/controllerregistration/resources/admission.go
+++ b/plugin/pkg/controllerregistration/resources/admission.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+
+	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
+	coreclientset "github.com/gardener/gardener/pkg/client/core/clientset/internalversion"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const (
+	// PluginName is the name of this admission plugin.
+	PluginName = "ControllerRegistrationResources"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, NewFactory)
+}
+
+// NewFactory creates a new PluginFactory.
+func NewFactory(config io.Reader) (admission.Interface, error) {
+	return New()
+}
+
+// Resources contains an admission handler and listers.
+type Resources struct {
+	*admission.Handler
+	coreClient coreclientset.Interface
+	readyFunc  admission.ReadyFunc
+}
+
+var (
+	_ = admissioninitializer.WantsInternalCoreClientset(&Resources{})
+
+	readyFuncs = []admission.ReadyFunc{}
+)
+
+// New creates a new Resources admission plugin.
+func New() (*Resources, error) {
+	return &Resources{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+	}, nil
+}
+
+// AssignReadyFunc assigns the ready function to the admission handler.
+func (r *Resources) AssignReadyFunc(f admission.ReadyFunc) {
+	r.readyFunc = f
+	r.SetReadyFunc(f)
+}
+
+// SetInternalCoreClientset gets the clientset from the Kubernetes client.
+func (r *Resources) SetInternalCoreClientset(c coreclientset.Interface) {
+	r.coreClient = c
+}
+
+// ValidateInitialization checks whether the plugin was correctly initialized.
+func (r *Resources) ValidateInitialization() error {
+	return nil
+}
+
+// Validate makes admissions decisions based on the resources specified in a ControllerRegistration object.
+// It does reject the request if there is any other existing ControllerRegistration object in the system that
+// specifies the same resource kind/type combination like the incoming object.
+func (r *Resources) Validate(a admission.Attributes) error {
+	// Wait until the caches have been synced
+	if r.readyFunc == nil {
+		r.AssignReadyFunc(func() bool {
+			for _, readyFunc := range readyFuncs {
+				if !readyFunc() {
+					return false
+				}
+			}
+			return true
+		})
+	}
+	if !r.WaitForReady() {
+		return admission.NewForbidden(a, errors.New("not yet ready to handle request"))
+	}
+
+	// Ignore all kinds other than Shoot or Project.
+	// TODO: in future the Kinds should be configurable
+	// https://v1-9.docs.kubernetes.io/docs/admin/admission-controllers/#imagepolicywebhook
+	if a.GetKind().GroupKind() != core.Kind("ControllerRegistration") {
+		return nil
+	}
+	controllerRegistration, ok := a.GetObject().(*core.ControllerRegistration)
+	if !ok {
+		return apierrors.NewBadRequest("could not convert resource into ControllerRegistration object")
+	}
+
+	// Live lookup to prevent missing any data
+	controllerRegistrationList, err := r.coreClient.Core().ControllerRegistrations().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	existingResources := map[string]string{}
+	for _, obj := range controllerRegistrationList.Items {
+		for _, resource := range obj.Spec.Resources {
+			existingResources[resource.Kind] = resource.Type
+		}
+	}
+
+	for _, resource := range controllerRegistration.Spec.Resources {
+		if t, ok := existingResources[resource.Kind]; ok && t == resource.Type {
+			return admission.NewForbidden(a, fmt.Errorf("another ControllerRegistration resource already exists that supports resource %s/%s", resource.Kind, resource.Type))
+		}
+	}
+
+	return nil
+}

--- a/plugin/pkg/controllerregistration/resources/admission_test.go
+++ b/plugin/pkg/controllerregistration/resources/admission_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources_test
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/client/core/clientset/internalversion/fake"
+	. "github.com/gardener/gardener/plugin/pkg/controllerregistration/resources"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("resources", func() {
+	Describe("#Admit", func() {
+		var (
+			controllerRegistration core.ControllerRegistration
+
+			attrs            admission.Attributes
+			admissionHandler *Resources
+
+			coreClient *fake.Clientset
+
+			resourceKind = "Foo"
+			resourceType = "bar"
+		)
+
+		BeforeEach(func() {
+			admissionHandler, _ = New()
+			admissionHandler.AssignReadyFunc(func() bool { return true })
+
+			coreClient = &fake.Clientset{}
+			admissionHandler.SetInternalCoreClientset(coreClient)
+
+			controllerRegistration = core.ControllerRegistration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "dummy",
+				},
+				Spec: core.ControllerRegistrationSpec{
+					Resources: []core.ControllerResource{
+						{
+							Kind: resourceKind,
+							Type: resourceType,
+						},
+					},
+				},
+			}
+		})
+
+		It("should do nothing because the resource is not ControllerRegistration", func() {
+			attrs = admission.NewAttributesRecord(nil, nil, core.Kind("SomeOtherResource").WithVersion("version"), "", controllerRegistration.Name, core.Resource("some-other-resource").WithVersion("version"), "", admission.Create, false, nil)
+
+			err := admissionHandler.Validate(attrs)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should allow the object because no other resource in the system uses the kind/type combination", func() {
+			attrs = admission.NewAttributesRecord(&controllerRegistration, nil, core.Kind("ControllerRegistration").WithVersion("version"), "", controllerRegistration.Name, core.Resource("controllerregistrations").WithVersion("version"), "", admission.Create, false, nil)
+
+			err := admissionHandler.Validate(attrs)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should deny the object because another resource in the system uses the kind/type combination", func() {
+			attrs = admission.NewAttributesRecord(&controllerRegistration, nil, core.Kind("ControllerRegistration").WithVersion("version"), "", controllerRegistration.Name, core.Resource("controllerregistrations").WithVersion("version"), "", admission.Create, false, nil)
+
+			controllerRegistration2 := controllerRegistration.DeepCopy()
+			controllerRegistration2.Name = "another-name"
+
+			coreClient.AddReactor("list", "controllerregistrations", func(action testing.Action) (bool, runtime.Object, error) {
+				return true, &core.ControllerRegistrationList{
+					Items: []core.ControllerRegistration{*controllerRegistration2},
+				}, nil
+			})
+
+			err := admissionHandler.Validate(attrs)
+
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsForbidden(err)).To(BeTrue())
+		})
+	})
+
+	Describe("#Register", func() {
+		It("should register the plugin", func() {
+			plugins := admission.NewPlugins()
+			Register(plugins)
+
+			registered := plugins.Registered()
+			Expect(registered).To(HaveLen(1))
+			Expect(registered).To(ContainElement(PluginName))
+		})
+	})
+
+	Describe("#NewFactory", func() {
+		It("should create a new PluginFactory", func() {
+			f, err := NewFactory(nil)
+
+			Expect(f).NotTo(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("#New", func() {
+		It("should only handle CREATE or UPDATE operations", func() {
+			dr, err := New()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dr.Handles(admission.Create)).To(BeTrue())
+			Expect(dr.Handles(admission.Update)).To(BeTrue())
+			Expect(dr.Handles(admission.Connect)).NotTo(BeTrue())
+			Expect(dr.Handles(admission.Delete)).NotTo(BeTrue())
+		})
+	})
+
+	Describe("#ValidateInitialization", func() {
+		It("should return no error", func() {
+			dr, _ := New()
+
+			err := dr.ValidateInitialization()
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/plugin/pkg/controllerregistration/resources/resources_suite_test.go
+++ b/plugin/pkg/controllerregistration/resources/resources_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestDeletionConfirmation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Admission ControllerRegistration Resources Suite")
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Added some extended validation for `ControllerRegistration` resource:
* Allow `ControllerRegistration` resources that do not specify `.spec.resources` (controllers that will just get deployed into the seed without listening specifically to an extension CRD)
* Prevent that multiple `ControllerRegistration` resources get created where the intersection of their `.spec.resources[]` is not empty.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
