### PR TITLE
Add verbose output to integration tests

### DIFF
--- a/.test-defs/SeedLoggingTest.yaml
+++ b/.test-defs/SeedLoggingTest.yaml
@@ -15,7 +15,7 @@ spec:
   - >-
     /tm/setup github.com/gardener gardener &&
     go test $GOPATH/src/github.com/gardener/gardener/test/integration/seeds/logging
-    -ginkgo.v -ginkgo.progress
+    --v -ginkgo.v -ginkgo.progress
     -kubeconfig=$TM_KUBECONFIG_PATH/gardener.config
     -shootName=$SHOOT_NAME
     -shootNamespace=$PROJECT_NAMESPACE

--- a/.test-defs/ShootAppTest.yaml
+++ b/.test-defs/ShootAppTest.yaml
@@ -13,7 +13,7 @@ spec:
   - >-
     /tm/setup github.com/gardener gardener &&
     go test $GOPATH/src/github.com/gardener/gardener/test/integration/shoots/applications
-    -ginkgo.v -ginkgo.progress
+    --v -ginkgo.v -ginkgo.progress
     -kubeconfig=$TM_KUBECONFIG_PATH/gardener.config
     -shootName=$SHOOT_NAME
     -shootNamespace=$PROJECT_NAMESPACE

--- a/test/integration/framework/shoot_operations.go
+++ b/test/integration/framework/shoot_operations.go
@@ -170,8 +170,8 @@ func (s *ShootGardenerTest) WaitForShootToBeCreated(ctx context.Context) error {
 			return true, nil
 		}
 		s.Logger.Infof("Waiting for shoot %s to be created", s.Shoot.Name)
-		if s.Shoot.Status.LastOperation != nil {
-			s.Logger.Debugf("%d%%: Shoot State: %s, Description: %s", s.Shoot.Status.LastOperation.Progress, s.Shoot.Status.LastOperation.State, s.Shoot.Status.LastOperation.Description)
+		if shoot.Status.LastOperation != nil {
+			s.Logger.Debugf("%d%%: Shoot State: %s, Description: %s", shoot.Status.LastOperation.Progress, shoot.Status.LastOperation.State, shoot.Status.LastOperation.Description)
 		}
 		return false, nil
 	}, ctx.Done())


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables verbose output of the integration tests.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
