### PR TITLE
upgrade prometheus to 2.7.1 and fix alert rules

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -55,7 +55,7 @@ images:
 - name: prometheus
   sourceRepository: github.com/prometheus/prometheus
   repository: quay.io/prometheus/prometheus
-  tag: v2.4.3
+  tag: v2.7.1
 - name: configmap-reloader
   sourceRepository: github.com/jimmidyson/configmap-reload
   repository: quay.io/coreos/configmap-reload

--- a/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.no-lockfile
         # Increase this once the memory issues have been resolved
-        - --storage.tsdb.retention=2h
+        - --storage.tsdb.retention.time=2h
         - --web.listen-address=0.0.0.0:{{ .Values.prometheus.port }}
         - --web.enable-lifecycle
         # Since v2.0.0-beta.3 prometheus runs as nobody user (fsGroup 65534/runAsUser 0)

--- a/charts/seed-monitoring/charts/prometheus/optional-rules/cluster-autoscaler.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/optional-rules/cluster-autoscaler.rules.yaml
@@ -10,6 +10,5 @@ groups:
       severity: critical
       type: seed
     annotations:
-      description: There is no running cluster autoscaler. Shoot's Nodes wont
-        be scaled dynamically, based on the load.
+      description: There is no running cluster autoscaler. Shoot's Nodes wont be scaled dynamically, based on the load.
       summary: Cluster autoscaler is down

--- a/charts/seed-monitoring/charts/prometheus/rules/alertmanager.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/alertmanager.rules.yaml
@@ -13,10 +13,7 @@ groups:
       summary: Alertmanager is down
       description: There is no running Alertmanagers. Alerts wont be send to operators.
   - alert: AlertmanagerConfigInconsistent
-    expr: |
-      count_values("config_hash", alertmanager_config_hash)
-      /
-      kube_statefulset_replicas{namespace="kube-system",statefulset="alertmanager"} != 1
+    expr: count_values("config_hash", alertmanager_config_hash) / kube_statefulset_replicas{namespace="kube-system",statefulset="alertmanager"} != 1
     for: 5m
     labels:
       service: alertmanager

--- a/charts/seed-monitoring/charts/prometheus/rules/cloud-controller-manager.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/cloud-controller-manager.rules.yaml
@@ -10,6 +10,7 @@ groups:
       severity: critical
       type: seed
     annotations:
-      description: There is no running K8S cloud controller manager. Cloud specific resources
+      description: |
+        There is no running K8S cloud controller manager. Cloud specific resources
         such as loadbalancers and persistent volumes are not reconcilded.
       summary: Cloud controller manager is down

--- a/charts/seed-monitoring/charts/prometheus/rules/kube-apiserver.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/kube-apiserver.rules.yaml
@@ -27,58 +27,46 @@ groups:
   # Some verbs excluded because they are expected to be long-lasting:
   # WATCHLIST is long-poll, CONNECT is `kubectl exec`.
   - alert: KubeApiServerLatency
-    expr: |
-      histogram_quantile(
-        0.99,
-        sum without (instance,resource) (apiserver_request_latencies_bucket{subresource!="log",verb!~"CONNECT|WATCHLIST|WATCH|PROXY|proxy"})
-      ) / 1e6 > 1.0
+    expr: histogram_quantile(0.99, sum without (instance,resource) (apiserver_request_latencies_bucket{subresource!="log",verb!~"CONNECT|WATCHLIST|WATCH|PROXY proxy"})) / 1e6 > 1.0
     for: 10m
     labels:
       service: kube-apiserver
       severity: warning
       type: seed
     annotations:
-      description: 99th percentile Latency for {{ $labels.verb }} requests to the
-        kube-apiserver is higher than 1s.
+      description: 99th percentile Latency for {{ $labels.verb }} requests to the kube-apiserver is higher than 1s.
       summary: Kubernetes apiserver latency is high
   ### API latency ###
   - record: apiserver_latency_seconds:quantile
-    expr: histogram_quantile(0.99, rate(apiserver_request_latencies_bucket[5m])) /
-      1e+06
+    expr: histogram_quantile(0.99, rate(apiserver_request_latencies_bucket[5m])) / 1e+06
     labels:
       quantile: "0.99"
   - record: apiserver_latency:quantile_seconds
