### PR TITLE
Scale down entire control plane if shoot gets hibernated

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hpa.yaml
@@ -4,8 +4,14 @@ metadata:
   name: kube-apiserver
   namespace: {{ .Release.Namespace }}
 spec:
-  maxReplicas: {{ .Values.maxReplicas }}
+  {{- /* .Values.replicas is of type 'float64', so let's cast it to string to have proper types for comparison */}}
+  {{- if eq (.Values.replicas | toString) "0" }}
+  minReplicas: 0
+  maxReplicas: 0
+  {{- else }}
   minReplicas: {{ .Values.minReplicas }}
+  maxReplicas: {{ .Values.maxReplicas }}
+  {{- end }}
   scaleTargetRef:
     apiVersion: {{ include "deploymentversion" . }}
     kind: Deployment

--- a/pkg/client/kubernetes/deployments.go
+++ b/pkg/client/kubernetes/deployments.go
@@ -17,8 +17,6 @@ package kubernetes
 import (
 	"sort"
 
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -44,33 +42,6 @@ func (c *Clientset) ListDeployments(namespace string, listOptions metav1.ListOpt
 // PatchDeployment patches a Deployment object.
 func (c *Clientset) PatchDeployment(namespace, name string, body []byte) (*appsv1.Deployment, error) {
 	return c.Kubernetes().AppsV1().Deployments(namespace).Patch(name, types.JSONPatchType, body)
-}
-
-// ScaleDeployment scales a Deployment object.
-func (c *Clientset) ScaleDeployment(namespace, name string, replicas int32) (*appsv1.Deployment, error) {
-	old, err := c.GetDeployment(namespace, name)
-	if err != nil {
-		return nil, err
-	}
-
-	new := old.DeepCopy()
-	new.Spec.Replicas = &replicas
-
-	return c.StrategicMergePatchDeployment(old, new)
-}
-
-// StrategicMergePatchDeployment performs a strategic merge patch on a Deployment object.
-func (c *Clientset) StrategicMergePatchDeployment(oldObj, newObj *appsv1.Deployment) (*appsv1.Deployment, error) {
-	patch, err := kutil.CreateTwoWayMergePatch(oldObj, newObj)
-	if err != nil {
-		return nil, err
-	}
-
-	if kutil.IsEmptyPatch(patch) {
-		return oldObj, nil
-	}
-
-	return c.kubernetes.AppsV1().Deployments(oldObj.Namespace).Patch(oldObj.Name, types.StrategicMergePatchType, patch)
 }
 
 // DeleteDeployment deletes a Deployment object.

--- a/pkg/client/kubernetes/scaling.go
+++ b/pkg/client/kubernetes/scaling.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ScaleStatefulSet scales a StatefulSet.
+func ScaleStatefulSet(ctx context.Context, c client.Client, key client.ObjectKey, replicas int32) error {
+	statefulset := &appsv1.StatefulSet{}
+	if err := c.Get(ctx, key, statefulset); err != nil {
+		return err
+	}
+
+	statefulset.Spec.Replicas = &replicas
+	return c.Update(ctx, statefulset)
+}
+
+// ScaleDeployment scales a Deployment.
+func ScaleDeployment(ctx context.Context, c client.Client, key client.ObjectKey, replicas int32) error {
+	deployment := &appsv1.Deployment{}
+	if err := c.Get(ctx, key, deployment); err != nil {
+		return err
+	}
+
+	deployment.Spec.Replicas = &replicas
+	return c.Update(ctx, deployment)
+}

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -276,8 +276,6 @@ type Interface interface {
 	// Deprecated: Use `Client()` and utils instead.
 	PatchDeployment(string, string, []byte) (*appsv1.Deployment, error)
 	// Deprecated: Use `Client()` and utils instead.
-	ScaleDeployment(string, string, int32) (*appsv1.Deployment, error)
-	// Deprecated: Use `Client()` and utils instead.
 	DeleteDeployment(string, string) error
 
 	// StatefulSets

--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -917,7 +917,7 @@ func (b *Botanist) HealthChecks(initializeShootClients func() error, thresholdMa
 	return b.pardonCondition(apiServerAvailable), b.pardonCondition(controlPlaneHealthy), b.pardonCondition(everyNodeReady), b.pardonCondition(systemComponentsHealthy)
 }
 
-// MonitoringHealthChecks performs the monitoring releated health checks.
+// MonitoringHealthChecks performs the monitoring related health checks.
 func (b *Botanist) MonitoringHealthChecks(checker *HealthChecker, inactiveAlerts *gardenv1beta1.Condition) *gardenv1beta1.Condition {
 	if b.Shoot.IsHibernated {
 		return shootHibernatedCondition(inactiveAlerts)

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -949,18 +949,11 @@ func dnsNamesForService(name, namespace string) []string {
 }
 
 func dnsNamesForEtcd(namespace string) []string {
-	var (
-		etcdMain   = fmt.Sprintf("etcd-%s", common.EtcdRoleMain)
-		etcdEvents = fmt.Sprintf("etcd-%s", common.EtcdRoleEvents)
-
-		names = []string{
-			fmt.Sprintf("%s-0", etcdMain),
-			fmt.Sprintf("%s-0", etcdEvents),
-		}
-	)
-
-	names = append(names, dnsNamesForService(fmt.Sprintf("%s-client", etcdMain), namespace)...)
-	names = append(names, dnsNamesForService(fmt.Sprintf("%s-client", etcdEvents), namespace)...)
-
+	names := []string{
+		fmt.Sprintf("%s-0", common.EtcdMainStatefulSetName),
+		fmt.Sprintf("%s-0", common.EtcdEventsStatefulSetName),
+	}
+	names = append(names, dnsNamesForService(fmt.Sprintf("%s-client", common.EtcdMainStatefulSetName), namespace)...)
+	names = append(names, dnsNamesForService(fmt.Sprintf("%s-client", common.EtcdEventsStatefulSetName), namespace)...)
 	return names
 }

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -87,8 +87,14 @@ const (
 	// EtcdRoleMain is the constant defining the role for main etcd storing data about objects in Shoot.
 	EtcdRoleMain = "main"
 
+	// EtcdMainStatefulSetName is the constant defining the statefulset name for the main etcd.
+	EtcdMainStatefulSetName = "etcd-main"
+
 	// EtcdRoleEvents is the constant defining the role for etcd storing events in Shoot.
 	EtcdRoleEvents = "events"
+
+	// EtcdEventsStatefulSetName is the constant defining the statefulset name for the events etcd.
+	EtcdEventsStatefulSetName = "etcd-events"
 
 	// GardenNamespace is the namespace in which the configuration and secrets for
 	// the Gardener controller manager will be stored (e.g., secrets for the Seed clusters).
@@ -321,6 +327,9 @@ const (
 	// Shoot Care controller and can be used to easily identify Shoot clusters with issues.
 	// Deprecated: Use ShootStatus instead
 	ShootUnhealthy = "shoot.garden.sapcloud.io/unhealthy"
+
+	// ShootHibernated is a constant for a label on the Shoot namespace in the Seed indicating the Shoot's hibernation status.
+	ShootHibernated = "shoot.garden.sapcloud.io/hibernated"
 
 	// ShootOperation is a constant for an annotation on a Shoot in a failed state indicating that an operation shall be performed.
 	ShootOperation = "shoot.garden.sapcloud.io/operation"

--- a/pkg/operation/hybridbotanist/machines.go
+++ b/pkg/operation/hybridbotanist/machines.go
@@ -15,16 +15,21 @@
 package hybridbotanist
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/common"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -128,7 +133,7 @@ func (b *HybridBotanist) ReconcileMachines() error {
 
 	// Scale down machine-controller-manager if shoot is hibernated.
 	if b.Shoot.IsHibernated {
-		if _, err := b.K8sSeedClient.ScaleDeployment(b.Shoot.SeedNamespace, common.MachineControllerManagerDeploymentName, 0); err != nil {
+		if err := kubernetes.ScaleDeployment(context.TODO(), b.K8sSeedClient.Client(), kutil.Key(b.Shoot.SeedNamespace, common.MachineControllerManagerDeploymentName), 0); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Scale down entire control plane if shoot gets hibernated to help reducing costs. So far, etcd and the kube-apiserver were kept running, but these components consume the majority of compute resource, so scaling them down will help to reduce costs.

**Special notes for your reviewer**:
This commit incorporates the following changes:
* Shoot garbage collection in care controller is only executed if shoot is not hibernated.
* The new last step in the shoot reconciliation flow scales down the remaining control plane components (etcd, kube-apiserver, ...).
* The `wakeUpControllers` step in the shoot deletion flow has been renamed to `wakeUpControlPlane` and does now scale up etcd, kube-apiserver, and the controllers that are needed for shoot deletion.
* Gardener does now label the shoot namespace in the seed with `hibernated={true,false}` to allow extensions to get this state information. (cc @vpnachev)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
If a shoot gets hibernated Gardener does now scale down the entire control plane (previously, etcd and kube-apiserver were still running).
```
