### PR TITLE
Configure seed prometheus to use storage and time based retention

### DIFF
--- a/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
@@ -32,6 +32,7 @@ spec:
         - --storage.tsdb.no-lockfile
         # Increase this once the memory issues have been resolved
         - --storage.tsdb.retention.time=2h
+        - --storage.tsdb.retention.size=5GB
         - --web.listen-address=0.0.0.0:{{ .Values.prometheus.port }}
         - --web.enable-lifecycle
         # Since v2.0.0-beta.3 prometheus runs as nobody user (fsGroup 65534/runAsUser 0)


### PR DESCRIPTION
**What this PR does / why we need it**:
Configures the seed prometheus to use the new flag `storage.tsdb.retention.size`. This means that once prometheus uses up that much disk storage it will start deleting the oldest blocks. This should reduce required ops for prometheus. 

**Which issue(s) this PR fixes**:
Fixes #699

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Seed prometheus now uses storage and time based retention.
```
