### PR TITLE
Upgrade Cert-Manager to v0.6.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -196,7 +196,7 @@ images:
 - name: cert-manager
   sourceRepository: github.com/jetstack/cert-manager
   repository: quay.io/jetstack/cert-manager-controller
-  tag: "v0.4.1"
+  tag: "v0.6.0"
 - name: cert-broker
   sourceRepository: github.com/gardener/cert-broker
   repository: eu.gcr.io/gardener-project/gardener/cert-broker

--- a/charts/seed-bootstrap/charts/cert-manager/Chart.yaml
+++ b/charts/seed-bootstrap/charts/cert-manager/Chart.yaml
@@ -1,4 +1,4 @@
 name: cert-manager
-version: v0.4.1
-appVersion: v0.4.1
+version: v0.6.0
+appVersion: v0.6.0
 description: A Helm chart for cert-manager

--- a/charts/seed-bootstrap/charts/cert-manager/templates/acme-crd.yaml
+++ b/charts/seed-bootstrap/charts/cert-manager/templates/acme-crd.yaml
@@ -1,0 +1,69 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: orders.certmanager.k8s.io
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    type: string
+    priority: 1
+  - JSONPath: .status.reason
+    name: Reason
+    type: string
+    priority: 1
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Order
+    plural: orders
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: challenges.certmanager.k8s.io
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .spec.dnsName
+    name: Domain
+    type: string
+  - JSONPath: .status.reason
+    name: Reason
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Challenge
+    plural: challenges
+  scope: Namespaced

--- a/charts/seed-bootstrap/charts/cert-manager/templates/certificate-crd.yaml
+++ b/charts/seed-bootstrap/charts/cert-manager/templates/certificate-crd.yaml
@@ -9,6 +9,28 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.secretName
+    name: Secret
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    type: string
+    priority: 1
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    type: string
+    priority: 1
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
   group: certmanager.k8s.io
   version: v1alpha1
   scope: Namespaced

--- a/charts/seed-bootstrap/charts/cert-manager/templates/clusterissuer.yaml
+++ b/charts/seed-bootstrap/charts/cert-manager/templates/clusterissuer.yaml
@@ -12,7 +12,8 @@ spec:
     dns01:
       providers:
       {{- range .Values.clusterissuer.acme.dns01.providers }}
-      - name: {{ .name }}
+      - cnameStrategy: {{ .cnameStrategy | default "None" | quote }} 
+        name: {{ .name }}
       {{- if eq .type "aws-route53" }}
         route53:
           region: {{ .region }}

--- a/charts/seed-bootstrap/charts/cert-manager/templates/rbac.yaml
+++ b/charts/seed-bootstrap/charts/cert-manager/templates/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
   - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "issuers", "clusterissuers"]
+    resources: ["certificates", "issuers", "clusterissuers", "orders", "challenges"]
     verbs: ["*"]
   - apiGroups: [""]
     resources: ["configmaps", "secrets", "events", "services", "pods"]

--- a/charts/seed-bootstrap/charts/cert-manager/values.yaml
+++ b/charts/seed-bootstrap/charts/cert-manager/values.yaml
@@ -95,11 +95,13 @@ clusterissuer:
     dns01:
       providers:
       - name: prod-route53
+        cnameStrategy: None
         type: aws-route53
         region: us-east-1
         accessKeyID:
         accessKey: your-access-key
       - name: prod-clouddns
+        cnameStrategy: None
         type: google-clouddns
         project:
         accessKey: your-access-key

--- a/charts/seed-bootstrap/requirements.yaml
+++ b/charts/seed-bootstrap/requirements.yaml
@@ -11,6 +11,6 @@ dependencies:
   condition: fluentd-es.enabled
 - name: cert-manager
   repository: http://localhost:10191
-  version: 0.4.1
+  version: 0.6.0
   # needed for the CertificateManagement feature gate
   condition: cert-manager.enabled

--- a/pkg/client/kubernetes/apply.go
+++ b/pkg/client/kubernetes/apply.go
@@ -66,7 +66,7 @@ func NewApplierForConfig(config *rest.Config) (*Applier, error) {
 	return NewApplierInternal(config, cachedDiscoveryClient)
 }
 
