### PR TITLE
Always deploy the user monitoring stack

### DIFF
--- a/pkg/apis/garden/v1beta1/helper/helpers.go
+++ b/pkg/apis/garden/v1beta1/helper/helpers.go
@@ -112,15 +112,6 @@ func ShootWantsAlertmanager(shoot *gardenv1beta1.Shoot, secrets map[string]*core
 	return false
 }
 
-// ShootWantsControlPlaneMonitoring checks if the given shoots needs a grafana monitoring stack for the shoot owner
-func ShootWantsControlPlaneMonitoring(shoot *gardenv1beta1.Shoot) bool {
-	wants := false
-	if value, ok := shoot.Annotations[common.GardenControlPlaneMonitoring]; ok {
-		wants, _ = strconv.ParseBool(value)
-	}
-	return wants
-}
-
 // ShootIgnoreAlerts checks if the alerts for the annotated shoot cluster should be ignored.
 func ShootIgnoreAlerts(shoot *gardenv1beta1.Shoot) bool {
 	ignore := false

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -424,14 +424,8 @@ func (b *Botanist) DeploySeedMonitoring() error {
 		return err
 	}
 
-	if b.Shoot.WantsControlPlaneMonitoring {
-		if err := b.deployGrafanaCharts("users", basicAuthUsers, "g-users"); err != nil {
-			return err
-		}
-	} else {
-		if err := common.DeleteGrafanaByRole(b.K8sSeedClient, b.Shoot.SeedNamespace, "users"); err != nil {
-			return err
-		}
+	if err := b.deployGrafanaCharts("users", basicAuthUsers, "g-users"); err != nil {
+		return err
 	}
 
 	// Check if we want to deploy an alertmanager into the shoot namespace.

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -899,20 +899,11 @@ func computeProjectSecretName(shootName, suffix string) string {
 	return fmt.Sprintf("%s.%s", shootName, suffix)
 }
 
-// SyncShootCredentialsToGarden copies the kubeconfig generated for the user as well as the SSH keypair to
-// the project namespace in the Garden cluster. If control plane monitoring is enabled, then the
-// monitoring credentials for the user-facing monitoring stack are also copied.
+// SyncShootCredentialsToGarden copies the kubeconfig generated for the user, the SSH keypair to
+// the project namespace in the Garden cluster and the monitoring credentials for the
+// user-facing monitoring stack are also copied.
 func (b *Botanist) SyncShootCredentialsToGarden() error {
-	projectSecrets := map[string]string{secretSuffixKubeConfig: "kubecfg", secretSuffixSSHKeyPair: gardencorev1alpha1.SecretNameSSHKeyPair}
-
-	if b.Shoot.WantsControlPlaneMonitoring {
-		projectSecrets[secretSuffixMonitoring] = "monitoring-ingress-credentials-users"
-	} else {
-		if err := b.K8sGardenClient.DeleteSecret(b.Shoot.Info.Namespace, computeProjectSecretName(b.Shoot.Info.Name, secretSuffixMonitoring)); err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
-
+	projectSecrets := map[string]string{secretSuffixKubeConfig: "kubecfg", secretSuffixSSHKeyPair: gardencorev1alpha1.SecretNameSSHKeyPair, secretSuffixMonitoring: "monitoring-ingress-credentials-users"}
 	for key, value := range projectSecrets {
 		secretObj := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -165,10 +165,6 @@ const (
 	// GardenRoleVpa is the value of GardenRole key indicating type 'vpa'.
 	GardenRoleVpa = "vpa"
 
-	// GardenControlPlaneMonitoring is the key for an annotation of a Shoot cluster whose value indicates if
-	// a monitoring stack for the shoot owner should be deployed.
-	GardenControlPlaneMonitoring = "monitoring.shoot.gardener.cloud/enabled"
-
 	// GardenCreatedBy is the key for an annotation of a Shoot cluster whose value indicates contains the username
 	// of the user that created the resource.
 	GardenCreatedBy = "garden.sapcloud.io/createdBy"
@@ -604,6 +600,7 @@ var (
 	// RequiredMonitoringSeedDeployments is a set of the required seed monitoring deployments.
 	RequiredMonitoringSeedDeployments = sets.NewString(
 		GrafanaOperatorsDeploymentName,
+		GrafanaUsersDeploymentName,
 		KubeStateMetricsSeedDeploymentName,
 		KubeStateMetricsShootDeploymentName,
 	)

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -131,7 +131,6 @@ func newOperation(
 		operation.Shoot = shootObj
 		operation.Shoot.IgnoreAlerts = helper.ShootIgnoreAlerts(shoot)
 		operation.Shoot.WantsAlertmanager = helper.ShootWantsAlertmanager(shoot, secrets) && !operation.Shoot.IgnoreAlerts
-		operation.Shoot.WantsControlPlaneMonitoring = helper.ShootWantsControlPlaneMonitoring(shoot)
 
 		shootedSeed, err := helper.ReadShootedSeed(shoot)
 		if err != nil {

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -37,11 +37,10 @@ type Shoot struct {
 	ExternalClusterDomain *string
 	ExternalDomain        *ExternalDomain
 
-	WantsClusterAutoscaler      bool
-	WantsAlertmanager           bool
-	WantsControlPlaneMonitoring bool
-	IgnoreAlerts                bool
-	IsHibernated                bool
+	WantsClusterAutoscaler bool
+	WantsAlertmanager      bool
+	IgnoreAlerts           bool
+	IsHibernated           bool
 
 	CloudConfigMap       map[string]CloudConfig
 	Extensions           map[string]Extension

--- a/test/integration/seeds/networkpolicies/aws/networkpolicy_aws_test.go
+++ b/test/integration/seeds/networkpolicies/aws/networkpolicy_aws_test.go
@@ -479,7 +479,7 @@ var _ = Describe("Network Policy Testing", func() {
 			ExpectedPolicies: sets.String{
 				"allow-from-prometheus":     sets.Empty{},
 				"allow-to-dns":              sets.Empty{},
-				"allow-to-blocked-cidrs":         sets.Empty{},
+				"allow-to-blocked-cidrs":    sets.Empty{},
 				"allow-to-private-networks": sets.Empty{},
 				"allow-to-public-networks":  sets.Empty{},
 				"allow-to-shoot-apiserver":  sets.Empty{},
@@ -510,7 +510,7 @@ var _ = Describe("Network Policy Testing", func() {
 			ExpectedPolicies: sets.String{
 				"allow-from-prometheus":     sets.Empty{},
 				"allow-to-dns":              sets.Empty{},
-				"allow-to-blocked-cidrs":         sets.Empty{},
+				"allow-to-blocked-cidrs":    sets.Empty{},
 				"allow-to-private-networks": sets.Empty{},
 				"allow-to-public-networks":  sets.Empty{},
 				"allow-to-shoot-apiserver":  sets.Empty{},

--- a/test/integration/seeds/networkpolicies/azure/networkpolicy_azure_test.go
+++ b/test/integration/seeds/networkpolicies/azure/networkpolicy_azure_test.go
@@ -453,7 +453,7 @@ var _ = Describe("Network Policy Testing", func() {
 			ExpectedPolicies: sets.String{
 				"allow-from-prometheus":     sets.Empty{},
 				"allow-to-dns":              sets.Empty{},
-				"allow-to-blocked-cidrs":         sets.Empty{},
+				"allow-to-blocked-cidrs":    sets.Empty{},
 				"allow-to-private-networks": sets.Empty{},
 				"allow-to-public-networks":  sets.Empty{},
 				"allow-to-shoot-apiserver":  sets.Empty{},
@@ -484,7 +484,7 @@ var _ = Describe("Network Policy Testing", func() {
 			ExpectedPolicies: sets.String{
 				"allow-from-prometheus":     sets.Empty{},
 				"allow-to-dns":              sets.Empty{},
-				"allow-to-blocked-cidrs":         sets.Empty{},
+				"allow-to-blocked-cidrs":    sets.Empty{},
 				"allow-to-private-networks": sets.Empty{},
 				"allow-to-public-networks":  sets.Empty{},
 				"allow-to-shoot-apiserver":  sets.Empty{},

--- a/test/integration/seeds/networkpolicies/gcp/networkpolicy_gcp_test.go
+++ b/test/integration/seeds/networkpolicies/gcp/networkpolicy_gcp_test.go
@@ -453,7 +453,7 @@ var _ = Describe("Network Policy Testing", func() {
 			ExpectedPolicies: sets.String{
 				"allow-from-prometheus":     sets.Empty{},
 				"allow-to-dns":              sets.Empty{},
-				"allow-to-blocked-cidrs":         sets.Empty{},
+				"allow-to-blocked-cidrs":    sets.Empty{},
 				"allow-to-private-networks": sets.Empty{},
 				"allow-to-public-networks":  sets.Empty{},
 				"allow-to-shoot-apiserver":  sets.Empty{},
@@ -484,7 +484,7 @@ var _ = Describe("Network Policy Testing", func() {
 			ExpectedPolicies: sets.String{
 				"allow-from-prometheus":     sets.Empty{},
 				"allow-to-dns":              sets.Empty{},
-				"allow-to-blocked-cidrs":         sets.Empty{},
+				"allow-to-blocked-cidrs":    sets.Empty{},
 				"allow-to-private-networks": sets.Empty{},
 				"allow-to-public-networks":  sets.Empty{},
 				"allow-to-shoot-apiserver":  sets.Empty{},

--- a/test/integration/seeds/networkpolicies/openstack/networkpolicy_openstack_test.go
+++ b/test/integration/seeds/networkpolicies/openstack/networkpolicy_openstack_test.go
@@ -455,7 +455,7 @@ var _ = Describe("Network Policy Testing", func() {
 			ExpectedPolicies: sets.String{
 				"allow-from-prometheus":     sets.Empty{},
 				"allow-to-dns":              sets.Empty{},
-				"allow-to-blocked-cidrs":         sets.Empty{},
+				"allow-to-blocked-cidrs":    sets.Empty{},
 				"allow-to-private-networks": sets.Empty{},
 				"allow-to-public-networks":  sets.Empty{},
 				"allow-to-shoot-apiserver":  sets.Empty{},
@@ -486,7 +486,7 @@ var _ = Describe("Network Policy Testing", func() {
 			ExpectedPolicies: sets.String{
 				"allow-from-prometheus":     sets.Empty{},
 				"allow-to-dns":              sets.Empty{},
-				"allow-to-blocked-cidrs":         sets.Empty{},
+				"allow-to-blocked-cidrs":    sets.Empty{},
 				"allow-to-private-networks": sets.Empty{},
 				"allow-to-public-networks":  sets.Empty{},
 				"allow-to-shoot-apiserver":  sets.Empty{},


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the annotation `monitoring.shoot.gardener.cloud/enabled`. The user-facing monitoring stack will now always be deployed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