-    expr: histogram_quantile(0.9, rate(apiserver_request_latencies_bucket[5m])) /
-      1e+06
+    expr: histogram_quantile(0.9, rate(apiserver_request_latencies_bucket[5m])) / 1e+06
     labels:
       quantile: "0.9"
   - record: apiserver_latency_seconds:quantile
-    expr: histogram_quantile(0.5, rate(apiserver_request_latencies_bucket[5m])) /
-      1e+06
+    expr: histogram_quantile(0.5, rate(apiserver_request_latencies_bucket[5m])) / 1e+06
     labels:
       quantile: "0.5"
   # TODO: DRY?
   - alert: KubeTooManyOpenFiles
-    expr: 100 * process_open_fds{job=~"^(?:kube-apiserver)$"} / process_max_fds >
-      50
+    expr: 100 * process_open_fds{job=~"^(?:kube-apiserver)$"} / process_max_fds > 50
     for: 10m
     labels:
       service: kube-apiserver
       severity: warning
       type: seed
     annotations:
-      description: '{{ $labels.node }} is using {{ $value }}% of the available file/socket
-        descriptors.'
+      description: '{{ $labels.node }} is using {{ $value }}% of the available file/socket descriptors.'
       summary: '{{ $labels.job }} has too many open file descriptors'
   - alert: KubeTooManyOpenFiles
-    expr: 100 * process_open_fds{job=~"^(?:kube-apiserver)$"} / process_max_fds >
-      80
+    expr: 100 * process_open_fds{job=~"^(?:kube-apiserver)$"} / process_max_fds > 80
     for: 10m
     labels:
       service: kube-apiserver
       severity: critical
       type: seed
     annotations:
-      description: '{{ $labels.node }} is using {{ $value }}% of the available file/socket
-        descriptors.'
+      description: '{{ $labels.node }} is using {{ $value }}% of the available file/socket descriptors.'
       summary: '{{ $labels.job }} has too many open file descriptors'

--- a/charts/seed-monitoring/charts/prometheus/rules/kube-controller-manager.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/kube-controller-manager.rules.yaml
@@ -10,6 +10,7 @@ groups:
       severity: critical
       type: seed
     annotations:
-      description: There is no running K8S controller manager. Deployments and replication
+      description: |
+        There is no running K8S controller manager. Deployments and replication
         controllers are not making progress.
-      summary: Controller manager is down
+      summary: Controller manager is down.

--- a/charts/seed-monitoring/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -1,7 +1,6 @@
 groups:
 - name: kube-etcd3.rules
   rules:
-
   # alert if main etcd is down
   - alert: KubeEtcdMainDown
     expr: sum(up{job="kube-etcd3",role="main"}) < 1
@@ -13,7 +12,6 @@ groups:
     annotations:
       description: etcd3 cluster {{ $labels.role }} is unavailable or cannot be scrapped
       summary: etcd3 main cluster down
-
   # alert if events etcd is down
   - alert: KubeEtcdEventsDown
     expr: sum(up{job="kube-etcd3",role="events"}) < 1
@@ -25,7 +23,6 @@ groups:
     annotations:
       description: etcd3 cluster {{ $labels.role }} is unavailable or cannot be scrapped
       summary: etcd3 events cluster down
-
   # etcd leader alerts
   - alert: KubeEtcd3NoLeader
     expr: etcd_server_has_leader{job="kube-etcd3"} == 0
@@ -37,7 +34,6 @@ groups:
     annotations:
       description: etcd3 member {{ $labels.pod }} has no leader
       summary: etcd3 member has no leader
-
   # alert if there are lots of leader changes
   - alert: KubeEtcd3HighNumberOfLeaderChanges
     expr: increase(etcd_server_leader_changes_seen_total{job="kube-etcd3"}[1h]) > 3
@@ -49,12 +45,9 @@ groups:
       description: etcd3 pod {{ $labels.pod }} has seen {{ $value }} leader changes
         within the last hour
       summary: a high number of leader changes within the etcd3 cluster are happening
-
   ### GRPC requests alerts ###
   - record: etcd3:failed_client_requests_ratio:sum
