### PR TITLE
Prevent gardener from reconciling vpa status away

### DIFF
--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -370,13 +370,14 @@ func BootstrapCluster(seed *Seed, secrets map[string]*corev1.Secret, imageVector
 	}
 
 	var (
-		applierOptions     = kubernetes.DefaultApplierOptions
-		clusterIssuerMerge = func(new, old *unstructured.Unstructured) {
-			// Apply status from old ClusterIssuer to retain the issuer's readiness state.
+		applierOptions          = kubernetes.DefaultApplierOptions
+		retainStatusInformation = func(new, old *unstructured.Unstructured) {
+			// Apply status from old Object to retain status information
 			new.Object["status"] = old.Object["status"]
 		}
 	)
-	applierOptions.MergeFuncs["ClusterIssuer"] = clusterIssuerMerge
+	applierOptions.MergeFuncs["ClusterIssuer"] = retainStatusInformation
+	applierOptions.MergeFuncs["VerticalPodAutoscaler"] = retainStatusInformation
 
 	return common.ApplyChartWithOptions(k8sSeedClient, chartRenderer, filepath.Join("charts", chartName), chartName, common.GardenNamespace, nil, map[string]interface{}{
 		"cloudProvider": seed.CloudProvider,


### PR DESCRIPTION
**What this PR does / why we need it**:
The gardener reconciles the `status` field in all vpa objects. The recommendations are stored in the `status` field. This should not happen and if the vpa were to change an object and the recommendations are not there then the pod would get its normal requests (defeating the purpose of the vpa). This prevents the `status` field from being overwritten.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
