### PR TITLE
Increase memory limit of curator cronJob

### DIFF
--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/curator-cronjob.yml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/curator-cronjob.yml
@@ -82,7 +82,7 @@ spec:
             resources:
               limits:
                 cpu: 10m
-                memory: 50Mi
+                memory: 70Mi
               requests:
                 cpu: 10m
                 memory: 30Mi


### PR DESCRIPTION
**What this PR does / why we need it**:
With the latest image of curator-es we observe that daily-curator cronJob gets `OOMKilled`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The memory limits of daily-curator cronJob are increased (from 50Mi to 70Mi) to prevent OOM issues.
```
