### PR TITLE
Overhaul of the vpn-connection metrics and alerts

### DIFF
--- a/charts/seed-monitoring/charts/prometheus/rules/vpn.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/vpn.rules.yaml
@@ -2,7 +2,7 @@ groups:
 - name: vpn.rules
   rules:
   - alert: VPNShootNoPods
-    expr:  kube_deployment_status_replicas_available{deployment="vpn-shoot"} == 0
+    expr: kube_deployment_status_replicas_available{deployment="vpn-shoot"} == 0
     for: 5m
     labels:
       service: vpn
@@ -12,12 +12,32 @@ groups:
       description: vpn-shoot deployment in Shoot cluster has 0 available pods. VPN won't work.
       summary: VPN Shoot deployment no pods
   - alert: VPNConnectionDown
-    expr: probe_success == 0
+    expr: absent(probe_success{job="vpn-connection"}) == 1 or probe_success{job="vpn-connection"} != 1
     for: 5m
     labels:
       service: vpn
       severity: critical
       type: shoot
     annotations:
-      description: VPN connection for {{ $labels.pod }} is down. No resources of the Shoot clustercan be accessed by this pod.
+      description: VPN connection check failed. No communication from control plane (Prometheus pod) to the Shoot workers possible.
       summary: VPN connection down
+  - alert: VPNProbeAPIServerProxyFailed
+    expr: absent(probe_success{job="vpn-probe-apiserver-proxy"}) == 1 or probe_success{job="vpn-probe-apiserver-proxy"} == 0 or probe_http_status_code{job="vpn-probe-apiserver-proxy"} != 200
+    for: 10m
+    labels:
+      service: vpn
+      severity: critical
+      type: shoot
+    annotations:
+      description: The API Server proxy functionality is not working. Probably the vpn connection from an API Server pod to the vpn-shoot endpoint on the Shoot workers does not work.
+      summary: API Server Proxy not usable
+  - alert: VPNProbeK8sServiceFailed
+    expr: absent(probe_success{job="vpn-probe-apiserver-proxy"}) == 1 or probe_success{job="vpn-probe-apiserver-proxy"} != 1
+    for: 10m
+    labels:
+      service: vpn
+      severity: warning
+      type: shoot
+    annotations:
+      description: The VPN probe via the kubernetes service does not work. The vpn connection from Prometheus to the vpn-shoot endpoint on the Shoot workers or the communication from the Shoot workers to the API Server via the kubernetes service is not working.
+      summary: VPN probe via kubernetes service failed

--- a/charts/seed-monitoring/charts/prometheus/templates/blackbox-exporter-config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/blackbox-exporter-config.yaml
@@ -9,9 +9,12 @@ metadata:
 data:
   blackbox.yaml: |
     modules:
+      icmp_probe:
+        prober: icmp
+        timeout: 5s
       tcp_vpn:
         prober: tcp
-        timeout: 2s
+        timeout: 5s
       http_apiserver:
         prober: http
         timeout: 10s

--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -439,7 +439,66 @@ data:
 
     - job_name: vpn-connection
       honor_labels: false
-      scrape_interval: 15s
+      metrics_path: /probe
+      params:
+        module:
+        - icmp_probe
+        target:
+        - {{ .Values.vpnEndpointIP }}
+      static_configs:
+      - targets:
+        - 127.0.0.1:9115
+      relabel_configs:
+      - target_label: type
+        replacement: seed
+      - source_labels: [ __param_target ]
+        target_label: instance
+        action: replace
+      - target_label: __address__
+        replacement: 127.0.0.1:9115
+        action: replace
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.vpn | indent 6 }}
+
+    # Fetch logs of the vpn-shoot pod via the kube-apiserver, which requires a functional vpn connection.
+    - job_name: vpn-probe-apiserver-proxy
+      honor_labels: false
+      metrics_path: /probe
+      params:
+        module:
+        - http_apiserver
+      kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: [ kube-system ]
+        api_server: kube-apiserver
+        tls_config:
+{{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
+      relabel_configs:
+      - target_label: type
+        replacement: seed
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        action: keep
+        regex: vpn-shoot-(.+)
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: __param_target
+        regex: (.+)
+        replacement: https://kube-apiserver:443/api/v1/namespaces/kube-system/pods/${1}/log?tailLines=1
+        action: replace
+      - source_labels: [ __param_target ]
+        target_label: instance
+        action: replace
+      - target_label: __address__
+        replacement: 127.0.0.1:9115
+        action: replace
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.vpn | indent 6 }}
+
+    # This probe is intended to be deprecated, because it is testing the vpn-tunnel and the
+    # reachability of the kube-apiservers from the shoot workers. We have introduced isolated
+    # probes for both cases and will therefore remove this probe in the future.
+    - job_name: vpn-probe-k8s-service
+      honor_labels: false
       scrape_timeout: 5s
       metrics_path: /probe
       params:
@@ -459,6 +518,8 @@ data:
         regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__meta_kubernetes_pod_name]
         target_label: pod
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.vpn | indent 6 }}
 
     - job_name: blackbox-apiserver
       params:

--- a/charts/seed-monitoring/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/prometheus/values.yaml
@@ -25,6 +25,7 @@ podAnnotations: {}
 replicas: 1
 apiserverServiceIP: 100.10.10.10
 port: 9090
+vpnEndpointIP: 192.168.123.1
 
 allowedMetrics:
   alertManager:
@@ -171,6 +172,9 @@ allowedMetrics:
   - probe_http_duration_seconds
   - probe_success
   - probe_http_status_code
+  vpn:
+  - probe_http_status_code
+  - probe_success
 
 seed:
   apiserver: https://api.foo.bar

--- a/charts/shoot-core/charts/monitoring/charts/prometheus-shoot/templates/rbac.yaml
+++ b/charts/shoot-core/charts/monitoring/charts/prometheus-shoot/templates/rbac.yaml
@@ -18,6 +18,7 @@ rules:
 - apiGroups: [""]
   resources:
   - nodes/metrics
+  - pods/log
   verbs:
   - get
 - nonResourceURLs:


### PR DESCRIPTION
**What this PR does / why we need it**:
The current vpn-connection metric represents the result of a blackbox-exporter probe, which tests if the Api Server can be reached via the `kubernetes` service. To archive this a working vpn connection from Prometheus (Seed) to the vpn-shoot endpoint (Shoot workers) is required.

We want to isolate those tests steps into dedicated probes to get better understanding which part is not working in case of an issue. A probe which tests the route via the `kubernetes` service already exists. This pr introduces a probe for the vpn connection exclusively and deprecates the old vpn probe.

In addition this pr introduces a second vpn related test, which tests if the port-forward, proxy and logs functionality is working. This test is an extension for the first vpn test, but we can't rely only on this test because there can be other reasons why the Api Server proxy functionality isn't working.

**Special notes for your reviewer**:
Interrupt the vpn connection and check if Prometheus raises vpn related alerts.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user|operator
Dedicated health probes for the vpn connection and corresponding alerts have been added. The existing vpn probe is now deprecated and will be removed in the future.
```
