### PR TITLE
Fix issue of Alicloud Cloud Controller Manager crash

### DIFF
--- a/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go
@@ -29,6 +29,8 @@ type cloudConfig struct {
 		UID                  string `json:"uid"`
 		VpcID                string `json:"vpcid"`
 		Region               string `json:"region"`
+		ZoneID               string `json:"zoneid"`
+		VswitchID            string `json:"vswitchid"`
 
 		AccessKeyID     string `json:"accessKeyID"`
 		AccessKeySecret string `json:"accessKeySecret"`
@@ -57,6 +59,8 @@ func (b *AlicloudBotanist) GenerateCloudProviderConfig() (string, error) {
 	cfg := &cloudConfig{}
 	cfg.Global.KubernetesClusterTag = b.Shoot.SeedNamespace
 	cfg.Global.VpcID = stateVariables[vpcID]
+	cfg.Global.ZoneID = b.Shoot.Info.Spec.Cloud.Alicloud.Zones[0]
+	cfg.Global.VswitchID = stateVariables[vswitchID]
 	cfg.Global.AccessKeyID = key
 	cfg.Global.AccessKeySecret = secret
 	cfg.Global.Region = b.Shoot.Info.Spec.Cloud.Region

--- a/pkg/operation/cloudbotanist/alicloudbotanist/controlplane_test.go
+++ b/pkg/operation/cloudbotanist/alicloudbotanist/controlplane_test.go
@@ -39,7 +39,9 @@ var _ = Describe("validation", func() {
 					{
 					  "kubernetesClusterTag":"my-k8s-test",
 					  "vpcid":"vpc-2zehpnv9w5escf1hfqjsg",
+					  "zoneID":"cn-beijing-f",
 					  "region":"cn-beijing",
+					  "vswitchid":"vsw-2ze3a4pi0j4wbt39g8r8i",
 					  "accessKeyID":"ABC",
 					  "accessKeySecret":"ABCD"
 					}
@@ -65,7 +67,7 @@ var _ = Describe("validation", func() {
 
 		It("should refresh OK", func() {
 			m2 := b.RefreshCloudProviderConfig(curMap)
-			expected := `{"Global":{"KubernetesClusterTag":"my-k8s-test","uid":"","vpcid":"vpc-2zehpnv9w5escf1hfqjsg","region":"cn-beijing","accessKeyID":"MTIz","accessKeySecret":"MTIzNA=="}}`
+			expected := `{"Global":{"KubernetesClusterTag":"my-k8s-test","uid":"","vpcid":"vpc-2zehpnv9w5escf1hfqjsg","region":"cn-beijing","zoneid":"cn-beijing-f","vswitchid":"vsw-2ze3a4pi0j4wbt39g8r8i","accessKeyID":"MTIz","accessKeySecret":"MTIzNA=="}}`
 			Expect(m2[common.CloudProviderConfigMapKey]).To(Equal(expected))
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, Alicloud CCM needs Zone and Switch info. It can get it from cloud meta-data. We have to feed this info when CCM is running in GCP.
 