### PR TITLE
Prevent elastic mapping collision

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -174,7 +174,7 @@ images:
 - name: fluent-bit
   sourceRepository: github.com/fluent/fluent-bit
   repository: fluent/fluent-bit
-  tag: "1.0.3"
+  tag: "1.0.4"
 - name: elasticsearch-oss
   sourceRepository: github.com/elastic/elasticsearch-docker
   repository: docker.elastic.co/elasticsearch/elasticsearch-oss

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
@@ -258,8 +258,8 @@ data:
         Match               kubernetes.*
         Kube_URL            https://kubernetes.default.svc.cluster.local:443
         Buffer_Size         1M
-        Merge_Log           On
         K8S-Logging.Parser  On
+        Annotations         Off
         tls.verify          Off
 
     [FILTER]
@@ -386,14 +386,33 @@ data:
 
   modify_severity.lua: |-
     function cb_modify(tag, timestamp, record)
-      local severity = record["severity"]
+      local removed_labels = cb_modify_remove_labels(record)
+      local unified_severity = cb_modify_unify_severity(record)
 
-      if severity == nil or severity == "" then
+      if (not removed_labels) and (not unified_severity) then
         return 0, 0, 0
       end
 
-      severity = trim(severity):upper()
+      return 1, timestamp, record
+    end
+
+    function cb_modify_remove_labels(record)
+      if record["kubernetes"] == nil or record["kubernetes"]["labels"] == nil then
+        return false
+      end
+
+      record["kubernetes"]["labels"] = nil
+      return true
+    end
+
+    function cb_modify_unify_severity(record)
       local modified = false
+      local severity = record["severity"]
+      if severity == nil or severity == "" then
+        return modified
+      end
+
+      severity = trim(severity):upper()
 
       if severity == "I" or severity == "INF" or severity == "INFO" then
         record["severity"] = "INFO"
@@ -415,11 +434,7 @@ data:
         modified = true
       end
 
-      if not modified then
-        return 0, 0, 0
-      end
-
-      return 1, timestamp, record
+      return modified
     end
 
     function trim(s)


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR prevents mapping collisions in elasticsearch. Currently dynamic mappings are being created in elastic for k8s resource labels, annotations. So if two different resources have the annotations `app: my_app` and `app.kubernetes.io/instance: my_app`, this will result in the following collision:
```
org.elasticsearch.index.mapper.MapperParsingException: Could not dynamically add mapping for field [app.kubernetes.io/instance]. Existing mapping for [kubernetes.labels.app] must be of type object but found [text].
```
The PR removes the k8s labels and annotations metadata from the log.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @KristianZH @vlvasilev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The version of `fluent-bit` has been upgraded from `1.0.3` to `1.0.4`.
```
