### PR TITLE
Fix validating webhook to work only for Project namespaces

### DIFF
--- a/charts/gardener/charts/application/templates/validatingwebhook-controller-manager.yaml
+++ b/charts/gardener/charts/application/templates/validatingwebhook-controller-manager.yaml
@@ -15,6 +15,9 @@ webhooks:
     resources:
     - namespaces
   failurePolicy: Fail
+  namespaceSelector:
+    matchLabels:
+      garden.sapcloud.io/role: project
   clientConfig:
     {{- if .Values.global.deployment.virtualGarden.enabled }}
     url: https://gardener-controller-manager.garden/webhooks/validate-namespace-deletion


### PR DESCRIPTION
**What this PR does / why we need it**:

The validating endpoint of the `gardener-controller-manager` only handles namespaces of Projects.

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Validating webhook `validate-namespace-deletion` is now called only for Project namespaces.
```
