### PR TITLE
updated golang image for testdefs

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -14,4 +14,4 @@ spec:
     /tm/setup github.com/gardener gardener &&
     go run $GOPATH/src/github.com/gardener/gardener/.test-defs/cmd/create-shoot
 
-  image: eu.gcr.io/gardener-project/gardener/testmachinery/golang:0.28.0
+  image: eu.gcr.io/gardener-project/gardener/testmachinery/golang:0.42.0

--- a/.test-defs/DeleteShoot.yaml
+++ b/.test-defs/DeleteShoot.yaml
@@ -14,4 +14,4 @@ spec:
     /tm/setup github.com/gardener gardener &&
     go run $GOPATH/src/github.com/gardener/gardener/.test-defs/cmd/delete-shoot
 
-  image: eu.gcr.io/gardener-project/gardener/testmachinery/golang:0.28.0
+  image: eu.gcr.io/gardener-project/gardener/testmachinery/golang:0.42.0

--- a/.test-defs/PlantTest.yaml
+++ b/.test-defs/PlantTest.yaml
@@ -19,4 +19,4 @@ spec:
       -plant-path=$GOPATH/src/github.com/gardener/gardener/example/100-plant.yaml
       -plant-test-namespace=$PROJECT_NAMESPACE
 
-  image: eu.gcr.io/gardener-project/gardener/testmachinery/golang:0.28.0
+  image: eu.gcr.io/gardener-project/gardener/testmachinery/golang:0.42.0

--- a/.test-defs/SeedLoggingTest.yaml
+++ b/.test-defs/SeedLoggingTest.yaml
@@ -19,4 +19,4 @@ spec:
     -kubeconfig=$TM_KUBECONFIG_PATH/gardener.config
     -shootName=$SHOOT_NAME
     -shootNamespace=$PROJECT_NAMESPACE
-  image: eu.gcr.io/gardener-project/gardener/testmachinery/golang:0.28.0
+  image: eu.gcr.io/gardener-project/gardener/testmachinery/golang:0.42.0

--- a/.test-defs/ShootAppTest.yaml
+++ b/.test-defs/ShootAppTest.yaml
@@ -17,4 +17,4 @@ spec:
     -kubeconfig=$TM_KUBECONFIG_PATH/gardener.config
     -shootName=$SHOOT_NAME
     -shootNamespace=$PROJECT_NAMESPACE
-  image: eu.gcr.io/gardener-project/gardener/testmachinery/golang:0.28.0
+  image: eu.gcr.io/gardener-project/gardener/testmachinery/golang:0.42.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the base golang image used to run the testdefs of gardener in the TestMachinery.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```
