### PR TITLE
Allow to change the CPU manager policy of the kubelet

### DIFF
--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet-config-file
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet-config-file
@@ -22,7 +22,7 @@ clusterDNS:
 - {{ required "kubernetes.clusterDNS is required" .Values.kubernetes.clusterDNS }}
 configTrialDuration: 10m0s
 cpuCFSQuota: {{ .Values.kubernetes.kubelet.cpuCFSQuota }}
-cpuManagerPolicy: none
+cpuManagerPolicy: {{ .Values.kubernetes.kubelet.cpuManagerPolicy }}
 cpuManagerReconcilePeriod: 10s
 enableControllerAttachDetach: true
 enableDebuggingHandlers: true

--- a/charts/seed-operatingsystemconfig/original/values.yaml
+++ b/charts/seed-operatingsystemconfig/original/values.yaml
@@ -23,6 +23,7 @@ kubernetes:
     enableCSI: false
     providerIDProvided: false
     cpuCFSQuota: true
+    cpuManagerPolicy: none
 #   podPIDsLimit: 24
     featureGates: {}
 #     CustomResourceValidation: true

--- a/example/90-shoot-alicloud.yaml
+++ b/example/90-shoot-alicloud.yaml
@@ -100,6 +100,7 @@ spec:
   #   mode: IPVS
   # kubelet:
   #   cpuCFSQuota: true
+  #   cpuManagerPolicy: none
   #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-aws.yaml
+++ b/example/90-shoot-aws.yaml
@@ -102,6 +102,7 @@ spec:
   #   mode: IPVS
   # kubelet:
   #   cpuCFSQuota: true
+  #   cpuManagerPolicy: none
   #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-azure.yaml
+++ b/example/90-shoot-azure.yaml
@@ -101,6 +101,7 @@ spec:
   #   mode: IPVS
   # kubelet:
   #   cpuCFSQuota: true
+  #   cpuManagerPolicy: none
   #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-gcp.yaml
+++ b/example/90-shoot-gcp.yaml
@@ -100,6 +100,7 @@ spec:
   #   mode: IPVS
   # kubelet:
   #   cpuCFSQuota: true
+  #   cpuManagerPolicy: none
   #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-openstack.yaml
+++ b/example/90-shoot-openstack.yaml
@@ -99,6 +99,7 @@ spec:
   #   mode: IPVS
   # kubelet:
   #   cpuCFSQuota: true
+  #   cpuManagerPolicy: none
   #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/example/90-shoot-packet.yaml
+++ b/example/90-shoot-packet.yaml
@@ -95,6 +95,7 @@ spec:
   #   mode: IPVS
   # kubelet:
   #   cpuCFSQuota: true
+  #   cpuManagerPolicy: none
   #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -366,6 +366,7 @@ spec:
     % else:
   # kubelet:
   #   cpuCFSQuota: true
+  #   cpuManagerPolicy: none
   #   podPidsLimit: 10
   #   featureGates:
   #     SomeKubernetesFeature: true

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -1388,7 +1388,11 @@ type KubeletConfig struct {
 	// PodPIDsLimit is the maximum number of process IDs per pod allowed by the kubelet.
 	PodPIDsLimit *int64
 	// CPUCFSQuota allows you to disable/enable CPU throttling for Pods.
+	// +optional
 	CPUCFSQuota *bool
+	// CPUManagerPolicy allows to set alternative CPU management policies (default: none).
+	// +optional
+	CPUManagerPolicy *string
 }
 
 // Maintenance contains information about the time window for maintenance operations and which

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -1442,7 +1442,11 @@ type KubeletConfig struct {
 	// +optional
 	PodPIDsLimit *int64 `json:"podPidsLimit,omitempty"`
 	// CPUCFSQuota allows you to disable/enable CPU throttling for Pods.
+	// +optional
 	CPUCFSQuota *bool `json:"cpuCFSQuota,omitempty"`
+	// CPUManagerPolicy allows to set alternative CPU management policies (default: none).
+	// +optional
+	CPUManagerPolicy *string `json:"cpuManagerPolicy,omitempty"`
 }
 
 // Maintenance contains information about the time window for maintenance operations and which

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -2962,6 +2962,7 @@ func autoConvert_v1beta1_KubeletConfig_To_garden_KubeletConfig(in *KubeletConfig
 	}
 	out.PodPIDsLimit = (*int64)(unsafe.Pointer(in.PodPIDsLimit))
 	out.CPUCFSQuota = (*bool)(unsafe.Pointer(in.CPUCFSQuota))
+	out.CPUManagerPolicy = (*string)(unsafe.Pointer(in.CPUManagerPolicy))
 	return nil
 }
 
@@ -2976,6 +2977,7 @@ func autoConvert_garden_KubeletConfig_To_v1beta1_KubeletConfig(in *garden.Kubele
 	}
 	out.PodPIDsLimit = (*int64)(unsafe.Pointer(in.PodPIDsLimit))
 	out.CPUCFSQuota = (*bool)(unsafe.Pointer(in.CPUCFSQuota))
+	out.CPUManagerPolicy = (*string)(unsafe.Pointer(in.CPUManagerPolicy))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -1679,6 +1679,11 @@ func (in *KubeletConfig) DeepCopyInto(out *KubeletConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CPUManagerPolicy != nil {
+		in, out := &in.CPUManagerPolicy, &out.CPUManagerPolicy
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -1667,6 +1667,11 @@ func (in *KubeletConfig) DeepCopyInto(out *KubeletConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.CPUManagerPolicy != nil {
+		in, out := &in.CPUManagerPolicy, &out.CPUManagerPolicy
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -4159,6 +4159,13 @@ func schema_pkg_apis_garden_v1beta1_KubeletConfig(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
+					"cpuManagerPolicy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CPUManagerPolicy allows to set alternative CPU management policies (default: none).",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/operation/hybridbotanist/cloud_config.go
+++ b/pkg/operation/hybridbotanist/cloud_config.go
@@ -158,8 +158,7 @@ func (b *HybridBotanist) generateOriginalConfig() (map[string]interface{}, error
 		cloudProvider["config"] = cloudProviderConfig
 	}
 
-	kubeletConfig := b.Shoot.Info.Spec.Kubernetes.Kubelet
-	if kubeletConfig != nil {
+	if kubeletConfig := b.Shoot.Info.Spec.Kubernetes.Kubelet; kubeletConfig != nil {
 		if featureGates := kubeletConfig.FeatureGates; featureGates != nil {
 			kubelet["featureGates"] = featureGates
 		}
@@ -168,6 +167,9 @@ func (b *HybridBotanist) generateOriginalConfig() (map[string]interface{}, error
 		}
 		if cpuCFSQuota := kubeletConfig.CPUCFSQuota; cpuCFSQuota != nil {
 			kubelet["cpuCFSQuota"] = *cpuCFSQuota
+		}
+		if cpuManagerPolicy := kubeletConfig.CPUManagerPolicy; cpuManagerPolicy != nil {
+			kubelet["cpuManagerPolicy"] = *cpuManagerPolicy
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow the user to change the CPU manager policy according to https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/

e.g.

```shell
  kubernetes:
    kubelet:
      cpuManagerPolicy: none # or static
```

**Which issue(s) this PR fixes**:
Fixes #987 

**Release note**:
```noteworthy user
It is now possible to configure CPU manager policy in the `.spec.kubernetes.kubelet` configuration for shoot clusters.
```
