### PR TITLE
Label shooted seeds with `garden.sapcloud.io/role=seed`

### DIFF
--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -117,6 +117,9 @@ func (b *Botanist) RegisterAsSeed(protected, visible *bool, minimumVolumeSize *s
 			Name:            b.Shoot.Info.Name,
 			OwnerReferences: ownerReferences,
 			Annotations:     annotations,
+			Labels: map[string]string{
+				common.GardenRole: common.GardenRoleSeed,
+			},
 		},
 		Spec: gardenv1beta1.SeedSpec{
 			Cloud: gardenv1beta1.SeedCloud{


### PR DESCRIPTION
**What this PR does / why we need it**:
When gardener create seeds from shoots in the `garden` namespace, let it put the label `garden.sapcloud.io/role=seed` on those seed resouces.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
Label shooted seeds with `garden.sapcloud.io/role=seed`
```
