### PR TITLE
[WIP]Remove blackbox exporter from Prometheus pod

### DIFF
--- a/charts/seed-monitoring/charts/prometheus/templates/blackbox-exporter-config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/blackbox-exporter-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: blackbox-exporter-config-prometheus
+  name: blackbox-exporter-config
   namespace: {{ .Release.Namespace }}
   labels:
     app: prometheus

--- a/charts/seed-monitoring/charts/prometheus/templates/blackbox-exporter-deployment.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/blackbox-exporter-deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: {{ include "deploymentversion" . }}
+kind: Deployment
+metadata:
+  name: blackbox-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: blackbox-exporter
+    role: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: blackbox-exporter
+      role: monitoring
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-blackbox-exporter-config: {{ include (print $.Template.BasePath "/blackbox-exporter-config.yaml") . | sha256sum }}
+      labels:
+        app: blackbox-exporter
+        role: monitoring
+    spec:
+      containers:
+      - name: blackbox-exporter
+        image: {{ index .Values.images "blackbox-exporter" }}
+        args:
+        - --config.file=/etc/blackbox_exporter/blackbox.yaml
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 5m
+            memory: 5Mi
+          limits:
+            cpu: 10m
+            memory: 25Mi
+        ports:
+        - containerPort: 9115
+          protocol: TCP
+          name: probe
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: blackbox-exporter-config
+          mountPath: /etc/blackbox_exporter
+        - mountPath: /var/run/secrets/blackbox
+          name: prometheus-kubeconfig
+          readOnly: true
+      - image: {{ index .Values.images "vpn-seed" }}
+        imagePullPolicy: IfNotPresent
+        name: vpn-seed
+        env:
+        - name: OPENVPN_PORT
+          value: "4314"
+        ports:
+        - name: https
+          containerPort: 1194
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+          limits:
+            cpu: 20m
+            memory: 25Mi
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /srv/secrets/vpn-seed
+          name: vpn-seed
+        - mountPath: /srv/secrets/tlsauth
+          name: vpn-seed-tlsauth
+        - mountPath: /srv/auth
+          name: kube-apiserver-basic-auth
+      volumes:
+      - name: blackbox-exporter-config
+        configMap:
+          name: blackbox-exporter-config
+      - name: prometheus-kubeconfig
+        secret:
+          secretName: prometheus
+      - name: vpn-seed
+        secret:
+          secretName: vpn-seed
+      - name: vpn-seed-tlsauth
+        secret:
+          secretName: vpn-seed-tlsauth
+      - name: kube-apiserver-basic-auth
+        secret:
+          secretName: kube-apiserver-basic-auth

--- a/charts/seed-monitoring/charts/prometheus/templates/blackbox-exporter-service.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/blackbox-exporter-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: blackbox-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: blackbox-exporter
+spec:
+  type: ClusterIP
+  ports:
+  - name: probe
+    port: 9115
+    protocol: TCP
+  selector:
+    app: blackbox-exporter

--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -446,24 +446,26 @@ data:
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.nodeExporter | indent 6 }}
 
     - job_name: vpn-connection
-      honor_labels: false
-      metrics_path: /probe
       params:
         module:
         - icmp_probe
         target:
         - {{ .Values.vpnEndpointIP }}
-      static_configs:
-      - targets:
-        - 127.0.0.1:9115
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [{{ .Release.Namespace }}]
+      metrics_path: /probe
       relabel_configs:
       - target_label: type
         replacement: seed
+      - source_labels:
+        - __meta_kubernetes_endpoints_name
+        - __meta_kubernetes_endpoint_port_name
+        action: keep
+        regex: blackbox-exporter;probe
       - source_labels: [ __param_target ]
         target_label: instance
-        action: replace
-      - target_label: __address__
-        replacement: 127.0.0.1:9115
         action: replace
       metric_relabel_configs:
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.vpn | indent 6 }}
@@ -497,35 +499,8 @@ data:
         target_label: instance
         action: replace
       - target_label: __address__
-        replacement: 127.0.0.1:9115
+        replacement: blackbox-exporter:9115
         action: replace
