### PR TITLE
annotate test shoots to ignore alerts

### DIFF
--- a/.test-defs/cmd/create-shoot/helper.go
+++ b/.test-defs/cmd/create-shoot/helper.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/gardener/pkg/operation/common"
 )
 
 // updateWorkerZone updates the zone of the workers.
@@ -105,4 +106,12 @@ func updateLoadBalancerProvider(shoot *gardenv1beta1.Shoot, loadBalancerProvider
 	if cloudprovider == gardenv1beta1.CloudProviderOpenStack && loadBalancerProvider != "" {
 		shoot.Spec.Cloud.OpenStack.LoadBalancerProvider = loadBalancerProvider
 	}
+}
+
+// updateAnnotations adds default annotations that should be present on any shoot created.
+func updateAnnotations(shoot *gardenv1beta1.Shoot) {
+	if shoot.Annotations == nil {
+		shoot.Annotations = map[string]string{}
+	}
+	shoot.Annotations[common.GardenIgnoreAlerts] = "true"
 }

--- a/.test-defs/cmd/create-shoot/main.go
+++ b/.test-defs/cmd/create-shoot/main.go
@@ -138,6 +138,7 @@ func main() {
 	shootObject.Spec.Cloud.Region = region
 	shootObject.Spec.Cloud.SecretBindingRef.Name = secretBindingName
 	shootObject.Spec.Kubernetes.Version = k8sVersion
+	updateAnnotations(shootObject)
 	updateWorkerZone(shootObject, cloudprovider, zone)
 	updateMachineType(shootObject, cloudprovider, machineType)
 	updateAutoscalerMinMax(shootObject, cloudprovider, autoScalerMin, autoScalerMax)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the annotation `shoot.garden.sapcloud.io/ignore-alerts: "true"` (recently introduced by PR #957) to all shoots created by the testmachinery testdefinition to exclude them from alerting.