### PR TITLE
Implement `location` for hibernation schedules

### DIFF
--- a/example/90-shoot-alicloud.yaml
+++ b/example/90-shoot-alicloud.yaml
@@ -93,6 +93,7 @@ spec:
 #   schedules:
 #   - start: "0 20 * * *" # Start hibernation every day at 8PM
 #     end: "0 6 * * *"    # Stop hibernation every day at 6AM
+#     location: "America/Los_Angeles" # Specify a location for the cron to run in
   maintenance:
     timeWindow:
       begin: 220000+0100

--- a/example/90-shoot-aws.yaml
+++ b/example/90-shoot-aws.yaml
@@ -97,6 +97,7 @@ spec:
 #   schedules:
 #   - start: "0 20 * * *" # Start hibernation every day at 8PM
 #     end: "0 6 * * *"    # Stop hibernation every day at 6AM
+#     location: "America/Los_Angeles" # Specify a location for the cron to run in
   maintenance:
     timeWindow:
       begin: 220000+0100

--- a/example/90-shoot-azure.yaml
+++ b/example/90-shoot-azure.yaml
@@ -96,6 +96,7 @@ spec:
 #   schedules:
 #   - start: "0 20 * * *" # Start hibernation every day at 8PM
 #     end: "0 6 * * *"    # Stop hibernation every day at 6AM
+#     location: "America/Los_Angeles" # Specify a location for the cron to run in
   maintenance:
     timeWindow:
       begin: 220000+0100

--- a/example/90-shoot-gcp.yaml
+++ b/example/90-shoot-gcp.yaml
@@ -95,6 +95,7 @@ spec:
 #   schedules:
 #   - start: "0 20 * * *" # Start hibernation every day at 8PM
 #     end: "0 6 * * *"    # Stop hibernation every day at 6AM
+#     location: "America/Los_Angeles" # Specify a location for the cron to run in
   maintenance:
     timeWindow:
       begin: 220000+0100

--- a/example/90-shoot-local.yaml
+++ b/example/90-shoot-local.yaml
@@ -85,6 +85,7 @@ spec:
 #   schedules:
 #   - start: "0 20 * * *" # Start hibernation every day at 8PM
 #     end: "0 6 * * *"    # Stop hibernation every day at 6AM
+#     location: "America/Los_Angeles" # Specify a location for the cron to run in
   maintenance:
     timeWindow:
       begin: 220000+0100

--- a/example/90-shoot-openstack.yaml
+++ b/example/90-shoot-openstack.yaml
@@ -94,6 +94,7 @@ spec:
 #   schedules:
 #   - start: "0 20 * * *" # Start hibernation every day at 8PM
 #     end: "0 6 * * *"    # Stop hibernation every day at 6AM
+#     location: "America/Los_Angeles" # Specify a location for the cron to run in
   maintenance:
     timeWindow:
       begin: 220000+0100

--- a/example/90-shoot-packet.yaml
+++ b/example/90-shoot-packet.yaml
@@ -88,6 +88,7 @@ spec:
 #   schedules:
 #   - start: "0 20 * * *" # Start hibernation every day at 8PM
 #     end: "0 6 * * *"    # Stop hibernation every day at 6AM
+#     location: "America/Los_Angeles" # Specify a location for the cron to run in
   maintenance:
     timeWindow:
       begin: 220000+0100

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -321,6 +321,7 @@ spec:
 #   schedules:
 #   - start: "0 20 * * *" # Start hibernation every day at 8PM
 #     end: "0 6 * * *"    # Stop hibernation every day at 6AM
+#     location: "America/Los_Angeles" # Specify a location for the cron to run in
   % endif
   maintenance:
     timeWindow:

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -362,6 +362,7 @@ type LocalMachineImage struct {
 	// Name is the name of the image.
 	Name MachineImageName
 }
