### PR TITLE
Add support for floatingpool name when creating openstack clusters in testmachinery

### DIFF
--- a/.test-defs/cmd/create-shoot/helper.go
+++ b/.test-defs/cmd/create-shoot/helper.go
@@ -92,3 +92,10 @@ func updateAutoscalerMinMax(shoot *gardenv1beta1.Shoot, cloudprovider gardenv1be
 		}
 	}
 }
+
+// updateFloatingPoolName updates the floatingPoolName if a openstack cluster is created.
+func updateFloatingPoolName(shoot *gardenv1beta1.Shoot, floatingPoolName string, cloudprovider gardenv1beta1.CloudProvider) {
+	if cloudprovider == gardenv1beta1.CloudProviderOpenStack {
+		shoot.Spec.Cloud.OpenStack.FloatingPoolName = floatingPoolName
+	}
+}

--- a/.test-defs/cmd/create-shoot/main.go
+++ b/.test-defs/cmd/create-shoot/main.go
@@ -42,6 +42,9 @@ var (
 	autoScalerMin *int
 	autoScalerMax *int
 
+	// required for openstack
+	floatingPoolName string
+
 	testLogger *logrus.Logger
 )
 
@@ -100,6 +103,11 @@ func init() {
 		}
 		autoScalerMax = &autoScalerMaxInt
 	}
+
+	floatingPoolName = os.Getenv("FLOATING_POOL_NAME")
+	if cloudprovider == gardenv1beta1.CloudProviderOpenStack && floatingPoolName == "" {
+		testLogger.Fatalf("EnvVar 'FLOATING_POOL_NAME' needs to be specified when creating a shoot on openstack")
+	}
 }
 
 func main() {
@@ -124,6 +132,7 @@ func main() {
 	updateWorkerZone(shootObject, cloudprovider, zone)
 	updateMachineType(shootObject, cloudprovider, machineType)
 	updateAutoscalerMinMax(shootObject, cloudprovider, autoScalerMin, autoScalerMax)
+	updateFloatingPoolName(shootObject, floatingPoolName, cloudprovider)
 
 	testLogger.Infof("Create shoot %s in namespace %s", shootName, projectNamespace)
 	shootGardenerTest.Shoot = shootObject


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a parameter to configure the floating pool name of an openstack cluster.
This parameter is required when the cloudprovider is `openstack` and is ignored in any other case.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
