### PR TITLE
Add support for cloud provider optionally to modify shoot vpn config

### DIFF
--- a/pkg/operation/cloudbotanist/alicloudbotanist/addons.go
+++ b/pkg/operation/cloudbotanist/alicloudbotanist/addons.go
@@ -83,3 +83,8 @@ func (b *AlicloudBotanist) GenerateStorageClassesConfig() (map[string]interface{
 	}, nil
 
 }
+
+// GenerateVPNShootConfig generate cloud-specific vpn override - nothing unique for alicloud
+func (b *AlicloudBotanist) GenerateVPNShootConfig() (map[string]interface{}, error) {
+	return nil, nil
+}

--- a/pkg/operation/cloudbotanist/awsbotanist/addons.go
+++ b/pkg/operation/cloudbotanist/awsbotanist/addons.go
@@ -164,3 +164,8 @@ func (b *AWSBotanist) GenerateNginxIngressConfig() (map[string]interface{}, erro
 		},
 	}, b.Shoot.NginxIngressEnabled()), nil
 }
+
+// GenerateVPNShootConfig generate cloud-specific vpn override - nothing unique for aws
+func (b *AWSBotanist) GenerateVPNShootConfig() (map[string]interface{}, error) {
+	return nil, nil
+}

--- a/pkg/operation/cloudbotanist/azurebotanist/addons.go
+++ b/pkg/operation/cloudbotanist/azurebotanist/addons.go
@@ -78,3 +78,8 @@ func (b *AzureBotanist) GenerateStorageClassesConfig() (map[string]interface{}, 
 func (b *AzureBotanist) GenerateNginxIngressConfig() (map[string]interface{}, error) {
 	return common.GenerateAddonConfig(nil, b.Shoot.NginxIngressEnabled()), nil
 }
+
+// GenerateVPNShootConfig generate cloud-specific vpn override - nothing unique for aws
+func (b *AzureBotanist) GenerateVPNShootConfig() (map[string]interface{}, error) {
+	return nil, nil
+}

--- a/pkg/operation/cloudbotanist/gcpbotanist/addons.go
+++ b/pkg/operation/cloudbotanist/gcpbotanist/addons.go
@@ -59,3 +59,8 @@ func (b *GCPBotanist) GenerateStorageClassesConfig() (map[string]interface{}, er
 func (b *GCPBotanist) GenerateNginxIngressConfig() (map[string]interface{}, error) {
 	return common.GenerateAddonConfig(nil, b.Shoot.NginxIngressEnabled()), nil
 }
+
+// GenerateVPNShootConfig generate cloud-specific vpn override - nothing unique for gcp
+func (b *GCPBotanist) GenerateVPNShootConfig() (map[string]interface{}, error) {
+	return nil, nil
+}

--- a/pkg/operation/cloudbotanist/localbotanist/addons.go
+++ b/pkg/operation/cloudbotanist/localbotanist/addons.go
@@ -49,3 +49,8 @@ func (b *LocalBotanist) GenerateStorageClassesConfig() (map[string]interface{}, 
 func (b *LocalBotanist) GenerateNginxIngressConfig() (map[string]interface{}, error) {
 	return common.GenerateAddonConfig(nil, b.Shoot.NginxIngressEnabled()), nil
 }
+
+// GenerateVPNShootConfig generate cloud-specific vpn override - nothing unique for local
+func (b *LocalBotanist) GenerateVPNShootConfig() (map[string]interface{}, error) {
+	return nil, nil
+}

--- a/pkg/operation/cloudbotanist/openstackbotanist/addons.go
+++ b/pkg/operation/cloudbotanist/openstackbotanist/addons.go
@@ -61,3 +61,8 @@ func (b *OpenStackBotanist) GenerateStorageClassesConfig() (map[string]interface
 func (b *OpenStackBotanist) GenerateNginxIngressConfig() (map[string]interface{}, error) {
 	return common.GenerateAddonConfig(nil, b.Shoot.NginxIngressEnabled()), nil
 }
+
+// GenerateVPNShootConfig generate cloud-specific vpn override - nothing unique for openstack
+func (b *OpenStackBotanist) GenerateVPNShootConfig() (map[string]interface{}, error) {
+	return nil, nil
+}

--- a/pkg/operation/cloudbotanist/types.go
+++ b/pkg/operation/cloudbotanist/types.go
@@ -58,4 +58,5 @@ type CloudBotanist interface {
 	GenerateKube2IAMConfig() (map[string]interface{}, error)
 	GenerateStorageClassesConfig() (map[string]interface{}, error)
 	GenerateNginxIngressConfig() (map[string]interface{}, error)
+	GenerateVPNShootConfig() (map[string]interface{}, error)
 }

--- a/pkg/operation/hybridbotanist/addons.go
+++ b/pkg/operation/hybridbotanist/addons.go
@@ -122,6 +122,11 @@ func (b *HybridBotanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart
 	if err != nil {
 		return nil, err
 	}
+	vpnShootCloudSpecific, err := b.ShootCloudBotanist.GenerateVPNShootConfig()
+	if err != nil {
+		return nil, err
+	}
+	vpnShoot = utils.MergeMaps(vpnShoot, vpnShootCloudSpecific)
 
 	nodeExporter, err := b.Botanist.InjectImages(nodeExporterConfig, b.ShootVersion(), b.ShootVersion(), common.NodeExporterImageName)
 	if err != nil {


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR completes the PRs merged earlier in gardener [here](
https://github.com/gardener/gardener/pull/798) and vpn [here](https://github.com/gardener/vpn/pull/39) adding runtime configuration options to the shoot VPN. It feeds the VPN config to the CloudBotanist after creating it, right before sending it to the helm chart. This gives it the option - but not the requirement - to modify it.

**Special notes for your reviewer**:
Discussed on Slack with @rfranzke 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Enable custom vpn configs by cloud provider, including runtime determination
```