### PR TITLE
Updates ClusterRole for system:cluster-autoscaler-shoot

### DIFF
--- a/charts/shoot-core/charts/cluster-autoscaler/templates/clusterrole-cluster-autoscaler.yaml
+++ b/charts/shoot-core/charts/cluster-autoscaler/templates/clusterrole-cluster-autoscaler.yaml
@@ -59,9 +59,11 @@ rules:
   - get
 - apiGroups:
   - extensions
+  - apps
   resources:
   - daemonsets
   - replicasets
+  - statefulsets
   verbs:
   - watch
   - list
@@ -73,14 +75,6 @@ rules:
   verbs:
   - watch
   - list
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - watch
-  - list
-  - get
 - apiGroups:
   - storage.k8s.io
   resources:


### PR DESCRIPTION
ReplicaSets, DaemonSets are expected to be present at both apiGroups of extension & apps.
Refer
	- https://github.com/kubernetes/autoscaler/commit/65297df234e300ad2860b3038f9e8c602b18cbbc
	- https://github.com/kubernetes/autoscaler/commit/2810425c2e400aec1a355ccdb2882790d815cee8

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #846 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
