### PR TITLE
Updated Prometheus to scrape more MCM metrics

### DIFF
--- a/charts/seed-monitoring/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/prometheus/values.yaml
@@ -136,6 +136,15 @@ allowedMetrics:
   machineControllerManager:
   - process_max_fds
   - process_open_fds
+  - mcm_machine_controller_frozen
+  - mcm_machine_items_total
+  - mcm_machineset_items_total
+  - mcm_machine_set_failed_machines
+  - mcm_machinedeployment_items_total
+  - mcm_machine_deployment_failed_machines
+  - mcm_cloud_api_requests_total
+  - mcm_cloud_api_requests_failed_total
+  - mcm_scrape_failure_total
   nodeExporter:
   - node_load1
   - node_load5


### PR DESCRIPTION
**What this PR does / why we need it**:
The following is the list of new metrics that Prometheus scrape's from MCM
  - mcm_machine_controller_frozen
  - mcm_machine_items_total
  - mcm_machineset_items_total
  - mcm_machine_set_failed_machines
  - mcm_machinedeployment_items_total
  - mcm_machine_deployment_failed_machines
  - mcm_cloud_api_requests_total
  - mcm_cloud_api_requests_failed_total
  - mcm_scrape_failure_total

**Which issue(s) this PR fixes**:
Partially https://github.com/gardener/machine-controller-manager/issues/211

**Special notes for your reviewer**:
I can see that a couple of MCM metrics are already scraped by the Prometheus. So I have tried to add a few more. This is my first time trying to work with metrics, so please double check that I am doing the right thing. 

Kindly take a look at the metrics currently MCM exposes here - https://github.com/gardener/machine-controller-manager/blob/master/pkg/metrics/metrics.go. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
MCM metrics are exposed to the Prometheus
```