-    expr: sum by(grpc_method) (rate(etcd_grpc_requests_failed_total{job="kube-etcd3"}[5m]))
-      / sum by(grpc_method) (rate(etcd_grpc_total{job="kube-etcd3"}[5m]))
-
+    expr: sum by(grpc_method) (rate(etcd_grpc_requests_failed_total{job="kube-etcd3"}[5m])) / sum by(grpc_method) (rate(etcd_grpc_total{job="kube-etcd3"}[5m]))
   # alert if more than 1% of requests to GRPC have failed
   - alert: KubeEtcd3HighNumberOfFailedGRPCRequests
     expr: etcd3:failed_client_requests_ratio:sum > 0.01
@@ -66,7 +59,6 @@ groups:
     annotations:
       description: '{{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd3 pod {{ $labels.pod }}'
       summary: a high number of etcd3 GRPC requests are failing
-
   # alert if more than 5% of requests to GRPC have failed
   - alert: KubeEtcd3HighNumberOfFailedGRPCRequests
     expr: etcd3:failed_client_requests_ratio:sum > 0.05
@@ -78,7 +70,6 @@ groups:
     annotations:
       description: '{{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd3 pod {{ $labels.pod }}'
       summary: a high number of etcd3 GRPC requests are failing
-
   # alert if the 99th percentile of GRPC requests take more than 150ms
   # etcd3 must be configured with --metrics="extensive" for histogram
   - alert: KubeEtcd3GRPCRequestsSlow
@@ -89,11 +80,9 @@ groups:
       severity: warning
       type: seed
     annotations:
-      description: on ectd3 instance {{ $labels.instance }} GRPC requests to {{ $label.grpc_method }} are slow
+      description: on ectd3 instance {{ $labels.instance }} GRPC requests to {{ $labels.grpc_method }} are slow
       summary: slow GRPC requests
-
   ### etcd proposal alerts ###
-
   # alert if there are several failed proposals within an hour
   - alert: KubeEtcd3HighNumberOfFailedProposals
     expr: increase(etcd_server_proposals_failed_total{job="kube-etcd3"}[1h]) > 5
@@ -105,9 +94,7 @@ groups:
       description: etcd3 pod {{ $labels.pod }} has seen {{ $value }} proposal failures
         within the last hour
       summary: a high number of failed proposals within the etcd cluster are happening
-
   ### etcd disk io latency alerts ###
-
   # alert if 99th percentile of fsync durations is higher than 500ms
   - alert: KubeEtcd3HighFsyncDurations
     expr: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) > 0.5
@@ -119,11 +106,9 @@ groups:
     annotations:
       description: ectd3 pod {{ $labels.pod }} fync durations are high
       summary: high fsync durations
-
   # alert if 99th percentile of commit durations is higher than 250ms
   - alert: KubeEtcd3HighCommitDurations
-    expr: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="kube-etcd3"}[5m]))
-      > 0.25
+    expr: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job="kube-etcd3"}[5m])) > 0.25
     for: 10m
     labels:
       service: etcd
@@ -132,20 +117,16 @@ groups:
     annotations:
       description: etcd3 pod {{ $labels.pod }} commit durations are high
       summary: high commit durations
-
   # etcd member communication alerts
   # ================================
-
   # alert if 99th percentile of round trips take 150ms
   - alert: KubeEtcd3MemberCommunicationSlow
-    expr: histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="kube-etcd3"}[5m]))
-      > 0.15
+    expr: histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job="kube-etcd3"}[5m])) > 0.15
     for: 10m
     labels:
       service: etcd
       severity: warning
       type: seed
     annotations:
-      description: etcd3 pod {{ $labels.pod }} member communication with {{ $label.To
-        }} is slow
-      summary: etcd member communication is slow
+      description: etcd3 pod {{ $labels.pod }} member communication with {{ $labels.To }} is slow
+      summary: etcd member communication is slow.

--- a/charts/seed-monitoring/charts/prometheus/rules/kube-kubelet.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/kube-kubelet.rules.yaml
@@ -10,7 +10,8 @@ groups:
       severity: blocker
       type: shoot
     annotations:
-      description: No kubelets are available in the shoot cluster, or all Kubelets
+      description: |
+        No kubelets are available in the shoot cluster, or all Kubelets
         have disappeared from service discovery.
       summary: Many Kubelets cannot be scraped
   - alert: KubeKubeletNodeDown
@@ -22,8 +23,7 @@ groups:
       severity: warning
       type: shoot
     annotations:
