### PR TITLE
etcd-main emits extensive (histogram) metrics.

### DIFF
--- a/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
@@ -119,3 +119,6 @@ data:
       # keep one day of history
       auto-compaction-mode: periodic
       auto-compaction-retention: "24"
+
+      # metrics configuration
+      metrics: {{ .Values.metrics }}

--- a/charts/seed-controlplane/charts/etcd/values.yaml
+++ b/charts/seed-controlplane/charts/etcd/values.yaml
@@ -23,6 +23,8 @@ podAnnotations: {}
 vpa:
   enabled: true
 
+metrics: basic
+
 # Aws S3 storage configuration
 # Note: No volumeMounts variable needed
 # storageProvider: "S3"

--- a/charts/seed-monitoring/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/prometheus/values.yaml
@@ -81,6 +81,9 @@ allowedMetrics:
   - etcd_server_proposals_pending
   - grpc_server_handled_total
   - grpc_server_started_total
+  - grpc_server_handling_seconds_count
+  - grpc_server_handling_seconds_sum
+  - grpc_server_handling_seconds_bucket
   - process_max_fds
   - process_open_fds
   - process_resident_memory_bytes

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -161,6 +161,9 @@ func (b *HybridBotanist) DeployETCD() error {
 				"storageProvider": "", // No storage provider means no backup
 			}
 			etcd["storageCapacity"] = b.Seed.GetValidVolumeSize("10Gi")
+		} else {
+			// etcd-main emits extensive (histogram) metrics
+			etcd["metrics"] = "extensive"
 		}
 
 		if b.Shoot.IsHibernated {


### PR DESCRIPTION
**What this PR does / why we need it**:
The histogram metrics of `etcd` can be used to analyse `etcd` request latency. But these metrics are by default disabled due to higher cardinality. But the equivalent `kube-apiserver` latency metrics are currently enabled. Enabling this would help in correlating the request latency of `kube-apiserver` and its potential downtime with the request latency of `etcd`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy operator
`etcd-main` now emits extensive (histogram) metrics. The cardinality of these metrics could be similar to the kube-apiserver's latency metrics.
```
