### PR TITLE
Prepare templates in hack/templates for pyyaml upgrade

### DIFF
--- a/hack/templates/resources/05-project-dev.yaml.tpl
+++ b/hack/templates/resources/05-project-dev.yaml.tpl
@@ -3,7 +3,7 @@
 
   values={}
   if context.get("values", "") != "":
-    values=yaml.load(open(context.get("values", "")))
+    values=yaml.load(open(context.get("values", "")), Loader=yaml.Loader)
 
   def value(path, default):
     keys=str.split(path, ".")
@@ -25,14 +25,14 @@ kind: Project
 metadata:
   name: ${value("metadata.name", "dev")}<% annotations = value("metadata.annotations", {}); labels = value("metadata.labels", {}) %>
   % if annotations != {}:
-  annotations: ${yaml.dump(annotations, width=10000)}
+  annotations: ${yaml.dump(annotations, width=10000, default_flow_style=None)}
   % endif
   % if labels != {}:
-  labels: ${yaml.dump(labels, width=10000)}
+  labels: ${yaml.dump(labels, width=10000, default_flow_style=None)}
   % endif
 spec:<% owner = value("spec.owner", {}); description = value("spec.description", ""); purpose = value("spec.purpose", ""); namespace = value("spec.namespace", ""); members = value("spec.members", []) %>
   % if owner != {}:
-  owner: ${yaml.dump(owner, width=10000)}
+  owner: ${yaml.dump(owner, width=10000, default_flow_style=None)}
   % else:
   owner:
     apiGroup: rbac.authorization.k8s.io