-      description: Prometheus could not scrape a {{ $labels.job }} for more than one
-        hour
+      description: Prometheus could not scrape a {{ $labels.job }} for more than one hour
       summary: Kubelet cannot be scraped
   - alert: KubeKubeletTooManyPods
     expr: kubelet_running_pod_count > 100
@@ -31,8 +31,7 @@ groups:
       service: kube-kubelet
       severity: warning
     annotations:
-      description: Kubelet {{$labels.instance}} is running {{$value}} pods, close
-        to the limit of 110
+      description: Kubelet {{$labels.instance}} is running {{$value}} pods, close to the limit of 110
       summary: Kubelet is close to pod limit
   - alert: KubeKubeletContainerReboot
     expr: increase(container_last_seen{container_name!="POD"}[1m]) < 50
@@ -40,9 +39,7 @@ groups:
       service: kube-kubelet
       severity: warning
     annotations:
-      description: '{{ $labels.container_label_io_kubernetes_pod_name }} has been
-        restarted {{ $labels.container_label_io_kubernetes_container_restartCount
-        }} times lately.'
+      description: '{{ $labels.container_label_io_kubernetes_pod_name }} has been restarted {{ $labels.container_label_io_kubernetes_container_restartCount }} times lately.'
       summary: High container reboot count
   - alert: KubeKubeletPodRestartingTooMuch
     expr: rate(kube_pod_container_status_restarts_total[1m]) > 12
@@ -51,7 +48,7 @@ groups:
       service: kube-kubelet
       severity: warning
     annotations:
-      description: '{{$labels.namespace}}/{{$label.pod}} is restarting too much.'
+      description: '{{$labels.namespace}}/{{$labels.pod}} is restarting too much.'
       summary: pod is restarting too much.
   - alert: KubeKubeletPodSlowToLaunch
     expr: rate(kubelet_pod_start_latency_microseconds{quantile="0.99"}[1m]) > 5
@@ -69,8 +66,7 @@ groups:
       service: kube-kubelet
       severity: warning
     annotations:
-      description: '{{ $labels.node }} is using {{ $value }}% of the available file/socket
-        descriptors.'
+      description: '{{ $labels.node }} is using {{ $value }}% of the available file/socket descriptors.'
       summary: '{{ $labels.job }} has too many open file descriptors'
   - alert: KubeTooManyOpenFiles
     expr: 100 * process_open_fds{job=~"^(?:kube-kubelet)$"} / process_max_fds > 80
@@ -79,13 +75,10 @@ groups:
       service: kube-kubelet
       severity: critical
     annotations:
-      description: '{{ $labels.node }} is using {{ $value }}% of the available file/socket
-        descriptors.'
+      description: '{{ $labels.node }} is using {{ $value }}% of the available file/socket descriptors.'
       summary: '{{ $labels.job }} has too many open file descriptors'
   - alert: KubePersistentVolumeUsageCritical
-    expr: |
-      100 * kubelet_volume_stats_available_bytes /
-      kubelet_volume_stats_capacity_bytes < 3
+    expr: 100 * kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes < 3
     for: 1m
     labels:
       service: kube-kubelet
@@ -95,17 +88,15 @@ groups:
       description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} is only {{ printf "%0.2f" $value }}% free.
       summary: PersistentVolume almost full.
   - alert: KubePersistentVolumeFullInFourDays
-    expr: |
-      100 * (kubelet_volume_stats_available_bytes /
-      kubelet_volume_stats_capacity_bytes) < 15
-      and predict_linear(kubelet_volume_stats_available_bytes[6h], 4 * 24 * 3600) < 0
+    expr: 100 * (kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes) < 15 and predict_linear(kubelet_volume_stats_available_bytes[6h], 4 * 24 * 3600) < 0
     for: 5m
     labels:
       service: kube-kubelet
       severity: critical
       type: seed
     annotations:
-      description: Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} is expected to
+      description: |
+        Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} is expected to
         fill up within four days.
         Currently {{ printf "%0.2f" $value }}% is available.
       summary: PersistentVolume will be full in four days.

--- a/charts/seed-monitoring/charts/prometheus/rules/kube-pods.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/kube-pods.rules.yaml
@@ -2,8 +2,7 @@ groups:
 - name: kube-pods.rules
   rules:
   - alert: KubePodPending
