### PR TITLE
Make .ci/{check,test} more flexible on systems without readlink -f

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -5,10 +5,30 @@ set -e
 # For the check step concourse will set the following environment variables:
 # SOURCE_PATH - path to component repository root directory.
 
+# not all platforms support readlink -f
+# SOURCE_PATH must be set, and treat it as absolute path
+rlink=""
+set +e
+readlink -f /tmp >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+  # do not support readlink -f, so need alternative
+  rlink="readlink -f"
+fi
+set -e
+
+
 if [[ -z "${SOURCE_PATH}" ]]; then
-  export SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
+  if [ -z "$rlink" ]; then
+    echo "ERROR: system does not support 'readlink -f' and SOURCE_PATH not set, exiting." >&2
+    exit 1
+  fi
+  export SOURCE_PATH="$($rlink "$(dirname ${0})/..")"
 else
-  export SOURCE_PATH="$(readlink -f ${SOURCE_PATH})"
+  if [ -z "$rlink" ]; then
+    echo "warning: system does not support 'readlink -f', treating SOURCE_PATH as absolute path with symlinks resolved." >&2
+  else
+    export SOURCE_PATH="$($rlink ${SOURCE_PATH})"
+  fi
 fi
 
 # The `go <cmd>` commands requires to see the target repository to be part of a

--- a/.ci/test
+++ b/.ci/test
@@ -5,10 +5,30 @@ set -e
 # For the test step concourse will set the following environment variables:
 # SOURCE_PATH - path to component repository root directory.
 
+# not all platforms support readlink -f
+# SOURCE_PATH must be set, and treat it as absolute path
+rlink=""
+set +e
+readlink -f /tmp >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+  # do not support readlink -f, so need alternative
+  rlink="readlink -f"
+fi
+set -e
+
+
 if [[ -z "${SOURCE_PATH}" ]]; then
-  export SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
+  if [ -z "$rlink" ]; then
+    echo "ERROR: system does not support 'readlink -f' and SOURCE_PATH not set, exiting." >&2
+    exit 1
+  fi
+  export SOURCE_PATH="$($rlink "$(dirname ${0})/..")"
 else
-  export SOURCE_PATH="$(readlink -f "${SOURCE_PATH}")"
+  if [ -z "$rlink" ]; then
+    echo "warning: system does not support 'readlink -f', treating SOURCE_PATH as absolute path with symlinks resolved." >&2
+  else
+    export SOURCE_PATH="$($rlink ${SOURCE_PATH})"
+  fi
 fi
 
 # The `go <cmd>` commands requires to see the target repository to be part of a


### PR DESCRIPTION
**What this PR does / why we need it**:

`make verify` runs `.ci/test` and `.ci/check`, both of which depend on `readlink -f`. The `-f` option does not exist on all systems. 

Current behaviour:

* If `SOURCE_PATH` is set, read its absolute path, resolving all links (using `readlink -f`)
* If `SOURCE_PATH` is not set, use the current working directory, read its absolute path, resolving all links (using `readlink -f`)

New behaviour:

* Systems that support `readlink -f`: unchanged
* Systems that do not support `readlink -f`: 
    * If `SOURCE_PATH` is not set, exit with an error
    * If `SOURCE_PATH` is set, accept it as is (since we cannot resolve following links without `readlink -f`)


**Special notes for your reviewer**:

Save a lot of headache building on BSD/BSD-like (like Mac) and other systems

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Make it easier to run on other platforms.
```