### PR TITLE
Add region info to Alicloud cloud controller

### DIFF
--- a/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go
@@ -63,6 +63,7 @@ func (b *AlicloudBotanist) GenerateCloudProviderConfig() (string, error) {
 	cfg.Global.VswitchID = stateVariables[vswitchID]
 	cfg.Global.AccessKeyID = key
 	cfg.Global.AccessKeySecret = secret
+	cfg.Global.Region = b.Shoot.Info.Spec.Cloud.Region
 
 	cfgJSON, err := json.Marshal(cfg)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Alicloud CCM needs region info. It can read from configuration. If there is no such info, it will try to get region info from meta-data endpoint (alicloud specific). This doesn't work correctly in GCP soil cluster.
 