### PR TITLE
Prevent volume usage alerts

### DIFF
--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/_resource.tpl
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/_resource.tpl
@@ -1,3 +1,0 @@
-{{- define "curator.disk_threshold" -}}
-{{ printf "%d" ( div ( mul (add ( mul 13 (div $.baseDiskThreshold 1000000) ) ( mul 1000 ( sub $.objectCount 1 ) ) ) 1000000 ) 13 ) }}
-{{- end -}}

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/curator-cronjob.yml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/curator-cronjob.yml
@@ -26,8 +26,8 @@ spec:
           containers:
           - image: {{ index .Values.global.images "curator-es" }}
             name: curator
-            command: ["/bin/sh","-c"]
-            args: ["curator-es --disk-space-threshold={{ include "curator.disk_threshold" .Values.curator }}; curator --config /etc/config/config.yml /etc/config/action_file.yml"]
+            command: ["/bin/sh", "-c"]
+            args: ["curator-es --disk-space-threshold={{ .Values.curator.diskSpaceThreshold | int64 }}; curator --config /etc/config/config.yml /etc/config/action_file.yml"]
             volumeMounts:
             - name: config
               mountPath: /etc/config

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/values.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/values.yaml
@@ -15,16 +15,15 @@ ingress:
   basicAuthSecret: YWRtaW46JGFwcjEkSWRSaVM5c3MkR3U1MHMxaGUwL2Z6Tzh2elE4S1BEMQ==
 
 curator:
-  objectCount: 1
-  # set curator threshold to 1GB
-  baseDiskThreshold: 1073741824
+  # Set curator threshold to 1.5Gi
+  diskSpaceThreshold: 1610612736
   hourly:
     schedule: "0 * * * *"
     suspend: false
   daily:
     schedule: "5 0,6,12,18 * * *"
     suspend: false
-    
+
 elasticsearch:
   replicaCount: 1
   persistence:

--- a/charts/seed-monitoring/charts/prometheus/rules/kube-kubelet.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/kube-kubelet.rules.yaml
@@ -67,7 +67,14 @@ groups:
       description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} is only {{ printf "%0.2f" $value }}% free.
       summary: PersistentVolume almost full.
   - alert: KubePersistentVolumeFullInFourDays
-    expr: 100 * (kubelet_volume_stats_available_bytes{type="seed"} / kubelet_volume_stats_capacity_bytes{type="seed"}) < 15 and predict_linear(kubelet_volume_stats_available_bytes{type="seed"}[30m], 4 * 24 * 3600) <= 0
+    expr: |
+      100 * (
+        kubelet_volume_stats_available_bytes{type="seed", persistentvolumeclaim!~"elasticsearch-logging-.*"}
+          /
+        kubelet_volume_stats_capacity_bytes{type="seed", persistentvolumeclaim!~"elasticsearch-logging-.*"}
+      ) < 15
+      and
+      predict_linear(kubelet_volume_stats_available_bytes{type="seed", persistentvolumeclaim!~"elasticsearch-logging-.*"}[30m], 4 * 24 * 3600) <= 0
     for: 1h
     labels:
       service: kube-kubelet-seed

