### PR TITLE
Etcd storageclass migration

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -18,7 +18,7 @@ images:
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.5.2"
+  tag: "0.6.0"
 - name: hyperkube
   sourceRepository: github.com/kubernetes/kubernetes
   repository: k8s.gcr.io/hyperkube

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -14,11 +14,11 @@ images:
 - name: etcd
   sourceRepository: github.com/coreos/etcd
   repository: quay.io/coreos/etcd
-  tag: v3.3.12
+  tag: v3.3.13
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.6.0"
+  tag: "0.6.2"
 - name: hyperkube
   sourceRepository: github.com/kubernetes/kubernetes
   repository: k8s.gcr.io/hyperkube

--- a/charts/seed-controlplane/charts/etcd-storageclass/Chart.yaml
+++ b/charts/seed-controlplane/charts/etcd-storageclass/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for etcd storageclass
-name: ertcd-storageclass
+name: etcd-storageclass
 version: 0.1.0

--- a/charts/seed-controlplane/charts/etcd-storageclass/Chart.yaml
+++ b/charts/seed-controlplane/charts/etcd-storageclass/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for etcd storageclass
+name: ertcd-storageclass
+version: 0.1.0

--- a/charts/seed-controlplane/charts/etcd-storageclass/charts/utils-templates
+++ b/charts/seed-controlplane/charts/etcd-storageclass/charts/utils-templates
@@ -1,0 +1,1 @@
+../../../../utils-templates

--- a/charts/seed-controlplane/charts/etcd-storageclass/templates/storageclass.yaml
+++ b/charts/seed-controlplane/charts/etcd-storageclass/templates/storageclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: {{ include "storageclassversion" . }}
+kind: StorageClass
+metadata:
+  name: {{ $.Values.name }}
+provisioner: {{ $.Values.provisioner }}
+allowVolumeExpansion: true
+parameters:
+{{- if $.Values.parameters }}
+{{ toYaml $.Values.parameters | indent 2 }}
+{{- end }}

--- a/charts/seed-controlplane/charts/etcd-storageclass/values.yaml
+++ b/charts/seed-controlplane/charts/etcd-storageclass/values.yaml
@@ -1,0 +1,3 @@
+name: default
+provisioner: docker.io/hostpath
+parameters: {}

--- a/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
@@ -9,23 +9,64 @@ metadata:
 data:
   bootstrap.sh: |-
     #!/bin/sh
-    while true;
-    do
-      wget http://localhost:8080/initialization/status -S -O status;
-      STATUS=`cat status`;
-      case $STATUS in
-      "New")
-            wget http://localhost:8080/initialization/start -S -O - ;;
-      "Progress")
-            sleep 5;
-            continue;;
-      "Failed")
-            continue;;
-      "Successful")
-            exec etcd --config-file /bootstrap/etcd.conf.yml
-            ;;
-      esac;
-    done
+    VALIDATION_MARKER=/var/etcd/data/validation_marker
+
+    trap_and_propagate() {
+        PID=$1
+        shift
+        for sig in "$@" ; do
+            trap "kill -$sig $PID" "$sig"
+        done
+    }
+
+    start_managed_etcd(){
+          rm -rf $VALIDATION_MARKER
+          etcd --config-file /bootstrap/etcd.conf.yml &
+          ETCDPID=$!
+          trap_and_propagate $ETCDPID INT TERM
+          wait $ETCDPID
+          RET=$?
+          echo $RET > $VALIDATION_MARKER
+          exit $RET
+    }
+
+    check_and_start_etcd(){
+          while true;
+          do
+            wget http://localhost:8080/initialization/status -S -O status;
+            STATUS=`cat status`;
+            case $STATUS in
+            "New")
+                  wget http://localhost:8080/initialization/start?mode=$1 -S -O - ;;
+            "Progress")
+                  sleep 1;
+                  continue;;
+            "Failed")
+                  continue;;
+            "Successful")
+                  start_managed_etcd
+                  break
+                  ;;
+            esac;
+          done
+    }
+
+    if [ ! -f $VALIDATION_MARKER ] ;
+    then
+          echo "No $VALIDATION_MARKER file. Perform complete initialization routine and start etcd."
+          check_and_start_etcd full
+    else
+          echo "$VALIDATION_MARKER file present. Check return status and decide on initialization"
+          run_status=`cat $VALIDATION_MARKER`
+          echo "$VALIDATION_MARKER content: $run_status"
+          if [ $run_status == '143' ] || [ $run_status == '130' ] || [ $run_status == '0' ] ; then
+                echo "Requesting sidecar to perform sanity validation"
+                check_and_start_etcd sanity
+          else
+                echo "Requesting sidecar to perform full validation"
+                check_and_start_etcd full
+          fi
+    fi
   etcd.conf.yml: |-
       # This is the configuration file for the etcd server.
 
