### PR TITLE
Added support for multi service dependancy watchdog.

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -41,7 +41,7 @@ images:
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog
-  tag: "0.1.1"
+  tag: "0.2.0"
 
 # Monitoring
 - name: alertmanager

--- a/charts/seed-controlplane/charts/dependency-watchdog/templates/configmap.yaml
+++ b/charts/seed-controlplane/charts/dependency-watchdog/templates/configmap.yaml
@@ -8,20 +8,36 @@ metadata:
     app: dependency-watchdog
 data:
   dep-config.yaml: |-
-      service: {{ .Values.dependencywatchdog.service.name }}
       namespace: {{ .Release.Namespace }}
-      labels:
-{{ toYaml .Values.dependencywatchdog.service.labels | indent 8 }}
-      dependantPods:
-      - name: controlplane
-        selector:
-          matchExpressions:
-          - key: garden.sapcloud.io/role
-            operator: In
-            values:
-            - controlplane
-          - key: role
-            operator: NotIn
-            values:
-            - main
-            - events
+      services:
+        kube-apiserver:
+          dependantPods:
+          - name: controlplane
+            selector:
+              matchExpressions:
+              - key: garden.sapcloud.io/role
+                operator: In
+                values:
+                - controlplane
+              - key: role
+                operator: NotIn
+                values:
+                - main
+              - key: role
+                operator: NotIn
+                values:
+                - apiserver
+        etcd-main-client:
+          dependantPods:
+          - name: controlplane
+            selector:
+              matchExpressions:
+              - key: garden.sapcloud.io/role
+                operator: In
+                values:
+                - controlplane
+              - key: role
+                operator: In
+                values:
+                - apiserver
+

--- a/charts/seed-controlplane/charts/dependency-watchdog/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/dependency-watchdog/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
         command:
         - /usr/local/bin/dependency-watchdog
         - --config-file=/etc/dependency-watchdog/config/dep-config.yaml
+        - --watch-duration=5m
         resources:
           requests:
             cpu: 50m

--- a/charts/seed-controlplane/charts/dependency-watchdog/templates/rbac.yaml
+++ b/charts/seed-controlplane/charts/dependency-watchdog/templates/rbac.yaml
@@ -4,16 +4,12 @@ kind: ServiceAccount
 metadata:
   name: dependency-watchdog
   namespace: {{ .Release.Namespace }}
-  labels:
-{{ toYaml .Values.dependencywatchdog.labels | indent 4 }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding
 metadata:
   name: gardener.cloud:dependency-watchdog:role-binding
   namespace: {{ .Release.Namespace }}
-  labels:
-{{ toYaml .Values.dependencywatchdog.labels | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -28,8 +24,6 @@ kind: Role
 metadata:
   name: gardener.cloud:dependency-watchdog:role
   namespace: {{ .Release.Namespace }}
-  labels:
-{{ toYaml .Values.dependencywatchdog.labels | indent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/charts/seed-controlplane/charts/dependency-watchdog/values.yaml
+++ b/charts/seed-controlplane/charts/dependency-watchdog/values.yaml
@@ -1,12 +1,4 @@
 podAnnotations: {}
 replicas: 1
-dependencywatchdog:
-  service: 
-    name: etcd-main-client
-    labels:
-      "app" : "etcd-statefulset"
-      "role" : "main"
-  labels:
-    role: dependency-watchdog	    
 images:
   dependency-watchdog: image-repository:image-tag

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -666,15 +666,6 @@ func (b *Botanist) DeploySeedLogging() error {
 func (b *Botanist) DeployDependencyWatchdog(ctx context.Context) error {
 	dependencyWatchdogConfig := map[string]interface{}{
 		"replicas": b.Shoot.GetReplicas(1),
-		"dependencywatchdog": map[string]interface{}{
-			"service": map[string]interface{}{
-				"name": "etcd-main-client",
-				"labels": map[string]interface{}{
-					"app":  "etcd-statefulset",
-					"role": "main",
-				},
-			},
-		},
 	}
 
 	dependencyWatchdog, err := b.InjectSeedSeedImages(dependencyWatchdogConfig, common.DependencyWatchdogDeploymentName)


### PR DESCRIPTION
**What this PR does / why we need it**:
The dependency watchdog now checks for service dependency hierarchy (eg. etcd -> apiserver, apiserver -> other controlplane components). The watch duration has been raised to 5m from 2m as it was observed that pods had entered into CrashloopBackoff after 2m post with Dependency watchdog.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The dependency-watchdog controller does now check for service dependency hierarchy (e.g., etcd -> kube-apiserver, kube-apiserver -> other control plane components). This will lead to even faster restarts of the control plane components after CrashLoopBackoffs.
```
``` improvement operator github.com/gardener/dependency-watchdog #6 @georgekuruvillak
Enabled the dependency-watchdog to have hierarchy of service-pod dependency.
```