### PR TITLE
Add shoot hibernation settings in Gardener chart

### DIFF
--- a/charts/gardener/charts/runtime/templates/configmap-controller-manager.yaml
+++ b/charts/gardener/charts/runtime/templates/configmap-controller-manager.yaml
@@ -92,6 +92,8 @@ data:
       shootQuota:
         concurrentSyncs: {{ required ".Values.global.controller.config.controllers.shootQuota.concurrentSyncs is required" .Values.global.controller.config.controllers.shootQuota.concurrentSyncs }}
         syncPeriod: {{ required ".Values.global.controller.config.controllers.shootQuota.syncPeriod is required" .Values.global.controller.config.controllers.shootQuota.syncPeriod }}
+      shootHibernation:
+        concurrentSyncs: {{ required ".Values.global.controller.config.controllers.shootHibernation.concurrentSyncs is required" .Values.global.controller.config.controllers.shootHibernation.concurrentSyncs }}
       backupInfrastructure:
         concurrentSyncs: {{ required ".Values.global.controller.config.controllers.backupInfrastructure.concurrentSyncs is required" .Values.global.controller.config.controllers.backupInfrastructure.concurrentSyncs }}
         syncPeriod: {{ required ".Values.global.controller.config.controllers.backupInfrastructure.syncPeriod is required" .Values.global.controller.config.controllers.backupInfrastructure.syncPeriod }}

--- a/charts/gardener/values.yaml
+++ b/charts/gardener/values.yaml
@@ -144,6 +144,8 @@ global:
         shootQuota:
           concurrentSyncs: 5
           syncPeriod: 60m
+        shootHibernation:
+          concurrentSyncs: 5
         backupInfrastructure:
           concurrentSyncs: 20
           syncPeriod: 24h


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable configuring Shoot hibernation workers in the Gardener chart.
cc @petersutter 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Shoot Hibernation workers can now be configured in the Gardener chart.
```
