### PR TITLE
Fix make check

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -39,7 +39,7 @@ fi
 if ! which helm 1>/dev/null; then
   echo -n "Installing helm... "
   install_helm_path="./get_helm.sh"
-  curl https://raw.githubusercontent.com/helm/helm/v2.9.1/scripts/get > "${install_helm_path}"
+  curl https://raw.githubusercontent.com/helm/helm/master/scripts/get > "${install_helm_path}"
   chmod 700 "${install_helm_path}"
   bash "${install_helm_path}"
   rm ./"${install_helm_path}"


### PR DESCRIPTION
**What this PR does / why we need it**:
`$ make check` fails with:
```
Downloading https://kubernetes-helm.storage.googleapis.com/helm-tooltipped-s
btn-primary
v2.13.0-linux-amd64.tar.gz
curl: (3) Illegal characters found in URL
Failed to install helm
	For support, go to https://github.com/kubernetes/helm.
```

The issues is that Github recently changed the output of the releases page and the helm install script v2.9.1 relied on the old release page.
See helm/helm#5478 and https://github.com/helm/helm/issues/4521#issuecomment-416005167 .

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@mvladev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