@@ -40,7 +40,7 @@ spec:<% owner = value("spec.owner", {}); description = value("spec.description",
     name: john.doe@example.com
   % endif
   % if members != []:
-  members: ${yaml.dump(members, width=10000)}
+  members: ${yaml.dump(members, width=10000, default_flow_style=None)}
   % else:
   members:
   - apiGroup: rbac.authorization.k8s.io

--- a/hack/templates/resources/100-plant.yaml.tpl
+++ b/hack/templates/resources/100-plant.yaml.tpl
@@ -3,7 +3,7 @@
 
   values={}
   if context.get("values", "") != "":
-    values=yaml.load(open(context.get("values", "")))
+    values=yaml.load(open(context.get("values", "")), Loader=yaml.Loader)
 
   def value(path, default):
     keys=str.split(path, ".")
@@ -27,10 +27,10 @@ metadata:
   name:  ${value("metadata.name", "example-plant")}<% annotations = value("metadata.annotations", {}); labels = value("metadata.labels", {}) %>
   namespace: ${value("metadata.namespace", "garden-dev")}
   % if annotations != {}:
-  annotations: ${yaml.dump(annotations, width=1000)}
+  annotations: ${yaml.dump(annotations, width=1000, default_flow_style=None)}
   % endif
   % if labels != {}:
-  labels: ${yaml.dump(labels, width=10000)}
+  labels: ${yaml.dump(labels, width=10000, default_flow_style=None)}
   % endif
 spec:
   secretRef:

--- a/hack/templates/resources/25-controllerinstallation.yaml.tpl
+++ b/hack/templates/resources/25-controllerinstallation.yaml.tpl
@@ -3,7 +3,7 @@
 
   values={}
   if context.get("values", "") != "":
-    values=yaml.load(open(context.get("values", "")))
+    values=yaml.load(open(context.get("values", "")), Loader=yaml.Loader)
 
   def value(path, default):
     keys=str.split(path, ".")
@@ -25,10 +25,10 @@ kind: ControllerInstallation
 metadata:
   name: ${value("metadata.name", "os-coreos")}<% annotations = value("metadata.annotations", {}); labels = value("metadata.labels", {}) %>
   % if annotations != {}:
-  annotations: ${yaml.dump(annotations, width=10000)}
+  annotations: ${yaml.dump(annotations, width=10000, default_flow_style=None)}
   % endif
   % if labels != {}:
-  labels: ${yaml.dump(labels, width=10000)}
+  labels: ${yaml.dump(labels, width=10000, default_flow_style=None)}
   % endif
 spec:
   registrationRef:

--- a/hack/templates/resources/25-controllerregistration.yaml.tpl
+++ b/hack/templates/resources/25-controllerregistration.yaml.tpl
@@ -3,7 +3,7 @@
 
   values={}
   if context.get("values", "") != "":
-    values=yaml.load(open(context.get("values", "")))
+    values=yaml.load(open(context.get("values", "")), Loader=yaml.Loader)
 
   def value(path, default):
     keys=str.split(path, ".")
@@ -25,10 +25,10 @@ kind: ControllerRegistration
 metadata:
   name: ${value("metadata.name", "os-coreos")}<% annotations = value("metadata.annotations", {}); labels = value("metadata.labels", {}) %>
   % if annotations != {}:
-  annotations: ${yaml.dump(annotations, width=10000)}
+  annotations: ${yaml.dump(annotations, width=10000, default_flow_style=None)}
   % endif
   % if labels != {}:
-  labels: ${yaml.dump(labels, width=10000)}
+  labels: ${yaml.dump(labels, width=10000, default_flow_style=None)}
   % endif
 spec:
   resources:

--- a/hack/templates/resources/30-cloudprofile.yaml.tpl
+++ b/hack/templates/resources/30-cloudprofile.yaml.tpl
@@ -3,7 +3,7 @@
 
   values={}
   if context.get("values", "") != "":
-    values=yaml.load(open(context.get("values", "")))
+    values=yaml.load(open(context.get("values", "")), Loader=yaml.Loader)
 
   if context.get("cloud", "") == "":
     raise Exception("missing --var cloud={aws,azure,gcp,alicloud,openstack,local,packet} flag")
@@ -42,10 +42,10 @@ kind: CloudProfile
 metadata:
   name: ${value("spec.profile", cloud)}<% annotations = value("metadata.annotations", {}); labels = value("metadata.labels", {}) %>
   % if annotations != {}:
-  annotations: ${yaml.dump(annotations, width=10000)}
+  annotations: ${yaml.dump(annotations, width=10000, default_flow_style=None)}
   % endif
   % if labels != {}:
-  labels: ${yaml.dump(labels, width=10000)}
+  labels: ${yaml.dump(labels, width=10000, default_flow_style=None)}
   % endif
 spec:<% caBundle=value("spec.caBundle", "") %>
   % if caBundle != "":
@@ -61,14 +61,14 @@ spec:<% caBundle=value("spec.caBundle", "") %>
     constraints:
       dnsProviders:<% dnsProviders=value("spec.aws.constraints.dnsProviders", []) %>
       % if dnsProviders != []:
-      ${yaml.dump(dnsProviders, width=10000)}
+      ${yaml.dump(dnsProviders, width=10000, default_flow_style=None)}
       % else:
       - name: unmanaged
       % endif
       kubernetes:
         versions:<% kubernetesVersions=value("spec.aws.constraints.kubernetes.versions", []) %>
         % if kubernetesVersions != []:
-        ${yaml.dump(kubernetesVersions, width=10000)}
+        ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
         - 1.14.0
         - 1.13.4
@@ -78,7 +78,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % endif
       machineImages:<% machineImages=value("spec.aws.constraints.machineImages", []) %>
       % if machineImages != []:
-      ${yaml.dump(machineImages, width=10000)}
+      ${yaml.dump(machineImages, width=10000, default_flow_style=None)}
       % else:
       # Keep in sync with https://coreos.com/dist/aws/aws-stable.json (HVM-based)
       - name: coreos
@@ -90,7 +90,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
       % endif
       machineTypes:<% machineTypes=value("spec.aws.constraints.machineTypes", []) %>
       % if machineTypes != []:
-      ${yaml.dump(machineTypes, width=10000)}
+      ${yaml.dump(machineTypes, width=10000, default_flow_style=None)}
       % else:
       - name: m4.large
         cpu: "2"
@@ -137,7 +137,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
       % endif
       volumeTypes:<% volumeTypes=value("spec.aws.constraints.volumeTypes", []) %>
       % if volumeTypes != []:
-      ${yaml.dump(volumeTypes, width=10000)}
+      ${yaml.dump(volumeTypes, width=10000, default_flow_style=None)}
       % else:
       - name: gp2
         class: standard
@@ -148,7 +148,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
       % endif
       zones:<% zones=value("spec.aws.constraints.zones", []) %>
       % if zones != []:
-      ${yaml.dump(zones, width=10000)}
+      ${yaml.dump(zones, width=10000, default_flow_style=None)}
       % else:
       - region: eu-west-1
         names:
@@ -167,14 +167,14 @@ spec:<% caBundle=value("spec.caBundle", "") %>
     constraints:
       dnsProviders:<% dnsProviders=value("spec.azure.constraints.dnsProviders", []) %>
       % if dnsProviders != []:
-      ${yaml.dump(dnsProviders, width=10000)}
+      ${yaml.dump(dnsProviders, width=10000, default_flow_style=None)}
       % else:
       - name: unmanaged
       % endif
       kubernetes:
         versions:<% kubernetesVersions=value("spec.azure.constraints.kubernetes.versions", []) %>
         % if kubernetesVersions != []:
-        ${yaml.dump(kubernetesVersions, width=10000)}
+        ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
         - 1.14.0
         - 1.13.4
@@ -184,7 +184,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % endif
       machineImages:<% machineImages=value("spec.azure.constraints.machineImages", []) %>
         % if machineImages != []:
-        ${yaml.dump(machineImages, width=10000)}
+        ${yaml.dump(machineImages, width=10000, default_flow_style=None)}
         % else:
       - name: coreos
         publisher: CoreOS
@@ -194,7 +194,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
       % endif
       machineTypes:<% machineTypes=value("spec.azure.constraints.machineTypes", []) %>
         % if machineTypes != []:
-        ${yaml.dump(machineTypes, width=10000)}
+        ${yaml.dump(machineTypes, width=10000, default_flow_style=None)}
         % else:
       - name: Standard_DS2_v2
         cpu: "2"
@@ -235,7 +235,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
       % endif
       volumeTypes:<% volumeTypes=value("spec.azure.constraints.volumeTypes", []) %>
       % if volumeTypes != []:
-      ${yaml.dump(volumeTypes, width=10000)}
+      ${yaml.dump(volumeTypes, width=10000, default_flow_style=None)}
       % else:
       - name: standard
         class: standard
@@ -246,7 +246,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
       % endif
     countUpdateDomains:<% countUpdateDomains=value("spec.azure.countUpdateDomains", []) %>
     % if countUpdateDomains != []:
-    ${yaml.dump(countUpdateDomains, width=10000)}
+    ${yaml.dump(countUpdateDomains, width=10000, default_flow_style=None)}
     % else:
     - region: westeurope
       count: 5
@@ -255,7 +255,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
     % endif
     countFaultDomains:<% countFaultDomains=value("spec.azure.countFaultDomains", []) %>
     % if countFaultDomains != []:
-    ${yaml.dump(countFaultDomains, width=10000)}
+    ${yaml.dump(countFaultDomains, width=10000, default_flow_style=None)}
     % else:
     - region: westeurope
       count: 2
@@ -268,14 +268,14 @@ spec:<% caBundle=value("spec.caBundle", "") %>
     constraints:
       dnsProviders:<% dnsProviders=value("spec.gcp.constraints.dnsProviders", []) %>
       % if dnsProviders != []:
-      ${yaml.dump(dnsProviders, width=10000)}
+      ${yaml.dump(dnsProviders, width=10000, default_flow_style=None)}
       % else:
       - name: unmanaged
       % endif
       kubernetes:
         versions:<% kubernetesVersions=value("spec.gcp.constraints.kubernetes.versions", []) %>
         % if kubernetesVersions != []:
-        ${yaml.dump(kubernetesVersions, width=10000)}
+        ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
         - 1.14.0
         - 1.13.4
@@ -285,14 +285,14 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % endif
       machineImages:<% machineImages=value("spec.gcp.constraints.machineImages", []) %>
       % if machineImages != []:
-      ${yaml.dump(machineImages, width=10000)}
+      ${yaml.dump(machineImages, width=10000, default_flow_style=None)}
       % else:
       - name: coreos
         image: projects/coreos-cloud/global/images/coreos-stable-2023-5-0-v20190312
       % endif
       machineTypes:<% machineTypes=value("spec.gcp.constraints.machineTypes", []) %>
       % if machineTypes != []:
-      ${yaml.dump(machineTypes, width=10000)}
+      ${yaml.dump(machineTypes, width=10000, default_flow_style=None)}
       % else:
       - name: n1-standard-2
         cpu: "2"
@@ -327,7 +327,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
       % endif
       volumeTypes:<% volumeTypes=value("spec.gcp.constraints.volumeTypes", []) %>
       % if volumeTypes != []:
-      ${yaml.dump(volumeTypes, width=10000)}
+      ${yaml.dump(volumeTypes, width=10000, default_flow_style=None)}
       % else:
       - name: pd-standard
         class: standard
@@ -338,7 +338,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
       % endif
       zones:<% zones=value("spec.gcp.constraints.zones", []) %>
       % if zones != []:
-      ${yaml.dump(zones, width=10000)}
+      ${yaml.dump(zones, width=10000, default_flow_style=None)}
       % else:
       - region: europe-west1
         names:
@@ -357,28 +357,28 @@ spec:<% caBundle=value("spec.caBundle", "") %>
     constraints:
       dnsProviders:<% dnsProviders=value("spec.alicloud.constraints.dnsProviders", []) %>
       % if dnsProviders != []:
-      ${yaml.dump(dnsProviders, width=10000)}
+      ${yaml.dump(dnsProviders, width=10000, default_flow_style=None)}
       % else:
       - name: alicloud-dns
       - name: unmanaged
       % endif
       kubernetes:<% kubernetesVersions=value("spec.alicloud.constraints.kubernetes.versions", []) %>
         % if kubernetesVersions != []:
-        ${yaml.dump(kubernetesVersions, width=10000)}
+        ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
         versions:
         - 1.13.4
         % endif
       machineImages:<% machineImages=value("spec.alicloud.constraints.machineImages", []) %>
       % if machineImages != []:
-      ${yaml.dump(machineImages, width=10000)}
+      ${yaml.dump(machineImages, width=10000, default_flow_style=None)}
       % else:
       - name: coreos-alicloud
         id: coreos_1911_5_0_64_30G_alibase_20181219.vhd
       % endif
       machineTypes:<% machineTypes=value("spec.alicloud.constraints.machineTypes", []) %>
       % if machineTypes != []:
-      ${yaml.dump(machineTypes, width=10000)}
+      ${yaml.dump(machineTypes, width=10000, default_flow_style=None)}
       % else:
       - name: ecs.sn2ne.large
         cpu: "2"
@@ -411,7 +411,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
       % endif
       volumeTypes:<% volumeTypes=value("spec.alicloud.constraints.volumeTypes", []) %>
       % if volumeTypes != []:
-      ${yaml.dump(volumeTypes, width=10000)}
+      ${yaml.dump(volumeTypes, width=10000, default_flow_style=None)}
       % else:
       - name: cloud_efficiency
         class: standard
@@ -426,7 +426,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
       % endif
       zones:<% zones=value("spec.alicloud.zones", []) %> # List of availablity zones together with resource contraints in a specific region
       % if zones != []:
-      ${yaml.dump(zones, width=10000)}
+      ${yaml.dump(zones, width=10000, default_flow_style=None)}
       % else:
       - region: cn-beijing
         names:
@@ -438,28 +438,28 @@ spec:<% caBundle=value("spec.caBundle", "") %>
     constraints:
       dnsProviders:<% dnsProviders=value("spec.packet.constraints.dnsProviders", []) %>
       % if dnsProviders != []:
-      ${yaml.dump(dnsProviders, width=10000)}
+      ${yaml.dump(dnsProviders, width=10000, default_flow_style=None)}
       % else:
       - name: aws-route53
       - name: unmanaged
       % endif
       kubernetes:<% kubernetesVersions=value("spec.packet.constraints.kubernetes.versions", []) %>
         % if kubernetesVersions != []:
-        ${yaml.dump(kubernetesVersions, width=10000)}
+        ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
         versions:
         - 1.13.3
         % endif
       machineImages:<% machineImages=value("spec.packet.constraints.machineImages", []) %>
       % if machineImages != []:
-      ${yaml.dump(machineImages, width=10000)}
+      ${yaml.dump(machineImages, width=10000, default_flow_style=None)}
       % else:
       - name: coreos
         id: d61c3912-8422-4daf-835e-854efa0062e4
       % endif
       machineTypes:<% machineTypes=value("spec.packet.constraints.machineTypes", []) %>
       % if machineTypes != []:
-      ${yaml.dump(machineTypes, width=10000)}
+      ${yaml.dump(machineTypes, width=10000, default_flow_style=None)}
       % else:
       - name: t1.small
         cpu: "4"
@@ -494,7 +494,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
       % endif
       volumeTypes:<% volumeTypes=value("spec.packet.constraints.volumeTypes", []) %>
       % if volumeTypes != []:
-      ${yaml.dump(volumeTypes, width=10000)}
+      ${yaml.dump(volumeTypes, width=10000, default_flow_style=None)}
       % else:
       - name: storage_1
         class: standard
@@ -505,7 +505,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
       % endif
       zones:<% zones=value("spec.packet.zones", []) %> # List of availablity zones together with resource contraints in a specific region
       % if zones != []:
-      ${yaml.dump(zones, width=10000)}
+      ${yaml.dump(zones, width=10000, default_flow_style=None)}
       % else:
       - region: EWR1
         names:
@@ -517,20 +517,20 @@ spec:<% caBundle=value("spec.caBundle", "") %>
     constraints:
       dnsProviders:<% dnsProviders=value("spec.openstack.constraints.dnsProviders", []) %>
       % if dnsProviders != []:
-      ${yaml.dump(dnsProviders, width=10000)}
+      ${yaml.dump(dnsProviders, width=10000, default_flow_style=None)}
       % else:
       - name: unmanaged
       % endif
       floatingPools:<% floatingPools=value("spec.openstack.constraints.floatingPools", []) %>
       % if floatingPools != []:
-      ${yaml.dump(floatingPools, width=10000)}
+      ${yaml.dump(floatingPools, width=10000, default_flow_style=None)}
       % else:
       - name: MY-FLOATING-POOL
       % endif
       kubernetes:
         versions:<% kubernetesVersions=value("spec.openstack.constraints.kubernetes.versions", []) %>
         % if kubernetesVersions != []:
-        ${yaml.dump(kubernetesVersions, width=10000)}
+        ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
         - 1.14.0
         - 1.13.4
@@ -540,20 +540,20 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % endif
       loadBalancerProviders:<% loadBalancerProviders=value("spec.openstack.constraints.loadBalancerProviders", []) %>
       % if loadBalancerProviders != []:
-      ${yaml.dump(loadBalancerProviders, width=10000)}
+      ${yaml.dump(loadBalancerProviders, width=10000, default_flow_style=None)}
       % else:
       - name: haproxy
       % endif
       machineImages:<% machineImages=value("spec.openstack.constraints.machineImages", []) %>
       % if machineImages != []:
-      ${yaml.dump(machineImages, width=10000)}
+      ${yaml.dump(machineImages, width=10000, default_flow_style=None)}
       % else:
       - name: coreos
         image: coreos-2023.5.0
       % endif
       machineTypes:<% machineTypes=value("spec.openstack.constraints.machineTypes", []) %>
       % if machineTypes != []:
-      ${yaml.dump(machineTypes, width=10000)}
+      ${yaml.dump(machineTypes, width=10000, default_flow_style=None)}
       % else:
       - name: medium_2_4
         cpu: "2"
@@ -572,7 +572,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
       % endif
       zones:<% zones=value("spec.openstack.constraints.zones", []) %>
       % if zones != []:
-      ${yaml.dump(zones, width=10000)}
+      ${yaml.dump(zones, width=10000, default_flow_style=None)}
       % else:
       - region: europe-1
         names:
@@ -600,7 +600,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
     constraints:
       dnsProviders:<% dnsProviders=value("spec.local.constraints.dnsProviders", []) %>
       % if dnsProviders != []:
-      ${yaml.dump(dnsProviders, width=10000)}
+      ${yaml.dump(dnsProviders, width=10000, default_flow_style=None)}
       % else:
       - name: unmanaged
       % endif

--- a/hack/templates/resources/40-secret-seed.yaml.tpl
+++ b/hack/templates/resources/40-secret-seed.yaml.tpl
@@ -3,7 +3,7 @@
 
   values={}
   if context.get("values", "") != "":
-    values=yaml.load(open(context.get("values", "")))
+    values=yaml.load(open(context.get("values", "")), Loader=yaml.Loader)
 
   if context.get("cloud", "") == "":
     raise Exception("missing --var cloud={aws,azure,gcp,alicloud,openstack,packet,local} flag")
@@ -41,10 +41,10 @@ metadata:
   name: ${value("metadata.name", "seed-" + cloud)}
   namespace: ${value("metadata.namespace", "garden")}<% annotations = value("metadata.annotations", {}); labels = value("metadata.labels", {}) %>
   % if annotations != {}:
-  annotations: ${yaml.dump(annotations, width=10000)}
+  annotations: ${yaml.dump(annotations, width=10000, default_flow_style=None)}
   % endif
   % if labels != {}:
-  labels: ${yaml.dump(labels, width=10000)}
+  labels: ${yaml.dump(labels, width=10000, default_flow_style=None)}
   % endif
 type: Opaque
 data:

--- a/hack/templates/resources/50-seed.yaml.tpl
+++ b/hack/templates/resources/50-seed.yaml.tpl
@@ -3,7 +3,7 @@
 
   values={}
   if context.get("values", "") != "":
-    values=yaml.load(open(context.get("values", "")))
+    values=yaml.load(open(context.get("values", "")), Loader=yaml.Loader)
 
   if context.get("cloud", "") == "":
     raise Exception("missing --var cloud={aws,azure,gcp,alicloud,openstack,packet,local} flag")
@@ -46,10 +46,10 @@ kind: Seed
 metadata:
   name: ${value("metadata.name", cloud)}
   % if annotations != {}:
-  annotations: ${yaml.dump(annotations, width=1000)}
+  annotations: ${yaml.dump(annotations, width=1000, default_flow_style=None)}
   % endif
   % if labels != {}:
-  labels: ${yaml.dump(labels, width=10000)}
+  labels: ${yaml.dump(labels, width=10000, default_flow_style=None)}
   % endif
 spec:
   cloud:

--- a/hack/templates/resources/60-quota.yaml.tpl
+++ b/hack/templates/resources/60-quota.yaml.tpl
@@ -3,7 +3,7 @@
 
   values={}
   if context.get("values", "") != "":
-    values=yaml.load(open(context.get("values", "")))
+    values=yaml.load(open(context.get("values", "")), Loader=yaml.Loader)
 
   def value(path, default):
     keys=str.split(path, ".")
@@ -25,10 +25,10 @@ metadata:
   name: ${value("metadata.name", "trial-quota")}
   namespace: ${value("metadata.namespace", "garden-trial")}<% annotations = value("metadata.annotations", {}); labels = value("metadata.labels", {}) %>
   % if annotations != {}:
-  annotations: ${yaml.dump(annotations, width=10000)}
+  annotations: ${yaml.dump(annotations, width=10000, default_flow_style=None)}
   % endif
   % if labels != {}:
-  labels: ${yaml.dump(labels, width=10000)}
+  labels: ${yaml.dump(labels, width=10000, default_flow_style=None)}
   % endif
 spec:
   scope: ${value("spec.scope", "secret")}<% clusterLifetimeDays = value("spec.clusterLifetimeDays", "") %>
@@ -39,7 +39,7 @@ spec:
   % endif
   metrics:<% metrics=value("spec.metrics", {}) %>
   % if metrics != {}:
-  ${yaml.dump(metrics, width=10000)}
+  ${yaml.dump(metrics, width=10000, default_flow_style=None)}
   % else:
     cpu: "200"
     gpu: "20"

--- a/hack/templates/resources/70-secret-cloudprovider.yaml.tpl
+++ b/hack/templates/resources/70-secret-cloudprovider.yaml.tpl
@@ -3,7 +3,7 @@
 
   values={}
   if context.get("values", "") != "":
-    values=yaml.load(open(context.get("values", "")))
+    values=yaml.load(open(context.get("values", "")), Loader=yaml.Loader)
 
   if context.get("cloud", "") == "":
     raise Exception("missing --var cloud={aws,azure,gcp,alicloud,openstack,packet,local} flag")
@@ -41,10 +41,10 @@ metadata:
   name: ${value("metadata.name", "core-" + cloud)}
   namespace: ${value("metadata.namespace", "garden-dev")}<% annotations = value("metadata.annotations", {}); labels = value("metadata.labels", {}) %>
   % if annotations != {}:
-  annotations: ${yaml.dump(annotations, width=10000)}
+  annotations: ${yaml.dump(annotations, width=10000, default_flow_style=None)}
   % endif
   % if labels != {}:
-  labels: ${yaml.dump(labels, width=10000)}
+  labels: ${yaml.dump(labels, width=10000, default_flow_style=None)}
   % else:
   labels:
     cloudprofile.garden.sapcloud.io/name: ${cloud} # label is only meaningful for Gardener dashboard

--- a/hack/templates/resources/80-secretbinding-cloudprovider.yaml.tpl
+++ b/hack/templates/resources/80-secretbinding-cloudprovider.yaml.tpl
@@ -3,7 +3,7 @@
 
   values={}
   if context.get("values", "") != "":
-    values=yaml.load(open(context.get("values", "")))
+    values=yaml.load(open(context.get("values", "")), Loader=yaml.Loader)
 
   if context.get("cloud", "") == "":
     raise Exception("missing --var cloud={aws,azure,gcp,alicloud,openstack,packet,local} flag")
@@ -42,10 +42,10 @@ metadata:
   name: ${value("metadata.name", "core-" + cloud)}
   namespace: ${value("metadata.namespace", "garden-dev")}<% annotations = value("metadata.annotations", {}); labels = value("metadata.labels", {}) %>
   % if annotations != {}:
-  annotations: ${yaml.dump(annotations, width=10000)}
+  annotations: ${yaml.dump(annotations, width=10000, default_flow_style=None)}
   % endif
   % if labels != {}:
-  labels: ${yaml.dump(labels, width=10000)}
+  labels: ${yaml.dump(labels, width=10000, default_flow_style=None)}
   % endif
   labels:
     cloudprofile.garden.sapcloud.io/name: ${cloud} # label is only meaningful for Gardener dashboard

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -3,7 +3,7 @@
 
   values={}
   if context.get("values", "") != "":
-    values=yaml.load(open(context.get("values", "")))
+    values=yaml.load(open(context.get("values", "")), Loader=yaml.Loader)
 
   if context.get("cloud", "") == "":
     raise Exception("missing --var cloud={aws,azure,gcp,alicloud,openstack,packet,local} flag")
@@ -51,10 +51,10 @@ metadata:
   name: ${value("metadata.name", "johndoe-" + cloud)}
   namespace: ${value("metadata.namespace", "garden-dev")}<% annotations = value("metadata.annotations", {}); labels = value("metadata.labels", {}) %>
   % if annotations != {}:
-  annotations: ${yaml.dump(annotations, width=10000)}
+  annotations: ${yaml.dump(annotations, width=10000, default_flow_style=None)}
   % endif
   % if labels != {}:
-  labels: ${yaml.dump(labels, width=10000)}
+  labels: ${yaml.dump(labels, width=10000, default_flow_style=None)}
   % endif
 spec:
   cloud:
@@ -78,7 +78,7 @@ spec:
         workers: ${value("spec.cloud.aws.networks.workers", ["10.250.0.0/19"])}
       workers:<% workers=value("spec.cloud.aws.workers", []) %>
       % if workers != []:
-      ${yaml.dump(workers, width=10000)}
+      ${yaml.dump(workers, width=10000, default_flow_style=None)}
       % else:
       - name: cpu-worker
         machineType: m4.large
@@ -112,7 +112,7 @@ spec:
         workers: ${value("spec.cloud.azure.networks.workers", "10.250.0.0/19")}
       workers:<% workers=value("spec.cloud.azure.workers", []) %>
       % if workers != []:
-      ${yaml.dump(workers, width=10000)}
+      ${yaml.dump(workers, width=10000, default_flow_style=None)}
       % else:
       - name: cpu-worker
         machineType: Standard_DS2_v2
@@ -138,7 +138,7 @@ spec:
         workers: ${value("spec.cloud.alicloud.networks.workers", ["10.250.0.0/19"])}
       workers:<% workers=value("spec.cloud.alicloud.workers", []) %>
       % if workers != []:
-      ${yaml.dump(workers, width=10000)}
+      ${yaml.dump(workers, width=10000, default_flow_style=None)}
       % else:
       - name: small
         machineType: ecs.sn2ne.xlarge
@@ -153,7 +153,7 @@ spec:
     packet:
       workers:<% workers=value("spec.cloud.packet.workers", []) %>
       % if workers != []:
-      ${yaml.dump(workers, width=10000)}
+      ${yaml.dump(workers, width=10000, default_flow_style=None)}
       % else:
       - name: small
         machineType: c1.small
@@ -178,7 +178,7 @@ spec:
         workers: ${value("spec.cloud.gcp.networks.workers", ["10.250.0.0/19"])}
       workers:<% workers=value("spec.cloud.gcp.workers", []) %>
       % if workers != []:
-      ${yaml.dump(workers, width=10000)}
+      ${yaml.dump(workers, width=10000, default_flow_style=None)}
       % else:
       - name: cpu-worker
         machineType: n1-standard-4
@@ -206,7 +206,7 @@ spec:
         workers: ${value("spec.cloud.openstack.networks.workers", ["10.250.0.0/19"])}
       workers:<% workers=value("spec.cloud.openstack.workers", []) %>
       % if workers != []:
-      ${yaml.dump(workers, width=10000)}
+      ${yaml.dump(workers, width=10000, default_flow_style=None)}
       % else:
       - name: cpu-worker
         machineType: medium_2_4
@@ -229,7 +229,7 @@ spec:
     version: ${value("spec.kubernetes.version", kubernetesVersion)}<% kubeAPIServer=value("spec.kubernetes.kubeAPIServer", {}) %><% cloudControllerManager=value("spec.kubernetes.cloudControllerManager", {}) %><% kubeControllerManager=value("spec.kubernetes.kubeControllerManager", {}) %><% kubeScheduler=value("spec.kubernetes.kubeScheduler", {}) %><% kubeProxy=value("spec.kubernetes.kubeProxy", {}) %><% kubelet=value("spec.kubernetes.kubelet", {}) %>
     allowPrivilegedContainers: ${value("spec.kubernetes.allowPrivilegedContainers", "true")} # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
     % if kubeAPIServer != {}:
-    kubeAPIServer: ${yaml.dump(kubeAPIServer, width=10000)}
+    kubeAPIServer: ${yaml.dump(kubeAPIServer, width=10000, default_flow_style=None)}
     % else:
   # kubeAPIServer:
   #   featureGates:
@@ -264,14 +264,14 @@ spec:
   #         name: auditpolicy
   % endif
     % if cloudControllerManager != {}:
-    cloudControllerManager: ${yaml.dump(cloudControllerManager, width=10000)}
+    cloudControllerManager: ${yaml.dump(cloudControllerManager, width=10000, default_flow_style=None)}
     % else:
   # cloudControllerManager:
   #   featureGates:
   #     SomeKubernetesFeature: true
   % endif
     % if kubeControllerManager != {}:
-    kubeControllerManager: ${yaml.dump(kubeControllerManager, width=10000)}
+    kubeControllerManager: ${yaml.dump(kubeControllerManager, width=10000, default_flow_style=None)}
     % else:
   # kubeControllerManager:
   #   featureGates:
@@ -288,14 +288,14 @@ spec:
   #     cpuInitializationPeriod: 5m0s
   % endif
     % if kubeScheduler != {}:
-    kubeScheduler: ${yaml.dump(kubeScheduler, width=10000)}
+    kubeScheduler: ${yaml.dump(kubeScheduler, width=10000, default_flow_style=None)}
     % else:
   # kubeScheduler:
   #   featureGates:
   #     SomeKubernetesFeature: true
   % endif
     % if kubeProxy != {}:
-    kubeProxy: ${yaml.dump(kubeProxy, width=10000)}
+    kubeProxy: ${yaml.dump(kubeProxy, width=10000, default_flow_style=None)}
     % else:
   # kubeProxy:
   #   featureGates:
@@ -303,7 +303,7 @@ spec:
   #   mode: IPVS
   % endif
     % if kubelet != {}:
-    kubelet: ${yaml.dump(kubelet, width=10000)}
+    kubelet: ${yaml.dump(kubelet, width=10000, default_flow_style=None)}
     % else:
   # kubelet:
   #   podPidsLimit: 10
@@ -314,7 +314,7 @@ spec:
   # provider: ${value("spec.dns.provider", "aws-route53") if cloud != "local" else "unmanaged"}
     domain: ${value("spec.dns.domain", value("metadata.name", "johndoe-" + cloud) + "." + value("metadata.namespace", "garden-dev") + ".example.com") if cloud != "local" else "<local-kubernetes-ip>.nip.io"}<% hibernation = value("spec.hibernation", {}) %>
   % if hibernation != {}:
-  hibernation: ${yaml.dump(hibernation, width=10000)}
+  hibernation: ${yaml.dump(hibernation, width=10000, default_flow_style=None)}
   % else:
 # hibernation:
 #   enabled: false
@@ -356,7 +356,7 @@ spec:
       enabled: ${value("spec.addons.kube2iam.enabled", "true")}
       roles:<% roles=value("spec.addons.kube2iam.roles", []) %>
       % if roles != []:
-      ${yaml.dump(roles, width=10000)}
+      ${yaml.dump(roles, width=10000, default_flow_style=None)}
       % else:
       - name: ecr
         description: "Allow access to ECR repositories beginning with 'my-images/', and creation of new repositories"

--- a/hack/templates/resources/95-configmap-custom-audit-policy.yaml.tpl
+++ b/hack/templates/resources/95-configmap-custom-audit-policy.yaml.tpl
@@ -3,7 +3,7 @@
 
   values={}
   if context.get("values", "") != "":
-    values=yaml.load(open(context.get("values", "")))
+    values=yaml.load(open(context.get("values", "")), Loader=yaml.Loader)
 
   def value(path, default):
     keys=str.split(path, ".")
@@ -24,15 +24,15 @@ metadata:
   name: ${value("metadata.name", "auditpolicy")}
   namespace: ${value("metadata.namespace", "garden-dev")}<% annotations = value("metadata.annotations", {}); labels = value("metadata.labels", {}) %>
   % if annotations != {}:
-  annotations: ${yaml.dump(annotations, width=10000)}
+  annotations: ${yaml.dump(annotations, width=10000, default_flow_style=None)}
   % endif
   % if labels != {}:
-  labels: ${yaml.dump(labels, width=10000)}
+  labels: ${yaml.dump(labels, width=10000, default_flow_style=None)}
   % endif
 data:
   policy: |-<% policy=value("data.policy", "") %>
     % if policy != "":
-    ${yaml.dump(policy, width=10000)}
+    ${yaml.dump(policy, width=10000, default_flow_style=None)}
     % else:
     apiVersion: audit.k8s.io/v1beta1
     kind: Policy


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the templates in `hack/templates` so that rendering them using mako will still work for users that have upgraded `pyyaml` to 5.1.

To elaborate further: In release 5.1, `pyyaml` changed their default dump-rendering behaviour from
> block style where possible, except for lists and dicts that contain no dicts or lists themselves

to
> always use block style

This has the effect of rendering simple data-structures differently. The proposed workaround consists of specifying the desired render format, which causes the format of the dumped yamls to stay the same in both 3.13 and 5.1.

Example:
```
{'foo': 'bar', 'baz': 'foobar'}
````
becomes 
````
{foo: 'bar', baz: 'foobar'}  # pyyaml 3.13 default / proposed change
````
or 
````
foo: 'bar'
baz: 'foobar'  # pyyaml 5.1 default
````
The latter will then be thoroughly mangled by Mako if the new line break isn't considered.


Furthermore, this PR also explicitly sets the loader for yaml.load(), which will squelch warnings in `pyyaml` 5.1, see https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```
NONE
```