### PR TITLE
Fix issue empty OSS buckets cannot be deleted

### DIFF
--- a/pkg/operation/cloudbotanist/alicloudbotanist/infrastructure.go
+++ b/pkg/operation/cloudbotanist/alicloudbotanist/infrastructure.go
@@ -227,9 +227,10 @@ func cleanSnapshots(bucketName, storageEndpoint, accessKeyID, accessKeySecret st
 		for _, object := range lsRes.Objects {
 			snapshots = append(snapshots, object.Key)
 		}
-		_, err = bucket.DeleteObjects(snapshots)
-		if err != nil {
-			return err
+		if len(snapshots) > 0 {
+			if _, err = bucket.DeleteObjects(snapshots); err != nil {
+				return err
+			}
 		}
 		if !lsRes.IsTruncated {
 			break


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to fix the issue OSS buckets cannot be deleted when there are no files in it.
**Which issue(s) this PR fixes**:
Fixes #
None
**Special notes for your reviewer**:
None
