### PR TITLE
Deprecate Nginx-Ingress-Addon

### DIFF
--- a/example/90-shoot-alicloud.yaml
+++ b/example/90-shoot-alicloud.yaml
@@ -106,8 +106,11 @@ spec:
     schedule: "0 */24 * * *"
     maximum: 7
   addons:
+    # nginx-ingress addon is still supported but deprecated.
+    # This field will be removed in the future. You should deploy your own ingress controller
+    # instead of enabling it here. You should not use this field anymore.
     nginx-ingress:
-      enabled: true
+      enabled: false
       loadBalancerSourceRanges: []
     kubernetes-dashboard:
       enabled: true
@@ -127,7 +130,7 @@ spec:
     # This field will be removed in the future. You should deploy your own kube-lego/cert-manager
     # instead of enabling it here. You should not use this field anymore.
     kube-lego:
-      enabled: true
+      enabled: false
       email: john.doe@example.com
     # Monocular addon is deprecated and no longer supported.
     # This field will be removed in the future and is only kept for API compatibility reasons. It is not

--- a/example/90-shoot-aws.yaml
+++ b/example/90-shoot-aws.yaml
@@ -110,8 +110,11 @@ spec:
     schedule: "0 */24 * * *"
     maximum: 7
   addons:
+    # nginx-ingress addon is still supported but deprecated.
+    # This field will be removed in the future. You should deploy your own ingress controller
+    # instead of enabling it here. You should not use this field anymore.
     nginx-ingress:
-      enabled: true
+      enabled: false
       loadBalancerSourceRanges: []
     kubernetes-dashboard:
       enabled: true
@@ -159,7 +162,7 @@ spec:
     # This field will be removed in the future. You should deploy your own kube-lego/cert-manager
     # instead of enabling it here. You should not use this field anymore.
     kube-lego:
-      enabled: true
+      enabled: false
       email: john.doe@example.com
     # Monocular addon is deprecated and no longer supported.
     # This field will be removed in the future and is only kept for API compatibility reasons. It is not

--- a/example/90-shoot-azure.yaml
+++ b/example/90-shoot-azure.yaml
@@ -109,8 +109,11 @@ spec:
     schedule: "0 */24 * * *"
     maximum: 7
   addons:
+    # nginx-ingress addon is still supported but deprecated.
+    # This field will be removed in the future. You should deploy your own ingress controller
+    # instead of enabling it here. You should not use this field anymore.
     nginx-ingress:
-      enabled: true
+      enabled: false
       loadBalancerSourceRanges: []
     kubernetes-dashboard:
       enabled: true
@@ -130,7 +133,7 @@ spec:
     # This field will be removed in the future. You should deploy your own kube-lego/cert-manager
     # instead of enabling it here. You should not use this field anymore.
     kube-lego:
-      enabled: true
+      enabled: false
       email: john.doe@example.com
     # Monocular addon is deprecated and no longer supported.
     # This field will be removed in the future and is only kept for API compatibility reasons. It is not

--- a/example/90-shoot-gcp.yaml
+++ b/example/90-shoot-gcp.yaml
@@ -108,8 +108,11 @@ spec:
     schedule: "0 */24 * * *"
     maximum: 7
   addons:
+    # nginx-ingress addon is still supported but deprecated.
+    # This field will be removed in the future. You should deploy your own ingress controller
+    # instead of enabling it here. You should not use this field anymore.
     nginx-ingress:
-      enabled: true
+      enabled: false
       loadBalancerSourceRanges: []
     kubernetes-dashboard:
       enabled: true
@@ -129,7 +132,7 @@ spec:
     # This field will be removed in the future. You should deploy your own kube-lego/cert-manager
     # instead of enabling it here. You should not use this field anymore.
     kube-lego:
-      enabled: true
+      enabled: false
       email: john.doe@example.com
     # Monocular addon is deprecated and no longer supported.
     # This field will be removed in the future and is only kept for API compatibility reasons. It is not

--- a/example/90-shoot-local.yaml
+++ b/example/90-shoot-local.yaml
@@ -89,8 +89,11 @@ spec:
     autoUpdate:
       kubernetesVersion: true
   addons:
+    # nginx-ingress addon is still supported but deprecated.
+    # This field will be removed in the future. You should deploy your own ingress controller
+    # instead of enabling it here. You should not use this field anymore.
     nginx-ingress:
-      enabled: true
+      enabled: false
       loadBalancerSourceRanges: []
     kubernetes-dashboard:
       enabled: true
