### PR TITLE
Deploy Alertmanager only when Shoot has an operatedBy annotation

### DIFF
--- a/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.emailConfigs }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -147,3 +148,4 @@ spec:
       resources:
         requests:
           storage: {{ .Values.storage }}
+{{- end }}

--- a/charts/seed-monitoring/charts/alertmanager/templates/config.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/config.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.emailConfigs }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,3 +6,4 @@ metadata:
   namespace: {{.Release.Namespace}}
 data:
   alertmanager.yaml: {{ include "config" . | b64enc }}
+{{- end }}

--- a/charts/seed-monitoring/charts/alertmanager/templates/ingress-auth-secret.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/ingress-auth-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.emailConfigs }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,3 +9,4 @@ metadata:
 type: Opaque
 data:
   auth: {{ .Values.ingress.basicAuthSecret }}
+{{- end }}

--- a/charts/seed-monitoring/charts/alertmanager/templates/ingress.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.emailConfigs }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -22,3 +23,4 @@ spec:
           serviceName: alertmanager-client
           servicePort: 9093
         path: /
+{{- end }}

--- a/charts/seed-monitoring/charts/prometheus/rules/alertmanager.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/alertmanager.rules.yaml
@@ -1,17 +1,6 @@
 groups:
 - name: alertmanager.rules
   rules:
-  - alert: AlertmanagerDown
-    expr: absent(up{job="alertmanager"} == 1)
-    for: 5m
-    labels:
-      job: alertmanager
-      service: alertmanager
-      severity: critical
-      type: seed
-    annotations:
-      summary: Alertmanager is down
-      description: There is no running Alertmanagers. Alerts wont be send to operators.
   - alert: AlertmanagerConfigInconsistent
     expr: count_values("config_hash", alertmanager_config_hash) / kube_statefulset_replicas{namespace="kube-system",statefulset="alertmanager"} != 1
     for: 5m

--- a/docs/usage/shoots.md
+++ b/docs/usage/shoots.md
@@ -43,3 +43,10 @@ spec:
 If you update the CloudProfile used in the Shoot and add `1.10.5` and `1.11.0` to the `.spec.<provider>.constraints.kubernetes.versions` list, the Shoot will be updated to `1.10.5` between 22:00-23:00 UTC. Your Shoot won't be updated to `1.11.0` even though its the highest Kubernetes in the CloudProfile, this is because that woulnd't be a patch release update but a minor release update, and potentially have breaking changes that could impact your deployed resources.
 
 In this example if the operator wants to update the Kubernetes version to `1.11.0`, he/she must update the Shoot's `.spec.kubernetes.version` to `1.11.0` manually.
+
+# Configure a Shoot cluster alert receiver
+The receiver of the Shoot alerts can be configured by adding the annotation `garden.sapcloud.io/operatedBy` to the Shoot resource. The value of the annotation has to be a valid mail address.
+
+The alerting for the Shoot clusters is handled by the Prometheus Alertmanager. The Alertmanager will be deployed next to the control plane when the `Shoot` resource is annotated with the `garden.sapcloud.io/operatedBy` annotation and if a [SMTP secret](../deployment/configuration.md) exists.
+
+If the annotation gets removed then the Alertmanager will be also removed during the next reconcilation of the cluster. The same is valid in the opposite if the annotation is added to an existing cluster.

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -498,3 +498,29 @@ func DeleteLoggingStack(k8sClient kubernetes.Interface, namespace string) error 
 	}
 	return nil
 }
+
+// DeleteAlertmanager deletes all resources of the Alertmanager in a given namespace.
+func DeleteAlertmanager(k8sClient kubernetes.Interface, namespace string) error {
+	var (
+		services = []string{"alertmanager-client", "alertmanager"}
+		secrets  = []string{"alertmanager-basic-auth", "alertmanager-tls", "alertmanager-config"}
+	)
+
+	if err := k8sClient.DeleteStatefulSet(namespace, AlertManagerStatefulSetName); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if err := k8sClient.DeleteIngress(namespace, "alertmanager"); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	for _, svc := range services {
+		if err := k8sClient.DeleteService(namespace, svc); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	for _, secret := range secrets {
+		if err := k8sClient.DeleteSecret(namespace, secret); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
We should only deploy the Alertmanager into a control plane when a receiver exists for the Shoot cluster (via annotation `garden.sapcloud.io/operatedBy: receiver@test.com`). Otherwise the Alertmanager will basically drop all alerts. If the annotation gets removed we can also remove the Alertmanager again.

For Gardener service maintainers/admins exists already a central Alertmanager per Seed (which will be deployed into the `garden` namespace during the seed bootstrap), which will route all alerts for all Shoots hosted on the Seed to the admins.

@wyb1 Could you please verify and review?

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```NONE

```
