### PR TITLE
Fix kube-proxy init container

### DIFF
--- a/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -37,9 +37,13 @@ spec:
       - name: disable-ipv6
         image: {{ index .Values.images "alpine"}}
         command:
-        - /sbin/sysctl
-        - -w
-        - net.ipv6.conf.all.disable_ipv6=1
+        - /bin/sh
+        - -c
+        args:
+        - >-
+          test -f /proc/net/if_inet6 &&
+          echo "IPv6 is enabled. Disabling..." &&
+          /sbin/sysctl -w net.ipv6.conf.all.disable_ipv6=1 || echo "IPv6 is already disabled. Doing nothing..."
         securityContext:
           privileged: true
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

For systems with disabled IPv6 kernel module, the init container was crashing with

```
sysctl: error: 'net.ipv6.conf.all.disable_ipv6' is an unknown key
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fix `kube-proxy` Init container crash, when `IPVS` is enabled on systems without loaded `IPv6` kernel module.
```
