### PR TITLE
Include memory metrics in scaling criteria for kube-apiserver-hpa.

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hpa.yaml
@@ -17,4 +17,8 @@ spec:
     resource:
       name: cpu
       targetAverageUtilization: {{ .Values.targetAverageUtilization }}
+  - type: Resource
+    resource:
+      name: memory
+      targetAverageUtilization: {{ .Values.targetAverageUtilization }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Handle the situation where CPU
utilization is low and memory utilization is high.

**Which issue(s) this PR fixes**:
Fixes #834 and #255 partially.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The `HorizontalPodAutoscaler` for `kube-apiserver` now scales based on memory metrics (in addition to the existing CPU metrics).
```
