### PR TITLE
Integrate gardener testframework and integration tests into testmachinery

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -1,0 +1,18 @@
+kind: TestDefinition
+metadata:
+  name: create-shoot
+spec:
+  owner: tim.schrodi@sap.com
+  recipientsOnFailure: DL_5C5BE3E2970B9F404D0E2F50@sap.com # OutputQualification DL
+  description: Tests the creation of a shoot.
+
+  activeDeadlineSeconds: 3600
+  labels: []
+
+  command: [bash, -c]
+  args:
+  - >-
+    /tm/setup github.com/gardener gardener &&
+    go run $GOPATH/src/github.com/gardener/gardener/.test-defs/cmd/create-shoot
+
+  image: eu.gcr.io/gardener-project/gardener/testmachinery/golang:0.28.0

--- a/.test-defs/DeleteShoot.yaml
+++ b/.test-defs/DeleteShoot.yaml
@@ -1,0 +1,18 @@
+kind: TestDefinition
+metadata:
+  name: delete-shoot
+spec:
+  owner: tim.schrodi@sap.com
+  recipientsOnFailure: DL_5C5BE3E2970B9F404D0E2F50@sap.com # OutputQualification DL
+  description: Tests the deletion of a shoot.
+
+  activeDeadlineSeconds: 1800
+  labels: []
+
+  command: [bash, -c]
+  args:
+  - >-
+    /tm/setup github.com/gardener gardener &&
+    go run $GOPATH/src/github.com/gardener/gardener/.test-defs/cmd/delete-shoot
+
+  image: eu.gcr.io/gardener-project/gardener/testmachinery/golang:0.28.0

--- a/.test-defs/ShootAppTest.yaml
+++ b/.test-defs/ShootAppTest.yaml
@@ -1,0 +1,21 @@
+kind: TestDefinition
+metadata:
+  name: shootapp-test
+spec:
+  owner: tim.schrodi@sap.com
+  recipientsOnFailure: DL_5C5BE3E2970B9F404D0E2F50@sap.com # OutputQualification DL
+  description: Tests the deployment of a guestbook.
+
+  activeDeadlineSeconds: 600
+  labels: ["default"]
+
+  command: [bash, -c]
+  args:
+  - >-
+    /tm/setup github.com/gardener gardener &&
+    go test $GOPATH/src/github.com/gardener/gardener/test/integration/shoots/applications
+    -ginkgo.v -ginkgo.progress
+    -kubeconfig=$TM_KUBECONFIG_PATH/gardener.config
+    -shootName=$SHOOT_NAME
+    -shootNamespace=$PROJECT_NAMESPACE
+  image: eu.gcr.io/gardener-project/gardener/testmachinery/golang:0.28.0

--- a/.test-defs/cmd/create-shoot/helper.go
+++ b/.test-defs/cmd/create-shoot/helper.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+)
+
+// updateWorkerZone updates the zone of the workers.
+// Azure shoots are ignored.
+func updateWorkerZone(shoot *gardenv1beta1.Shoot, cloudprovider gardenv1beta1.CloudProvider, zone string) {
+	switch cloudprovider {
+	case gardenv1beta1.CloudProviderAWS:
+		shoot.Spec.Cloud.AWS.Zones = []string{zone}
+	case gardenv1beta1.CloudProviderGCP:
+		shoot.Spec.Cloud.GCP.Zones = []string{zone}
+	case gardenv1beta1.CloudProviderAzure:
+		return
+	case gardenv1beta1.CloudProviderOpenStack:
+		shoot.Spec.Cloud.OpenStack.Zones = []string{zone}
+	default:
+		testLogger.Warnf("unsupported cloudprovider %s", cloudprovider)
+	}
+}
+
+// updateMachineType updates the machine type of a shoot if a machinetype is provided.
+func updateMachineType(shoot *gardenv1beta1.Shoot, cloudprovider gardenv1beta1.CloudProvider, machinetype string) {
+	if machinetype != "" {
+		switch cloudprovider {
+		case gardenv1beta1.CloudProviderAWS:
+			shoot.Spec.Cloud.AWS.Workers[0].MachineType = machinetype
+		case gardenv1beta1.CloudProviderGCP:
+			shoot.Spec.Cloud.GCP.Workers[0].MachineType = machinetype
+		case gardenv1beta1.CloudProviderAzure:
+			shoot.Spec.Cloud.Azure.Workers[0].MachineType = machinetype
+		case gardenv1beta1.CloudProviderOpenStack:
+			shoot.Spec.Cloud.OpenStack.Workers[0].MachineType = machinetype
+		default:
+			testLogger.Warnf("unsupported cloudprovider %s", cloudprovider)
+		}
+	}
+}
+
+// updateAutoscalerMinMax updates autoscalerMin and autoscalerMax of the worker if they are defined.
+func updateAutoscalerMinMax(shoot *gardenv1beta1.Shoot, cloudprovider gardenv1beta1.CloudProvider, min, max *int) {
+	if min != nil {
+		switch cloudprovider {
+		case gardenv1beta1.CloudProviderAWS:
+			shoot.Spec.Cloud.AWS.Workers[0].AutoScalerMin = *min
+		case gardenv1beta1.CloudProviderGCP:
+			shoot.Spec.Cloud.GCP.Workers[0].AutoScalerMin = *min
+		case gardenv1beta1.CloudProviderAzure:
+			shoot.Spec.Cloud.Azure.Workers[0].AutoScalerMin = *min
+		case gardenv1beta1.CloudProviderOpenStack:
+			shoot.Spec.Cloud.OpenStack.Workers[0].AutoScalerMin = *min
+		default:
+			testLogger.Warnf("unsupported cloudprovider %s", cloudprovider)
+		}
+	}
+	if max != nil {
+		switch cloudprovider {
+		case gardenv1beta1.CloudProviderAWS:
+			shoot.Spec.Cloud.AWS.Workers[0].AutoScalerMax = *max
+		case gardenv1beta1.CloudProviderGCP:
+			shoot.Spec.Cloud.GCP.Workers[0].AutoScalerMax = *max
+		case gardenv1beta1.CloudProviderAzure:
+			shoot.Spec.Cloud.Azure.Workers[0].AutoScalerMax = *max
+		case gardenv1beta1.CloudProviderOpenStack:
+			shoot.Spec.Cloud.OpenStack.Workers[0].AutoScalerMax = *max
+		default:
+			testLogger.Warnf("unsupported cloudprovider %s", cloudprovider)
+		}
+	}
+}

