### PR TITLE
Tweaked control-plane and system components.

### DIFF
--- a/charts/seed-controlplane/charts/kube-scheduler/values.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/values.yaml
@@ -11,5 +11,5 @@ resources:
     cpu: 100m
     memory: 32Mi
   limits:
-    cpu: 200m
-    memory: 256Mi
+    cpu: 400m
+    memory: 512Mi

--- a/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -70,9 +70,6 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
-          limits:
-            cpu: 900m
-            memory: 400Mi
         volumeMounts:
         - name: kubeconfig
           mountPath: /var/lib/kube-proxy

--- a/charts/shoot-core/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -23,6 +23,14 @@ spec:
         garden.sapcloud.io/role: system-component
         component: blackbox-exporter
     spec:
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      priorityClassName: system-cluster-critical
       securityContext:
         runAsUser: 65534
         fsGroup: 65534

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -70,34 +70,34 @@ func getResourcesForAPIServer(nodeCount int) (string, string, string, string) {
 	switch {
 	case nodeCount <= 2:
 		cpuRequest = "800m"
-		memoryRequest = "600Mi"
-
-		cpuLimit = "1000m"
-		memoryLimit = "900Mi"
-	case nodeCount <= 10:
-		cpuRequest = "1000m"
 		memoryRequest = "800Mi"
 
+		cpuLimit = "1000m"
+		memoryLimit = "1200Mi"
+	case nodeCount <= 10:
+		cpuRequest = "1000m"
+		memoryRequest = "1100Mi"
+
 		cpuLimit = "1200m"
-		memoryLimit = "1400Mi"
+		memoryLimit = "1900Mi"
 	case nodeCount <= 50:
 		cpuRequest = "1200m"
-		memoryRequest = "1200Mi"
+		memoryRequest = "1600Mi"
 
 		cpuLimit = "1500m"
-		memoryLimit = "3000Mi"
+		memoryLimit = "3900Mi"
 	case nodeCount <= 100:
 		cpuRequest = "2500m"
-		memoryRequest = "4000Mi"
+		memoryRequest = "5200Mi"
 
 		cpuLimit = "3000m"
-		memoryLimit = "4500Mi"
+		memoryLimit = "5900Mi"
 	default:
 		cpuRequest = "3000m"
-		memoryRequest = "4000Mi"
+		memoryRequest = "5200Mi"
 
 		cpuLimit = "4000m"
-		memoryLimit = "6000Mi"
+		memoryLimit = "7800Mi"
 	}
 
 	return cpuRequest, memoryRequest, cpuLimit, memoryLimit
@@ -555,7 +555,7 @@ func (b *HybridBotanist) DeployKubeScheduler() error {
 		defaultValues["resources"] = map[string]interface{}{
 			"limits": map[string]interface{}{
 				"cpu":    "300m",
-				"memory": "350Mi",
+				"memory": "512Mi",
 			},
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The shoot cluster's control-plane and system components require scaling up to handler larger workloads.
 
**Which issue(s) this PR fixes**:
Part of #255.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
Improved resource management:
* kube-scheduler limits raised to 512Mi to support larger workloads (~4.5k pods).
* kube-proxy limits removed in accordance with [upstream
reference](https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/kube-proxy/kube-proxy-ds.yaml)
* blackbox-exporter in the shoot cluster gets a priority class to make sure it stays scheduled during a capacity crunch.
* kube-apiserver requests and limits are raised by 30% for the different node count buckets.
```
