### PR TITLE
Enable kube-proxy cleanup

### DIFF
--- a/pkg/operation/shoot/shoot_test.go
+++ b/pkg/operation/shoot/shoot_test.go
@@ -67,7 +67,6 @@ var _ = Describe("shoot", func() {
 		Describe("#IPVSEnabled", func() {
 			It("should return false when KubeProxy is null", func() {
 				shoot.Info.Spec.Kubernetes.KubeProxy = nil
-
 				Expect(shoot.IPVSEnabled()).To(BeFalse())
 			})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes Gardener prohibiting to change the `Kube-Proxy` mode for Shoot clusters >= 1.14.1 because the corresponding clean-up logic is broken.

https://github.com/kubernetes/kubernetes/issues/78735 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
It is no longer possible to switch the kube-proxy mode for Kubernetes clusters >= 1.14.1 because Kube-Proxy's cleanup logic is broken (https://github.com/kubernetes/kubernetes/issues/78735).
```
