### PR TITLE
Support k8s v1.13 on Alicloud

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -149,22 +149,48 @@ images:
   sourceRepository: https://github.com/kubernetes-csi/external-attacher
   repository: quay.io/k8scsi/csi-attacher
   tag: v0.3.0
-  version: 1.11.x
+  versions: 1.11.x
 - name: csi-driver-registrar
   sourceRepository: https://github.com/kubernetes-csi/driver-registrar
   repository: quay.io/k8scsi/driver-registrar
   tag: v0.3.0
-  version: 1.11.x
+  versions: 1.11.x
 - name: csi-provisioner
   sourceRepository: https://github.com/kubernetes-csi/external-provisioner
   repository: quay.io/k8scsi/csi-provisioner
   tag: v0.3.0
-  version: 1.11.x
+  versions: 1.11.x
 - name: csi-plugin-alicloud
   sourceRepository: https://github.com/AliyunContainerService/csi-plugin
   repository: jerryjxj/csi-plugin-alicloud
-  tag: v0.3.0
-  version: 1.11.x
+  tag: v0.3.1
+  versions: 1.11.x
+
+- name: csi-attacher
+  sourceRepository: https://github.com/kubernetes-csi/external-attacher
+  repository: quay.io/k8scsi/csi-attacher
+  tag: v1.0.1
+  versions: 1.13.x
+- name: csi-node-driver-registrar
+  sourceRepository: https://github.com/kubernetes-csi/node-driver-registrar
+  repository: quay.io/k8scsi/csi-node-driver-registrar
+  tag: v1.0.1
+  versions: 1.13.x
+- name: csi-provisioner
+  sourceRepository: https://github.com/kubernetes-csi/external-provisioner
+  repository: quay.io/k8scsi/csi-provisioner
+  tag: v1.0.1
+  versions: 1.13.x
+- name: csi-snapshotter
+  sourceRepository: https://github.com/kubernetes-csi/external-snapshotter
+  repository: quay.io/k8scsi/csi-snapshotter
+  tag: v1.0.1
+  versions: 1.13.x
+- name: csi-plugin-alicloud
+  sourceRepository: https://github.com/AliyunContainerService/csi-plugin
+  repository: jerryjxj/csi-plugin-alicloud
+  tag: v1.0.0
+  versions: 1.13.x
 
 # Logging
 - name: fluentd-es

--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -70,8 +70,8 @@ spec:
         {{- end }}
         {{- if not .Values.enableCSI}}
         - --external-cloud-volume-plugin={{ .Values.cloudProvider }}
-        {{- end }}
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf
+        {{- end }}
         - --cluster-cidr={{ .Values.podNetwork }}
         - --cluster-name={{ .Values.clusterName }}
         - --cluster-signing-cert-file=/srv/kubernetes/ca/ca.crt

