### PR TITLE
read /etc/hostname when overriding hostname

### DIFF
--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.service
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.service
@@ -17,7 +17,7 @@
     EnvironmentFile=-/var/lib/kubelet/extra_args
     ExecStartPre=/bin/docker run --rm -v /opt/bin:/opt/bin:rw {{ required "images.hyperkube is required" .Values.images.hyperkube }} cp /hyperkube /opt/bin/
 {{- if .Values.kubernetes.kubelet.hostnameOverride }}
-    ExecStartPre=/bin/sh -c 'hostnamectl set-hostname $(echo $HOSTNAME | cut -d '.' -f 1)'
+    ExecStartPre=/bin/sh -c 'hostnamectl set-hostname $(cat /etc/hostname | cut -d '.' -f 1)'
 {{- end }}
     ExecStart=/opt/bin/hyperkube kubelet \
 {{ include "kubelet-flags" . | indent 8 }}

--- a/docs/proposals/01-extensibility.md
+++ b/docs/proposals/01-extensibility.md
@@ -496,7 +496,7 @@ spec:
       RestartSec=10
       EnvironmentFile=/etc/environment
       ExecStartPre=/bin/docker run --rm -v /opt/bin:/opt/bin:rw k8s.gcr.io/hyperkube:v1.11.2 cp /hyperkube /opt/bin/
-      ExecStartPre=/bin/sh -c 'hostnamectl set-hostname $(echo $HOSTNAME | cut -d '.' -f 1)'
+      ExecStartPre=/bin/sh -c 'hostnamectl set-hostname $(cat /etc/hostname | cut -d '.' -f 1)'
       ExecStart=/opt/bin/hyperkube kubelet \
           --allow-privileged=true \
           --bootstrap-kubeconfig=/var/lib/kubelet/kubeconfig-bootstrap \


### PR DESCRIPTION
**What this PR does / why we need it**:

Reading from `/etc/hostname` is the canonical way to get the system static hostname.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
`kubelet.service` now reads from `/etc/hostname` for hostname override.
```
