### PR TITLE
gardener.unprivileged PSP default seccomp profile

### DIFF
--- a/charts/shoot-core/charts/podsecuritypolicies/templates/_defaults.tpl
+++ b/charts/shoot-core/charts/podsecuritypolicies/templates/_defaults.tpl
@@ -1,0 +1,15 @@
+{{- define "podsecuritypolicies.seccompDefaultProfileName" -}}
+{{- if semverCompare ">= 1.11" .Values.global.kubernetesVersion -}}
+runtime/default
+{{- else -}}
+docker/default
+{{- end -}}
+{{- end -}}
+
+{{- define "podsecuritypolicies.seccompAllowedProfileNames" -}}
+{{- if semverCompare ">= 1.11" .Values.global.kubernetesVersion -}}
+runtime/default,docker/default
+{{- else -}}
+docker/default
+{{- end -}}
+{{- end -}}

--- a/charts/shoot-core/charts/podsecuritypolicies/templates/unprivileged-psp.yaml
+++ b/charts/shoot-core/charts/podsecuritypolicies/templates/unprivileged-psp.yaml
@@ -3,11 +3,9 @@ kind: PodSecurityPolicy
 metadata:
   name: gardener.unprivileged
   annotations:
-    # seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
-    # seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default,docker/default'
-    # 'runtime/default' is already the default, but must be filled in on the
-    # pod to pass admission.
-    # apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: '{{ template "podsecuritypolicies.seccompDefaultProfileName" . }}'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '{{ template "podsecuritypolicies.seccompAllowedProfileNames" . }}'
+    # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
     # apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
     garden.sapcloud.io/description: |
       gardener.unprivileged grants the mininimum amount of privileges necessary to run non-privileged Pods.

--- a/charts/shoot-core/charts/podsecuritypolicies/values.yaml
+++ b/charts/shoot-core/charts/podsecuritypolicies/values.yaml
@@ -1,1 +1,3 @@
 allowPrivilegedContainers: false
+global:
+  kubernetesVersion: 1.12.1


### PR DESCRIPTION
**What this PR does / why we need it**:

The `PodSecurityPolicy` `gardener.unprivileged` now has a default seccomp policy `runtime/default` for clusters `>= 1.11` and `docker/default` for clusters `< 1.11`.
See https://github.com/kubernetes/kubernetes/pull/62662 for more info.

Allowed seccomp profiles now include `runtime/default` and `docker/default`.

This allows users to explicitly specify `seccomp.security.alpha.kubernetes.io/pod: runtime/default` as annotation on their Pods.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
n/a

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       noteworthy
- target_group:   user
-->
```improvement operator
`PodSecurityPolicy` `gardener.unprivileged` now has a default seccomp policy `runtime/default` for clusters `>= 1.11` and `docker/default` for clusters `< 1.11`.
```

```action user
`PodSecurityPolicy` `gardener.unprivileged` now uses the default docker seccomp policy (https://docs.docker.com/engine/security/seccomp/). 
If privileged containers are disabled via `.spec.kubernetes.allowPrivilegedContainers=false` and blocked system calls are used by containers, then a new `PodSecurityPolicy` needs to be created, allowing `unconfined` seccomp access. See https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp.
```
