### PR TITLE
Upgrade VPA to 0.5.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -198,12 +198,12 @@ images:
 - name: vpa-admission-controller
   sourceRepository: github.com/kubernetes/autoscaler
   repository: k8s.gcr.io/vpa-admission-controller
-  tag: "0.4.0"
+  tag: "0.5.0"
 - name: vpa-recommender
   sourceRepository: github.com/kubernetes/autoscaler
   repository: k8s.gcr.io/vpa-recommender
-  tag: "0.4.0"
+  tag: "0.5.0"
 - name: vpa-updater
   sourceRepository: github.com/kubernetes/autoscaler
   repository: k8s.gcr.io/vpa-updater
-  tag: "0.4.0"
+  tag: "0.5.0"

--- a/charts/seed-bootstrap/charts/vpa/templates/admission-controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/admission-controller-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: 8000
+      targetPort: 443
   selector:
     app: vpa-admission-controller
 ---
@@ -46,13 +46,16 @@ spec:
       serviceAccountName: vpa-admission-controller
       containers:
       - name: admission-controller
-        args:
+        command:
         - ./admission-controller
+        args:
         - --v=4
         - --stderrthreshold=info
         - --client-ca-file=/etc/tls-certs/ca.crt
         - --tls-cert-file=/etc/tls-certs/tls.crt
         - --tls-private-key=/etc/tls-certs/tls.key
+        - --address=:8944
+        - --port=443
         image: {{ index .Values.global.images "vpa-admission-controller" }}
         imagePullPolicy: IfNotPresent
         env:
@@ -72,7 +75,7 @@ spec:
             cpu: 50m
             memory: 200Mi
         ports:
-        - containerPort: 8000
+        - containerPort: 443
       volumes:
         - name: vpa-tls-certs
           secret:

--- a/charts/seed-bootstrap/charts/vpa/templates/vpa-crd.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/vpa-crd.yaml
@@ -6,7 +6,6 @@ metadata:
 {{ toYaml .Values.vpa.labels | indent 4 }}
 spec:
   group: autoscaling.k8s.io
-  version: v1beta1
   scope: Namespaced
   names:
     plural: verticalpodautoscalers
@@ -48,7 +47,6 @@ metadata:
 {{ toYaml .Values.vpa.labels | indent 4 }}
 spec:
   group: autoscaling.k8s.io
-  version: v1beta1
   scope: Namespaced
   names:
     plural: verticalpodautoscalercheckpoints


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR upgrades the VPA to the newest version `0.5.0`. The newest version allows changing vpa-webhook backend port. The port is now `443` to prevent issues on the GKE clusters. By default the GKE cluster's API server can only communicate with the cluster via port 443 and 10250 (firewall rules). If the VPA webhook backend uses port 8000, it always times out. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
upgrade vertical-pod-autoscaler to `0.5.0`
```
