### PR TITLE
Increase integration test timeout and set verbose output for delete-shoot

### DIFF
--- a/.test-defs/ShootAppTest.yaml
+++ b/.test-defs/ShootAppTest.yaml
@@ -5,8 +5,8 @@ spec:
   owner: DL_5C5BE3E2970B9F404D0E2F50@sap.com # OutputQualification DL
   description: Tests the deployment of a guestbook.
 
-  activeDeadlineSeconds: 600
-  labels: ["default"]
+  activeDeadlineSeconds: 1800
+  labels: ["default", "release"]
 
   command: [bash, -c]
   args:

--- a/.test-defs/cmd/delete-shoot/main.go
+++ b/.test-defs/cmd/delete-shoot/main.go
@@ -35,7 +35,7 @@ var (
 )
 
 func init() {
-	testLogger = logger.NewLogger("info")
+	testLogger = logger.NewLogger("debug")
 
 	shootName = os.Getenv("SHOOT_NAME")
 	if shootName == "" {

--- a/test/integration/framework/shoot_operations.go
+++ b/test/integration/framework/shoot_operations.go
@@ -189,7 +189,9 @@ func (s *ShootGardenerTest) WaitForShootToBeDeleted(ctx context.Context) error {
 			return false, err
 		}
 		s.Logger.Infof("waiting for shoot %s to be deleted", s.Shoot.Name)
+		if shoot.Status.LastOperation != nil {
+			s.Logger.Debugf("%d%: Shoot state: %s, Description: %s", shoot.Status.LastOperation.Progress, shoot.Status.LastOperation.State, shoot.Status.LastOperation.Description)
+		}
 		return false, nil
-
 	}, ctx.Done())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Increase the timeout for the application integration test to 30min.
- Add verbose output when deleting a shoot.
- Add a new `release` label to the application integration test to show it release relevance

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
