### PR TITLE
Remove propagation policy from cleanup delete call

### DIFF
--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -176,9 +176,9 @@ func cleanResourceFn(c client.Client, deleteSelector, checkSelector *client.List
 	mkCleaner := func(finalize bool) flow.TaskFn {
 		var opts []client.DeleteOptionFunc
 		if !finalize {
-			opts = []client.DeleteOptionFunc{client.GracePeriodSeconds(60), client.PropagationPolicy(metav1.DeletePropagationForeground)}
+			opts = []client.DeleteOptionFunc{client.GracePeriodSeconds(60)}
 		} else {
-			opts = []client.DeleteOptionFunc{client.GracePeriodSeconds(0), client.PropagationPolicy(metav1.DeletePropagationBackground)}
+			opts = []client.DeleteOptionFunc{client.GracePeriodSeconds(0)}
 		}
 
 		return func(ctx context.Context) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix cleanup delete calls not to specify a deletion policy.

**Special notes for your reviewer**:
cc @rfranzke 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
