### PR TITLE
Add region infor to Alicloud cloud controller

### DIFF
--- a/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go
@@ -62,6 +62,7 @@ func (b *AlicloudBotanist) GenerateCloudProviderConfig() (string, error) {
 	cfg.Global.VswitchID = stateVariables[vswitchID]
 	cfg.Global.AccessKeyID = key
 	cfg.Global.AccessKeySecret = secret
+	cfg.Global.Region = b.Shoot.Info.Spec.Cloud.Region
 
 	cfgJSON, err := json.Marshal(cfg)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
If there is no region info, alicloud ccm will read meta-data info. This will not work when we deploy seed cluster from soil cluster (GKE)
 