### PR TITLE
increase blackbox exporter timeout to 5s 

### DIFF
--- a/charts/seed-monitoring/charts/prometheus/rules/apiserver-connectivity-check.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/apiserver-connectivity-check.rules.yaml
@@ -1,13 +1,23 @@
 groups:
-- name: apiserver-connectivity-check.rules
-  rules:
-  - alert: ApiServerUnreachableViaKubernetesService
-    expr: probe_success{job="blackbox-exporter-k8s-service-check"} != 1
-    for: 3m
-    labels:
-      service: apiserver-connectivity-check
-      severity: critical
-      type: shoot
-    annotations:
-      summary: Api server unreachable via the kubernetes service.
-      description: The Api server has been unreachable for 3 minutes via the kubernetes service in the shoot.
+  - name: apiserver-connectivity-check.rules
+    rules:
+      - alert: ApiServerUnreachableViaKubernetesService
+        expr: probe_success{job="blackbox-exporter-k8s-service-check"} != 1
+        for: 3m
+        labels:
+          service: apiserver-connectivity-check
+          severity: critical
+          type: shoot
+        annotations:
+          summary: Api server unreachable via the kubernetes service.
+          description: The Api server has been unreachable for 3 minutes via the kubernetes service in the shoot.
+      - alert: HighLatencyFromShootToApiServer
+        expr: probe_duration_seconds{job="blackbox-exporter-k8s-service-check"} > 3
+        for: 3m
+        labels:
+          service: apiserver-connectivity-check
+          severity: warning
+          type: shoot
+        annotations:
+          summary: There is a high latency between the shoot and Api server.
+          description: Probes to the Api server from the shoot took longer than 3s for 3m.

--- a/charts/shoot-core/charts/monitoring/charts/blackbox-exporter/templates/config.yaml
+++ b/charts/shoot-core/charts/monitoring/charts/blackbox-exporter/templates/config.yaml
@@ -12,7 +12,7 @@ data:
     modules:
       http_kubernetes_service:
         prober: http
-        timeout: 2s
+        timeout: 5s
         http:
           headers:
             Accept: "*/*"


### PR DESCRIPTION
**What this PR does / why we need it**:
Increases the timeout in the blackbox exporter in the shoot from 2s to 5s. There have been false positive alerts for `ApiServerUnreachableViaKubernetesService`. Some probes to the Api server took longer than 2s so the probe failed and created false positives. If there is a high latency, we should look into it so there is an additional warning level alert for latency. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
