### PR TITLE
Revert "Remove rewrite_tag_filter"

### DIFF
--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-configmap.yaml
@@ -16,18 +16,30 @@ data:
     </source>
 
   output.conf: |-
+    # Decide which is shoot record and which is not
+    <match kubernetes.**>
+      @id rewrite_tag_filter
+      @type rewrite_tag_filter
+      @log_level warn
+      <rule>
+        key $.kubernetes.namespace_name
+        pattern ^(shoot.*)
+        tag $1
+      </rule>
+      <rule>
+        key $.kubernetes.namespace_name
+        pattern ^shoot.*
+        invert true
+        tag seed
+      </rule>
+    </match>
+
     <filter **>
       @type elasticsearch_genid
     </filter>
 
     # Match shoot namespace.
-    #
-    # The tag is in format kubernetes.<file-name> where <file-name> is the file name in /var/log/containers/.
-    # <file-name> is in format <pod-name>_<namespace_name>_<container-name>-<container-id>.log, for example:
-    #
-    #   coredns-67df79bbdd-lhg4s_kube-system_coredns-6d439ffb30c628d2261895247d18b49434c3e6d0c6a728f3fa5952f7cd1da6b4.log
-    #
-    <match kubernetes.*_shoot-*_*.**>
+    <match shoot**>
       @id elasticsearch_dynamic_fault_tolerant
       @type elasticsearch_dynamic_fault_tolerant
       @log_level warn


### PR DESCRIPTION
**What this PR does / why we need it**:
Revert #841. Basically my idea was to remove rewrite_tag_plugin and use fluentd pattern matching primitives. The part I missed was that the tag also is par of buffering that creates new chunks per tag and with the new tag we will have much more chunks. So for now we will need this external plugin.
Sorry about the merge && revert.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
