### PR TITLE
Block new incoming connections to seed cluster from vpn tunnel

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
@@ -33,6 +33,15 @@ spec:
       tolerations:
       - effect: NoExecute
         operator: Exists
+      initContainers:
+      - name: set-iptable-rules
+        image: {{ index .Values.images "alpine" }}
+        command: ['/bin/sh', '-c', 'apk update && apk add iptables && iptables -A INPUT -i tun0 -p icmp -j ACCEPT && iptables -A INPUT -i tun0 -m state --state NEW -j DROP']
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
       containers:
       - name: kube-apiserver
         image: {{ index .Values.images "hyperkube" }}

--- a/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
@@ -61,6 +61,15 @@ spec:
     spec:
       # used to talk to Seed's API server.
       serviceAccountName: prometheus
+      initContainers:
+      - name: set-iptable-rules
+        image: {{ index .Values.images "alpine" }}
+        command: ['/bin/sh', '-c', 'apk update && apk add iptables && iptables -A INPUT -i tun0 -p icmp -j ACCEPT && iptables -A INPUT -i tun0 -m state --state NEW -j DROP']
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
       containers:
       - name: prometheus
         image: {{ index .Values.images "prometheus" }}

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -362,6 +362,7 @@ func (b *Botanist) DeploySeedMonitoring() error {
 		common.ConfigMapReloaderImageName,
 		common.VPNSeedImageName,
 		common.BlackboxExporterImageName,
+		common.AlpineImageName,
 	)
 	if err != nil {
 		return err

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -380,6 +380,7 @@ func (b *HybridBotanist) DeployKubeAPIServer() error {
 		common.HyperkubeImageName,
 		common.VPNSeedImageName,
 		common.BlackboxExporterImageName,
+		common.AlpineImageName,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
Set iptable rule to block new incoming connections from shoot cluster but allow icmp connections. 

**Which issue(s) this PR fixes**:
Fixes: https://github.com/gardener/vpn/issues/40

**Special notes for your reviewer**:
The important traffic is going through the public endpoint, so not affected by this PR. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
Traffic from shoot to seed via the VPN endpoint is now blocked.
```
