### PR TITLE
Increasing the memory limit for kube-proxy and node-exporter daemonsets

### DIFF
--- a/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -72,7 +72,7 @@ spec:
             memory: 64Mi
           limits:
             cpu: 900m
-            memory: 200Mi
+            memory: 400Mi
         volumeMounts:
         - name: kubeconfig
           mountPath: /var/lib/kube-proxy

--- a/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -101,7 +101,7 @@ spec:
             memory: 10Mi
           limits:
             cpu: 15m
-            memory: 50Mi
+            memory: 100Mi
         volumeMounts:
         - name: proc
           readOnly:  true


### PR DESCRIPTION
**What this PR does / why we need it**:
Increasing the memory limit for kube-proxy daemonset to 400Mi as we have seen workloads that use around 200Mi memory, which is the current limit

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  NONE
-->
```improvement operator
The memory limits for `kube-proxy` and `node-exporter` have been doubled.
```
