### PR TITLE
Prevent concurrent map writes when generating cloud config

### DIFF
--- a/pkg/operation/hybridbotanist/cloud_config.go
+++ b/pkg/operation/hybridbotanist/cloud_config.go
@@ -86,7 +86,7 @@ func (b *HybridBotanist) ComputeShootOperatingSystemConfig() error {
 
 		go func(worker gardenv1beta1.Worker) {
 			defer wg.Done()
-			cloudConfig, err := b.computeOperatingSystemConfigsForWorker(machineTypes, machineImageName, downloaderConfig, originalConfig, worker)
+			cloudConfig, err := b.computeOperatingSystemConfigsForWorker(machineTypes, machineImageName, utils.MergeMaps(downloaderConfig, nil), utils.MergeMaps(originalConfig, nil), worker)
 			results <- &oscOutput{worker.Name, cloudConfig, err}
 		}(worker)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We do now pass every goroutine its own copy of the map that it can
extend as desired (without the risk that another goroutine is
concurrently writing to it).

```
fatal error: concurrent map writes

goroutine 2228260 [running]:
runtime.throw(0x1e4a86e, 0x15)
	/usr/local/go/src/runtime/panic.go:608 +0x72 fp=0xc0027b1c88 sp=0xc0027b1c58 pc=0x42b2d2
runtime.mapassign_faststr(0x1ae8e40, 0xc00aacef30, 0x1e3a0b0, 0xa, 0x19)
	/usr/local/go/src/runtime/map_faststr.go:199 +0x3da fp=0xc0027b1cf0 sp=0xc0027b1c88 pc=0x4123da
github.com/gardener/gardener/pkg/operation/hybridbotanist.(*HybridBotanist).computeOperatingSystemConfigsForWorker(0xc000cc8b70, 0xc000c86000, 0x19, 0x20, 0xc005433184, 0x6, 0xc00aacef30, 0xc00aacf050, 0xc005433224, 0x6, ...)
	/go/src/github.com/gardener/gardener/pkg/operation/hybridbotanist/cloud_config.go:175 +0x163 fp=0xc0027b1e88 sp=0xc0027b1cf0 pc=0x1845ac3
github.com/gardener/gardener/pkg/operation/hybridbotanist.(*HybridBotanist).ComputeShootOperatingSystemConfig.func1(0xc005ff6310, 0xc000cc8b70, 0xc000c86000, 0x19, 0x20, 0xc005433184, 0x6, 0xc00aacef30, 0xc00aacf050, 0xc00396d0e0, ...)
	/go/src/github.com/gardener/gardener/pkg/operation/hybridbotanist/cloud_config.go:89 +0xfc fp=0xc0027b1f50 sp=0xc0027b1e88 pc=0x185246c
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1333 +0x1 fp=0xc0027b1f58 sp=0xc0027b1f50 pc=0x458721
created by github.com/gardener/gardener/pkg/operation/hybridbotanist.(*HybridBotanist).ComputeShootOperatingSystemConfig
	/go/src/github.com/gardener/gardener/pkg/operation/hybridbotanist/cloud_config.go:87 +0x33c
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
