### PR TITLE
Update logging to 0.19.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -166,7 +166,7 @@ images:
 - name: fluentd-es
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluentd-es
-  tag: "0.18.0"
+  tag: "0.19.0"
 - name: fluent-bit
   sourceRepository: github.com/fluent/fluent-bit
   repository: fluent/fluent-bit
@@ -178,7 +178,7 @@ images:
 - name: curator-es
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/curator-es
-  tag: "0.18.0"
+  tag: "0.19.0"
 - name: kibana-oss
   sourceRepository: github.com/elastic/kibana-docker
   repository: docker.elastic.co/kibana/kibana-oss

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/curator-configmap.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/curator-configmap.yaml
@@ -34,7 +34,7 @@ data:
     client:
       hosts:
         - elasticsearch-logging.{{ .Release.Namespace }}.svc
-      port: 9200
+      port: {{ .Values.global.elasticsearchPorts.db }}
       url_prefix:
       use_ssl: False
       certificate:
@@ -118,7 +118,7 @@ data:
     client:
       hosts:
         - elasticsearch-logging.{{ .Release.Namespace }}.svc
-      port: 9200
+      port: {{ .Values.global.elasticsearchPorts.db }}
       url_prefix:
       use_ssl: False
       certificate:

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/curator-cronjob.yml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/curator-cronjob.yml
@@ -27,14 +27,14 @@ spec:
           - image: {{ index .Values.global.images "curator-es" }}
             name: curator
             command: ["/bin/sh","-c"]
-            args: ["extra-deleter --disk_threshold={{ include "curator.disk_threshold" .Values.curator }}; curator --config /etc/config/config.yml /etc/config/action_file.yml"]
+            args: ["curator-es --disk-space-threshold={{ include "curator.disk_threshold" .Values.curator }}; curator --config /etc/config/config.yml /etc/config/action_file.yml"]
             volumeMounts:
             - name: config
               mountPath: /etc/config
             resources:
               limits:
                 cpu: 10m
-                memory: 50Mi
+                memory: 60Mi
               requests:
                 cpu: 10m
                 memory: 30Mi


### PR DESCRIPTION
**What this PR does / why we need it**:
See [0.19.0 release notes](https://github.com/gardener/logging/releases/tag/0.19.0).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
``` improvement operator github.com/gardener/logging #25 @ialidzhikov
fluentd image version has beed upgraded to v2.5.0.
```

``` improvement operator github.com/gardener/logging #24 @ialidzhikov
Curator now supports `http_auth` option for basic auth against elasticsearch.
```

``` improvement operator github.com/gardener/logging #23 @ialidzhikov
The golang version has been upgraded to `v1.12.0`.
```