### PR TITLE
Adds 'docker for desktop' support to local seed setup

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -8,7 +8,7 @@ Further details could be found in
 1. [Kubernetes Development Guide](https://github.com/kubernetes/community/tree/master/contributors/devel)
 1. [Architecture of the Garden](https://github.com/gardener/documentation/wiki/Architecture)
 
-This setup is based on [minikube](https://github.com/kubernetes/minikube), a Kubernetes cluster running on a single node.
+This setup is based on [minikube](https://github.com/kubernetes/minikube), a Kubernetes cluster running on a single node. Docker Desktop Edge is also supported.
 
 ## Installing Golang environment
 
@@ -222,7 +222,7 @@ validatingwebhookconfiguration.admissionregistration.k8s.io/validate-namespace-d
 Optionally, you can switch off the `Logging` feature gate of Gardener Controller Manager to save resources:
 
 ```bash
-$ sed -e 's/Logging: true/Logging: false/g' -i dev/20-componentconfig-gardener-controller-manager.yaml
+$ sed -i -e 's/Logging: true/Logging: false/g' dev/20-componentconfig-gardener-controller-manager.yaml
 ```
 
 The Gardener exposes the API servers of Shoot clusters via Kubernetes services of type `LoadBalancer`. In order to establish stable endpoints (robust against changes of the load balancer address), it creates DNS records pointing to these load balancer addresses. They are used internally and by all cluster components to communicate.
@@ -345,7 +345,7 @@ $ kubectl apply -f dev/90-shoot-local.yaml
 shoot "local" created
 ```
 
-Wait until the 2 secrets `osc-result-cloud-config-local-*` appear in the Shoot cluster namespace and then copy `cloud_config` from the secret `osc-result-cloud-config-local-xxxxx-downloader` to the local file `dev/user-data`. This file is used to pass the downloader configuration to the Vagrant machine, which triggers the mechanism that configures the machine properly and causes it to join the Shoot cluster as a node. 
+Wait until the 2 secrets `osc-result-cloud-config-local-*` appear in the Shoot cluster namespace and then copy `cloud_config` from the secret `osc-result-cloud-config-local-xxxxx-downloader` to the local file `dev/user-data`. This file is used to pass the downloader configuration to the Vagrant machine, which triggers the mechanism that configures the machine properly and causes it to join the Shoot cluster as a node.
 
 ```bash
 $ kubectl get secrets -n shoot--dev--local | grep osc-result-cloud-config-local

--- a/example/50-seed-local.yaml
+++ b/example/50-seed-local.yaml
@@ -11,7 +11,7 @@ spec:
   secretRef:
     name: seed-local
     namespace: garden
-  ingressDomain: <minikube-ip>.nip.io
+  ingressDomain: <local-kubernetes-ip>.nip.io
   networks: # Seed and Shoot networks must be disjunct
     nodes: 192.168.99.100/25
     pods: 172.17.0.0/16

--- a/example/90-shoot-local.yaml
+++ b/example/90-shoot-local.yaml
@@ -76,7 +76,7 @@ spec:
   #     SomeKubernetesFeature: true
   dns:
     provider: unmanaged
-    domain: <minikube-ip>.nip.io
+    domain: <local-kubernetes-ip>.nip.io
 # hibernation:
 #   enabled: false
 #   schedules:

--- a/hack/dev-setup
+++ b/hack/dev-setup
@@ -20,10 +20,10 @@ DEV_DIR=$(dirname "${0}")/../dev
 EXAMPLE_DIR=$(dirname "${0}")/../example
 
 source $(dirname "${0}")/common
-env="$(k8s_env)"
+kubernetes_env="$(k8s_env)"
 
 # test if we are running against a Minikube, Docker or kind Kubernetes local setup
-case "$env" in
+case "${kubernetes_env}" in
     $KIND)
         echo "Found kind ..."
         LOCAL_K8S_HOST_IP=localhost

--- a/hack/dev-setup-local
+++ b/hack/dev-setup-local
@@ -16,13 +16,59 @@
 
 source $(dirname "${0}")/common
 
+function __expose_docker_api_server() {
+    local _docker_api_server_secure_port="6443"
+    local _docker_kube_apiserver_service="kube-apiserver-docker-desktop"
+    kubectl -n kube-system get services ${_docker_kube_apiserver_service} &>/dev/null || \
+      kubectl -n kube-system expose pod ${_docker_kube_apiserver_service} --type=NodePort --name=${_docker_kube_apiserver_service} --port=${_docker_api_server_secure_port} &>/dev/null
+    local _exposed_apiserver_port=$(kubectl -n kube-system get service ${_docker_kube_apiserver_service} -o jsonpath="{.spec.ports[?(.port == ${_docker_api_server_secure_port})].nodePort}")
+    echo ${_exposed_apiserver_port}
+}
+
+function __generate_docker_client_cert_files() {
+    local _cert=${1}
+    local _key=${2}
+    local _docker_user=$(k8s_username)
+    kubectl config view --raw --flatten -o jsonpath="{.users[?(.name == \"${_docker_user}\")].user.client-certificate-data}" | base64 -d > ${_cert}
+    kubectl config view --raw --flatten -o jsonpath="{.users[?(.name == \"${_docker_user}\")].user.client-key-data}" | base64 -d > ${_key}
+}
+
 DEV_DIR=$(dirname "${0}")/../dev
 EXAMPLE_DIR=$(dirname "${0}")/../example
-MINIKUBE_IP=$(minikube ip)
-MINIKUBE_IP_DASHES=$(echo ${MINIKUBE_IP} | tr '.' '-')
 IP_ROUTE=$(ip route get 1)
 IP_ADDRESS=$(echo ${IP_ROUTE#*src} | awk '{print $1}')
-MINIKUBE_SEED_KUBECONFIG=${DEV_DIR}/minikube-seed-kubeconfig
+
+mkdir -p ${DEV_DIR}
+
+kubernetes_env="$(k8s_env)"
+
+case "${kubernetes_env}" in
+    $DOCKER_FOR_DESKTOP)
+        echo "Found Docker Kubernetes ..."
+        LOCAL_K8S_HOST_IP=$IP_ADDRESS
+        API_SERVER_SECURE_PORT="$(__expose_docker_api_server)"
+        TLS_VERIFICATION="--insecure-skip-tls-verify=true --embed-certs=false"
+        docker_client_cert="${DEV_DIR}/docker-k8s-client.crt"
+        docker_client_key="${DEV_DIR}/docker-k8s-client.key"
+        __generate_docker_client_cert_files ${docker_client_cert} ${docker_client_key}
+        CLIENT_CERTIFICATE="${docker_client_cert}"
+        CLIENT_KEY="${docker_client_key}"
+        ;;
+    $MINIKUBE)
+        echo "Found Minikube ..."
+        LOCAL_K8S_HOST_IP="$(minikube ip)"
+        TLS_VERIFICATION="--certificate-authority=${HOME}/.minikube/ca.crt --embed-certs=true"
+        CLIENT_CERTIFICATE="${HOME}/.minikube/client.crt"
+        CLIENT_KEY="${HOME}/.minikube/client.key"
+        ;;
+    *)
+        echo "Unsupported k8s environment for local seed: ${kubernetes_env}"
+        exit 1
+        ;;
+esac
+
+LOCAL_K8S_HOST_IP_DASHES=$(echo ${LOCAL_K8S_HOST_IP} | tr '.' '-')
+LOCAL_SEED_KUBECONFIG=${DEV_DIR}/local-seed-kubeconfig
 
 kubectl apply -f ${EXAMPLE_DIR}/00-namespace-garden-dev.yaml
 kubectl apply -f ${EXAMPLE_DIR}/05-project-dev.yaml
@@ -31,38 +77,37 @@ kubectl apply -f ${EXAMPLE_DIR}/70-secret-cloudprovider-local.yaml
 kubectl apply -f ${EXAMPLE_DIR}/80-secretbinding-cloudprovider-local.yaml
 
 kubectl config set-cluster gardener-dev \
-  --kubeconfig ${MINIKUBE_SEED_KUBECONFIG} \
-  --certificate-authority $HOME/.minikube/ca.crt \
-  --server https://${MINIKUBE_IP}:$API_SERVER_SECURE_PORT \
-  --embed-certs=true
+  --kubeconfig ${LOCAL_SEED_KUBECONFIG} \
+  ${TLS_VERIFICATION} \
+  --server https://${LOCAL_K8S_HOST_IP}:$API_SERVER_SECURE_PORT \
 
 kubectl config set-credentials gardener-dev \
-  --kubeconfig ${MINIKUBE_SEED_KUBECONFIG} \
-  --client-certificate $HOME/.minikube/client.crt \
-  --client-key $HOME/.minikube/client.key \
+  --kubeconfig ${LOCAL_SEED_KUBECONFIG} \
+  --client-certificate ${CLIENT_CERTIFICATE} \
+  --client-key ${CLIENT_KEY} \
   --embed-certs=true
 
 kubectl config set-context gardener-dev \
-  --kubeconfig ${MINIKUBE_SEED_KUBECONFIG} \
+  --kubeconfig ${LOCAL_SEED_KUBECONFIG} \
   --cluster gardener-dev \
   --user gardener-dev
 
 kubectl config use-context gardener-dev \
-  --kubeconfig ${MINIKUBE_SEED_KUBECONFIG}
+  --kubeconfig ${LOCAL_SEED_KUBECONFIG}
 
 # Different base64 implementations have different flags
-MINIKUBE_SEED_KUBECONFIG_B64=$(base64 ${MINIKUBE_SEED_KUBECONFIG} | tr -d '\r\n')
+LOCAL_SEED_KUBECONFIG_B64=$(base64 ${LOCAL_SEED_KUBECONFIG} | tr -d '\r\n')
 
 sed -e "s/name: my-seed/name: local/g" example/25-controllerinstallation.yaml | \
   kubectl apply -f -
 
-sed -e "s/kubeconfig: base64(kubeconfig-for-seed-cluster)/kubeconfig: ${MINIKUBE_SEED_KUBECONFIG_B64}/g" example/40-secret-seed-local.yaml | \
+sed -e "s/kubeconfig: base64(kubeconfig-for-seed-cluster)/kubeconfig: ${LOCAL_SEED_KUBECONFIG_B64}/g" example/40-secret-seed-local.yaml | \
   kubectl apply -f -
 
-sed -e "s/ingressDomain: <minikube-ip>.nip.io/ingressDomain: ${MINIKUBE_IP_DASHES}.nip.io/g" example/50-seed-local.yaml | \
+sed -e "s/ingressDomain: <local-kubernetes-ip>.nip.io/ingressDomain: ${LOCAL_K8S_HOST_IP_DASHES}.nip.io/g" example/50-seed-local.yaml | \
   kubectl apply -f -
 
-sed -e "s/domain: <minikube-ip>.nip.io/domain: ${MINIKUBE_IP_DASHES}.nip.io/g" example/90-shoot-local.yaml | \
+sed -e "s/domain: <local-kubernetes-ip>.nip.io/domain: ${LOCAL_K8S_HOST_IP_DASHES}.nip.io/g" example/90-shoot-local.yaml | \
   sed -e "s/endpoint: localhost:3777/endpoint: ${IP_ADDRESS}:3777/g" | \
   sed -e "s/name: johndoe-local/name: local/g" >${DEV_DIR}/90-shoot-local.yaml
 

--- a/hack/templates/resources/50-seed.yaml.tpl
+++ b/hack/templates/resources/50-seed.yaml.tpl
@@ -56,7 +56,7 @@ spec:
   secretRef:
     name: ${value("spec.secretRef.name", "seed-" + cloud)}
     namespace: ${value("spec.secretRef.namespace", "garden")}
-  ingressDomain: ${value("spec.ingressDomain", "dev." + cloud + ".seed.example.com") if cloud != "local" else "<minikube-ip>.nip.io"}
+  ingressDomain: ${value("spec.ingressDomain", "dev." + cloud + ".seed.example.com") if cloud != "local" else "<local-kubernetes-ip>.nip.io"}
   networks: # Seed and Shoot networks must be disjunct
     nodes: ${value("spec.networks.nodes", "10.240.0.0/16") if cloud != "local" else "192.168.99.100/25"}
     pods: ${value("spec.networks.pods", "10.241.128.0/17") if cloud != "local" else "172.17.0.0/16"}

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -291,7 +291,7 @@ spec:
   % endif
   dns:
     provider: ${value("spec.dns.provider", "aws-route53") if cloud != "local" else "unmanaged"}
-    domain: ${value("spec.dns.domain", value("metadata.name", "johndoe-" + cloud) + "." + value("metadata.namespace", "garden-dev") + ".example.com") if cloud != "local" else "<minikube-ip>.nip.io"}<% hibernation = value("spec.hibernation", {}) %>
+    domain: ${value("spec.dns.domain", value("metadata.name", "johndoe-" + cloud) + "." + value("metadata.namespace", "garden-dev") + ".example.com") if cloud != "local" else "<local-kubernetes-ip>.nip.io"}<% hibernation = value("spec.hibernation", {}) %>
   % if hibernation != {}:
   hibernation: ${yaml.dump(hibernation, width=10000)}
   % else:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for docker for desktop to the dev-setup-local script.
 
**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
The kubernetes apiserver is additionally exposed with a service of type NodePort to keep the local seed setup logic simpler and similar to the setup for minikube.

**Release note**:
None