### PR TITLE
Cleanup orphan etcd main PVC due to recent migration

### DIFF
--- a/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
@@ -51,45 +51,6 @@ data:
           done
     }
 
-{{- if eq .Values.role "main" }}
-    migrate_data() {
-      OLD_DATA_DIR=/var/etcd/old-data
-      NEW_DATA_DIR=/var/etcd/data
-      MIGRATION_MARKER=$OLD_DATA_DIR/migration.marker
-
-      if [ ! -f $MIGRATION_MARKER ]; then
-            # Keep this for debugging purpose
-            echo "old data directory content: $OLD_DATA_DIR"
-            ls -A $OLD_DATA_DIR
-            echo "New data directory content: $NEW_DATA_DIR"
-            ls -A $NEW_DATA_DIR
-
-            echo "Removing content of new data directory $NEW_DATA_DIR"
-            rm -rf $NEW_DATA_DIR/*
-
-            # Copy only if not empty
-            if [ "$(ls -A $OLD_DATA_DIR)" ];
-            then
-            echo "Migrating content of old data directory $OLD_DATA_DIR to $NEW_DATA_DIR"
-            time cp -rf $OLD_DATA_DIR/* $NEW_DATA_DIR/
-            if [ ! $? -eq 0 ] ;
-            then
-            exit $?
-            fi
-            time sync
-            fi
-
-            # Mark migration
-            echo "Creating migration successful marker file $MIGRATION_MARKER"
-            touch $MIGRATION_MARKER
-      else
-            echo "$MIGRATION_MARKER is present. Skipping migration."
-      fi
-    }
-
-    # Do migration
-    migrate_data
-{{- end }}
     # Do validation and bootstrap
     if [ ! -f $VALIDATION_MARKER ] ;
     then

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
@@ -74,8 +74,6 @@ spec:
             memory: 4Gi
         volumeMounts:
 {{- if eq .Values.role "main" }}
-        - name: etcd-{{ .Values.role }}
-          mountPath: /var/etcd/old-data
         - name: {{ .Values.role }}-etcd
           mountPath: /var/etcd/data
 {{- else }}
@@ -173,7 +171,7 @@ spec:
       resources:
         requests:
           storage: {{ .Values.storageCapacity }}
-{{- end }}
+{{- else }}
   - metadata:
       name: etcd-{{ .Values.role }}
     spec:
@@ -181,4 +179,5 @@ spec:
       - "ReadWriteOnce"
       resources:
         requests:
-          storage: {{ .Values.storage }}
+          storage: {{ .Values.storageCapacity }}
+{{- end }}

--- a/charts/seed-controlplane/charts/etcd/values.yaml
+++ b/charts/seed-controlplane/charts/etcd/values.yaml
@@ -5,7 +5,6 @@ images:
   etcd: image-repository:image-tag
   etcd-backup-restore: image-repository:image-tag
 
-storage: 10Gi
 storageClassName: default
 storageCapacity: 16Gi
 

--- a/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
@@ -154,6 +154,11 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 			Fn:           flow.TaskFn(botanist.WaitUntilEtcdReady).SkipIf(o.Shoot.IsHibernated),
 			Dependencies: flow.NewTaskIDs(deployETCD),
 		})
+		_ = g.Add(flow.Task{
+			Name:         "Deleting orphan etcd main persistent volume due to recent migration",
+			Fn:           flow.TaskFn(botanist.DeleteOrphanEtcdMainPVC),
+			Dependencies: flow.NewTaskIDs(deployETCD),
+		})
 		deployCloudProviderConfig = g.Add(flow.Task{
 			Name:         "Deploying cloud provider configuration",
 			Fn:           flow.SimpleTaskFn(hybridBotanist.DeployCloudProviderConfig).RetryUntilTimeout(defaultInterval, defaultTimeout),

--- a/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/alicloudbotanist/controlplane.go
@@ -139,7 +139,7 @@ func (b *AlicloudBotanist) GenerateETCDStorageClassConfig() map[string]interface
 	if b.Operation.Seed.GetPersistentVolumeProvider() == "FlexVolume" {
 		return map[string]interface{}{
 			"name":        "gardener.cloud-fast",
-			"capacity":    "25Gi",
+			"capacity":    b.Seed.GetValidVolumeSize("25Gi"),
 			"provisioner": "alicloud/disk",
 			"parameters": map[string]interface{}{
 				"type": "cloud_ssd",
@@ -148,7 +148,7 @@ func (b *AlicloudBotanist) GenerateETCDStorageClassConfig() map[string]interface
 	}
 	return map[string]interface{}{
 		"name":        "gardener.cloud-fast",
-		"capacity":    "25Gi",
+		"capacity":    b.Seed.GetValidVolumeSize("25Gi"),
 		"provisioner": "diskplugin.csi.alibabacloud.com",
 		"parameters": map[string]interface{}{
 			"csi.storage.k8s.io/fstype": "ext4",

--- a/pkg/operation/cloudbotanist/awsbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/awsbotanist/controlplane.go
@@ -160,7 +160,7 @@ func getAWSCredentialsEnvironment() []map[string]interface{} {
 func (b *AWSBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
 	return map[string]interface{}{
 		"name":        "gardener.cloud-fast",
-		"capacity":    "80Gi",
+		"capacity":    b.Seed.GetValidVolumeSize("80Gi"),
 		"provisioner": "kubernetes.io/aws-ebs",
 		"parameters": map[string]interface{}{
 			"type": "gp2",

--- a/pkg/operation/cloudbotanist/azurebotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/azurebotanist/controlplane.go
@@ -192,7 +192,7 @@ func (b *AzureBotanist) GenerateKubeSchedulerConfig() (map[string]interface{}, e
 func (b *AzureBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
 	return map[string]interface{}{
 		"name":        "gardener.cloud-fast",
-		"capacity":    "33Gi",
+		"capacity":    b.Seed.GetValidVolumeSize("33Gi"),
 		"provisioner": "kubernetes.io/azure-disk",
 		"parameters": map[string]interface{}{
 			"storageaccounttype": "Premium_LRS",

--- a/pkg/operation/cloudbotanist/gcpbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/gcpbotanist/controlplane.go
@@ -140,7 +140,7 @@ func (b *GCPBotanist) GenerateKubeSchedulerConfig() (map[string]interface{}, err
 func (b *GCPBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
 	return map[string]interface{}{
 		"name":        "gardener.cloud-fast",
-		"capacity":    "25Gi",
+		"capacity":    b.Seed.GetValidVolumeSize("25Gi"),
 		"provisioner": "kubernetes.io/gce-pd",
 		"parameters": map[string]interface{}{
 			"type": "pd-ssd",

--- a/pkg/operation/cloudbotanist/openstackbotanist/controlplane.go
+++ b/pkg/operation/cloudbotanist/openstackbotanist/controlplane.go
@@ -166,7 +166,7 @@ func (b *OpenStackBotanist) GenerateKubeSchedulerConfig() (map[string]interface{
 func (b *OpenStackBotanist) GenerateETCDStorageClassConfig() map[string]interface{} {
 	return map[string]interface{}{
 		"name":        "gardener.cloud-fast",
-		"capacity":    "25Gi",
+		"capacity":    b.Seed.GetValidVolumeSize("25Gi"),
 		"provisioner": "kubernetes.io/cinder",
 		"parameters":  map[string]interface{}{},
 	}

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -139,7 +139,6 @@ func (b *HybridBotanist) DeployETCD() error {
 		"vpa": map[string]interface{}{
 			"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
 		},
-		"storage":          b.Seed.GetValidVolumeSize("10Gi"),
 		"storageClassName": storageClassConfig["name"].(string),
 		"storageCapacity":  storageClassConfig["capacity"].(string),
 	}
@@ -161,6 +160,7 @@ func (b *HybridBotanist) DeployETCD() error {
 			etcd["backup"] = map[string]interface{}{
 				"storageProvider": "", // No storage provider means no backup
 			}
+			etcd["storageCapacity"] = b.Seed.GetValidVolumeSize("10Gi")
 		}
 
 		if b.Shoot.IsHibernated {
@@ -180,6 +180,7 @@ func (b *HybridBotanist) DeployETCD() error {
 			if role == common.EtcdRoleMain {
 				// Since we have to update volumeClaimTemplate in existing statefulset, which is forbidden
 				// by k8s. So, we have to explicitly delete the old statefulset and create new one.
+				// TODO: This is backward compatibility code and should be removed in further releases.
 				if apierrors.IsInvalid(err) {
 					if err := b.K8sSeedClient.DeleteStatefulSet(b.Shoot.SeedNamespace, fmt.Sprintf("etcd-%s", role)); err != nil && !apierrors.IsNotFound(err) {
 						return err


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
With [release 0.22.0](https://github.com/gardener/gardener/releases/tag/0.22.0), we migrated the data for etcd-main from PV provisioned with slow disk configuration to fast disk configuration. This PR cleanse up the old orphan PVC with slow disk configuration i.e. default storageclass which was earlier used as storage for etcd-main.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Please check the hibernation and deactivated shoot reconciliation scenario carefully.  This PR assumes that all shoot are reconciled with latest release. And avoids handling of scenario where last shoot reconciliation is with gardener version older than 0.22.0.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
Gardener will now cleanup the unused PVC `etcd-main-etcd-main-0` which was previously backing etcd-main pod before gardener version `0.22.0`. This will result in a restart of all etcd pods.
```
```action operator
:warning: This is optional step. Before bumping the gardener version to latest, make sure that all the shoots are reconciled with gardener version `0.22.0+`. Use the [helping script](https://github.com/gardener/gardener/blob/master/hack/migrate-etcd) to perform migration of etcd PVC for hibernated cluster. This will reduce the time for etcd migration.
```