### PR TITLE
integrate vpa exporter

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -231,3 +231,7 @@ images:
   sourceRepository: github.com/kubernetes/autoscaler
   repository: k8s.gcr.io/vpa-updater
   tag: "0.5.0"
+- name: vpa-exporter
+  sourceRepository: github.com/gardener/vpa-exporter
+  repository: eu.gcr.io/gardener-project/gardener/vpa-exporter
+  tag: "0.1.5"

--- a/charts/seed-bootstrap/charts/vpa/templates/vpa-exporter-rbac.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/vpa-exporter-rbac.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vpa-exporter
+  namespace: garden
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: system:vpa-exporter-role-binding
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:vpa-exporter-role
+subjects:
+- kind: ServiceAccount
+  name: vpa-exporter
+  namespace: garden
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: system:vpa-exporter-role
+  labels:
+{{ toYaml .Values.vpa.labels | indent 4 }}
+rules:
+- apiGroups:
+  - "autoscaling.k8s.io"
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - get
+  - watch
+  - list

--- a/charts/seed-bootstrap/charts/vpa/templates/vpa-exporter.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/vpa-exporter.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: {{ include "deploymentversion" . }}
+kind: Deployment
+metadata:
+  labels:
+    app: vpa-exporter
+{{ toYaml .Values.vpa.labels | indent 4 }}
+  name: vpa-exporter
+  namespace: garden
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vpa-exporter
+{{ toYaml .Values.vpa.labels | indent 6 }}
+  template:
+    metadata:
+      labels:
+        app: vpa-exporter
+{{ toYaml .Values.vpa.labels | indent 8 }}
+    spec:
+      serviceAccountName: vpa-exporter
+      containers:
+      - command:
+        - /usr/local/bin/vpa-exporter
+        image: {{ index .Values.global.images "vpa-exporter" }}
+        imagePullPolicy: IfNotPresent
+        name: exporter
+        ports:
+        - name: metrics
+          containerPort: 9570
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 50m
+            memory: 200Mi
+          limits:
+            cpu: 200m
+            memory: 500Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vpa-exporter
+  namespace: garden
+  labels:
+    app: vpa-exporter
+{{ toYaml .Values.vpa.labels | indent 4 }}
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  selector:
+    app: vpa-exporter
+  ports:
+  - name: metrics
+    protocol: TCP
+    port: 9570
+    targetPort: 9570

--- a/charts/seed-bootstrap/charts/vpa/values.yaml
+++ b/charts/seed-bootstrap/charts/vpa/values.yaml
@@ -3,6 +3,7 @@ global:
     vpa-admission-controller: image-repository:image-tag
     vpa-recommender: image-repository:image-tag
     vpa-updater: image-repository:image-tag
+    vpa-exporter: image-repository:image-tag
 
 vpa:
   podAnnotations: {}

