### PR TITLE
Add option for initImages with mount to /init-config

### DIFF
--- a/charts/shoot-core/charts/vpn-shoot/templates/deployment.yaml
+++ b/charts/shoot-core/charts/vpn-shoot/templates/deployment.yaml
@@ -41,7 +41,8 @@ spec:
       - name: init-{{ $index }}
         image: {{ $ctr.image }}
         {{- if $ctr.command }}
-        command: {{ $ctr.command }}
+        command:
+{{ toYaml $ctr.command | indent 8 }}
         {{- end }}
         volumeMounts:
         - name: shared-init-config

--- a/charts/shoot-core/charts/vpn-shoot/templates/deployment.yaml
+++ b/charts/shoot-core/charts/vpn-shoot/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
       {{- range $index, $ctr := .Values.initContainers }}
       - name: init-{{ $index }}
         image: {{ $ctr.image }}
-        {{- if $ctr | .command }}
+        {{- if $ctr.command }}
         command: {{ $ctr.command }}
         {{- end }}
         volumeMounts:

--- a/charts/shoot-core/charts/vpn-shoot/templates/deployment.yaml
+++ b/charts/shoot-core/charts/vpn-shoot/templates/deployment.yaml
@@ -35,6 +35,19 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+{{- if .Values.initContainers }}
+      initContainers:
+      {{- range $index, $ctr := .Values.initContainers }}
+      - name: init-{{ $index }}
+        image: {{ $ctr.image }}
+        {{- if $ctr | .command }}
+        command: {{ $ctr.command }}
+        {{- end }}
+        volumeMounts:
+        - name: shared-init-config
+          mountPath: /init-config
+      {{- end }}
+{{- end }}
       containers:
       - name: vpn-shoot
         image: {{ index .Values.images "vpn-shoot" }}
@@ -65,6 +78,8 @@ spec:
           name: vpn-shoot-tlsauth
         - mountPath: /srv/secrets/dh
           name: vpn-shoot-dh
+        - name: shared-init-config
+          mountPath: /init-config
       volumes:
       - name: vpn-shoot
         secret:
@@ -75,3 +90,5 @@ spec:
       - name: vpn-shoot-dh
         secret:
           secretName: vpn-shoot-dh
+      - name: shared-init-config
+        emptyDir: {}

--- a/charts/shoot-core/charts/vpn-shoot/templates/psp/vpn-shoot-psp.yaml
+++ b/charts/shoot-core/charts/vpn-shoot/templates/psp/vpn-shoot-psp.yaml
@@ -8,6 +8,7 @@ spec:
   privileged: true
   volumes:
   - secret
+  - emptyDir
   allowedCapabilities:
   - NET_ADMIN
   runAsUser:

--- a/charts/shoot-core/charts/vpn-shoot/values.yaml
+++ b/charts/shoot-core/charts/vpn-shoot/values.yaml
@@ -6,3 +6,12 @@ nodeNetwork: 172.16.0.0/20
 podAnnotations: {}
 diffieHellmanKey: LS0tLS1CRUdJTiBESCBQQVJBTUVURVJTLS0tLS0KTUlJQkNBS0NBUUVBN2NCWHhHOWFuNktSei9zQjV1aVNPVGY3RWcrdVdWa2hYTzRwZUtEVEFSek1ZYThiN1dSOApCL0F3K0F5VVh0QjN0WHRyemVDNU0zSUhudWhGd01vM0s0b1NPa0ZKeGF0TGxZS2VZMTVyK0t0NXZuT09UM0JXCmVONU9uV2xSNVdpN0daQldiYVFnWFZSNzlONHlzdDQzc1ZoSnVzNkJ5MGxONk9sYzl4RC95czlHSC95a0pWSWgKWi9OTHJ4QUM1bHhqd0NxSk1kOGhycnlDaHVEbHo1OTd2ZzZnWUZ1UlY2MFUvWVU0REs3MUY0SDdtSTA3YUdKOQpsK1NLOFRia0tXRjVJVEk3a1lXYmM0em10ZlhTWGFHak1oTTlvbVFVYVRIOWNzQjk2aHpGSmRlWjRYanh5YlJmClZjM3Q3WFA1cTdhZmVhS21NM0ZoU1hkZUhLQ1RxUXpRdXdJQkFnPT0KLS0tLS1FTkQgREggUEFSQU1FVEVSUy0tLS0tCg==
 tlsAuth: dummy-b64-data
+# 
+# optional initContainers
+# used to generate the nodeNetwork runtime, if it is not available at config time
+# to use, comment out the nodeNetwork key above, and create this
+# it should save the cidr to the file /init-config/nodeNetwork
+#initContainers:
+#- image: image-repository:image-tag
+#  command: ["sh","-c", "ip a eth0 > /init-config/nodeNetwork"]
+


### PR DESCRIPTION
**What this PR does / why we need it**:

As discussed in slack with @rfranzke , this PR creates the ability to specify `initImages` in the VPN configuration. This makes it possible to determine one or more configuration components for the VPN dynamically by running an image and saving its output to `/init-config`. As of right now, this is used for Packet, where the node range (and thus the vpn target range) is unknown until the servers are running. In general, it is intended to add any form of dynamic flexibility. 

**Special notes for your reviewer**:

There will be 2 follow-up PRs to this:

1. Documentation, specifying how to use this.
2. vpn image itself, to consume information from a file in `/init-config/`, if it is available.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add support for vpn dynamic configuration via `initContainers`.
```

