### PR TITLE
Prevent seed controller and HPA thrashing

### DIFF
--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-hpa.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-hpa.yaml
@@ -1,11 +1,12 @@
+{{- if .Values.fluentd.autoscaling.enabled }}
 apiVersion: {{ include "hpaversion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: fluentd-es
   namespace: {{ .Release.Namespace }}
 spec:
-  maxReplicas: 10
-  minReplicas: 1
+  minReplicas: {{ .Values.fluentd.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.fluentd.autoscaling.maxReplicas }}
   scaleTargetRef:
     apiVersion: {{ include "statefulsetversion" . }}
     kind: StatefulSet
@@ -14,8 +15,9 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: 70
+      targetAverageUtilization: {{ .Values.fluentd.autoscaling.targetCPUUtilizationPercentage }}
   - type: Resource
     resource:
       name: memory
-      targetAverageUtilization: 70
+      targetAverageUtilization: {{ .Values.fluentd.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-statefulset.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-statefulset.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
 {{ toYaml .Values.fluentd.labels | indent 4 }}
 spec:
+  replicas: {{ .Values.fluentd.replicaCount }}
   updateStrategy:
     type: RollingUpdate
   serviceName: fluentd-es

--- a/charts/seed-bootstrap/charts/fluentd-es/values.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/values.yaml
@@ -7,6 +7,7 @@ global:
     fluent-bit: image-repository:image-tag
 
 fluentd:
+  replicaCount: 1
   storage: 9Gi
   ports:
     forward: 24224
@@ -14,6 +15,13 @@ fluentd:
     garden.sapcloud.io/role: logging
     app: fluentd-es
     role: logging
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 70
+
 fluentbit:
   labels:
     garden.sapcloud.io/role: logging

--- a/pkg/operation/seed/seed_suite_test.go
+++ b/pkg/operation/seed/seed_suite_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package seed_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Seed Operation Suite")
+}

--- a/pkg/operation/seed/seed_test.go
+++ b/pkg/operation/seed/seed_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seed_test
+
+import (
+	"context"
+
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	mock "github.com/gardener/gardener/pkg/mock/gardener/kubernetes"
+	. "github.com/gardener/gardener/pkg/operation/seed"
+	"github.com/golang/mock/gomock"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("seed", func() {
+	var (
+		ctrl           *gomock.Controller
+		restMockClient *mock.MockInterface
+		runtimeClient  *mockclient.MockClient
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		restMockClient = mock.NewMockInterface(ctrl)
+		runtimeClient = mockclient.NewMockClient(ctrl)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#GetFluentdReplicaCount", func() {
+		It("should return single replica when stateful set does not exist", func() {
+			restMockClient.EXPECT().Client().Return(runtimeClient)
+			runtimeClient.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, key client.ObjectKey, _ *appsv1.StatefulSet) error {
+				return errors.NewNotFound(appsv1.Resource("StatefulSet"), key.Name)
+			})
+
+			replicas, err := GetFluentdReplicaCount(restMockClient)
+
+			Expect(err).NotTo(HaveOccurred())
+			var expectedReplicas int32 = 1
+			Expect(replicas).To(Equal(expectedReplicas))
+		})
+
+		It("should get stateful set replicas", func() {
+			var expectedReplicas int32 = 3
+			restMockClient.EXPECT().Client().Return(runtimeClient)
+			runtimeClient.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ client.ObjectKey, statefulSet *appsv1.StatefulSet) error {
+				statefulSet.Spec.Replicas = &expectedReplicas
+				return nil
+			})
+
+			replicas, err := GetFluentdReplicaCount(restMockClient)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(replicas).To(Equal(expectedReplicas))
+		})
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently seed controller is applying fluentd chart with `replicas: 1` for fluentd sts which overrides replicas managed by HPA. And this all results in thrashing like:
```
$ k get sts -n garden -l app=fluentd-es -w
NAME         DESIRED   CURRENT   AGE
[...]
fluentd-es   3     3     124d    # <- set to 3 by HPA
fluentd-es   1     3     124d    # <- set to 1 by seed controller
fluentd-es   1     3     124d
fluentd-es   1     2     124d
fluentd-es   3     2     124d    # <- set to 3 by HPA
fluentd-es   3     2     124d
fluentd-es   3     2     124d
fluentd-es   3     2     124d
fluentd-es   1     2     124d    # <- set to 1 by seed controller
fluentd-es   1     2     124d
fluentd-es   1     1     124d
fluentd-es   3     1     124d
fluentd-es   3     2     124d
fluentd-es   3     3     124d
fluentd-es   1     3     124d
fluentd-es   1     3     124d
fluentd-es   1     2     124d
fluentd-es   1     2     124d
fluentd-es   3     2     124d
fluentd-es   3     2     124d
fluentd-es   3     2     124d
fluentd-es   3     3     124d
```

The PR modifies seed controller to use current fluentd sts replicas (similarly to kube-apiserver chart).

/kind bug

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
