### PR TITLE
Delete WAL when prometheus starts

### DIFF
--- a/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
@@ -26,15 +26,16 @@ spec:
       - name: prometheus
         image: {{ index .Values.global.images "prometheus" }}
         imagePullPolicy: IfNotPresent
+        command: ["/bin/sh","-c"]
         args:
-        - --config.file=/etc/prometheus/config/prometheus.yaml
-        - --storage.tsdb.path=/var/prometheus/data
-        - --storage.tsdb.no-lockfile
-        # Increase this once the memory issues have been resolved
-        - --storage.tsdb.retention.time=2h
-        - --storage.tsdb.retention.size=5GB
-        - --web.listen-address=0.0.0.0:{{ .Values.prometheus.port }}
-        - --web.enable-lifecycle
+          - rm -rf /var/prometheus/data/*; /bin/prometheus
+            --config.file=/etc/prometheus/config/prometheus.yaml
+            --storage.tsdb.path=/var/prometheus/data
+            --storage.tsdb.no-lockfile
+            --storage.tsdb.retention.time=2h
+            --storage.tsdb.retention.size=1GB
+            --web.listen-address=0.0.0.0:{{ .Values.prometheus.port }}
+            --web.enable-lifecycle
         # Since v2.0.0-beta.3 prometheus runs as nobody user (fsGroup 65534/runAsUser 0)
         # data volume needs to be mounted with the same permissions,
         # otherwise we will have Permission denied problems


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes the central Prometheus has issues with its WAL or disk (corrupt WAL, disk full, etc.). This reduces ops efforts by always deleting Prometheus' data whenever it starts. We only need the data for a short amount of time so deleting data is not an issue.
Also reduced retention size to 1GB.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
