### PR TITLE
Run logrotate timer hourly

### DIFF
--- a/charts/shoot-cloud-config/charts/original/templates/_cloud-config.tpl
+++ b/charts/shoot-cloud-config/charts/original/templates/_cloud-config.tpl
@@ -9,14 +9,15 @@ coreos:
     mask: true
   - name: locksmithd.service
     mask: true
-{{ include "logrotate" . | indent 2 }}
+{{ include "docker-logrotate" . | indent 2 }}
+{{ include "docker-logrotate-timer" . | indent 2 }}
 {{ include "docker-monitor" . | indent 2 }}
 {{ include "kubelet" . | indent 2 }}
 {{ include "kubelet-monitor" . | indent 2 }}
 {{ include "update-ca-certs" . | indent 2 }}
 {{ include "systemd-sysctl" . | indent 2 }}
 write_files:
-{{ include "logrotate-config" . }}
+{{ include "docker-logrotate-config" . }}
 {{ include "journald-config" . }}
 {{ include "kubelet-binary" . }}
 {{ include "root-certs" . }}

--- a/charts/shoot-cloud-config/charts/original/templates/logrotate/_docker-logrotate-config
+++ b/charts/shoot-cloud-config/charts/original/templates/logrotate/_docker-logrotate-config
@@ -1,5 +1,5 @@
-{{- define "logrotate-config" -}}
-- path: /etc/logrotate.d/docker.conf
+{{- define "docker-logrotate-config" -}}
+- path: /etc/systemd/docker.conf
   permissions: 0644
   content: |
 {{ include "docker-config" . | indent 4 }}

--- a/charts/shoot-cloud-config/charts/original/templates/logrotate/_docker-logrotate.service
+++ b/charts/shoot-cloud-config/charts/original/templates/logrotate/_docker-logrotate.service
@@ -1,12 +1,12 @@
-{{ define "logrotate" -}}
-- name: logrotate.service
+{{ define "docker-logrotate" -}}
+- name: docker-logrotate.service
   enable: true
   content: |
     [Unit]
     Description=Rotate and Compress System Logs
 
     [Service]
-    ExecStart=/usr/sbin/logrotate /usr/share/logrotate/logrotate.conf
+    ExecStart=/usr/sbin/logrotate /etc/systemd/docker.conf
 
     [Install]
     WantedBy=multi-user.target

--- a/charts/shoot-cloud-config/charts/original/templates/logrotate/_docker-logrotate.timer
+++ b/charts/shoot-cloud-config/charts/original/templates/logrotate/_docker-logrotate.timer
@@ -1,0 +1,16 @@
+{{- define "docker-logrotate-timer" -}}
+- name: docker-logrotate.timer
+  enable: true
+  command: start
+  content: |
+    [Unit]
+    Description=Hourly Log Rotation
+
+    [Timer]
+    OnCalendar=hourly
+    AccuracySec=10m
+    Persistent=true
+
+    [Install]
+    WantedBy=multi-user.target
+{{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently logrotate.timer runs once a day (`daily`):
```
$ cat /usr/lib/systemd/system/logrotate.timer
[Unit]
Description=Daily Log Rotation

[Timer]
OnCalendar=daily
AccuracySec=1h
Persistent=true
```

This means that in 24h customer workload with verbose logging can result in several gb log files and can lead the node to run out of disk space. The new `docker-logrotate.timer` runs `hourly` and rotates if file size > 200mb or a day passed since the last log rotation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
A new `docker-logrotate.timer` is created because the default one `logrotate.timer` is located under `/usr/` and `/usr/` in coreos is read-only.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Logrotate timer on all shoot worker VMs does now run hourly (instead of daily).
```
