### PR TITLE
Allow configuration of authentication mode for kubernetes-dashboard

### DIFF
--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         args:
           - --auto-generate-certificates
-          - --authentication-mode=basic
+          - --authentication-mode={{ .Values.authenticationMode }}
 {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 10 }}
 {{- end }}

--- a/charts/shoot-addons/charts/kubernetes-dashboard/values.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/values.yaml
@@ -13,6 +13,8 @@ httpsPort: 443
 
 serviceType: ClusterIP
 
+authenticationMode: basic
+
 resources:
   requests:
     cpu: 50m

--- a/example/90-shoot-alicloud.yaml
+++ b/example/90-shoot-alicloud.yaml
@@ -116,6 +116,7 @@ spec:
       loadBalancerSourceRanges: []
     kubernetes-dashboard:
       enabled: true
+    # authenticationMode: basic # allowed values: basic,token
     # Heapster addon is deprecated and no longer supported. Gardener deploys the Kubernetes metrics-server
     # into the kube-system namespace of shoots (cannot be turned off) for fetching metrics and enabling
     # horizontal pod auto-scaling.

--- a/example/90-shoot-aws.yaml
+++ b/example/90-shoot-aws.yaml
@@ -120,6 +120,7 @@ spec:
       loadBalancerSourceRanges: []
     kubernetes-dashboard:
       enabled: true
+    # authenticationMode: basic # allowed values: basic,token
     # kube2iam addon is still supported but deprecated.
     # This field will be removed in the future. You should deploy kube2iam as well as
     # the desired AWS IAM roles on your own instead of enabling it here. Please do not

--- a/example/90-shoot-azure.yaml
+++ b/example/90-shoot-azure.yaml
@@ -119,6 +119,7 @@ spec:
       loadBalancerSourceRanges: []
     kubernetes-dashboard:
       enabled: true
+    # authenticationMode: basic # allowed values: basic,token
     # Heapster addon is deprecated and no longer supported. Gardener deploys the Kubernetes metrics-server
     # into the kube-system namespace of shoots (cannot be turned off) for fetching metrics and enabling
     # horizontal pod auto-scaling.

--- a/example/90-shoot-gcp.yaml
+++ b/example/90-shoot-gcp.yaml
@@ -118,6 +118,7 @@ spec:
       loadBalancerSourceRanges: []
     kubernetes-dashboard:
       enabled: true
+    # authenticationMode: basic # allowed values: basic,token
     # Heapster addon is deprecated and no longer supported. Gardener deploys the Kubernetes metrics-server
     # into the kube-system namespace of shoots (cannot be turned off) for fetching metrics and enabling
     # horizontal pod auto-scaling.

--- a/example/90-shoot-local.yaml
+++ b/example/90-shoot-local.yaml
@@ -101,6 +101,7 @@ spec:
       loadBalancerSourceRanges: []
     kubernetes-dashboard:
       enabled: true
+    # authenticationMode: basic # allowed values: basic,token
     # Heapster addon is deprecated and no longer supported. Gardener deploys the Kubernetes metrics-server
     # into the kube-system namespace of shoots (cannot be turned off) for fetching metrics and enabling
     # horizontal pod auto-scaling.

--- a/example/90-shoot-openstack.yaml
+++ b/example/90-shoot-openstack.yaml
@@ -117,6 +117,7 @@ spec:
       loadBalancerSourceRanges: []
     kubernetes-dashboard:
       enabled: true
+    # authenticationMode: basic # allowed values: basic,token
     # Heapster addon is deprecated and no longer supported. Gardener deploys the Kubernetes metrics-server
     # into the kube-system namespace of shoots (cannot be turned off) for fetching metrics and enabling
     # horizontal pod auto-scaling.

--- a/example/90-shoot-packet.yaml
+++ b/example/90-shoot-packet.yaml
@@ -111,6 +111,7 @@ spec:
       loadBalancerSourceRanges: []
     kubernetes-dashboard:
       enabled: true
+    # authenticationMode: basic # allowed values: basic,token
     # Heapster addon is deprecated and no longer supported. Gardener deploys the Kubernetes metrics-server
     # into the kube-system namespace of shoots (cannot be turned off) for fetching metrics and enabling
     # horizontal pod auto-scaling.

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -351,6 +351,7 @@ spec:
       loadBalancerSourceRanges: ${value("spec.addons.nginx-ingress.loadBalancerSourceRanges", [])}
     kubernetes-dashboard:
       enabled: ${value("spec.addons.kubernetes-dashboard.enabled", "true")}
