### PR TITLE
Expose etcd-backup-restore metrics to prometheus

### DIFF
--- a/charts/seed-controlplane/charts/etcd/templates/allow-from-apiserver-network-policy.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/allow-from-apiserver-network-policy.yaml
@@ -26,6 +26,8 @@ spec:
     ports:
     - protocol: TCP
       port: {{ .Values.servicePorts.client }}
+    - protocol: TCP
+      port: {{ .Values.servicePorts.backuprestore }}
   policyTypes:
   - Ingress
   egress: []

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-client-service.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-client-service.yaml
@@ -17,3 +17,11 @@ spec:
     protocol: TCP
     port: {{ .Values.servicePorts.client }}
     targetPort: {{ .Values.servicePorts.client }}
+  - name: server
+    protocol: TCP
+    port: {{ .Values.servicePorts.server }}
+    targetPort: {{ .Values.servicePorts.server }}
+  - name: backuprestore
+    protocol: TCP
+    port: {{ .Values.servicePorts.backuprestore }}
+    targetPort: {{ .Values.servicePorts.backuprestore }}

--- a/charts/seed-controlplane/charts/etcd/values.yaml
+++ b/charts/seed-controlplane/charts/etcd/values.yaml
@@ -22,6 +22,7 @@ podAnnotations: {}
 servicePorts:
   client: 2379
   server: 2380
+  backuprestore: 8080
 
 vpa:
   enabled: true

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -73,6 +73,27 @@ data:
         action: labeldrop
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.kubeETCD3 | indent 6 }}
 
+    - job_name: kube-etcd3-backup-restore
+      scheme: http
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [{{ .Release.Namespace }}]
+      relabel_configs:
+      - source_labels: 
+        - __meta_kubernetes_service_label_app
+        - __meta_kubernetes_endpoint_port_name
+        action: keep
+        regex: etcd-statefulset;backuprestore
+      - source_labels: [ __meta_kubernetes_service_label_role ]
+        target_label: role
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
+      metric_relabel_configs:
+      - regex: ^instance$
+        action: labeldrop
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.kubeETCD3BR | indent 6 }}
+
     - job_name: kube-apiserver
       scheme: https
       kubernetes_sd_configs:

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -87,6 +87,25 @@ allowedMetrics:
   - process_max_fds
   - process_open_fds
   - process_resident_memory_bytes
+  kubeETCD3BR:
+  - etcdbr_snapshot_gc_total
+  - etcdbr_snapshot_latest_revision
+  - etcdbr_snapshot_latest_timestamp
+  - etcdbr_snapshot_duration_seconds_bucket
+  - etcdbr_snapshot_duration_seconds_count
+  - etcdbr_snapshot_duration_seconds_sum
+  - etcdbr_validation_duration_seconds_bucket
+  - etcdbr_validation_duration_seconds_count
+  - etcdbr_validation_duration_seconds_sum
+  - etcdbr_restoration_duration_seconds_bucket
+  - etcdbr_restoration_duration_seconds_count
+  - etcdbr_restoration_duration_seconds_sum
+  - etcdbr_defragmentation_duration_seconds_bucket
+  - etcdbr_defragmentation_duration_seconds_count
+  - etcdbr_defragmentation_duration_seconds_sum
+  - etcdbr_network_transmitted_bytes
+  - etcdbr_network_received_bytes
+  - process_resident_memory_bytes
   kubeScheduler:
   - scheduler_binding_latency_microseconds_bucket
   - scheduler_e2e_scheduling_latency_microseconds_bucket


### PR DESCRIPTION
**What this PR does / why we need it**:
ETCD backup-restore expose few metrics, will be helpful to expose these metrics to Prometheus so that appropriate dashboards can be created as well alerts can defined as required

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Kindly review:
1. exposed services for etcd-server[2380] and backuprestore[8080] 
2. defined new scrape_config for etcd-backup-restore and whitelisted the metrics under allowedmetrics

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Exposed etcd-backup-restore metrics to Prometheus 
```
