### PR TITLE
Update etcd bootstrap script to validate only on abrupt etcd termination.

### DIFF
--- a/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
@@ -9,23 +9,64 @@ metadata:
 data:
   bootstrap.sh: |-
     #!/bin/sh
-    while true;
-    do
-      wget http://localhost:8080/initialization/status -S -O status;
-      STATUS=`cat status`;
-      case $STATUS in
-      "New")
-            wget http://localhost:8080/initialization/start -S -O - ;;
-      "Progress")
-            sleep 5;
-            continue;;
-      "Failed")
-            continue;;
-      "Successful")
-            exec etcd --config-file /bootstrap/etcd.conf.yml
-            ;;
-      esac;
-    done
+    VALIDATION_MARKER=/var/etcd/data/validation_marker
+
+    trap_and_propagate() {
+        PID=$1
+        shift
+        for sig in "$@" ; do
+            trap "kill -$sig $PID" "$sig"
+        done
+    }
+
+    start_managed_etcd(){
+          rm -rf $VALIDATION_MARKER
+          etcd --config-file /bootstrap/etcd.conf.yml &
+          ETCDPID=$!
+          trap_and_propagate $ETCDPID INT TERM
+          wait $ETCDPID
+          RET=$?
+          echo $RET > $VALIDATION_MARKER
+          exit $RET
+    }
+
+    check_and_start_etcd(){
+          while true;
+          do
+            wget http://localhost:8080/initialization/status -S -O status;
+            STATUS=`cat status`;
+            case $STATUS in
+            "New")
+                  wget http://localhost:8080/initialization/start?mode=$1 -S -O - ;;
+            "Progress")
+                  sleep 1;
+                  continue;;
+            "Failed")
+                  continue;;
+            "Successful")
+                  start_managed_etcd
+                  break
+                  ;;
+            esac;
+          done
+    }
+
+    if [ ! -f $VALIDATION_MARKER ] ;
+    then
+          echo "No $VALIDATION_MARKER file. Perform complete initialization routine and start etcd."
+          check_and_start_etcd full
+    else
+          echo "$VALIDATION_MARKER file present. Check return status and decide on initialization"
+          run_status=`cat $VALIDATION_MARKER`
+          echo "$VALIDATION_MARKER content: $run_status"
+          if [ $run_status == '143' ] || [ $run_status == '130' ] || [ $run_status == '0' ] ; then
+                echo "Requesting sidecar to perform sanity validation"
+                check_and_start_etcd sanity
+          else
+                echo "Requesting sidecar to perform full validation"
+                check_and_start_etcd full
+          fi
+    fi
   etcd.conf.yml: |-
       # This is the configuration file for the etcd server.
 
@@ -65,7 +106,7 @@ data:
       initial-cluster-state: 'new'
 
       # Number of committed transactions to trigger a snapshot to disk.
-      snapshot-count: 75000  
+      snapshot-count: 75000
 
       # Raise alarms when backend size exceeds the given quota. 0 means use the
       # default quota.

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
@@ -85,11 +85,11 @@ spec:
           protocol: TCP
         resources:
           requests:
-            cpu: 200m
-            memory: 500Mi
+            cpu: 500m
+            memory: 1000Mi
           limits:
-            cpu: 1000m
-            memory: 2560Mi
+            cpu: 2500m
+            memory: 3584Mi
         volumeMounts:
         - name: etcd-{{ .Values.role }}
           mountPath: /var/etcd/data


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
Currently, we validate etcd data directory on each restart of etcd container. The task is time consuming and DB size dependent. Recent release 0.6.0 of etcd-backup-restore accommodated the changes on etcd-backup-restore side to avoid the DB verification if not required. This PR adds the associated changes on bootstrap script from gardener as part of etcd deployment in gardener. 
Now, full etcd data directory validation is done only if last etcd shutdown is not graceful.
.
cc: @georgekuruvillak @shreyas-s-rao 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
None
```
