### PR TITLE
Configure prometheus to scrape metrics for elasticsearch

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -203,6 +203,10 @@ images:
   sourceRepository: github.com/elastic/elasticsearch-docker
   repository: docker.elastic.co/elasticsearch/elasticsearch-oss
   tag: "6.7.1"
+- name: elasticsearch-metrics-exporter
+  sourceRepository: github.com/justwatchcom/elasticsearch_exporter
+  repository: justwatch/elasticsearch_exporter
+  tag: "1.0.2"
 - name: curator-es
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/curator-es

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/service.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/service.yaml
@@ -8,9 +8,13 @@ metadata:
     role: logging
 spec:
   ports:
-  - port: {{ .Values.global.elasticsearchPorts.db }}
+  - name: db
+    port: {{ .Values.global.elasticsearchPorts.db }}
     protocol: TCP
     targetPort: http
+  - name: metrics
+    port: {{ .Values.global.elasticsearchPorts.metricsExporter }}
+    protocol: TCP
   selector:
     app: elasticsearch-logging
     role: logging

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/statefulset.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/statefulset.yaml
@@ -91,6 +91,30 @@ spec:
         - name: config
           mountPath: /usr/share/elasticsearch/config/jvm.options
           subPath: jvm.options
+      - name: metrics-exporter
+        image: {{ index .Values.global.images "elasticsearch-metrics-exporter" }}
+        imagePullPolicy: IfNotPresent
+        command: ["elasticsearch_exporter"]
+        args:
+          - -es.uri=http://localhost:{{ .Values.global.elasticsearchPorts.db }}
+          - -es.all=true
+          - -es.indices=true
+          - -es.timeout=30s
+          - -web.listen-address=:{{ .Values.global.elasticsearchPorts.metricsExporter }}
+        securityContext:
+          capabilities:
+            {{- toYaml .Values.elasticsearch.metricsExporter.securityContext.capabilities | nindent 12 }}
+          readOnlyRootFilesystem: true
+        resources:
+          {{- toYaml .Values.elasticsearch.metricsExporter.resources | nindent 10 }}
+        ports:
+          - containerPort: {{ .Values.global.elasticsearchPorts.metricsExporter }}
+            name: metrics
+            protocol: TCP
+        livenessProbe:
+          {{- toYaml .Values.elasticsearch.metricsExporter.livenessProbe | nindent 10 }}
+        readinessProbe:
+          {{- toYaml .Values.elasticsearch.metricsExporter.readinessProbe | nindent 10 }}
       volumes:
       - name: config
         configMap:

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/values.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/values.yaml
@@ -3,10 +3,12 @@ global:
     alpine: image-repository:image-tag
     curator-es: image-repository:image-tag
     elasticsearch-oss: image-repository:image-tag
+    elasticsearch-metrics-exporter: image-repository:image-tag
     kibana-oss: image-repository:image-tag
   elasticsearchPorts:
     db: 9200
     transport: 9300
+    metricsExporter: 9114
 
 ingress:
   enabled: true
@@ -65,6 +67,43 @@ elasticsearch:
       port: http
     initialDelaySeconds: 20
     timeoutSeconds: 5
+  metricsExporter:
+    securityContext:
+      capabilities:
+        drop:
+          - SETPCAP
+          - MKNOD
+          - AUDIT_WRITE
+          - CHOWN
+          - NET_RAW
+          - DAC_OVERRIDE
+          - FOWNER
+          - FSETID
+          - KILL
+          - SETGID
+          - SETUID
+          - NET_BIND_SERVICE
+          - SYS_CHROOT
+          - SETFCAP
+    resources:
+      limits:
+        cpu: 20m
+        memory: 32Mi
+      requests:
+        cpu: 2m
+        memory: 16Mi
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: metrics
+      initialDelaySeconds: 30
+      timeoutSeconds: 10
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: metrics
+      initialDelaySeconds: 10
+      timeoutSeconds: 10
 
 kibana:
   replicaCount: 1