-      metric_relabel_configs:
-{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.vpn | indent 6 }}
-
-    # This probe is intended to be deprecated, because it is testing the vpn-tunnel and the
-    # reachability of the kube-apiservers from the shoot workers. We have introduced isolated
-    # probes for both cases and will therefore remove this probe in the future.
-    - job_name: vpn-probe-k8s-service
-      honor_labels: false
-      scrape_timeout: 5s
-      metrics_path: /probe
-      params:
-        module:
-        - tcp_vpn
-        target:
-        - {{ .Values.apiserverServiceIP }}:443
-      kubernetes_sd_configs:
-      - role: pod
-        namespaces:
-          names: [{{ .Release.Namespace }}]
-      relabel_configs:
-      - source_labels: [ __meta_kubernetes_pod_container_port_name ]
-        action: keep
-        regex: blackbox-export
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
-      - source_labels: [__meta_kubernetes_pod_name]
-        target_label: pod
       metric_relabel_configs:
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.vpn | indent 6 }}
 
@@ -533,23 +508,26 @@ data:
       params:
         module:
         - http_apiserver
-      scrape_timeout: 10s
-      metrics_path: /probe
-      static_configs:
-      - targets:
+        target:
         - {{ .Values.shoot.apiserver }}/healthz
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [{{ .Release.Namespace }}]
+      metrics_path: /probe
       relabel_configs:
       - target_label: type
-        replacement: seed
-      - source_labels: [__address__]
-        target_label: __param_target
-        action: replace
-      - source_labels: [__param_target]
+        replacement: shoot
+      - source_labels:
+        - __meta_kubernetes_endpoints_name
+        - __meta_kubernetes_endpoint_port_name
+        action: keep
+        regex: blackbox-exporter;probe
+      - source_labels: [ __param_target ]
         target_label: instance
         action: replace
-      - target_label: __address__
-        replacement: 127.0.0.1:9115
-        action: replace
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.blackboxExporter | indent 8 }}
 
     - job_name: blackbox-exporter-k8s-service-check
       params:

--- a/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
@@ -48,9 +48,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configmap-config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
-        checksum/configmap-rules: {{ include (print $.Template.BasePath "/rules.yaml") . | sha256sum }}
-        checksum/configmap-blackbox-exporter: {{ include (print $.Template.BasePath "/blackbox-exporter-config.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
@@ -133,6 +130,23 @@ spec:
         # we mount the Shoot cluster's CA and certs
         - mountPath: /etc/prometheus/seed
           name: prometheus-kubeconfig
+      - name: prometheus-config-reloader
+        image: {{ index .Values.images "configmap-reloader" }}
+        imagePullPolicy: IfNotPresent
+        args:
+        - -webhook-url=http://localhost:9090/-/reload
+        - -volume-dir=/etc/prometheus/config
+        - -volume-dir=/etc/prometheus/rules
+        resources:
+          requests:
+            cpu: 5m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /etc/prometheus/config
+          name: config
+          readOnly: true
+        - mountPath: /etc/prometheus/rules
+          name: rules
       - image: {{ index .Values.images "vpn-seed" }}
         imagePullPolicy: IfNotPresent
         name: vpn-seed
@@ -164,28 +178,6 @@ spec:
           name: vpn-seed-tlsauth
         - mountPath: /srv/auth
           name: kube-apiserver-basic-auth
-      - name: blackbox-exporter
-        image: {{ index .Values.images "blackbox-exporter" }}
-        args:
-        - --config.file=/vpn/blackbox.yaml
-        ports:
-        # port name must be max 15 characters long
-        - name: blackbox-export
-          containerPort: 9115
-          protocol: TCP
-        resources:
-          requests:
-            cpu: 5m
-            memory: 16Mi
-          limits:
-            cpu: 50m
-            memory: 128Mi
-        volumeMounts:
-        - name: blackbox-exporter-config-prometheus
-          mountPath: /vpn
-        - mountPath: /var/run/secrets/blackbox
-          name: prometheus-kubeconfig
-          readOnly: true
       terminationGracePeriodSeconds: 300
       volumes:
       - name: config
@@ -221,9 +213,6 @@ spec:
       - name: prometheus-kubelet
         secret:
           secretName: prometheus-kubelet
-      - name: blackbox-exporter-config-prometheus
-        configMap:
-          name: blackbox-exporter-config-prometheus
   volumeClaimTemplates:
   - metadata:
       name: prometheus-db


### PR DESCRIPTION
- Removed blackbox-exporter sidecar from Prometheus
- Created separate blackbox-exporter deployment
- Added config map reloader as sidecar to prometheus

**What this PR does / why we need it**:
Removes the blackbox exporter sidecar from prometheus and deploys it in its own deployment. We need this for security reasons.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Checksums for prometheus have been removed to allow the config map reloader to work without having prometheus restart.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Removed blackbox-exporter sidecar from Prometheus
```
```improvement operator
Created separate deployment for blackbox-exporter
```
