### PR TITLE
Fix calico kube-controllers PSP

### DIFF
--- a/charts/shoot-core/charts/calico/templates/calico.yaml
+++ b/charts/shoot-core/charts/calico/templates/calico.yaml
@@ -413,26 +413,37 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       tolerations:
-        # Mark the pod as a critical add-on for rescheduling.
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
+      # Mark the pod as a critical add-on for rescheduling.
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       serviceAccountName: calico-kube-controllers
+      hostIPC: false
+      hostNetwork: false
+      hostPID: false
       containers:
-        - name: calico-kube-controllers
-          image: {{ index .Values.images "calico-kube-controllers" }}
-          env:
-            # Choose which controllers to run.
-            - name: ENABLED_CONTROLLERS
-              value: node
-            - name: DATASTORE_TYPE
-              value: kubernetes
-          readinessProbe:
-            exec:
-              command:
-              - /usr/bin/check-status
-              - -r
+      - name: calico-kube-controllers
+        image: {{ index .Values.images "calico-kube-controllers" }}
+        env:
+        # Choose which controllers to run.
+        - name: ENABLED_CONTROLLERS
+          value: node
+        - name: DATASTORE_TYPE
+          value: kubernetes
+        readinessProbe:
+          exec:
+            command:
+            - /usr/bin/check-status
+            - -r
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          allowPrivilegeEscalation: true
+          # Health checks are written on a file which is
+          # writable only to root
+          privileged: true
 
 ---
 # Create all the CustomResourceDefinitions needed for

--- a/charts/shoot-core/charts/calico/templates/psp/calico-kube-controllers-clusterrole.yaml
+++ b/charts/shoot-core/charts/calico/templates/psp/calico-kube-controllers-clusterrole.yaml
@@ -1,0 +1,17 @@
+
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: garden.sapcloud.io:psp:kube-system:calico-kube-controllers
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups:
+  - policy
+  - extensions
+  resourceNames:
+  - gardener.kube-system.calico-kube-controllers
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/charts/shoot-core/charts/calico/templates/psp/calico-kube-controllers-clusterrolebinding.yaml
+++ b/charts/shoot-core/charts/calico/templates/psp/calico-kube-controllers-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: {{ include "rbacversion" . }}
+kind: RoleBinding
+metadata:
+  name: garden.sapcloud.io:psp:calico-kube-controllers
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: garden.sapcloud.io:psp:kube-system:calico-kube-controllers
+subjects:
+- kind: ServiceAccount
+  name: calico-kube-controllers
+  namespace: kube-system

--- a/charts/shoot-core/charts/calico/templates/psp/calico-kube-controllers-psp.yaml
+++ b/charts/shoot-core/charts/calico/templates/psp/calico-kube-controllers-psp.yaml
@@ -1,0 +1,23 @@
+apiVersion: {{ include "podsecuritypolicyversion" .}}
+kind: PodSecurityPolicy
+metadata:
+  name: gardener.kube-system.calico-kube-controllers
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  volumes:
+  - secret
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  privileged: true
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny


### PR DESCRIPTION
**What this PR does / why we need it**:

`calico-kube-controllers` need root to write on the file-system for health checks and they were broken when PSP was fully enabled.

**Which issue(s) this PR fixes**:
Fixes #1119 

**Special notes for your reviewer**:

We should add `e2e` tests for PSP functionality.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
Add `PodSecurityPolicy` for `calico-kube-controller`.
```
