### PR TITLE
Respect the value of the ignore annotation

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_utils.go
+++ b/pkg/controllermanager/controller/shoot/shoot_utils.go
@@ -16,6 +16,7 @@ package shoot
 
 import (
 	"fmt"
+	"strconv"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
@@ -88,7 +89,11 @@ func StatusLabelTransform(status Status) func(*gardenv1beta1.Shoot) (*gardenv1be
 }
 
 func mustIgnoreShoot(annotations map[string]string, respectSyncPeriodOverwrite *bool) bool {
-	_, ignore := annotations[common.ShootIgnore]
+	ignore := false
+	if value, ok := annotations[common.ShootIgnore]; ok {
+		ignore, _ = strconv.ParseBool(value)
+	}
+
 	return respectSyncPeriodOverwrite != nil && *respectSyncPeriodOverwrite && ignore
 }
 

--- a/plugin/pkg/global/deletionconfirmation/admission.go
+++ b/plugin/pkg/global/deletionconfirmation/admission.go
@@ -273,7 +273,10 @@ func shootIgnored(obj metav1.Object) bool {
 	if annotations == nil {
 		return false
 	}
-	_, ignore := annotations[common.ShootIgnore]
+	ignore := false
+	if value, ok := annotations[common.ShootIgnore]; ok {
+		ignore, _ = strconv.ParseBool(value)
+	}
 	return ignore
 }
 

--- a/plugin/pkg/global/deletionconfirmation/admission_test.go
+++ b/plugin/pkg/global/deletionconfirmation/admission_test.go
@@ -161,12 +161,12 @@ var _ = Describe("deleteconfirmation", func() {
 			})
 
 			Context("no ignore annotation", func() {
-				It("should reject if the ignore-shoot annotation is set field", func() {
+				It("should reject if the ignore-shoot annotation is set", func() {
 					attrs = admission.NewAttributesRecord(nil, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Delete, false, nil)
 
 					shoot.Annotations = map[string]string{
 						common.ConfirmationDeletion: "true",
-						common.ShootIgnore:          "",
+						common.ShootIgnore:          "true",
 					}
 					Expect(shootStore.Add(&shoot)).NotTo(HaveOccurred())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Until now the shoot ignore check was to check the presence of `shoot.garden.sapcloud.io/ignore` annotation. This PR modifies the check to respect the value of the annotation. Truthy values are "1", "t", "T", "true", "TRUE", "True".

**Which issue(s) this PR fixes**:
Fixes #867 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
The gardener-controller-manager does now not only check the presence but also the value of the `shoot.garden.sapcloud.io/ignore` annotation. 
:warning: Existing shoots with the `shoot.garden.sapcloud.io/ignore` annotation but any other value than ("1", "t", "T", "true", "TRUE", "True") will be considered for reconciliation. 
```
