### PR TITLE
Prevent panic due to invalid type conversion

### DIFF
--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -389,7 +389,7 @@ func DeleteVpa(k8sClient kubernetes.Interface, namespace string) error {
 }
 
 // InjectCSIFeatureGates adds required feature gates for csi when starting Kubelet/Kube-APIServer based on kubernetes version
-func InjectCSIFeatureGates(kubeVersion string, featureGates map[string]interface{}) (map[string]interface{}, error) {
+func InjectCSIFeatureGates(kubeVersion string, featureGates map[string]bool) (map[string]bool, error) {
 	lessV1_13, err := utils.CompareVersions(kubeVersion, "<", "v1.13.0")
 	if err != nil {
 		return featureGates, err
@@ -399,7 +399,7 @@ func InjectCSIFeatureGates(kubeVersion string, featureGates map[string]interface
 	}
 
 	//https://kubernetes-csi.github.io/docs/Setup.html
-	csiFG := map[string]interface{}{
+	csiFG := map[string]bool{
 		"VolumeSnapshotDataSource": true,
 		"KubeletPluginsWatcher":    true,
 		"CSINodeInfo":              true,

--- a/pkg/operation/hybridbotanist/cloud_config.go
+++ b/pkg/operation/hybridbotanist/cloud_config.go
@@ -168,20 +168,16 @@ func (b *HybridBotanist) generateOriginalConfig() (map[string]interface{}, error
 	}
 
 	if b.Shoot.UsesCSI() {
-		var existingFeatureGates map[string]interface{}
-		if fg, ok := kubelet["featureGates"]; !ok {
-			existingFeatureGates = nil
-		} else {
-			existingFeatureGates = fg.(map[string]interface{})
+		var existingFeatureGates map[string]bool
+		if fg, ok := kubelet["featureGates"]; ok {
+			existingFeatureGates = fg.(map[string]bool)
 		}
 
 		featureGates, err := common.InjectCSIFeatureGates(b.ShootVersion(), existingFeatureGates)
 		if err != nil {
 			return nil, err
 		}
-		if featureGates != nil {
-			kubelet["featureGates"] = featureGates
-		}
+		kubelet["featureGates"] = featureGates
 	}
 
 	if caBundle := b.Shoot.CloudProfile.Spec.CABundle; caBundle != nil {

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -366,17 +366,16 @@ func (b *HybridBotanist) DeployKubeAPIServer() error {
 	defaultValues["admissionPlugins"] = admissionPlugins
 
 	if b.Shoot.UsesCSI() {
-		var featureGates map[string]interface{}
-		if defaultValues["featureGates"] != nil {
-			featureGates = defaultValues["featureGates"].(map[string]interface{})
+		var existingFeatureGates map[string]bool
+		if fg, ok := defaultValues["featureGates"]; ok {
+			existingFeatureGates = fg.(map[string]bool)
 		}
-		featureGates, err := common.InjectCSIFeatureGates(b.ShootVersion(), featureGates)
+
+		featureGates, err := common.InjectCSIFeatureGates(b.ShootVersion(), existingFeatureGates)
 		if err != nil {
 			return err
 		}
-		if featureGates != nil {
-			defaultValues["featureGates"] = featureGates
-		}
+		defaultValues["featureGates"] = featureGates
 	} else {
 		// Needed due to https://github.com/kubernetes/kubernetes/pull/73102
 		defaultValues["cloudProvider"] = b.ShootCloudBotanist.GetCloudProviderName()


### PR DESCRIPTION
**What this PR does / why we need it**:

```
panic: interface conversion: interface {} is map[string]bool, not map[string]interface {}

goroutine 91750 [running]:
github.com/gardener/gardener/pkg/operation/hybridbotanist.(*HybridBotanist).DeployKubeAPIServer(0xc005f64d50, 0xc007880af0, 0xc001f4ade8)
        /go/src/github.com/gardener/gardener/pkg/operation/hybridbotanist/controlplane.go:363 +0x32bc
github.com/gardener/gardener/pkg/utils/flow.SimpleTaskFn.func1(0x26b8dc0, 0xc007880ae0, 0x631952e, 0xf0c6dfdf97f21)
        /go/src/github.com/gardener/gardener/pkg/utils/flow/taskfn.go:36 +0x26
github.com/gardener/gardener/pkg/utils/flow.TaskFn.RetryUntilTimeout.func1.1(0xbf27e5328631952e, 0xc7d061b33, 0x4117260)
        /go/src/github.com/gardener/gardener/pkg/utils/flow/taskfn.go:75 +0x37
github.com/gardener/gardener/pkg/utils.RetryUntil(0x26b8dc0, 0xc007880ae0, 0x12a05f200, 0xc00ccff360, 0xc007880ae0, 0xc00c6d8690)
        /go/src/github.com/gardener/gardener/pkg/utils/retry.go:119 +0x6a
github.com/gardener/gardener/pkg/utils/flow.TaskFn.RetryUntilTimeout.func1(0x26b8dc0, 0xc007880ae0, 0x0, 0x0)
        /go/src/github.com/gardener/gardener/pkg/utils/flow/taskfn.go:74 +0xfb
github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode.func1(0xc002f1caa0, 0x2329bad, 0x1f, 0x26b8d80, 0xc00005a018)
        /go/src/github.com/gardener/gardener/pkg/utils/flow/flow.go:209 +0x242
created by github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode
        /go/src/github.com/gardener/gardener/pkg/utils/flow/flow.go:204 +0x13b
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
An invalid type conversion that may lead to panics has been fixed.
```
