### PR TITLE
Increase NetworkPolicy tests timeout

### DIFF
--- a/test/integration/framework/networkpolicies/netpol-gen/generators/networkpolicies.go
+++ b/test/integration/framework/networkpolicies/netpol-gen/generators/networkpolicies.go
@@ -449,8 +449,8 @@ var (
 )
 
 const (
-	InitializationTimeout = 600 * time.Second
-	FinalizationTimeout   = 1800 * time.Second
+	InitializationTimeout = 10 * time.Minute
+	FinalizationTimeout   = time.Minute
 	DefaultTestTimeout    = 10 * time.Second
 )
 
@@ -572,7 +572,7 @@ var setBody = `
 	)
 
 	SynchronizedBeforeSuite(func() []byte {
-		ctx, cancel := context.WithTimeout(context.TODO(), time.Minute)
+		ctx, cancel := context.WithTimeout(context.TODO(), InitializationTimeout)
 		defer cancel()
 
 		setGlobals(ctx)
@@ -762,7 +762,7 @@ var setBody = `
 
 		return b
 	}, func(data []byte) {
-		ctx, cancel := context.WithTimeout(context.TODO(), DefaultTestTimeout)
+		ctx, cancel := context.WithTimeout(context.TODO(), InitializationTimeout)
 		defer cancel()
 
 		sr := &networkpolicies.SharedResources{}
@@ -779,7 +779,7 @@ var setBody = `
 			return
 		}
 
-		ctx, cancel := context.WithTimeout(context.TODO(), DefaultTestTimeout)
+		ctx, cancel := context.WithTimeout(context.TODO(), FinalizationTimeout)
 		defer cancel()
 
 		setGlobals(ctx)

--- a/test/integration/seeds/networkpolicies/alicloud/networkpolicy_alicloud_test.go
+++ b/test/integration/seeds/networkpolicies/alicloud/networkpolicy_alicloud_test.go
@@ -56,8 +56,8 @@ var (
 )
 
 const (
-	InitializationTimeout = 600 * time.Second
-	FinalizationTimeout   = 1800 * time.Second
+	InitializationTimeout = 10 * time.Minute
+	FinalizationTimeout   = time.Minute
 	DefaultTestTimeout    = 10 * time.Second
 )
 
@@ -741,7 +741,7 @@ var _ = Describe("Network Policy Testing", func() {
 	)
 
 	SynchronizedBeforeSuite(func() []byte {
-		ctx, cancel := context.WithTimeout(context.TODO(), time.Minute)
+		ctx, cancel := context.WithTimeout(context.TODO(), InitializationTimeout)
 		defer cancel()
 
 		setGlobals(ctx)
@@ -931,7 +931,7 @@ var _ = Describe("Network Policy Testing", func() {
 
 		return b
 	}, func(data []byte) {
-		ctx, cancel := context.WithTimeout(context.TODO(), DefaultTestTimeout)
+		ctx, cancel := context.WithTimeout(context.TODO(), InitializationTimeout)
 		defer cancel()
 
 		sr := &networkpolicies.SharedResources{}
@@ -948,7 +948,7 @@ var _ = Describe("Network Policy Testing", func() {
 			return
 		}
 
-		ctx, cancel := context.WithTimeout(context.TODO(), DefaultTestTimeout)
+		ctx, cancel := context.WithTimeout(context.TODO(), FinalizationTimeout)
 		defer cancel()
 
 		setGlobals(ctx)

--- a/test/integration/seeds/networkpolicies/aws/networkpolicy_aws_test.go
+++ b/test/integration/seeds/networkpolicies/aws/networkpolicy_aws_test.go
@@ -56,8 +56,8 @@ var (
 )
 
 const (
-	InitializationTimeout = 600 * time.Second
-	FinalizationTimeout   = 1800 * time.Second
+	InitializationTimeout = 10 * time.Minute
+	FinalizationTimeout   = time.Minute
 	DefaultTestTimeout    = 10 * time.Second
 )
 
@@ -775,7 +775,7 @@ var _ = Describe("Network Policy Testing", func() {
 	)
 
 	SynchronizedBeforeSuite(func() []byte {
-		ctx, cancel := context.WithTimeout(context.TODO(), time.Minute)
+		ctx, cancel := context.WithTimeout(context.TODO(), InitializationTimeout)
 		defer cancel()
 
 		setGlobals(ctx)
@@ -965,7 +965,7 @@ var _ = Describe("Network Policy Testing", func() {
 
 		return b
 	}, func(data []byte) {
-		ctx, cancel := context.WithTimeout(context.TODO(), DefaultTestTimeout)
+		ctx, cancel := context.WithTimeout(context.TODO(), InitializationTimeout)
 		defer cancel()
 
 		sr := &networkpolicies.SharedResources{}
@@ -982,7 +982,7 @@ var _ = Describe("Network Policy Testing", func() {
 			return
 		}
 
-		ctx, cancel := context.WithTimeout(context.TODO(), DefaultTestTimeout)
+		ctx, cancel := context.WithTimeout(context.TODO(), FinalizationTimeout)
 		defer cancel()
 
 		setGlobals(ctx)

--- a/test/integration/seeds/networkpolicies/azure/networkpolicy_azure_test.go
+++ b/test/integration/seeds/networkpolicies/azure/networkpolicy_azure_test.go
@@ -56,8 +56,8 @@ var (
 )
 
 const (
-	InitializationTimeout = 600 * time.Second
-	FinalizationTimeout   = 1800 * time.Second
+	InitializationTimeout = 10 * time.Minute
+	FinalizationTimeout   = time.Minute
 	DefaultTestTimeout    = 10 * time.Second
 )
 
@@ -748,7 +748,7 @@ var _ = Describe("Network Policy Testing", func() {
 	)
 
 	SynchronizedBeforeSuite(func() []byte {
-		ctx, cancel := context.WithTimeout(context.TODO(), time.Minute)
+		ctx, cancel := context.WithTimeout(context.TODO(), InitializationTimeout)
 		defer cancel()
 
 		setGlobals(ctx)
@@ -938,7 +938,7 @@ var _ = Describe("Network Policy Testing", func() {
 
 		return b
 	}, func(data []byte) {
-		ctx, cancel := context.WithTimeout(context.TODO(), DefaultTestTimeout)
+		ctx, cancel := context.WithTimeout(context.TODO(), InitializationTimeout)
 		defer cancel()
 
 		sr := &networkpolicies.SharedResources{}
@@ -955,7 +955,7 @@ var _ = Describe("Network Policy Testing", func() {
 			return
 		}
 
-		ctx, cancel := context.WithTimeout(context.TODO(), DefaultTestTimeout)
+		ctx, cancel := context.WithTimeout(context.TODO(), FinalizationTimeout)
 		defer cancel()
 
 		setGlobals(ctx)

--- a/test/integration/seeds/networkpolicies/gcp/networkpolicy_gcp_test.go
+++ b/test/integration/seeds/networkpolicies/gcp/networkpolicy_gcp_test.go
@@ -56,8 +56,8 @@ var (
 )
 
 const (
-	InitializationTimeout = 600 * time.Second
-	FinalizationTimeout   = 1800 * time.Second
+	InitializationTimeout = 10 * time.Minute
+	FinalizationTimeout   = time.Minute
 	DefaultTestTimeout    = 10 * time.Second
 )
 
@@ -748,7 +748,7 @@ var _ = Describe("Network Policy Testing", func() {
 	)
 
 	SynchronizedBeforeSuite(func() []byte {
-		ctx, cancel := context.WithTimeout(context.TODO(), time.Minute)
+		ctx, cancel := context.WithTimeout(context.TODO(), InitializationTimeout)
 		defer cancel()
 
 		setGlobals(ctx)
@@ -938,7 +938,7 @@ var _ = Describe("Network Policy Testing", func() {
 
 		return b
 	}, func(data []byte) {
-		ctx, cancel := context.WithTimeout(context.TODO(), DefaultTestTimeout)
+		ctx, cancel := context.WithTimeout(context.TODO(), InitializationTimeout)
 		defer cancel()
 
 		sr := &networkpolicies.SharedResources{}
@@ -955,7 +955,7 @@ var _ = Describe("Network Policy Testing", func() {
 			return
 		}
 
-		ctx, cancel := context.WithTimeout(context.TODO(), DefaultTestTimeout)
+		ctx, cancel := context.WithTimeout(context.TODO(), FinalizationTimeout)
 		defer cancel()
 
 		setGlobals(ctx)

--- a/test/integration/seeds/networkpolicies/openstack/networkpolicy_openstack_test.go
+++ b/test/integration/seeds/networkpolicies/openstack/networkpolicy_openstack_test.go
@@ -56,8 +56,8 @@ var (
 )
 
 const (
-	InitializationTimeout = 600 * time.Second
-	FinalizationTimeout   = 1800 * time.Second
+	InitializationTimeout = 10 * time.Minute
+	FinalizationTimeout   = time.Minute
 	DefaultTestTimeout    = 10 * time.Second
 )
 
@@ -750,7 +750,7 @@ var _ = Describe("Network Policy Testing", func() {
 	)
 
 	SynchronizedBeforeSuite(func() []byte {
-		ctx, cancel := context.WithTimeout(context.TODO(), time.Minute)
+		ctx, cancel := context.WithTimeout(context.TODO(), InitializationTimeout)
 		defer cancel()
 
 		setGlobals(ctx)
@@ -940,7 +940,7 @@ var _ = Describe("Network Policy Testing", func() {
 
 		return b
 	}, func(data []byte) {
-		ctx, cancel := context.WithTimeout(context.TODO(), DefaultTestTimeout)
+		ctx, cancel := context.WithTimeout(context.TODO(), InitializationTimeout)
 		defer cancel()
 
 		sr := &networkpolicies.SharedResources{}
@@ -957,7 +957,7 @@ var _ = Describe("Network Policy Testing", func() {
 			return
 		}
 
-		ctx, cancel := context.WithTimeout(context.TODO(), DefaultTestTimeout)
+		ctx, cancel := context.WithTimeout(context.TODO(), FinalizationTimeout)
 		defer cancel()
 
 		setGlobals(ctx)


### PR DESCRIPTION
**What this PR does / why we need it**:

On test runners where `CPU` might be limited, running in parallel can hit CPU throttling and cause tests to timeout.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
