### PR TITLE
Fix local dev setup

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -234,17 +234,6 @@ I0201 15:39:43.750573   84958 serve.go:89] Serving securely on [::]:8443
 [...]
 ```
 
-In another terminal, run the following script to install extension controllers - make sure that you install all of them required for your local development.
-
-Also, please refer to [this document](../extensions/controllerregistration.md) for further information about how extensions are registered in case you want to use other versions than the latest releases.
-
-```bash
-$ make dev-setup-extensions
-
-> Found extension 'os-coreos'. Do you want to install it into your local Gardener setup? (y/n)
-...
-```
-
 Now you are ready to launch the Gardener Controller Manager
 
 ```bash
@@ -265,6 +254,18 @@ time="2018-02-20T13:24:39+02:00" level=info msg="Seed controller initialized."
 ```
 
 :information_source: Your username is inferred from the user you are logged in with on your machine. The version is incremented based on the content of the `VERSION` file. The version is important for the Gardener in order to identify which Gardener version has last operated a Shoot cluster.
+
+In another terminal, run the following script to install extension controllers - make sure that you install all of them required for your local development.
+
+Also, please refer to [this document](../extensions/controllerregistration.md) for further information about how extensions are registered in case you want to use other versions than the latest releases.
+
+```bash
+$ make dev-setup-extensions
+
+> Found extension 'os-coreos'. Do you want to install it into your local Gardener setup? (y/n)
+...
+```
+
 
 The Gardener should now be ready to operate on Shoot resources. You can use
 

--- a/pkg/apis/garden/v1beta1/helper/helpers.go
+++ b/pkg/apis/garden/v1beta1/helper/helpers.go
@@ -163,6 +163,8 @@ func GetMachineImageNameFromShoot(cloudProvider gardenv1beta1.CloudProvider, sho
 		return shoot.Spec.Cloud.Alicloud.MachineImage.Name
 	case gardenv1beta1.CloudProviderOpenStack:
 		return shoot.Spec.Cloud.OpenStack.MachineImage.Name
+	case gardenv1beta1.CloudProviderLocal:
+		return "coreos"
 	}
 	return ""
 }

--- a/pkg/apis/garden/v1beta1/helper/helpers_test.go
+++ b/pkg/apis/garden/v1beta1/helper/helpers_test.go
@@ -188,6 +188,17 @@ var _ = Describe("helper", func() {
 			},
 			gardenv1beta1.MachineImageName("some-machineimage"),
 		),
+		Entry("Local",
+			gardenv1beta1.CloudProviderLocal,
+			&gardenv1beta1.Shoot{
+				Spec: gardenv1beta1.ShootSpec{
+					Cloud: gardenv1beta1.Cloud{
+						Local:&gardenv1beta1.Local{},
+					},
+				},
+			},
+			gardenv1beta1.MachineImageName("coreos"),
+		),
 	)
 
 	DescribeTable("#ShootWantsClusterAutoscaler",

--- a/pkg/controllermanager/controller/shoot/shoot.go
+++ b/pkg/controllermanager/controller/shoot/shoot.go
@@ -260,6 +260,10 @@ func (c *Controller) Run(ctx context.Context, shootWorkers, shootCareWorkers, sh
 		// Migration from in-tree CoreOS/operating system support to out-of-tree: We have to rename the old machine image names so that
 		// they fit with the new extension controllers.
 		// This code can be removed in a further version.
+		//'local' cloud provider doesn't need machine name migration
+		if newShoot.Spec.Cloud.Local != nil {
+			continue
+		}
 		utilruntime.Must(errors.Wrapf(c.migrateMachineImageNames(newShoot), "Failed to migrate machine image for shoot %q", shoot.Name))
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a few small issues with current local dev setup.
1. The docs state that `make dev-setup-extensions` should be called before `make start`, when the controllers are not initialized and therefore fails.
2. Before, when shoot reconciliation needed to get the shoot machine image, it would return blank for machine image in cloud 'local', and therefore would fail reconciliation checking the presence of the extension controllers.
3. Machine image migration would fail on cloud 'local', when it is not actually required.