-    expr: (kube_pod_status_phase{phase="Pending", type="shoot"} == 1 and on(pod) kube_pod_labels{label_origin="gardener"})
-      or kube_pod_status_phase{phase="Pending", type="seed"} == 1
+    expr: (kube_pod_status_phase{phase="Pending", type="shoot"} == 1 and on(pod) kube_pod_labels{label_origin="gardener"}) or kube_pod_status_phase{phase="Pending", type="seed"} == 1
     for: 10m
     labels:
       service: kube-kubelet
@@ -12,8 +11,7 @@ groups:
       description: Pod {{ $labels.pod }} is in Pending state for more than 10 minutes
       summary: Pod is in Pending state
   - alert: KubePodNotReady
-    expr: (kube_pod_status_ready{condition="true", type="shoot"} == 0 and on(pod) kube_pod_labels{label_origin="gardener"})
-      or kube_pod_status_ready{condition="true", type="seed"} == 0
+    expr: (kube_pod_status_ready{condition="true", type="shoot"} == 0 and on(pod) kube_pod_labels{label_origin="gardener"}) or kube_pod_status_ready{condition="true", type="seed"} == 0
     for: 10m
     labels:
       service: kube-kubelet

--- a/charts/seed-monitoring/charts/prometheus/rules/kube-scheduler.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/kube-scheduler.rules.yaml
@@ -10,53 +10,43 @@ groups:
       severity: critical
       type: seed
     annotations:
-      description: There is no running K8S scheduler. New pods are not being assigned
-        to nodes.
+      description: There is no running K8S scheduler. New pods are not being assigned to nodes.
       summary: Scheduler is down
 
   ### Scheduling latency ###
   - record: cluster:scheduler_e2e_scheduling_latency_seconds:quantile
