### PR TITLE
Make GroupKind the key of ApplierOptions

### DIFF
--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -37,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
 	kubernetesclientset "k8s.io/client-go/kubernetes"
@@ -176,15 +177,12 @@ type Applier struct {
 	discovery discovery.CachedDiscoveryInterface
 }
 
-// Kind is a type alias for a k8s Kind of ObjectKind.
-type Kind string
-
 // MergeFunc determines how oldOj is merged into new oldObj.
 type MergeFunc func(newObj, oldObj *unstructured.Unstructured)
 
 // ApplierOptions contains options used by the Applier.
 type ApplierOptions struct {
-	MergeFuncs map[Kind]MergeFunc
+	MergeFuncs map[schema.GroupKind]MergeFunc
 }
 
 // ApplierInterface is an interface which describes declarative operations to apply multiple

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/gardener/gardener/pkg/apis/garden"
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
@@ -386,9 +388,12 @@ func BootstrapCluster(seed *Seed, secrets map[string]*corev1.Secret, imageVector
 			// Apply status from old Object to retain status information
 			new.Object["status"] = old.Object["status"]
 		}
+		vpaGK    = schema.GroupKind{Group: "autoscaling.k8s.io", Kind: "VerticalPodAutoscaler"}
+		issuerGK = schema.GroupKind{Group: "certmanager.k8s.io", Kind: "ClusterIssuer"}
 	)
-	applierOptions.MergeFuncs["ClusterIssuer"] = retainStatusInformation
-	applierOptions.MergeFuncs["VerticalPodAutoscaler"] = retainStatusInformation
+
+	applierOptions.MergeFuncs[vpaGK] = retainStatusInformation
+	applierOptions.MergeFuncs[issuerGK] = retainStatusInformation
 
 	return chartApplier.ApplyChartWithOptions(context.TODO(), filepath.Join("charts", chartName), common.GardenNamespace, chartName, nil, map[string]interface{}{
 		"cloudProvider": seed.CloudProvider,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the key of the `ApplierOptions` from `Kind` to `GroupKind` which is more accurate.

/cc @adracus 

**Special notes for your reviewer**:
I also removed the [initial invalidation](https://github.com/gardener/gardener/blob/da15a37de8912afcc3c2113456f12c2b6d502f0b/pkg/client/kubernetes/apply.go#L74) of the `DiscoveryClient`. Due to https://github.com/kubernetes/kubernetes/commit/c94bee0b8b88851e5f5fd6538b99adff8b3a13f0#diff-498e117e58cba7576e99cf7fd3cb023eR129, this is not required anymore.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
