### PR TITLE
Enable reverse proxy protocol for nginx to provide source ip to applications on all cloudproviders

### DIFF
--- a/charts/shoot-addons/charts/nginx-ingress/values.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/values.yaml
@@ -12,7 +12,7 @@ controller:
 
   config:
     server-name-hash-bucket-size: "256"
-    use-proxy-protocol: "false"
+    use-proxy-protocol: "true"
     worker-processes: "2"
 
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
@@ -81,6 +81,8 @@ controller:
   service:
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: '*'
+      nginx.ingress.kubernetes.io/auth-snippet: |
+        proxy_set_input_header X-Real-IP $remote_addr; proxy_set_input_header X-Forwarded-For $remote_addr;
     clusterIP: ""
 
     ## List of IP addresses at which the controller services are available
@@ -94,7 +96,7 @@ controller:
     ## Set external traffic policy to: "Local" to preserve source IP on
     ## providers supporting it
     ## Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
-    externalTrafficPolicy: ""
+    externalTrafficPolicy: "Local"
 
     targetPorts:
       http: 80

--- a/pkg/operation/cloudbotanist/alicloudbotanist/addons.go
+++ b/pkg/operation/cloudbotanist/alicloudbotanist/addons.go
@@ -36,13 +36,7 @@ func (b *AlicloudBotanist) GenerateKube2IAMConfig() (map[string]interface{}, err
 
 // GenerateNginxIngressConfig generates values which are required to render the chart nginx-ingress properly.
 func (b *AlicloudBotanist) GenerateNginxIngressConfig() (map[string]interface{}, error) {
-	return common.GenerateAddonConfig(map[string]interface{}{
-		"controller": map[string]interface{}{
-			"config": map[string]interface{}{
-				"use-proxy-protocol": "false",
-			},
-		},
-	}, b.Shoot.NginxIngressEnabled()), nil
+	return common.GenerateAddonConfig(nil, b.Shoot.NginxIngressEnabled()), nil
 }
 
 // GenerateStorageClassesConfig generates values which are required to render the chart shoot-storageclasses properly.

--- a/pkg/operation/cloudbotanist/awsbotanist/addons.go
+++ b/pkg/operation/cloudbotanist/awsbotanist/addons.go
@@ -156,13 +156,7 @@ func (b *AWSBotanist) GenerateStorageClassesConfig() (map[string]interface{}, er
 
 // GenerateNginxIngressConfig generates values which are required to render the chart nginx-ingress properly.
 func (b *AWSBotanist) GenerateNginxIngressConfig() (map[string]interface{}, error) {
-	return common.GenerateAddonConfig(map[string]interface{}{
-		"controller": map[string]interface{}{
-			"config": map[string]interface{}{
-				"use-proxy-protocol": "true",
-			},
-		},
-	}, b.Shoot.NginxIngressEnabled()), nil
+	return common.GenerateAddonConfig(nil, b.Shoot.NginxIngressEnabled()), nil
 }
 
 // GenerateVPNShootConfig generate cloud-specific vpn override - nothing unique for aws


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable reverse proxy protocol for nginx to provide source ip to applications on all cloudproviders
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Source IP Address is no provided in the HEADER field.
![Screenshot 2019-03-20 at 12 47 03](https://user-images.githubusercontent.com/30324854/54682175-79681380-4b0e-11e9-823c-7687c9f516fd.png)

Was tested for ```aws, azure, gcp``` and has to be tested for ```openstack``` and ```alicloud```. 

⚠️Do not merge!⚠️

**Release note**:
<!--  Write your release note:
-->
```user operator
Enable reverse proxy protocol on nginx to provide source ip in header field
```