--- a/.test-defs/cmd/create-shoot/main.go
+++ b/.test-defs/cmd/create-shoot/main.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/test/integration/framework"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	shootName         string
+	projectNamespace  string
+	kubeconfigPath    string
+	cloudprovider     gardenv1beta1.CloudProvider
+	cloudprofileName  string
+	secretBindingName string
+	region            string
+	zone              string
+	k8sVersion        string
+
+	// optional parameters
+	machineType   string
+	autoScalerMin *int
+	autoScalerMax *int
+
+	testLogger *logrus.Logger
+)
+
+func init() {
+	testLogger = logger.NewLogger("debug")
+
+	shootName = os.Getenv("SHOOT_NAME")
+	if shootName == "" {
+		testLogger.Fatalf("EnvVar 'SHOOT_NAME' needs to be specified")
+	}
+	projectNamespace = os.Getenv("PROJECT_NAMESPACE")
+	if projectNamespace == "" {
+		testLogger.Fatalf("EnvVar 'PROJECT_NAMESPACE' needs to be specified")
+	}
+	kubeconfigPath = os.Getenv("TM_KUBECONFIG_PATH")
+	if kubeconfigPath == "" {
+		testLogger.Fatalf("EnvVar 'TM_KUBECONFIG_PATH' needs to be specified")
+	}
+	cloudprovider = gardenv1beta1.CloudProvider(os.Getenv("CLOUDPROVIDER"))
+	if cloudprovider == "" {
+		testLogger.Fatalf("EnvVar 'CLOUDPROVIDER' needs to be specified")
+	}
+	cloudprofileName = os.Getenv("CLOUDPROFILE")
+	if cloudprofileName == "" {
+		testLogger.Fatalf("EnvVar 'CLOUDPROFILE' needs to be specified")
+	}
+	secretBindingName = os.Getenv("SECRET_BINDING")
+	if secretBindingName == "" {
+		testLogger.Fatalf("EnvVar 'SECRET_BINDING' needs to be specified")
+	}
+	region = os.Getenv("REGION")
+	if region == "" {
+		testLogger.Fatalf("EnvVar 'REGION' needs to be specified")
+	}
+	zone = os.Getenv("ZONE")
+	if zone == "" && cloudprovider != gardenv1beta1.CloudProviderAzure {
+		testLogger.Fatalf("EnvVar 'ZONE' needs to be specified")
+	}
+	k8sVersion = os.Getenv("K8S_VERSION")
+	if k8sVersion == "" {
+		testLogger.Fatalf("EnvVar 'K8S_VERSION' needs to be specified")
+	}
+
+	machineType = os.Getenv("MACHINE_TYPE")
+	if autoScalerMinEnv := os.Getenv("AUTOSCALER_MIN"); autoScalerMinEnv != "" {
+		autoScalerMinInt, err := strconv.Atoi(autoScalerMinEnv)
+		if err != nil {
+			testLogger.Infof("Cannot parse %s: %s", autoScalerMinEnv, err.Error())
+		}
+		autoScalerMin = &autoScalerMinInt
+	}
+	if autoScalerMaxEnv := os.Getenv("AUTOSCALER_MAX"); autoScalerMaxEnv != "" {
+		autoScalerMaxInt, err := strconv.Atoi(autoScalerMaxEnv)
+		if err != nil {
+			testLogger.Infof("Cannot parse %s: %s", autoScalerMaxEnv, err.Error())
+		}
+		autoScalerMax = &autoScalerMaxInt
+	}
+}
+
+func main() {
+	gardenerConfigPath := fmt.Sprintf("%s/gardener.config", kubeconfigPath)
+
+	shootGardenerTest, err := framework.NewShootGardenerTest(gardenerConfigPath, nil, testLogger)
+	if err != nil {
+		testLogger.Fatalf("Cannot create ShootGardenerTest %s", err.Error())
+	}
+
+	_, shootObject, err := framework.CreateShootTestArtifacts(fmt.Sprintf("example/90-shoot-%s.yaml", cloudprovider), "")
+	if err != nil {
+		testLogger.Fatalf("Cannot create shoot artifact %s", err.Error())
+	}
+
+	shootObject.Name = shootName
+	shootObject.Namespace = projectNamespace
+	shootObject.Spec.Cloud.Profile = cloudprofileName
+	shootObject.Spec.Cloud.Region = region
+	shootObject.Spec.Cloud.SecretBindingRef.Name = secretBindingName
+	shootObject.Spec.Kubernetes.Version = k8sVersion
+	updateWorkerZone(shootObject, cloudprovider, zone)
+	updateMachineType(shootObject, cloudprovider, machineType)
+	updateAutoscalerMinMax(shootObject, cloudprovider, autoScalerMin, autoScalerMax)
+
+	testLogger.Infof("Create shoot %s in namespace %s", shootName, projectNamespace)
+	shootGardenerTest.Shoot = shootObject
+	shootObject, err = shootGardenerTest.CreateShoot(context.TODO())
+	if err != nil {
+		testLogger.Fatalf("Cannot create shoot %s: %s", shootName, err.Error())
+	}
+	testLogger.Infof("Successfully created shoot %s", shootName)
+
+	shootTestOperations, err := framework.NewGardenTestOperation(context.TODO(), shootGardenerTest.GardenClient, testLogger, shootObject)
+	if err != nil {
+		testLogger.Fatalf("Cannot create shoot %s: %s", shootName, err.Error())
+	}
+
+	err = shootTestOperations.DownloadKubeconfig(context.TODO(), shootTestOperations.SeedClient, shootTestOperations.ShootSeedNamespace(), gardenv1beta1.GardenerName, fmt.Sprintf("%s/shoot.config", kubeconfigPath))
+	if err != nil {
+		testLogger.Fatalf("Cannot download shoot kubeconfig: %s", err.Error())
+	}
+	testLogger.Infof("Finished creating shoot %s", shootName)
+}