@@ -65,7 +106,7 @@ data:
       initial-cluster-state: 'new'
 
       # Number of committed transactions to trigger a snapshot to disk.
-      snapshot-count: 75000  
+      snapshot-count: 75000
 
       # Raise alarms when backend size exceeds the given quota. 0 means use the
       # default quota.

--- a/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
@@ -51,6 +51,7 @@ data:
           done
     }
 
+{{- if eq .Values.role "main" }}
     migrate_data() {
       OLD_DATA_DIR=/var/etcd/old-data
       NEW_DATA_DIR=/var/etcd/data
@@ -88,6 +89,7 @@ data:
 
     # Do migration
     migrate_data
+{{- end }}
     # Do validation and bootstrap
     if [ ! -f $VALIDATION_MARKER ] ;
     then

--- a/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
@@ -51,6 +51,44 @@ data:
           done
     }
 
+    migrate_data() {
+      OLD_DATA_DIR=/var/etcd/old-data
+      NEW_DATA_DIR=/var/etcd/data
+      MIGRATION_MARKER=$OLD_DATA_DIR/migration.marker
+
+      if [ ! -f $MIGRATION_MARKER ]; then
+            # Keep this for debugging purpose
+            echo "old data directory content: $OLD_DATA_DIR"
+            ls -A $OLD_DATA_DIR
+            echo "New data directory content: $NEW_DATA_DIR"
+            ls -A $NEW_DATA_DIR
+
+            echo "Removing content of new data directory $NEW_DATA_DIR"
+            rm -rf $NEW_DATA_DIR/*
+
+            # Copy only if not empty
+            if [ "$(ls -A $OLD_DATA_DIR)" ];
+            then
+            echo "Migrating content of old data directory $OLD_DATA_DIR to $NEW_DATA_DIR"
+            time cp -rf $OLD_DATA_DIR/* $NEW_DATA_DIR/
+            if [ ! $? -eq 0 ] ;
+            then
+            exit $?
+            fi
+            time sync
+            fi
+
+            # Mark migration
+            echo "Creating migration successful marker file $MIGRATION_MARKER"
+            touch $MIGRATION_MARKER
+      else
+            echo "$MIGRATION_MARKER is present. Skipping migration."
+      fi
+    }
+
+    # Do migration
+    migrate_data
+    # Do validation and bootstrap
     if [ ! -f $VALIDATION_MARKER ] ;
     then
           echo "No $VALIDATION_MARKER file. Perform complete initialization routine and start etcd."

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-client-service.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-client-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-{{ .Values.role }}-client
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: etcd-statefulset
+    role: {{ .Values.role }}
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  selector:
+    app: etcd-statefulset
+    role: {{ .Values.role }}
+  ports:
+  - name: client
+    protocol: TCP
+    port: 2379
+    targetPort: 2379

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
@@ -85,11 +85,11 @@ spec:
           protocol: TCP
         resources:
           requests:
-            cpu: 200m
-            memory: 500Mi
+            cpu: 500m
+            memory: 1000Mi
           limits:
-            cpu: 1000m
-            memory: 2560Mi
+            cpu: 2500m
+            memory: 3584Mi
         volumeMounts:
         - name: etcd-{{ .Values.role }}
           mountPath: /var/etcd/data

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
@@ -73,10 +73,15 @@ spec:
             cpu: 2500m
             memory: 4Gi
         volumeMounts:
+{{- if eq .Values.role "main" }}
         - name: etcd-{{ .Values.role }}
           mountPath: /var/etcd/old-data
         - name: {{ .Values.role }}-etcd
           mountPath: /var/etcd/data
+{{- else }}
+        - name: etcd-{{ .Values.role }}
+          mountPath: /var/etcd/data
+{{- end}}
         - name: etcd-bootstrap
           mountPath: /bootstrap
         - name: ca-etcd
@@ -124,8 +129,13 @@ spec:
 {{ toYaml .Values.backup.env | indent 8 }}
 {{- end }}
         volumeMounts:
+{{- if eq .Values.role "main" }}
         - name: {{ .Values.role }}-etcd
           mountPath: /var/etcd/data
+{{- else }}
+        - name: etcd-{{ .Values.role }}
+          mountPath: /var/etcd/data
+{{- end}}
         - name: ca-etcd
           mountPath: /var/etcd/ssl/ca
         - name: etcd-client-tls
@@ -153,6 +163,7 @@ spec:
           secretName: {{ .Values.backup.backupSecret }}
 {{- end }}
   volumeClaimTemplates:
+{{- if eq .Values.role "main" }}
   - metadata:
       name: {{ .Values.role }}-etcd
     spec:
@@ -162,6 +173,7 @@ spec:
       resources:
         requests:
           storage: {{ .Values.storageCapacity }}
+{{- end }}
   - metadata:
       name: etcd-{{ .Values.role }}
     spec:

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
@@ -41,7 +41,7 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 15
+          initialDelaySeconds: 5
           periodSeconds: 5
         livenessProbe:
           exec:

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
@@ -1,26 +1,8 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: etcd-{{ .Values.role }}-client
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: etcd-statefulset
-    role: {{ .Values.role }}
-spec:
-  type: ClusterIP
-  sessionAffinity: None
-  selector:
-    app: etcd-statefulset
-    role: {{ .Values.role }}
-  ports:
-  - name: client
-    protocol: TCP
-    port: 2379
-    targetPort: 2379
----
 apiVersion: {{ include "statefulsetversion" . }}
 kind: StatefulSet
 metadata:
+  annotations:
+    "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
   name: etcd-{{ .Values.role }}
   namespace: {{ .Release.Namespace }}
   labels:
@@ -89,9 +71,11 @@ spec:
             memory: 1000Mi
           limits:
             cpu: 2500m
-            memory: 3584Mi
+            memory: 4Gi
         volumeMounts:
         - name: etcd-{{ .Values.role }}
+          mountPath: /var/etcd/old-data
+        - name: {{ .Values.role }}-etcd
           mountPath: /var/etcd/data
         - name: etcd-bootstrap
           mountPath: /bootstrap
@@ -132,7 +116,7 @@ spec:
             memory: 128Mi
           limits:
             cpu: 500m
-            memory: 1.5Gi
+            memory: 2Gi
         env:
         - name: STORAGE_CONTAINER
           value: {{ .Values.backup.storageContainer }}
@@ -140,7 +124,7 @@ spec:
 {{ toYaml .Values.backup.env | indent 8 }}
 {{- end }}
         volumeMounts:
-        - name: etcd-{{ .Values.role }}
+        - name: {{ .Values.role }}-etcd
           mountPath: /var/etcd/data
         - name: ca-etcd
           mountPath: /var/etcd/ssl/ca
@@ -169,6 +153,15 @@ spec:
           secretName: {{ .Values.backup.backupSecret }}
 {{- end }}
   volumeClaimTemplates:
+  - metadata:
+      name: {{ .Values.role }}-etcd
+    spec:
+      accessModes:
+      - "ReadWriteOnce"
+      storageClassName: {{ .Values.storageClassName }}
+      resources:
+        requests:
+          storage: {{ .Values.storageCapacity }}
   - metadata:
       name: etcd-{{ .Values.role }}
     spec:

--- a/charts/seed-controlplane/charts/etcd/values.yaml
+++ b/charts/seed-controlplane/charts/etcd/values.yaml
@@ -6,6 +6,8 @@ images:
   etcd-backup-restore: image-repository:image-tag
 
 storage: 10Gi
+storageClassName: default
+storageCapacity: 16Gi
 
 backup:
   schedule: "0 */24 * * *" # cron standard schedule

--- a/charts/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/shoot-storageclasses/templates/storageclasses.yaml
@@ -4,7 +4,6 @@ apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
   name: {{ $storageClass.Name }}
-  namespace: {{ $.Release.Namespace }}
   {{- if $storageClass.IsDefaultClass }}
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"

--- a/charts/utils-templates/templates/_versions.tpl
+++ b/charts/utils-templates/templates/_versions.tpl
@@ -87,3 +87,11 @@ networking.k8s.io/v1beta1
 extensions/v1beta1
 {{- end -}}
 {{- end -}}
+
+{{- define "storageclassversion" -}}
+{{- if semverCompare ">= 1.13-0" .Capabilities.KubeVersion.GitVersion -}}
+storage.k8s.io/v1
+{{- else -}}
+storage.k8s.io/v1beta1
+{{- end -}}
+{{- end -}}

--- a/docs/usage/supported_k8s_versions.md
+++ b/docs/usage/supported_k8s_versions.md
@@ -10,9 +10,7 @@ The reason for that is that the least supported Kubernetes version in Gardener i
 ## Seed cluster versions
 
 :warning: The minimum version of a seed cluster that can be connected to Gardener is **`1.11.x`**.
-The reason for that is that we require CRD status subresources for the extension controllers that we install into the seeds.
-CRD status subresources are alpha in `1.10` and can be enabled with the `CustomResourceSubresources` feature gate.
-They are enabled by default in `1.11`. Also, we install VPA as a part of controlplane component with version 0.5.0, which does not work on kubernetes version below `1.11`.
+The reason for that is that we require CRD status subresources for the extension controllers that we install into the seeds. They are enabled by default in `1.11`. Also, we install VPA as a part of controlplane component with version 0.5.0, which does not work on kubernetes version below `1.11`.
 
 ## Shoot cluster versions
 

--- a/docs/usage/supported_k8s_versions.md
+++ b/docs/usage/supported_k8s_versions.md
@@ -9,10 +9,10 @@ The reason for that is that the least supported Kubernetes version in Gardener i
 
 ## Seed cluster versions
 
-:warning: The minimum version of a seed cluster that can be connected to Gardener is **`1.10.x`**.
+:warning: The minimum version of a seed cluster that can be connected to Gardener is **`1.11.x`**.
 The reason for that is that we require CRD status subresources for the extension controllers that we install into the seeds.
 CRD status subresources are alpha in `1.10` and can be enabled with the `CustomResourceSubresources` feature gate.
-They are enabled by default in `1.11`. We allow `1.10` but users must make sure that the feature gate is enabled in this case.
+They are enabled by default in `1.11`. Also, we install VPA as a part of controlplane component with version 0.5.0, which does not work on kubernetes version below `1.11`.
 
 ## Shoot cluster versions
 

--- a/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
@@ -129,10 +129,14 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 			Fn:           flow.SimpleTaskFn(botanist.WaitUntilBackupInfrastructureReconciled).DoIf(isCloud),
 			Dependencies: flow.NewTaskIDs(deployBackupInfrastructure),
 		})
