### PR TITLE
Add generic domains for integration tests

### DIFF
--- a/.test-defs/cmd/create-shoot/main.go
+++ b/.test-defs/cmd/create-shoot/main.go
@@ -111,6 +111,8 @@ func init() {
 }
 
 func main() {
+	ctx := context.Background()
+	defer ctx.Done()
 	gardenerConfigPath := fmt.Sprintf("%s/gardener.config", kubeconfigPath)
 
 	shootGardenerTest, err := framework.NewShootGardenerTest(gardenerConfigPath, nil, testLogger)
@@ -136,18 +138,18 @@ func main() {
 
 	testLogger.Infof("Create shoot %s in namespace %s", shootName, projectNamespace)
 	shootGardenerTest.Shoot = shootObject
-	shootObject, err = shootGardenerTest.CreateShoot(context.TODO())
+	shootObject, err = shootGardenerTest.CreateShoot(ctx)
 	if err != nil {
 		testLogger.Fatalf("Cannot create shoot %s: %s", shootName, err.Error())
 	}
 	testLogger.Infof("Successfully created shoot %s", shootName)
 
-	shootTestOperations, err := framework.NewGardenTestOperation(context.TODO(), shootGardenerTest.GardenClient, testLogger, shootObject)
+	shootTestOperations, err := framework.NewGardenTestOperation(ctx, shootGardenerTest.GardenClient, testLogger, shootObject)
 	if err != nil {
 		testLogger.Fatalf("Cannot create shoot %s: %s", shootName, err.Error())
 	}
 
-	err = shootTestOperations.DownloadKubeconfig(context.TODO(), shootTestOperations.SeedClient, shootTestOperations.ShootSeedNamespace(), gardenv1beta1.GardenerName, fmt.Sprintf("%s/shoot.config", kubeconfigPath))
+	err = shootTestOperations.DownloadKubeconfig(ctx, shootTestOperations.SeedClient, shootTestOperations.ShootSeedNamespace(), gardenv1beta1.GardenerName, fmt.Sprintf("%s/shoot.config", kubeconfigPath))
 	if err != nil {
 		testLogger.Fatalf("Cannot download shoot kubeconfig: %s", err.Error())
 	}

--- a/test/integration/framework/common.go
+++ b/test/integration/framework/common.go
@@ -54,9 +54,7 @@ func CreateShootTestArtifacts(shootTestYamlPath, prefix string) (string, *v1beta
 	}
 
 	shoot.Name = integrationTestName
-	shootToReturnDomain := integrationTestName + ".shoot.dev.k8s-hana.ondemand.com"
-	shoot.Spec.DNS.Domain = &shootToReturnDomain
-
+	shoot.Spec.DNS.Domain = nil
 	return integrationTestName, shoot, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets the `dns.domain` name to nil so that the gardener automatically assigns a proper domain.
Currently this domain is hardcoded to `integrationTestName + ".shoot.dev.k8s-hana.ondemand.com"`.

**Special notes for your reviewer**:
@zanetworker I implemented the functionality as a util function in the framework.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
NONE
```
