### PR TITLE
Increased failedProposal count to 80 for an alert

### DIFF
--- a/charts/seed-monitoring/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
@@ -20,7 +20,7 @@ tests:
     values: '0+0x30'
   # KubeEtcd3HighNumberOfFailedProposals
   - series: 'etcd_server_proposals_failed_total{job="kube-etcd3", pod="etcd"}'
-    values: '0+0x15 1+0x15 2+0x15 3+0x15 4+0x15 5+0x15 6+0x15 7+0x15'
+    values: '0+1x85'
   alert_rule_test:
   - eval_time: 5m
     alertname: KubeEtcdMainDown
@@ -77,6 +77,6 @@ tests:
         pod: etcd
         job: kube-etcd3
       exp_annotations:
-        description: Etcd3 pod etcd has seen 7 proposal failures
+        description: Etcd3 pod etcd has seen 85.5 proposal failures
           within the last hour.
         summary: High number of failed etcd proposals

--- a/charts/seed-monitoring/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
@@ -20,7 +20,7 @@ tests:
     values: '0+0x30'
   # KubeEtcd3HighNumberOfFailedProposals
   - series: 'etcd_server_proposals_failed_total{job="kube-etcd3", pod="etcd"}'
-    values: '0+1x85'
+    values: '0+1x81 81+0x39'
   alert_rule_test:
   - eval_time: 5m
     alertname: KubeEtcdMainDown
@@ -77,6 +77,6 @@ tests:
         pod: etcd
         job: kube-etcd3
       exp_annotations:
-        description: Etcd3 pod etcd has seen 85.5 proposal failures
+        description: Etcd3 pod etcd has seen 81 proposal failures
           within the last hour.
         summary: High number of failed etcd proposals

--- a/charts/seed-monitoring/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -51,8 +51,11 @@ groups:
 
   ### etcd proposal alerts ###
   # alert if there are several failed proposals within an hour
+  # Note: Increasing the failedProposals count to 50, known issue in etcd, fix in progress
+  # https://github.com/kubernetes/kubernetes/pull/64539 - fix in Kubernetes to be released with v1.15
+  # https://github.com/etcd-io/etcd/issues/9360 - ongoing discussion in etcd
   - alert: KubeEtcd3HighNumberOfFailedProposals
-    expr: increase(etcd_server_proposals_failed_total{job="kube-etcd3"}[1h]) > 5
+    expr: increase(etcd_server_proposals_failed_total{job="kube-etcd3"}[1h]) > 50
     labels:
       service: etcd
       severity: warning

--- a/charts/seed-monitoring/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -51,11 +51,11 @@ groups:
 
   ### etcd proposal alerts ###
   # alert if there are several failed proposals within an hour
-  # Note: Increasing the failedProposals count to 50, known issue in etcd, fix in progress
+  # Note: Increasing the failedProposals count to 80, known issue in etcd, fix in progress
   # https://github.com/kubernetes/kubernetes/pull/64539 - fix in Kubernetes to be released with v1.15
   # https://github.com/etcd-io/etcd/issues/9360 - ongoing discussion in etcd
   - alert: KubeEtcd3HighNumberOfFailedProposals
-    expr: increase(etcd_server_proposals_failed_total{job="kube-etcd3"}[1h]) > 50
+    expr: increase(etcd_server_proposals_failed_total{job="kube-etcd3"}[1h]) > 80
     labels:
       service: etcd
       severity: warning


### PR DESCRIPTION
**What this PR does / why we need it**:
There are frequent failedProposal alerts _KubeEtcd3HighNumberOfFailedProposals_ from etcd 
There are fixes expected from the upstream [etcd - [#9360](https://github.com/etcd-io/etcd/issues/9360) and Kubernetes - [#64539](https://github.com/kubernetes/kubernetes/pull/64539)]
Until the fixes are available from the upstream, increasing the failedProposal count from 5 to 80 in order to avoid frequent alerts

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Increased the failedProposal count in the alert KubeEtcd3HighNumberOfFailedProposals to 80 in order to raise an etcd alert
```
