### PR TITLE
Clean up cluster-service label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.12.4 AS builder
+FROM golang:1.12.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .

--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment.yaml
@@ -9,7 +9,6 @@ metadata:
     chart: {{ template "kubernetes-dashboard.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     origin: gardener
 spec:
@@ -21,7 +20,6 @@ spec:
       heritage: "{{ .Release.Service }}"
       release: "{{ .Release.Name }}"
       chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-      kubernetes.io/cluster-service: "true"
   strategy:
     rollingUpdate:
       maxSurge: 0
@@ -38,7 +36,6 @@ spec:
         heritage: "{{ .Release.Service }}"
         release: "{{ .Release.Name }}"
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-        kubernetes.io/cluster-service: "true"
     spec:
       securityContext:
         runAsUser: 65534

--- a/example/30-cloudprofile-alicloud.yaml
+++ b/example/30-cloudprofile-alicloud.yaml
@@ -15,7 +15,8 @@ spec:
       - name: unmanaged
       kubernetes:
         versions:
-        - 1.13.4
+        - 1.14.0
+        - 1.13.6
       machineImages:
       - name: coreos-alicloud
         id: coreos_1911_5_0_64_30G_alibase_20181219.vhd

--- a/example/30-cloudprofile-aws.yaml
+++ b/example/30-cloudprofile-aws.yaml
@@ -15,9 +15,9 @@ spec:
       kubernetes:
         versions:
         - 1.14.0
-        - 1.13.4
-        - 1.12.6
-        - 1.11.8
+        - 1.13.6
+        - 1.12.8
+        - 1.11.10
         - 1.10.13
       machineImages:
       # Keep in sync with https://coreos.com/dist/aws/aws-stable.json (HVM-based)

--- a/example/30-cloudprofile-azure.yaml
+++ b/example/30-cloudprofile-azure.yaml
@@ -15,9 +15,9 @@ spec:
       kubernetes:
         versions:
         - 1.14.0
-        - 1.13.4
-        - 1.12.6
-        - 1.11.8
+        - 1.13.6
+        - 1.12.8
+        - 1.11.10
         - 1.10.13
       machineImages:
       - name: coreos

--- a/example/30-cloudprofile-gcp.yaml
+++ b/example/30-cloudprofile-gcp.yaml
@@ -15,9 +15,9 @@ spec:
       kubernetes:
         versions:
         - 1.14.0
-        - 1.13.4
-        - 1.12.6
-        - 1.11.8
+        - 1.13.6
+        - 1.12.8
+        - 1.11.10
         - 1.10.13
       machineImages:
       - name: coreos

--- a/example/30-cloudprofile-openstack.yaml
+++ b/example/30-cloudprofile-openstack.yaml
@@ -17,9 +17,9 @@ spec:
       kubernetes:
         versions:
         - 1.14.0
-        - 1.13.4
-        - 1.12.6
-        - 1.11.8
+        - 1.13.6
+        - 1.12.8
+        - 1.11.10
         - 1.10.13
       loadBalancerProviders:
       - name: haproxy

--- a/example/90-shoot-alicloud.yaml
+++ b/example/90-shoot-alicloud.yaml
@@ -25,7 +25,7 @@ spec:
         autoScalerMax: 2
       zones: ['cn-beijing-f']
   kubernetes:
-    version: 1.13.4
+    version: 1.14.0
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   featureGates:

--- a/hack/templates/resources/30-cloudprofile.yaml.tpl
+++ b/hack/templates/resources/30-cloudprofile.yaml.tpl
@@ -71,9 +71,9 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
         - 1.14.0
-        - 1.13.4
-        - 1.12.6
-        - 1.11.8
+        - 1.13.6
+        - 1.12.8
+        - 1.11.10
         - 1.10.13
         % endif
       machineImages:<% machineImages=value("spec.aws.constraints.machineImages", []) %>
@@ -177,9 +177,9 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
         - 1.14.0
-        - 1.13.4
-        - 1.12.6
-        - 1.11.8
+        - 1.13.6
+        - 1.12.8
+        - 1.11.10
         - 1.10.13
         % endif
       machineImages:<% machineImages=value("spec.azure.constraints.machineImages", []) %>
@@ -278,9 +278,9 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
         - 1.14.0
-        - 1.13.4
-        - 1.12.6
-        - 1.11.8
+        - 1.13.6
+        - 1.12.8
+        - 1.11.10
         - 1.10.13
         % endif
       machineImages:<% machineImages=value("spec.gcp.constraints.machineImages", []) %>
@@ -367,7 +367,8 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
         versions:
-        - 1.13.4
+        - 1.14.0
+        - 1.13.6
         % endif
       machineImages:<% machineImages=value("spec.alicloud.constraints.machineImages", []) %>
       % if machineImages != []:
@@ -533,9 +534,9 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
         - 1.14.0
-        - 1.13.4
-        - 1.12.6
-        - 1.11.8
+        - 1.13.6
+        - 1.12.8
+        - 1.11.10
         - 1.10.13
         % endif
       loadBalancerProviders:<% loadBalancerProviders=value("spec.openstack.constraints.loadBalancerProviders", []) %>

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -34,7 +34,7 @@
     kubernetesVersion="1.14.0"
   elif cloud == "alicloud":
     region="cn-beijing"
-    kubernetesVersion="1.13.4"
+    kubernetesVersion="1.14.0"
   elif cloud == "packet":
     region="EWR1"
     kubernetesVersion="1.14.0"

--- a/pkg/apis/core/types_plant.go
+++ b/pkg/apis/core/types_plant.go
@@ -45,7 +45,7 @@ type PlantList struct {
 }
 
 const (
-	// EveryPlantNodeReady is a constant for a condition type indicating the node health.
+	// PlantEveryNodeReady is a constant for a condition type indicating the node health.
 	PlantEveryNodeReady ConditionType = "EveryNodeReady"
 	// PlantAPIServerAvailable is a constant for a condition type indicating that the Plant cluster API server is available.
 	PlantAPIServerAvailable ConditionType = "APIServerAvailable"

--- a/pkg/apis/core/types_utils.go
+++ b/pkg/apis/core/types_utils.go
@@ -56,7 +56,7 @@ const (
 	ConditionTrue ConditionStatus = "True"
 	// ConditionFalse means a resource is not in the condition.
 	ConditionFalse ConditionStatus = "False"
-	// ConditionUnknown" means Gardener can't decide if a resource is in the condition or not.
+	// ConditionUnknown means Gardener can't decide if a resource is in the condition or not.
 	ConditionUnknown ConditionStatus = "Unknown"
 	// ConditionProgressing means the condition was seen true, failed but stayed within a predefined failure threshold.
 	// In the future, we could add other intermediate conditions, e.g. ConditionDegraded.

--- a/pkg/apis/core/v1alpha1/types_plant.go
+++ b/pkg/apis/core/v1alpha1/types_plant.go
@@ -46,7 +46,7 @@ type PlantList struct {
 }
 
 const (
-	// EveryPlantNodeReady is a constant for a condition type indicating the node health.
+	// PlantEveryNodeReady is a constant for a condition type indicating the node health.
 	PlantEveryNodeReady ConditionType = "EveryNodeReady"
 	// PlantAPIServerAvailable is a constant for a condition type indicating that the Plant cluster API server is available.
 	PlantAPIServerAvailable ConditionType = "APIServerAvailable"

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -128,7 +128,7 @@ type WorkerStatus struct {
 	MachineDeployments []MachineDeployment `json:"machineDeployments,omitempty"`
 }
 
-// MachineDeployments is a created machine deployments.
+// MachineDeployment is a created machine deployment.
 type MachineDeployment struct {
 	// Name is the name of the `MachineDeployment` resource.
 	Name string `json:"name"`

--- a/pkg/chartrenderer/sorter.go
+++ b/pkg/chartrenderer/sorter.go
@@ -61,15 +61,6 @@ var InstallOrder SortOrder = []string{
 	"APIService",
 }
 
-// sortByKind does an in-place sort of manifests by Kind.
-//
-// Results are sorted by 'ordering'
-func sortByKind(manifests []manifest.Manifest, ordering SortOrder) []manifest.Manifest {
-	ks := newKindSorter(manifests, ordering)
-	sort.Sort(ks)
-	return ks.manifests
-}
-
 type kindSorter struct {
 	ordering  map[string]int
 	manifests []manifest.Manifest

--- a/pkg/controllermanager/controller/secretbinding/secretbinding.go
+++ b/pkg/controllermanager/controller/secretbinding/secretbinding.go
@@ -37,8 +37,6 @@ type Controller struct {
 	k8sGardenClient    kubernetes.Interface
 	k8sGardenInformers gardeninformers.SharedInformerFactory
 
-	k8sInformers kubeinformers.SharedInformerFactory
-
 	control  ControlInterface
 	recorder record.EventRecorder
 

--- a/pkg/controllermanager/controller/seed/seed.go
+++ b/pkg/controllermanager/controller/seed/seed.go
@@ -40,8 +40,6 @@ type Controller struct {
 	k8sGardenClient    kubernetes.Interface
 	k8sGardenInformers gardeninformers.SharedInformerFactory
 
-	k8sInformers kubeinformers.SharedInformerFactory
-
 	config *config.ControllerManagerConfiguration
 
 	control  ControlInterface


### PR DESCRIPTION
**What this PR does / why we need it**:
- kubernetes.io/cluster-service label is deprecated by kube-addon-manager. The label is used by `kubectl cluster-info` only for `kind: Service` resources. Ref kubernetes/kubernetes#72757.
- Update example resources
- Improve goreport

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
