### PR TITLE
Enable pod pid limit configuration for kubelet to protect fork bombs

### DIFF
--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet-config-file
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet-config-file
@@ -78,6 +78,9 @@ maxOpenFiles: 1000000
 maxPods: 110
 nodeStatusUpdateFrequency: 10s
 podsPerCore: 0
+{{- if .Values.kubernetes.kubelet.podPIDsLimit }}
+podPIDsLimit: {{ .Values.kubernetes.kubelet.podPIDsLimit }}
+{{- end }}
 readOnlyPort: 0
 registryPullQPS: 5
 registryBurst: 10

--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.flags
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.flags
@@ -33,4 +33,7 @@
 {{- if semverCompare "< 1.11" .Values.kubernetes.version }}
 --feature-gates=PodPriority=true \
 {{- end }}
+{{- if semverCompare "< 1.14" .Values.kubernetes.version }}
+--feature-gates=SupportPodPidsLimit=true \
+{{- end }}
 {{- end -}}

--- a/charts/seed-operatingsystemconfig/original/values.yaml
+++ b/charts/seed-operatingsystemconfig/original/values.yaml
@@ -22,6 +22,7 @@ kubernetes:
     parameters: []
     enableCSI: false
     providerIDProvided: false
+#   podPIDsLimit: 24
     featureGates: {}
 #     CustomResourceValidation: true
 #     RotateKubeletServerCertificate: false

--- a/example/90-shoot-alicloud.yaml
+++ b/example/90-shoot-alicloud.yaml
@@ -82,6 +82,7 @@ spec:
   #     SomeKubernetesFeature: true
   #   mode: IPVS
   # kubelet:
+  #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true
   dns:

--- a/example/90-shoot-aws.yaml
+++ b/example/90-shoot-aws.yaml
@@ -86,6 +86,7 @@ spec:
   #     SomeKubernetesFeature: true
   #   mode: IPVS
   # kubelet:
+  #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true
   dns:

--- a/example/90-shoot-azure.yaml
+++ b/example/90-shoot-azure.yaml
@@ -85,6 +85,7 @@ spec:
   #     SomeKubernetesFeature: true
   #   mode: IPVS
   # kubelet:
+  #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true
   dns:

--- a/example/90-shoot-gcp.yaml
+++ b/example/90-shoot-gcp.yaml
@@ -84,6 +84,7 @@ spec:
   #     SomeKubernetesFeature: true
   #   mode: IPVS
   # kubelet:
+  #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true
   dns:

--- a/example/90-shoot-local.yaml
+++ b/example/90-shoot-local.yaml
@@ -72,6 +72,7 @@ spec:
   #     SomeKubernetesFeature: true
   #   mode: IPVS
   # kubelet:
+  #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true
   dns:

--- a/example/90-shoot-openstack.yaml
+++ b/example/90-shoot-openstack.yaml
@@ -83,6 +83,7 @@ spec:
   #     SomeKubernetesFeature: true
   #   mode: IPVS
   # kubelet:
+  #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true
   dns:

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -286,6 +286,7 @@ spec:
     kubelet: ${yaml.dump(kubelet, width=10000)}
     % else:
   # kubelet:
+  #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true
   % endif

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -1403,6 +1403,8 @@ const (
 // KubeletConfig contains configuration settings for the kubelet.
 type KubeletConfig struct {
 	KubernetesConfig
+	// PodPIDsLimit is the maximum number of process IDs per pod allowed by the kubelet.
+	PodPIDsLimit *int64
 }
 
 // Maintenance contains information about the time window for maintenance operations and which

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -1452,6 +1452,9 @@ const (
 // KubeletConfig contains configuration settings for the kubelet.
 type KubeletConfig struct {
 	KubernetesConfig `json:",inline"`
+	// PodPIDsLimit is the maximum number of process IDs per pod allowed by the kubelet.
+	// +optional
+	PodPIDsLimit *int64 `json:"podPidsLimit,omitempty"`
 }
 
 // Maintenance contains information about the time window for maintenance operations and which

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -3142,6 +3142,7 @@ func autoConvert_v1beta1_KubeletConfig_To_garden_KubeletConfig(in *KubeletConfig
 	if err := Convert_v1beta1_KubernetesConfig_To_garden_KubernetesConfig(&in.KubernetesConfig, &out.KubernetesConfig, s); err != nil {
 		return err
 	}
+	out.PodPIDsLimit = (*int64)(unsafe.Pointer(in.PodPIDsLimit))
 	return nil
 }
 
@@ -3154,6 +3155,7 @@ func autoConvert_garden_KubeletConfig_To_v1beta1_KubeletConfig(in *garden.Kubele
 	if err := Convert_garden_KubernetesConfig_To_v1beta1_KubernetesConfig(&in.KubernetesConfig, &out.KubernetesConfig, s); err != nil {
 		return err
 	}
+	out.PodPIDsLimit = (*int64)(unsafe.Pointer(in.PodPIDsLimit))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -1742,6 +1742,11 @@ func (in *KubeSchedulerConfig) DeepCopy() *KubeSchedulerConfig {
 func (in *KubeletConfig) DeepCopyInto(out *KubeletConfig) {
 	*out = *in
 	in.KubernetesConfig.DeepCopyInto(&out.KubernetesConfig)
+	if in.PodPIDsLimit != nil {
+		in, out := &in.PodPIDsLimit, &out.PodPIDsLimit
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -1723,6 +1723,11 @@ func (in *KubeSchedulerConfig) DeepCopy() *KubeSchedulerConfig {
 func (in *KubeletConfig) DeepCopyInto(out *KubeletConfig) {
 	*out = *in
 	in.KubernetesConfig.DeepCopyInto(&out.KubernetesConfig)
+	if in.PodPIDsLimit != nil {
+		in, out := &in.PodPIDsLimit, &out.PodPIDsLimit
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/openapi/api_violations.report
+++ b/pkg/openapi/api_violations.report
@@ -9,6 +9,7 @@ API rule violation: names_match,github.com/gardener/gardener/pkg/apis/garden/v1b
 API rule violation: names_match,github.com/gardener/gardener/pkg/apis/garden/v1beta1,GardenerDuration,Duration
 API rule violation: names_match,github.com/gardener/gardener/pkg/apis/garden/v1beta1,KubeControllerManagerConfig,HorizontalPodAutoscalerConfig
 API rule violation: names_match,github.com/gardener/gardener/pkg/apis/garden/v1beta1,KubeLego,Mail
+API rule violation: names_match,github.com/gardener/gardener/pkg/apis/garden/v1beta1,KubeletConfig,PodPIDsLimit
 API rule violation: names_match,github.com/gardener/gardener/pkg/apis/garden/v1beta1,OpenStackProfile,KeyStoneURL
 API rule violation: names_match,k8s.io/api/core/v1,AzureDiskVolumeSource,DataDiskURI
 API rule violation: names_match,k8s.io/api/core/v1,ContainerStatus,LastTerminationState

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3692,6 +3692,13 @@ func schema_pkg_apis_garden_v1beta1_KubeletConfig(ref common.ReferenceCallback) 
 							},
 						},
 					},
+					"podPidsLimit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PodPIDsLimit is the maximum number of process IDs per pod allowed by the kubelet.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
End-users can now configure `.spec.kubernetes.kubelet.podPidsLimit` to limit the number of pids per pod based on Kubernetes `SupportPodPidsLimit` feature.

**Which issue(s) this PR fixes**:
Fixes #663 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
It is now possible to configure the maximum number of PIDs per pod by setting the `.spec.kubernetes.kubelet.podPidsLimit` flag in the `Shoot` specification.
```
