### PR TITLE
Add VPA into Seed

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -197,3 +197,17 @@ images:
   sourceRepository: github.com/gardener/cert-broker
   repository: eu.gcr.io/gardener-project/gardener/cert-broker
   tag: "0.2.0"
+
+# VPA
+- name: vpa-admission-controller
+  sourceRepository: github.com/kubernetes/autoscaler
+  repository: k8s.gcr.io/vpa-admission-controller
+  tag: "0.3.1"
+- name: vpa-recommender
+  sourceRepository: github.com/kubernetes/autoscaler
+  repository: k8s.gcr.io/vpa-recommender
+  tag: "0.3.1"
+- name: vpa-updater
+  sourceRepository: github.com/kubernetes/autoscaler
+  repository: k8s.gcr.io/vpa-updater
+  tag: "0.3.1"

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -202,12 +202,12 @@ images:
 - name: vpa-admission-controller
   sourceRepository: github.com/kubernetes/autoscaler
   repository: k8s.gcr.io/vpa-admission-controller
-  tag: "0.3.1"
+  tag: "0.4.0"
 - name: vpa-recommender
   sourceRepository: github.com/kubernetes/autoscaler
   repository: k8s.gcr.io/vpa-recommender
-  tag: "0.3.1"
+  tag: "0.4.0"
 - name: vpa-updater
   sourceRepository: github.com/kubernetes/autoscaler
   repository: k8s.gcr.io/vpa-updater
-  tag: "0.3.1"
+  tag: "0.4.0"

--- a/charts/seed-bootstrap/charts/vpa/Chart.yaml
+++ b/charts/seed-bootstrap/charts/vpa/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A helm chart to bootstrap the vpa
+name: vpa
+version: 0.1.0

--- a/charts/seed-bootstrap/charts/vpa/charts/utils-templates
+++ b/charts/seed-bootstrap/charts/vpa/charts/utils-templates
@@ -1,0 +1,1 @@
+../../../../utils-templates