--- a/charts/seed-monitoring/charts/grafana/dashboards/vpa-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/vpa-dashboard.json
@@ -1,0 +1,585 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": false,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "Shows the recommendations that the VPA gives as target usage. The graph also shows the actual usage of each container.",
+      "fill": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(vpa_status_recommendation{recommendation=\"$recommendation\", resource=\"memory\", targetName=\"$targetName\"})",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "sum recommendation",
+          "refId": "A"
+        },
+        {
+          "expr": "sum (container_memory_working_set_bytes{pod_name=~\"$targetName(.+)\"})",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "sum actual usage",
+          "refId": "B"
+        },
+        {
+          "expr": "container_memory_working_set_bytes{pod_name=~\"$targetName(.+)\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ container_name }} actual usage",
+          "refId": "D"
+        },
+        {
+          "expr": "vpa_status_recommendation{recommendation=\"$recommendation\", resource=\"memory\", targetName=\"$targetName\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ container }}-recommendation",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory Target vs Memory Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": "Bytes",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "Shows the recommendation of the VPA and compares it to the requests and limits of all containers in a pod. \n\n**Requests and/or limits may not reflect useful values if they are not defined for each container in a pod.",
+      "fill": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(vpa_status_recommendation{targetName=\"$targetName\", resource=\"memory\", recommendation=~\"$recommendation\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "recommendation",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(kube_pod_container_resource_requests_memory_bytes{pod=~\"$targetName(.+)\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "requests",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(kube_pod_container_resource_limits_memory_bytes{pod=~\"$targetName(.+)\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "limits",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VPA Memory Recommendations vs Requests and Limits",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": "Bytes",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "Shows the recommendations that the VPA gives as target usage. The graph also shows the actual usage of each container.",
+      "fill": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(vpa_status_recommendation{recommendation=~\"$recommendation\", resource=\"cpu\", targetName=\"$targetName\"})",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "recommendation sum",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\"$targetName(.+)\"}[1m])) * 1000",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "sum actual usage",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(container_cpu_usage_seconds_total{pod_name=~\"$targetName(.+)\"}[1m]) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ container_name }} actual usage",
+          "refId": "D"
+        },
+        {
+          "expr": "vpa_status_recommendation{recommendation=~\"$recommendation\", resource=\"cpu\", targetName=\"$targetName\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ container }}-recommendation",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU Target vs CPU Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "Millicores",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "Shows the recommendation of the VPA and compares it to the requests and limits of all containers in a pod. \n\n**Requests and/or limits may not reflect useful values if they are not defined for each container in a pod.",
+      "fill": 0,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(vpa_status_recommendation{targetName=\"$targetName\", resource=\"cpu\", recommendation=~\"$recommendation\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "recommendation",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(kube_pod_container_resource_requests_cpu_cores{pod=~\"$targetName(.+)\"}) * 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "requests",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(kube_pod_container_resource_limits_cpu_cores{pod=~\"$targetName(.+)\"})* 1000",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "limits",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "VPA CPU Recommendations vs Requests and Limits",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "Millicores",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "target",
+          "value": "target"
+        },
+        "datasource": "prometheus",
+        "definition": "label_values(vpa_status_recommendation, recommendation)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Recommendation",
+        "multi": false,
+        "name": "recommendation",
+        "options": [
+          {
+            "selected": false,
+            "text": "lowerBound",
+            "value": "lowerBound"
+          },
+          {
+            "selected": true,
+            "text": "target",
+            "value": "target"
+          },
+          {
+            "selected": false,
+            "text": "uncappedTarget",
+            "value": "uncappedTarget"
+          },
+          {
+            "selected": false,
+            "text": "upperBound",
+            "value": "upperBound"
+          }
+        ],
+        "query": "label_values(vpa_status_recommendation, recommendation)",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "kube-apiserver",
+          "value": "kube-apiserver"
+        },
+        "datasource": "prometheus",
+        "definition": "label_values(vpa_status_recommendation, targetName)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Target",
+        "multi": false,
+        "name": "targetName",
+        "options": [
+          {
+            "selected": false,
+            "text": "etcd-events",
+            "value": "etcd-events"
+          },
+          {
+            "selected": false,
+            "text": "etcd-main",
+            "value": "etcd-main"
+          },
+          {
+            "selected": true,
+            "text": "kube-apiserver",
+            "value": "kube-apiserver"
+          },
+          {
+            "selected": false,
+            "text": "prometheus",
+            "value": "prometheus"
+          },
+          {
+            "selected": false,
+            "text": "cloud-controller-manager",
+            "value": "cloud-controller-manager"
+          },
+          {
+            "selected": false,
+            "text": "kube-addon-manager",
+            "value": "kube-addon-manager"
+          },
+          {
+            "selected": false,
+            "text": "kube-controller-manager",
+            "value": "kube-controller-manager"
+          },
+          {
+            "selected": false,
+            "text": "kube-scheduler",
+            "value": "kube-scheduler"
+          },
+          {
+            "selected": false,
+            "text": "machine-controller-manager",
+            "value": "machine-controller-manager"
+          }
+        ],
+        "query": "label_values(vpa_status_recommendation, targetName)",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "VPA Recommendations",
+  "uid": "vyrKWTkWk",
+  "version": 1
+}

--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -578,3 +578,20 @@ data:
       metric_relabel_configs:
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.blackboxExporter | indent 8 }}
 
+    - job_name: 'vpa-exporter'
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [ garden ]
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+        - __meta_kubernetes_namespace
+        action: keep
+        regex: vpa-exporter;metrics;garden
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.vpa | indent 6 }}
+      - source_labels: [ namespace ]
+        action: keep
+        regex: ^{{ .Release.Namespace }}$

--- a/charts/seed-monitoring/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/prometheus/values.yaml
@@ -182,6 +182,10 @@ allowedMetrics:
   - probe_http_duration_seconds
   - probe_success
   - probe_http_status_code
+  vpa:
+  - vpa_status_recommendation
+  - vpa_spec_container_resource_policy_allowed
+  - vpa_metadata_generation
   vpn:
   - probe_http_status_code
   - probe_success

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -552,6 +552,9 @@ const (
 
 	// VpaUpdaterImageName is the name of the vpa-updater image
 	VpaUpdaterImageName = "vpa-updater"
+
+	// VpaExporterImageName is the name of the vpa-exporter image
+	VpaExporterImageName = "vpa-exporter"
 )
 
 var (

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -375,6 +375,12 @@ func DeleteVpa(k8sClient kubernetes.Interface, namespace string) error {
 		return err
 	}
 
+	// Delete vpa-exporter service
+	if err := k8sClient.Kubernetes().CoreV1().Services(namespace).Delete("vpa-exporter",
+		&metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
 	// Delete Service
 	if err := k8sClient.Client().Delete(context.TODO(), &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "vpa-webhook"}}); err != nil && !apierrors.IsNotFound(err) {
 		return err

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -239,6 +239,7 @@ func BootstrapCluster(seed *Seed, secrets map[string]*corev1.Secret, imageVector
 			common.PauseContainerImageName,
 			common.PrometheusImageName,
 			common.VpaAdmissionControllerImageName,
+			common.VpaExporterImageName,
 			common.VpaRecommenderImageName,
 			common.VpaUpdaterImageName,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Integrates the [vpa-exporter](https://github.com/gardener/vpa-exporter) which exposes `vpa` metrics for prometheus. This PR also introduces a dashboard to view the VPA recommendations.

**Which issue(s) this PR fixes**:
Fixes #885

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Integrate `vpa-exporter` into seeds.
```
``` improvement operator github.com/gardener/vpa-exporter #2 @wyb1
Upperbound metrics are now properly exposed.
```
``` improvement operator github.com/gardener/vpa-exporter #2 @wyb1
Changed the metric names exported for VPA.
```
``` improvement operator github.com/gardener/vpa-exporter #5 @wyb1
Change default port to `9570`
```
``` improvement operator github.com/gardener/vpa-exporter #3 @wyb1
Added `--port` flag to specify on which port prometheus metrics should be exposed.
```
``` improvement operator github.com/gardener/vpa-exporter #3 @wyb1
Expose CPU metrics as millicores instead of cores.
```
``` improvement operator github.com/gardener/vpa-exporter #6 @wyb1
Add `targetName` and `targetKind` labels
```