### PR TITLE
Update gardener API default audit policy

### DIFF
--- a/charts/gardener/values.yaml
+++ b/charts/gardener/values.yaml
@@ -85,10 +85,10 @@ global:
           - system:kube-aggregator
           - system:kube-proxy
           - system:apiserver
-          - system:apiserver
           - system:serviceaccount:garden:gardener-controller-manager
           - system:serviceaccount:garden:gardener-metrics-exporter
           - system:serviceaccount:kube-system:generic-garbage-collector
+          - system:serviceaccount:kube-system:namespace-controller
           - garden.sapcloud.io:monitoring
           - garden.sapcloud.io:monitoring:prometheus
           - garden.sapcloud.io:monitoring:kube-state-metrics


### PR DESCRIPTION
**What this PR does / why we need it**:
* Remove the duplicated user `system:apiserver`.
* Do not audit log `system:serviceaccount:kube-system:namespace-controller` user


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The default audit log policy for Gardener has been refined.
```
