### PR TITLE
Add Skip_Long_Lines config

### DIFF
--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
@@ -26,6 +26,7 @@ data:
         Exclude_Path      *_garden_fluent-bit-*.log,*_garden_fluentd-es-*.log
         Parser            docker
         DB                /var/log/flb_kube.db
+        Skip_Long_Lines   On
         Mem_Buf_Limit     12MB
         Refresh_Interval  10
         Ignore_Older      1800s


### PR DESCRIPTION
**What this PR does / why we need it**:
When fluent-bit finds a log line that exceeds its Buffer_Chunk_Size (defaults to 32K), the default behaviour is to stop monitoring the log file. 
```
[2019/04/25 14:24:30] [error] [in_tail] file=/var/log/containers/[pod-name]_[ns]_[container-name]-[docker-id].log requires a larger buffer size, lines are too long. Skipping file.
```
Skip_Long_Lines alters this behaviour - it skips lines that are > Buffer_Chunk_Size and continues to process the other ones that fit into Buffer_Chunk_Size.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
https://docs.fluentbit.io/manual/input/tail

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
