### PR TITLE
Project controller is reconciling on gcm update

### DIFF
--- a/pkg/controllermanager/controller/project/project_control.go
+++ b/pkg/controllermanager/controller/project/project_control.go
@@ -44,6 +44,12 @@ func (c *Controller) projectAdd(obj interface{}) {
 }
 
 func (c *Controller) projectUpdate(oldObj, newObj interface{}) {
+	newProject := newObj.(*gardenv1beta1.Project)
+
+	if newProject.Generation == newProject.Status.ObservedGeneration {
+		return
+	}
+
 	c.projectAdd(newObj)
 }
 
@@ -125,10 +131,8 @@ func (c *defaultControl) ReconcileProject(obj *gardenv1beta1.Project) (bool, err
 	if project.DeletionTimestamp != nil {
 		return c.delete(project, projectLogger)
 	}
-	if project.Generation != project.Status.ObservedGeneration {
-		return false, c.reconcile(project, projectLogger)
-	}
-	return false, nil
+
+	return false, c.reconcile(project, projectLogger)
 }
 
 func (c *defaultControl) updateProjectStatus(objectMeta metav1.ObjectMeta, transform func(project *gardenv1beta1.Project) (*gardenv1beta1.Project, error)) (*gardenv1beta1.Project, error) {


### PR DESCRIPTION
**What this PR does / why we need it**: 
Project controller is reconciling projects on gardener controller manager restart. 

**Which issue(s) this PR fixes**:
Fixes: Project resources were not reconciled on chart update

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Gardener now reconciles project resources on restart.
```
