### PR TITLE
Fix alicloud metadata reachability and adapt integration test

### DIFF
--- a/charts/seed-controlplane/charts/cloud-metadata-service/templates/_egress.tpl
+++ b/charts/seed-controlplane/charts/cloud-metadata-service/templates/_egress.tpl
@@ -7,5 +7,9 @@ egress:
     # Allow all except metadata-service
       cidr: 0.0.0.0/0
       except:
+      {{ if eq .Values.cloudProvider "alicloud" }}
+      - 100.100.100.200/32
+      {{ else }}
       - 169.254.169.254/32
+      {{ end }}
 {{- end}}

--- a/charts/seed-controlplane/charts/cloud-metadata-service/values.yaml
+++ b/charts/seed-controlplane/charts/cloud-metadata-service/values.yaml
@@ -1,0 +1,1 @@
+cloudProvider: ""

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/network-policy.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/network-policy.yaml
@@ -39,7 +39,11 @@ spec:
         - {{ .Values.seedNetworks.pod }}
         - {{ .Values.seedNetworks.node }}
         - {{ .Values.seedNetworks.service }}
+        {{- if eq .Values.cloudProvider "alicloud" }}
+        - 100.100.100.200/32
+        {{- else }}
         - 169.254.169.254/32
+        {{- end }}
   podSelector:
     matchLabels:
       app: kubernetes

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -114,7 +114,10 @@ func (b *Botanist) deleteNamespace(name string) error {
 // DeployCloudMetadataServiceNetworkPolicy creates a global network policy that allows access to the meta-data service only from
 // the cloud-controller-manager and the kube-controller-manager
 func (b *Botanist) DeployCloudMetadataServiceNetworkPolicy() error {
-	return b.ApplyChartSeed(filepath.Join(chartPathControlPlane, "cloud-metadata-service"), b.Shoot.SeedNamespace, "cloud-metadata-service", nil, nil)
+	values := map[string]interface{}{
+		"cloudProvider": b.Seed.CloudProvider,
+	}
+	return b.ApplyChartSeed(filepath.Join(chartPathControlPlane, "cloud-metadata-service"), b.Shoot.SeedNamespace, "cloud-metadata-service", values, nil)
 }
 
 // DeleteKubeAPIServer deletes the kube-apiserver deployment in the Seed cluster which holds the Shoot's control plane.

--- a/test/integration/shoots/applications/shoot_app_test.go
+++ b/test/integration/shoots/applications/shoot_app_test.go
@@ -400,9 +400,9 @@ var _ = Describe("Shoot application testing", func() {
 
 		CIt("should block traffic to the metadataservice", func(ctx context.Context) {
 			if cloudProvider == v1beta1.CloudProviderAlicloud {
-				Expect(ExecNCOnAPIServer(ctx, "100.100.100.200", "80")).NotTo(HaveOccurred())
+				Expect(ExecNCOnAPIServer(ctx, "100.100.100.200", "80")).To(HaveOccurred())
 			} else {
-				Expect(ExecNCOnAPIServer(ctx, "169.254.169.254", "80")).NotTo(HaveOccurred())
+				Expect(ExecNCOnAPIServer(ctx, "169.254.169.254", "80")).To(HaveOccurred())
 			}
 		}, NetworkPolicyTimeout)
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the reachability of the metadata service in alicloud

**Fixes issue**:
https://github.com/gardener/gardener/issues/722

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
The metadata service of Alicloud is now blocked for all pods in the seed other than the kube-controller-manager and the cloud-controller-manager.
```
