### PR TITLE
Add alicloud support for testmachinery

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -2,8 +2,7 @@ kind: TestDefinition
 metadata:
   name: create-shoot
 spec:
-  owner: tim.schrodi@sap.com
-  recipientsOnFailure: DL_5C5BE3E2970B9F404D0E2F50@sap.com # OutputQualification DL
+  owner: DL_5C5BE3E2970B9F404D0E2F50@sap.com
   description: Tests the creation of a shoot.
 
   activeDeadlineSeconds: 3600

--- a/.test-defs/DeleteShoot.yaml
+++ b/.test-defs/DeleteShoot.yaml
@@ -2,8 +2,7 @@ kind: TestDefinition
 metadata:
   name: delete-shoot
 spec:
-  owner: tim.schrodi@sap.com
-  recipientsOnFailure: DL_5C5BE3E2970B9F404D0E2F50@sap.com # OutputQualification DL
+  owner: DL_5C5BE3E2970B9F404D0E2F50@sap.com # OutputQualification DL
   description: Tests the deletion of a shoot.
 
   activeDeadlineSeconds: 1800

--- a/.test-defs/ShootAppTest.yaml
+++ b/.test-defs/ShootAppTest.yaml
@@ -2,8 +2,7 @@ kind: TestDefinition
 metadata:
   name: shootapp-test
 spec:
-  owner: tim.schrodi@sap.com
-  recipientsOnFailure: DL_5C5BE3E2970B9F404D0E2F50@sap.com # OutputQualification DL
+  owner: DL_5C5BE3E2970B9F404D0E2F50@sap.com # OutputQualification DL
   description: Tests the deployment of a guestbook.
 
   activeDeadlineSeconds: 600

--- a/.test-defs/cmd/create-shoot/helper.go
+++ b/.test-defs/cmd/create-shoot/helper.go
@@ -30,6 +30,8 @@ func updateWorkerZone(shoot *gardenv1beta1.Shoot, cloudprovider gardenv1beta1.Cl
 		return
 	case gardenv1beta1.CloudProviderOpenStack:
 		shoot.Spec.Cloud.OpenStack.Zones = []string{zone}
+	case gardenv1beta1.CloudProviderAlicloud:
+		shoot.Spec.Cloud.Alicloud.Zones = []string{zone}
 	default:
 		testLogger.Warnf("unsupported cloudprovider %s", cloudprovider)
 	}
@@ -47,6 +49,8 @@ func updateMachineType(shoot *gardenv1beta1.Shoot, cloudprovider gardenv1beta1.C
 			shoot.Spec.Cloud.Azure.Workers[0].MachineType = machinetype
 		case gardenv1beta1.CloudProviderOpenStack:
 			shoot.Spec.Cloud.OpenStack.Workers[0].MachineType = machinetype
+		case gardenv1beta1.CloudProviderAlicloud:
+			shoot.Spec.Cloud.Alicloud.Workers[0].MachineType = machinetype
 		default:
 			testLogger.Warnf("unsupported cloudprovider %s", cloudprovider)
 		}
@@ -65,6 +69,8 @@ func updateAutoscalerMinMax(shoot *gardenv1beta1.Shoot, cloudprovider gardenv1be
 			shoot.Spec.Cloud.Azure.Workers[0].AutoScalerMin = *min
 		case gardenv1beta1.CloudProviderOpenStack:
 			shoot.Spec.Cloud.OpenStack.Workers[0].AutoScalerMin = *min
+		case gardenv1beta1.CloudProviderAlicloud:
+			shoot.Spec.Cloud.Alicloud.Workers[0].AutoScalerMin = *min
 		default:
 			testLogger.Warnf("unsupported cloudprovider %s", cloudprovider)
 		}
@@ -79,6 +85,8 @@ func updateAutoscalerMinMax(shoot *gardenv1beta1.Shoot, cloudprovider gardenv1be
 			shoot.Spec.Cloud.Azure.Workers[0].AutoScalerMax = *max
 		case gardenv1beta1.CloudProviderOpenStack:
 			shoot.Spec.Cloud.OpenStack.Workers[0].AutoScalerMax = *max
+		case gardenv1beta1.CloudProviderAlicloud:
+			shoot.Spec.Cloud.Alicloud.Workers[0].AutoScalerMax = *max
 		default:
 			testLogger.Warnf("unsupported cloudprovider %s", cloudprovider)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for alicloud in the create-shoot utility for the testmachinery, that we can extend our tests to alicloud clusters.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
 NONE
```
