### PR TITLE
Fix HPA handling when Shoot is hibernated

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hpa.yaml
@@ -1,17 +1,13 @@
+{{- /* .Values.replicas is of type 'float64', so let's cast it to string to have proper types for comparison */}}
+{{- if ne (.Values.replicas | toString) "0" }}
 apiVersion: {{ include "hpaversion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: kube-apiserver
   namespace: {{ .Release.Namespace }}
 spec:
-  {{- /* .Values.replicas is of type 'float64', so let's cast it to string to have proper types for comparison */}}
-  {{- if eq (.Values.replicas | toString) "0" }}
-  minReplicas: 0
-  maxReplicas: 0
-  {{- else }}
   minReplicas: {{ .Values.minReplicas }}
   maxReplicas: {{ .Values.maxReplicas }}
-  {{- end }}
   scaleTargetRef:
     apiVersion: {{ include "deploymentversion" . }}
     kind: Deployment
@@ -21,3 +17,4 @@ spec:
     resource:
       name: cpu
       targetAverageUtilization: {{ .Values.targetAverageUtilization }}
+{{- end }}

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -358,6 +358,13 @@ func (b *HybridBotanist) DeployKubeAPIServer() error {
 		return err
 	}
 
+	// If shoot is hibernated we don't want the HPA to interfer with our scaling decisions.
+	if b.Shoot.IsHibernated {
+		if err := b.K8sSeedClient.DeleteHorizontalPodAutoscaler(b.Shoot.SeedNamespace, common.KubeAPIServerDeploymentName); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+
 	if err := b.ApplyChartSeed(filepath.Join(chartPathControlPlane, common.KubeAPIServerDeploymentName), common.KubeAPIServerDeploymentName, b.Shoot.SeedNamespace, values, utils.MergeMaps(cloudSpecificExposeValues, cloudSpecificValues)); err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue in the Gardener-Controller-Manager which happens during reconciliation of hibernated Shoot clusters. The `hpa` resource of a Shoot's Kube-Apiserver must be deleted (once in #786) rather than setting `minReplicas` and `maxReplicas` to 0 because this is [prohibited](https://github.com/kubernetes/kubernetes/blob/release-1.13/pkg/apis/autoscaling/validation/validation.go#L45) by K8s. 

```improvement operator
NONE
```
