### PR TITLE
Add BackupInfrastructure deletion annotation to test shoots

### DIFF
--- a/.test-defs/cmd/create-shoot/helper.go
+++ b/.test-defs/cmd/create-shoot/helper.go
@@ -15,8 +15,12 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/test/integration/framework"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // updateWorkerZone updates the zone of the workers.
@@ -114,4 +118,27 @@ func updateAnnotations(shoot *gardenv1beta1.Shoot) {
 		shoot.Annotations = map[string]string{}
 	}
 	shoot.Annotations[common.GardenIgnoreAlerts] = "true"
+}
+
+// updateBackupInfrastructureAnnotations adds default annotations that should be present on any backupinfrastructure created.
+func updateBackupInfrastructureAnnotations(backup *gardenv1beta1.BackupInfrastructure) {
+	if backup.Annotations == nil {
+		backup.Annotations = map[string]string{}
+	}
+	backup.Annotations[common.BackupInfrastructureForceDeletion] = "true"
+}
+
+// getBackupInfrastructureOfShoot returns the BackupInfrastructure object of the shoot
+func getBackupInfrastructureOfShoot(ctx  context.Context, shootGardenerTest *framework.ShootGardenerTest) (*gardenv1beta1.BackupInfrastructure, error) {
+	backups := &gardenv1beta1.BackupInfrastructureList{}
+	err := shootGardenerTest.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: shootGardenerTest.Shoot.Namespace}, backups)
+	if err != nil {
+		return nil, err
+	}
+	for _, backup := range backups.Items {
+		if backup.Spec.ShootUID == shootGardenerTest.Shoot.Status.UID {
+			return &backup, nil
+		}
+	}
+	return nil, fmt.Errorf("cannot find backup infrastructure for shoot with uid %s", shootGardenerTest.Shoot.Status.UID)
 }

--- a/.test-defs/cmd/create-shoot/main.go
+++ b/.test-defs/cmd/create-shoot/main.go
@@ -160,6 +160,17 @@ func main() {
 	}
 	testLogger.Infof("Successfully created shoot %s", shootName)
 
+
+	backupInfrastructure, err := getBackupInfrastructureOfShoot(ctx, shootGardenerTest)
+	if err != nil {
+		testLogger.Fatal(err)
+	}
+	updateBackupInfrastructureAnnotations(backupInfrastructure)
+	if err := shootGardenerTest.GardenClient.Client().Update(ctx, backupInfrastructure); err != nil {
+		testLogger.Fatalf("Cannot update annotation of backupinfrastructure %s: %s", backupInfrastructure.Name, err.Error())
+	}
+
+
 	shootTestOperations, err := framework.NewGardenTestOperation(ctx, shootGardenerTest.GardenClient, testLogger, shootObject)
 	if err != nil {
 		testLogger.Fatalf("Cannot create shoot %s: %s", shootName, err.Error())
@@ -168,6 +179,10 @@ func main() {
 	err = shootTestOperations.DownloadKubeconfig(ctx, shootTestOperations.SeedClient, shootTestOperations.ShootSeedNamespace(), gardenv1beta1.GardenerName, fmt.Sprintf("%s/shoot.config", kubeconfigPath))
 	if err != nil {
 		testLogger.Fatalf("Cannot download shoot kubeconfig: %s", err.Error())
+	}
+	err = shootTestOperations.DownloadKubeconfig(ctx, shootTestOperations.GardenClient, shootTestOperations.Seed.Spec.SecretRef.Namespace, shootTestOperations.Seed.Spec.SecretRef.Name, fmt.Sprintf("%s/seed.config", kubeconfigPath))
+	if err != nil {
+		testLogger.Fatalf("Cannot download seed kubeconfig: %s", err.Error())
 	}
 	testLogger.Infof("Finished creating shoot %s", shootName)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the the force deletion annotation (https://github.com/gardener/gardener/pull/1058) for the backup infrastructure to shoots created for integration tests.

And the create-shoot test now downloads the seed kubeconfig so that it is available for further tests.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