--- a/docs/usage/shoots.md
+++ b/docs/usage/shoots.md
@@ -24,7 +24,7 @@ If a shoot has `.spec.maintenance.autoUpdate.kubernetesVersion: true` in the man
 
 Since Kubernetes follows [Semantic Versioning](http://semver.org/), if indicated so, Gardener will automatically apply the patch release updates. But it will never auto update the Major or Minor releases since there is no effort to keep backward compatibility in those releases.
 
-Major or Minor updates must be handled by updating the `.spec.kubernetes.version` field manually, theese updates will be executed immediately and will not wait for maintenance time window. **Before applying such update on Minor or Major releases, operators should check for all the breaking chances introduced in the target release Changelog**.
+Major or Minor updates must be handled by updating the `.spec.kubernetes.version` field manually, these updates will be executed immediately and will not wait for maintenance time window. **Before applying such update on Minor or Major releases, operators should check for all the breaking changes introduced in the target release Changelog**.
 
 E.g. If you have a shoot cluster with below field values (only related fields are shown):
 

--- a/pkg/apis/core/v1alpha1/types_utils.go
+++ b/pkg/apis/core/v1alpha1/types_utils.go
@@ -62,7 +62,7 @@ const (
 	ConditionTrue ConditionStatus = "True"
 	// ConditionFalse means a resource is not in the condition.
 	ConditionFalse ConditionStatus = "False"
-	// ConditionUnknown" means Gardener can't decide if a resource is in the condition or not.
+	// ConditionUnknown means Gardener can't decide if a resource is in the condition or not.
 	ConditionUnknown ConditionStatus = "Unknown"
 	// ConditionProgressing means the condition was seen true, failed but stayed within a predefined failure threshold.
 	// In the future, we could add other intermediate conditions, e.g. ConditionDegraded.

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -38,27 +38,27 @@ import (
 )
 
 var wantedCertificateAuthorities = map[string]*secrets.CertificateSecretConfig{
-	gardencorev1alpha1.SecretNameCACluster: &secrets.CertificateSecretConfig{
+	gardencorev1alpha1.SecretNameCACluster: {
 		Name:       gardencorev1alpha1.SecretNameCACluster,
 		CommonName: "kubernetes",
 		CertType:   secrets.CACert,
 	},
-	gardencorev1alpha1.SecretNameCAETCD: &secrets.CertificateSecretConfig{
+	gardencorev1alpha1.SecretNameCAETCD: {
 		Name:       gardencorev1alpha1.SecretNameCAETCD,
 		CommonName: "etcd",
 		CertType:   secrets.CACert,
 	},
-	gardencorev1alpha1.SecretNameCAFrontProxy: &secrets.CertificateSecretConfig{
+	gardencorev1alpha1.SecretNameCAFrontProxy: {
 		Name:       gardencorev1alpha1.SecretNameCAFrontProxy,
 		CommonName: "front-proxy",
 		CertType:   secrets.CACert,
 	},
-	gardencorev1alpha1.SecretNameCAKubelet: &secrets.CertificateSecretConfig{
+	gardencorev1alpha1.SecretNameCAKubelet: {
 		Name:       gardencorev1alpha1.SecretNameCAKubelet,
 		CommonName: "kubelet",
 		CertType:   secrets.CACert,
 	},
-	gardencorev1alpha1.SecretNameCAMetricsServer: &secrets.CertificateSecretConfig{
+	gardencorev1alpha1.SecretNameCAMetricsServer: {
 		Name:       gardencorev1alpha1.SecretNameCAMetricsServer,
 		CommonName: "metrics-server",
 		CertType:   secrets.CACert,

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -183,9 +183,6 @@ const (
 	// AWSLBReadvertiserDeploymentName is the name for the aws-lb-readvertiser
 	AWSLBReadvertiserDeploymentName = "aws-lb-readvertiser"
 
-	// EnableHPANodeCount is the number of nodes in shoot cluster after which HPA is deployed to autoscale kube-apiserver.
-	EnableHPANodeCount = 5
-
 	// CloudControllerManagerDeploymentName is the name of the cloud-controller-manager deployment.
 	CloudControllerManagerDeploymentName = "cloud-controller-manager"
 

--- a/pkg/operation/garden/garden_test.go
+++ b/pkg/operation/garden/garden_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Garden", func() {
 
 		It("should return an error", func() {
 			secrets := map[string]*corev1.Secret{
-				fmt.Sprintf("%s-%s", common.GardenRoleDefaultDomain, "nip"): &corev1.Secret{
+				fmt.Sprintf("%s-%s", common.GardenRoleDefaultDomain, "nip"): {
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							common.DNSProvider: "aws",
@@ -122,7 +122,7 @@ var _ = Describe("Garden", func() {
 
 		It("should return an error", func() {
 			secrets := map[string]*corev1.Secret{
-				common.GardenRoleInternalDomain: &corev1.Secret{
+				common.GardenRoleInternalDomain: {
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{
 							common.DNSProvider: "aws",

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -52,7 +52,7 @@ const (
 )
 
 var wantedCertificateAuthorities = map[string]*utilsecrets.CertificateSecretConfig{
-	caSeed: &utilsecrets.CertificateSecretConfig{
+	caSeed: {
 		Name:       caSeed,
 		CommonName: "kubernetes",
 		CertType:   utilsecrets.CACert,
@@ -418,13 +418,13 @@ func BootstrapCluster(seed *Seed, secrets map[string]*corev1.Secret, imageVector
 				"host":            kibanaHost,
 			},
 			"curator": map[string]interface{}{
-				"objectCount":       nodeCount,
-				"baseDiskThreshold": 2 * 1073741824,
+				// Set curator threshold to 5Gi
+				"diskSpaceThreshold": 5 * 1024 * 1024 * 1024,
 			},
 			"elasticsearch": map[string]interface{}{
 				"objectCount": nodeCount,
 				"persistence": map[string]interface{}{
-					"size": "100Gi",
+					"size": seed.GetValidVolumeSize("100Gi"),
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
`KubePersistentVolumeUsageCritical` is filed when pv free disk space goes below 5%. The PR sets elasticsearch curator disk space threshold also to 5% (1.5Gi for shoot cp, and 5Gi for garden ns) to prevent the alert.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@wyb1 , @mvladev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
