### PR TITLE
Use fully qualified domain names to query CoreDNS

### DIFF
--- a/charts/shoot-core/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -43,6 +43,10 @@ spec:
         volumeMounts:
         - name: blackbox-exporter-config
           mountPath: /etc/blackbox_exporter
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "3"
       volumes:
       - name: blackbox-exporter-config
         configMap:


### PR DESCRIPTION
**What this PR does / why we need it**:
make the requests coming from the `black-box-exporter` fully qualified. This way no un-necessary requests will go to `CoreDNS` and the load on it will be less. 

**Release note**:

```improvement user
The load on `CoreDNS` produced by the `blackbox-exporter` running in the shoot cluster's `kube-system` is now reduced
```
