### PR TITLE
Add vpa-exporter to prometheus network policy

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-prometheus-network-policy.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-prometheus-network-policy.yaml
@@ -36,6 +36,13 @@ spec:
       namespaceSelector:
         matchLabels:
           role: garden
+    - podSelector:
+        matchLabels:
+          app: vpa-exporter
+          garden.sapcloud.io/role: vpa
+      namespaceSelector:
+        matchLabels:
+          role: garden
   ingress:
   - from:
     - podSelector:


### PR DESCRIPTION
**What this PR does / why we need it**:
With the new network policies Prometheus could not scrape the `vpa-exporter`. This PR allows Prometheus to scrape the `vpa-exporter`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
