### PR TITLE
disable node-exporter netclass collector

### DIFF
--- a/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -78,6 +78,7 @@ spec:
         - --collector.filesystem.ignored-mount-points=^/(rootfs/|host/)?(sys|proc|dev|host|etc|var/lib/docker)($|/)
         - --web.listen-address=:{{ .Values.ports.metrics }}
         - --log.level=error
+        - --no-collector.netclass
         ports:
         - containerPort: {{ .Values.ports.metrics }}
           protocol: TCP


### PR DESCRIPTION
**What this PR does / why we need it**:
We are still getting many alerts about the `node-exporter` not being reachable from Prometheus. This is because the node-exporter sometimes takes over 10s to respond to its `/metrics` endpoint. The node-exporter takes so long because of the netclass collector. We do not need the metrics that the netclass collector gathers, so this PR disables it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