+
 // KubernetesConstraints contains constraints regarding allowed values of the 'kubernetes' block in the Shoot specification.
 type KubernetesConstraints struct {
 	// Versions is the list of allowed Kubernetes versions for Shoot clusters (e.g., 1.13.1).
@@ -1279,6 +1280,9 @@ type HibernationSchedule struct {
 	// End is a Cron spec at which time a Shoot will be woken up.
 	// +optional
 	End *string
+	// Location is the time location in which both start and and shall be evaluated.
+	// +optional
+	Location *string
 }
 
 // Kubernetes contains the version and configuration variables for the Shoot control plane.

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -363,6 +363,7 @@ type LocalMachineImage struct {
 	// Name is the name of the image.
 	Name MachineImageName `json:"name"`
 }
+
 // KubernetesConstraints contains constraints regarding allowed values of the 'kubernetes' block in the Shoot specification.
 type KubernetesConstraints struct {
 	// Versions is the list of allowed Kubernetes versions for Shoot clusters (e.g., 1.13.1).
@@ -1275,6 +1276,9 @@ type HibernationSchedule struct {
 	// End is a Cron spec at which time a Shoot will be woken up.
 	// +optional
 	End *string `json:"end,omitempty"`
+	// Location is the time location in which both start and and shall be evaluated.
+	// +optional
+	Location *string `json:"location,omitempty"`
 }
 
 // Kubernetes contains the version and configuration variables for the Shoot control plane.

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -2925,6 +2925,7 @@ func Convert_garden_Hibernation_To_v1beta1_Hibernation(in *garden.Hibernation, o
 func autoConvert_v1beta1_HibernationSchedule_To_garden_HibernationSchedule(in *HibernationSchedule, out *garden.HibernationSchedule, s conversion.Scope) error {
 	out.Start = (*string)(unsafe.Pointer(in.Start))
 	out.End = (*string)(unsafe.Pointer(in.End))
+	out.Location = (*string)(unsafe.Pointer(in.Location))
 	return nil
 }
 
@@ -2936,6 +2937,7 @@ func Convert_v1beta1_HibernationSchedule_To_garden_HibernationSchedule(in *Hiber
 func autoConvert_garden_HibernationSchedule_To_v1beta1_HibernationSchedule(in *garden.HibernationSchedule, out *HibernationSchedule, s conversion.Scope) error {
 	out.Start = (*string)(unsafe.Pointer(in.Start))
 	out.End = (*string)(unsafe.Pointer(in.End))
+	out.Location = (*string)(unsafe.Pointer(in.Location))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -1479,6 +1479,11 @@ func (in *HibernationSchedule) DeepCopyInto(out *HibernationSchedule) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Location != nil {
+		in, out := &in.Location, &out.Location
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/garden/validation/validation.go
+++ b/pkg/apis/garden/validation/validation.go
@@ -1959,6 +1959,17 @@ func ValidateHibernationCronSpec(seenSpecs sets.String, spec string, fldPath *fi
 	return allErrs
 }
 
+// ValidateHibernationScheduleLocation validates that the location of a HibernationSchedule is correct.
+func ValidateHibernationScheduleLocation(location string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if _, err := time.LoadLocation(location); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath, location, fmt.Sprintf("not a valid location: %v", err)))
+	}
+
+	return allErrs
+}
+
 // ValidateHibernationSchedule validates the correctness of a HibernationSchedule.
 // It checks whether the set start and end time are valid cron specs.
 func ValidateHibernationSchedule(seenSpecs sets.String, schedule *garden.HibernationSchedule, fldPath *field.Path) field.ErrorList {
@@ -1972,6 +1983,9 @@ func ValidateHibernationSchedule(seenSpecs sets.String, schedule *garden.Hiberna
 	}
 	if schedule.End != nil {
 		allErrs = append(allErrs, ValidateHibernationCronSpec(seenSpecs, *schedule.End, fldPath.Child("end"))...)
+	}
+	if schedule.Location != nil {
+		allErrs = append(allErrs, ValidateHibernationScheduleLocation(*schedule.Location, fldPath.Child("location"))...)
 	}
 
 	return allErrs

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -1460,6 +1460,11 @@ func (in *HibernationSchedule) DeepCopyInto(out *HibernationSchedule) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Location != nil {
+		in, out := &in.Location, &out.Location
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controllermanager/controller/shoot/shoot.go
+++ b/pkg/controllermanager/controller/shoot/shoot.go
@@ -67,7 +67,7 @@ type Controller struct {
 	secrets                       map[string]*corev1.Secret
 	imageVector                   imagevector.ImageVector
 	scheduler                     reconcilescheduler.Interface
-	shootToHibernationCron        map[string]*cron.Cron
+	shootToHibernationCron        map[string]map[string]*cron.Cron
 
 	seedLister                   gardenlisters.SeedLister
 	shootLister                  gardenlisters.ShootLister
@@ -143,7 +143,7 @@ func NewShootController(k8sGardenClient kubernetes.Interface, k8sGardenInformers
 		secrets:                       secrets,
 		imageVector:                   imageVector,
 		scheduler:                     reconcilescheduler.New(nil),
-		shootToHibernationCron:        make(map[string]*cron.Cron),
+		shootToHibernationCron:        make(map[string]map[string]*cron.Cron),
 
 		seedLister:                   seedLister,
 		shootLister:                  shootLister,

--- a/pkg/controllermanager/controller/shoot/shoot_hibernation_test.go
+++ b/pkg/controllermanager/controller/shoot/shoot_hibernation_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package shoot_test
+
+import (
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/gardener/pkg/controllermanager/controller/shoot"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Shoot Hibernation", func() {
+	Describe("#GroupHibernationSchedulesByLocation", func() {
+		It("should group the hibernation schedules with the same location together", func() {
+			var (
+				locationEuropeBerlin = "Europe/Berlin"
+				locationUSCentral    = "US/Central"
+
+				s1 = gardenv1beta1.HibernationSchedule{Location: &locationEuropeBerlin}
+				s2 = gardenv1beta1.HibernationSchedule{Location: &locationEuropeBerlin}
+				s3 = gardenv1beta1.HibernationSchedule{Location: &locationUSCentral}
+				s4 = gardenv1beta1.HibernationSchedule{}
+			)
+
+			grouped := shoot.GroupHibernationSchedulesByLocation([]gardenv1beta1.HibernationSchedule{s1, s2, s3, s4})
+			Expect(grouped).To(Equal(map[string][]gardenv1beta1.HibernationSchedule{
+				locationEuropeBerlin: {s1, s2},
+				locationUSCentral:    {s3},
+				time.UTC.String():    {s4},
+			}))
+		})
+	})
+})

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3444,6 +3444,13 @@ func schema_pkg_apis_garden_v1beta1_HibernationSchedule(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"location": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Location is the time location in which both start and and shall be evaluated.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable hibernation schedules to specify a location in which they want to run. This fixes an issue with hibernation schedules running in locations where there is e.g. a shift from winter to summer time.

**Which issue(s) this PR fixes**:
Fixes #862 

**Special notes for your reviewer**:
cc @grolu 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
You can now specify a `location` (timezone) for your hibernation schedules in the `Shoot` resource. 
```
