### PR TITLE
Deploy `deny-all` network policy last.

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
@@ -86,6 +86,14 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 			Fn:           flow.SimpleTaskFn(botanist.DeployNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(syncClusterResourceToSeed),
 		})
+		// TODO: this is only needed to ensure that when old clusters are being reconciled,
+		// existing components don't break due to the new deny-all network policy .
+		// This should be removed after one release.
+		_ = g.Add(flow.Task{
+			Name:         "Deploying limited network policies",
+			Fn:           flow.TaskFn(hybridBotanist.DeployLimitedNetworkPolicies).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Dependencies: flow.NewTaskIDs(deployNamespace),
+		})
 		deployCloudProviderSecret = g.Add(flow.Task{
 			Name:         "Deploying cloud provider account secret",
 			Fn:           flow.SimpleTaskFn(botanist.DeployCloudProviderSecret).RetryUntilTimeout(defaultInterval, defaultTimeout),


### PR DESCRIPTION
**What this PR does / why we need it**:

This is needed to ensure that existing running components don't break when we apply the new `deny-all` policy.

The temporary migration flow for now is

- The new NetworkPolicies are deployed with `deny-all` being inactive.
- As old policies are not removed, existing components are able to talk to each other.
- Components are updated with new labels, selecting the new NetworkPolicies.
- Old deprecated network policies are removed.
- `deny-all` policy is updated and now stops all communication in the Shoot namespace.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
