### PR TITLE
Add configmap-reloader to Prometheus

### DIFF
--- a/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
@@ -97,6 +97,7 @@ spec:
           readOnly: true
         - mountPath: /etc/prometheus/rules
           name: rules
+          readOnly: true
       terminationGracePeriodSeconds: 300
       volumes:
       - name: config

--- a/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/prometheus.yaml
@@ -48,8 +48,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configmap-config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
-        checksum/configmap-rules: {{ include (print $.Template.BasePath "/rules.yaml") . | sha256sum }}
         checksum/configmap-blackbox-exporter: {{ include (print $.Template.BasePath "/blackbox-exporter-config.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
@@ -186,6 +184,27 @@ spec:
           mountPath: /vpn
         - mountPath: /var/run/secrets/blackbox
           name: prometheus-kubeconfig
+          readOnly: true
+      - name: prometheus-config-reloader
+        image: {{ index .Values.images "configmap-reloader" }}
+        imagePullPolicy: IfNotPresent
+        args:
+        - -webhook-url=http://localhost:{{ .Values.port }}/-/reload
+        - -volume-dir=/etc/prometheus/config
+        - -volume-dir=/etc/prometheus/rules
+        resources:
+          requests:
+            cpu: 5m
+            memory: 10Mi
+          limits:
+            cpu: 10m
+            memory: 20Mi
+        volumeMounts:
+        - mountPath: /etc/prometheus/config
+          name: config
+          readOnly: true
+        - mountPath: /etc/prometheus/rules
+          name: rules
           readOnly: true
       terminationGracePeriodSeconds: 300
       volumes:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the configmap-reloader to Prometheus. Prometheus will now be able to load new config without having to restart. This means less downtime for prometheus. Changes to the blackbox exporter config will still trigger a Prometheus restart.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Removed checksum annotations for configs and rules to prevent the Prometheus pod from restarting.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