--- a/.test-defs/cmd/delete-shoot/main.go
+++ b/.test-defs/cmd/delete-shoot/main.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/test/integration/framework"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	shootName        string
+	projectNamespace string
+	kubeconfigPath   string
+	testLogger       *logrus.Logger
+)
+
+func init() {
+	testLogger = logger.NewLogger("info")
+
+	shootName = os.Getenv("SHOOT_NAME")
+	if shootName == "" {
+		testLogger.Fatalf("EnvVar 'SHOOT_NAME' needs to be specified")
+	}
+	projectNamespace = os.Getenv("PROJECT_NAMESPACE")
+	if projectNamespace == "" {
+		testLogger.Fatalf("EnvVar 'PROJECT_NAMESPACE' needs to be specified")
+	}
+	kubeconfigPath = os.Getenv("TM_KUBECONFIG_PATH")
+	if kubeconfigPath == "" {
+		testLogger.Fatalf("EnvVar 'TM_KUBECONFIG_PATH' needs to be specified")
+	}
+}
+
+func main() {
+	gardenerConfigPath := fmt.Sprintf("%s/gardener.config", kubeconfigPath)
+
+	shoot := &v1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Namespace: projectNamespace, Name: shootName}}
+	shootGardenerTest, err := framework.NewShootGardenerTest(gardenerConfigPath, shoot, testLogger)
+	if err != nil {
+		testLogger.Fatalf("Cannot create ShootGardenerTest %s", err.Error())
+	}
+
+	if err := shootGardenerTest.DeleteShoot(context.TODO()); err != nil && !errors.IsNotFound(err) {
+		testLogger.Fatalf("Cannot delete shoot %s: %s", shootName, err.Error())
+	}
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR exposes the creation and deletion of a shoot with the test framework as util-commands to be consumed by the Testmachinery.
These util-commands standardize basic test operations and allow shared usage between different integration tests of various components. 

In addition, TestDefinitions for the Testmachinery are added to the `.test-defs`folder where they are picked up and executed by the Testmachinery.

**Special notes for your reviewer**:
Is the `.test-defs` the right path for these util-commands?

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
