### PR TITLE
Add GetExtensionType method to ControlPlane

### DIFF
--- a/pkg/apis/extensions/v1alpha1/types_controlplane.go
+++ b/pkg/apis/extensions/v1alpha1/types_controlplane.go
@@ -35,6 +35,11 @@ type ControlPlane struct {
 	Status ControlPlaneStatus `json:"status"`
 }
 
+// GetExtensionType returns the type of this ControlPlane resource.
+func (cp *ControlPlane) GetExtensionType() string {
+	return cp.Spec.Type
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ControlPlaneList is a list of ControlPlane resources.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds GetExtensionType method to ControlPlane. This fixes Type predicate behavior with ControlPlane resources.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
