### PR TITLE
Added dependency-watchdog

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -42,6 +42,10 @@ images:
   sourceRepository: github.com/gardener/aws-lb-readvertiser
   repository: eu.gcr.io/gardener-project/gardener/aws-lb-readvertiser
   tag: "0.6.0"
+- name: dependency-watchdog
+  sourceRepository: github.com/gardener/dependency-watchdog
+  repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog
+  tag: "0.1.1"
 
 # Monitoring
 - name: alertmanager

--- a/charts/seed-controlplane/charts/dependency-watchdog/Chart.yaml
+++ b/charts/seed-controlplane/charts/dependency-watchdog/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Helm chart for dependency-watchdog
+name: dependency-watchdog
+version: 0.1.0

--- a/charts/seed-controlplane/charts/dependency-watchdog/charts/utils-templates
+++ b/charts/seed-controlplane/charts/dependency-watchdog/charts/utils-templates
@@ -1,0 +1,1 @@
+../../../../utils-templates

--- a/charts/seed-controlplane/charts/dependency-watchdog/templates/configmap.yaml
+++ b/charts/seed-controlplane/charts/dependency-watchdog/templates/configmap.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dependency-watchdog-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: dependency-watchdog
+data:
+  dep-config.yaml: |-
+      service: {{ .Values.dependencywatchdog.service.name }}
+      namespace: {{ .Release.Namespace }}
+      labels:
+{{ toYaml .Values.dependencywatchdog.service.labels | indent 8 }}
+      dependantPods:
+      - name: controlplane
+        selector:
+          matchExpressions:
+          - key: garden.sapcloud.io/role
+            operator: In
+            values:
+            - controlplane
+          - key: role
+            operator: NotIn
+            values:
+            - main
+            - events

--- a/charts/seed-controlplane/charts/dependency-watchdog/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/dependency-watchdog/templates/deployment.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: {{ include "deploymentversion" . }}
+kind: Deployment
+metadata:
+  name: dependency-watchdog
+  namespace: {{ .Release.Namespace }}
+  labels:
+    role: dependency-watchdog
+    garden.sapcloud.io/role: controlplane
+spec:
+  replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      role: dependency-watchdog
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-dep-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+      labels:
+        role: dependency-watchdog
+    spec:
+      serviceAccountName: dependency-watchdog
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: dependency-watchdog
+        image: {{ index .Values.images "dependency-watchdog" }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /usr/local/bin/dependency-watchdog
+        - --config-file=/etc/dependency-watchdog/config/dep-config.yaml
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            memory: "128Mi"
+            cpu: "50m"
+        volumeMounts:
+        - mountPath: /etc/dependency-watchdog/config
+          name: config
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: dependency-watchdog-config

--- a/charts/seed-controlplane/charts/dependency-watchdog/templates/rbac.yaml
+++ b/charts/seed-controlplane/charts/dependency-watchdog/templates/rbac.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dependency-watchdog
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ toYaml .Values.dependencywatchdog.labels | indent 4 }}
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: RoleBinding
+metadata:
+  name: gardener.cloud:dependency-watchdog:role-binding
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ toYaml .Values.dependencywatchdog.labels | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gardener.cloud:dependency-watchdog:role
+subjects:
+- kind: ServiceAccount
+  name: dependency-watchdog
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: Role
+metadata:
+  name: gardener.cloud:dependency-watchdog:role
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ toYaml .Values.dependencywatchdog.labels | indent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch

--- a/charts/seed-controlplane/charts/dependency-watchdog/values.yaml
+++ b/charts/seed-controlplane/charts/dependency-watchdog/values.yaml
@@ -1,0 +1,12 @@
+podAnnotations: {}
+replicas: 1
+dependencywatchdog:
+  service: 
+    name: etcd-main-client
+    labels:
+      "app" : "etcd-statefulset"
+      "role" : "main"
+  labels:
+    role: dependency-watchdog	    
+images:
+  dependency-watchdog: image-repository:image-tag

