### PR TITLE
Remove rewrite_tag_filter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.12.0 AS builder
+FROM golang:1.12.1 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-configmap.yaml
@@ -16,29 +16,18 @@ data:
     </source>
 
   output.conf: |-
-    # Decide which is shoot record and which is not
-    <match kubernetes.**>
-      @id rewrite_tag_filter
-      @type rewrite_tag_filter
-      @log_level warn
-      <rule>
-        key $.kubernetes.namespace_name
-        pattern ^(shoot.*)
-        tag $1
-      </rule>
-      <rule>
-        key $.kubernetes.namespace_name
-        pattern ^shoot.*
-        invert true
-        tag seed
-      </rule>
-    </match>
-
     <filter **>
       @type elasticsearch_genid
     </filter>
 
-    <match shoot**>
+    # Match shoot namespace.
+    #
+    # The tag is in format kubernetes.<file-name> where <file-name> is the file name in /var/log/containers/.
+    # <file-name> is in format <pod-name>_<namespace_name>_<container-name>-<container-id>.log, for example:
+    #
+    #   coredns-67df79bbdd-lhg4s_kube-system_coredns-6d439ffb30c628d2261895247d18b49434c3e6d0c6a728f3fa5952f7cd1da6b4.log
+    #
+    <match kubernetes.*_shoot-*_*.**>
       @id elasticsearch_dynamic_fault_tolerant
       @type elasticsearch_dynamic_fault_tolerant
       @log_level warn


### PR DESCRIPTION
**What this PR does / why we need it**:
- Remove fluent/fluent-plugin-rewrite-tag-filter as the pattern matching can be done with fluentd primitives.
- Update golang to 1.12.1.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@vpnachev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
