### PR TITLE
Enable subresource status for VPA

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/templates/vpa-crd.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/vpa-crd.yaml
@@ -14,6 +14,8 @@ spec:
     kind: VerticalPodAutoscaler
     shortNames:
     - vpa
+  subresources:
+    status: {}
   version: v1beta1
   versions:
   - name: v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:
The gardener reconciles the `/status` field in all vpa objects. The recommendations are stored in the `/status` field. This should not happen and if the vpa were to change an object and the recommendations are not there then the pod would get its normal requests (defeating the purpose of the vpa). This enables the subresource status for the VPA and prevents this behavior. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Gardener no longer reconciles `status` in VPA objects.
```