+		deployETCDStorageClass = g.Add(flow.Task{
+			Name: "Deploying storageclass for etcd",
+			Fn:   flow.SimpleTaskFn(hybridBotanist.DeployETCDStorageClass).RetryUntilTimeout(defaultInterval, defaultTimeout),
+		})
 		deployETCD = g.Add(flow.Task{
 			Name:         "Deploying main and events etcd",
 			Fn:           flow.SimpleTaskFn(hybridBotanist.DeployETCD).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(deploySecrets, deployCloudProviderSecret, waitUntilBackupInfrastructureReconciled),
+			Dependencies: flow.NewTaskIDs(deploySecrets, deployCloudProviderSecret, waitUntilBackupInfrastructureReconciled, deployETCDStorageClass),
 		})
 		waitUntilEtcdReady = g.Add(flow.Task{
 			Name:         "Waiting until main and event etcd report readiness",

--- a/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
@@ -131,7 +131,7 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 		})
 		deployETCDStorageClass = g.Add(flow.Task{
 			Name: "Deploying storageclass for etcd",
-			Fn:   flow.SimpleTaskFn(hybridBotanist.DeployETCDStorageClass).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:   flow.TaskFn(hybridBotanist.DeployETCDStorageClass).RetryUntilTimeout(defaultInterval, defaultTimeout),
 		})
 		deployETCD = g.Add(flow.Task{
 			Name:         "Deploying main and events etcd",

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -89,15 +89,15 @@ func (b *Botanist) WaitUntilEtcdReady() error {
 }
 
 // WaitUntilEtcdStatefulsetDeleted waits until the etcd statefulsets get deleted.
-func (b *Botanist) WaitUntilEtcdStatefulsetDeleted(role string) error {
-	return wait.Poll(5*time.Second, 300*time.Second, func() (bool, error) {
+func (b *Botanist) WaitUntilEtcdStatefulsetDeleted(ctx context.Context, role string) error {
+	return wait.PollUntil(5*time.Second, func() (bool, error) {
 		b.Logger.Infof("Waiting until the etcd-%s statefulset get deleted...", role)
 		_, err := b.K8sSeedClient.Kubernetes().AppsV1().StatefulSets(b.Shoot.SeedNamespace).Get(fmt.Sprintf("etcd-%s", role), metav1.GetOptions{})
 		if err != nil && apierrors.IsNotFound(err) {
 			return true, nil
 		}
 		return false, err
-	})
+	}, ctx.Done())
 }
 
 // WaitUntilKubeAPIServerReady waits until the kube-apiserver pod(s) indicate readiness in their statuses.

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -24,7 +24,6 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,6 +85,18 @@ func (b *Botanist) WaitUntilEtcdReady() error {
 
 		b.Logger.Info("Waiting until the both etcd statefulsets are ready...")
 		return false, nil
+	})
+}
+
+// WaitUntilEtcdStatefulsetDeleted waits until the etcd statefulsets get deleted.
+func (b *Botanist) WaitUntilEtcdStatefulsetDeleted(role string) error {
+	return wait.Poll(5*time.Second, 300*time.Second, func() (bool, error) {
+		b.Logger.Infof("Waiting until the etcd-%s statefulset get deleted...", role)
+		_, err := b.K8sSeedClient.Kubernetes().AppsV1().StatefulSets(b.Shoot.SeedNamespace).Get(fmt.Sprintf("etcd-%s", role), metav1.GetOptions{})
+		if err != nil && apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
 	})
 }
 

--- a/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go
@@ -129,6 +129,22 @@ func (b *AlicloudBotanist) GenerateKubeSchedulerConfig() (map[string]interface{}
 	return nil, nil
 }
 
+// GenerateETCDStorageClassConfig generates values which are required to create etcd volume storageclass properly.
+func (b *AlicloudBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"name":        "etcd-fast",
+		"capacity":    "25Gi",
+		"provisioner": "csi-diskplugin",
+		"parameters": map[string]interface{}{
+			"regionId": b.Shoot.Info.Spec.Cloud.Region,
+			"zoneId":   b.Shoot.Info.Spec.Cloud.Alicloud.Zones[0],
+			"fsType":   "ext4",
+			"type":     "cloud_ssd",
+			"readOnly": "false",
+		},
+	}
+}
+
 // GenerateEtcdBackupConfig returns the etcd backup configuration for the etcd Helm chart.
 func (b *AlicloudBotanist) GenerateEtcdBackupConfig() (map[string][]byte, map[string]interface{}, error) {
 	tf, err := b.NewBackupInfrastructureTerraformer()

--- a/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go
@@ -132,15 +132,13 @@ func (b *AlicloudBotanist) GenerateKubeSchedulerConfig() (map[string]interface{}
 // GenerateETCDStorageClassConfig generates values which are required to create etcd volume storageclass properly.
 func (b *AlicloudBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"name":        "etcd-fast",
+		"name":        "gardener.cloud-fast",
 		"capacity":    "25Gi",
-		"provisioner": "csi-diskplugin",
+		"provisioner": "diskplugin.csi.alibabacloud.com",
 		"parameters": map[string]interface{}{
-			"regionId": b.Shoot.Info.Spec.Cloud.Region,
-			"zoneId":   b.Shoot.Info.Spec.Cloud.Alicloud.Zones[0],
-			"fsType":   "ext4",
-			"type":     "cloud_ssd",
-			"readOnly": "false",
+			"csi.storage.k8s.io/fstype": "ext4",
+			"type":                      "cloud_ssd",
+			"readOnly":                  "false",
 		},
 	}
 }

--- a/pkg/operation/cloudbotanist/awsbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/awsbotanist/controlplane.go
@@ -151,6 +151,18 @@ func getAWSCredentialsEnvironment() []map[string]interface{} {
 	}
 }
 
