### PR TITLE
Use host-local IPAM for Calico

### DIFF
--- a/charts/shoot-core/charts/calico/templates/calico.yaml
+++ b/charts/shoot-core/charts/calico/templates/calico.yaml
@@ -80,27 +80,6 @@ spec:
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
       initContainers:
-      # This container performs upgrade from host-local IPAM to calico-ipam.
-      # It can be deleted if this is a fresh installation, or if you have already
-      # upgraded to use calico-ipam.
-      - name: upgrade-ipam
-        image: {{ index .Values.images "calico-cni" }}
-        command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
-        env:
-          - name: KUBERNETES_NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-          - name: CALICO_NETWORKING_BACKEND
-            valueFrom:
-              configMapKeyRef:
-                name: calico-config
-                key: calico_backend
-        volumeMounts:
-          - mountPath: /var/lib/cni/networks
-            name: host-local-net-dir
-          - mountPath: /host/opt/cni/bin
-            name: cni-bin-dir
       # This container installs the Calico CNI binaries
       # and CNI network config file on each node.
       - name: install-cni
@@ -265,12 +244,6 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
-        # Mount in the directory for host-local IPAM allocations. This is
-        # used when upgrading from host-local to calico-ipam, and can be removed
-        # if not using the upgrade-ipam init container.
-        - name: host-local-net-dir
-          hostPath:
-            path: /var/lib/cni/networks
 ---
 
 # This manifest creates a Service, which will be backed by Calico's Typha daemon.

--- a/charts/shoot-core/charts/calico/templates/config.yaml
+++ b/charts/shoot-core/charts/calico/templates/config.yaml
@@ -30,7 +30,8 @@ data:
           "nodename": "__KUBERNETES_NODE_NAME__",
           "mtu": __CNI_MTU__,
           "ipam": {
-            "type": "calico-ipam"
+            "type": "host-local",
+            "subnet": "usePodCidr"
           },
           "policy": {
             "type": "k8s"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reverts the IPAM mode changed in #1018.
We depend on `host-local` IPAM because `calico-ipam` breaks routing capabilities on Azure.

It'd be required to have Azure IPAM plugin in combination with Azure CNI (https://docs.projectcalico.org/v3.7/reference/public-cloud/azure).

**Which issue(s) this PR fixes**:
Fixes #1032

/cc @marwinski 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
