### PR TITLE
Support FlexVolume in Alicloud for etcd

### DIFF
--- a/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go
@@ -131,6 +131,16 @@ func (b *AlicloudBotanist) GenerateKubeSchedulerConfig() (map[string]interface{}
 
 // GenerateETCDStorageClassConfig generates values which are required to create etcd volume storageclass properly.
 func (b *AlicloudBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
+	if b.Operation.Seed.GetPersistentVolumeProvider() == "FlexVolume" {
+		return map[string]interface{}{
+			"name":        "gardener.cloud-fast",
+			"capacity":    "25Gi",
+			"provisioner": "alicloud/disk",
+			"parameters": map[string]interface{}{
+				"type": "cloud_ssd",
+			},
+		}
+	}
 	return map[string]interface{}{
 		"name":        "gardener.cloud-fast",
 		"capacity":    "25Gi",

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -384,8 +384,11 @@ const (
 	// then the namespace in the seed will be annotated with <AnnotateSeedNamespacePrefix>key=value, as well.
 	AnnotateSeedNamespacePrefix = "custom.shoot.sapcloud.io/"
 
-	//AnnotatePersistentVolumeMinimumSize is used to specify the minimum size of persistent volume in the cluster
+	// AnnotatePersistentVolumeMinimumSize is used to specify the minimum size of persistent volume in the cluster
 	AnnotatePersistentVolumeMinimumSize = "persistentvolume.garden.sapcloud.io/minimumSize"
+
+	// AnnotatePersistentVolumeProvider is used to tell volume provider in the k8s cluster
+	AnnotatePersistentVolumeProvider = "persistentvolume.garden.sapcloud.io/provider"
 
 	// BackupNamespacePrefix is a constant for backup namespace created for shoot's backup infrastructure related resources.
 	BackupNamespacePrefix = "backup"

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -608,3 +608,12 @@ func (s *Seed) GetValidVolumeSize(size string) string {
 
 	return size
 }
+
+// GetPersistentVolumeProvider gets the Persistent Volume Provider of seed cluster. If it is not specified, return ""
+func (s *Seed) GetPersistentVolumeProvider() string {
+	if s.Info.Annotations == nil {
+		return ""
+	}
+
+	return s.Info.Annotations[common.AnnotatePersistentVolumeProvider]
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
We are encountering an issue in gardener setup on Alicloud. It is related to the change on this part code https://github.com/gardener/gardener/blob/master/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go#L134-L142. In order to setup garden, seed clusters on Alicloud, we leverage the k8s cluster provided by Alicloud. However, k8s provided by Alicloud container service doesn't support csi and only supports flexvolume. We **cannot** bind this pvc when create main-etcd when create the first shoot (as seed for further shoot) in the **soil** cluster
 