-    expr: histogram_quantile(0.99, sum(scheduler_e2e_scheduling_latency_microseconds_bucket)
-      BY (le, cluster)) / 1e+06
+    expr: histogram_quantile(0.99, sum(scheduler_e2e_scheduling_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
     labels:
       quantile: "0.99"
   - record: cluster:scheduler_e2e_scheduling_latency_seconds:quantile
-    expr: histogram_quantile(0.9, sum(scheduler_e2e_scheduling_latency_microseconds_bucket)
-      BY (le, cluster)) / 1e+06
+    expr: histogram_quantile(0.9, sum(scheduler_e2e_scheduling_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
     labels:
       quantile: "0.9"
   - record: cluster:scheduler_e2e_scheduling_latency_seconds:quantile
-    expr: histogram_quantile(0.5, sum(scheduler_e2e_scheduling_latency_microseconds_bucket)
-      BY (le, cluster)) / 1e+06
+    expr: histogram_quantile(0.5, sum(scheduler_e2e_scheduling_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
     labels:
       quantile: "0.5"
   - record: cluster:scheduler_scheduling_algorithm_latency_seconds:quantile
-    expr: histogram_quantile(0.99, sum(scheduler_scheduling_algorithm_latency_microseconds_bucket)
-      BY (le, cluster)) / 1e+06
+    expr: histogram_quantile(0.99, sum(scheduler_scheduling_algorithm_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
     labels:
       quantile: "0.99"
   - record: cluster:scheduler_scheduling_algorithm_latency_seconds:quantile
-    expr: histogram_quantile(0.9, sum(scheduler_scheduling_algorithm_latency_microseconds_bucket)
-      BY (le, cluster)) / 1e+06
+    expr: histogram_quantile(0.9, sum(scheduler_scheduling_algorithm_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
     labels:
       quantile: "0.9"
   - record: cluster:scheduler_scheduling_algorithm_latency_seconds:quantile
-    expr: histogram_quantile(0.5, sum(scheduler_scheduling_algorithm_latency_microseconds_bucket)
-      BY (le, cluster)) / 1e+06
+    expr: histogram_quantile(0.5, sum(scheduler_scheduling_algorithm_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
     labels:
       quantile: "0.5"
   - record: cluster:scheduler_binding_latency_seconds:quantile
-    expr: histogram_quantile(0.99, sum(scheduler_binding_latency_microseconds_bucket)
-      BY (le, cluster)) / 1e+06
+    expr: histogram_quantile(0.99, sum(scheduler_binding_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
     labels:
       quantile: "0.99"
   - record: cluster:scheduler_binding_latency_seconds:quantile
-    expr: histogram_quantile(0.9, sum(scheduler_binding_latency_microseconds_bucket)
-      BY (le, cluster)) / 1e+06
+    expr: histogram_quantile(0.9, sum(scheduler_binding_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
     labels:
       quantile: "0.9"
   - record: cluster:scheduler_binding_latency_seconds:quantile
-    expr: histogram_quantile(0.5, sum(scheduler_binding_latency_microseconds_bucket)
-      BY (le, cluster)) / 1e+06
+    expr: histogram_quantile(0.5, sum(scheduler_binding_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
     labels:
       quantile: "0.5"

--- a/charts/seed-monitoring/charts/prometheus/rules/machine-controller-manager.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/machine-controller-manager.rules.yaml
@@ -10,6 +10,5 @@ groups:
       severity: critical
       type: seed
     annotations:
-      description: There is no running machine controller manager. No Shoot Nodes
-        can be created.
+      description: There is no running machine controller manager. No Shoot Nodes can be created.
       summary: Machine controller manager is down

--- a/charts/seed-monitoring/charts/prometheus/rules/node-explorer.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/node-explorer.rules.yaml
@@ -136,8 +136,7 @@ groups:
       severity: critical
       type: shoot
     annotations:
-      description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust
-        in file descriptors soon'
+      description: '{{ $labels.job }} instance {{ $labels.instance }} will exhaust in file descriptors soon'
       summary: file descriptors soon exhausted
 
   # Alert for Swap Usage Warning
@@ -149,8 +148,7 @@ groups:
       severity: warning
       type: shoot
     annotations:
-      description: instance {{ $labels.instance }} is currently using {{ $value }}%
-        of its swap memory
+      description: instance {{ $labels.instance }} is currently using {{ $value }}% of its swap memory
       summary: swap usage
 
   # Alert for Swap Usage Crtical
@@ -162,6 +160,5 @@ groups:
       severity: severe
       type: shoot
     annotations:
-      description: instance {{ $labels.instance }} has is using {{ value }}% of its
-        swap memory
+      description: instance {{ $labels.instance }} has is using {{ value }}% of its swap memory
       summary: high swap usage

--- a/charts/seed-monitoring/charts/prometheus/rules/prometheus.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/prometheus.rules.yaml
@@ -21,8 +21,7 @@ groups:
       severity: warning
       type: seed
     annotations:
-      description: Prometheus failed to scrape metrics. Instance {{ $labels.instance
-        }}, job {{ $labels.job }}.
+      description: Prometheus failed to scrape metrics. Instance {{ $labels.instance}}, job {{ $labels.job }}.
       summary: No metrics are scraped from target
   - alert: PrometheusConfigurationFailure
     expr: prometheus_config_last_reload_successful == 0
@@ -32,6 +31,5 @@ groups:
       severity: warning
       type: seed
     annotations:
-      description: Latest Prometheus configuration is broken and Prometheus is using
-        the previous one
+      description: Latest Prometheus configuration is broken and Prometheus is using the previous one
       summary: Prometheus is misconfigured

--- a/charts/seed-monitoring/charts/prometheus/rules/vpn.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/vpn.rules.yaml
@@ -19,6 +19,5 @@ groups:
       severity: critical
       type: shoot
     annotations:
-      description: VPN connection for {{ $labels.pod }} is down. No resources of the Shoot cluster
-        can be accessed by this pod.
+      description: VPN connection for {{ $labels.pod }} is down. No resources of the Shoot clustercan be accessed by this pod.
       summary: VPN connection down

--- a/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
@@ -69,7 +69,7 @@ spec:
         - --config.file=/etc/prometheus/config/prometheus.yaml
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.no-lockfile
-        - --storage.tsdb.retention=180h
+        - --storage.tsdb.retention.time=180h
         - --web.route-prefix=/
         - --web.enable-lifecycle
         - --web.listen-address=0.0.0.0:{{ .Values.port }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade prometheus to version 2.7.1. Prometheus 2.7.x has a new flag `--storage.tsdb.retention.size` which is needed for #699. The upgrade will also allow us to write Alertmanager unit tests in the future. Prometheus now validates alert rules on startup and several alerts that were invalid are now fixed.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Prometheus has been upgraded to `v2.7.1`.
```
