### PR TITLE
Fix shootapp test and introduce helm version

### DIFF
--- a/test/integration/framework/framework_test.go
+++ b/test/integration/framework/framework_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Framework tests", func() {
 				Logger: logger.AddWriter(logger.NewLogger("info"), GinkgoWriter),
 			}
 
-			err := shootTestOperation.DownloadChartArtifacts(context.TODO(), helm, chartRepo, "stable/redis")
+			err := shootTestOperation.DownloadChartArtifacts(context.TODO(), helm, chartRepo, "stable/redis", "7.0.0")
 			Expect(err).NotTo(HaveOccurred())
 
 			expectedCachePath := filepath.Join(resourcesDir, "repository", "cache", "stable-index.yaml")

--- a/test/integration/framework/helm_utils.go
+++ b/test/integration/framework/helm_utils.go
@@ -34,7 +34,7 @@ const (
 )
 
 // downloadChart downloads a native chart with <name> to <downloadDestination> from <stableRepoURL>
-func downloadChart(ctx context.Context, name, downloadDestination, stableRepoURL string, helmSettings HelmAccess) (string, error) {
+func downloadChart(ctx context.Context, name, version, downloadDestination, stableRepoURL string, helmSettings HelmAccess) (string, error) {
 	providers := getter.All(environment.EnvSettings{})
 	dl := downloader.ChartDownloader{
 		Getters:  providers,
@@ -48,7 +48,7 @@ func downloadChart(ctx context.Context, name, downloadDestination, stableRepoURL
 	}
 
 	// Download the chart
-	filename, _, err := dl.DownloadTo(name, "", downloadDestination)
+	filename, _, err := dl.DownloadTo(name, version, downloadDestination)
 	if err != nil {
 		return "", err
 	}

--- a/test/integration/framework/shoot_app.go
+++ b/test/integration/framework/shoot_app.go
@@ -258,7 +258,7 @@ func (o *GardenerTestOperation) GetCloudProvider() (v1beta1.CloudProvider, error
 }
 
 // DownloadChartArtifacts downloads a helm chart from helm stable repo url available in resources/repositories
-func (o *GardenerTestOperation) DownloadChartArtifacts(ctx context.Context, helm Helm, chartRepoDestination, chartNameToDownload string) error {
+func (o *GardenerTestOperation) DownloadChartArtifacts(ctx context.Context, helm Helm, chartRepoDestination, chartNameToDownload, chartVersionToDownload string) error {
 	exists, err := Exists(chartRepoDestination)
 	if err != nil {
 		return err
@@ -288,7 +288,7 @@ func (o *GardenerTestOperation) DownloadChartArtifacts(ctx context.Context, helm
 	}
 
 	if !chartDownloaded {
-		chartPath, err = downloadChart(ctx, chartNameToDownload, chartRepoDestination, stableRepo.URL, HelmAccess{
+		chartPath, err = downloadChart(ctx, chartNameToDownload, chartVersionToDownload, chartRepoDestination, stableRepo.URL, HelmAccess{
 			HelmPath: helm,
 		})
 		if err != nil {

--- a/test/integration/shoots/applications/shoot_app_test.go
+++ b/test/integration/shoots/applications/shoot_app_test.go
@@ -71,8 +71,9 @@ const (
 	APIServer             = "kube-apiserver"
 	GuestBookTemplateName = "guestbook-app.yaml.tpl"
 
-	helmDeployNamespace = metav1.NamespaceSystem
+	helmDeployNamespace = metav1.NamespaceDefault
 	RedisChart          = "stable/redis"
+	RedisChartVersion   = "7.0.0"
 )
 
 func validateFlags() {
@@ -220,7 +221,7 @@ var _ = Describe("Shoot application testing", func() {
 					},
 				}
 
-				redisSlaveDeploymentToDelete = &appsv1.Deployment{
+				redisSlaveStatefulSetToDelete = &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: helmDeployNamespace,
 						Name:      RedisSalve,
@@ -237,7 +238,7 @@ var _ = Describe("Shoot application testing", func() {
 			err = deleteResource(ctx, redisSlaveServiceToDelete)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = deleteResource(ctx, redisSlaveDeploymentToDelete)
+			err = deleteResource(ctx, redisSlaveStatefulSetToDelete)
 			Expect(err).NotTo(HaveOccurred())
 		}
 		cleanupGuestbook()
@@ -273,7 +274,7 @@ var _ = Describe("Shoot application testing", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Downloading chart artifacts")
-		err = shootTestOperations.DownloadChartArtifacts(ctx, helm, chartRepo, RedisChart)
+		err = shootTestOperations.DownloadChartArtifacts(ctx, helm, chartRepo, RedisChart, RedisChartVersion)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Applying redis chart")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the guestbook test which currently uses the latest stable redis chart.
The latest update of this chart introduced some major changes like changing the slave deployment to a slave statefulset.
In addition, a fixed chart version has been introduced and the namespace is changed from `kube-system` to `default` which fixes the k8s e2e tests.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Add fixed version of charts in the integration tests
```
