### PR TITLE
Increase node-exporter CPU

### DIFF
--- a/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -100,7 +100,7 @@ spec:
             cpu: 5m
             memory: 10Mi
           limits:
-            cpu: 15m
+            cpu: 25m
             memory: 100Mi
         volumeMounts:
         - name: proc


### PR DESCRIPTION
**What this PR does / why we need it**:
We have been receiving the alert `PrometheusCantScrape` for several shoot clusters and it is always because Prometheus cannot scrape the `node-exporter`. For some clusters the limit of `15m` cpu is not enough causing the node-exporter to be slow. In some cases it took 2+ minutes for the node-exporter to respond to its `/metrics` endpoint. Below is a screenshot of a node-exporter's CPU usage.

<img width="1818" alt="Screen Shot 2019-05-06 at 11 10 39" src="https://user-images.githubusercontent.com/8710621/57216278-b705fa80-6fef-11e9-859c-73330938695a.png">

This PR increases the CPU from `15m` to `25m`. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
