### PR TITLE
Enforce secure connections to Azure StorageAccounts

### DIFF
--- a/charts/seed-terraformer/charts/azure-backup/templates/_main.tf
+++ b/charts/seed-terraformer/charts/azure-backup/templates/_main.tf
@@ -12,14 +12,15 @@ resource "azurerm_resource_group" "rg" {
 }
 
 resource "azurerm_storage_account" "storageAccount" {
-  name                     = "{{ required "azure.storageAccountName is required" .Values.azure.storageAccountName }}"
-  location                 = "{{ required "azure.region is required" .Values.azure.region }}"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
-  account_kind             = "BlobStorage"
-  access_tier              = "Hot"
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-  enable_blob_encryption   = true
+  name                      = "{{ required "azure.storageAccountName is required" .Values.azure.storageAccountName }}"
+  location                  = "{{ required "azure.region is required" .Values.azure.region }}"
+  resource_group_name       = "${azurerm_resource_group.rg.name}"
+  account_kind              = "BlobStorage"
+  access_tier               = "Hot"
+  account_tier              = "Standard"
+  account_replication_type  = "LRS"
+  enable_blob_encryption    = true
+  enable_https_traffic_only = true
 }
 
 resource "azurerm_storage_container" "container" {


### PR DESCRIPTION
Enforce secure connections to Azure StorageAccount
The StorageAccounts are used to store ETCD Backups for Shoots hosted on Azure Seeds.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
