### PR TITLE
Fix ports orders for nginx-ingress service

### DIFF
--- a/charts/shoot-addons/charts/nginx-ingress/templates/controller-service.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/controller-service.yaml
@@ -33,19 +33,19 @@ spec:
   externalTrafficPolicy: "{{ .Values.controller.service.externalTrafficPolicy }}"
 {{- end }}
   ports:
-    - name: http
-      port: 80
-      protocol: TCP
-      targetPort: {{ .Values.controller.service.targetPorts.http }}
-      {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.http))) }}
-      nodePort: {{ .Values.controller.service.nodePorts.http }}
-      {{- end }}
     - name: https
       port: 443
       protocol: TCP
       targetPort: {{ .Values.controller.service.targetPorts.https }}
       {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.https))) }}
       nodePort: {{ .Values.controller.service.nodePorts.https }}
+      {{- end }}
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: {{ .Values.controller.service.targetPorts.http }}
+      {{- if (and (eq .Values.controller.service.type "NodePort") (not (empty .Values.controller.service.nodePorts.http))) }}
+      nodePort: {{ .Values.controller.service.nodePorts.http }}
       {{- end }}
   {{- range $key, $value := .Values.tcp }}
     - name: "{{ $key }}-tcp"


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the order of the ports for the nginx-ingress services prioritises port 80 over port 443. This can sometimes lead the ELB Health-checks to fail on AWS because it always picks the first port to do the health check on, and in the case a network-policy for port 80 is installed, the health checks will fail. 

**Release note**:
```improvement operator
switch the order of ports for the nginx-ingress service to prioritize https over http. 
```
