### PR TITLE
Adjust tests to new DNS controller

### DIFF
--- a/.test-defs/cmd/create-shoot/main.go
+++ b/.test-defs/cmd/create-shoot/main.go
@@ -39,7 +39,6 @@ var (
 
 	// optional parameters
 	shootArtifactPath string
-	dnsProvider       gardenv1beta1.DNSProvider
 	machineType       string
 	autoScalerMin     *int
 	autoScalerMax     *int
@@ -95,7 +94,6 @@ func init() {
 	if shootArtifactPath == "" {
 		shootArtifactPath = fmt.Sprintf("example/90-shoot-%s.yaml", cloudprovider)
 	}
-	dnsProvider = gardenv1beta1.DNSProvider(os.Getenv("DNS_PROVIDER"))
 	machineType = os.Getenv("MACHINE_TYPE")
 	if autoScalerMinEnv := os.Getenv("AUTOSCALER_MIN"); autoScalerMinEnv != "" {
 		autoScalerMinInt, err := strconv.Atoi(autoScalerMinEnv)
@@ -145,9 +143,6 @@ func main() {
 	updateAutoscalerMinMax(shootObject, cloudprovider, autoScalerMin, autoScalerMax)
 	updateFloatingPoolName(shootObject, floatingPoolName, cloudprovider)
 	updateLoadBalancerProvider(shootObject, loadBalancerProvider, cloudprovider)
-	if dnsProvider != "" {
-		shootObject.Spec.DNS.Provider = dnsProvider
-	}
 
 	// TODO: tests need to be adopted when nginx gets removed.
 	shootObject.Spec.Addons.NginxIngress = &gardenv1beta1.NginxIngress{

--- a/test/integration/framework/common.go
+++ b/test/integration/framework/common.go
@@ -54,7 +54,7 @@ func CreateShootTestArtifacts(shootTestYamlPath, prefix string) (string, *v1beta
 	}
 
 	shoot.Name = integrationTestName
-	shoot.Spec.DNS.Domain = nil
+	shoot.Spec.DNS = v1beta1.DNS{}
 	return integrationTestName, shoot, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Removed dns provider from create-shoot test.
- Changed the dns in the integration test framework to use the recommended default: `dns: {}`
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
