### PR TITLE
Use internal cluster domain for probe

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -339,7 +339,7 @@ func (b *Botanist) DeploySeedMonitoring() error {
 				},
 			},
 			"shoot": map[string]interface{}{
-				"apiserver": fmt.Sprintf("https://%s", b.APIServerAddress),
+				"apiserver": fmt.Sprintf("https://%s", b.Shoot.InternalClusterDomain),
 			},
 			"vpa": map[string]interface{}{
 				"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),


### PR DESCRIPTION
**What this PR does / why we need it**:
The api server certificate no longer contains the external IP/ hostname (see #839). A probe that checks the availability of the api server uses the external IP/ hostname, but because it is no longer in the certificate the probe fails. Every new cluster created will fire a false positive alert `ApiServerNotReachable`. To fix the issue the probe now uses the internal domain, which is contained in the certificate.

Can we hotfix this?

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
