### PR TITLE
Apply vpa resources based on feature gate value

### DIFF
--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -515,6 +515,9 @@ func (b *HybridBotanist) DeployCloudControllerManager() error {
 			"checksum/secret-cloudprovider":                   b.CheckSums[common.CloudProviderSecretName],
 			"checksum/configmap-cloud-provider-config":        b.CheckSums[common.CloudProviderConfigName],
 		},
+		"vpa": map[string]interface{}{
+			"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
+		},
 	}
 	cloudSpecificValues, chartName, err := b.ShootCloudBotanist.GenerateCloudControllerManagerConfig()
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Apply vpa resources for cloud-controller-manager based on feature gate value. This allows reconciling shoots successfully when the `VPA` feature gate is off.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
