### PR TITLE
Extend Project with Viewers

### DIFF
--- a/charts/garden-project/charts/project-rbac/templates/clusterrole-project-viewer.yaml
+++ b/charts/garden-project/charts/project-rbac/templates/clusterrole-project-viewer.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: garden.sapcloud.io:system:project-viewer:{{ .Values.project.name }}
+  ownerReferences:
+  - apiVersion: garden.sapcloud.io/v1beta1
+    kind: Project
+    blockOwnerDeletion: false
+    controller: true
+    name: {{ .Values.project.name | quote }}
+    uid: {{ .Values.project.uid | quote }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  resourceNames:
+  - {{ .Release.Namespace | quote }}
+  verbs:
+  - get
+- apiGroups:
+  - garden.sapcloud.io
+  resources:
+  - projects
+  resourceNames:
+  - {{ .Values.project.name | quote }}
+  verbs:
+  - get

--- a/charts/garden-project/charts/project-rbac/templates/clusterrolebinding-project-viewers.yaml
+++ b/charts/garden-project/charts/project-rbac/templates/clusterrolebinding-project-viewers.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: garden.sapcloud.io:system:project-viewer:{{ .Values.project.name }}
+  ownerReferences:
+  - apiVersion: garden.sapcloud.io/v1beta1
+    kind: Project
+    blockOwnerDeletion: false
+    controller: true
+    name: {{ .Values.project.name | quote }}
+    uid: {{ .Values.project.uid | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: garden.sapcloud.io:system:project-viewer:{{ .Values.project.name }}
+{{- if .Values.project.viewers }}
+subjects:
+{{ toYaml .Values.project.viewers }}
+{{- else }}
+subjects: []
+{{- end }}

--- a/charts/garden-project/charts/project-rbac/templates/rolebinding-project-viewers.yaml
+++ b/charts/garden-project/charts/project-rbac/templates/rolebinding-project-viewers.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: RoleBinding
+metadata:
+  name: garden.sapcloud.io:system:project-viewer
+  namespace: {{ .Release.Namespace }}
+  ownerReferences:
+  - apiVersion: garden.sapcloud.io/v1beta1
+    kind: Project
+    blockOwnerDeletion: false
+    controller: true
+    name: {{ .Values.project.name | quote }}
+    uid: {{ .Values.project.uid | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: garden.sapcloud.io:system:project-viewer
+{{- if .Values.project.viewers }}
+subjects:
+{{ toYaml .Values.project.viewers }}
+{{- else }}
+subjects: []
+{{- end }}

--- a/charts/garden-project/charts/project-rbac/values.yaml
+++ b/charts/garden-project/charts/project-rbac/values.yaml
@@ -9,3 +9,7 @@ project:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: alice.doe@example.com
+  viewers:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: bob.doe@example.com

--- a/charts/gardener/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/charts/application/templates/rbac-user.yaml
@@ -155,3 +155,45 @@ rules:
   - patch
   - update
   - watch
+
+# Cluster role setting the permissions for a project viweer. It gets bound by a RoleBinding
+# in a respective project namespace.
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: garden.sapcloud.io:system:project-viewer
+  labels:
+    garden.sapcloud.io/role: project-viewer
+    app: gardener
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - garden.sapcloud.io
+  resources:
+  - shoots
+  - secretbindings
+  - quotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - core.gardener.cloud
+  resources:
+  - plants
+  verbs:
+  - get
+  - list
+  - watch

--- a/example/05-project-dev.yaml
+++ b/example/05-project-dev.yaml
@@ -14,6 +14,10 @@ spec:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: alice.doe@example.com
+  viewers:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: bob.doe@example.com
 # description: "This is my first project"
 # purpose: "Experimenting with Gardener"
   # The `spec.namespace` field is optional and will be initialized if unset - the resulting

--- a/hack/templates/resources/05-project-dev.yaml.tpl
+++ b/hack/templates/resources/05-project-dev.yaml.tpl
@@ -30,7 +30,7 @@ metadata:
   % if labels != {}:
   labels: ${yaml.dump(labels, width=10000, default_flow_style=None)}
   % endif
-spec:<% owner = value("spec.owner", {}); description = value("spec.description", ""); purpose = value("spec.purpose", ""); namespace = value("spec.namespace", ""); members = value("spec.members", []) %>
+spec:<% owner = value("spec.owner", {}); description = value("spec.description", ""); purpose = value("spec.purpose", ""); namespace = value("spec.namespace", ""); members = value("spec.members", []); viewers = value("spec.viewers", []) %>
   % if owner != {}:
   owner: ${yaml.dump(owner, width=10000, default_flow_style=None)}
   % else:
@@ -46,6 +46,14 @@ spec:<% owner = value("spec.owner", {}); description = value("spec.description",
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: alice.doe@example.com
+  % endif
+  % if viewers != []:
+  viewers: ${yaml.dump(viewers, width=10000, default_flow_style=None)}
+  % else:
+  viewers:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: bob.doe@example.com
   % endif
   % if description != "":
   description: ${description}

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -482,12 +482,15 @@ type ProjectSpec struct {
 	// +optional
 	Purpose *string
 	// Members is a list of subjects representing a user name, an email address, or any other identifier of a user
-	// that should be part of this project.
+	// that should be part of this project with full permissions to manage it.
 	// +optional
 	Members []rbacv1.Subject
 	// Namespace is the name of the namespace that has been created for the Project object.
 	// +optional
 	Namespace *string
+	// Viewers is a list of subjects representing a user name, an email address, or any other identifier of a user
+	// that should be part of this project with limited permissions to only view some resources.
+	Viewers []rbacv1.Subject `json:"viewers,omitempty"`
 }
 
 // ProjectStatus holds the most recently observed status of the project.

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -478,13 +478,17 @@ type ProjectSpec struct {
 	// +optional
 	Purpose *string `json:"purpose,omitempty"`
 	// Members is a list of subjects representing a user name, an email address, or any other identifier of a user
-	// that should be part of this project.
+	// that should be part of this project with full permissions to manage it.
 	// +optional
 	Members []rbacv1.Subject `json:"members,omitempty"`
 	// Namespace is the name of the namespace that has been created for the Project object.
 	// A nil value means that Gardener will determine the name of the namespace.
 	// +optional
 	Namespace *string `json:"namespace,omitempty"`
+	// Viewers is a list of subjects representing a user name, an email address, or any other identifier of a user
+	// that should be part of this project with limited permissions to only view some resources.
+	// +optional
+	Viewers []rbacv1.Subject `json:"viewers,omitempty"`
 }
 
 // ProjectStatus holds the most recently observed status of the project.

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -4119,6 +4119,7 @@ func autoConvert_v1beta1_ProjectSpec_To_garden_ProjectSpec(in *ProjectSpec, out 
 	out.Purpose = (*string)(unsafe.Pointer(in.Purpose))
 	out.Members = *(*[]rbacv1.Subject)(unsafe.Pointer(&in.Members))
 	out.Namespace = (*string)(unsafe.Pointer(in.Namespace))
+	out.Viewers = *(*[]rbacv1.Subject)(unsafe.Pointer(&in.Viewers))
 	return nil
 }
 
@@ -4134,6 +4135,7 @@ func autoConvert_garden_ProjectSpec_To_v1beta1_ProjectSpec(in *garden.ProjectSpe
 	out.Purpose = (*string)(unsafe.Pointer(in.Purpose))
 	out.Members = *(*[]rbacv1.Subject)(unsafe.Pointer(&in.Members))
 	out.Namespace = (*string)(unsafe.Pointer(in.Namespace))
+	out.Viewers = *(*[]rbacv1.Subject)(unsafe.Pointer(&in.Viewers))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -2622,6 +2622,11 @@ func (in *ProjectSpec) DeepCopyInto(out *ProjectSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Viewers != nil {
+		in, out := &in.Viewers, &out.Viewers
+		*out = make([]rbacv1.Subject, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/garden/validation/validation.go
+++ b/pkg/apis/garden/validation/validation.go
@@ -644,6 +644,9 @@ func ValidateProjectSpec(projectSpec *garden.ProjectSpec, fldPath *field.Path) f
 	for i, member := range projectSpec.Members {
 		allErrs = append(allErrs, ValidateSubject(member, fldPath.Child("members").Index(i))...)
 	}
+	for i, viewer := range projectSpec.Viewers {
+		allErrs = append(allErrs, ValidateSubject(viewer, fldPath.Child("viewers").Index(i))...)
+	}
 	if createdBy := projectSpec.CreatedBy; createdBy != nil {
 		allErrs = append(allErrs, ValidateSubject(*createdBy, fldPath.Child("createdBy"))...)
 	}

--- a/pkg/apis/garden/validation/validation_test.go
+++ b/pkg/apis/garden/validation/validation_test.go
@@ -1840,6 +1840,13 @@ var _ = Describe("validation", func() {
 							Name:     "alice.doe@example.com",
 						},
 					},
+					Viewers: []rbacv1.Subject{
+						{
+							APIGroup: "rbac.authorization.k8s.io",
+							Kind:     rbacv1.UserKind,
+							Name:     "bob.doe@example.com",
+						},
+					},
 				},
 			}
 		})

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -2599,6 +2599,11 @@ func (in *ProjectSpec) DeepCopyInto(out *ProjectSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Viewers != nil {
+		in, out := &in.Viewers, &out.Viewers
+		*out = make([]rbacv1.Subject, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -117,6 +117,7 @@ func (c *defaultControl) reconcile(project *gardenv1beta1.Project, projectLogger
 			"uid":     project.UID,
 			"owner":   project.Spec.Owner,
 			"members": project.Spec.Members,
+			"viewers": project.Spec.Viewers,
 		},
 	}, nil); err != nil {
 		c.reportEvent(project, true, gardenv1beta1.ProjectEventNamespaceReconcileFailed, "Error while creating RBAC rules for namespace %q: %+v", namespace.Name, err)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -5616,7 +5616,7 @@ func schema_pkg_apis_garden_v1beta1_ProjectSpec(ref common.ReferenceCallback) co
 					},
 					"members": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Members is a list of subjects representing a user name, an email address, or any other identifier of a user that should be part of this project.",
+							Description: "Members is a list of subjects representing a user name, an email address, or any other identifier of a user that should be part of this project with full permissions to manage it.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -5632,6 +5632,19 @@ func schema_pkg_apis_garden_v1beta1_ProjectSpec(ref common.ReferenceCallback) co
 							Description: "Namespace is the name of the namespace that has been created for the Project object. A nil value means that Gardener will determine the name of the namespace.",
 							Type:        []string{"string"},
 							Format:      "",
+						},
+					},
+					"viewers": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Viewers is a list of subjects representing a user name, an email address, or any other identifier of a user that should be part of this project with limited permissions to only view some resources.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/rbac/v1.Subject"),
+									},
+								},
+							},
 						},
 					},
 				},

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -140,7 +140,7 @@ const (
 	// GardenRoleOpenVPNDiffieHellman is the value of the GardenRole key indicating type 'openvpn-diffie-hellman'.
 	GardenRoleOpenVPNDiffieHellman = "openvpn-diffie-hellman"
 
-	// GardenRoleMembers ist the value of GardenRole key indicating type 'members'.
+	// GardenRoleMembers is the value of GardenRole key indicating type 'members'.
 	GardenRoleMembers = "members"
 
 	//GardenRoleProject is the value of GardenRole key indicating type 'project'.


### PR DESCRIPTION
**What this PR does / why we need it**:
The `Project` resource is extended with optional field `Viewers` which gives read-only access to the gardener API.

**Which issue(s) this PR fixes**:
Fixes #984 

**Special notes for your reviewer**:
At the moment `Members` can create `ServiceAccounts`, but they cannot create roles and rolebindings. As alternative solution I was thinking about to let members create their own `RoleBindings` but in that way they could escalate their privileges(rolebinding to the clusterrole `cluster-admin`), so I decided not to do it in this way.

/cc @marwinski  @ThormaehlenFred 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
The `Project` resource is extended with the optional field `viewers` which is a list of subjects with read-only access (except `Secret`s) to the Gardener API.
```
