### PR TITLE
Add VPA objects for control plane components

### DIFF
--- a/charts/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager-vpa.yaml
+++ b/charts/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager-vpa.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.vpa.enabled }}
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: cloud-controller-manager-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRef:
+    apiVersion: {{ include "deploymentversion" . }}
+    kind: Deployment
+    name: cloud-controller-manager
+  updatePolicy:
+    updateMode: "Off"
+{{ end }}

--- a/charts/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -19,3 +19,6 @@ resources:
   limits:
     cpu: 250m
     memory: 300Mi
+
+vpa:
+  enabled: true

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-vpa.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-vpa.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.vpa.enabled }}
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: etcd-{{ .Values.role }}-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRef:
+    apiVersion: {{ include "statefulsetversion" . }}
+    kind: StatefulSet
+    name: etcd-{{ .Values.role }}
+  updatePolicy:
+    updateMode: "Off"
+{{ end }}

--- a/charts/seed-controlplane/charts/etcd/values.yaml
+++ b/charts/seed-controlplane/charts/etcd/values.yaml
@@ -19,6 +19,9 @@ tlsServerSecretName: etcd-server-tls
 tlsClientSecretName: etcd-client-tls
 podAnnotations: {}
 
+vpa:
+  enabled: true
+
 # Aws S3 storage configuration
 # Note: No volumeMounts variable needed
 # storageProvider: "S3"

--- a/charts/seed-controlplane/charts/kube-addon-manager/templates/kube-addon-manager-vpa.yaml
+++ b/charts/seed-controlplane/charts/kube-addon-manager/templates/kube-addon-manager-vpa.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.vpa.enabled }}
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: kube-addon-manager-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRef:
+    apiVersion: {{ include "deploymentversion" . }}
+    kind: Deployment
+    name: kube-addon-manager
+  updatePolicy:
+    updateMode: "Off"
+{{ end }}

--- a/charts/seed-controlplane/charts/kube-addon-manager/values.yaml
+++ b/charts/seed-controlplane/charts/kube-addon-manager/values.yaml
@@ -11,3 +11,6 @@ shootAPIServer:
   Capabilities:
     KubeVersion:
       GitVersion: v1.13
+
+vpa:
+  enabled: true

--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager-vpa.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager-vpa.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.vpa.enabled }}
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: kube-controller-manager-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRef:
+    apiVersion: {{ include "deploymentversion" . }}
+    kind: Deployment
+    name: kube-controller-manager
+  updatePolicy:
+    updateMode: "Off"
+{{ end }}

--- a/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
@@ -47,3 +47,6 @@ resources:
       perObject: 50
       weight: 5
       unit: Mi
+
+vpa:
+  enabled: true

--- a/charts/seed-controlplane/charts/kube-scheduler/templates/kube-scheduler-vpa.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/templates/kube-scheduler-vpa.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.vpa.enabled }}
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: kube-scheduler-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRef:
+    apiVersion: {{ include "deploymentversion" . }}
+    kind: Deployment
+    name: kube-scheduler
+  updatePolicy:
+    updateMode: "Off"
+{{ end }}

--- a/charts/seed-controlplane/charts/kube-scheduler/values.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/values.yaml
@@ -13,3 +13,6 @@ resources:
   limits:
     cpu: 400m
     memory: 512Mi
+
+vpa:
+  enabled: true

--- a/charts/seed-controlplane/charts/machine-controller-manager/templates/mcm-vpa.yaml
+++ b/charts/seed-controlplane/charts/machine-controller-manager/templates/mcm-vpa.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.vpa.enabled }}
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: machine-controller-manager-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRef:
+    apiVersion: {{ include "deploymentversion" . }}
+    kind: Deployment
+    name: machine-controller-manager
+  updatePolicy:
+    updateMode: "Off"
+{{ end }}

--- a/charts/seed-controlplane/charts/machine-controller-manager/values.yaml
+++ b/charts/seed-controlplane/charts/machine-controller-manager/values.yaml
@@ -8,3 +8,6 @@ namespace:
   uid: uuid-of-namespace
 
 metricsPort: 10258
+
+vpa:
+  enabled: true

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -201,6 +201,9 @@ func (b *Botanist) DeployMachineControllerManager() error {
 			"namespace": map[string]interface{}{
 				"uid": b.SeedNamespaceObject.UID,
 			},
+			"vpa": map[string]interface{}{
+				"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
+			},
 		}
 	)
 

--- a/pkg/operation/hybridbotanist/addon_manager.go
+++ b/pkg/operation/hybridbotanist/addon_manager.go
@@ -17,6 +17,8 @@ package hybridbotanist
 import (
 	"path/filepath"
 
+	controllermanagerfeatures "github.com/gardener/gardener/pkg/controllermanager/features"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/operation/common"
 )
 
@@ -58,6 +60,9 @@ func (b *HybridBotanist) DeployKubeAddonManager() error {
 					"GitVersion": b.Shoot.Info.Spec.Kubernetes.Version,
 				},
 			},
+		},
+		"vpa": map[string]interface{}{
+			"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
 		},
 	}
 

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -23,6 +23,8 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	controllermanagerfeatures "github.com/gardener/gardener/pkg/controllermanager/features"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -126,6 +128,9 @@ func (b *HybridBotanist) DeployETCD() error {
 			"checksum/secret-etcd-client-tls": b.CheckSums["etcd-client-tls"],
 		},
 		"storage": b.Seed.GetValidVolumeSize("10Gi"),
+		"vpa": map[string]interface{}{
+			"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
+		},
 	}
 
 	// Some cloud botanists do not yet support backup and won't return backup config data.
@@ -456,6 +461,9 @@ func (b *HybridBotanist) DeployKubeControllerManager() error {
 			"checksum/configmap-cloud-provider-config":       b.CheckSums[common.CloudProviderConfigName],
 		},
 		"objectCount": b.Shoot.GetNodeCount(),
+		"vpa": map[string]interface{}{
+			"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
+		},
 	}
 	cloudSpecificValues, err := b.ShootCloudBotanist.GenerateKubeControllerManagerConfig()
 	if err != nil {
@@ -544,6 +552,9 @@ func (b *HybridBotanist) DeployKubeScheduler() error {
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-kube-scheduler":        b.CheckSums[common.KubeSchedulerDeploymentName],
 			"checksum/secret-kube-scheduler-server": b.CheckSums[common.KubeSchedulerServerName],
+		},
+		"vpa": map[string]interface{}{
+			"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
 		},
 	}
 	cloudValues, err := b.ShootCloudBotanist.GenerateKubeSchedulerConfig()


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds VPA objects for most of the control plane components.  Will be useful for cost analysis, to see how many resources each component really uses. VPA objects are all in `Off` mode so there will be no disruption.
/cc @mliepold 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Kube-apiserver was excluded because the VPA should not be used with an object that uses an HPA based on cpu or memory metrics.
Some other components were also excluded because they are not deployed in every control plane (Infrastructure specific or behind feature gate).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Added VPA objects for control plane components. VPA objects are in `Off` mode.
```
