### PR TITLE
Fix pardon condition on empty last operation

### DIFF
--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -875,7 +875,10 @@ func isUnstableOperationType(lastOperationType gardenv1beta1.ShootLastOperationT
 // in create or delete state.
 func (b *Botanist) pardonCondition(condition *gardenv1beta1.Condition) *gardenv1beta1.Condition {
 	shoot := b.Shoot.Info
-	if lastOp := shoot.Status.LastOperation; shoot.Status.LastError == nil && lastOp != nil && isUnstableOperationType(lastOp.Type) && condition.Status == gardenv1beta1.ConditionFalse {
+	if shoot.Status.LastError != nil {
+		return condition
+	}
+	if lastOp := shoot.Status.LastOperation; (lastOp == nil || (lastOp != nil && isUnstableOperationType(lastOp.Type))) && condition.Status == gardenv1beta1.ConditionFalse {
 		return helper.UpdatedCondition(condition, gardenv1beta1.ConditionProgressing, condition.Reason, condition.Message)
 	}
 	return condition


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes conditions being pardoned when the `lastOperation` is still empty.

**Which issue(s) this PR fixes**:
Fixes #780 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