--- a/charts/seed-monitoring/charts/prometheus/optional-rules/elasticsearch.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/optional-rules/elasticsearch.rules.yaml
@@ -1,0 +1,14 @@
+groups:
+- name: elasticsearch.rules
+  rules:
+  - alert: ElasticsearchDown
+    expr: absent(up{job="elasticsearch-logging"} == 1)
+    for: 20m
+    labels:
+      service: elasticsearch-logging
+      severity: warning
+      type: seed
+      visibility: operator
+    annotations:
+      description: There are no running elasticsearch pods. No logs will be collected.
+      summary: Elasticsearch is down

--- a/charts/seed-monitoring/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/prometheus/templates/config.yaml
@@ -568,3 +568,25 @@ data:
       - source_labels: [ namespace ]
         action: keep
         regex: ^{{ .Release.Namespace }}$
+
+{{- if  (index .Values.rules.optional "elasticsearch" ).enabled }}
+    - job_name: elasticsearch-logging
+      honor_labels: false
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [{{ .Release.Namespace }}]
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+        action: keep
+        regex: elasticsearch-logging;metrics
+      # common metrics
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.elasticsearch | indent 6 }}
+{{- end }}

--- a/charts/seed-monitoring/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/prometheus/values.yaml
@@ -189,6 +189,19 @@ allowedMetrics:
   vpn:
   - probe_http_status_code
   - probe_success
+  elasticsearch:
+  - elasticsearch_cluster_health_active_primary_shards
+  - elasticsearch_cluster_health_active_shards
+  - elasticsearch_cluster_health_delayed_unassigned_shards
+  - elasticsearch_cluster_health_number_of_pending_tasks
+  - elasticsearch_cluster_health_status
+  - elasticsearch_filesystem_data_free_bytes
+  - elasticsearch_indices_flush_time_seconds
+  - elasticsearch_indices_flush_total
+  - elasticsearch_indices_segments_count
+  - elasticsearch_indices_segments_memory_bytes
+  - elasticsearch_jvm_memory_pool_used_bytes
+  - elasticsearch_jvm_memory_pool_max_bytes
 
 seed:
   apiserver: https://api.foo.bar
@@ -205,6 +218,8 @@ rules:
       enabled: true
     alertmanager:
       enabled: false
+    elasticsearch:
+      enabled: true
 
 ignoreAlerts: false
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -339,6 +339,9 @@ func (b *Botanist) DeploySeedMonitoring() error {
 					"alertmanager": map[string]interface{}{
 						"enabled": b.Shoot.WantsAlertmanager,
 					},
+					"elasticsearch": map[string]interface{}{
+						"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.Logging),
+					},
 				},
 			},
 			"shoot": map[string]interface{}{
@@ -487,6 +490,7 @@ func (b *Botanist) DeploySeedLogging() error {
 
 	images, err := b.InjectSeedSeedImages(map[string]interface{}{},
 		common.ElasticsearchImageName,
+		common.ElasticsearchMetricsExporterImageName,
 		common.CuratorImageName,
 		common.KibanaImageName,
 		common.AlpineImageName,

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -508,6 +508,9 @@ const (
 	// ElasticsearchImageName is the name of the Elastic-Search image used for logging
 	ElasticsearchImageName = "elasticsearch-oss"
 
+	// ElasticsearchMetricsExporterImageName is the name of the metrics exporter image used to fetch elasticsearch metrics.
+	ElasticsearchMetricsExporterImageName = "elasticsearch-metrics-exporter"
+
 	// CuratorImageName is the name of the curator image used to alter the Elastic-search logs
 	CuratorImageName = "curator-es"
 

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -229,6 +229,7 @@ func BootstrapCluster(seed *Seed, secrets map[string]*corev1.Secret, imageVector
 			common.ConfigMapReloaderImageName,
 			common.CuratorImageName,
 			common.ElasticsearchImageName,
+			common.ElasticsearchMetricsExporterImageName,
 			common.FluentBitImageName,
 			common.FluentdEsImageName,
 			common.KibanaImageName,


### PR DESCRIPTION
**What this PR does / why we need it**:

Prometheus will scape metrics for each elasticsearch in the `shoot` namespace.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@ialidzhikov @vlvasilev @dkistner @wyb1 

```improvement operator
NONE
```
