### PR TITLE
universal date

### DIFF
--- a/hack/get-build-ld-flags
+++ b/hack/get-build-ld-flags
@@ -17,4 +17,4 @@
 echo "-X github.com/gardener/gardener/pkg/version.gitVersion=$(cat VERSION)
       -X github.com/gardener/gardener/pkg/version.gitTreeState=$([ -z git status --porcelain 2>/dev/null ] && echo clean || echo dirty)
       -X github.com/gardener/gardener/pkg/version.gitCommit=$(git rev-parse --verify HEAD)
-      -X github.com/gardener/gardener/pkg/version.buildDate=$(date --rfc-3339=seconds | sed 's/ /T/')"
+      -X github.com/gardener/gardener/pkg/version.buildDate=$(date '+%Y-%m-%dT%H:%M:%S%z' | sed 's/\([0-9][0-9]\)$/:\1/g')"


### PR DESCRIPTION
**What this PR does / why we need it**:

The `date` command included in [hack/get-build-ld-flags](https://github.com/gardener/gardener/blob/master/hack/get-build-ld-flags) only works on certain versions of the `date` format. Because it is [included in Makefile](https://github.com/gardener/gardener/blob/master/Makefile#L21) as part of variable setting early on, if you run it on a system without the support for `--rfc-3339` (Mac, Alpine, to name a few), you cannot call any make targets.

This PR replaces the specific `date --rfc-3339=seconds` with the universal format `date '+%Y-%m-%dT%H:%M:%S%z'` so it can run anywhere. The result is the same format for date, e.g. `2019-03-19T08:02:06+02:00`

**Special notes for your reviewer**:

Small change, big convenience. :-)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```