### PR TITLE
Change node-exporter's port

### DIFF
--- a/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -20,7 +20,7 @@ spec:
   clusterIP: None
   ports:
   - name: metrics
-    port: 9100
+    port: {{ .Values.ports.metrics }}
     protocol: TCP
   selector:
     component: node-exporter
@@ -76,23 +76,23 @@ spec:
         - --path.sysfs=/host/sys
         - --collector.filesystem.ignored-fs-types=^(tmpfs|cgroup|nsfs|fuse\.lxcfs|rpc_pipefs)$
         - --collector.filesystem.ignored-mount-points=^/(rootfs/|host/)?(sys|proc|dev|host|etc|var/lib/docker)($|/)
-        - --web.listen-address=:9100
+        - --web.listen-address=:{{ .Values.ports.metrics }}
         - --log.level=error
         ports:
-        - containerPort: 9100
+        - containerPort: {{ .Values.ports.metrics }}
           protocol: TCP
-          hostPort: 9100
+          hostPort: {{ .Values.ports.metrics }}
           name: scrape
         livenessProbe:
           httpGet:
             path: /
-            port: 9100
+            port: {{ .Values.ports.metrics }}
           initialDelaySeconds: 5
           timeoutSeconds: 5
         readinessProbe:
           httpGet:
             path: /
-            port: 9100
+            port: {{ .Values.ports.metrics }}
           initialDelaySeconds: 5
           timeoutSeconds: 5
         resources:

--- a/charts/shoot-core/charts/monitoring/charts/node-exporter/values.yaml
+++ b/charts/shoot-core/charts/monitoring/charts/node-exporter/values.yaml
@@ -1,2 +1,5 @@
 images:
   node-exporter: image-repository:image-tag
+
+ports:
+  metrics: 16909


### PR DESCRIPTION
**What this PR does / why we need it**:

This makes sure that when users deploy their own `node-exporter` versions, they are able to run without changing their ports.


**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
`node-exporter` deployed in `kube-system` now runs on port `16909`. 
```

```action user
`node-exporter` deployed by Gardener in `kube-system` now runs on port `16909`. Adjust your Prometheus configuration, if it uses the old `9100` port.
```