### PR TITLE
Fix control plane condition to consider the alertmanager statefulset

### DIFF
--- a/pkg/apis/garden/v1beta1/helper/helpers.go
+++ b/pkg/apis/garden/v1beta1/helper/helpers.go
@@ -25,6 +25,7 @@ import (
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -98,6 +99,16 @@ func ShootWantsClusterAutoscaler(shoot *gardenv1beta1.Shoot) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// ShootWantsAlertmanager checks if the given Shoot needs an Alertmanger.
+func ShootWantsAlertmanager(shoot *gardenv1beta1.Shoot, secrets map[string]*corev1.Secret) bool {
+	if alertingSMTPSecret := common.GetSecretKeysWithPrefix(common.GardenRoleAlertingSMTP, secrets); len(alertingSMTPSecret) > 0 {
+		if address, ok := shoot.Annotations[common.GardenOperatedBy]; ok && utils.TestEmail(address) {
+			return true
+		}
+	}
+	return false
 }
 
 // GetShootCloudProviderWorkers retrieves the cloud-specific workers of the given Shoot.

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -556,12 +556,6 @@ var (
 		KubeStateMetricsShootDeploymentName,
 	)
 
-	// RequiredMonitoringSeedStatefulSets is a set of the required seed monitoring stateful sets.
-	RequiredMonitoringSeedStatefulSets = sets.NewString(
-		AlertManagerStatefulSetName,
-		PrometheusStatefulSetName,
-	)
-
 	// RequiredMonitoringShootDaemonSets is a set of the required shoot monitoring daemon sets.
 	RequiredMonitoringShootDaemonSets = sets.NewString(
 		NodeExporterDaemonSetName,

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -110,6 +110,7 @@ func newOperation(
 			return nil, err
 		}
 		operation.Shoot = shootObj
+		operation.Shoot.WantsAlertmanager = helper.ShootWantsAlertmanager(shoot, secrets)
 
 		shootedSeed, err := helper.ReadShootedSeed(shoot)
 		if err != nil {

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -32,5 +32,6 @@ type Shoot struct {
 	KubernetesMajorMinorVersion string
 
 	WantsClusterAutoscaler bool
+	WantsAlertmanager      bool
 	IsHibernated           bool
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
With PR #709 the Alertmanager is only deployed when the Shoot resource is annotated with the `garden.sapcloud.io/operatedBy` annotation. The control plane condition requires a running Alertmanager StatefulSet to be healthy. 

With this PR the control plane condition will require an  Alertmanager StatefulSet only if the Shoot resource is annotated properly.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```NONE

```
