### PR TITLE
bug() #844 Changed PLEG log counting

### DIFF
--- a/charts/seed-operatingsystemconfig/original/templates/scripts/_health-monitor.sh
+++ b/charts/seed-operatingsystemconfig/original/templates/scripts/_health-monitor.sh
@@ -129,7 +129,7 @@
             fi
 
             # Check whether kubelet reports "PLEG not healthy" too often within the last 10 minutes and reboot VM if necessary.
-            if count_pleg_not_healthy="$(journalctl --since="$(date --date '-10min' "+%Y-%m-%d %T")" -u kubelet | grep "PLEG is not healthy" | wc -l)"; then
+            if count_pleg_not_healthy="$(journalctl --since="$(date --date '-10min' "+%Y-%m-%d %T")" -u kubelet | grep "PLEG is not healthy" | cut -f3 -d' '| cut -f2 -d':' | sort | uniq | wc -l)"; then
               if [[ $count_pleg_not_healthy -ge 10 ]]; then
                 sudo reboot
               fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This is fixing where health-monitor is using a duplicate hyperkube log for restarts.

**Which issue(s) this PR fixes**:
Fixes #844 


**Release note**:
```category operator
This fixes bug #844 which can cause shoot node reboot loops.
```
