### PR TITLE
Improve seed logging integration test

### DIFF
--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
@@ -258,7 +258,6 @@ data:
         Match               kubernetes.*
         Kube_URL            https://kubernetes.default.svc.cluster.local:443
         Buffer_Size         1M
-        K8S-Logging.Parser  On
         Annotations         Off
         tls.verify          Off
 
@@ -274,7 +273,6 @@ data:
         Match           *
         Host            ${FLUENTD_HOST}
         Port            ${FLUENTD_PORT}
-        Time_as_Integer True
 
   parsers.conf: |-
     [PARSER]

--- a/example/30-cloudprofile-alicloud.yaml
+++ b/example/30-cloudprofile-alicloud.yaml
@@ -15,7 +15,7 @@ spec:
       - name: unmanaged
       kubernetes:
         versions:
-        - 1.11.7
+        - 1.11.8
       machineImages:
       - name: coreos-alicloud
         id: coreos_1911_5_0_64_30G_alibase_20181219.vhd

--- a/example/30-cloudprofile-aws.yaml
+++ b/example/30-cloudprofile-aws.yaml
@@ -17,7 +17,7 @@ spec:
         versions:
         - 1.13.4
         - 1.12.6
-        - 1.11.7
+        - 1.11.8
         - 1.10.13
       machineImages:
       - name: coreos

--- a/example/30-cloudprofile-azure.yaml
+++ b/example/30-cloudprofile-azure.yaml
@@ -17,7 +17,7 @@ spec:
         versions:
         - 1.13.4
         - 1.12.6
-        - 1.11.7
+        - 1.11.8
         - 1.10.13
       machineImages:
       - name: coreos

--- a/example/30-cloudprofile-gcp.yaml
+++ b/example/30-cloudprofile-gcp.yaml
@@ -17,7 +17,7 @@ spec:
         versions:
         - 1.13.4
         - 1.12.6
-        - 1.11.7
+        - 1.11.8
         - 1.10.13
       machineImages:
       - name: coreos

--- a/example/30-cloudprofile-openstack.yaml
+++ b/example/30-cloudprofile-openstack.yaml
@@ -19,7 +19,7 @@ spec:
         versions:
         - 1.13.4
         - 1.12.6
-        - 1.11.7
+        - 1.11.8
         - 1.10.13
       loadBalancerProviders:
       - name: haproxy

--- a/example/90-shoot-alicloud.yaml
+++ b/example/90-shoot-alicloud.yaml
@@ -25,7 +25,7 @@ spec:
         autoScalerMax: 2
       zones: ['cn-beijing-f']
   kubernetes:
-    version: 1.11.7
+    version: 1.11.8
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   featureGates:

--- a/hack/templates/resources/30-cloudprofile.yaml.tpl
+++ b/hack/templates/resources/30-cloudprofile.yaml.tpl
@@ -71,7 +71,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % else:
         - 1.13.4
         - 1.12.6
-        - 1.11.7
+        - 1.11.8
         - 1.10.13
         % endif
       machineImages:<% machineImages=value("spec.aws.constraints.machineImages", []) %>
@@ -176,7 +176,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % else:
         - 1.13.4
         - 1.12.6
-        - 1.11.7
+        - 1.11.8
         - 1.10.13
         % endif
       machineImages:<% machineImages=value("spec.azure.constraints.machineImages", []) %>
@@ -277,7 +277,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % else:
         - 1.13.4
         - 1.12.6
-        - 1.11.7
+        - 1.11.8
         - 1.10.13
         % endif
       machineImages:<% machineImages=value("spec.gcp.constraints.machineImages", []) %>
@@ -364,7 +364,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         ${yaml.dump(kubernetesVersions, width=10000)}
         % else:
         versions:
-        - 1.11.7
+        - 1.11.8
         % endif
       machineImages:<% machineImages=value("spec.alicloud.constraints.machineImages", []) %>
       % if machineImages != []:
@@ -453,7 +453,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % else:
         - 1.13.4
         - 1.12.6
-        - 1.11.7
+        - 1.11.8
         - 1.10.13
         % endif
       loadBalancerProviders:<% loadBalancerProviders=value("spec.openstack.constraints.loadBalancerProviders", []) %>

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -34,7 +34,7 @@
     kubernetesVersion="1.13.4"
   elif cloud == "alicloud":
     region="cn-beijing"
-    kubernetesVersion="1.11.7"
+    kubernetesVersion="1.11.8"
   elif cloud == "openstack" or cloud == "os":
     region="europe-1"
     kubernetesVersion="1.13.4"

--- a/test/integration/framework/shoot_app.go
+++ b/test/integration/framework/shoot_app.go
@@ -372,8 +372,8 @@ func (o *GardenerTestOperation) GetElasticsearchLogs(ctx context.Context, elasti
 	}))
 
 	now := time.Now()
-	formattedDate := fmt.Sprintf("%d.%02d.%d", now.Year(), now.Month(), now.Day())
-	command := fmt.Sprintf("curl http://localhost:%d/logstash-%s/_search?q=kubernetes.pod_name:%s", elasticsearchPort, formattedDate, podName)
+	index := fmt.Sprintf("logstash-%d.%02d.%02d", now.Year(), now.Month(), now.Day())
+	command := fmt.Sprintf("curl http://localhost:%d/%s/_search?q=kubernetes.pod_name:%s", elasticsearchPort, index, podName)
 	reader, err := o.PodExecByLabel(ctx, elasticsearchLabels, elasticsearchLogging,
 		command, elasticsearchNamespace, client)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Logging integration test was searching for wrong index name - for example `logstash-2019.03.4`. The correct index name should be `logstash-2019.03.04`. The PR contains a fix about it.
- Removes two config properties for fluent-bit. `Time_as_Integer` is used compatibility with old fluend versions (https://docs.fluentbit.io/manual/output/forward) and `K8S-Logging.Parser` is for enabling parser configs by annotations, currently we don't use this annotation approach (https://docs.fluentbit.io/manual/filter/kubernetes).
- Update example resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
