### PR TITLE
increase prometheus memory

### DIFF
--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -28,7 +28,7 @@ prometheus:
         unit: m
       memory:
         base: 200
-        perObject: 36
+        perObject: 64
         weight: 5
         unit: Mi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Some prometheus instances are in `CrashLoopBackoff` because they are getting `OOMKilled`. This is only the case for prometheus instances that are monitoring large clusters (30+ nodes). Since we need prometheus to be up for monitoring I've increased the amount of memory that prometheus gets per node. Hopefully we can move away from this scaling method once we trust the VPA enough. 

Example usage:
1-4 Nodes
```yaml
resources:
  limits:
    cpu: 150m
    memory: 200Mi
  requests:
    cpu: 100m
    memory: 150Mi
```
5 - 9 Nodes
```yaml
resources:
  limits:
    cpu: 190m
    memory: 520Mi
  requests:
    cpu: 120m
    memory: 240Mi
```
10 - 14 Nodes
```yaml
resources:
  limits:
    cpu: 230m
    memory: 840Mi
  requests:
    cpu: 140m
    memory: 330Mi   
```
30 - 34 Nodes
```yaml
resources:
  limits:
    cpu: 390m
    memory: 2120Mi
  requests:
    cpu: 220m
    memory: 690Mi
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
