### PR TITLE
Remove chart.Values type, fix type conversion

### DIFF
--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -319,22 +319,22 @@ func (o *Operation) ShootVersion() string {
 	return o.Shoot.Info.Spec.Kubernetes.Version
 }
 
-func (o *Operation) injectImages(values chart.Values, names []string, opts ...imagevector.FindOptionFunc) (chart.Values, error) {
+func (o *Operation) injectImages(values map[string]interface{}, names []string, opts ...imagevector.FindOptionFunc) (map[string]interface{}, error) {
 	return chart.InjectImages(values, o.ImageVector, names, opts...)
 }
 
 // InjectSeedSeedImages injects images that shall run on the Seed and target the Seed's Kubernetes version.
-func (o *Operation) InjectSeedSeedImages(values chart.Values, names ...string) (chart.Values, error) {
+func (o *Operation) InjectSeedSeedImages(values map[string]interface{}, names ...string) (map[string]interface{}, error) {
 	return o.injectImages(values, names, imagevector.RuntimeVersion(o.SeedVersion()), imagevector.TargetVersion(o.SeedVersion()))
 }
 
 // InjectSeedShootImages injects images that shall run on the Seed but target the Shoot's Kubernetes version.
-func (o *Operation) InjectSeedShootImages(values chart.Values, names ...string) (chart.Values, error) {
+func (o *Operation) InjectSeedShootImages(values map[string]interface{}, names ...string) (map[string]interface{}, error) {
 	return o.injectImages(values, names, imagevector.RuntimeVersion(o.SeedVersion()), imagevector.TargetVersion(o.ShootVersion()))
 }
 
 // InjectShootShootImages injects images that shall run on the Shoot and target the Shoot's Kubernetes version.
-func (o *Operation) InjectShootShootImages(values chart.Values, names ...string) (chart.Values, error) {
+func (o *Operation) InjectShootShootImages(values map[string]interface{}, names ...string) (map[string]interface{}, error) {
 	return o.injectImages(values, names, imagevector.RuntimeVersion(o.ShootVersion()), imagevector.TargetVersion(o.ShootVersion()))
 }
 

--- a/pkg/utils/chart/chart.go
+++ b/pkg/utils/chart/chart.go
@@ -82,7 +82,7 @@ func (c *Chart) getValues(
 ) (map[string]interface{}, error) {
 
 	// Get default values
-	values := make(Values)
+	values := make(map[string]interface{})
 	var err error
 	if c.ValuesFunc != nil {
 		values, err = c.ValuesFunc(clusterName, shoot, checksums)
@@ -151,12 +151,9 @@ func objectKey(namespace, name string) client.ObjectKey {
 	return client.ObjectKey{Namespace: namespace, Name: name}
 }
 
-// Values are values used in Helm charts.
-type Values map[string]interface{}
-
 // CopyValues creates a shallow copy of the given Values.
-func CopyValues(values Values) Values {
-	copiedValues := make(Values, len(values))
+func CopyValues(values map[string]interface{}) map[string]interface{} {
+	copiedValues := make(map[string]interface{}, len(values))
 	for k, v := range values {
 		copiedValues[k] = v
 	}
@@ -164,8 +161,8 @@ func CopyValues(values Values) Values {
 }
 
 // ImageMapToValues transforms the given image name to image mapping into chart Values.
-func ImageMapToValues(m map[string]*imagevector.Image) Values {
-	out := make(Values, len(m))
+func ImageMapToValues(m map[string]*imagevector.Image) map[string]interface{} {
+	out := make(map[string]interface{}, len(m))
 	for k, v := range m {
 		out[k] = v.String()
 	}
@@ -174,7 +171,7 @@ func ImageMapToValues(m map[string]*imagevector.Image) Values {
 
 // InjectImages finds the images with the given names and opts, makes a shallow copy of the given
 // Values and injects a name to image string mapping at the `images` key of that map and returns it.
-func InjectImages(values Values, v imagevector.ImageVector, names []string, opts ...imagevector.FindOptionFunc) (Values, error) {
+func InjectImages(values map[string]interface{}, v imagevector.ImageVector, names []string, opts ...imagevector.FindOptionFunc) (map[string]interface{}, error) {
 	images, err := imagevector.FindImages(v, names, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/utils/chart/chart_test.go
+++ b/pkg/utils/chart/chart_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Chart", func() {
 				img1.Name: img1,
 				img2.Name: img2,
 			})
-			Expect(values).To(Equal(Values{
+			Expect(values).To(Equal(map[string]interface{}{
 				img1.Name: img1.String(),
 				img2.Name: img2.String(),
 			}))
@@ -55,7 +55,7 @@ var _ = Describe("Chart", func() {
 	Describe("#InjectImages", func() {
 		It("should find the images and inject the image as value map at the 'images' key into a shallow copy", func() {
 			var (
-				values Values
+				values map[string]interface{}
 				img1   = &imagevector.ImageSource{
 					Name:       "img1",
 					Repository: "repo1",
@@ -69,8 +69,8 @@ var _ = Describe("Chart", func() {
 
 			injected, err := InjectImages(values, v, []string{img1.Name, img2.Name})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(injected).To(Equal(Values{
-				"images": Values{
+			Expect(injected).To(Equal(map[string]interface{}{
+				"images": map[string]interface{}{
 					img1.Name: img1.ToImage(nil).String(),
 					img2.Name: img2.ToImage(nil).String(),
 				},
@@ -80,7 +80,7 @@ var _ = Describe("Chart", func() {
 
 	Describe("#CopyValues", func() {
 		It("should create a shallow copy of the map", func() {
-			v := Values{"foo": nil, "bar": Values{"baz": nil}}
+			v := map[string]interface{}{"foo": nil, "bar": map[string]interface{}{"baz": nil}}
 
 			c := CopyValues(v)
 
@@ -89,8 +89,8 @@ var _ = Describe("Chart", func() {
 			c["foo"] = 1
 			Expect(v["foo"]).To(BeNil())
 
-			c["bar"].(Values)["baz"] = "bang"
-			Expect(v["bar"].(Values)["baz"]).To(Equal("bang"))
+			c["bar"].(map[string]interface{})["baz"] = "bang"
+			Expect(v["bar"].(map[string]interface{})["baz"]).To(Equal("bang"))
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove `chart.Values` type alias due to conversion panic.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
