### PR TITLE
Added fine grained scale down options for CA

### DIFF
--- a/charts/seed-controlplane/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/cluster-autoscaler/templates/deployment.yaml
@@ -46,8 +46,6 @@ spec:
         - --skip-nodes-with-local-storage=false
         - --expander=least-waste
         - --expendable-pods-priority-cutoff=-10
-        - --scale-down-delay-after-add=60m
-        - --scale-down-unneeded-time=30m
         {{- range $key, $flag := .Values.flags }}
         - --{{ $flag.name }}={{ $flag.value }}
         {{- end }}

--- a/example/90-shoot-alicloud.yaml
+++ b/example/90-shoot-alicloud.yaml
@@ -37,6 +37,11 @@ spec:
   kubernetes:
   # clusterAutoscaler:
   #   scaleDownUtilizationThreshold: 0.5
+  #   scaleDownUnneededTime: 30m
+  #   scaleDownDelayAfterAdd: 60m
+  #   scaleDownDelayAfterFailure: 10m
+  #   scaleDownDelayAfterDelete: 10s
+  #   scanInterval: 10s
     version: 1.14.0
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:

--- a/example/90-shoot-aws.yaml
+++ b/example/90-shoot-aws.yaml
@@ -39,6 +39,11 @@ spec:
   kubernetes:
   # clusterAutoscaler:
   #   scaleDownUtilizationThreshold: 0.5
+  #   scaleDownUnneededTime: 30m
+  #   scaleDownDelayAfterAdd: 60m
+  #   scaleDownDelayAfterFailure: 10m
+  #   scaleDownDelayAfterDelete: 10s
+  #   scanInterval: 10s
     version: 1.14.0
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:

--- a/example/90-shoot-azure.yaml
+++ b/example/90-shoot-azure.yaml
@@ -38,6 +38,11 @@ spec:
   kubernetes:
   # clusterAutoscaler:
   #   scaleDownUtilizationThreshold: 0.5
+  #   scaleDownUnneededTime: 30m
+  #   scaleDownDelayAfterAdd: 60m
+  #   scaleDownDelayAfterFailure: 10m
+  #   scaleDownDelayAfterDelete: 10s
+  #   scanInterval: 10s
     version: 1.14.0
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:

--- a/example/90-shoot-gcp.yaml
+++ b/example/90-shoot-gcp.yaml
@@ -37,6 +37,11 @@ spec:
   kubernetes:
   # clusterAutoscaler:
   #   scaleDownUtilizationThreshold: 0.5
+  #   scaleDownUnneededTime: 30m
+  #   scaleDownDelayAfterAdd: 60m
+  #   scaleDownDelayAfterFailure: 10m
+  #   scaleDownDelayAfterDelete: 10s
+  #   scanInterval: 10s
     version: 1.14.0
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:

--- a/example/90-shoot-openstack.yaml
+++ b/example/90-shoot-openstack.yaml
@@ -36,6 +36,11 @@ spec:
   kubernetes:
   # clusterAutoscaler:
   #   scaleDownUtilizationThreshold: 0.5
+  #   scaleDownUnneededTime: 30m
+  #   scaleDownDelayAfterAdd: 60m
+  #   scaleDownDelayAfterFailure: 10m
+  #   scaleDownDelayAfterDelete: 10s
+  #   scanInterval: 10s
     version: 1.14.0
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:

--- a/example/90-shoot-packet.yaml
+++ b/example/90-shoot-packet.yaml
@@ -32,6 +32,11 @@ spec:
   kubernetes:
   # clusterAutoscaler:
   #   scaleDownUtilizationThreshold: 0.5
+  #   scaleDownUnneededTime: 30m
+  #   scaleDownDelayAfterAdd: 60m
+  #   scaleDownDelayAfterFailure: 10m
+  #   scaleDownDelayAfterDelete: 10s
+  #   scanInterval: 10s
     version: 1.14.0
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -280,6 +280,11 @@ spec:
   kubernetes:
   # clusterAutoscaler:
   #   scaleDownUtilizationThreshold: 0.5
