### PR TITLE
revisionHistoryLimit was contained twice in the deployment spec

### DIFF
--- a/charts/seed-monitoring/charts/kube-state-metrics-shoot/templates/kube-state-metrics.yaml
+++ b/charts/seed-monitoring/charts/kube-state-metrics-shoot/templates/kube-state-metrics.yaml
@@ -33,7 +33,6 @@ spec:
     matchLabels:
       component: kube-state-metrics
       type: shoot
-  revisionHistoryLimit: 10
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
**What this PR does / why we need it**:
kube-state-metrics deployment chart contained the field `revisionHistoryLimit` two times.
Removed the unwanted/old one.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
