### PR TITLE
Allow disabling CPU throttling

### DIFF
--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet-config-file
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet-config-file
@@ -21,7 +21,7 @@ clusterDomain: {{ required "kubernetes.domain is required" .Values.kubernetes.do
 clusterDNS:
 - {{ required "kubernetes.clusterDNS is required" .Values.kubernetes.clusterDNS }}
 configTrialDuration: 10m0s
-cpuCFSQuota: true
+cpuCFSQuota: {{ .Values.kubernetes.kubelet.cpuCFSQuota }}
 cpuManagerPolicy: none
 cpuManagerReconcilePeriod: 10s
 enableControllerAttachDetach: true

--- a/charts/seed-operatingsystemconfig/original/values.yaml
+++ b/charts/seed-operatingsystemconfig/original/values.yaml
@@ -22,6 +22,7 @@ kubernetes:
     parameters: []
     enableCSI: false
     providerIDProvided: false
+    cpuCFSQuota: true
 #   podPIDsLimit: 24
     featureGates: {}
 #     CustomResourceValidation: true

--- a/example/90-shoot-alicloud.yaml
+++ b/example/90-shoot-alicloud.yaml
@@ -92,6 +92,7 @@ spec:
   #     SomeKubernetesFeature: true
   #   mode: IPVS
   # kubelet:
+  #   cpuCFSQuota: true
   #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-aws.yaml
+++ b/example/90-shoot-aws.yaml
@@ -94,6 +94,7 @@ spec:
   #     SomeKubernetesFeature: true
   #   mode: IPVS
   # kubelet:
+  #   cpuCFSQuota: true
   #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-azure.yaml
+++ b/example/90-shoot-azure.yaml
@@ -93,6 +93,7 @@ spec:
   #     SomeKubernetesFeature: true
   #   mode: IPVS
   # kubelet:
+  #   cpuCFSQuota: true
   #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-gcp.yaml
+++ b/example/90-shoot-gcp.yaml
@@ -92,6 +92,7 @@ spec:
   #     SomeKubernetesFeature: true
   #   mode: IPVS
   # kubelet:
+  #   cpuCFSQuota: true
   #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-local.yaml
+++ b/example/90-shoot-local.yaml
@@ -74,6 +74,7 @@ spec:
   #     SomeKubernetesFeature: true
   #   mode: IPVS
   # kubelet:
+  #   cpuCFSQuota: true
   #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-openstack.yaml
+++ b/example/90-shoot-openstack.yaml
@@ -91,6 +91,7 @@ spec:
   #     SomeKubernetesFeature: true
   #   mode: IPVS
   # kubelet:
+  #   cpuCFSQuota: true
   #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-packet.yaml
+++ b/example/90-shoot-packet.yaml
@@ -87,6 +87,7 @@ spec:
   #     SomeKubernetesFeature: true
   #   mode: IPVS
   # kubelet:
+  #   cpuCFSQuota: true
   #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -358,6 +358,7 @@ spec:
     kubelet: ${yaml.dump(kubelet, width=10000, default_flow_style=None)}
     % else:
   # kubelet:
+  #   cpuCFSQuota: true
   #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -1471,6 +1471,8 @@ type KubeletConfig struct {
 	KubernetesConfig
 	// PodPIDsLimit is the maximum number of process IDs per pod allowed by the kubelet.
 	PodPIDsLimit *int64
+	// CPUCFSQuota allows you to disable/enable CPU throttling for Pods.
+	CPUCFSQuota *bool
 }
 
 // Maintenance contains information about the time window for maintenance operations and which

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -1525,6 +1525,8 @@ type KubeletConfig struct {
 	// PodPIDsLimit is the maximum number of process IDs per pod allowed by the kubelet.
 	// +optional
 	PodPIDsLimit *int64 `json:"podPidsLimit,omitempty"`
+	// CPUCFSQuota allows you to disable/enable CPU throttling for Pods.
+	CPUCFSQuota *bool `json:"cpuCFSQuota,omitempty"`
 }
 
 // Maintenance contains information about the time window for maintenance operations and which

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -3167,6 +3167,7 @@ func autoConvert_v1beta1_KubeletConfig_To_garden_KubeletConfig(in *KubeletConfig
 		return err
 	}
 	out.PodPIDsLimit = (*int64)(unsafe.Pointer(in.PodPIDsLimit))
+	out.CPUCFSQuota = (*bool)(unsafe.Pointer(in.CPUCFSQuota))
 	return nil
 }
 
@@ -3180,6 +3181,7 @@ func autoConvert_garden_KubeletConfig_To_v1beta1_KubeletConfig(in *garden.Kubele
 		return err
 	}
 	out.PodPIDsLimit = (*int64)(unsafe.Pointer(in.PodPIDsLimit))
+	out.CPUCFSQuota = (*bool)(unsafe.Pointer(in.CPUCFSQuota))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -1719,6 +1719,11 @@ func (in *KubeletConfig) DeepCopyInto(out *KubeletConfig) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.CPUCFSQuota != nil {
+		in, out := &in.CPUCFSQuota, &out.CPUCFSQuota
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -1708,6 +1708,11 @@ func (in *KubeletConfig) DeepCopyInto(out *KubeletConfig) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.CPUCFSQuota != nil {
+		in, out := &in.CPUCFSQuota, &out.CPUCFSQuota
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -4274,6 +4274,13 @@ func schema_pkg_apis_garden_v1beta1_KubeletConfig(ref common.ReferenceCallback) 
 							Format:      "int64",
 						},
 					},
+					"cpuCFSQuota": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CPUCFSQuota allows you to disable/enable CPU throttling for Pods.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/operation/hybridbotanist/cloud_config.go
+++ b/pkg/operation/hybridbotanist/cloud_config.go
@@ -165,6 +165,9 @@ func (b *HybridBotanist) generateOriginalConfig() (map[string]interface{}, error
 		if podPIDsLimit := kubeletConfig.PodPIDsLimit; podPIDsLimit != nil {
 			kubelet["podPIDsLimit"] = *podPIDsLimit
 		}
+		if cpuCFSQuota := kubeletConfig.CPUCFSQuota; cpuCFSQuota != nil {
+			kubelet["cpuCFSQuota"] = *cpuCFSQuota
+		}
 	}
 
 	if b.Shoot.UsesCSI() {


### PR DESCRIPTION
**What this PR does / why we need it**:
For latency critical workload you might want to disable the `--cpu-cfs-quota` flag on the kubelet (default is true). This PR allows you do that via the `shoot` spec

```
  kubernetes:
    kubelet:
      cpuCFSQuota: false
```
 
**Release note**:
```noteworthy user
It is now possible to configure CPU throttling in the `.spec.kubernetes.kubelet` configuration for shoot clusters.
```
