### PR TITLE
Fix feature gate check in logging integration test

### DIFF
--- a/docs/testing/integration_tests.md
+++ b/docs/testing/integration_tests.md
@@ -173,9 +173,6 @@ shootTestYamlPath    = flag.String("shootpath", "", "the path to the shoot yaml 
 logLevel             = flag.String("verbose", "", "verbosity level, when set, logging level will be DEBUG")
 logsCount            = flag.Uint64("logsCount", 10000, "the logs count to be logged by the logger application")
 
-// If specified the test will skip the feature gate check
-skipFeatureGateCheck = flag.Bool("skipFeatureGateCheck", false, "whether to skip the feature gate check or not")
-
 // If specified the test will clean up the created shoot
 cleanup              = flag.Bool("cleanup", false, "deletes the newly created test shoot after the test suite is done")
 ```

--- a/test/integration/framework/common.go
+++ b/test/integration/framework/common.go
@@ -30,8 +30,8 @@ import (
 var (
 	decoder = serializer.NewCodecFactory(kubernetes.GardenScheme).UniversalDecoder()
 
-	// GuestBookTemplateDir relative path for guestbook app template dir
-	GuestBookTemplateDir = filepath.Join("..", "..", "resources", "templates")
+	// TemplateDir relative path for helm templates dir
+	TemplateDir = filepath.Join("..", "..", "resources", "templates")
 )
 
 const (

--- a/test/integration/framework/utils.go
+++ b/test/integration/framework/utils.go
@@ -156,8 +156,8 @@ func shootCreationCompleted(newStatus *v1beta1.ShootStatus) bool {
 			}
 		}
 	}
-	return true
 
+	return true
 }
 
 func getObjectFromSecret(ctx context.Context, k8sClient kubernetes.Interface, namespace, secretName, objectKey string) (string, error) {

--- a/test/integration/shoots/applications/shoot_app_test.go
+++ b/test/integration/shoots/applications/shoot_app_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Shoot application testing", func() {
 			"app":  "kubernetes",
 			"role": "apiserver",
 		}))
-		guestBooktpl = template.Must(template.ParseFiles(filepath.Join(GuestBookTemplateDir, GuestBookTemplateName)))
+		guestBooktpl = template.Must(template.ParseFiles(filepath.Join(TemplateDir, GuestBookTemplateName)))
 	}, InitializationTimeout)
 
 	CAfterSuite(func(ctx context.Context) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Until now the logging integration test was checking whether the logging feature is enabled by reading the `gardener-controller-manager-configmap`. The test relied that the cm exists in the garden cluster which is not always true. And the test execution failed with:
```
configmaps \"gardener-controller-manager-configmap\" not found
```
The PR removes this feature gate check and simply checks for required logging resources in seed such as `fluent-bit`, `fluentd-es`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
