### PR TITLE
Add force delete annotation on backupinfra resource

### DIFF
--- a/pkg/apis/garden/validation/validation.go
+++ b/pkg/apis/garden/validation/validation.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
-
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/garden"
 	"github.com/gardener/gardener/pkg/apis/garden/helper"
@@ -33,7 +32,7 @@ import (
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
 
 	"github.com/robfig/cron"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -2026,9 +2025,24 @@ func ValidateBackupInfrastructure(backupInfrastructure *garden.BackupInfrastruct
 func ValidateBackupInfrastructureUpdate(newBackupInfrastructure, oldBackupInfrastructure *garden.BackupInfrastructure) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newBackupInfrastructure.ObjectMeta, &oldBackupInfrastructure.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateBackupInfrastructureMetaUpdate(&newBackupInfrastructure.ObjectMeta, &oldBackupInfrastructure.ObjectMeta,field.NewPath("metadata"))...)
 	allErrs = append(allErrs, ValidateBackupInfrastructureSpecUpdate(&newBackupInfrastructure.Spec, &oldBackupInfrastructure.Spec, newBackupInfrastructure.DeletionTimestamp != nil, field.NewPath("spec"))...)
 	allErrs = append(allErrs, ValidateBackupInfrastructure(newBackupInfrastructure)...)
+
+	return allErrs
+}
+
+// ValidateBackupInfrastructureMetaUpdate validates the updates in metadata of a BackupInfrastructure object.
+func ValidateBackupInfrastructureMetaUpdate(newMeta, oldMeta *metav1.ObjectMeta, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(newMeta, oldMeta, fldPath)...)
+
+	oldPresent, _:= strconv.ParseBool(oldMeta.Annotations[common.BackupInfrastructureForceDeletion])
+	newPresent, _:= strconv.ParseBool(newMeta.Annotations[common.BackupInfrastructureForceDeletion])
+	if oldPresent && !newPresent {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("annotations"), newMeta.Annotations, "force delete annotation cannot be updated once set to true"))
+	}
 
 	return allErrs
 }

--- a/pkg/controllermanager/controller/backupinfrastructure/backup_infrastructure_control.go
+++ b/pkg/controllermanager/controller/backupinfrastructure/backup_infrastructure_control.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
@@ -190,7 +191,8 @@ func (c *defaultControl) ReconcileBackupInfrastructure(obj *gardenv1beta1.Backup
 	// When this happens the controller will remove the finalizer from the BackupInfrastructure so that it can be garbage collected.
 	if backupInfrastructure.DeletionTimestamp != nil {
 		gracePeriod := computeGracePeriod(c.config)
-		if time.Now().Sub(backupInfrastructure.DeletionTimestamp.Time) > gracePeriod {
+		present, _ := strconv.ParseBool(backupInfrastructure.ObjectMeta.Annotations[common.BackupInfrastructureForceDeletion])
+		if present || time.Now().Sub(backupInfrastructure.DeletionTimestamp.Time) > gracePeriod {
 			if updateErr := c.updateBackupInfrastructureStatus(op, gardencorev1alpha1.LastOperationStateProcessing, operationType, "Deletion of Backup Infrastructure in progress.", 1, nil); updateErr != nil {
 				backupInfrastructureLogger.Errorf("Could not update the BackupInfrastructure status after deletion start: %+v", updateErr)
 				return false, updateErr

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -29,6 +29,9 @@ const (
 	// authenticate against the respective cloud provider (required to store the backups of Shoot clusters).
 	BackupSecretName = "etcd-backup"
 
+	// BackupInfrastructureForceDeletion is a constant for an annotation on a Backupinfrastructure indicating that it should be force deleted.
+	BackupInfrastructureForceDeletion = "backupinfrastructure.garden.sapcloud.io/force-deletion"
+
 	// BackupInfrastructureOperation is a constant for an annotation on a Backupinfrastructure indicating that an operation shall be performed.
 	BackupInfrastructureOperation = "backupinfrastructure.garden.sapcloud.io/operation"
 

--- a/pkg/registry/garden/backupinfrastructure/strategy.go
+++ b/pkg/registry/garden/backupinfrastructure/strategy.go
@@ -16,13 +16,13 @@ package backupinfrastructure
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/garden"
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/garden/validation"
 	"github.com/gardener/gardener/pkg/operation/common"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -76,7 +76,9 @@ func mustIncreaseGeneration(oldBackupInfrastructure, newBackupInfrastructure *ga
 		return true
 	}
 
-	if kutil.HasMetaDataAnnotation(&newBackupInfrastructure.ObjectMeta, common.BackupInfrastructureOperation, common.BackupInfrastructureReconcile) {
+	oldPresent, _ := strconv.ParseBool(oldBackupInfrastructure.ObjectMeta.Annotations[common.BackupInfrastructureForceDeletion])
+	newPresent, _ := strconv.ParseBool(newBackupInfrastructure.ObjectMeta.Annotations[common.BackupInfrastructureForceDeletion])
+	if oldPresent != newPresent && newPresent {
 		return true
 	}
 


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
This PR allow us to force delete the `BackupInfra` resource before globally configured `deletionGracePeriodDays` by adding annotating resource with `backupinfrastructure.garden.sapcloud.io/forcedelete="true"`. This is helpful for operator to cleanup the backup resource created for temporary shoot like test cluster

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
It is now possible to force the deletion of pending `BackupInfrastructure` resources prior to globally configured `deletionGracePeriodDays` by annotating the resource with `backupinfrastructure.garden.sapcloud.io/force-deletion=true`.
```
