### PR TITLE
fix missing security context for Shoot addons

### DIFF
--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         kubernetes.io/cluster-service: "true"
     spec:
+      securityContext:
+        runAsUser: 65534
+        fsGroup: 65534
       serviceAccountName: {{ template "kubernetes-dashboard.fullname" . }}
       containers:
       - name: {{ .Chart.Name }}

--- a/charts/shoot-core/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         garden.sapcloud.io/role: system-component
         component: blackbox-exporter
     spec:
+      securityContext:
+        runAsUser: 65534
+        fsGroup: 65534
       containers:
       - name: blackbox-exporter
         image: {{ index .Values.images "blackbox-exporter" }}
@@ -51,4 +54,3 @@ spec:
       - name: blackbox-exporter-config
         configMap:
           name: blackbox-exporter-config
-


### PR DESCRIPTION
**What this PR does / why we need it**: 
Kubernetes dashboard and blackbox exporter components are not required to be root. Their start-up fails for Shoots with disabled privileged containers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
A bug has been fixed that prevented `kube-dashboard` and `blackbox-exporter` to start if `.spec.kubernetes.allowPrivilegedContainers` was set to `false` (`securityContext` was missing).
```