+// GenerateETCDStorageClassConfig generates values which are required to create etcd volume storageclass properly.
+func (b *AWSBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"name":        "etcd-fast",
+		"capacity":    "80Gi",
+		"provisioner": "kubernetes.io/aws-ebs",
+		"parameters": map[string]interface{}{
+			"type": "gp2",
+		},
+	}
+}
+
 // GenerateEtcdBackupConfig returns the etcd backup configuration for the etcd Helm chart.
 func (b *AWSBotanist) GenerateEtcdBackupConfig() (map[string][]byte, map[string]interface{}, error) {
 	bucketName := "bucketName"

--- a/pkg/operation/cloudbotanist/awsbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/awsbotanist/controlplane.go
@@ -154,7 +154,7 @@ func getAWSCredentialsEnvironment() []map[string]interface{} {
 // GenerateETCDStorageClassConfig generates values which are required to create etcd volume storageclass properly.
 func (b *AWSBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"name":        "etcd-fast",
+		"name":        "gardener.cloud-fast",
 		"capacity":    "80Gi",
 		"provisioner": "kubernetes.io/aws-ebs",
 		"parameters": map[string]interface{}{

--- a/pkg/operation/cloudbotanist/azurebotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/azurebotanist/controlplane.go
@@ -176,6 +176,19 @@ func (b *AzureBotanist) GenerateKubeSchedulerConfig() (map[string]interface{}, e
 	return nil, nil
 }
 
+// GenerateETCDStorageClassConfig generates values which are required to create etcd volume storageclass properly.
+func (b *AzureBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"name":        "etcd-fast",
+		"capacity":    "33Gi",
+		"provisioner": "kubernetes.io/azure-disk",
+		"parameters": map[string]interface{}{
+			"storageaccounttype": "Premium_LRS",
+			"kind":               "managed",
+		},
+	}
+}
+
 // GenerateEtcdBackupConfig returns the etcd backup configuration for the etcd Helm chart.
 func (b *AzureBotanist) GenerateEtcdBackupConfig() (map[string][]byte, map[string]interface{}, error) {
 	var (

--- a/pkg/operation/cloudbotanist/azurebotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/azurebotanist/controlplane.go
@@ -179,7 +179,7 @@ func (b *AzureBotanist) GenerateKubeSchedulerConfig() (map[string]interface{}, e
 // GenerateETCDStorageClassConfig generates values which are required to create etcd volume storageclass properly.
 func (b *AzureBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"name":        "etcd-fast",
+		"name":        "gardener.cloud-fast",
 		"capacity":    "33Gi",
 		"provisioner": "kubernetes.io/azure-disk",
 		"parameters": map[string]interface{}{

--- a/pkg/operation/cloudbotanist/gcpbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/gcpbotanist/controlplane.go
@@ -136,6 +136,18 @@ func (b *GCPBotanist) GenerateKubeSchedulerConfig() (map[string]interface{}, err
 	return nil, nil
 }
 
+// GenerateETCDStorageClassConfig generates values which are required to create etcd volume storageclass properly.
+func (b *GCPBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"name":        "etcd-fast",
+		"capacity":    "25Gi",
+		"provisioner": "kubernetes.io/gce-pd",
+		"parameters": map[string]interface{}{
+			"type": "pd-ssd",
+		},
+	}
+}
+
 // GenerateEtcdBackupConfig returns the etcd backup configuration for the etcd Helm chart.
 func (b *GCPBotanist) GenerateEtcdBackupConfig() (map[string][]byte, map[string]interface{}, error) {
 	var (

--- a/pkg/operation/cloudbotanist/gcpbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/gcpbotanist/controlplane.go
@@ -139,7 +139,7 @@ func (b *GCPBotanist) GenerateKubeSchedulerConfig() (map[string]interface{}, err
 // GenerateETCDStorageClassConfig generates values which are required to create etcd volume storageclass properly.
 func (b *GCPBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"name":        "etcd-fast",
+		"name":        "gardener.cloud-fast",
 		"capacity":    "25Gi",
 		"provisioner": "kubernetes.io/gce-pd",
 		"parameters": map[string]interface{}{

--- a/pkg/operation/cloudbotanist/localbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/localbotanist/controlplane.go
@@ -88,7 +88,7 @@ func (b *LocalBotanist) GenerateKubeSchedulerConfig() (map[string]interface{}, e
 // GenerateETCDStorageClassConfig generates values which are required to create etcd volume storageclass properly.
 func (b *LocalBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"name":        "etcd-fast",
+		"name":        "gardener.cloud-fast",
 		"capacity":    "25Gi",
 		"provisioner": "k8s.io/minikube-hostpath",
 		"parameters":  map[string]interface{}{},

--- a/pkg/operation/cloudbotanist/localbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/localbotanist/controlplane.go
@@ -85,6 +85,16 @@ func (b *LocalBotanist) GenerateKubeSchedulerConfig() (map[string]interface{}, e
 	return nil, nil
 }
 
+// GenerateETCDStorageClassConfig generates values which are required to create etcd volume storageclass properly.
+func (b *LocalBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"name":        "etcd-fast",
+		"capacity":    "25Gi",
+		"provisioner": "k8s.io/minikube-hostpath",
+		"parameters":  map[string]interface{}{},
+	}
+}
+
 // GenerateEtcdBackupConfig returns the etcd backup configuration for the etcd Helm chart.
 func (b *LocalBotanist) GenerateEtcdBackupConfig() (map[string][]byte, map[string]interface{}, error) {
 	backupConfigData := map[string]interface{}{

--- a/pkg/operation/cloudbotanist/openstackbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/openstackbotanist/controlplane.go
@@ -158,6 +158,19 @@ func (b *OpenStackBotanist) GenerateKubeSchedulerConfig() (map[string]interface{
 	return nil, nil
 }
 
+// GenerateETCDStorageClassConfig generates values which are required to create etcd volume storageclass properly.
+func (b *OpenStackBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
+	return map[string]interface{}{
+		"name":        "etcd-fast",
+		"capacity":    "25Gi",
+		"provisioner": "kubernetes.io/cinder",
+		"parameters": map[string]interface{}{
+			"availability": b.Shoot.Info.Spec.Cloud.OpenStack.Zones[0],
+		},
+	}
+
+}
+
 // GenerateEtcdBackupConfig returns the etcd backup configuration for the etcd Helm chart.
 func (b *OpenStackBotanist) GenerateEtcdBackupConfig() (map[string][]byte, map[string]interface{}, error) {
 	containerName := "containerName"

--- a/pkg/operation/cloudbotanist/openstackbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/openstackbotanist/controlplane.go
@@ -161,12 +161,10 @@ func (b *OpenStackBotanist) GenerateKubeSchedulerConfig() (map[string]interface{
 // GenerateETCDStorageClassConfig generates values which are required to create etcd volume storageclass properly.
 func (b *OpenStackBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"name":        "etcd-fast",
+		"name":        "gardener.cloud-fast",
 		"capacity":    "25Gi",
 		"provisioner": "kubernetes.io/cinder",
-		"parameters": map[string]interface{}{
-			"availability": b.Shoot.Info.Spec.Cloud.OpenStack.Zones[0],
-		},
+		"parameters":  map[string]interface{}{},
 	}
 
 }

--- a/pkg/operation/cloudbotanist/types.go
+++ b/pkg/operation/cloudbotanist/types.go
@@ -35,6 +35,7 @@ type CloudBotanist interface {
 	GenerateCloudProviderConfig() (string, error)
 	RefreshCloudProviderConfig(map[string]string) map[string]string
 	GenerateCloudConfigUserDataConfig() *common.CloudConfigUserDataConfig
+	GenerateETCDStorageClassConfig() map[string]interface{}
 	GenerateEtcdBackupConfig() (map[string][]byte, map[string]interface{}, error)
 	GenerateKubeAPIServerServiceConfig() (map[string]interface{}, error)
 	GenerateKubeAPIServerExposeConfig() (map[string]interface{}, error)

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -106,8 +106,17 @@ func getResourcesForAPIServer(nodeCount int) (string, string, string, string) {
 	return cpuRequest, memoryRequest, cpuLimit, memoryLimit
 }
 
+// DeployETCDStorageClass create the high iops storageclass required for volume used by etcd pods in seed cluster.
+func (b *HybridBotanist) DeployETCDStorageClass() error {
+	storageClassConfig := b.SeedCloudBotanist.GenerateETCDStorageClassConfig()
+	if err := b.ApplyChartSeed(filepath.Join(chartPathControlPlane, "etcd-storageclass"), b.Shoot.SeedNamespace, "etcd-storageclass", nil, storageClassConfig); err != nil {
+		return err
+	}
+	return nil
+}
+
 // DeployETCD deploys two etcd clusters via StatefulSets. The first etcd cluster (called 'main') is used for all the
-/// data the Shoot Kubernetes cluster needs to store, whereas the second etcd luster (called 'events') is only used to
+// data the Shoot Kubernetes cluster needs to store, whereas the second etcd luster (called 'events') is only used to
 // store the events data. The objectstore is also set up to store the backups.
 func (b *HybridBotanist) DeployETCD() error {
 	secretData, backupConfigData, err := b.SeedCloudBotanist.GenerateEtcdBackupConfig()
@@ -122,16 +131,19 @@ func (b *HybridBotanist) DeployETCD() error {
 		}
 	}
 
+	storageClassConfig := b.SeedCloudBotanist.GenerateETCDStorageClassConfig()
 	etcdConfig := map[string]interface{}{
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-etcd-ca":         b.CheckSums[gardencorev1alpha1.SecretNameCAETCD],
 			"checksum/secret-etcd-server-tls": b.CheckSums["etcd-server-tls"],
 			"checksum/secret-etcd-client-tls": b.CheckSums["etcd-client-tls"],
 		},
-		"storage": b.Seed.GetValidVolumeSize("10Gi"),
 		"vpa": map[string]interface{}{
 			"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
 		},
+		"storage":          b.Seed.GetValidVolumeSize("10Gi"),
+		"storageClassName": storageClassConfig["name"].(string),
+		"storageCapacity":  storageClassConfig["capacity"].(string),
 	}
 
 	// Some cloud botanists do not yet support backup and won't return backup config data.
@@ -167,7 +179,19 @@ func (b *HybridBotanist) DeployETCD() error {
 		}
 
 		if err := b.ApplyChartSeed(filepath.Join(chartPathControlPlane, "etcd"), b.Shoot.SeedNamespace, fmt.Sprintf("etcd-%s", role), nil, etcd); err != nil {
-			return err
+			if apierrors.IsInvalid(err) {
+				if err := b.K8sSeedClient.DeleteStatefulSet(b.Shoot.SeedNamespace, fmt.Sprintf("etcd-%s", role)); err != nil && !apierrors.IsNotFound(err) {
+					return err
+				}
+				if err := b.Botanist.WaitUntilEtcdStatefulsetDeleted(role); err != nil {
+					return err
+				}
+				if err := b.ApplyChartSeed(filepath.Join(chartPathControlPlane, "etcd"), b.Shoot.SeedNamespace, fmt.Sprintf("etcd-%s", role), nil, etcd); err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
 		}
 		if err := b.K8sSeedClient.DeleteService(b.Shoot.SeedNamespace, fmt.Sprintf("etcd-%s", role)); err != nil && !apierrors.IsNotFound(err) {
 			return err


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Upgraded the etcd-backup-restore image version from 0.5.2 -> 0.6.0
2. Adds the required bootstrap script changes with etcd-backup-restore version update to gardener. This will avoid on DB directory validation time on etcd restart, post graceful deletion. 
3. Creates new etcd volumes specific storage class and migrate data form old PV to new PV.
4. Increase the resource  limit on etcd and backup-restore container. Etcd requires ~3.5Gi+ memory with e2e test. So, memory limit set to 4Gi. (cc @shreyas-s-rao )
5. Adds annotation `"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"` to etcd pods, so that cluster autoscaler will not remove nodes on which etcd will be running.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/etcd-backup-restore/issues/142

**Special notes for your reviewer**:
The old volumes remaining with default storage class will be removed in next release. Where migration part in script will be removed. 
Though i have tested for all cloud providers. Please check again for all cloud providers.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
``` improvement operator github.com/gardener/etcd-backup-restore #157 @shreyas-s-rao
Optimized WAL verification memory usage.
```

``` noteworthy user github.com/gardener/etcd-backup-restore #157 @shreyas-s-rao
Updated etcd vendoring version to 3.3.13.
```

``` noteworthy user github.com/gardener/etcd-backup-restore #157 @shreyas-s-rao
Full snapshot on etcd startup will now be deferred in favour of an initial delta snapshot, followed by a full snapshot and subsequent delta snapshots.
```

``` improvement operator github.com/gardener/etcd-backup-restore #153 @shreyas-s-rao
Reduced etcd downtime by optimizing readiness probe.
```

``` improvement operator github.com/gardener/etcd-backup-restore #153 @shreyas-s-rao
Updated the base image of alpine in docker container to 3.9.3.
```

``` noteworthy user github.com/gardener/etcd-backup-restore #134 @shreyas-s-rao
Added the `embedded-etcd-quota-bytes` flag to allow configuring the backend quota size of the embedded etcd instance used during restoration of data.
```

``` improvement operator github.com/gardener/etcd-backup-restore #132 @ialidzhikov
The golang version has been upgraded to `v1.12.0`.
```

``` improvement operator github.com/gardener/etcd-backup-restore #122 @swapnilgm
In case of storage provider is not configured, i.e. backup disabled, we skip the backup dependent sanity checks.
```

``` noteworthy user github.com/gardener/etcd-backup-restore #93 @georgekuruvillak
Unnecessary data validation will now be skipped, allowing for quicker etcd restarts.
```

```noteworthy operator
PVC for etcd-main `StatefulSet` will now use `gardener.cloud-fast` storage class which will be configured to have fast cloud provider disks with more IOPS. The size of PV attached to etcd-main pods will differ per cloud provider.
:warning: Seed infrastructure account will now have one additional volumes per shoot; one extra for etcd-main. The old etcd volumes will continue to exist and will be cleaned up with next Gardener release.
```

```noteworthy operator
Etcd pods will be marked with annotation `cluster-autoscaler.kubernetes.io/safe-to-evict=false`, hence, seed nodes on which etcd is scheduled will be refrained for removal by cluster autoscale in case of scale down. 
```

```action operator
Minimum supported version for seed cluster is now `1.11.x`.  Before updating to this Gardener version you will have to update seed cluster to at least Kubernetes version `1.11.x`.
```
cc: @amshuman-kr  @vlerenc @PadmaB 