+    # authenticationMode: basic # allowed values: basic,token
   % if cloud == "aws":
     # kube2iam addon is still supported but deprecated.
     # This field will be removed in the future. You should deploy kube2iam as well as

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -1153,6 +1153,9 @@ type Heapster struct {
 // KubernetesDashboard describes configuration values for the kubernetes-dashboard addon.
 type KubernetesDashboard struct {
 	Addon
+	// AuthenticationMode defines the authentication mode for the kubernetes-dashboard.
+	// +optional
+	AuthenticationMode *string
 }
 
 // ClusterAutoscaler describes configuration values for the cluster-autoscaler addon.

--- a/pkg/apis/garden/v1beta1/defaults.go
+++ b/pkg/apis/garden/v1beta1/defaults.go
@@ -193,6 +193,15 @@ func SetDefaults_Project(obj *Project) {
 	}
 }
 
+// SetDefaults_KubernetesDashboard sets default values for KubernetesDashboard objects.
+func SetDefaults_KubernetesDashboard(obj *KubernetesDashboard) {
+	defaultAuthMode := "basic"
+	if obj.AuthenticationMode == nil {
+		obj.AuthenticationMode = &defaultAuthMode
+	}
+}
+
+// SetDefaults_Worker sets default values for Worker objects.
 func SetDefaults_Worker(obj *Worker) {
 	if obj.MaxSurge == nil {
 		obj.MaxSurge = &DefaultWorkerMaxSurge

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -1149,6 +1149,9 @@ type Heapster struct {
 // KubernetesDashboard describes configuration values for the kubernetes-dashboard addon.
 type KubernetesDashboard struct {
 	Addon `json:",inline"`
+	// AuthenticationMode defines the authentication mode for the kubernetes-dashboard.
+	// +optional
+	AuthenticationMode *string `json:"authenticationMode,omitempty"`
 }
 
 // ClusterAutoscaler describes configuration values for the cluster-autoscaler addon.

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -3266,6 +3266,7 @@ func autoConvert_v1beta1_KubernetesDashboard_To_garden_KubernetesDashboard(in *K
 	if err := Convert_v1beta1_Addon_To_garden_Addon(&in.Addon, &out.Addon, s); err != nil {
 		return err
 	}
+	out.AuthenticationMode = (*string)(unsafe.Pointer(in.AuthenticationMode))
 	return nil
 }
 
@@ -3278,6 +3279,7 @@ func autoConvert_garden_KubernetesDashboard_To_v1beta1_KubernetesDashboard(in *g
 	if err := Convert_garden_Addon_To_v1beta1_Addon(&in.Addon, &out.Addon, s); err != nil {
 		return err
 	}
+	out.AuthenticationMode = (*string)(unsafe.Pointer(in.AuthenticationMode))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -280,7 +280,7 @@ func (in *Addons) DeepCopyInto(out *Addons) {
 	if in.KubernetesDashboard != nil {
 		in, out := &in.KubernetesDashboard, &out.KubernetesDashboard
 		*out = new(KubernetesDashboard)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	if in.NginxIngress != nil {
 		in, out := &in.NginxIngress, &out.NginxIngress
@@ -1831,6 +1831,11 @@ func (in *KubernetesConstraints) DeepCopy() *KubernetesConstraints {
 func (in *KubernetesDashboard) DeepCopyInto(out *KubernetesDashboard) {
 	*out = *in
 	out.Addon = in.Addon
+	if in.AuthenticationMode != nil {
+		in, out := &in.AuthenticationMode, &out.AuthenticationMode
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.defaults.go
@@ -126,6 +126,11 @@ func SetObjectDefaults_SeedList(in *SeedList) {
 
 func SetObjectDefaults_Shoot(in *Shoot) {
 	SetDefaults_Shoot(in)
+	if in.Spec.Addons != nil {
+		if in.Spec.Addons.KubernetesDashboard != nil {
+			SetDefaults_KubernetesDashboard(in.Spec.Addons.KubernetesDashboard)
+		}
+	}
 	if in.Spec.Cloud.AWS != nil {
 		for i := range in.Spec.Cloud.AWS.Workers {
 			a := &in.Spec.Cloud.AWS.Workers[i]

--- a/pkg/apis/garden/validation/validation.go
+++ b/pkg/apis/garden/validation/validation.go
@@ -45,9 +45,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-var availableProxyMode = sets.NewString(
-	string(garden.ProxyModeIPTables),
-	string(garden.ProxyModeIPVS),
+var (
+	availableProxyMode = sets.NewString(
+		string(garden.ProxyModeIPTables),
+		string(garden.ProxyModeIPVS),
+	)
+	availableKubernetesDashboardAuthenticationModes = sets.NewString(
+		"basic",
+		"token",
+	)
 )
 
 // ValidateName is a helper function for validating that a name is a DNS sub domain.
@@ -1048,6 +1054,12 @@ func validateAddons(addons *garden.Addons, fldPath *field.Path) field.ErrorList 
 	if addons.KubeLego != nil && addons.KubeLego.Enabled {
 		if !utils.TestEmail(addons.KubeLego.Mail) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("kube-lego", "mail"), addons.KubeLego.Mail, "must provide a valid email address when kube-lego is enabled"))
+		}
+	}
+
+	if addons.KubernetesDashboard != nil && addons.KubernetesDashboard.Enabled {
+		if authMode := addons.KubernetesDashboard.AuthenticationMode; authMode != nil && !availableKubernetesDashboardAuthenticationModes.Has(*authMode) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("kubernetes-dashboard", "authenticationMode"), *authMode, availableKubernetesDashboardAuthenticationModes.List()))
 		}
 	}
 

--- a/pkg/apis/garden/validation/validation_test.go
+++ b/pkg/apis/garden/validation/validation_test.go
@@ -1611,7 +1611,7 @@ var _ = Describe("validation", func() {
 					Spec: garden.CloudProfileSpec{
 						Packet: &garden.PacketProfile{
 							Constraints: garden.PacketConstraints{
-								Kubernetes:   kubernetesVersionConstraint,
+								Kubernetes: kubernetesVersionConstraint,
 								MachineImages: []garden.PacketMachineImage{
 									{
 										Name: "Container Linux - Stable",
@@ -2683,26 +2683,31 @@ var _ = Describe("validation", func() {
 				},
 			}
 			shoot.Spec.Addons.KubeLego.Mail = "some-invalid-email"
+			shoot.Spec.Addons.KubernetesDashboard.AuthenticationMode = makeStringPointer("does-not-exist")
 
 			errorList := ValidateShoot(shoot)
 
-			Expect(len(errorList)).To(Equal(4))
-			Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
 				"Field": Equal("spec.addons.kube2iam.roles[0].name"),
-			}))
-			Expect(*errorList[1]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("spec.addons.kube2iam.roles[0].description"),
-			}))
-			Expect(*errorList[2]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("spec.addons.kube2iam.roles[0].policy"),
-			}))
-			Expect(*errorList[3]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("spec.addons.kube-lego.mail"),
-			}))
+			})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.addons.kube2iam.roles[0].description"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.addons.kube2iam.roles[0].policy"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.addons.kube-lego.mail"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeNotSupported),
+					"Field": Equal("spec.addons.kubernetes-dashboard.authenticationMode"),
+				})),
+			))
 		})
 
 		It("should forbid unsupported cloud specification (provider independent)", func() {

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -278,7 +278,7 @@ func (in *Addons) DeepCopyInto(out *Addons) {
 	if in.KubernetesDashboard != nil {
 		in, out := &in.KubernetesDashboard, &out.KubernetesDashboard
 		*out = new(KubernetesDashboard)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	if in.NginxIngress != nil {
 		in, out := &in.NginxIngress, &out.NginxIngress
@@ -1812,6 +1812,11 @@ func (in *KubernetesConstraints) DeepCopy() *KubernetesConstraints {
 func (in *KubernetesDashboard) DeepCopyInto(out *KubernetesDashboard) {
 	*out = *in
 	out.Addon = in.Addon
+	if in.AuthenticationMode != nil {
+		in, out := &in.AuthenticationMode, &out.AuthenticationMode
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -4244,6 +4244,13 @@ func schema_pkg_apis_garden_v1beta1_KubernetesDashboard(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"authenticationMode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AuthenticationMode defines the authentication mode for the kubernetes-dashboard.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"enabled"},
 			},

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -55,7 +55,18 @@ func (b *Botanist) DestroyIngressDNSRecord(ctx context.Context) error {
 // GenerateKubernetesDashboardConfig generates the values which are required to render the chart of
 // the kubernetes-dashboard properly.
 func (b *Botanist) GenerateKubernetesDashboardConfig() (map[string]interface{}, error) {
-	return common.GenerateAddonConfig(nil, b.Shoot.KubernetesDashboardEnabled()), nil
+	var (
+		enabled = b.Shoot.KubernetesDashboardEnabled()
+		values  map[string]interface{}
+	)
+
+	if enabled && b.Shoot.Info.Spec.Addons.KubernetesDashboard.AuthenticationMode != nil {
+		values = map[string]interface{}{
+			"authenticationMode": *b.Shoot.Info.Spec.Addons.KubernetesDashboard.AuthenticationMode,
+		}
+	}
+
+	return common.GenerateAddonConfig(values, enabled), nil
 }
 
 // GenerateKubeLegoConfig generates the values which are required to render the chart of


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow configurability for authentication mode of Kubernetes dashboard.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
The authentication mode of the Kubernetes Dashboard managed by Gardener can now be controlled via `.spec.addons.kubenetes-dashboard.authenticationMode={basic,token}` (defaults to `basic`).
```
