### PR TITLE
Reduce Amount of Audit Logs to Reasonable Volume

### DIFF
--- a/charts/gardener/values.yaml
+++ b/charts/gardener/values.yaml
@@ -86,6 +86,9 @@ global:
           - system:kube-proxy
           - system:apiserver
           - system:apiserver
+          - system:serviceaccount:garden:gardener-controller-manager
+          - system:serviceaccount:garden:gardener-metrics-exporter
+          - system:serviceaccount:kube-system:generic-garbage-collector
           - garden.sapcloud.io:monitoring
           - garden.sapcloud.io:monitoring:prometheus
           - garden.sapcloud.io:monitoring:kube-state-metrics
@@ -99,7 +102,7 @@ global:
           - group: ""
             resources: ["events"]
         - level: None
-          verbs: ["get"]
+          verbs: ["get", "list", "watch"]
         - level: Metadata
       webhook: {}
  #      batchBufferSize: 10000


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR the gardener API will produce less audit logs.

I have gathered the audit events from a working Garden API server(634402 events, nearly 581MB without compression produced for 3 hours and 50 minutes) and here is what I find:

* serviceaccounts:
  - system:serviceaccount:garden:gardener-controller-manager
    contributes 70.87% of all audit logs
  - system:serviceaccount:garden:gardener-metrics-exporter
    contributes only 0.04% of all audit logs
  - system:serviceaccount:kube-system:generic-garbage-collector
    contributes only 0.12% of all audit logs

* verbs:
  - list
    contributes only 30.6% of all audit logs
  - watch
    contributes only 0.35% of all audit logs


As it can be seen, most of the audit logs are produced by the gardener controllers and its components.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The default audit log policy for Gardener has been improved to reduce the amount to a reasonable volume.
```
