### PR TITLE
Remove bird as a calico backend for Azure

### DIFF
--- a/charts/shoot-core/charts/calico/templates/calico.yaml
+++ b/charts/shoot-core/charts/calico/templates/calico.yaml
@@ -201,8 +201,10 @@ spec:
             exec:
               command:
               - /bin/calico-node
-              - -bird-ready
               - -felix-ready
+              {{- if ne .Values.cloudProvider "azure" }}
+              - -bird-ready
+              {{- end }}
             periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules

--- a/charts/shoot-core/charts/calico/templates/config.yaml
+++ b/charts/shoot-core/charts/calico/templates/config.yaml
@@ -13,7 +13,7 @@ data:
   # essential.
   typha_service_name: "none"
   # Configure the Calico backend to use.
-  calico_backend: "bird"
+  calico_backend: {{ if ne .Values.cloudProvider "azure" }}"bird"{{ else }}"none"{{ end }}
 
   # Configure the MTU to use
   veth_mtu: "1440"


### PR DESCRIPTION
**What this PR does / why we need it**:
Azure does not support **IPinIP** and as a result **Calico's Bird** can not be used, this PR removes bird as a calico backend for Azure. 

For more information: https://docs.projectcalico.org/v3.5/reference/public-cloud/azure

```noteworthy user
Calico is now only used for policies on Azure, Bird backend is removed.
```
