### PR TITLE
Use internal cluster domain for probe

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -339,7 +339,7 @@ func (b *Botanist) DeploySeedMonitoring() error {
 				},
 			},
 			"shoot": map[string]interface{}{
-				"apiserver": fmt.Sprintf("https://%s", b.APIServerAddress),
+				"apiserver": fmt.Sprintf("https://%s", b.Shoot.InternalClusterDomain),
 			},
 			"vpa": map[string]interface{}{
 				"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),


### PR DESCRIPTION
(cherry picked from commit 30188f60a8d652644464733ccbf81cf5dfb5276c)

**What this PR does / why we need it**:
Fixes false positive alert `ApiServerNotReachable` whenever a new shoot is created.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
An issue with Prometheus alerts that caused firing false positive `ApiServerNotReachable` alerts has been fixed.
```
