### PR TITLE
Make backup extension resource cluster scoped

### DIFF
--- a/pkg/apis/extensions/v1alpha1/types_backupbucket.go
+++ b/pkg/apis/extensions/v1alpha1/types_backupbucket.go
@@ -20,6 +20,7 @@ import (
 )
 
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // BackupBucket is a specification for backup bucket.

--- a/pkg/apis/extensions/v1alpha1/types_backupentry.go
+++ b/pkg/apis/extensions/v1alpha1/types_backupentry.go
@@ -20,6 +20,7 @@ import (
 )
 
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // BackupEntry is a specification for backup Entry.

--- a/pkg/client/extensions/clientset/versioned/typed/extensions/v1alpha1/backupbucket.go
+++ b/pkg/client/extensions/clientset/versioned/typed/extensions/v1alpha1/backupbucket.go
@@ -16,7 +16,7 @@ import (
 // BackupBucketsGetter has a method to return a BackupBucketInterface.
 // A group's client should implement this interface.
 type BackupBucketsGetter interface {
-	BackupBuckets(namespace string) BackupBucketInterface
+	BackupBuckets() BackupBucketInterface
 }
 
 // BackupBucketInterface has methods to work with BackupBucket resources.
@@ -36,14 +36,12 @@ type BackupBucketInterface interface {
 // backupBuckets implements BackupBucketInterface
 type backupBuckets struct {
 	client rest.Interface
-	ns     string
 }
 
 // newBackupBuckets returns a BackupBuckets
-func newBackupBuckets(c *ExtensionsV1alpha1Client, namespace string) *backupBuckets {
+func newBackupBuckets(c *ExtensionsV1alpha1Client) *backupBuckets {
 	return &backupBuckets{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -51,7 +49,6 @@ func newBackupBuckets(c *ExtensionsV1alpha1Client, namespace string) *backupBuck
 func (c *backupBuckets) Get(name string, options v1.GetOptions) (result *v1alpha1.BackupBucket, err error) {
 	result = &v1alpha1.BackupBucket{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("backupbuckets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -68,7 +65,6 @@ func (c *backupBuckets) List(opts v1.ListOptions) (result *v1alpha1.BackupBucket
 	}
 	result = &v1alpha1.BackupBucketList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("backupbuckets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -85,7 +81,6 @@ func (c *backupBuckets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("backupbuckets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -96,7 +91,6 @@ func (c *backupBuckets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 func (c *backupBuckets) Create(backupBucket *v1alpha1.BackupBucket) (result *v1alpha1.BackupBucket, err error) {
 	result = &v1alpha1.BackupBucket{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("backupbuckets").
 		Body(backupBucket).
 		Do().
@@ -108,7 +102,6 @@ func (c *backupBuckets) Create(backupBucket *v1alpha1.BackupBucket) (result *v1a
 func (c *backupBuckets) Update(backupBucket *v1alpha1.BackupBucket) (result *v1alpha1.BackupBucket, err error) {
 	result = &v1alpha1.BackupBucket{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("backupbuckets").
 		Name(backupBucket.Name).
 		Body(backupBucket).
@@ -123,7 +116,6 @@ func (c *backupBuckets) Update(backupBucket *v1alpha1.BackupBucket) (result *v1a
 func (c *backupBuckets) UpdateStatus(backupBucket *v1alpha1.BackupBucket) (result *v1alpha1.BackupBucket, err error) {
 	result = &v1alpha1.BackupBucket{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("backupbuckets").
 		Name(backupBucket.Name).
 		SubResource("status").
@@ -136,7 +128,6 @@ func (c *backupBuckets) UpdateStatus(backupBucket *v1alpha1.BackupBucket) (resul
 // Delete takes name of the backupBucket and deletes it. Returns an error if one occurs.
 func (c *backupBuckets) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("backupbuckets").
 		Name(name).
 		Body(options).
@@ -151,7 +142,6 @@ func (c *backupBuckets) DeleteCollection(options *v1.DeleteOptions, listOptions 
 		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("backupbuckets").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -164,7 +154,6 @@ func (c *backupBuckets) DeleteCollection(options *v1.DeleteOptions, listOptions 
 func (c *backupBuckets) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.BackupBucket, err error) {
 	result = &v1alpha1.BackupBucket{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("backupbuckets").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/client/extensions/clientset/versioned/typed/extensions/v1alpha1/backupentry.go
+++ b/pkg/client/extensions/clientset/versioned/typed/extensions/v1alpha1/backupentry.go
@@ -16,7 +16,7 @@ import (
 // BackupEntriesGetter has a method to return a BackupEntryInterface.
 // A group's client should implement this interface.
 type BackupEntriesGetter interface {
-	BackupEntries(namespace string) BackupEntryInterface
+	BackupEntries() BackupEntryInterface
 }
 
 // BackupEntryInterface has methods to work with BackupEntry resources.
@@ -36,14 +36,12 @@ type BackupEntryInterface interface {
 // backupEntries implements BackupEntryInterface
 type backupEntries struct {
 	client rest.Interface
-	ns     string
 }
 
 // newBackupEntries returns a BackupEntries
-func newBackupEntries(c *ExtensionsV1alpha1Client, namespace string) *backupEntries {
+func newBackupEntries(c *ExtensionsV1alpha1Client) *backupEntries {
 	return &backupEntries{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -51,7 +49,6 @@ func newBackupEntries(c *ExtensionsV1alpha1Client, namespace string) *backupEntr
 func (c *backupEntries) Get(name string, options v1.GetOptions) (result *v1alpha1.BackupEntry, err error) {
 	result = &v1alpha1.BackupEntry{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("backupentries").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -68,7 +65,6 @@ func (c *backupEntries) List(opts v1.ListOptions) (result *v1alpha1.BackupEntryL
 	}
 	result = &v1alpha1.BackupEntryList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("backupentries").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -85,7 +81,6 @@ func (c *backupEntries) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("backupentries").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -96,7 +91,6 @@ func (c *backupEntries) Watch(opts v1.ListOptions) (watch.Interface, error) {
 func (c *backupEntries) Create(backupEntry *v1alpha1.BackupEntry) (result *v1alpha1.BackupEntry, err error) {
 	result = &v1alpha1.BackupEntry{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("backupentries").
 		Body(backupEntry).
 		Do().
@@ -108,7 +102,6 @@ func (c *backupEntries) Create(backupEntry *v1alpha1.BackupEntry) (result *v1alp
 func (c *backupEntries) Update(backupEntry *v1alpha1.BackupEntry) (result *v1alpha1.BackupEntry, err error) {
 	result = &v1alpha1.BackupEntry{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("backupentries").
 		Name(backupEntry.Name).
 		Body(backupEntry).
@@ -123,7 +116,6 @@ func (c *backupEntries) Update(backupEntry *v1alpha1.BackupEntry) (result *v1alp
 func (c *backupEntries) UpdateStatus(backupEntry *v1alpha1.BackupEntry) (result *v1alpha1.BackupEntry, err error) {
 	result = &v1alpha1.BackupEntry{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("backupentries").
 		Name(backupEntry.Name).
 		SubResource("status").
@@ -136,7 +128,6 @@ func (c *backupEntries) UpdateStatus(backupEntry *v1alpha1.BackupEntry) (result 
 // Delete takes name of the backupEntry and deletes it. Returns an error if one occurs.
 func (c *backupEntries) Delete(name string, options *v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("backupentries").
 		Name(name).
 		Body(options).
@@ -151,7 +142,6 @@ func (c *backupEntries) DeleteCollection(options *v1.DeleteOptions, listOptions 
 		timeout = time.Duration(*listOptions.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("backupentries").
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -164,7 +154,6 @@ func (c *backupEntries) DeleteCollection(options *v1.DeleteOptions, listOptions 
 func (c *backupEntries) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.BackupEntry, err error) {
 	result = &v1alpha1.BackupEntry{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("backupentries").
 		SubResource(subresources...).
 		Name(name).

--- a/pkg/client/extensions/clientset/versioned/typed/extensions/v1alpha1/extensions_client.go
+++ b/pkg/client/extensions/clientset/versioned/typed/extensions/v1alpha1/extensions_client.go
@@ -27,12 +27,12 @@ type ExtensionsV1alpha1Client struct {
 	restClient rest.Interface
 }
 
-func (c *ExtensionsV1alpha1Client) BackupBuckets(namespace string) BackupBucketInterface {
-	return newBackupBuckets(c, namespace)
+func (c *ExtensionsV1alpha1Client) BackupBuckets() BackupBucketInterface {
+	return newBackupBuckets(c)
 }
 
-func (c *ExtensionsV1alpha1Client) BackupEntries(namespace string) BackupEntryInterface {
-	return newBackupEntries(c, namespace)
+func (c *ExtensionsV1alpha1Client) BackupEntries() BackupEntryInterface {
+	return newBackupEntries(c)
 }
 
 func (c *ExtensionsV1alpha1Client) Clusters() ClusterInterface {

--- a/pkg/client/extensions/clientset/versioned/typed/extensions/v1alpha1/fake/fake_backupbucket.go
+++ b/pkg/client/extensions/clientset/versioned/typed/extensions/v1alpha1/fake/fake_backupbucket.go
@@ -15,7 +15,6 @@ import (
 // FakeBackupBuckets implements BackupBucketInterface
 type FakeBackupBuckets struct {
 	Fake *FakeExtensionsV1alpha1
-	ns   string
 }
 
 var backupbucketsResource = schema.GroupVersionResource{Group: "extensions.gardener.cloud", Version: "v1alpha1", Resource: "backupbuckets"}
@@ -25,8 +24,7 @@ var backupbucketsKind = schema.GroupVersionKind{Group: "extensions.gardener.clou
 // Get takes name of the backupBucket, and returns the corresponding backupBucket object, and an error if there is any.
 func (c *FakeBackupBuckets) Get(name string, options v1.GetOptions) (result *v1alpha1.BackupBucket, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(backupbucketsResource, c.ns, name), &v1alpha1.BackupBucket{})
-
+		Invokes(testing.NewRootGetAction(backupbucketsResource, name), &v1alpha1.BackupBucket{})
 	if obj == nil {
 		return nil, err
 	}
@@ -36,8 +34,7 @@ func (c *FakeBackupBuckets) Get(name string, options v1.GetOptions) (result *v1a
 // List takes label and field selectors, and returns the list of BackupBuckets that match those selectors.
 func (c *FakeBackupBuckets) List(opts v1.ListOptions) (result *v1alpha1.BackupBucketList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(backupbucketsResource, backupbucketsKind, c.ns, opts), &v1alpha1.BackupBucketList{})
-
+		Invokes(testing.NewRootListAction(backupbucketsResource, backupbucketsKind, opts), &v1alpha1.BackupBucketList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -58,15 +55,13 @@ func (c *FakeBackupBuckets) List(opts v1.ListOptions) (result *v1alpha1.BackupBu
 // Watch returns a watch.Interface that watches the requested backupBuckets.
 func (c *FakeBackupBuckets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(backupbucketsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(backupbucketsResource, opts))
 }
 
 // Create takes the representation of a backupBucket and creates it.  Returns the server's representation of the backupBucket, and an error, if there is any.
 func (c *FakeBackupBuckets) Create(backupBucket *v1alpha1.BackupBucket) (result *v1alpha1.BackupBucket, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(backupbucketsResource, c.ns, backupBucket), &v1alpha1.BackupBucket{})
-
+		Invokes(testing.NewRootCreateAction(backupbucketsResource, backupBucket), &v1alpha1.BackupBucket{})
 	if obj == nil {
 		return nil, err
 	}
@@ -76,8 +71,7 @@ func (c *FakeBackupBuckets) Create(backupBucket *v1alpha1.BackupBucket) (result 
 // Update takes the representation of a backupBucket and updates it. Returns the server's representation of the backupBucket, and an error, if there is any.
 func (c *FakeBackupBuckets) Update(backupBucket *v1alpha1.BackupBucket) (result *v1alpha1.BackupBucket, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(backupbucketsResource, c.ns, backupBucket), &v1alpha1.BackupBucket{})
-
+		Invokes(testing.NewRootUpdateAction(backupbucketsResource, backupBucket), &v1alpha1.BackupBucket{})
 	if obj == nil {
 		return nil, err
 	}
@@ -88,8 +82,7 @@ func (c *FakeBackupBuckets) Update(backupBucket *v1alpha1.BackupBucket) (result 
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeBackupBuckets) UpdateStatus(backupBucket *v1alpha1.BackupBucket) (*v1alpha1.BackupBucket, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(backupbucketsResource, "status", c.ns, backupBucket), &v1alpha1.BackupBucket{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(backupbucketsResource, "status", backupBucket), &v1alpha1.BackupBucket{})
 	if obj == nil {
 		return nil, err
 	}
@@ -99,14 +92,13 @@ func (c *FakeBackupBuckets) UpdateStatus(backupBucket *v1alpha1.BackupBucket) (*
 // Delete takes name of the backupBucket and deletes it. Returns an error if one occurs.
 func (c *FakeBackupBuckets) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(backupbucketsResource, c.ns, name), &v1alpha1.BackupBucket{})
-
+		Invokes(testing.NewRootDeleteAction(backupbucketsResource, name), &v1alpha1.BackupBucket{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeBackupBuckets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(backupbucketsResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(backupbucketsResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.BackupBucketList{})
 	return err
@@ -115,8 +107,7 @@ func (c *FakeBackupBuckets) DeleteCollection(options *v1.DeleteOptions, listOpti
 // Patch applies the patch and returns the patched backupBucket.
 func (c *FakeBackupBuckets) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.BackupBucket, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(backupbucketsResource, c.ns, name, pt, data, subresources...), &v1alpha1.BackupBucket{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(backupbucketsResource, name, pt, data, subresources...), &v1alpha1.BackupBucket{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/extensions/clientset/versioned/typed/extensions/v1alpha1/fake/fake_backupentry.go
+++ b/pkg/client/extensions/clientset/versioned/typed/extensions/v1alpha1/fake/fake_backupentry.go
@@ -15,7 +15,6 @@ import (
 // FakeBackupEntries implements BackupEntryInterface
 type FakeBackupEntries struct {
 	Fake *FakeExtensionsV1alpha1
-	ns   string
 }
 
 var backupentriesResource = schema.GroupVersionResource{Group: "extensions.gardener.cloud", Version: "v1alpha1", Resource: "backupentries"}
@@ -25,8 +24,7 @@ var backupentriesKind = schema.GroupVersionKind{Group: "extensions.gardener.clou
 // Get takes name of the backupEntry, and returns the corresponding backupEntry object, and an error if there is any.
 func (c *FakeBackupEntries) Get(name string, options v1.GetOptions) (result *v1alpha1.BackupEntry, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(backupentriesResource, c.ns, name), &v1alpha1.BackupEntry{})
-
+		Invokes(testing.NewRootGetAction(backupentriesResource, name), &v1alpha1.BackupEntry{})
 	if obj == nil {
 		return nil, err
 	}
@@ -36,8 +34,7 @@ func (c *FakeBackupEntries) Get(name string, options v1.GetOptions) (result *v1a
 // List takes label and field selectors, and returns the list of BackupEntries that match those selectors.
 func (c *FakeBackupEntries) List(opts v1.ListOptions) (result *v1alpha1.BackupEntryList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(backupentriesResource, backupentriesKind, c.ns, opts), &v1alpha1.BackupEntryList{})
-
+		Invokes(testing.NewRootListAction(backupentriesResource, backupentriesKind, opts), &v1alpha1.BackupEntryList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -58,15 +55,13 @@ func (c *FakeBackupEntries) List(opts v1.ListOptions) (result *v1alpha1.BackupEn
 // Watch returns a watch.Interface that watches the requested backupEntries.
 func (c *FakeBackupEntries) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(backupentriesResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(backupentriesResource, opts))
 }
 
 // Create takes the representation of a backupEntry and creates it.  Returns the server's representation of the backupEntry, and an error, if there is any.
 func (c *FakeBackupEntries) Create(backupEntry *v1alpha1.BackupEntry) (result *v1alpha1.BackupEntry, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(backupentriesResource, c.ns, backupEntry), &v1alpha1.BackupEntry{})
-
+		Invokes(testing.NewRootCreateAction(backupentriesResource, backupEntry), &v1alpha1.BackupEntry{})
 	if obj == nil {
 		return nil, err
 	}
@@ -76,8 +71,7 @@ func (c *FakeBackupEntries) Create(backupEntry *v1alpha1.BackupEntry) (result *v
 // Update takes the representation of a backupEntry and updates it. Returns the server's representation of the backupEntry, and an error, if there is any.
 func (c *FakeBackupEntries) Update(backupEntry *v1alpha1.BackupEntry) (result *v1alpha1.BackupEntry, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(backupentriesResource, c.ns, backupEntry), &v1alpha1.BackupEntry{})
-
+		Invokes(testing.NewRootUpdateAction(backupentriesResource, backupEntry), &v1alpha1.BackupEntry{})
 	if obj == nil {
 		return nil, err
 	}
@@ -88,8 +82,7 @@ func (c *FakeBackupEntries) Update(backupEntry *v1alpha1.BackupEntry) (result *v
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeBackupEntries) UpdateStatus(backupEntry *v1alpha1.BackupEntry) (*v1alpha1.BackupEntry, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(backupentriesResource, "status", c.ns, backupEntry), &v1alpha1.BackupEntry{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(backupentriesResource, "status", backupEntry), &v1alpha1.BackupEntry{})
 	if obj == nil {
 		return nil, err
 	}
@@ -99,14 +92,13 @@ func (c *FakeBackupEntries) UpdateStatus(backupEntry *v1alpha1.BackupEntry) (*v1
 // Delete takes name of the backupEntry and deletes it. Returns an error if one occurs.
 func (c *FakeBackupEntries) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(backupentriesResource, c.ns, name), &v1alpha1.BackupEntry{})
-
+		Invokes(testing.NewRootDeleteAction(backupentriesResource, name), &v1alpha1.BackupEntry{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeBackupEntries) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(backupentriesResource, c.ns, listOptions)
+	action := testing.NewRootDeleteCollectionAction(backupentriesResource, listOptions)
 
 	_, err := c.Fake.Invokes(action, &v1alpha1.BackupEntryList{})
 	return err
@@ -115,8 +107,7 @@ func (c *FakeBackupEntries) DeleteCollection(options *v1.DeleteOptions, listOpti
 // Patch applies the patch and returns the patched backupEntry.
 func (c *FakeBackupEntries) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha1.BackupEntry, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(backupentriesResource, c.ns, name, pt, data, subresources...), &v1alpha1.BackupEntry{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(backupentriesResource, name, pt, data, subresources...), &v1alpha1.BackupEntry{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/client/extensions/clientset/versioned/typed/extensions/v1alpha1/fake/fake_extensions_client.go
+++ b/pkg/client/extensions/clientset/versioned/typed/extensions/v1alpha1/fake/fake_extensions_client.go
@@ -12,12 +12,12 @@ type FakeExtensionsV1alpha1 struct {
 	*testing.Fake
 }
 
-func (c *FakeExtensionsV1alpha1) BackupBuckets(namespace string) v1alpha1.BackupBucketInterface {
-	return &FakeBackupBuckets{c, namespace}
+func (c *FakeExtensionsV1alpha1) BackupBuckets() v1alpha1.BackupBucketInterface {
+	return &FakeBackupBuckets{c}
 }
 
-func (c *FakeExtensionsV1alpha1) BackupEntries(namespace string) v1alpha1.BackupEntryInterface {
-	return &FakeBackupEntries{c, namespace}
+func (c *FakeExtensionsV1alpha1) BackupEntries() v1alpha1.BackupEntryInterface {
+	return &FakeBackupEntries{c}
 }
 
 func (c *FakeExtensionsV1alpha1) Clusters() v1alpha1.ClusterInterface {

--- a/pkg/client/extensions/informers/externalversions/extensions/v1alpha1/backupbucket.go
+++ b/pkg/client/extensions/informers/externalversions/extensions/v1alpha1/backupbucket.go
@@ -25,33 +25,32 @@ type BackupBucketInformer interface {
 type backupBucketInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewBackupBucketInformer constructs a new informer for BackupBucket type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewBackupBucketInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredBackupBucketInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewBackupBucketInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredBackupBucketInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredBackupBucketInformer constructs a new informer for BackupBucket type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredBackupBucketInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredBackupBucketInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExtensionsV1alpha1().BackupBuckets(namespace).List(options)
+				return client.ExtensionsV1alpha1().BackupBuckets().List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExtensionsV1alpha1().BackupBuckets(namespace).Watch(options)
+				return client.ExtensionsV1alpha1().BackupBuckets().Watch(options)
 			},
 		},
 		&extensionsv1alpha1.BackupBucket{},
@@ -61,7 +60,7 @@ func NewFilteredBackupBucketInformer(client versioned.Interface, namespace strin
 }
 
 func (f *backupBucketInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredBackupBucketInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredBackupBucketInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *backupBucketInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/extensions/informers/externalversions/extensions/v1alpha1/backupentry.go
+++ b/pkg/client/extensions/informers/externalversions/extensions/v1alpha1/backupentry.go
@@ -25,33 +25,32 @@ type BackupEntryInformer interface {
 type backupEntryInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewBackupEntryInformer constructs a new informer for BackupEntry type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewBackupEntryInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredBackupEntryInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewBackupEntryInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredBackupEntryInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredBackupEntryInformer constructs a new informer for BackupEntry type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredBackupEntryInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredBackupEntryInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExtensionsV1alpha1().BackupEntries(namespace).List(options)
+				return client.ExtensionsV1alpha1().BackupEntries().List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.ExtensionsV1alpha1().BackupEntries(namespace).Watch(options)
+				return client.ExtensionsV1alpha1().BackupEntries().Watch(options)
 			},
 		},
 		&extensionsv1alpha1.BackupEntry{},
@@ -61,7 +60,7 @@ func NewFilteredBackupEntryInformer(client versioned.Interface, namespace string
 }
 
 func (f *backupEntryInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredBackupEntryInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredBackupEntryInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *backupEntryInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/extensions/informers/externalversions/extensions/v1alpha1/interface.go
+++ b/pkg/client/extensions/informers/externalversions/extensions/v1alpha1/interface.go
@@ -41,12 +41,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // BackupBuckets returns a BackupBucketInformer.
 func (v *version) BackupBuckets() BackupBucketInformer {
-	return &backupBucketInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &backupBucketInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // BackupEntries returns a BackupEntryInformer.
 func (v *version) BackupEntries() BackupEntryInformer {
-	return &backupEntryInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &backupEntryInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // Clusters returns a ClusterInformer.

--- a/pkg/client/extensions/listers/extensions/v1alpha1/backupbucket.go
+++ b/pkg/client/extensions/listers/extensions/v1alpha1/backupbucket.go
@@ -13,8 +13,8 @@ import (
 type BackupBucketLister interface {
 	// List lists all BackupBuckets in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.BackupBucket, err error)
-	// BackupBuckets returns an object that can list and get BackupBuckets.
-	BackupBuckets(namespace string) BackupBucketNamespaceLister
+	// Get retrieves the BackupBucket from the index for a given name.
+	Get(name string) (*v1alpha1.BackupBucket, error)
 	BackupBucketListerExpansion
 }
 
@@ -36,38 +36,9 @@ func (s *backupBucketLister) List(selector labels.Selector) (ret []*v1alpha1.Bac
 	return ret, err
 }
 
-// BackupBuckets returns an object that can list and get BackupBuckets.
-func (s *backupBucketLister) BackupBuckets(namespace string) BackupBucketNamespaceLister {
-	return backupBucketNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// BackupBucketNamespaceLister helps list and get BackupBuckets.
-type BackupBucketNamespaceLister interface {
-	// List lists all BackupBuckets in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1alpha1.BackupBucket, err error)
-	// Get retrieves the BackupBucket from the indexer for a given namespace and name.
-	Get(name string) (*v1alpha1.BackupBucket, error)
-	BackupBucketNamespaceListerExpansion
-}
-
-// backupBucketNamespaceLister implements the BackupBucketNamespaceLister
-// interface.
-type backupBucketNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all BackupBuckets in the indexer for a given namespace.
-func (s backupBucketNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.BackupBucket, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.BackupBucket))
-	})
-	return ret, err
-}
-
-// Get retrieves the BackupBucket from the indexer for a given namespace and name.
-func (s backupBucketNamespaceLister) Get(name string) (*v1alpha1.BackupBucket, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the BackupBucket from the index for a given name.
+func (s *backupBucketLister) Get(name string) (*v1alpha1.BackupBucket, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/extensions/listers/extensions/v1alpha1/backupentry.go
+++ b/pkg/client/extensions/listers/extensions/v1alpha1/backupentry.go
@@ -13,8 +13,8 @@ import (
 type BackupEntryLister interface {
 	// List lists all BackupEntries in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.BackupEntry, err error)
-	// BackupEntries returns an object that can list and get BackupEntries.
-	BackupEntries(namespace string) BackupEntryNamespaceLister
+	// Get retrieves the BackupEntry from the index for a given name.
+	Get(name string) (*v1alpha1.BackupEntry, error)
 	BackupEntryListerExpansion
 }
 
@@ -36,38 +36,9 @@ func (s *backupEntryLister) List(selector labels.Selector) (ret []*v1alpha1.Back
 	return ret, err
 }
 
-// BackupEntries returns an object that can list and get BackupEntries.
-func (s *backupEntryLister) BackupEntries(namespace string) BackupEntryNamespaceLister {
-	return backupEntryNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// BackupEntryNamespaceLister helps list and get BackupEntries.
-type BackupEntryNamespaceLister interface {
-	// List lists all BackupEntries in the indexer for a given namespace.
-	List(selector labels.Selector) (ret []*v1alpha1.BackupEntry, err error)
-	// Get retrieves the BackupEntry from the indexer for a given namespace and name.
-	Get(name string) (*v1alpha1.BackupEntry, error)
-	BackupEntryNamespaceListerExpansion
-}
-
-// backupEntryNamespaceLister implements the BackupEntryNamespaceLister
-// interface.
-type backupEntryNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all BackupEntries in the indexer for a given namespace.
-func (s backupEntryNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.BackupEntry, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.BackupEntry))
-	})
-	return ret, err
-}
-
-// Get retrieves the BackupEntry from the indexer for a given namespace and name.
-func (s backupEntryNamespaceLister) Get(name string) (*v1alpha1.BackupEntry, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the BackupEntry from the index for a given name.
+func (s *backupEntryLister) Get(name string) (*v1alpha1.BackupEntry, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/extensions/listers/extensions/v1alpha1/expansion_generated.go
+++ b/pkg/client/extensions/listers/extensions/v1alpha1/expansion_generated.go
@@ -6,17 +6,9 @@ package v1alpha1
 // BackupBucketLister.
 type BackupBucketListerExpansion interface{}
 
-// BackupBucketNamespaceListerExpansion allows custom methods to be added to
-// BackupBucketNamespaceLister.
-type BackupBucketNamespaceListerExpansion interface{}
-
 // BackupEntryListerExpansion allows custom methods to be added to
 // BackupEntryLister.
 type BackupEntryListerExpansion interface{}
-
-// BackupEntryNamespaceListerExpansion allows custom methods to be added to
-// BackupEntryNamespaceLister.
-type BackupEntryNamespaceListerExpansion interface{}
 
 // ClusterListerExpansion allows custom methods to be added to
 // ClusterLister.


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
This PR makes backup extension resource cluster scoped.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
