### PR TITLE
Fix regression of new controller runtime in shoot creation of tests

### DIFF
--- a/.test-defs/cmd/helper.go
+++ b/.test-defs/cmd/helper.go
@@ -174,7 +174,7 @@ func UpdateBackupInfrastructureAnnotations(backup *gardenv1beta1.BackupInfrastru
 // GetBackupInfrastructureOfShoot returns the BackupInfrastructure object of the shoot
 func GetBackupInfrastructureOfShoot(ctx  context.Context, shootGardenerTest *framework.ShootGardenerTest, shootObject *gardenv1beta1.Shoot) (*gardenv1beta1.BackupInfrastructure, error) {
 	backups := &gardenv1beta1.BackupInfrastructureList{}
-	err := shootGardenerTest.GardenClient.Client().List(ctx, &client.ListOptions{Namespace: shootObject.Namespace}, backups)
+	err := shootGardenerTest.GardenClient.Client().List(ctx, backups, client.InNamespace(shootObject.Namespace))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adjust create-shoot test to the new controller-runtime client list function.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
