### PR TITLE
Improve coredns containerPorts

### DIFF
--- a/charts/shoot-core/charts/coredns/templates/coredns-deployment.yaml
+++ b/charts/shoot-core/charts/coredns/templates/coredns-deployment.yaml
@@ -50,7 +50,7 @@ spec:
         ports:
         - containerPort: {{ .Values.deployment.spec.containers.ports.dns }}
           name: dns-udp
-          protocol:
+          protocol: UDP
         - containerPort: {{ .Values.deployment.spec.containers.ports.dns }}
           name: dns-tcp
           protocol: TCP


### PR DESCRIPTION
**What this PR does / why we need it**:
Trying to enable the `ServerSideApply` feature gate, noticed on kube-addon-manager side:
```
Error from server: error when creating "/etc/kubernetes/addons/core/..data/shoot-core_charts_coredns_templates_coredns-deployment.yaml": failed to update object (Create for apps/v1, Kind=Deployment) managed fields: failed to create typed new object: .spec.template.spec.containers[name="coredns"].ports: duplicate entries for key [containerPort=8053,protocol="TCP"]
```

The `protocol` fields defaults to TCP.
The PR prevents specifying two ports with same `containerPort` and `protocol`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
