### PR TITLE
Configure prometheus to scrape metrics for the central logging stack

### DIFF
--- a/.ci/test
+++ b/.ci/test
@@ -54,3 +54,8 @@ echo "Executing Prometheus alert tests"
 pushd $SOURCE_PATH/charts/seed-monitoring/charts/core/charts/prometheus > /dev/null
   promtool test rules rules-tests/*test.yaml
 popd > /dev/null
+
+echo "Executing aggregate Prometheus alert tests"
+pushd $SOURCE_PATH/charts/seed-bootstrap/aggregate-prometheus-rules-tests > /dev/null
+  promtool test rules *test.yaml
+popd > /dev/null

--- a/charts/seed-bootstrap/aggregate-prometheus-rules-tests/elasticsearch.rules.test.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules-tests/elasticsearch.rules.test.yaml
@@ -1,0 +1,23 @@
+rule_files:
+- ../aggregate-prometheus-rules/elasticsearch.rules.yaml
+
+evaluation_interval: 30s
+
+tests:
+- interval: 30s
+  input_series:
+  # ElasticsearchDown
+  - series: 'up{job="elasticsearch-logging"}'
+    values: '0+0x30'
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: ElasticsearchDown
+    exp_alerts:
+    - exp_labels:
+        service: elasticsearch-logging
+        severity: warning
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: There are no running elasticsearch pods. No logs will be collected.
+        summary: Elasticsearch is down

--- a/charts/seed-bootstrap/aggregate-prometheus-rules-tests/fluent-bit.rules.test.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules-tests/fluent-bit.rules.test.yaml
@@ -1,0 +1,24 @@
+rule_files:
+- ../aggregate-prometheus-rules/fluent-bit.rules.yaml
+
+evaluation_interval: 30s
+
+tests:
+- interval: 30s
+  input_series:
+  # FluentBitDown
+  - series: 'up{job="fluent-bit"}'
+    values: '0+0x30'
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: FluentBitDown
+    exp_alerts:
+    - exp_labels:
+        service: fluent-bit
+        severity: warning
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: There are no running fluent-bit pods. No logs will be collected.
+        summary: Fluent-bit is down
+

--- a/charts/seed-bootstrap/aggregate-prometheus-rules-tests/fluentd.rules.test.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules-tests/fluentd.rules.test.yaml
@@ -1,0 +1,24 @@
+rule_files:
+- ../aggregate-prometheus-rules/fluentd.rules.yaml
+
+evaluation_interval: 30s
+
+tests:
+- interval: 30s
+  input_series:
+  # FluentdDown
+  - series: 'up{app="fluentd-es"}'
+    values: '0+0x30'
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: FluentdDown
+    exp_alerts:
+    - exp_labels:
+        service: fluentd-es
+        severity: warning
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: There are no running fluentd pods. No logs will be collected.
+        summary: Fluentd is down
+

--- a/charts/seed-bootstrap/aggregate-prometheus-rules/elasticsearch.rules.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules/elasticsearch.rules.yaml
@@ -1,0 +1,14 @@
+groups:
+- name: elasticsearch.rules
+  rules:
+  - alert: ElasticsearchDown
+    expr: absent(up{job="elasticsearch-logging"} == 1)
+    for: 15m
+    labels:
+      service: elasticsearch-logging
+      severity: warning
+      type: seed
+      visibility: operator
+    annotations:
+      description: There are no running elasticsearch pods. No logs will be collected.
+      summary: Elasticsearch is down

--- a/charts/seed-bootstrap/aggregate-prometheus-rules/fluent-bit.rules.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules/fluent-bit.rules.yaml
@@ -1,0 +1,14 @@
+groups:
+- name: fluent-bit.rules
+  rules:
+  - alert: FluentBitDown
+    expr: absent(up{job="fluent-bit"} == 1)
+    for: 15m
+    labels:
+      service: fluent-bit
+      severity: warning
+      type: seed
+      visibility: operator
+    annotations:
+      description: There are no running fluent-bit pods. No logs will be collected.
+      summary: Fluent-bit is down

--- a/charts/seed-bootstrap/aggregate-prometheus-rules/fluentd.rules.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules/fluentd.rules.yaml
@@ -1,0 +1,14 @@
+groups:
+- name: fluentd.rules
+  rules:
+  - alert: FluentdDown
+    expr: absent(up{app="fluentd-es"} == 1)
+    for: 15m
+    labels:
+      service: fluentd-es
+      severity: warning
+      type: seed
+      visibility: operator
+    annotations:
+      description: There are no running fluentd pods. No logs will be collected.
+      summary: Fluentd is down

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/allow-to-elasticsearch-network-policy.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/allow-to-elasticsearch-network-policy.yaml
@@ -21,8 +21,6 @@ spec:
     ports:
     - protocol: TCP
       port: {{ .Values.global.elasticsearchPorts.db }}
-    - protocol: TCP
-      port: {{ .Values.global.elasticsearchPorts.metricsExporter }}
   policyTypes:
   - Egress
   ingress: []

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
@@ -12,6 +12,9 @@ data:
         Daemon          Off
         Log_Level       info
         Parsers_File    parsers.conf
+        HTTP_Server     On
+        HTTP_Listen     0.0.0.0
+        HTTP_PORT       {{ .Values.fluentbit.ports.metrics }}
 
     @INCLUDE input-kubernetes.conf
     @INCLUDE input-systemd.conf
@@ -30,6 +33,9 @@ data:
         Mem_Buf_Limit     12MB
         Refresh_Interval  10
         Ignore_Older      1800s
+        
+    [INPUT]
+        Name cpu
 
   input-systemd.conf: |-
     [INPUT]
@@ -292,6 +298,10 @@ data:
         Match           *
         Host            ${FLUENTD_HOST}
         Port            ${FLUENTD_PORT}
+
+    [OUTPUT]
+        Name  stdout
+        Match *
 
   parsers.conf: |-
     [PARSER]

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-daemonset.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
 {{ toYaml .Values.fluentbit.labels | indent 4 }}
 spec:
+  serviceName: fluent-bit
   selector:
     matchLabels:
 {{ toYaml .Values.fluentbit.labels | indent 6 }}

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-service.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fluent-bit
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+{{ toYaml .Values.fluentbit.labels | indent 4 }}
+  ports:
+  - name: metrics
+    port: {{ .Values.fluentbit.ports.metrics }}
+    protocol: TCP
+    targetPort: {{ .Values.fluentbit.ports.metrics }}

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-configmap.yaml
@@ -15,6 +15,33 @@ data:
       bind 0.0.0.0
     </source>
 
+  monitoring.conf: |-
+    # Prometheus Exporter Plugin
+    # input plugin that exports metrics
+    <source>
+      @id prometheus
+      @type prometheus
+    </source>
+    <source>
+      @id monitor_agent
+      @type monitor_agent
+    </source>
+    # input plugin that collects metrics from MonitorAgent
+    <source>
+      @id prometheus_monitor
+      @type prometheus_monitor
+    </source>
+    # input plugin that collects metrics for output plugin
+    <source>
+      @id prometheus_output_monitor
+      @type prometheus_output_monitor
+    </source>
+    # input plugin that collects metrics for in_tail plugin
+    <source>
+      @id prometheus_tail_monitor
+      @type prometheus_tail_monitor
+    </source>
+
   output.conf: |-
     # Decide which is shoot record and which is not
     <match kubernetes.**>

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-service.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-service.yaml
@@ -17,3 +17,7 @@ spec:
     port: {{ .Values.fluentd.ports.forward }}
     protocol: UDP
     targetPort: fwd-input-udp
+  - name: metrics
+    port: {{ .Values.fluentd.ports.metrics }}
+    protocol: TCP
+    targetPort: {{ .Values.fluentd.ports.metrics }}

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-statefulset.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-statefulset.yaml
@@ -23,6 +23,7 @@ spec:
         checksum/fluentd-es-configmap: {{ include (print $.Template.BasePath "/fluentd-es-configmap.yaml") . | sha256sum }}
       labels:
 {{ toYaml .Values.fluentd.labels | indent 8 }}
+        networking.gardener.cloud/from-aggregate-prometheus: allowed
         networking.gardener.cloud/to-dns: allowed
     spec:
       affinity:
@@ -60,6 +61,9 @@ spec:
         - containerPort: {{ .Values.fluentd.ports.forward }}
           name: fwd-input-udp
           protocol: UDP
+        - name: metrics
+          protocol: TCP
+          containerPort: {{ .Values.fluentd.ports.metrics }}
         livenessProbe:
           tcpSocket:
             port: {{ .Values.fluentd.ports.forward }}

--- a/charts/seed-bootstrap/charts/fluentd-es/values.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/values.yaml
@@ -11,6 +11,7 @@ fluentd:
   storage: 9Gi
   ports:
     forward: 24224
+    metrics: 24231
   labels:
     garden.sapcloud.io/role: logging
     app: fluentd-es
@@ -27,3 +28,5 @@ fluentbit:
     garden.sapcloud.io/role: logging
     app: fluent-bit
     role: logging
+  ports:
+    metrics: 2020

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/allow-from-aggregate-prometheus-network-policy.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/allow-from-aggregate-prometheus-network-policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: {{ include "networkpolicyversion" . }}
+kind: NetworkPolicy
+metadata:
+  annotations:
+    gardener.cloud/description: |
+      Allows Ingress from Prometheus to pods labeled with 'networking.gardener.cloud/from-prometheus=allowed'
+      and ports named 'metrics' in the PodSpecification.
+  name: allow-from-aggregate-prometheus
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      networking.gardener.cloud/from-aggregate-prometheus: allowed
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: aggregate-prometheus
+          role: monitoring
+    ports:
+    - port: metrics
+      protocol: TCP
+  policyTypes:
+  - Ingress
+  egress: []

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
@@ -12,6 +12,9 @@ data:
       external_labels:
         seed: seed
 
+    rule_files:
+    - /etc/prometheus/rules/*.yaml
+
     scrape_configs:
     - job_name: shoot-prometheus
       metrics_path: /federate
@@ -67,18 +70,63 @@ data:
         regex: ^{{ .Release.Namespace }}$
 
     - job_name: elasticsearch-logging
+      honor_labels: false
       kubernetes_sd_configs:
       - role: endpoints
         namespaces:
-          names: [{{ .Release.Namespace }}]
+          names: [ garden ]
       relabel_configs:
       - source_labels:
-        - __meta_kubernetes_endpoints_name
+        - __meta_kubernetes_service_name
         - __meta_kubernetes_endpoint_port_name
-        regex: elasticsearch-logging;metrics
         action: keep
+        regex: elasticsearch-logging;metrics
+      # common metrics
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
       metric_relabel_configs:
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.elasticsearch | indent 6 }}
-      - source_labels: [ namespace ]
+
+    - job_name: fluentd
+      honor_labels: false
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [ garden ]
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
         action: keep
-        regex: ^{{ .Release.Namespace }}$
+        regex: fluentd-es;metrics
+      # common metrics
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.fluentd | indent 6 }}
+
+    - job_name: fluent-bit
+      honor_labels: false
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [ garden ]
+      relabel_configs:
+      - target_label: __metrics_path__
+        replacement: /api/v1/metrics/prometheus
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+        action: keep
+        regex: fluent-bit;metrics
+      # common metrics
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.fluentbit| indent 6 }}

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/rules.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/rules.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aggregate-prometheus-rules
+  namespace: {{ .Release.Namespace }}
+data:
+{{ (.Files.Glob "aggregate-prometheus-rules/**").AsConfig | indent 2 }}

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/statefulset.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/statefulset.yaml
@@ -68,12 +68,16 @@ spec:
         - mountPath: /var/prometheus/data
           name: prometheus-db
           subPath: prometheus-
+        - mountPath: /etc/prometheus/rules
+          name: rules
+          readOnly: true
       - name: prometheus-config-reloader
         image: {{ index .Values.global.images "configmap-reloader" }}
         imagePullPolicy: IfNotPresent
         args:
         - -webhook-url=http://localhost:{{ .Values.aggregatePrometheus.port }}/-/reload
         - -volume-dir=/etc/prometheus/config
+        - -volume-dir=/etc/prometheus/rules
         resources:
           requests:
             cpu: 5m
@@ -85,12 +89,19 @@ spec:
         - mountPath: /etc/prometheus/config
           name: config
           readOnly: true
+        - mountPath: /etc/prometheus/rules
+          name: rules
+          readOnly: true
       terminationGracePeriodSeconds: 300
       volumes:
       - name: config
         configMap:
           defaultMode: 420
           name: aggregate-prometheus-config
+      - name: rules
+        configMap:
+          defaultMode: 420
+          name: aggregate-prometheus-rules
   volumeClaimTemplates:
   - metadata:
       name: prometheus-db

--- a/charts/seed-bootstrap/templates/prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/config.yaml
@@ -111,3 +111,4 @@ data:
 
       metric_relabel_configs:
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.kubelet | indent 6 }}
+

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -10,6 +10,7 @@ aggregatePrometheus:
 
 allowedMetrics:
   alertmanager: []
+
   cAdvisor:
   - container_cpu_cfs_periods_total
   - container_cpu_usage_seconds_total
@@ -22,10 +23,44 @@ allowedMetrics:
   - container_memory_working_set_bytes
   - container_network_receive_bytes_total
   - container_network_transmit_bytes_total
-  elasticsearch: []
+
   kubelet:
   - kubelet_volume_stats_available_bytes
   - kubelet_volume_stats_capacity_bytes
+
+  fluentd:
+  - fluentd_output_status_buffer_queue_length
+  - fluentd_output_status_buffer_total_bytes
+  - fluentd_output_status_retry_count
+  - fluentd_output_status_num_errors
+  - fluentd_output_status_emit_count
+  - fluentd_output_status_retry_wait
+  - fluentd_output_status_emit_records
+  - fluentd_output_status_write_count
+  - fluentd_output_status_rollback_count
+
+  fluentbit:
+  - fluentbit_input_records_total
+  - fluentbit_input_bytes_total
+  - fluentbit_output_proc_records_total
+  - fluentbit_output_proc_bytes_total
+  - fluentbit_output_errors_total
+  - fluentbit_output_retries_total
+  - fluentbit_output_retries_failed_total
+
+  elasticsearch:
+  - elasticsearch_cluster_health_active_primary_shards
+  - elasticsearch_cluster_health_active_shards
+  - elasticsearch_cluster_health_delayed_unassigned_shards
+  - elasticsearch_cluster_health_number_of_pending_tasks
+  - elasticsearch_cluster_health_status
+  - elasticsearch_filesystem_data_free_bytes
+  - elasticsearch_indices_flush_time_seconds
+  - elasticsearch_indices_flush_total
+  - elasticsearch_indices_segments_count
+  - elasticsearch_indices_segments_memory_bytes
+  - elasticsearch_jvm_memory_pool_used_bytes
+  - elasticsearch_jvm_memory_pool_max_bytes
 
 
 ingress:


### PR DESCRIPTION
**What this PR does / why we need it**:

Prometheus will scape metrics for fluent-bit, fluentd and elasticsearch in `garden` namespace

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@ialidzhikov @vpnachev @mvladev 

**Release note**:

```improvement operator
Prometheus will now scrape metrics for `fluent-bit`, `fluentd`, and `elasticsearch` in the `garden` namespace.
```