### PR TITLE
Allow garden administrators to read namespace

### DIFF
--- a/charts/gardener/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/charts/application/templates/rbac-user.yaml
@@ -14,6 +14,12 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
 
 # Aggregated cluster role specifying garden administrators.
 # IMPORTANT: You need to define a corresponding ClusterRoleBinding binding specific users


### PR DESCRIPTION
**What this PR does / why we need it**:
For most calls to the Kubernetes API Server from the `gardener dashboard` `backend` the user credentials are used.
One exception where the dashboard's admin user is used is to read the namespace (https://github.com/gardener/dashboard/blob/03059189bad3422e024f6282ebb7acd08ad16a89/backend/lib/services/projects.js#L103). 
With #690 a project member has the privilege to read the corresponding namespace.
But a gardener administrator still does not have the privilege to read namespaces (if he is not a member of the respective project), hence this PR.

This PR is a prerequisite for https://github.com/gardener/dashboard/pull/349

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The `garden.sapcloud.io:admin` cluster role does now allow reading namespaces.
```
