### PR TITLE
Parallelize LB Service/Infra/Etcd setup during the Shoot creation

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
@@ -100,7 +100,7 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 		deploySecrets = g.Add(flow.Task{
 			Name:         "Deploying Shoot certificates / keys",
 			Fn:           flow.SimpleTaskFn(botanist.DeploySecrets),
-			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerServiceIsReady),
+			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying internal domain DNS record",

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -26,7 +26,7 @@ func (b *Botanist) EnsureIngressDNSRecord() error {
 		return b.DestroyIngressDNSRecord()
 	}
 
-	loadBalancerIngress, _, err := common.GetLoadBalancerIngress(b.K8sShootClient, metav1.NamespaceSystem, "addons-nginx-ingress-controller")
+	loadBalancerIngress, err := common.GetLoadBalancerIngress(b.K8sShootClient, metav1.NamespaceSystem, "addons-nginx-ingress-controller")
 	if err != nil {
 		return err
 	}

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -36,14 +36,13 @@ import (
 func (b *Botanist) WaitUntilKubeAPIServerServiceIsReady() error {
 	var e error
 	if err := wait.Poll(5*time.Second, 600*time.Second, func() (bool, error) {
-		loadBalancerIngress, serviceStatusIngress, err := common.GetLoadBalancerIngress(b.K8sSeedClient, b.Shoot.SeedNamespace, common.KubeAPIServerDeploymentName)
+		loadBalancerIngress, err := common.GetLoadBalancerIngress(b.K8sSeedClient, b.Shoot.SeedNamespace, common.KubeAPIServerDeploymentName)
 		if err != nil {
 			e = err
 			b.Logger.Info("Waiting until the kube-apiserver service is ready...")
 			return false, nil
 		}
 		b.Operation.APIServerAddress = loadBalancerIngress
-		b.Operation.APIServerIngresses = serviceStatusIngress
 		return true, nil
 	}); err != nil {
 		return e

--- a/pkg/operation/cloudbotanist/localbotanist/localbotanist.go
+++ b/pkg/operation/cloudbotanist/localbotanist/localbotanist.go
@@ -17,8 +17,6 @@ package localbotanist
 import (
 	"errors"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/gardener/gardener/pkg/operation"
 )
 
@@ -35,7 +33,6 @@ func New(o *operation.Operation) (*LocalBotanist, error) {
 	}
 	vb.APIServerAddress = *o.Shoot.Info.Spec.DNS.Domain
 	vb.Shoot.InternalClusterDomain = *o.Shoot.Info.Spec.DNS.Domain + ":31443"
-	vb.APIServerIngresses = []corev1.LoadBalancerIngress{{Hostname: *o.Shoot.Info.Spec.DNS.Domain}}
 	return vb, nil
 }
 

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -203,7 +203,7 @@ func GenerateAddonConfig(values map[string]interface{}, enabled bool) map[string
 // GetLoadBalancerIngress takes a K8SClient, a namespace and a service name. It queries for a load balancer's technical name
 // (ip address or hostname). It returns the value of the technical name whereby it always prefers the IP address (if given)
 // over the hostname. It also returns the list of all load balancer ingresses.
-func GetLoadBalancerIngress(client kubernetes.Interface, namespace, name string) (string, []corev1.LoadBalancerIngress, error) {
+func GetLoadBalancerIngress(client kubernetes.Interface, namespace, name string) (string, error) {
 	var (
 		loadBalancerIngress  string
 		serviceStatusIngress []corev1.LoadBalancerIngress
@@ -211,13 +211,13 @@ func GetLoadBalancerIngress(client kubernetes.Interface, namespace, name string)
 
 	service, err := client.GetService(namespace, name)
 	if err != nil {
-		return "", nil, err
+		return "", err
 	}
 
 	serviceStatusIngress = service.Status.LoadBalancer.Ingress
 	length := len(serviceStatusIngress)
 	if length == 0 {
-		return "", nil, errors.New("`.status.loadBalancer.ingress[]` has no elements yet, i.e. external load balancer has not been created (is your quota limit exceeded/reached?)")
+		return "", errors.New("`.status.loadBalancer.ingress[]` has no elements yet, i.e. external load balancer has not been created (is your quota limit exceeded/reached?)")
 	}
 
 	if serviceStatusIngress[length-1].IP != "" {
@@ -225,9 +225,9 @@ func GetLoadBalancerIngress(client kubernetes.Interface, namespace, name string)
 	} else if serviceStatusIngress[length-1].Hostname != "" {
 		loadBalancerIngress = serviceStatusIngress[length-1].Hostname
 	} else {
-		return "", nil, errors.New("`.status.loadBalancer.ingress[]` has an element which does neither contain `.ip` nor `.hostname`")
+		return "", errors.New("`.status.loadBalancer.ingress[]` has an element which does neither contain `.ip` nor `.hostname`")
 	}
-	return loadBalancerIngress, serviceStatusIngress, nil
+	return loadBalancerIngress, nil
 }
 
 // GenerateTerraformVariablesEnvironment takes a <secret> and a <keyValueMap> and builds an environment which

--- a/pkg/operation/types.go
+++ b/pkg/operation/types.go
@@ -54,7 +54,6 @@ type Operation struct {
 	ChartGardenRenderer  chartrenderer.Interface
 	ChartSeedRenderer    chartrenderer.Interface
 	ChartShootRenderer   chartrenderer.Interface
-	APIServerIngresses   []corev1.LoadBalancerIngress
 	APIServerAddress     string
 	SeedNamespaceObject  *corev1.Namespace
 	BackupInfrastructure *gardenv1beta1.BackupInfrastructure


### PR DESCRIPTION
**What this PR does / why we need it**:
It seems not necessary to wait until the ip/hostname of the `kube-apiserver` lb service has been written to the `Status` of the appropriate `Service` resource, before Gardener can start to run the `deploySecrets` task.

This is a small performance improvement for the Shoot creation process on infrastructures where their belonging Kubernetes cloud provider write the ip/hostname to the `Service` resource only after the entire lb + ip has been completely created. This is for instance on Azure the case.

Gardener will not block anymore until the service is ready before continuing with the creation of the infrastructure and etcds (including their disks). So those tasks can be parallelized.

Thats the new dependency graph of the relevant tasks. As you can see the tasks before `deployKubeAPIServer` can now run in parallel.
```
deployNamespace
-- deployKubeAPIServerService
  -- waitUntilKubeAPIServerServiceIsReady
    -- deployKubeAPIServer
-- deploySecrets
  -- deployInfrastructure
  -- deployETCD
    -- deployKubeAPIServer
```

**Special notes for your reviewer**:
Tested so far on AWS and Azure and it seems to behave as expected.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
Due to flow/performance optimisations in the shoot creation process Gardener does not longer wait until the load balancer for the kube-apiserver is fully provisioned/ready before starting to create the infrastructure and the etcd volumes. As a consequence, Gardener will not longer add the ip/hostname of the load balancer as SAN to the kube-apiserver's server certificate.
```

```action user
The kube-apiserver server certificate does not contain the external ip/hostname of its load balancer anymore (only for new clusters). In case you use the ip/hostname directly, then client-side SSL validation will not work anymore (you have to disable it).
```
