### PR TITLE
Added helm chart flag to make virtual garden namespace creation optional

### DIFF
--- a/charts/gardener/charts/application/templates/namespace-garden.yaml
+++ b/charts/gardener/charts/application/templates/namespace-garden.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.deployment.virtualGarden.enabled }}
+{{- if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.createNamespace }}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/charts/gardener/values.yaml
+++ b/charts/gardener/values.yaml
@@ -268,3 +268,4 @@ global:
     virtualGarden:
       enabled: false
       clusterIP: 1.2.3.4
+      createNamespace: true


### PR DESCRIPTION
**What this PR does / why we need it**:
In the multigarden setup we have to create the virtual garden namespace before the gardener installation.

**Which issue(s) this PR fixes**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

NONE
-->
