### PR TITLE
Delete hibernate shoot cluster on alicloud

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -618,6 +618,7 @@ func (b *Botanist) DeleteCertBroker() error {
 // * cloud-controller-manager
 // * kube-controller-manager
 // * machine-controller-manager
+// * csi-controllers
 func (b *Botanist) WakeUpControlPlane(ctx context.Context) error {
 	client := b.K8sSeedClient.Client()
 

--- a/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go
@@ -204,23 +204,6 @@ func (b *AlicloudBotanist) GenerateKubeAPIServerExposeConfig() (map[string]inter
 // GenerateCSIConfig generates the configuration for CSI charts
 func (b *AlicloudBotanist) GenerateCSIConfig() (map[string]interface{}, error) {
 	//TODO: This part is just for release 0.21 and will be deleted in release 0.22
-
-	if err := b.K8sSeedClient.DeleteService(b.Shoot.SeedNamespace, common.CSIPluginController); err != nil && !apierrors.IsNotFound(err) {
-		return nil, err
-	}
-
-	if err := b.K8sSeedClient.DeleteDeployment(b.Shoot.SeedNamespace, common.CSIAttacher); err != nil && !apierrors.IsNotFound(err) {
-		return nil, err
-	}
-
-	if err := b.K8sSeedClient.DeleteDeployment(b.Shoot.SeedNamespace, common.CSIProvisioner); err != nil && !apierrors.IsNotFound(err) {
-		return nil, err
-	}
-
-	if err := b.K8sSeedClient.DeleteDeployment(b.Shoot.SeedNamespace, common.CSISnapshotter); err != nil && !apierrors.IsNotFound(err) {
-		return nil, err
-	}
-
 	storageClass := &storagev1.StorageClass{}
 	if b.K8sShootClient != nil {
 		if err := b.K8sShootClient.Client().Get(context.TODO(), kutil.Key("default"), storageClass); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
On Alicloud, we move some of csi controllers to seed clusters. There is an issue when the shoot cluster was created in verison prior to 0.21 and hibernated. After we upgrade Gardener to 0.21 and delete this shoot without awake it. The deletion will fail at the step waiting for CSI controllers be ready.

To fix it, we will add csi controller deployment in deletion flow.

```improvement user
An issue that prevented deleting hibernated Alicloud clusters has been fixed.
```