### PR TITLE
Scrape CCM via HTTP on Alicloud

### DIFF
--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -287,12 +287,14 @@ data:
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.kubeScheduler | indent 6 }}
 
     - job_name: cloud-controller-manager
-      {{- if semverCompare ">= 1.13" .Values.kubernetesVersion }}
+      {{- if not (eq "alicloud" .Values.shoot.provider) }}
+      {{- if semverCompare ">= 1.13" .Values.kubernetesVersion  }}
       scheme: https
       tls_config:
         insecure_skip_verify: true
         cert_file: /etc/prometheus/seed/prometheus.crt
         key_file: /etc/prometheus/seed/prometheus.key
+      {{- end }}
       {{- end }}
       honor_labels: false
       kubernetes_sd_configs:

--- a/charts/seed-monitoring/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/prometheus/values.yaml
@@ -193,6 +193,7 @@ seed:
 
 shoot:
   apiserver: https://api.foo.bar
+  provider: aws
 
 rules:
   optional:

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -349,6 +349,7 @@ func (b *Botanist) DeploySeedMonitoring() error {
 			},
 			"shoot": map[string]interface{}{
 				"apiserver": fmt.Sprintf("https://%s", b.Shoot.InternalClusterDomain),
+				"provider":  b.Shoot.CloudProvider,
 			},
 			"vpa": map[string]interface{}{
 				"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),


### PR DESCRIPTION
**What this PR does / why we need it**:
Prometheus now only scrapes the CCM on alicloud via HTTP. This will prevent prometheus from firing false positive alerts.

/cc @jia-jerry @minchaow 

**Which issue(s) this PR fixes**:
Fixes #963

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
