### PR TITLE
Add support for loadBalancer provider in integration tests

### DIFF
--- a/.test-defs/SeedLoggingTest.yaml
+++ b/.test-defs/SeedLoggingTest.yaml
@@ -15,7 +15,7 @@ spec:
   - >-
     /tm/setup github.com/gardener gardener &&
     go test $GOPATH/src/github.com/gardener/gardener/test/integration/seeds/logging
-    --v -ginkgo.v -ginkgo.progress
+    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
     -kubeconfig=$TM_KUBECONFIG_PATH/gardener.config
     -shootName=$SHOOT_NAME
     -shootNamespace=$PROJECT_NAMESPACE

--- a/.test-defs/ShootAppTest.yaml
+++ b/.test-defs/ShootAppTest.yaml
@@ -13,7 +13,7 @@ spec:
   - >-
     /tm/setup github.com/gardener gardener &&
     go test $GOPATH/src/github.com/gardener/gardener/test/integration/shoots/applications
-    --v -ginkgo.v -ginkgo.progress
+    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
     -kubeconfig=$TM_KUBECONFIG_PATH/gardener.config
     -shootName=$SHOOT_NAME
     -shootNamespace=$PROJECT_NAMESPACE

--- a/.test-defs/cmd/create-shoot/helper.go
+++ b/.test-defs/cmd/create-shoot/helper.go
@@ -93,9 +93,16 @@ func updateAutoscalerMinMax(shoot *gardenv1beta1.Shoot, cloudprovider gardenv1be
 	}
 }
 
-// updateFloatingPoolName updates the floatingPoolName if a openstack cluster is created.
+// updateFloatingPoolName updates the floatingPoolName if an openstack cluster is created.
 func updateFloatingPoolName(shoot *gardenv1beta1.Shoot, floatingPoolName string, cloudprovider gardenv1beta1.CloudProvider) {
 	if cloudprovider == gardenv1beta1.CloudProviderOpenStack {
 		shoot.Spec.Cloud.OpenStack.FloatingPoolName = floatingPoolName
+	}
+}
+
+// updateLoadBalancerProvider updates the loadBalancerProvider if an openstack cluster is created.
+func updateLoadBalancerProvider(shoot *gardenv1beta1.Shoot, loadBalancerProvider string, cloudprovider gardenv1beta1.CloudProvider) {
+	if cloudprovider == gardenv1beta1.CloudProviderOpenStack && loadBalancerProvider != "" {
+		shoot.Spec.Cloud.OpenStack.LoadBalancerProvider = loadBalancerProvider
 	}
 }

--- a/.test-defs/cmd/create-shoot/main.go
+++ b/.test-defs/cmd/create-shoot/main.go
@@ -46,6 +46,7 @@ var (
 
 	// required for openstack
 	floatingPoolName string
+	loadBalancerProvider string
 
 	testLogger *logrus.Logger
 )
@@ -111,6 +112,7 @@ func init() {
 		autoScalerMax = &autoScalerMaxInt
 	}
 
+	loadBalancerProvider = os.Getenv("LOADBALANCER_PROVIDER")
 	floatingPoolName = os.Getenv("FLOATING_POOL_NAME")
 	if cloudprovider == gardenv1beta1.CloudProviderOpenStack && floatingPoolName == "" {
 		testLogger.Fatalf("EnvVar 'FLOATING_POOL_NAME' needs to be specified when creating a shoot on openstack")
@@ -142,6 +144,7 @@ func main() {
 	updateMachineType(shootObject, cloudprovider, machineType)
 	updateAutoscalerMinMax(shootObject, cloudprovider, autoScalerMin, autoScalerMax)
 	updateFloatingPoolName(shootObject, floatingPoolName, cloudprovider)
+	updateLoadBalancerProvider(shootObject, loadBalancerProvider, cloudprovider)
 	if dnsProvider != "" {
 		shootObject.Spec.DNS.Provider = dnsProvider
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support to specify the loadbalancer provider in an openstack cluster.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
