### PR TITLE
bug() removed PLEG is not healthy check.

### DIFF
--- a/charts/seed-operatingsystemconfig/original/templates/scripts/_health-monitor.sh
+++ b/charts/seed-operatingsystemconfig/original/templates/scripts/_health-monitor.sh
@@ -128,13 +128,6 @@
               last_kubelet_ready_state="$status"
             fi
 
-            # Check whether kubelet reports "PLEG not healthy" too often within the last 10 minutes and reboot VM if necessary.
-            if count_pleg_not_healthy="$(journalctl --since="$(date --date '-10min' "+%Y-%m-%d %T")" -u kubelet | grep "PLEG is not healthy" | wc -l)"; then
-              if [[ $count_pleg_not_healthy -ge 10 ]]; then
-                sudo reboot
-              fi
-            fi
-
             sleep $SLEEP_SECONDS
           done
         }


### PR DESCRIPTION
**What this PR does / why we need it**:
This removes an unrealiable health check, which causes shoot node reboot loops.

**Which issue(s) this PR fixes**:
Fixes #844 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.
-->

```improvement operator
The kubelet-monitor does no longer restart the kubelet if it reports PLEG is not healthy errors.
```
