### PR TITLE
Add interface to get Type of Extensions resources

### DIFF
--- a/pkg/apis/extensions/v1alpha1/register.go
+++ b/pkg/apis/extensions/v1alpha1/register.go
@@ -53,3 +53,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }
+
+// ExtensionType is an interface for Gardener extensions API types.
+type ExtensionType interface {
+	GetExtensionType() string
+}

--- a/pkg/apis/extensions/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/extensions/v1alpha1/types_infrastructure.go
@@ -32,6 +32,11 @@ type Infrastructure struct {
 	Status InfrastructureStatus `json:"status"`
 }
 
+// GetExtensionType returns the type of this Infrastructure resource.
+func (i *Infrastructure) GetExtensionType() string {
+	return i.Spec.Type
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // InfrastructureList is a list of Infrastructure resources.

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -34,6 +34,11 @@ type OperatingSystemConfig struct {
 	Status OperatingSystemConfigStatus `json:"status"`
 }
 
+// GetExtensionType returns the type of this OperatingSystemConfig resource.
+func (o *OperatingSystemConfig) GetExtensionType() string {
+	return o.Spec.Type
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // OperatingSystemConfigList is a list of OperatingSystemConfig resources.

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -33,6 +33,11 @@ type Worker struct {
 	Status WorkerStatus `json:"status"`
 }
 
+// GetExtensionType returns the type of this Worker resource.
+func (w *Worker) GetExtensionType() string {
+	return w.Spec.Type
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // WorkerList is a list of Worker resources.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an interface which is supposed to be implemented by Gardener Extensions to get their `type` information. Especially for extension controllers it will get handy to use this common accessor.

```improvement operator
NONE
```
