### PR TITLE
Ensure that terraformer jobs always run completely

### DIFF
--- a/pkg/operation/terraformer/terraformer.go
+++ b/pkg/operation/terraformer/terraformer.go
@@ -336,6 +336,7 @@ func (t *Terraformer) podSpec(scriptName string) *corev1.PodSpec {
 	)
 
 	activeDeadlineSeconds := int64(1800)
+	terminationGracePeriodSeconds := int64(1800)
 	shCommand := fmt.Sprintf("sh /terraform.sh %s", scriptName)
 	if scriptName != "validate" {
 		shCommand += " 2>&1; [[ -f /success ]] && exit 0 || exit 1"
@@ -373,6 +374,7 @@ func (t *Terraformer) podSpec(scriptName string) *corev1.PodSpec {
 			},
 		},
 		ServiceAccountName: serviceAccountName,
+		TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 		Volumes: []corev1.Volume{
 			{
 				Name: tfVolume,


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the seed cluster-autoscaler can terminate running TF pods. A TerminationGracePeriodSeconds is specified for the TF job to ensure that it always run completely.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/terraformer/issues/20

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```
NONE
```