--- a/pkg/operation/botanist/botanist_suite_test.go
+++ b/pkg/operation/botanist/botanist_suite_test.go
@@ -219,6 +219,7 @@ var _ = Describe("health check", func() {
 		kubeControllerManagerDeployment    = newDeployment(seedNamespace, common.KubeControllerManagerDeploymentName, common.GardenRoleControlPlane, true)
 		kubeSchedulerDeployment            = newDeployment(seedNamespace, common.KubeSchedulerDeploymentName, common.GardenRoleControlPlane, true)
 		machineControllerManagerDeployment = newDeployment(seedNamespace, common.MachineControllerManagerDeploymentName, common.GardenRoleControlPlane, true)
+		dependencyWatchdogDeployment       = newDeployment(seedNamespace, common.DependancyWatchdogDeploymentName, common.GardenRoleControlPlane, true)
 		awsLBReadvertiserDeployment        = newDeployment(seedNamespace, common.AWSLBReadvertiserDeploymentName, common.GardenRoleControlPlane, true)
 		clusterAutoscalerDeployment        = newDeployment(seedNamespace, gardencorev1alpha1.DeploymentNameClusterAutoscaler, common.GardenRoleControlPlane, true)
 
@@ -229,6 +230,7 @@ var _ = Describe("health check", func() {
 			kubeControllerManagerDeployment,
 			kubeSchedulerDeployment,
 			machineControllerManagerDeployment,
+			dependencyWatchdogDeployment,
 			awsLBReadvertiserDeployment,
 			clusterAutoscalerDeployment,
 		}
@@ -331,6 +333,7 @@ var _ = Describe("health check", func() {
 				kubeControllerManagerDeployment,
 				kubeSchedulerDeployment,
 				machineControllerManagerDeployment,
+				dependencyWatchdogDeployment,
 				awsLBReadvertiserDeployment,
 			},
 			requiredControlPlaneStatefulSets,
@@ -346,6 +349,7 @@ var _ = Describe("health check", func() {
 				kubeControllerManagerDeployment,
 				kubeSchedulerDeployment,
 				machineControllerManagerDeployment,
+				dependencyWatchdogDeployment,
 				clusterAutoscalerDeployment,
 			},
 			requiredControlPlaneStatefulSets,
@@ -360,6 +364,7 @@ var _ = Describe("health check", func() {
 				kubeControllerManagerDeployment,
 				kubeSchedulerDeployment,
 				machineControllerManagerDeployment,
+				dependencyWatchdogDeployment,
 			},
 			requiredControlPlaneStatefulSets,
 			nil,
@@ -374,6 +379,7 @@ var _ = Describe("health check", func() {
 				kubeControllerManagerDeployment,
 				kubeSchedulerDeployment,
 				machineControllerManagerDeployment,
+				dependencyWatchdogDeployment,
 			},
 			requiredControlPlaneStatefulSets,
 			nil,
@@ -407,6 +413,7 @@ var _ = Describe("health check", func() {
 				kubeControllerManagerDeployment,
 				kubeSchedulerDeployment,
 				machineControllerManagerDeployment,
+				dependencyWatchdogDeployment,
 			},
 			requiredControlPlaneStatefulSets,
 			[]*machinev1alpha1.MachineDeployment{

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -538,6 +538,9 @@ const (
 	// CertBrokerResourceName is the name of the Cert-Broker resources.
 	CertBrokerResourceName = "cert-broker"
 
+	// DependancyWatchdogDeploymentName is the name of the dependency controller resources.
+	DependancyWatchdogDeploymentName = "dependency-watchdog"
+
 	// SeedSpecHash is a constant for a label on `ControllerInstallation`s (similar to `pod-template-hash` on `Pod`s).
 	SeedSpecHash = "seed-spec-hash"
 
@@ -575,6 +578,7 @@ var (
 		KubeControllerManagerDeploymentName,
 		KubeSchedulerDeploymentName,
 		MachineControllerManagerDeploymentName,
+		DependancyWatchdogDeploymentName,
 	)
 
 	// RequiredControlPlaneStatefulSets is a set of the required shoot control plane stateful


### PR DESCRIPTION
**What this PR does / why we need it**: When etcd-main becomes ready after a prolonged period of time, the control-plane components had gone into CrashloopBackoff`. The control-plane pods may have to wait till 300 seconds before restarting containers. This fix aims to reduce the downtime caused due to pod waiting for  [MaxContainerBackOff](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet.go#L131) to have the container recreated by restarting the control-plane pods in CrashloopBackoff when the etcd-main service gets serviceable endpoints.

**Which issue(s) this PR fixes**:
Fixes [#148](https://github.com/gardener/etcd-backup-restore/issues/148)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
The [dependency-watchdog controller](https://github.com/gardener/dependency-watchdog) is now deployed next to every control plane in the seed.
```

``` noteworthy user github.com/gardener/dependency-watchdog #0 @georgekuruvillak
dependency-watchdog checks for the readiness of a service. If the endpoints are ready to accept requests, the dependant pods as specified in the config is restarted if found to be in `CrashLoopBackoff`.
```
