### PR TITLE
Wait for Nodes clean-up when entering hibernation

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
@@ -165,7 +165,7 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 		})
 		initializeShootClients = g.Add(flow.Task{
 			Name:         "Initializing connection to Shoot",
-			Fn:           flow.SimpleTaskFn(botanist.InitializeShootClients).RetryUntilTimeout(defaultInterval, 2*time.Minute).SkipIf(o.Shoot.IsHibernated),
+			Fn:           flow.SimpleTaskFn(botanist.InitializeShootClients).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady, deployCloudSpecificControlPlane),
 		})
 		_ = g.Add(flow.Task{
@@ -255,7 +255,7 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Hibernating control plane",
-			Fn:           flow.TaskFn(botanist.HibernateControlPlane).RetryUntilTimeout(defaultInterval, defaultTimeout).DoIf(o.Shoot.IsHibernated),
+			Fn:           flow.TaskFn(botanist.HibernateControlPlane).RetryUntilTimeout(defaultInterval, 2*time.Minute).DoIf(o.Shoot.IsHibernated),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, deploySeedMonitoring, deploySeedLogging, deployClusterAutoscaler),
 		})
 		f = g.Compile()

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -34,6 +34,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -538,4 +539,16 @@ func GetDomainInfoFromAnnotations(annotations map[string]string) (provider strin
 	}
 
 	return
+}
+
+// CurrentReplicaCount returns the current replicaCount for the given deployment.
+func CurrentReplicaCount(client client.Client, namespace, deploymentName string) (int32, error) {
+	deployment := &appsv1.Deployment{}
+	if err := client.Get(context.TODO(), kutil.Key(namespace, deploymentName), deployment); err != nil && !apierrors.IsNotFound(err) {
+		return 0, err
+	}
+	if deployment.Spec.Replicas == nil {
+		return 0, nil
+	}
+	return *deployment.Spec.Replicas, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR scales down `Cloud-Controller-Manager` for Shoots entering hibernation only after all K8s Nodes have been removed from the cluster. This is necessary because as of K8s 1.14 `Cloud-Controller-Manager` took over the responsibility from `Kube-Controller-Manager`.

**Special notes for your reviewer**:
The timeout for `HibernateControlPlane` has been increased from 30 secs to 2 mins because it can take a while until all Nodes have been cleaned up.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Fixes an issue which left stale, unhealthy `Nodes` in the Shoot cluster after ending hibernation.
```
