### PR TITLE
Fix elastic metrics-exporter

### DIFF
--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/statefulset.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/statefulset.yaml
@@ -110,7 +110,11 @@ spec:
         imagePullPolicy: IfNotPresent
         command: ["elasticsearch_exporter"]
         args:
+{{- if .Values.searchguard.enabled }}
+          - -es.uri=http://{{ .Values.elasticsearch.metricsExporter.username }}:{{ .Values.elasticsearch.metricsExporter.password }}@localhost:{{ .Values.global.elasticsearchPorts.db }}
+{{- else }}
           - -es.uri=http://localhost:{{ .Values.global.elasticsearchPorts.db }}
+{{- end }}
           - -es.all=true
           - -es.indices=true
           - -es.timeout=30s

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/values.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/values.yaml
@@ -101,8 +101,9 @@ elasticsearch:
         port: metrics
       initialDelaySeconds: 10
       timeoutSeconds: 10
-    httpAuth: YWRtaW46YWRtaW4K
-    
+  # username: USERNAME
+  # password: PASSWORD
+
   sgadmin:
     resources:
       requests:

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -545,9 +545,10 @@ func (b *Botanist) DeploySeedLogging() error {
 		kibanaHost                             = b.Seed.GetIngressFQDN("k", b.Shoot.Info.Name, b.Garden.Project.Name)
 		kibanaCredentials                      = b.Secrets["kibana-logging-sg-credentials"]
 		kibanaUserIngressCredentialsSecretName = "logging-ingress-credentials-users"
+		sgKibanaUsername                       = kibanaCredentials.Data[secrets.DataKeyUserName]
 		sgKibanaPassword                       = kibanaCredentials.Data[secrets.DataKeyPassword]
 		sgKibanaPasswordHash                   = kibanaCredentials.Data[secrets.DataKeyPasswordBcryptHash]
-		basicAuth                              = utils.EncodeBase64([]byte(fmt.Sprintf("%s:%s", kibanaCredentials.Data[secrets.DataKeyUserName], sgKibanaPassword)))
+		basicAuth                              = utils.EncodeBase64([]byte(fmt.Sprintf("%s:%s", sgKibanaUsername, sgKibanaPassword)))
 
 		sgCuratorPassword     = b.Secrets["curator-sg-credentials"].Data[secrets.DataKeyPassword]
 		sgCuratorPasswordHash = b.Secrets["curator-sg-credentials"].Data[secrets.DataKeyPasswordBcryptHash]
@@ -607,6 +608,10 @@ func (b *Botanist) DeploySeedLogging() error {
 			"replicaCount": b.Shoot.GetReplicas(1),
 			"readinessProbe": map[string]interface{}{
 				"httpAuth": basicAuth,
+			},
+			"metricsExporter": map[string]interface{}{
+				"username": string(sgKibanaUsername),
+				"password": string(sgKibanaPassword),
 			},
 		},
 		"kibana": map[string]interface{}{


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently elastic metrics-exporter fails with 
```
level=warn ts=2019-06-17T07:47:53.039452292Z caller=cluster_health.go:258 msg="failed to fetch and decode cluster health" err="HTTP Request failed with code 401"
```

trying to fetch elastics metrics. The PR adds the appropriate username/password to the metrics-exporter.

/kind bug

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@wyb1 , @KristianZH 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
