### PR TITLE
Add unit tests for chart artifacts in testing framework

### DIFF
--- a/test/integration/framework/common.go
+++ b/test/integration/framework/common.go
@@ -30,9 +30,6 @@ import (
 var (
 	decoder = serializer.NewCodecFactory(kubernetes.GardenScheme).UniversalDecoder()
 
-	// ResourcesDir relative path for resources dir
-	ResourcesDir = filepath.Join("..", "..", "resources")
-
 	// GuestBookTemplateDir relative path for guestbook app template dir
 	GuestBookTemplateDir = filepath.Join("..", "..", "resources", "templates")
 )

--- a/test/integration/framework/errors.go
+++ b/test/integration/framework/errors.go
@@ -17,12 +17,6 @@ package framework
 import "errors"
 
 var (
-	// ErrEmptyShootGardenerTest can not use an empty ShootGardenerTest object
-	ErrEmptyShootGardenerTest = errors.New("can not use an empty ShootGardenerTest object")
-
-	// ErrEmptyShootNamespaceNames can not use an empty seed/shoot/namespace strings
-	ErrEmptyShootNamespaceNames = errors.New("can not use an empty  shoot/namespace strings")
-
 	// ErrNoRepositoriesFound no repositories found in repoitories file
 	ErrNoRepositoriesFound = errors.New("no repositories found in repoitories file")
 

--- a/test/integration/framework/framework_test.go
+++ b/test/integration/framework/framework_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gardener/gardener/pkg/logger"
+	. "github.com/gardener/gardener/test/integration/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestFramework(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Framework Test Suite")
+}
+
+var _ = Describe("Framework tests", func() {
+
+	Context("Download Chart Artifacts", func() {
+		var (
+			resourcesDir = filepath.Join("..", "resources")
+			chartRepo    = filepath.Join(resourcesDir, "charts")
+			helm         = Helm(resourcesDir)
+		)
+
+		AfterEach(func() {
+			err := os.RemoveAll(filepath.Join(resourcesDir, "charts", "redis"))
+			Expect(err).NotTo(HaveOccurred())
+
+			err = os.RemoveAll(filepath.Join(resourcesDir, "repository", "cache"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should download chart artifacts", func() {
+			shootTestOperation := GardenerTestOperation{
+				Logger: logger.AddWriter(logger.NewLogger("info"), GinkgoWriter),
+			}
+
+			err := shootTestOperation.DownloadChartArtifacts(context.TODO(), helm, chartRepo, "stable/redis")
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedCachePath := filepath.Join(resourcesDir, "repository", "cache", "stable-index.yaml")
+			cacheIndexExists, err := Exists(expectedCachePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cacheIndexExists).To(BeTrue())
+
+			expectedRedisChartPath := filepath.Join(resourcesDir, "charts", "redis")
+			chartExists, err := Exists(expectedRedisChartPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(chartExists).To(BeTrue())
+		})
+	})
+})

--- a/test/integration/framework/helm_utils.go
+++ b/test/integration/framework/helm_utils.go
@@ -84,6 +84,7 @@ func ensureCacheIndex(ctx context.Context, helmSettings HelmAccess, stableRepoUR
 			if err != nil {
 				return err
 			}
+			return nil
 		}
 		return err
 	}
@@ -106,6 +107,5 @@ func downloadCacheIndex(ctx context.Context, cacheFile, stableRepositoryURL stri
 	if err := r.DownloadIndexFile(""); err != nil {
 		return nil, fmt.Errorf("looks like %q is not a valid chart repository or cannot be reached: %s", stableRepositoryURL, err.Error())
 	}
-
 	return &c, nil
 }

--- a/test/integration/framework/types.go
+++ b/test/integration/framework/types.go
@@ -62,7 +62,7 @@ type ShootGardenerTest struct {
 	Logger *logrus.Logger
 }
 
-// GardenerTestOperation holds all requried instances for doing a test operation
+// GardenerTestOperation holds all required instances for doing a test operation
 type GardenerTestOperation struct {
 	Logger       logrus.FieldLogger
 	GardenClient kubernetes.Interface


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a simple unit test for chart artifacts. It makes sure that all the chart artifacts (e.g., cache-index files) are downloaded and available before the test begins.

**Release note**

```improvement operator
NONE
```
