### PR TITLE
Add annotation to ignore alerts from a shoot

### DIFF
--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -21,6 +21,7 @@ data:
         seed_api: {{ .Values.seed.apiserver }}
         seed_region: {{ .Values.seed.region }}
         seed_profile: {{ .Values.seed.profile }}
+        ignoreAlerts: {{ .Values.ignoreAlerts }}
     rule_files:
     - /etc/prometheus/rules/*.yaml
     alerting:
@@ -40,6 +41,10 @@ data:
         - source_labels: [ __meta_kubernetes_endpoint_port_name ]
           action: keep
           regex: metrics
+      alert_relabel_configs:
+      - source_labels: [ ignoreAlerts ]
+        regex: true
+        action: drop
     scrape_configs:
     - job_name: kube-etcd3
       scheme: https

--- a/charts/seed-monitoring/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/prometheus/values.yaml
@@ -200,6 +200,8 @@ rules:
     alertmanager:
       enabled: false
 
+ignoreAlerts: false
+
 # object can be any object you want to scale Prometheus on:
 # - number of Pods
 # - number of Nodes

--- a/pkg/apis/garden/v1beta1/helper/helpers.go
+++ b/pkg/apis/garden/v1beta1/helper/helpers.go
@@ -114,6 +114,15 @@ func ShootWantsAlertmanager(shoot *gardenv1beta1.Shoot, secrets map[string]*core
 	return false
 }
 
+// ShootIgnoreAlerts checks if the alerts for the annotated shoot cluster should be ignored.
+func ShootIgnoreAlerts(shoot *gardenv1beta1.Shoot) bool {
+	ignore := false
+	if value, ok := shoot.Annotations[common.GardenIgnoreAlerts]; ok {
+		ignore, _ = strconv.ParseBool(value)
+	}
+	return ignore
+}
+
 // GetShootCloudProviderWorkers retrieves the cloud-specific workers of the given Shoot.
 func GetShootCloudProviderWorkers(cloudProvider gardenv1beta1.CloudProvider, shoot *gardenv1beta1.Shoot) []gardenv1beta1.Worker {
 	var (

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -353,6 +353,7 @@ func (b *Botanist) DeploySeedMonitoring() error {
 			"vpa": map[string]interface{}{
 				"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
 			},
+			"ignoreAlerts": b.Shoot.IgnoreAlerts,
 		}
 		kubeStateMetricsSeedConfig = map[string]interface{}{
 			"replicas": b.Shoot.GetReplicas(1),

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -163,6 +163,10 @@ const (
 	// is used to send alerts to.
 	GardenOperatedBy = "garden.sapcloud.io/operatedBy"
 
+	// GardenIgnoreAlerts is the key for an annotation of a Shoot cluster whose value indicates
+	// if alerts for this cluster should be ignored
+	GardenIgnoreAlerts = "shoot.garden.sapcloud.io/ignore-alerts"
+
 	// IngressPrefix is the part of a FQDN which will be used to construct the domain name for an ingress controller of
 	// a Shoot cluster. For example, when a Shoot specifies domain 'cluster.example.com', the ingress domain would be
 	// '*.<IngressPrefix>.cluster.example.com'.

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -119,7 +119,8 @@ func newOperation(
 			return nil, err
 		}
 		operation.Shoot = shootObj
-		operation.Shoot.WantsAlertmanager = helper.ShootWantsAlertmanager(shoot, secrets)
+		operation.Shoot.IgnoreAlerts = helper.ShootIgnoreAlerts(shoot)
+		operation.Shoot.WantsAlertmanager = helper.ShootWantsAlertmanager(shoot, secrets) && !operation.Shoot.IgnoreAlerts
 
 		shootedSeed, err := helper.ReadShootedSeed(shoot)
 		if err != nil {

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -35,6 +35,7 @@ type Shoot struct {
 
 	WantsClusterAutoscaler bool
 	WantsAlertmanager      bool
+	IgnoreAlerts           bool
 	IsHibernated           bool
 
 	CloudConfigMap map[string]CloudConfig


### PR DESCRIPTION
**What this PR does / why we need it**:
Shoot owners can now add the annotation `shoot.garden.sapcloud.io/ignore-alerts` to their shoots. If the value of this annotation is `true` then all alerts from this shoot cluster will be ignored. If the annotation `garden.sapcloud.io/operatedBy` is set and the annotation `shoot.garden.sapcloud.io/ignore-alerts` is set to `true` then no Alertmanager will be deployed into the shoot's namespace.

/cc @dguendisch @OlegLoewen @schrodit

**Which issue(s) this PR fixes**:
Fixes #938

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Shoot owners can set the annotation `shoot.garden.sapcloud.io/ignore-alerts` to `true` if they want don't want alerts to fire for their shoot cluster.
```
