### PR TITLE
Add additional debug message for integration tests

### DIFF
--- a/test/integration/framework/shoot_operations.go
+++ b/test/integration/framework/shoot_operations.go
@@ -170,6 +170,9 @@ func (s *ShootGardenerTest) WaitForShootToBeCreated(ctx context.Context) error {
 			return true, nil
 		}
 		s.Logger.Infof("Waiting for shoot %s to be created", s.Shoot.Name)
+		if s.Shoot.Status.LastOperation != nil {
+			s.Logger.Debugf("%d%%: Shoot State: %s, Description: %s", s.Shoot.Status.LastOperation.Progress, s.Shoot.Status.LastOperation.State, s.Shoot.Status.LastOperation.Description)
+		}
 		return false, nil
 	}, ctx.Done())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds additional debug information for the integration test when creating a shoot.
This helps us investigating erroneous shoot creations. 

**Special notes for your reviewer**:
Is there any other metric that can be helpful for us?

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
