### PR TITLE
Change blackbox exporter listen address to 127.0.0.1

### DIFF
--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -502,33 +502,6 @@ data:
       metric_relabel_configs:
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.vpn | indent 6 }}
 
-    # This probe is intended to be deprecated, because it is testing the vpn-tunnel and the
-    # reachability of the kube-apiservers from the shoot workers. We have introduced isolated
-    # probes for both cases and will therefore remove this probe in the future.
-    - job_name: vpn-probe-k8s-service
-      honor_labels: false
-      scrape_timeout: 5s
-      metrics_path: /probe
-      params:
-        module:
-        - tcp_vpn
-        target:
-        - {{ .Values.apiserverServiceIP }}:443
-      kubernetes_sd_configs:
-      - role: pod
-        namespaces:
-          names: [{{ .Release.Namespace }}]
-      relabel_configs:
-      - source_labels: [ __meta_kubernetes_pod_container_port_name ]
-        action: keep
-        regex: blackbox-export
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
-      - source_labels: [__meta_kubernetes_pod_name]
-        target_label: pod
-      metric_relabel_configs:
-{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.vpn | indent 6 }}
-
     - job_name: blackbox-apiserver
       params:
         module:

--- a/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
@@ -168,6 +168,7 @@ spec:
         image: {{ index .Values.images "blackbox-exporter" }}
         args:
         - --config.file=/vpn/blackbox.yaml
+        - --web.listen-address=127.0.0.1:9115
         ports:
         # port name must be max 15 characters long
         - name: blackbox-export


### PR DESCRIPTION
**What this PR does / why we need it**:
Set the listen address of the blackbox-exporter to `127.0.0.1:9115`. This means that the blackbox-exporter is only reachable via localhost (i.e. only reachable from Prometheus). Other components should not be able to talk to the blackbox-exporter. Also removed the deprecated vpn test.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
