### PR TITLE
Default Nodes CIDR only when there is one worker group

### DIFF
--- a/pkg/apis/garden/v1beta1/defaults.go
+++ b/pkg/apis/garden/v1beta1/defaults.go
@@ -45,7 +45,7 @@ func SetDefaults_Shoot(obj *Shoot) {
 		if cloud.AWS.Networks.Nodes == nil {
 			if cloud.AWS.Networks.VPC.CIDR != nil {
 				obj.Spec.Cloud.AWS.Networks.Nodes = cloud.AWS.Networks.VPC.CIDR
-			} else if len(cloud.AWS.Networks.Workers) > 0 {
+			} else if len(cloud.AWS.Networks.Workers) == 1 {
 				obj.Spec.Cloud.AWS.Networks.Nodes = &cloud.AWS.Networks.Workers[0]
 			}
 		}
@@ -70,7 +70,7 @@ func SetDefaults_Shoot(obj *Shoot) {
 		if cloud.GCP.Networks.Services == nil {
 			obj.Spec.Cloud.GCP.Networks.Services = &defaultServiceCIDR
 		}
-		if cloud.GCP.Networks.Nodes == nil && len(cloud.GCP.Networks.Workers) > 0 {
+		if cloud.GCP.Networks.Nodes == nil && len(cloud.GCP.Networks.Workers) == 1 {
 			obj.Spec.Cloud.GCP.Networks.Nodes = &cloud.GCP.Networks.Workers[0]
 		}
 	}
@@ -87,7 +87,7 @@ func SetDefaults_Shoot(obj *Shoot) {
 		if cloud.Alicloud.Networks.Nodes == nil {
 			if cloud.Alicloud.Networks.VPC.CIDR != nil {
 				obj.Spec.Cloud.Alicloud.Networks.Nodes = cloud.Alicloud.Networks.VPC.CIDR
-			} else if len(cloud.Alicloud.Networks.Workers) > 0 {
+			} else if len(cloud.Alicloud.Networks.Workers) == 1 {
 				obj.Spec.Cloud.Alicloud.Networks.Nodes = &cloud.Alicloud.Networks.Workers[0]
 			}
 		}
@@ -100,7 +100,7 @@ func SetDefaults_Shoot(obj *Shoot) {
 		if cloud.OpenStack.Networks.Services == nil {
 			obj.Spec.Cloud.OpenStack.Networks.Services = &defaultServiceCIDR
 		}
-		if cloud.OpenStack.Networks.Nodes == nil && len(cloud.OpenStack.Networks.Workers) > 0 {
+		if cloud.OpenStack.Networks.Nodes == nil && len(cloud.OpenStack.Networks.Workers) == 1 {
 			obj.Spec.Cloud.OpenStack.Networks.Nodes = &cloud.OpenStack.Networks.Workers[0]
 		}
 	}

--- a/pkg/apis/garden/v1beta1/defaults_test.go
+++ b/pkg/apis/garden/v1beta1/defaults_test.go
@@ -1,0 +1,393 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1_test
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	"github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/gardener/pkg/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+var _ = Describe("#SetDefaults_Shoot", func() {
+	var (
+		shoot *v1beta1.Shoot
+	)
+
+	JustBeforeEach(func() {
+		v1beta1.SetDefaults_Shoot(shoot)
+	})
+
+	BeforeEach(func() {
+		shoot = &v1beta1.Shoot{}
+	})
+
+	Context("cloud", func() {
+
+		Context("aws", func() {
+			var (
+				aws *v1beta1.AWSCloud
+			)
+			BeforeEach(func() {
+				aws = &v1beta1.AWSCloud{}
+				shoot.Spec.Cloud.AWS = aws
+			})
+
+			Context("Shoot Networks", func() {
+
+				It("should set default Pod CIDR", func() {
+					Expect(shoot.Spec.Cloud.AWS.Networks.Pods).To(PointTo(Equal(v1alpha1.CIDR("100.96.0.0/11"))))
+				})
+
+				It("should set default Services CIDR", func() {
+					Expect(shoot.Spec.Cloud.AWS.Networks.Services).To(PointTo(Equal(v1alpha1.CIDR("100.64.0.0/13"))))
+				})
+
+				Context("nodes", func() {
+					Context("provided VPC CIDR", func() {
+						const vpcCIDR = v1alpha1.CIDR("1.1.0.0/24")
+						BeforeEach(func() {
+							cidr := vpcCIDR
+							aws.Networks.VPC.CIDR = &cidr
+						})
+
+						It("should set the nodes to the VPC CIDR", func() {
+							Expect(shoot.Spec.Cloud.AWS.Networks.Nodes).To(PointTo(Equal(vpcCIDR)))
+						})
+					})
+
+					Context("not provide VPC CIDR", func() {
+						Context("without any workers", func() {
+							It("should be nil", func() {
+								Expect(shoot.Spec.Cloud.AWS.Networks.Nodes).To(BeNil())
+							})
+						})
+
+						Context("with one worker", func() {
+							const workerCIDR = v1alpha1.CIDR("1.1.0.0/24")
+
+							BeforeEach(func() {
+								aws.Networks.Workers = []v1alpha1.CIDR{workerCIDR}
+							})
+
+							It("should be the same value as aws.networks.workers[0]", func() {
+								Expect(shoot.Spec.Cloud.AWS.Networks.Nodes).To(PointTo(Equal(workerCIDR)))
+							})
+						})
+
+						Context("wtih more than one workers", func() {
+							BeforeEach(func() {
+								aws.Networks.Workers = []v1alpha1.CIDR{"1.1.0.0/24", "1.1.2.0/24"}
+							})
+
+							It("should be nil", func() {
+								Expect(shoot.Spec.Cloud.AWS.Networks.Nodes).To(BeNil())
+							})
+						})
+					})
+				})
+			})
+		})
+
+		Context("azure", func() {
+			var (
+				azure *v1beta1.AzureCloud
+			)
+			BeforeEach(func() {
+				azure = &v1beta1.AzureCloud{}
+				shoot.Spec.Cloud.Azure = azure
+			})
+
+			Context("Shoot Networks", func() {
+
+				It("should set default Pod CIDR", func() {
+					Expect(shoot.Spec.Cloud.Azure.Networks.Pods).To(PointTo(Equal(v1alpha1.CIDR("100.96.0.0/11"))))
+				})
+
+				It("should set default Services CIDR", func() {
+					Expect(shoot.Spec.Cloud.Azure.Networks.Services).To(PointTo(Equal(v1alpha1.CIDR("100.64.0.0/13"))))
+				})
+
+				Context("with one worker", func() {
+					const workerCIDR = v1alpha1.CIDR("1.1.0.0/24")
+
+					BeforeEach(func() {
+						azure.Networks.Workers = workerCIDR
+					})
+
+					It("should be the same value as azure.networks.workers[0]", func() {
+						Expect(shoot.Spec.Cloud.Azure.Networks.Nodes).To(PointTo(Equal(workerCIDR)))
+					})
+				})
+			})
+		})
+
+		Context("gcp", func() {
+			var (
+				gcp *v1beta1.GCPCloud
+			)
+			BeforeEach(func() {
+				gcp = &v1beta1.GCPCloud{}
+				shoot.Spec.Cloud.GCP = gcp
+			})
+
+			Context("Shoot Networks", func() {
+
+				It("should set default Pod CIDR", func() {
+					Expect(shoot.Spec.Cloud.GCP.Networks.Pods).To(PointTo(Equal(v1alpha1.CIDR("100.96.0.0/11"))))
+				})
+
+				It("should set default Services CIDR", func() {
+					Expect(shoot.Spec.Cloud.GCP.Networks.Services).To(PointTo(Equal(v1alpha1.CIDR("100.64.0.0/13"))))
+				})
+
+				Context("nodes", func() {
+
+					Context("without any workers", func() {
+						It("should be nil", func() {
+							Expect(shoot.Spec.Cloud.GCP.Networks.Nodes).To(BeNil())
+						})
+					})
+
+					Context("with one worker", func() {
+						const workerCIDR = v1alpha1.CIDR("1.1.0.0/24")
+
+						BeforeEach(func() {
+							gcp.Networks.Workers = []v1alpha1.CIDR{workerCIDR}
+						})
+
+						It("should be the same value as gcp.networks.workers[0]", func() {
+							Expect(shoot.Spec.Cloud.GCP.Networks.Nodes).To(PointTo(Equal(workerCIDR)))
+						})
+					})
+
+					Context("wtih more than one workers", func() {
+						BeforeEach(func() {
+							gcp.Networks.Workers = []v1alpha1.CIDR{"1.1.0.0/24", "1.1.2.0/24"}
+						})
+
+						It("should be nil", func() {
+							Expect(shoot.Spec.Cloud.GCP.Networks.Nodes).To(BeNil())
+						})
+					})
+				})
+			})
+		})
+
+		Context("alicloud", func() {
+			var (
+				alicloud *v1beta1.Alicloud
+			)
+			BeforeEach(func() {
+				alicloud = &v1beta1.Alicloud{}
+				shoot.Spec.Cloud.Alicloud = alicloud
+			})
+
+			Context("Shoot Networks", func() {
+
+				It("should set default Pod CIDR", func() {
+					Expect(shoot.Spec.Cloud.Alicloud.Networks.Pods).To(PointTo(Equal(v1alpha1.CIDR("100.64.0.0/11"))))
+				})
+
+				It("should set default Services CIDR", func() {
+					Expect(shoot.Spec.Cloud.Alicloud.Networks.Services).To(PointTo(Equal(v1alpha1.CIDR("100.104.0.0/13"))))
+				})
+
+				Context("nodes", func() {
+					Context("provided VPC CIDR", func() {
+						const vpcCIDR = v1alpha1.CIDR("1.1.0.0/24")
+						BeforeEach(func() {
+							cidr := vpcCIDR
+							alicloud.Networks.VPC.CIDR = &cidr
+						})
+
+						It("should set the nodes to the VPC CIDR", func() {
+							Expect(shoot.Spec.Cloud.Alicloud.Networks.Nodes).To(PointTo(Equal(vpcCIDR)))
+						})
+					})
+
+					Context("not provide VPC CIDR", func() {
+						Context("without any workers", func() {
+							It("should be nil", func() {
+								Expect(shoot.Spec.Cloud.Alicloud.Networks.Nodes).To(BeNil())
+							})
+						})
+
+						Context("with one worker", func() {
+							const workerCIDR = v1alpha1.CIDR("1.1.0.0/24")
+
+							BeforeEach(func() {
+								alicloud.Networks.Workers = []v1alpha1.CIDR{workerCIDR}
+							})
+
+							It("should be the same value as alicloud.networks.workers[0]", func() {
+								Expect(shoot.Spec.Cloud.Alicloud.Networks.Nodes).To(PointTo(Equal(workerCIDR)))
+							})
+						})
+
+						Context("wtih more than one workers", func() {
+							BeforeEach(func() {
+								alicloud.Networks.Workers = []v1alpha1.CIDR{"1.1.0.0/24", "1.1.2.0/24"}
+							})
+
+							It("should be nil", func() {
+								Expect(shoot.Spec.Cloud.Alicloud.Networks.Nodes).To(BeNil())
+							})
+						})
+					})
+				})
+			})
+		})
+
+		Context("openstack", func() {
+			var (
+				openstack *v1beta1.OpenStackCloud
+			)
+			BeforeEach(func() {
+				openstack = &v1beta1.OpenStackCloud{}
+				shoot.Spec.Cloud.OpenStack = openstack
+			})
+
+			Context("Shoot Networks", func() {
+
+				It("should set default Pod CIDR", func() {
+					Expect(shoot.Spec.Cloud.OpenStack.Networks.Pods).To(PointTo(Equal(v1alpha1.CIDR("100.96.0.0/11"))))
+				})
+
+				It("should set default Services CIDR", func() {
+					Expect(shoot.Spec.Cloud.OpenStack.Networks.Services).To(PointTo(Equal(v1alpha1.CIDR("100.64.0.0/13"))))
+				})
+
+				Context("nodes", func() {
+
+					Context("without any workers", func() {
+						It("should be nil", func() {
+							Expect(shoot.Spec.Cloud.OpenStack.Networks.Nodes).To(BeNil())
+						})
+					})
+
+					Context("with one worker", func() {
+						const workerCIDR = v1alpha1.CIDR("1.1.0.0/24")
+
+						BeforeEach(func() {
+							openstack.Networks.Workers = []v1alpha1.CIDR{workerCIDR}
+						})
+
+						It("should be the same value as openstack.networks.workers[0]", func() {
+							Expect(shoot.Spec.Cloud.OpenStack.Networks.Nodes).To(PointTo(Equal(workerCIDR)))
+						})
+					})
+
+					Context("wtih more than one workers", func() {
+						BeforeEach(func() {
+							openstack.Networks.Workers = []v1alpha1.CIDR{"1.1.0.0/24", "1.1.2.0/24"}
+						})
+
+						It("should be nil", func() {
+							Expect(shoot.Spec.Cloud.OpenStack.Networks.Nodes).To(BeNil())
+						})
+					})
+				})
+			})
+		})
+
+		Context("packet", func() {
+			var (
+				packet *v1beta1.PacketCloud
+			)
+			BeforeEach(func() {
+				packet = &v1beta1.PacketCloud{}
+				shoot.Spec.Cloud.Packet = packet
+			})
+
+			Context("Shoot Networks", func() {
+
+				It("should set default Pod CIDR", func() {
+					Expect(shoot.Spec.Cloud.Packet.Networks.Pods).To(PointTo(Equal(v1alpha1.CIDR("100.96.0.0/11"))))
+				})
+
+				It("should set default Services CIDR", func() {
+					Expect(shoot.Spec.Cloud.Packet.Networks.Services).To(PointTo(Equal(v1alpha1.CIDR("100.64.0.0/13"))))
+				})
+			})
+		})
+	})
+
+	Context("kubernetes", func() {
+		It("should enable priviliged containers by default", func() {
+			Expect(shoot.Spec.Kubernetes.AllowPrivilegedContainers).To(PointTo(BeTrue()))
+		})
+
+		Context("kubeproxy", func() {
+			// TODO: Fix this in next API version of the Shoot spec.
+			It("should use not set kube-proxy to any value", func() {
+				Expect(shoot.Spec.Kubernetes.KubeProxy).To(BeNil())
+			})
+			Context("when kubeProxy is not nil", func() {
+				BeforeEach(func() {
+					shoot.Spec.Kubernetes.KubeProxy = &v1beta1.KubeProxyConfig{}
+				})
+				It("should use iptables as default mode", func() {
+					// Don't change this value to guarantee backwards compability.
+					defaultMode := v1beta1.ProxyMode("IPTables")
+					Expect(shoot.Spec.Kubernetes.KubeProxy.Mode).To(PointTo(Equal(defaultMode)))
+				})
+			})
+
+		})
+	})
+
+	Context("maintenance", func() {
+
+		Context("without provided maitanence", func() {
+			It("should automatically update the Kubernetes version", func() {
+				Expect(shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion).To(BeTrue())
+			})
+
+			It("should have a valid mataince start time", func() {
+				Expect(utils.ParseMaintenanceTime(shoot.Spec.Maintenance.TimeWindow.Begin)).ShouldNot(PointTo(BeNil()))
+			})
+
+			It("should have a valid mataince end time", func() {
+				Expect(utils.ParseMaintenanceTime(shoot.Spec.Maintenance.TimeWindow.End)).ShouldNot(PointTo(BeNil()))
+			})
+		})
+
+		Context("with provided maitanence", func() {
+			var maintanence *v1beta1.Maintenance
+
+			BeforeEach(func() {
+				maintanence = &v1beta1.Maintenance{}
+				shoot.Spec.Maintenance = maintanence
+			})
+
+			It("should automatically update the Kubernetes version", func() {
+				Expect(shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion).To(BeTrue())
+			})
+
+			It("should have a valid mataince start time", func() {
+				Expect(utils.ParseMaintenanceTime(shoot.Spec.Maintenance.TimeWindow.Begin)).ShouldNot(PointTo(BeNil()))
+			})
+
+			It("should have a valid mataince end time", func() {
+				Expect(utils.ParseMaintenanceTime(shoot.Spec.Maintenance.TimeWindow.End)).ShouldNot(PointTo(BeNil()))
+			})
+
+		})
+
+	})
+})

--- a/pkg/apis/garden/v1beta1/v1beta1_suite_test.go
+++ b/pkg/apis/garden/v1beta1/v1beta1_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestV1beta1(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Garden v1beta1 Suite")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`spec.cloud.{PROVIDER}.networks.nodes` is now defaulted to the first worker CIDR, only if there is one worker in `spec.cloud.{PROVIDER}.networks.workers`.

With the previous behavior, if end-user provided more than 1 worker CIDRs, it would be defaulted to the first one, leading to conflicting behavior.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```noteworthy user
`spec.cloud.{PROVIDER}.networks.nodes` is now defaulted to the first worker CIDR, only if there is one worker in `spec.cloud.{PROVIDER}.networks.workers`.
```
