### PR TITLE
Fix seed condition reporting

### DIFF
--- a/pkg/apis/core/v1alpha1/helper/helper.go
+++ b/pkg/apis/core/v1alpha1/helper/helper.go
@@ -67,6 +67,15 @@ func GetCondition(conditions []gardencorev1alpha1.Condition, conditionType garde
 	return nil
 }
 
+// GetOrInitCondition tries to retrieve the condition with the given condition type from the given conditions.
+// If the condition could not be found, it returns an initialized condition of the given type.
+func GetOrInitCondition(conditions []gardencorev1alpha1.Condition, conditionType gardencorev1alpha1.ConditionType) gardencorev1alpha1.Condition {
+	if condition := GetCondition(conditions, conditionType); condition != nil {
+		return *condition
+	}
+	return InitCondition(conditionType)
+}
+
 // UpdatedCondition updates the properties of one specific condition.
 func UpdatedCondition(condition gardencorev1alpha1.Condition, status gardencorev1alpha1.ConditionStatus, reason, message string) gardencorev1alpha1.Condition {
 	newCondition := gardencorev1alpha1.Condition{

--- a/pkg/apis/core/v1alpha1/helper/helpers_test.go
+++ b/pkg/apis/core/v1alpha1/helper/helpers_test.go
@@ -17,6 +17,7 @@ package helper_test
 import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	. "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -140,6 +141,27 @@ var _ = Describe("helper", func() {
 				cond := GetCondition(conditions, conditionType)
 
 				Expect(cond).To(BeNil())
+			})
+		})
+
+		Describe("#GetOrInitCondition", func() {
+			It("should get the existing condition", func() {
+				var (
+					c          = gardencorev1alpha1.Condition{Type: "foo"}
+					conditions = []gardencorev1alpha1.Condition{c}
+				)
+
+				Expect(GetOrInitCondition(conditions, "foo")).To(Equal(c))
+			})
+
+			It("should return a new, initialized condition", func() {
+				tmp := Now
+				Now = func() metav1.Time {
+					return metav1.NewTime(time.Unix(0, 0))
+				}
+				defer func() { Now = tmp }()
+
+				Expect(GetOrInitCondition(nil, "foo")).To(Equal(InitCondition("foo")))
 			})
 		})
 


### PR DESCRIPTION
implement `GetOrInitCondition` to simplify retrieving or initializing
conditions for health checks
fix seed condition reporting by using the right condition to modify
remove ConditionValid from the Seed
add tests

**Special notes for your reviewer**:
cc @rfranzke 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