--- a/charts/seed-bootstrap/charts/vpa/templates/admission-controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/admission-controller-deployment.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vpa-webhook
+  namespace: garden
+spec:
+  ports:
+    - port: 443
+      targetPort: 8000
+  selector:
+    app: vpa-admission-controller
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vpa-admission-controller
+  namespace: garden
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+---
+apiVersion: {{ include "deploymentversion" . }}
+kind: Deployment
+metadata:
+  name: vpa-admission-controller
+  namespace: garden
+  labels:
+    app: vpa-admission-controller
+{{ toYaml .Values.vpa.labels | indent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vpa-admission-controller
+{{ toYaml .Values.vpa.labels | indent 6 }}
+  template:
+    metadata:
+      annotations:
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+      labels:
+        app: vpa-admission-controller
+{{ toYaml .Values.vpa.labels | indent 8 }}
+    spec:
+      serviceAccountName: vpa-admission-controller
+      containers:
+      - name: admission-controller
+        args:
+        - ./admission-controller
+        - --v=4
+        - --stderrthreshold=info
+        - --client-ca-file=/etc/tls-certs/ca.crt
+        - --tls-cert-file=/etc/tls-certs/tls.crt
+        - --tls-private-key=/etc/tls-certs/tls.key
+        image: {{ index .Values.global.images "vpa-admission-controller" }}
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+          - name: vpa-tls-certs
+            mountPath: "/etc/tls-certs"
+            readOnly: true
+        resources:
+          limits:
+            cpu: 200m
+            memory: 500Mi
+          requests:
+            cpu: 50m
+            memory: 200Mi
+        ports:
+        - containerPort: 8000
+      volumes:
+        - name: vpa-tls-certs
+          secret:
+            secretName: vpa-tls-certs

--- a/charts/seed-bootstrap/charts/vpa/templates/recommender-deployment.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/recommender-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vpa-recommender
+  namespace: garden
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+---
+apiVersion: {{ include "deploymentversion" . }}
+kind: Deployment
+metadata:
+  name: vpa-recommender
+  namespace: garden
+  labels:
+    app: vpa-recommender
+{{ toYaml .Values.vpa.labels | indent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vpa-recommender
+{{ toYaml .Values.vpa.labels | indent 6 }}
+  template:
+    metadata:
+      labels:
+        app: vpa-recommender
+{{ toYaml .Values.vpa.labels | indent 8 }}
+    spec:
+      serviceAccountName: vpa-recommender
+      containers:
+      - name: recommender
+        image: {{ index .Values.global.images "vpa-recommender" }}
+        imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 200m
+            memory: 1000Mi
+          requests:
+            cpu: 50m
+            memory: 500Mi
+        ports:
+        - containerPort: 8080

--- a/charts/seed-bootstrap/charts/vpa/templates/recommender-deployment.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/recommender-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
       - name: recommender
         image: {{ index .Values.global.images "vpa-recommender" }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         resources:
           limits:
             cpu: 200m

--- a/charts/seed-bootstrap/charts/vpa/templates/updater-deployment.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/updater-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
       - name: updater
         image: {{ index .Values.global.images "vpa-updater" }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         resources:
           limits:
             cpu: 200m

--- a/charts/seed-bootstrap/charts/vpa/templates/updater-deployment.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/updater-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vpa-updater
+  namespace: garden
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+---
+apiVersion: {{ include "deploymentversion" . }}
+kind: Deployment
+metadata:
+  name: vpa-updater
+  namespace: garden
+  labels:
+    app: vpa-updater
+{{ toYaml .Values.vpa.labels | indent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vpa-updater
+{{ toYaml .Values.vpa.labels | indent 6 }}
+  template:
+    metadata:
+      labels:
+        app: vpa-updater
+{{ toYaml .Values.vpa.labels | indent 8 }}
+    spec:
+      serviceAccountName: vpa-updater
+      containers:
+      - name: updater
+        image: {{ index .Values.global.images "vpa-updater" }}
+        imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 200m
+            memory: 1000Mi
+          requests:
+            cpu: 50m
+            memory: 500Mi
+        ports:
+        - containerPort: 8080

--- a/charts/seed-bootstrap/charts/vpa/templates/vpa-crd.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/vpa-crd.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalers.autoscaling.k8s.io
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+spec:
+  group: autoscaling.k8s.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalers
+    singular: verticalpodautoscaler
+    kind: VerticalPodAutoscaler
+    shortNames:
+    - vpa
+  validation:
+    # openAPIV3Schema is the schema for validating custom objects.
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+            - selector
+          properties:
+            selector:
+              type: object
+            updatePolicy:
+              properties:
+                updateMode:
+                  type: string
+            resourcePolicy:
+              properties:
+                containerPolicies:
+                  type: array
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+spec:
+  group: autoscaling.k8s.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    plural: verticalpodautoscalercheckpoints
+    singular: verticalpodautoscalercheckpoint
+    kind: VerticalPodAutoscalerCheckpoint
+    shortNames:
+    - vpacheckpoint

--- a/charts/seed-bootstrap/charts/vpa/templates/vpa-crd.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/vpa-crd.yaml
@@ -14,15 +14,22 @@ spec:
     kind: VerticalPodAutoscaler
     shortNames:
     - vpa
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true
   validation:
     # openAPIV3Schema is the schema for validating custom objects.
     openAPIV3Schema:
       properties:
         spec:
-          required:
-            - selector
+          required: []
           properties:
-            selector:
+            targetRef:
               type: object
             updatePolicy:
               properties:
@@ -49,3 +56,11 @@ spec:
     kind: VerticalPodAutoscalerCheckpoint
     shortNames:
     - vpacheckpoint
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true

--- a/charts/seed-bootstrap/charts/vpa/templates/vpa-rbac.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/vpa-rbac.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
@@ -166,7 +167,7 @@ subjects:
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: system:controllers-reader
+  name: system:vpa-target-reader
   labels:
 {{ toYaml .Values.vpa.labels | indent 4 }}
 rules:
@@ -181,8 +182,18 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - statefulsets
+  - daemonsets
+  - deployments
   - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
   verbs:
   - get
   - list
@@ -191,14 +202,20 @@ rules:
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: system:vpa-updater-controllers-reader-binding
+  name: system:vpa-target-reader-binding
   labels:
 {{ toYaml .Values.vpa.labels | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:controllers-reader
+  name: system:vpa-target-reader
 subjects:
+- kind: ServiceAccount
+  name: vpa-recommender
+  namespace: garden
+- kind: ServiceAccount
+  name: vpa-admission-controller
+  namespace: garden
 - kind: ServiceAccount
   name: vpa-updater
   namespace: garden
@@ -216,6 +233,12 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: vpa-updater
+  namespace: garden
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vpa-admission-controller
   namespace: garden
 ---
 apiVersion: {{ include "rbacversion" . }}

--- a/charts/seed-bootstrap/charts/vpa/templates/vpa-rbac.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/vpa-rbac.yaml
@@ -1,0 +1,277 @@
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: system:metrics-reader
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+rules:
+- apiGroups:
+  - "metrics.k8s.io"
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: system:vpa-actor
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
+  - "poc.autoscaling.k8s.io"
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - "autoscaling.k8s.io"
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: system:vpa-checkpoint-actor
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+rules:
+- apiGroups:
+  - "poc.autoscaling.k8s.io"
+  resources:
+  - verticalpodautoscalercheckpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete
+- apiGroups:
+  - "autoscaling.k8s.io"
+  resources:
+  - verticalpodautoscalercheckpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: system:evictioner
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+rules:
+- apiGroups:
+  - "extensions"
+  - "apps"
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-reader
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: vpa-recommender
+  namespace: garden
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-actor
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-actor
+subjects:
+- kind: ServiceAccount
+  name: vpa-recommender
+  namespace: garden
+- kind: ServiceAccount
+  name: vpa-updater
+  namespace: garden
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-checkpoint-actor
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-checkpoint-actor
+subjects:
+- kind: ServiceAccount
+  name: vpa-recommender
+  namespace: garden
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: system:controllers-reader
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-updater-controllers-reader-binding
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:controllers-reader
+subjects:
+- kind: ServiceAccount
+  name: vpa-updater
+  namespace: garden
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-evictionter-binding
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:evictioner
+subjects:
+- kind: ServiceAccount
+  name: vpa-updater
+  namespace: garden
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: system:vpa-admission-controller
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - configmaps
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "admissionregistration.k8s.io"
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+- apiGroups:
+  - "poc.autoscaling.k8s.io"
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "autoscaling.k8s.io"
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-admission-controller
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-admission-controller
+subjects:
+- kind: ServiceAccount
+  name: vpa-admission-controller
+  namespace: garden

--- a/charts/seed-bootstrap/charts/vpa/values.yaml
+++ b/charts/seed-bootstrap/charts/vpa/values.yaml
@@ -1,0 +1,11 @@
+global:
+  images:
+    vpa-admission-controller: image-repository:image-tag
+    vpa-recommender: image-repository:image-tag
+    vpa-updater: image-repository:image-tag
+
+vpa:
+  podAnnotations: {}
+  enabled: true
+  labels:
+    garden.sapcloud.io/role: vpa

--- a/charts/seed-bootstrap/requirements.yaml
+++ b/charts/seed-bootstrap/requirements.yaml
@@ -14,3 +14,7 @@ dependencies:
   version: 0.6.0
   # needed for the CertificateManagement feature gate
   condition: cert-manager.enabled
+- name: vpa
+  repository: http://localhost:10191
+  version: 0.1.0
+  condition: vpa.enabled

--- a/charts/seed-bootstrap/templates/prometheus/prometheus-vpa.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/prometheus-vpa.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.vpa.enabled }}
+apiVersion: "autoscaling.k8s.io/v1beta1"
+kind: VerticalPodAutoscaler
+metadata:
+  name: prometheus-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: prometheus
+      role: monitoring
+  updatePolicy:
+    updateMode: "Off"
+{{ end }}

--- a/charts/seed-bootstrap/templates/prometheus/prometheus-vpa.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/prometheus-vpa.yaml
@@ -1,14 +1,14 @@
 {{ if .Values.vpa.enabled }}
-apiVersion: "autoscaling.k8s.io/v1beta1"
+apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
   name: prometheus-vpa
   namespace: {{ .Release.Namespace }}
 spec:
-  selector:
-    matchLabels:
-      app: prometheus
-      role: monitoring
+  targetRef:
+    apiVersion: {{ include "statefulsetversion" . }}
+    kind: StatefulSet
+    name: prometheus
   updatePolicy:
     updateMode: "Off"
 {{ end }}

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -67,6 +67,9 @@ global:
     kibana-oss: image-repository:image-tag
     pause-container: image-repository:image-tag
     prometheus: image-repository:image-tag
+    vpa-admission-controller: image-repository:image-tag
+    vpa-recommender: image-repository:image-tag
+    vpa-updater: image-repository:image-tag
 
   elasticsearchPorts:
     db: 9200
@@ -91,4 +94,7 @@ alertmanager:
   storage: 1Gi
 
 cert-manager:
+  enabled: true
+
+vpa:
   enabled: true

--- a/charts/seed-monitoring/charts/prometheus/templates/prometheus-vpa.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/prometheus-vpa.yaml
@@ -1,14 +1,14 @@
-{{- if .Values.vpa.enabled -}}
-apiVersion: "autoscaling.k8s.io/v1beta1"
+{{ if .Values.vpa.enabled }}
+apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
   name: prometheus-vpa
   namespace: {{ .Release.Namespace }}
 spec:
-  selector:
-    matchLabels:
-      app: prometheus
-      role: monitoring
+  targetRef:
+    apiVersion: {{ include "statefulsetversion" . }}
+    kind: StatefulSet
+    name: prometheus
   updatePolicy:
     updateMode: "Off"
 {{ end }}

--- a/charts/seed-monitoring/charts/prometheus/templates/prometheus-vpa.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/prometheus-vpa.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.vpa.enabled -}}
+apiVersion: "autoscaling.k8s.io/v1beta1"
+kind: VerticalPodAutoscaler
+metadata:
+  name: prometheus-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: prometheus
+      role: monitoring
+  updatePolicy:
+    updateMode: "Off"
+{{ end }}

--- a/charts/seed-monitoring/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/prometheus/values.yaml
@@ -217,3 +217,6 @@ resources:
       perObject: 60
       weight: 5
       unit: Mi
+
+vpa:
+  enabled: false

--- a/charts/seed-monitoring/values.yaml
+++ b/charts/seed-monitoring/values.yaml
@@ -19,6 +19,8 @@ prometheus:
     prometheus: image-repository:image-tag
     configmap-reloader: image-repository:image-tag
     vpn-seed: image-repository:image-tag
+  vpa:
+    enabled: false
 grafana:
   replicas: 1
   images:

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -68,3 +68,4 @@ featureGates:
   # If enabled you require a proper configuration, please see example/10-secret-certificate-management-config.yaml
   # and https://gardener.cloud/050-tutorials/content/howto/gardener_certificate_management/.
   CertificateManagement: false
+  VPA: true

--- a/pkg/controllermanager/features/features.go
+++ b/pkg/controllermanager/features/features.go
@@ -25,6 +25,7 @@ var (
 	featureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
 		features.Logging:               {Default: false, PreRelease: utilfeature.Alpha},
 		features.CertificateManagement: {Default: false, PreRelease: utilfeature.Alpha},
+		features.VPA:                   {Default: false, PreRelease: utilfeature.Alpha},
 	}
 )
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -35,4 +35,9 @@ const (
 	// owner @timuthy, @zanetworker
 	// alpha: v0.1.0
 	CertificateManagement utilfeature.Feature = "CertificateManagement"
+
+	// VPA enables vertical pod autoscaling in Seed clusters.
+	// owner @wyb1
+	// alpha: v0.1.0
+	VPA utilfeature.Feature = "VPA"
 )

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -340,6 +340,9 @@ func (b *Botanist) DeploySeedMonitoring() error {
 			"shoot": map[string]interface{}{
 				"apiserver": fmt.Sprintf("https://%s", b.APIServerAddress),
 			},
+			"vpa": map[string]interface{}{
+				"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
+			},
 		}
 		kubeStateMetricsSeedConfig = map[string]interface{}{
 			"replicas": b.Shoot.GetReplicas(1),

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -149,6 +149,9 @@ const (
 	// GardenRoleCertificateManagement is the value of GardenRole key indicating type 'certificate-management'.
 	GardenRoleCertificateManagement = "certificate-management"
 
+	// GardenRoleVpa is the value of GardenRole key indecating type 'vpa'.
+	GardenRoleVpa = "vpa"
+
 	// GardenCreatedBy is the key for an annotation of a Shoot cluster whose value indicates contains the username
 	// of the user that created the resource.
 	GardenCreatedBy = "garden.sapcloud.io/createdBy"
@@ -522,6 +525,15 @@ const (
 
 	// RegistrationSpecHash is a constant for a label on `ControllerInstallation`s (similar to `pod-template-hash` on `Pod`s).
 	RegistrationSpecHash = "registration-spec-hash"
+
+	// VpaAdmissionControllerImageName is the name of the vpa-admission-controller image
+	VpaAdmissionControllerImageName = "vpa-admission-controller"
+
+	// VpaRecommenderImageName is the name of the vpa-recommender image
+	VpaRecommenderImageName = "vpa-recommender"
+
+	// VpaUpdaterImageName is the name of the vpa-updater image
+	VpaUpdaterImageName = "vpa-updater"
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the vertical pod autoscaler behind a feature gate. The VPA components are added into the seed in the garden namespace. It will now be possible to create VPA CRs. Additionally, a VPA CR is created for each prometheus. 
**Which issue(s) this PR fixes**:
Fixes #715 

**Special notes for your reviewer**:
/cc  @georgekuruvillak @amshuman-kr @swapnilgm 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
If the new `VPA` feature gate is enabled then Gardener will deploy the [Vertical Pod Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) into the `garden` namespace of every seed cluster.
```
```noteworthy operator
If the new `VPA` feature gate is enabled then the vertical pod autoscaler will provide scaling recommendations for the central Prometheus in the `garden` namespace as well as all shoot-specific Prometheus instances. It will not yet scale them automatically. We might enable this in a future release.
```
