### PR TITLE
Use alpine image with iptables pre-installed for prometheus and kube-apiserver 

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -155,6 +155,9 @@ images:
 - name: alpine
   repository: alpine
   tag: "3.8"
+- name: alpine-iptables
+  repository: eu.gcr.io/gardener-project/alpine-iptables
+  tag: "3.9"
 
 # CSI
 - name: csi-attacher

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
@@ -40,8 +40,8 @@ spec:
         operator: Exists
       initContainers:
       - name: set-iptable-rules
-        image: {{ index .Values.images "alpine" }}
-        command: ['/bin/sh', '-c', 'apk update && apk add iptables && iptables -A INPUT -i tun0 -p icmp -j ACCEPT && iptables -A INPUT -i tun0 -m state --state NEW -j DROP']
+        image: {{ index .Values.images "alpine-iptables" }}
+        command: ['/bin/sh', '-c', 'iptables -A INPUT -i tun0 -p icmp -j ACCEPT && iptables -A INPUT -i tun0 -m state --state NEW -j DROP']
         securityContext:
           capabilities:
             add:

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -66,8 +66,8 @@ spec:
       serviceAccountName: prometheus
       initContainers:
       - name: set-iptable-rules
-        image: {{ index .Values.images "alpine" }}
-        command: ['/bin/sh', '-c', 'apk update && apk add iptables && iptables -A INPUT -i tun0 -p icmp -j ACCEPT && iptables -A INPUT -i tun0 -m state --state NEW -j DROP']
+        image: {{ index .Values.images "alpine-iptables" }}
+        command: ['/bin/sh', '-c', 'iptables -A INPUT -i tun0 -p icmp -j ACCEPT && iptables -A INPUT -i tun0 -m state --state NEW -j DROP']
         securityContext:
           capabilities:
             add:

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -386,7 +386,7 @@ func (b *Botanist) DeploySeedMonitoring() error {
 		common.ConfigMapReloaderImageName,
 		common.VPNSeedImageName,
 		common.BlackboxExporterImageName,
-		common.AlpineImageName,
+		common.AlpineIptablesImageName,
 	)
 	if err != nil {
 		return err

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -533,6 +533,9 @@ const (
 	// AlpineImageName is the name of alpine image
 	AlpineImageName = "alpine"
 
+	// AlpineIptablesImageName is the name of the alpine image with pre-installed iptable rules
+	AlpineIptablesImageName = "alpine-iptables"
+
 	// DependencyWatchdogDeploymentName is the name of the dependency controller resources.
 	DependencyWatchdogDeploymentName = "dependency-watchdog"
 

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -509,7 +509,7 @@ func (b *HybridBotanist) DeployKubeAPIServer() error {
 		common.HyperkubeImageName,
 		common.VPNSeedImageName,
 		common.BlackboxExporterImageName,
-		common.AlpineImageName,
+		common.AlpineIptablesImageName,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
Use alpine image with iptables pre-installed for prometheus and kube-apiserver 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
None
```