+  #   scaleDownUnneededTime: 30m
+  #   scaleDownDelayAfterAdd: 60m
+  #   scaleDownDelayAfterFailure: 10m
+  #   scaleDownDelayAfterDelete: 10s
+  #   scanInterval: 10s
     version: ${value("spec.kubernetes.version", kubernetesVersion)}<% kubeAPIServer=value("spec.kubernetes.kubeAPIServer", {}) %><% cloudControllerManager=value("spec.kubernetes.cloudControllerManager", {}) %><% kubeControllerManager=value("spec.kubernetes.kubeControllerManager", {}) %><% kubeScheduler=value("spec.kubernetes.kubeScheduler", {}) %><% kubeProxy=value("spec.kubernetes.kubeProxy", {}) %><% kubelet=value("spec.kubernetes.kubelet", {}) %>
     allowPrivilegedContainers: ${value("spec.kubernetes.allowPrivilegedContainers", "true")} # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
     % if kubeAPIServer != {}:

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -1206,6 +1206,21 @@ type ClusterAutoscaler struct {
 	// ScaleDownUtilizationThreshold defines the threshold in % under which a node is being removed
 	// +optional
 	ScaleDownUtilizationThreshold *float64
+	// ScaleDownUnneededTime defines how long a node should be unneeded before it is eligible for scale down (default: 10 mins).
+	// +optional
+	ScaleDownUnneededTime *metav1.Duration
+	// ScaleDownDelayAfterAdd defines how long after scale up that scale down evaluation resumes (default: 10 mins).
+	// +optional
+	ScaleDownDelayAfterAdd *metav1.Duration
+	// ScaleDownDelayAfterFailure how long after scale down failure that scale down evaluation resumes (default: 3 mins).
+	// +optional
+	ScaleDownDelayAfterFailure *metav1.Duration
+	// ScaleDownDelayAfterDelete how long after node deletion that scale down evaluation resumes, defaults to scanInterval (defaults to ScanInterval).
+	// +optional
+	ScaleDownDelayAfterDelete *metav1.Duration
+	// ScanInterval how often cluster is reevaluated for scale up or down (default: 10 secs).
+	// +optional
+	ScanInterval *metav1.Duration
 }
 
 // KubernetesConfig contains common configuration fields for the control plane components.

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -1204,6 +1204,21 @@ type ClusterAutoscaler struct {
 	// ScaleDownUtilizationThreshold defines the threshold in % under which a node is being removed
 	// +optional
 	ScaleDownUtilizationThreshold *float64 `json:"scaleDownUtilizationThreshold,omitempty"`
+	// ScaleDownUnneededTime defines how long a node should be unneeded before it is eligible for scale down (default: 10 mins).
+	// +optional
+	ScaleDownUnneededTime *metav1.Duration `json:"scaleDownUnneededTime,omitempty"`
+	// ScaleDownDelayAfterAdd defines how long after scale up that scale down evaluation resumes (default: 10 mins).
+	// +optional
+	ScaleDownDelayAfterAdd *metav1.Duration `json:"scaleDownDelayAfterAdd,omitempty"`
+	// ScaleDownDelayAfterFailure how long after scale down failure that scale down evaluation resumes (default: 3 mins).
+	// +optional
+	ScaleDownDelayAfterFailure *metav1.Duration `json:"scaleDownDelayAfterFailure,omitempty"`
+	// ScaleDownDelayAfterDelete how long after node deletion that scale down evaluation resumes, defaults to scanInterval (defaults to ScanInterval).
+	// +optional
+	ScaleDownDelayAfterDelete *metav1.Duration `json:"scaleDownDelayAfterDelete,omitempty"`
+	// ScanInterval how often cluster is reevaluated for scale up or down (default: 10 secs).
+	// +optional
+	ScanInterval *metav1.Duration `json:"scanInterval,omitempty"`
 }
 
 // KubernetesConfig contains common configuration fields for the control plane components.

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -2338,6 +2338,11 @@ func Convert_garden_CloudProfileSpec_To_v1beta1_CloudProfileSpec(in *garden.Clou
 
 func autoConvert_v1beta1_ClusterAutoscaler_To_garden_ClusterAutoscaler(in *ClusterAutoscaler, out *garden.ClusterAutoscaler, s conversion.Scope) error {
 	out.ScaleDownUtilizationThreshold = (*float64)(unsafe.Pointer(in.ScaleDownUtilizationThreshold))
+	out.ScaleDownUnneededTime = (*metav1.Duration)(unsafe.Pointer(in.ScaleDownUnneededTime))
+	out.ScaleDownDelayAfterAdd = (*metav1.Duration)(unsafe.Pointer(in.ScaleDownDelayAfterAdd))
+	out.ScaleDownDelayAfterFailure = (*metav1.Duration)(unsafe.Pointer(in.ScaleDownDelayAfterFailure))
+	out.ScaleDownDelayAfterDelete = (*metav1.Duration)(unsafe.Pointer(in.ScaleDownDelayAfterDelete))
+	out.ScanInterval = (*metav1.Duration)(unsafe.Pointer(in.ScanInterval))
 	return nil
 }
 
@@ -2348,6 +2353,11 @@ func Convert_v1beta1_ClusterAutoscaler_To_garden_ClusterAutoscaler(in *ClusterAu
 
 func autoConvert_garden_ClusterAutoscaler_To_v1beta1_ClusterAutoscaler(in *garden.ClusterAutoscaler, out *ClusterAutoscaler, s conversion.Scope) error {
 	out.ScaleDownUtilizationThreshold = (*float64)(unsafe.Pointer(in.ScaleDownUtilizationThreshold))
+	out.ScaleDownUnneededTime = (*metav1.Duration)(unsafe.Pointer(in.ScaleDownUnneededTime))
+	out.ScaleDownDelayAfterAdd = (*metav1.Duration)(unsafe.Pointer(in.ScaleDownDelayAfterAdd))
+	out.ScaleDownDelayAfterFailure = (*metav1.Duration)(unsafe.Pointer(in.ScaleDownDelayAfterFailure))
+	out.ScaleDownDelayAfterDelete = (*metav1.Duration)(unsafe.Pointer(in.ScaleDownDelayAfterDelete))
+	out.ScanInterval = (*metav1.Duration)(unsafe.Pointer(in.ScanInterval))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ import (
 	v1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -1059,6 +1060,31 @@ func (in *ClusterAutoscaler) DeepCopyInto(out *ClusterAutoscaler) {
 	if in.ScaleDownUtilizationThreshold != nil {
 		in, out := &in.ScaleDownUtilizationThreshold, &out.ScaleDownUtilizationThreshold
 		*out = new(float64)
+		**out = **in
+	}
+	if in.ScaleDownUnneededTime != nil {
+		in, out := &in.ScaleDownUnneededTime, &out.ScaleDownUnneededTime
+		*out = new(metav1.Duration)
+		**out = **in
+	}
+	if in.ScaleDownDelayAfterAdd != nil {
+		in, out := &in.ScaleDownDelayAfterAdd, &out.ScaleDownDelayAfterAdd
+		*out = new(metav1.Duration)
+		**out = **in
+	}
+	if in.ScaleDownDelayAfterFailure != nil {
+		in, out := &in.ScaleDownDelayAfterFailure, &out.ScaleDownDelayAfterFailure
+		*out = new(metav1.Duration)
+		**out = **in
+	}
+	if in.ScaleDownDelayAfterDelete != nil {
+		in, out := &in.ScaleDownDelayAfterDelete, &out.ScaleDownDelayAfterDelete
+		*out = new(metav1.Duration)
+		**out = **in
+	}
+	if in.ScanInterval != nil {
+		in, out := &in.ScanInterval, &out.ScanInterval
+		*out = new(metav1.Duration)
 		**out = **in
 	}
 	return

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -1066,6 +1066,31 @@ func (in *ClusterAutoscaler) DeepCopyInto(out *ClusterAutoscaler) {
 		*out = new(float64)
 		**out = **in
 	}
+	if in.ScaleDownUnneededTime != nil {
+		in, out := &in.ScaleDownUnneededTime, &out.ScaleDownUnneededTime
+		*out = new(metav1.Duration)
+		**out = **in
+	}
+	if in.ScaleDownDelayAfterAdd != nil {
+		in, out := &in.ScaleDownDelayAfterAdd, &out.ScaleDownDelayAfterAdd
+		*out = new(metav1.Duration)
+		**out = **in
+	}
+	if in.ScaleDownDelayAfterFailure != nil {
+		in, out := &in.ScaleDownDelayAfterFailure, &out.ScaleDownDelayAfterFailure
+		*out = new(metav1.Duration)
+		**out = **in
+	}
+	if in.ScaleDownDelayAfterDelete != nil {
+		in, out := &in.ScaleDownDelayAfterDelete, &out.ScaleDownDelayAfterDelete
+		*out = new(metav1.Duration)
+		**out = **in
+	}
+	if in.ScanInterval != nil {
+		in, out := &in.ScanInterval, &out.ScanInterval
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3147,9 +3147,41 @@ func schema_pkg_apis_garden_v1beta1_ClusterAutoscaler(ref common.ReferenceCallba
 							Format:      "double",
 						},
 					},
+					"scaleDownUnneededTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ScaleDownUnneededTime defines how long a node should be unneeded before it is eligible for scale down (default: 10 mins).",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
+					"scaleDownDelayAfterAdd": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ScaleDownDelayAfterAdd defines how long after scale up that scale down evaluation resumes (default: 10 mins).",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
+					"scaleDownDelayAfterFailure": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ScaleDownDelayAfterFailure how long after scale down failure that scale down evaluation resumes (default: 3 mins).",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
+					"scaleDownDelayAfterDelete": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ScaleDownDelayAfterDelete how long after node deletion that scale down evaluation resumes, defaults to scanInterval (defaults to ScanInterval).",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
+					"scanInterval": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ScanInterval how often cluster is reevaluated for scale up or down (default: 10 secs).",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
 				},
 			},
 		},
+		Dependencies: []string{
+			"k8s.io/apimachinery/pkg/apis/meta/v1.Duration"},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Added the following CA flags to Shoot Spec allowing to have more control over the scale down behavior of the CA:

```
kubernetes:
  clusterAutoscaler:
    scaleDownUnneededTime: 30m
    scaleDownDelayAfterAdd: 60m
    scaleDownDelayAfterFailure: 10m
    scaleDownDelayAfterDelete: 10s
    scanInterval: 10s
```

**Which issue(s) this PR fixes**:
Fixes #546 

**Release note**:
```noteworthy user
It is now possible to configure various settings (`scaleDownUnneededTime`, `scaleDownDelayAfterAdd`, `scaleDownDelayAfterFailure`, `scaleDownDelayAfterDelete`, `scanInterval`) for the cluster-autoscaler in the shoot. Please consult the [example `Shoot` manifests](https://github.com/gardener/gardener/blob/master/example/90-shoot-aws.yaml#L40) for details.
```
