### PR TITLE
ClusterRole for cluster-autoscaler-shoot has been updated

### DIFF
--- a/charts/shoot-core/charts/cluster-autoscaler/templates/clusterrole-cluster-autoscaler.yaml
+++ b/charts/shoot-core/charts/cluster-autoscaler/templates/clusterrole-cluster-autoscaler.yaml
@@ -61,6 +61,7 @@ rules:
   - extensions
   resources:
   - daemonsets
+  - replicasets
   verbs:
   - watch
   - list
@@ -76,7 +77,6 @@ rules:
   - apps
   resources:
   - statefulsets
-  - replicasets
   verbs:
   - watch
   - list


### PR DESCRIPTION
The ClusterRole for the Cluster-Autoscaler is updated to use extensions apiGroup instead of apps.
Inline with - https://github.com/kubernetes/autoscaler/blob/cluster-autoscaler-release-1.12/cluster-autoscaler/cloudprovider/aws/examples/cluster-autoscaler-autodiscover.yaml#L19-L49

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
