### PR TITLE
Mitigate systemd-journald high memory usage

### DIFF
--- a/charts/shoot-cloud-config/charts/original/templates/_cloud-config.tpl
+++ b/charts/shoot-cloud-config/charts/original/templates/_cloud-config.tpl
@@ -15,6 +15,8 @@ coreos:
 {{ include "kubelet-monitor" . | indent 2 }}
 {{ include "update-ca-certs" . | indent 2 }}
 {{ include "systemd-sysctl" . | indent 2 }}
+{{ include "systemd-journald-restart" . | indent 2 }}
+{{ include "systemd-journald-restart-timer" . | indent 2 }}
 write_files:
 {{ include "logrotate-config" . }}
 {{ include "journald-config" . }}

--- a/charts/shoot-cloud-config/charts/original/templates/journald/_journald-restart.service
+++ b/charts/shoot-cloud-config/charts/original/templates/journald/_journald-restart.service
@@ -1,0 +1,14 @@
+{{ define "systemd-journald-restart" -}}
+- name: systemd-journald-restart.service
+  enable: true
+  command: start
+  content: |
+    [Unit]
+    Description=Restart systemd-journald
+
+    [Service]
+    ExecStart=/usr/bin/systemctl restart systemd-journald
+
+    [Install]
+    WantedBy=multi-user.target
+{{- end}}

--- a/charts/shoot-cloud-config/charts/original/templates/journald/_journald-restart.timer
+++ b/charts/shoot-cloud-config/charts/original/templates/journald/_journald-restart.timer
@@ -1,0 +1,16 @@
+{{- define "systemd-journald-restart-timer" -}}
+- name: systemd-journald-restart.timer
+  enable: true
+  command: start
+  content: |
+    [Unit]
+    Description=Restart systemd-journald at 30 minutes
+
+    [Timer]
+    OnUnitActiveSec=30m
+    AccuracySec=10m
+    Persistent=true
+
+    [Install]
+    WantedBy=multi-user.target
+{{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
We observe high-memory usage on some shoot nodes from `systemd-journald`. For more details see [#2564](https://github.com/coreos/bugs/issues/2564).
This PR is a proposal for a mitigation until we find out the real root cause.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@rfranzke @mvladev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
High-memory usage of `systemd-journald` on shoot nodes is mitigated.
```
