### PR TITLE
Allow project members to read the project namespace resource

### DIFF
--- a/charts/garden-project/charts/project-rbac/templates/clusterrole-project-members.yaml
+++ b/charts/garden-project/charts/project-rbac/templates/clusterrole-project-members.yaml
@@ -12,6 +12,14 @@ metadata:
     uid: {{ .Values.project.uid | quote }}
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  resourceNames:
+  - {{ .Release.Namespace | quote }}
+  verbs:
+  - get
+- apiGroups:
   - garden.sapcloud.io
   resources:
   - projects


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR should allow project members to read the corresponding namespace of a gardener project. If a user only knows the project namespace he should be able to find out to which project this namespace belongs. The namespace has a label which contains the name of the project.
```
apiVersion: v1
kind: Namespace
metadata:
  labels:
    garden.sapcloud.io/role: project
    project.garden.sapcloud.io/name: core
  name: garden-core
spec:
  finalizers:
  - kubernetes
``` 