-func (c *Applier) applyObject(ctx context.Context, desired *unstructured.Unstructured) error {
+func (c *Applier) applyObject(ctx context.Context, desired *unstructured.Unstructured, options ApplierOptions) error {
 	if desired.GetNamespace() == "" {
 		desired.SetNamespace(metav1.NamespaceDefault)
 	}
@@ -94,50 +94,59 @@ func (c *Applier) applyObject(ctx context.Context, desired *unstructured.Unstruc
 		return err
 	}
 
-	if err := c.mergeObjects(desired, current); err != nil {
+	if err := c.mergeObjects(desired, current, options.MergeFuncs); err != nil {
 		return err
 	}
 
 	return c.client.Update(ctx, desired)
 }
 
-func (c *Applier) mergeObjects(newObj *unstructured.Unstructured, oldObj *unstructured.Unstructured) error {
+// DefaultApplierOptions contains options for common k8s objects, e.g. Service, ServiceAccount.
+var DefaultApplierOptions = ApplierOptions{
+	MergeFuncs: map[Kind]MergeFunc{
+		"Service": func(newObj, oldObj *unstructured.Unstructured) {
+			// We do not want to overwrite a Service's `.spec.clusterIP' or '.spec.ports[*].nodePort' values.
+			oldPorts := oldObj.Object["spec"].(map[string]interface{})["ports"].([]interface{})
+			newPorts := newObj.Object["spec"].(map[string]interface{})["ports"].([]interface{})
+			ports := []map[string]interface{}{}
+
+			// Check whether ports of the newObj have also been present previously. If yes, take the nodePort
+			// of the existing object.
+			for _, newPort := range newPorts {
+				np := newPort.(map[string]interface{})
+
+				for _, oldPort := range oldPorts {
+					op := oldPort.(map[string]interface{})
+					// np["port"] is of type float64 (due to Helm Tiller rendering) while op["port"] is of type int64.
+					// Equality can only be checked via their string representations.
+					if fmt.Sprintf("%v", np["port"]) == fmt.Sprintf("%v", op["port"]) {
+						if nodePort, ok := op["nodePort"]; ok {
+							np["nodePort"] = nodePort
+						}
+					}
+				}
+				ports = append(ports, np)
+			}
+
+			newObj.Object["spec"].(map[string]interface{})["clusterIP"] = oldObj.Object["spec"].(map[string]interface{})["clusterIP"]
+			newObj.Object["spec"].(map[string]interface{})["ports"] = ports
+		},
+		"ServiceAccount": func(newObj, oldObj *unstructured.Unstructured) {
+			// We do not want to overwrite a ServiceAccount's `.secrets[]` list or `.imagePullSecrets[]`.
+			newObj.Object["secrets"] = oldObj.Object["secrets"]
+			newObj.Object["imagePullSecrets"] = oldObj.Object["imagePullSecrets"]
+		},
+	},
+}
+
+func (c *Applier) mergeObjects(newObj, oldObj *unstructured.Unstructured, mergeFuncs map[Kind]MergeFunc) error {
 	newObj.SetResourceVersion(oldObj.GetResourceVersion())
 
 	// We do not want to overwrite the Finalizers.
 	newObj.Object["metadata"].(map[string]interface{})["finalizers"] = oldObj.Object["metadata"].(map[string]interface{})["finalizers"]
 
-	switch newObj.GetKind() {
-	case "Service":
-		// We do not want to overwrite a Service's `.spec.clusterIP' or '.spec.ports[*].nodePort' values.
-		oldPorts := oldObj.Object["spec"].(map[string]interface{})["ports"].([]interface{})
-		newPorts := newObj.Object["spec"].(map[string]interface{})["ports"].([]interface{})
-		ports := []map[string]interface{}{}
-
-		// Check whether ports of the newObj have also been present previously. If yes, take the nodePort
-		// of the existing object.
-		for _, newPort := range newPorts {
-			np := newPort.(map[string]interface{})
-
-			for _, oldPort := range oldPorts {
-				op := oldPort.(map[string]interface{})
-				// np["port"] is of type float64 (due to Helm Tiller rendering) while op["port"] is of type int64.
-				// Equality can only be checked via their string representations.
-				if fmt.Sprintf("%v", np["port"]) == fmt.Sprintf("%v", op["port"]) {
-					if nodePort, ok := op["nodePort"]; ok {
-						np["nodePort"] = nodePort
-					}
-				}
-			}
-			ports = append(ports, np)
-		}
-
-		newObj.Object["spec"].(map[string]interface{})["clusterIP"] = oldObj.Object["spec"].(map[string]interface{})["clusterIP"]
-		newObj.Object["spec"].(map[string]interface{})["ports"] = ports
-	case "ServiceAccount":
-		// We do not want to overwrite a ServiceAccount's `.secrets[]` list or `.imagePullSecrets[]`.
-		newObj.Object["secrets"] = oldObj.Object["secrets"]
-		newObj.Object["imagePullSecrets"] = oldObj.Object["imagePullSecrets"]
+	if merge, ok := mergeFuncs[Kind(newObj.GetKind())]; ok {
+		merge(newObj, oldObj)
 	}
 
 	return nil
@@ -146,12 +155,12 @@ func (c *Applier) mergeObjects(newObj *unstructured.Unstructured, oldObj *unstru
 // ApplyManifest is a function which does the same like `kubectl apply -f <file>`. It takes a bunch of manifests <m>,
 // all concatenated in a byte slice, and sends them one after the other to the API server. If a resource
 // already exists at the API server, it will update it. It returns an error as soon as the first error occurs.
-func (c *Applier) ApplyManifest(ctx context.Context, r UnstructuredReader) error {
+func (c *Applier) ApplyManifest(ctx context.Context, r UnstructuredReader, options ApplierOptions) error {
 	for obj, err := r.Read(); err == nil; obj, err = r.Read() {
 		if obj == nil {
 			continue
 		}
-		if err := c.applyObject(ctx, obj); err != nil {
+		if err := c.applyObject(ctx, obj, options); err != nil {
 			return err
 		}
 		obj = nil

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"context"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 
 	gardenclientset "github.com/gardener/gardener/pkg/client/garden/clientset/versioned"
@@ -174,10 +176,21 @@ type Applier struct {
 	discovery discovery.CachedDiscoveryInterface
 }
 
+// Kind is a type alias for a k8s Kind of ObjectKind.
+type Kind string
+
+// MergeFunc determines how oldOj is merged into new oldObj.
+type MergeFunc func(newObj, oldObj *unstructured.Unstructured)
+
+// ApplierOptions contains options used by the Applier.
+type ApplierOptions struct {
+	MergeFuncs map[Kind]MergeFunc
+}
+
 // ApplierInterface is an interface which describes declarative operations to apply multiple
 // Kubernetes objects.
 type ApplierInterface interface {
-	ApplyManifest(ctx context.Context, unstructured UnstructuredReader) error
+	ApplyManifest(ctx context.Context, unstructured UnstructuredReader, options ApplierOptions) error
 }
 
 // Interface is used to wrap the interactions with a Kubernetes cluster

--- a/pkg/controllermanager/controller/controllerinstallation/controllerinstallation_control.go
+++ b/pkg/controllermanager/controller/controllerinstallation/controllerinstallation_control.go
@@ -268,7 +268,7 @@ func (c *defaultControllerInstallationControl) reconcile(controllerInstallation 
 		return err
 	}
 
-	if err := k8sSeedClient.Applier().ApplyManifest(context.TODO(), kubernetes.NewManifestReader(release.Manifest())); err != nil {
+	if err := k8sSeedClient.Applier().ApplyManifest(context.TODO(), kubernetes.NewManifestReader(release.Manifest()), kubernetes.DefaultApplierOptions); err != nil {
 		conditionInstalled = helper.UpdatedCondition(conditionInstalled, corev1.ConditionFalse, "InstallationFailed", fmt.Sprintf("Installation of new resources failed: %+v", err))
 		return err
 	}

--- a/test/integration/shoots/applications/shoot_app_test.go
+++ b/test/integration/shoots/applications/shoot_app_test.go
@@ -288,7 +288,7 @@ var _ = Describe("Shoot application testing", func() {
 		// Apply the guestbook app resources to shoot
 
 		manifestReader := kubernetes.NewManifestReader(writer.Bytes())
-		err = shootTestOperations.ShootClient.Applier().ApplyManifest(ctx, manifestReader)
+		err = shootTestOperations.ShootClient.Applier().ApplyManifest(ctx, manifestReader, kubernetes.DefaultApplierOptions)
 		Expect(err).NotTo(HaveOccurred())
 
 		// define guestbook app urls


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR upgrades Cert-Manager from `v0.4.1` to `v0.6.0`.

**Which issue(s) this PR fixes**:
Fixes #678 

**Special notes for your reviewer**:
It was necessary to extract `ApplierOptions` because Cert-Manager caches some readiness information about `CluserIssuers` in the status object which must be retained when Seeds are reconciled.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Cert-Manager version has been changed from `v0.4.1` to `v0.6.0`.
```