### PR TITLE
Increased the limits for seed kube-apiserver.

### DIFF
--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -353,8 +353,8 @@ func (b *HybridBotanist) DeployKubeAPIServer() error {
 		defaultValues["maxReplicas"] = autoscaler.MaxReplicas
 		defaultValues["apiServerResources"] = map[string]interface{}{
 			"limits": map[string]interface{}{
-				"cpu":    "1500m",
-				"memory": "4000Mi",
+				"cpu":    "2000m",
+				"memory": "7000Mi",
 			},
 		}
 	} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
In some of the landscapes, the `kube-apiserver` replicas of the (shooted) seed clusters get `OOMKilled` from time to time. The limits for the `kube-apiserver` of such (shooted) seed clusters are increased based on consistent recommendation from VPA. The requests are left untouched.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The limits of kube-apiserver of shooted seed clusters have been increased to `2000m` CPU and `7Gi` memory, based on consistent recommendation from VPA. The requests are left untouched.
```
