### PR TITLE
Update images used for Alicloud

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -106,7 +106,7 @@ images:
 # Alicloud Controller Manger
 - name: alicloud-controller-manager
   sourceRepository: https://github.com/kubernetes/cloud-provider-alibaba-cloud
-  repository: jerryjxj/alicloud-controller-manager
+  repository: registry.eu-central-1.aliyuncs.com/gardener-de/alibaba-cloud-controller-manager
   tag: "1.9.8"
 
 # Shoot optional addons
@@ -162,7 +162,7 @@ images:
   versions: 1.11.x
 - name: csi-plugin-alicloud
   sourceRepository: https://github.com/AliyunContainerService/csi-plugin
-  repository: jerryjxj/csi-plugin-alicloud
+  repository: registry.eu-central-1.aliyuncs.com/gardener-de/csi-plugin-alicloud
   tag: v0.3.1
   versions: 1.11.x
 
@@ -188,7 +188,7 @@ images:
   versions: 1.13.x
 - name: csi-plugin-alicloud
   sourceRepository: https://github.com/AliyunContainerService/csi-plugin
-  repository: jerryjxj/csi-plugin-alicloud
+  repository: registry.eu-central-1.aliyuncs.com/gardener-de/csi-plugin-alicloud
   tag: v1.0.0
   versions: 1.13.x
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update cloud provider image for Alicloud. The base image is changed to be Alpine. The repo is changed to Alicloud
** It fixed **
New CCM for Alicloud fixes node automatic eviction issue.