### PR TITLE
Set vpa mode to Auto for prometheus

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/templates/admission-controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/admission-controller-deployment.yaml
@@ -49,7 +49,7 @@ spec:
         command:
         - ./admission-controller
         args:
-        - --v=4
+        - --v=2
         - --stderrthreshold=info
         - --client-ca-file=/etc/tls-certs/ca.crt
         - --tls-cert-file=/etc/tls-certs/tls.crt

--- a/charts/seed-bootstrap/charts/vpa/templates/recommender-deployment.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/recommender-deployment.yaml
@@ -30,6 +30,13 @@ spec:
       containers:
       - name: recommender
         image: {{ index .Values.global.images "vpa-recommender" }}
+        command:
+        - ./recommender
+        args:
+        - --v=2
+        - --stderrthreshold=info
+        - --pod-recommendation-min-cpu-millicores=5
+        - --pod-recommendation-min-memory-mb=10
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/charts/seed-bootstrap/charts/vpa/templates/updater-deployment.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/updater-deployment.yaml
@@ -31,6 +31,11 @@ spec:
       - name: updater
         image: {{ index .Values.global.images "vpa-updater" }}
         imagePullPolicy: IfNotPresent
+        command:
+        - ./updater
+        args:
+        - --v=2
+        - --stderrthreshold=info
         resources:
           limits:
             cpu: 200m

--- a/charts/seed-bootstrap/templates/prometheus/prometheus-vpa.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/prometheus-vpa.yaml
@@ -10,5 +10,5 @@ spec:
     kind: StatefulSet
     name: prometheus
   updatePolicy:
-    updateMode: "Off"
+    updateMode: "Auto"
 {{ end }}

--- a/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
@@ -60,7 +60,13 @@ spec:
           successThreshold: 1
           timeoutSeconds: 3
         resources:
-{{- include "util-templates.resource-quantity" .Values.prometheus | indent 10 }}
+{{- if .Values.vpa.enabled }}
+          requests:
+            cpu: 30m
+            memory: 500Mi
+{{- else }}
+{{- include "util-templates.resource-quantity" .Values.prometheus | indent 10 -}}
+{{ end }}
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/charts/seed-monitoring/charts/prometheus/templates/prometheus-vpa.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/prometheus-vpa.yaml
@@ -10,5 +10,5 @@ spec:
     kind: StatefulSet
     name: prometheus
   updatePolicy:
-    updateMode: "Off"
+    updateMode: "Auto"
 {{ end }}

--- a/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
@@ -107,7 +107,13 @@ spec:
           successThreshold: 1
           timeoutSeconds: 3
         resources:
-{{- include "util-templates.resource-quantity" .Values | indent 10 }}
+{{- if .Values.vpa.enabled }}
+          requests:
+            cpu: 30m
+            memory: 500Mi
+{{- else }}
+{{- include "util-templates.resource-quantity" .Values | indent 10 -}}
+{{ end }}
         volumeMounts:
         - mountPath: /srv/kubernetes/prometheus-kubelet
           name: prometheus-kubelet

--- a/charts/seed-monitoring/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/prometheus/values.yaml
@@ -219,4 +219,4 @@ resources:
       unit: Mi
 
 vpa:
-  enabled: false
+  enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets the the prometheus VPAs to mode `Auto`. This means that the pod's requests will change based on the recommendations of the VPA. If prometheus is using too much/ too little resources it will be killed by the VPA and given new requests (can only happen to pods that are 12h+ old or get killed through other means). The old scaling method will still be used if the VPA feature flag is disabled. 

Additionally, the minimum recommendations for the the VPA have been decreased from the default `cpu: 25m, mem: 250MB` to `cpu: 5m, mem: 10MB`. This will allow the VPA to make useful recommendations for pods that use low amounts of resources. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
If you have enabled the `VPA` feature gate then the VPA mode for all Prometheus instances in the seed will now be set to `Auto` mode. That means that the pod's resource requests will change based on the recommendations of the VPA. If Prometheus is using too much/too little resources it will be killed by the VPA and given new resource requests (can only happen to pods that are 12h+ old or get killed through other means).
```
