### PR TITLE
Remove flaky seed-logging test from default tests

### DIFF
--- a/.test-defs/SeedLoggingTest.yaml
+++ b/.test-defs/SeedLoggingTest.yaml
@@ -8,7 +8,7 @@ spec:
   description: Tests shoot control plane logging.
 
   activeDeadlineSeconds: 600
-  labels: ["default"]
+  labels: [ "logging", "beta" ]
 
   command: [bash, -c]
   args:

--- a/.test-defs/SeedNetworkPoliciesTest.yaml
+++ b/.test-defs/SeedNetworkPoliciesTest.yaml
@@ -6,7 +6,7 @@ spec:
   description: Tests NetworkPolicies between various components.
 
   activeDeadlineSeconds: 1800
-  labels: ["default"]
+  labels: ["beta"]
   behavior: ["serial"]
 
   command: [bash, -c]


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove default label from seed-logging test as it is currently to flaky

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
