### PR TITLE
Change Alicloud EIP type PayByTraffic

### DIFF
--- a/charts/seed-terraformer/charts/alicloud-infra/templates/_main.tf
+++ b/charts/seed-terraformer/charts/alicloud-infra/templates/_main.tf
@@ -37,8 +37,9 @@ resource "alicloud_vswitch" "vsw_z{{ $index }}" {
 // Create a new EIP.
 resource "alicloud_eip" "eip_natgw_z{{ $index }}" {
   name                 = "{{ required "clusterName is required" $.Values.clusterName }}-eip-natgw-z{{ $index }}"
-  bandwidth            = "20"
-  internet_charge_type = "PayByBandwidth"
+  bandwidth            = "100"
+  instance_charge_type = "PostPaid"
+  internet_charge_type = "{{ required "vpc.internetChargeType is required" $.Values.vpc.internetChargeType }}"
 }
 
 resource "alicloud_eip_association" "eip_natgw_asso_z{{ $index }}" {

--- a/charts/seed-terraformer/charts/alicloud-infra/values.yaml
+++ b/charts/seed-terraformer/charts/alicloud-infra/values.yaml
@@ -13,7 +13,7 @@ vpc:
   cidr: 10.10.10.10/6
   natGatewayID: ${alicloud_nat_gateway.nat_gateway.id}
   snatTableID: ${alicloud_nat_gateway.nat_gateway.snat_table_ids} 
-
+  internetChargeType: PayByTraffic
 
 zones:
 - name: cn-beijing-a

--- a/pkg/client/alicloud/types.go
+++ b/pkg/client/alicloud/types.go
@@ -19,4 +19,5 @@ type ClientInterface interface {
 	GetCIDR(vpcID string) (string, error)
 	//Return NatGatewayID, SnatTableID
 	GetNatGatewayInfo(vpcID string) (string, string, error)
+	GetEIPInternetChargeType(vpcID string) (string, error)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Change Alicloud EIP type PayByTraffic. It will save a lot of money. Origin setup was charged more than 1/2 of VM instances!!!
 
```improvement user
Gardener does now create Alicloud EIPs with `PayByTraffic` policy for new clusters to save costs.
```