### PR TITLE
Do not Require Running DNS Extension for `unmanaged` Provider

### DIFF
--- a/example/90-shoot-local.yaml
+++ b/example/90-shoot-local.yaml
@@ -78,7 +78,7 @@ spec:
   #   featureGates:
   #     SomeKubernetesFeature: true
   dns:
-  # provider: unmanaged
+    provider: unmanaged
     domain: <local-kubernetes-ip>.nip.io
 # hibernation:
 #   enabled: false

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -311,7 +311,11 @@ spec:
   #     SomeKubernetesFeature: true
   % endif
   dns:
-  # provider: ${value("spec.dns.provider", "aws-route53") if cloud != "local" else "unmanaged"}
+  % if cloud != "local":
+  # provider: ${value("spec.dns.provider", "aws-route53")}
+  % else:
+    provider: unmanaged
+  % endif
     domain: ${value("spec.dns.domain", value("metadata.name", "johndoe-" + cloud) + "." + value("metadata.namespace", "garden-dev") + ".example.com") if cloud != "local" else "<local-kubernetes-ip>.nip.io"}<% hibernation = value("spec.hibernation", {}) %>
   % if hibernation != {}:
   hibernation: ${yaml.dump(hibernation, width=10000, default_flow_style=None)}

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -199,10 +199,13 @@ func (b *Botanist) RequiredExtensionsExist() error {
 func (b *Botanist) computeRequiredExtensions() map[string]string {
 	requiredExtensions := map[string]string{
 		extensionsv1alpha1.OperatingSystemConfigResource: string(b.Shoot.GetMachineImageName()),
-		dnsv1alpha1.DNSProviderKind:                      b.Garden.InternalDomain.Provider,
 	}
 
-	if b.Shoot.ExternalDomain != nil {
+	if b.Garden.InternalDomain.Provider != gardenv1beta1.DNSUnmanaged {
+		requiredExtensions[dnsv1alpha1.DNSProviderKind] = b.Garden.InternalDomain.Provider
+	}
+
+	if b.Shoot.ExternalDomain != nil && b.Shoot.ExternalDomain.Provider != gardenv1beta1.DNSUnmanaged {
 		requiredExtensions[dnsv1alpha1.DNSProviderKind] = b.Shoot.ExternalDomain.Provider
 	}
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	"github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	controllermanagerfeatures "github.com/gardener/gardener/pkg/controllermanager/features"
 	"github.com/gardener/gardener/pkg/features"
@@ -627,7 +628,11 @@ func (b *Botanist) WakeUpControlPlane(ctx context.Context) error {
 		return err
 	}
 
-	for _, deployment := range []string{common.KubeControllerManagerDeploymentName, common.CloudControllerManagerDeploymentName, common.MachineControllerManagerDeploymentName} {
+	controllerManagerDeployments := []string{common.KubeControllerManagerDeploymentName}
+	if b.Shoot.CloudProvider != v1beta1.CloudProviderLocal {
+		controllerManagerDeployments = append(controllerManagerDeployments, common.CloudControllerManagerDeploymentName, common.MachineControllerManagerDeploymentName)
+	}
+	for _, deployment := range controllerManagerDeployments {
 		if err := kubernetes.ScaleDeployment(ctx, client, kutil.Key(b.Shoot.SeedNamespace, deployment), 1); err != nil {
 			return err
 		}

--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -218,6 +218,9 @@ func computeRequiredControlPlaneDeployments(
 			requiredControlPlaneDeployments.Insert(gardencorev1alpha1.DeploymentNameClusterAutoscaler)
 		}
 	}
+	if seedCloudProvider == gardenv1beta1.CloudProviderLocal {
+		requiredControlPlaneDeployments.Delete(common.MachineControllerManagerDeploymentName, common.CloudControllerManagerDeploymentName)
+	}
 
 	return requiredControlPlaneDeployments, nil
 }

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -316,9 +316,6 @@ const (
 	// TerraformerPurposeKube2IAM is a constant for the complete Terraform setup with purpose 'kube2iam roles'.
 	TerraformerPurposeKube2IAM = "kube2iam"
 
-	// TerraformerPurposeIngress is a constant for the complete Terraform setup with purpose 'ingress'.
-	TerraformerPurposeIngress = "ingress"
-
 	// ShootExpirationTimestamp is an annotation on a Shoot resource whose value represents the time when the Shoot lifetime
 	// is expired. The lifetime can be extended, but at most by the minimal value of the 'clusterLifetimeDays' property
 	// of referenced quotas.


### PR DESCRIPTION
**What this PR does / why we need it**:
Do not require running DNS extension for `unmanaged` provider.
Also, I propose fixes for health check and hibernation for the local provider.

**Which issue(s) this PR fixes**:
Fixes #910 

**Special notes for your reviewer**:
/cc @ialidzhikov @pablochacin 

I will squash the commits once we agree how the change will look like.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Gardener does now respect the `unmanaged` DNS provider and does not deploy DNS records for it.
```
