### PR TITLE
Added script for etcd migration.

### DIFF
--- a/hack/migrate-etcd
+++ b/hack/migrate-etcd
@@ -1,0 +1,242 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ----------------------------
+# Rationale behind this script
+# ----------------------------
+# Etcd statefulsets for the seed/shoot clusters have been updated to use a fast storage volume. However, the migration of etcd 
+# data directory from the old volume to the new volume happens only when the etcd pod runs post migration. For hibernated clus-
+# ters, this is not the case. Hence, migration does not happen in these clusters. To force migration of etcd in these clusters, 
+# we should use this script to scale up the etcd statefulsets from hibernation and subsequently scale it back down post migrat-
+# ion. 
+#
+# ----------------------
+# How to run this script
+# ----------------------
+# ./migrate-etcd [kubeconfig] [true/false]      [true/false]
+#                               dryrun      skip reconcile-ignored 
+# The first argument is the kubeconfig of the garden cluster. The script works by checking the namespaces for shoots which are 
+# hibernated. 
+#
+# The second argument is a boolean which acertains if its a dryrun to fetch the clusters pending migration. Only allowed arguments 
+# are [true/false].
+#
+# The third is a boolean which indicates whether to skip clusters for which reconciliation has been disabled. Only allowed arguments 
+# are [true/false].
+# 
+# 'migration_succeeded.txt' & 'migration_failed.txt' will contain the list of the hibernated clusters where migration has succeeded or 
+# failed respectively.
+
+set -u
+function getNamespaces()
+{
+    namespaces=`kubectl get ns --kubeconfig=${gardenkubeconfig} -o custom-columns=NAME:.metadata.name | tail -n +2`
+    echo "${namespaces[@]}"
+}
+
+function getShootsInNamespace()
+{
+    local namespace=$1
+    local shoots=`kubectl get shoot --kubeconfig=${gardenkubeconfig} -n ${namespace} -o custom-columns=NAME:.metadata.name | tail -n +2`
+    echo "${shoots[@]}"
+}
+
+function processShoot()
+{
+    local shoot=$1
+    local namespace=$2
+    local shootJson=`kubectl get shoot ${shoot} --kubeconfig=${gardenkubeconfig} -n ${namespace} -o json`
+    if [[ "$?" != "0" ]] || [[ "${shootJson}" == "" ]];
+    then 
+        echo "Shoot information not available for ${namespace}/${shoot}."
+        return 
+    fi
+    local hibernation_status=`echo -n ${shootJson} | jq .spec.hibernation.enabled`
+    if [ "$hibernation_status" != "true" ]
+    then
+        echo "${namespace}/${shoot} is not hibernated. Skipping forced migration."
+        return
+    fi
+    
+    if [ "${skip_reconcile_check}" != "true" ]
+    then
+        local reconcile_enabled=`echo -n ${shootJson} | jq .metadata.annotations | grep 'shoot.garden.sapcloud.io/ignore' | wc -l`
+        if [ ! "${reconcile_enabled}" == "0" ]
+        then
+            echo "${namespace}/${shoot} is not reconciled. Skipping forced migration."
+            echo "${namespace}/${shoot}:reconcile disabled" >> $MIGRATION_FAILED
+            return
+        fi
+    fi
+    
+    local seed=`echo -n ${shootJson} | jq .spec.cloud.seed | sed s/\"//g`
+    fetchKubeconfigForSeed ${seed}
+    if [[ ! -e $KUBECONFIGS_DIR/seed-${seed}.kubeconfig ]]
+    then
+        echo "Failed to fetch kubeconfig for seed ${seed}"
+        echo "${namespace}/${shoot}:failed to access seed" >> $MIGRATION_FAILED
+        return
+    fi
+    
+    namespace_in_seed=`echo -n ${shootJson} | jq .status.technicalID | sed s/\"//g`
+    has_etcd_main=`kubectl get statefulset etcd-main -n ${namespace_in_seed} --kubeconfig=$KUBECONFIGS_DIR/seed-${seed}.kubeconfig | wc -l`
+    if [ "${has_etcd_main}" == "0" ]
+    then
+        echo "Shoot ${namespace}/${shoot} does not have etcd-main statefulset. Cannot migrate."
+        echo "${namespace}/${shoot}: no etcd-main statefulset" >> $MIGRATION_FAILED
+        return
+    fi
+    echo "Checking migration status for shoot ${namespace}/${shoot}."
+    status=`checkMigrationStatus ${namespace_in_seed} ${seed}`
+    if [ "${status}" == "DONE" ]
+    then
+        echo "Migration was already successful. Skipping shoot ${namespace}/${shoot}."
+        return
+    fi
+    echo "Starting migration of shoot ${namespace}/${shoot}."
+    
+    if [ "${dryrun}" != "true" ]
+    then
+        migrateShootEtcd ${namespace_in_seed} ${seed}
+    else
+        echo "${namespace}/${shoot} ${seed}" >> $MIGRATION_SUCCEEDED
+        return
+    fi
+    echo "${namespace}/${shoot} ${seed}" >> $MIGRATION_SUCCEEDED
+    echo "Completed migration of shoot ${shoot}."
+}
+
+function migrateShootEtcd()
+{
+    local namespace=$1
+    local seed=$2
+    kubectl -n ${namespace} scale statefulset/etcd-main --replicas=1 --kubeconfig=$KUBECONFIGS_DIR/seed-${seed}.kubeconfig
+    waitTillMigrationCompleted ${namespace} ${seed}
+    kubectl -n ${namespace} scale statefulset/etcd-main --replicas=0 --kubeconfig=$KUBECONFIGS_DIR/seed-${seed}.kubeconfig
+
+}
+
+function waitTillMigrationCompleted()
+{
+    local namespace=$1
+    local seed=$2
+    old_data_dir=/var/etcd/old-data
+    migration_marker=$old_data_dir/migration.marker
+    echo "Wait for etcd migration in ${namespace}"
+    kubectl exec -it etcd-main-0 -c etcd -n ${namespace} --kubeconfig=$KUBECONFIGS_DIR/seed-${seed}.kubeconfig -- ls ${migration_marker}
+    while [ "$?" != "0" ]
+    do
+        sleep 5
+        echo "Wait for migration completion in ${namespace}"
+        kubectl exec -it etcd-main-0 -c etcd -n ${namespace} --kubeconfig=$KUBECONFIGS_DIR/seed-${seed}.kubeconfig -- ls ${migration_marker}
+    done
+}
+
+function checkMigrationStatus()
+{
+    local namespace=$1
+    local seed=$2
+    etcd_pvc_count=`kubectl -n ${namespace} --kubeconfig=$KUBECONFIGS_DIR/seed-${seed}.kubeconfig get pvc | grep "main-etcd" | wc -l`
+    if [[ "${etcd_pvc_count}" == 2 ]]
+    then
+        echo "DONE"
+        return
+    fi
+    echo "PENDING"
+}
+
+function fetchKubeconfigForSeed()
+{
+    local seed=$1
+    if [[ -e $KUBECONFIGS_DIR/seed-${seed}.kubeconfig ]]
+    then
+        return
+    fi
+    local seedJson=`kubectl --kubeconfig=${gardenkubeconfig} get seed ${seed} -o json`
+    local secretRefName=`echo -n ${seedJson} | jq .spec.secretRef.name | sed s/\"//g`
+    local secretRefNamespace=`echo -n ${seedJson} | jq .spec.secretRef.namespace | sed s/\"//g`
+    echo "Fetching kubeconfig for seed cluster ${seed}."
+    kubectl --kubeconfig=${gardenkubeconfig} get secret ${secretRefName} -n ${secretRefNamespace} -o json | jq .data.kubeconfig | sed s/\"//g | base64 -d > $KUBECONFIGS_DIR/seed-${seed}.kubeconfig
+}
+
+function processNamespace()
+{
+    local namespaces=("$@")
+    echo "Namespaces: ${namespaces[@]}"
+    for namespace in ${namespaces}
+    do
+        declare -a shoots
+        echo "Fetching shoots in ${namespace}."
+        shoots=`getShootsInNamespace ${namespace}`
+        if [ "${shoots}" == "" ] | [ "${#shoots[@]}" == "0" ];
+        then
+            continue
+        fi
+        for shoot in ${shoots}
+        do  
+            echo "Processing shoot ${shoot} in ${namespace}"
+            processShoot ${shoot} ${namespace}
+        done
+    done
+}
+
+MIGRATION_SUCCEEDED=`pwd`/migration_succeeded.txt
+MIGRATION_FAILED=`pwd`/migration_failed.txt
+
+if [ "$#" != "3" ]
+then 
+    echo "Arguments missing."
+    exit 1
+fi
+
+if [[ "$2" = "true" ]] || [[ "$2" = "false" ]]; then
+    dryrun=${2}
+else
+    exit 1
+fi
+
+if [[ "$3" == "true" ]] || [[ "$3" == "false" ]]; then
+    skip_reconcile_check=${3}
+else
+    exit 1  
+fi
+groupsize=10
+namespaces=()
+gardenkubeconfig=$1
+KUBECONFIGS_DIR=`pwd`/kubeconfigs
+if [ ! -d $KUBECONFIGS_DIR ]
+then
+    mkdir -p $KUBECONFIGS_DIR
+fi
+
+truncate -s0 $MIGRATION_SUCCEEDED $MIGRATION_FAILED
+echo "Fetching namespaces in garden cluster."
+namespaces=`getNamespaces`
+ns_count=`echo ${namespaces[@]} | wc -w`
+pids=()
+for i in `seq 0 ${groupsize} ${ns_count}`
+do
+  part=`echo ${namespaces[@]} | cut -d " " -f $(( i+1 ))-$(( i+groupsize ))`
+  processNamespace "${part[@]}" &
+  pid=$!
+  pids+=( $pid )
+done
+echo "Parallel threads: ${#pids[@]}"
+for i in ${pids[@]}
+do 
+    wait $i
+done
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Etcd statefulsets for the seed/shoot clusters have been updated to use a fast storage volume. However, the migration of etcd data directory from the old volume to the new volume happens only when the etcd pod runs post migration. For hibernated clusters, this is not the case. Hence, migration does not happen in these clusters. To force migration of etcd in these clusters, we should use this script to scale up the etcd statefulsets from hibernation and subsequently scale it back down post migration. 

This script is meant to be run once before the next step of migration that removes the slow volumes of etcd.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```action operator
In the previous release, all main etcd `StatefulSet`s for the shoot clusters have been updated to use a fast storage volume. However, the migration of etcd data directory from the old volume to the new volume happens only when the etcd pod runs post migration. For hibernated clusters, this is not the case. Hence, migration does not happen for these clusters. To force migration of etcd for these clusters, we should use this script to scale up the etcd `StatefulSet`s from hibernation and subsequently scale it back down post migration. This script is meant to be run once before the next release of Gardener which removes the slow volumes of etcd.
```
