### PR TITLE
Increase machine drain and scale down timeouts

### DIFF
--- a/charts/seed-controlplane/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/cluster-autoscaler/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
         - --skip-nodes-with-local-storage=false
         - --expander=least-waste
         - --expendable-pods-priority-cutoff=-10
+        - --scale-down-delay-after-add=60m
+        - --scale-down-unneeded-time=30m
         - --v=2
         env:
         - name: CONTROL_NAMESPACE

--- a/charts/seed-controlplane/charts/machine-controller-manager/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/machine-controller-manager/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - --namespace={{ .Release.Namespace }}
         - --port={{ .Values.metricsPort }}
         - --machine-creation-timeout=20m
-        - --machine-drain-timeout=5m
+        - --machine-drain-timeout=20m
         - --machine-health-timeout=10m
         - --machine-safety-apiserver-statuscheck-timeout=30s
         - --machine-safety-apiserver-statuscheck-period=1m


### PR DESCRIPTION
**What this PR does / why we need it**:
- We see machines on some infrastructures (E.g. Azure) fail to detach data disks attached to a machine in the current drain timeout window of 5mins sometimes leading to machines in a hung state. 
- Machines in the cluster seem to be scaling up and down frequently due to small changes in cluster load.

**Which issue(s) this PR fixes**:
Fixes #1010 

**Special notes for your reviewer**:
- The maximum time taken to drain a node has been updated from 5mins to 20mins
- Scale down before removing an underutilized node has been updated from 10mins to 30mins
- Scale down after adding of a node is only possible after 60mins

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Increased machine drain and scale down timeouts
```