--- a/charts/shoot-core/charts/csi-alicloud/templates/crd-csidriver.yaml
+++ b/charts/shoot-core/charts/csi-alicloud/templates/crd-csidriver.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.enabled }}
+{{- if semverCompare ">= 1.13" .Values.kubernetesVersion -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: csidrivers.csi.storage.k8s.io
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  group: csi.storage.k8s.io
+  names:
+    kind: CSIDriver
+    plural: csidrivers
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: Specification of the CSI Driver.
+          properties:
+            attachRequired:
+              description: Indicates this CSI volume driver requires an attach operation,
+                and that Kubernetes should call attach and wait for any attach operation
+                to complete before proceeding to mount.
+              type: boolean
+            podInfoOnMountVersion:
+              description: Indicates this CSI volume driver requires additional pod
+                information (like podName, podUID, etc.) during mount operations.
+              type: string
+  version: v1alpha1
+{{- end -}}
+{{- end -}}

--- a/charts/shoot-core/charts/csi-alicloud/templates/csi-attacher-dep.yaml
+++ b/charts/shoot-core/charts/csi-alicloud/templates/csi-attacher-dep.yaml
@@ -1,4 +1,62 @@
 {{- if .Values.enabled }}
+{{- if semverCompare ">= 1.13" .Values.kubernetesVersion -}}
+kind: Deployment
+apiVersion: {{ include "deploymentversion" . }}
+metadata:
+  name: csi-attacher
+  namespace: kube-system
+  labels:
+    origin: gardener
+    app: csi-attacher
+    garden.sapcloud.io/role: system-component
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-attacher
+  template:
+    metadata:
+      labels:
+        origin: gardener
+        garden.sapcloud.io/role: system-component
+        app: csi-attacher
+    spec:
+      priorityClassName: system-cluster-critical
+      serviceAccount: csi-attacher
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      containers:
+        - name: csi-attacher
+          image: {{ index .Values.images "csi-attacher" }}
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--leader-election-namespace=$(MY_NAMESPACE)"
+            - "--leader-election-identity=$(MY_NAME)"
+          env:
+            - name: MY_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ADDRESS
+              value: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com
+            type: DirectoryOrCreate
+{{- else -}}
 kind: Deployment
 apiVersion: {{ include "deploymentversion" . }}
 metadata:
@@ -61,4 +119,5 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/csi-diskplugin
             type: DirectoryOrCreate
+{{- end -}}
 {{- end -}}

--- a/charts/shoot-core/charts/csi-alicloud/templates/csi-crd-nodeinfo.yaml
+++ b/charts/shoot-core/charts/csi-alicloud/templates/csi-crd-nodeinfo.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.enabled }}
+{{- if semverCompare ">= 1.13" .Values.kubernetesVersion -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: csinodeinfos.csi.storage.k8s.io
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  group: csi.storage.k8s.io
+  names:
+    kind: CSINodeInfo
+    plural: csinodeinfos
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        csiDrivers:
+          description: List of CSI drivers running on the node and their properties.
+          items:
+            properties:
+              driver:
+                description: The CSI driver that this object refers to.
+                type: string
+              nodeID:
+                description: The node from the driver point of view.
+                type: string
+              topologyKeys:
+                description: List of keys supported by the driver.
+                items:
+                  type: string
+                type: array
+          type: array
+  version: v1alpha1
+{{- end -}}
+{{- end -}}

--- a/charts/shoot-core/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
+++ b/charts/shoot-core/charts/csi-alicloud/templates/csi-diskplugin-ds.yaml
@@ -1,4 +1,103 @@
 {{- if .Values.enabled }}
+{{- if semverCompare ">= 1.13" .Values.kubernetesVersion -}}
+kind: DaemonSet
+apiVersion: {{ include "daemonsetversion" . }}
+metadata:
+  name: csi-disk-plugin-alicloud
+  namespace: kube-system
+  labels:
+    origin: gardener
+    garden.sapcloud.io/role: system-component
+    app: csi-disk-plugin-alicloud
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  selector:
+    matchLabels:
+      app: csi-disk-plugin-alicloud
+  template:
+    metadata:
+      annotations:
+        checksum/secret-csi-diskplugin-alicloud: {{ include (print $.Template.BasePath "/credential-secret.yaml") . | sha256sum }}
+      labels:
+        app: csi-disk-plugin-alicloud
+        origin: gardener
+        garden.sapcloud.io/role: system-component
+    spec:
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      serviceAccount: csi-disk-plugin-alicloud
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      containers:
+        - name: driver-registrar
+          image: {{ index .Values.images "csi-node-driver-registrar" }} 
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/diskplugin.csi.alibabacloud.com /registration/diskplugin.csi.alibabacloud.com-reg.sock"]
+          args:
+            - "--v=5"
+            - "--csi-address=/csi/csi.sock"
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com/csi.sock
+          env:
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+        - name: csi-diskplugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: {{ index .Values.images "csi-plugin-alicloud" }}
+          args :
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--v=5"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix://var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com/csi.sock
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: csi-diskplugin-alicloud
+                  key: accessKeyID
+            - name: ACCESS_KEY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: csi-diskplugin-alicloud
+                  key: accessKeySecret
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - mountPath: /dev
+              name: host-dev
+              mountPropagation: "HostToContainer"
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+            type: DirectoryOrCreate
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: host-dev
+          hostPath:
+            path: /dev
+{{- else -}}
 kind: DaemonSet
 apiVersion: {{ include "daemonsetversion" . }}
 metadata:
@@ -58,14 +157,9 @@ spec:
             allowPrivilegeEscalation: true
           image: {{ index .Values.images "csi-plugin-alicloud" }}
           args :
-            - "--nodeid=$(NODE_ID)"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--v=5"
           env:
-            - name: NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
               value: unix://var/lib/kubelet/plugins/csi-diskplugin/csi.sock
             - name: ACCESS_KEY_ID
@@ -127,4 +221,5 @@ spec:
         - name: lib-modules
           hostPath:
             path: /lib/modules
+{{- end -}}
 {{- end -}}

--- a/charts/shoot-core/charts/csi-alicloud/templates/csi-provisioner-ss.yaml
+++ b/charts/shoot-core/charts/csi-alicloud/templates/csi-provisioner-ss.yaml
@@ -1,4 +1,53 @@
 {{- if .Values.enabled }}
+{{- if semverCompare ">= 1.13" .Values.kubernetesVersion -}}
+kind: StatefulSet
+apiVersion: {{ include "statefulsetversion" . }}
+metadata:
+  name: csi-provisioner
+  namespace: kube-system
+  labels:
+    app: csi-provisioner
+    origin: gardener
+    garden.sapcloud.io/role: system-component
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  serviceName: csi-provisioner
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-provisioner
+  template:
+    metadata:
+      labels:
+        origin: gardener
+        garden.sapcloud.io/role: system-component
+        app: csi-provisioner
+    spec:
+      priorityClassName: system-cluster-critical
+      serviceAccount: csi-provisioner
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      containers:
+        - name: csi-provisioner
+          image: {{ index .Values.images "csi-provisioner" }}
+          args:
+            - "--provisioner=diskplugin.csi.alibabacloud.com"
+            - "--csi-address=$(ADDRESS)"
+            - "--feature-gates=Topology=True"
+          env:
+            - name: ADDRESS
+              value: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com
+            type: DirectoryOrCreate
+{{- else -}}
 kind: StatefulSet
 apiVersion: {{ include "statefulsetversion" . }}
 metadata:
@@ -51,4 +100,5 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins/csi-diskplugin
             type: DirectoryOrCreate
+{{- end -}}
 {{- end -}}

--- a/charts/shoot-core/charts/csi-alicloud/templates/csi-snapshotter-ss.yaml
+++ b/charts/shoot-core/charts/csi-alicloud/templates/csi-snapshotter-ss.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.enabled }}
+{{- if semverCompare ">= 1.13" .Values.kubernetesVersion -}}
+kind: StatefulSet
+apiVersion: {{ include "statefulsetversion" . }}
+metadata:
+  name: csi-snapshotter
+  namespace: kube-system
+  labels:
+    app: csi-snapshotter
+    origin: gardener
+    garden.sapcloud.io/role: system-component
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  serviceName: csi-snapshotter
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-snapshotter
+  template:
+    metadata:
+      labels:
+        origin: gardener
+        garden.sapcloud.io/role: system-component
+        app: csi-snapshotter
+    spec:
+      priorityClassName: system-cluster-critical
+      serviceAccount: csi-snapshotter
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      containers:
+        - name: csi-snapshotter
+          image: {{ index .Values.images "csi-snapshotter" }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--connection-timeout=15s"
+          env:
+            - name: ADDRESS
+              value: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com
+            type: DirectoryOrCreate
+{{- end -}}
+{{- end -}}

--- a/charts/shoot-core/charts/csi-alicloud/templates/psp/csi-attacher-psp.yaml
+++ b/charts/shoot-core/charts/csi-alicloud/templates/psp/csi-attacher-psp.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
-  name: gardener.kube-system.attacher
+  name: gardener.kube-system.csi-attacher
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
@@ -11,7 +11,11 @@ spec:
   - hostPath
   hostNetwork: false
   allowedHostPaths:
+{{- if semverCompare ">= 1.13" .Values.kubernetesVersion }}
+  - pathPrefix: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com
+{{- else }}
   - pathPrefix: /var/lib/kubelet/plugins/csi-diskplugin
+{{- end }}
   runAsUser:
     rule: RunAsAny
   seLinux:

--- a/charts/shoot-core/charts/csi-alicloud/templates/psp/csi-attacher-rbac.yaml
+++ b/charts/shoot-core/charts/csi-alicloud/templates/psp/csi-attacher-rbac.yaml
@@ -40,7 +40,7 @@ rules:
     resources: ["events"]
     verbs: ["create", "patch", "update"]
   - apiGroups: ["policy", "extensions"]
-    resourceNames: ["gardener.kube-system.attacher"]
+    resourceNames: ["gardener.kube-system.csi-attacher"]
     resources: ["podsecuritypolicies"]
     verbs: ["use"]
 

--- a/charts/shoot-core/charts/csi-alicloud/templates/psp/csi-plugin-psp.yaml
+++ b/charts/shoot-core/charts/csi-alicloud/templates/psp/csi-plugin-psp.yaml
@@ -13,6 +13,10 @@ spec:
   - secret
   hostNetwork: true
   allowedHostPaths:
+{{- if semverCompare ">= 1.13" .Values.kubernetesVersion }}
+  - pathPrefix: /var/lib/kubelet
+  - pathPrefix: /dev
+{{- else }}
   - pathPrefix: /var/lib/kubelet/plugins/csi-diskplugin
   - pathPrefix: /var/lib/kubelet/plugins/kubernetes.io/csi/pv
   - pathPrefix: /var/lib/kubelet/pods
@@ -20,6 +24,7 @@ spec:
   - pathPrefix: /run/dbus
   - pathPrefix: /sys
   - pathPrefix: /lib/modules
+{{- end -}}
   runAsUser:
     rule: RunAsAny
   seLinux:

--- a/charts/shoot-core/charts/csi-alicloud/templates/psp/csi-provisioner-rbac.yaml
+++ b/charts/shoot-core/charts/csi-alicloud/templates/psp/csi-provisioner-rbac.yaml
@@ -26,11 +26,23 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
   - apiGroups:
     - policy
     - extensions
     resourceNames:
-    - gardener.kube-system.csi-diskplugin
+    - gardener.kube-system.csi-provisioner
     resources:
     - podsecuritypolicies
     verbs:

--- a/charts/shoot-core/charts/csi-alicloud/templates/psp/csi-snapshotter-psp.yaml
+++ b/charts/shoot-core/charts/csi-alicloud/templates/psp/csi-snapshotter-psp.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
-  name: gardener.kube-system.csi-provisioner
+  name: gardener.kube-system.csi-snapshotter
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
@@ -11,11 +11,7 @@ spec:
   - hostPath
   hostNetwork: false
   allowedHostPaths:
-{{- if semverCompare ">= 1.13" .Values.kubernetesVersion }}
   - pathPrefix: /var/lib/kubelet/plugins/diskplugin.csi.alibabacloud.com
-{{- else }}
-  - pathPrefix: /var/lib/kubelet/plugins/csi-diskplugin
-{{- end }}
   runAsUser:
     rule: RunAsAny
   seLinux:

--- a/charts/shoot-core/charts/csi-alicloud/templates/psp/csi-snapshotter-rbac.yaml
+++ b/charts/shoot-core/charts/csi-alicloud/templates/psp/csi-snapshotter-rbac.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-snapshotter
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: garden.sapcloud.io:psp:kube-system:csi-snapshotter
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete"]
+  - apiGroups: ["policy", "extensions"]
+    resourceNames: ["gardener.kube-system.csi-snapshotter"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: garden.sapcloud.io:psp:csi-snapshotter
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+subjects:
+  - kind: ServiceAccount
+    name: csi-snapshotter 
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: garden.sapcloud.io:psp:kube-system:csi-snapshotter
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/shoot-core/charts/csi-alicloud/values.yaml
+++ b/charts/shoot-core/charts/csi-alicloud/values.yaml
@@ -3,9 +3,11 @@ images:
   csi-driver-registrar: image-repository:image-tag
   csi-provisioner: image-repository:image-tag
   csi-plugin-alicloud: image-repository:image-tag
- 
+  csi-node-driver-registrar: image-repository:image-tag
+  csi-snapshotter: image-repository:image-tag
 credential:
   accessKeyID: keyID
   accessKeySecret: secret
 
+kubernetesVersion: v1.13.0
 enabled: false

--- a/cmd/gardener-controller-manager/charts
+++ b/cmd/gardener-controller-manager/charts
@@ -1,0 +1,1 @@
+/Users/i041966/projects/alicloud/ali-k8s-dev/debug-gardener/charts

--- a/docs/usage/supported_k8s_versions.md
+++ b/docs/usage/supported_k8s_versions.md
@@ -22,4 +22,4 @@ They are enabled by default in `1.11`. We allow `1.10` but users must make sure 
 | Azure          | 1.10.1+         | 1.11.0+         | 1.12.1+         | 1.13.0+         |
 | GCP            | 1.10.0+         | 1.11.0+         | 1.12.1+         | 1.13.0+         |
 | OpenStack      | 1.10.1+         | 1.11.0+         | 1.12.1+         | 1.13.0+         |
-| Alicloud       | unsupported     | 1.11.0+         | unsupported     | unsupported     |
+| Alicloud       | unsupported     | unsupported     | unsupported     | 1.13.0+         |

--- a/example/30-cloudprofile-alicloud.yaml
+++ b/example/30-cloudprofile-alicloud.yaml
@@ -15,7 +15,7 @@ spec:
       - name: unmanaged
       kubernetes:
         versions:
-        - 1.11.8
+        - 1.13.4
       machineImages:
       - name: coreos-alicloud
         id: coreos_1911_5_0_64_30G_alibase_20181219.vhd

--- a/example/90-shoot-alicloud.yaml
+++ b/example/90-shoot-alicloud.yaml
@@ -25,7 +25,7 @@ spec:
         autoScalerMax: 2
       zones: ['cn-beijing-f']
   kubernetes:
-    version: 1.11.8
+    version: 1.13.4
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   featureGates:

--- a/hack/templates/resources/30-cloudprofile.yaml.tpl
+++ b/hack/templates/resources/30-cloudprofile.yaml.tpl
@@ -364,7 +364,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         ${yaml.dump(kubernetesVersions, width=10000)}
         % else:
         versions:
-        - 1.11.8
+        - 1.13.4
         % endif
       machineImages:<% machineImages=value("spec.alicloud.constraints.machineImages", []) %>
       % if machineImages != []:

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -34,7 +34,7 @@
     kubernetesVersion="1.13.4"
   elif cloud == "alicloud":
     region="cn-beijing"
-    kubernetesVersion="1.11.8"
+    kubernetesVersion="1.13.4"
   elif cloud == "openstack" or cloud == "os":
     region="europe-1"
     kubernetesVersion="1.13.4"

--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -56,6 +56,7 @@ var (
 		},
 		kubernetes.StatefulSets: {
 			fmt.Sprintf("%s/csi-provisioner", metav1.NamespaceSystem): true,
+			fmt.Sprintf("%s/csi-snapshotter", metav1.NamespaceSystem): true,
 		},
 		kubernetes.Namespaces: {
 			metav1.NamespacePublic:  true,

--- a/pkg/operation/cloudbotanist/alicloudbotanist/addons.go
+++ b/pkg/operation/cloudbotanist/alicloudbotanist/addons.go
@@ -16,6 +16,7 @@ package alicloudbotanist
 
 import (
 	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/utils"
 )
 
 // DeployKube2IAMResources - Not needed on Alicloud
@@ -46,15 +47,33 @@ func (b *AlicloudBotanist) GenerateNginxIngressConfig() (map[string]interface{},
 
 // GenerateStorageClassesConfig generates values which are required to render the chart shoot-storageclasses properly.
 func (b *AlicloudBotanist) GenerateStorageClassesConfig() (map[string]interface{}, error) {
+	lessV1_13, err := utils.CompareVersions(b.ShootVersion(), "<", "v1.13.0")
+	if err != nil || lessV1_13 {
+		return map[string]interface{}{
+			"StorageClasses": []map[string]interface{}{
+				{
+					"Name":           "default",
+					"IsDefaultClass": true,
+					"Provisioner":    "csi-diskplugin",
+					"Parameters": map[string]interface{}{
+						"regionId": b.Shoot.Info.Spec.Cloud.Region,
+						"zoneId":   b.Shoot.Info.Spec.Cloud.Alicloud.Zones[0],
+						"fsType":   "ext4",
+						"type":     "cloud_ssd",
+						"readOnly": "false",
+					},
+				},
+			},
+		}, nil
+	}
+
 	return map[string]interface{}{
 		"StorageClasses": []map[string]interface{}{
 			{
 				"Name":           "default",
 				"IsDefaultClass": true,
-				"Provisioner":    "csi-diskplugin",
+				"Provisioner":    "diskplugin.csi.alibabacloud.com",
 				"Parameters": map[string]interface{}{
-					"regionId": b.Shoot.Info.Spec.Cloud.Region,
-					"zoneId":   b.Shoot.Info.Spec.Cloud.Alicloud.Zones[0],
 					"fsType":   "ext4",
 					"type":     "cloud_ssd",
 					"readOnly": "false",
@@ -62,4 +81,5 @@ func (b *AlicloudBotanist) GenerateStorageClassesConfig() (map[string]interface{
 			},
 		},
 	}, nil
+
 }

--- a/pkg/operation/cloudbotanist/alicloudbotanist/controlplane_test.go
+++ b/pkg/operation/cloudbotanist/alicloudbotanist/controlplane_test.go
@@ -39,9 +39,7 @@ var _ = Describe("validation", func() {
 					{
 					  "kubernetesClusterTag":"my-k8s-test",
 					  "vpcid":"vpc-2zehpnv9w5escf1hfqjsg",
-					  "zoneID":"cn-beijing-f",
 					  "region":"cn-beijing",
-					  "vswitchid":"vsw-2ze3a4pi0j4wbt39g8r8i",
 					  "accessKeyID":"ABC",
 					  "accessKeySecret":"ABCD"
 					}
@@ -67,7 +65,7 @@ var _ = Describe("validation", func() {
 
 		It("should refresh OK", func() {
 			m2 := b.RefreshCloudProviderConfig(curMap)
-			expected := `{"Global":{"KubernetesClusterTag":"my-k8s-test","uid":"","vpcid":"vpc-2zehpnv9w5escf1hfqjsg","region":"cn-beijing","zoneid":"cn-beijing-f","vswitchid":"vsw-2ze3a4pi0j4wbt39g8r8i","accessKeyID":"MTIz","accessKeySecret":"MTIzNA=="}}`
+			expected := `{"Global":{"KubernetesClusterTag":"my-k8s-test","uid":"","vpcid":"vpc-2zehpnv9w5escf1hfqjsg","region":"cn-beijing","accessKeyID":"MTIz","accessKeySecret":"MTIzNA=="}}`
 			Expect(m2[common.CloudProviderConfigMapKey]).To(Equal(expected))
 		})
 	})

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -472,8 +472,14 @@ const (
 	// CSIDriverRegistrarImageName is the name of driver registrar - https://github.com/kubernetes-csi/driver-registrar
 	CSIDriverRegistrarImageName = "csi-driver-registrar"
 
+	// CSINodeDriverRegistrarImageName is the name of driver registrar - https://github.com/kubernetes-csi/node-driver-registrar
+	CSINodeDriverRegistrarImageName = "csi-node-driver-registrar"
+
 	// CSIProvisionerImageName is the name of csi provisioner - https://github.com/kubernetes-csi/external-provisioner
 	CSIProvisionerImageName = "csi-provisioner"
+
+	// CSISnapshotterImageName is the name of csi plugin for Alicloud - https://github.com/kubernetes-csi/external-snapshotter
+	CSISnapshotterImageName = "csi-snapshotter"
 
 	// CSIPluginAlicloudImageName is the name of csi plugin for Alicloud - https://github.com/AliyunContainerService/csi-plugin
 	CSIPluginAlicloudImageName = "csi-plugin-alicloud"

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -349,6 +349,20 @@ func (b *HybridBotanist) DeployKubeAPIServer() error {
 	}
 	defaultValues["admissionPlugins"] = admissionPlugins
 
+	if b.Shoot.UsesCSI() {
+		var featureGates map[string]interface{}
+		if defaultValues["featureGates"] != nil {
+			featureGates = defaultValues["featureGates"].(map[string]interface{})
+		}
+		featureGates, err := common.InjectCSIFeatureGates(b.ShootVersion(), featureGates)
+		if err != nil {
+			return err
+		}
+		if featureGates != nil {
+			defaultValues["featureGates"] = featureGates
+		}
+	}
+
 	values, err := b.Botanist.InjectImages(defaultValues, b.SeedVersion(), b.ShootVersion(),
 		common.HyperkubeImageName,
 		common.VPNSeedImageName,


### PR DESCRIPTION
**What this PR does / why we need it**:
K8s 1.13.X only support csi-v1.0, so the PR add supports for csi-v1.0
 
**Release note**:
Alicloud csi provider csi-v1.0 is not compatible with csi-0.3.0. So it is suggested we only supports k8s v1.13 on Alicloud

```noteworthy user
Alicloud does now support 1.13 shoot clusters. The support for 1.11 will be dropped. Please refrain from creating 1.11 clusters and recreate your existing clusters with Kubernetes version 1.13.
```