@@ -110,7 +113,7 @@ spec:
     # This field will be removed in the future. You should deploy your own kube-lego/cert-manager
     # instead of enabling it here. You should not use this field anymore.
     kube-lego:
-      enabled: true
+      enabled: false
       email: john.doe@example.com
     # Monocular addon is deprecated and no longer supported.
     # This field will be removed in the future and is only kept for API compatibility reasons. It is not

--- a/example/90-shoot-openstack.yaml
+++ b/example/90-shoot-openstack.yaml
@@ -107,8 +107,11 @@ spec:
     schedule: "0 */24 * * *"
     maximum: 7
   addons:
+    # nginx-ingress addon is still supported but deprecated.
+    # This field will be removed in the future. You should deploy your own ingress controller
+    # instead of enabling it here. You should not use this field anymore.
     nginx-ingress:
-      enabled: true
+      enabled: false
       loadBalancerSourceRanges: []
     kubernetes-dashboard:
       enabled: true
@@ -128,7 +131,7 @@ spec:
     # This field will be removed in the future. You should deploy your own kube-lego/cert-manager
     # instead of enabling it here. You should not use this field anymore.
     kube-lego:
-      enabled: true
+      enabled: false
       email: john.doe@example.com
     # Monocular addon is deprecated and no longer supported.
     # This field will be removed in the future and is only kept for API compatibility reasons. It is not

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -317,8 +317,11 @@ spec:
     maximum: ${value("backup.maximum", "7")}
   % endif
   addons:
+    # nginx-ingress addon is still supported but deprecated.
+    # This field will be removed in the future. You should deploy your own ingress controller
+    # instead of enabling it here. You should not use this field anymore.
     nginx-ingress:
-      enabled: ${value("spec.addons.nginx-ingress.enabled", "true")}
+      enabled: ${value("spec.addons.nginx-ingress.enabled", "false")}
       loadBalancerSourceRanges: ${value("spec.addons.nginx-ingress.loadBalancerSourceRanges", [])}
     kubernetes-dashboard:
       enabled: ${value("spec.addons.kubernetes-dashboard.enabled", "true")}
@@ -372,7 +375,7 @@ spec:
     # This field will be removed in the future. You should deploy your own kube-lego/cert-manager
     # instead of enabling it here. You should not use this field anymore.
     kube-lego:
-      enabled: ${value("spec.addons.kube-lego.enabled", "true")}
+      enabled: ${value("spec.addons.kube-lego.enabled", "false")}
       email: ${value("spec.addons.kube-lego.email", "john.doe@example.com")}
     # Monocular addon is deprecated and no longer supported.
     # This field will be removed in the future and is only kept for API compatibility reasons. It is not

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -1042,6 +1042,7 @@ type Addons struct {
 	// +optional
 	KubernetesDashboard *KubernetesDashboard
 	// NginxIngress holds configuration settings for the nginx-ingress addon.
+	// DEPRECATED: This field will be removed in a future version.
 	// +optional
 	NginxIngress *NginxIngress
 

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -1037,6 +1037,7 @@ type Addons struct {
 	// +optional
 	KubernetesDashboard *KubernetesDashboard `json:"kubernetes-dashboard,omitempty"`
 	// NginxIngress holds configuration settings for the nginx-ingress addon.
+	// DEPRECATED: This field will be removed in a future version.
 	// +optional
 	NginxIngress *NginxIngress `json:"nginx-ingress,omitempty"`
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1283,7 +1283,7 @@ func schema_pkg_apis_garden_v1beta1_Addons(ref common.ReferenceCallback) common.
 					},
 					"nginx-ingress": {
 						SchemaProps: spec.SchemaProps{
-							Description: "NginxIngress holds configuration settings for the nginx-ingress addon.",
+							Description: "NginxIngress holds configuration settings for the nginx-ingress addon. DEPRECATED: This field will be removed in a future version.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/garden/v1beta1.NginxIngress"),
 						},
 					},
@@ -3633,8 +3633,9 @@ func schema_pkg_apis_garden_v1beta1_KubeProxyConfig(ref common.ReferenceCallback
 					},
 					"mode": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Mode specifies which proxy mode to use. defaults to IPTables.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR deprecates the `nginx-ingress` addon. Instead Shoot owners are encouraged to deploy any Ingress controller, version, configuration combination according to their preference.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
:warning: The `nginx-ingress` addon for shoot clusters is now deprecated (but still supported for a couple of releases). Shoot owners are now encouraged to deploy an `Ingress` controller according to their preferences themselves.
```
