### PR TITLE
Enhance `lastError` with timestamp

### DIFF
--- a/charts/seed-bootstrap/templates/extensions/crd-controlplane.yaml
+++ b/charts/seed-bootstrap/templates/extensions/crd-controlplane.yaml
@@ -84,6 +84,10 @@ spec:
                   description: A human readable message indicating details about the
                     last error.
                   type: string
+                lastUpdateTime:
+                  description: Last time the error was reported
+                  format: date-time
+                  type: string
               required:
               - description
               type: object

--- a/charts/seed-bootstrap/templates/extensions/crd-extension.yaml
+++ b/charts/seed-bootstrap/templates/extensions/crd-extension.yaml
@@ -71,6 +71,10 @@ spec:
                   description: A human readable message indicating details about the
                     last error.
                   type: string
+                lastUpdateTime:
+                  description: Last time the error was reported
+                  format: date-time
+                  type: string
               required:
               - description
               type: object

--- a/charts/seed-bootstrap/templates/extensions/crd-operatingsystemconfig.yaml
+++ b/charts/seed-bootstrap/templates/extensions/crd-operatingsystemconfig.yaml
@@ -194,6 +194,10 @@ spec:
                   description: A human readable message indicating details about the
                     last error.
                   type: string
+                lastUpdateTime:
+                  description: Last time the error was reported
+                  format: date-time
+                  type: string
               required:
                 - description
               type: object

--- a/pkg/apis/core/types_common.go
+++ b/pkg/apis/core/types_common.go
@@ -14,7 +14,9 @@
 
 package core
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 // ErrorCode is a string alias.
 type ErrorCode string
@@ -37,6 +39,8 @@ type LastError struct {
 	// Well-defined error codes of the last error(s).
 	// +optional
 	Codes []ErrorCode
+	// Last time the error was reported
+	LastUpdateTime *metav1.Time
 }
 
 // LastOperationType is a string alias.

--- a/pkg/apis/core/v1alpha1/helper/errors.go
+++ b/pkg/apis/core/v1alpha1/helper/errors.go
@@ -18,9 +18,11 @@ import (
 	"errors"
 	"regexp"
 	"strings"
+	"time"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type errorWithCode struct {
@@ -99,7 +101,13 @@ func FormatLastErrDescription(err error) string {
 	return errString
 }
 
-// LastError creates a new LastError with the given description and optional codes.
+// LastError creates a new LastError with the given description, optional codes and sets timestamp when the error is lastly observed.
 func LastError(description string, codes ...gardencorev1alpha1.ErrorCode) *gardencorev1alpha1.LastError {
-	return &gardencorev1alpha1.LastError{Description: description, Codes: codes}
+	return &gardencorev1alpha1.LastError{
+		Description: description,
+		Codes:       codes,
+		LastUpdateTime: &metav1.Time{
+			Time: time.Now(),
+		},
+	}
 }

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -37,6 +37,9 @@ type LastError struct {
 	// Well-defined error codes of the last error(s).
 	// +optional
 	Codes []ErrorCode `json:"codes,omitempty"`
+	// Last time the error was reported
+	// +optional
+	LastUpdateTime *metav1.Time `json:"lastUpdateTime,omitempty"`
 }
 
 // LastOperationType is a string alias.

--- a/pkg/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.conversion.go
@@ -612,6 +612,7 @@ func Convert_core_Kubernetes_To_v1alpha1_Kubernetes(in *core.Kubernetes, out *Ku
 func autoConvert_v1alpha1_LastError_To_core_LastError(in *LastError, out *core.LastError, s conversion.Scope) error {
 	out.Description = in.Description
 	out.Codes = *(*[]core.ErrorCode)(unsafe.Pointer(&in.Codes))
+	out.LastUpdateTime = (*v1.Time)(unsafe.Pointer(in.LastUpdateTime))
 	return nil
 }
 
@@ -623,6 +624,7 @@ func Convert_v1alpha1_LastError_To_core_LastError(in *LastError, out *core.LastE
 func autoConvert_core_LastError_To_v1alpha1_LastError(in *core.LastError, out *LastError, s conversion.Scope) error {
 	out.Description = in.Description
 	out.Codes = *(*[]ErrorCode)(unsafe.Pointer(&in.Codes))
+	out.LastUpdateTime = (*v1.Time)(unsafe.Pointer(in.LastUpdateTime))
 	return nil
 }
 

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -390,6 +390,10 @@ func (in *LastError) DeepCopyInto(out *LastError) {
 		*out = make([]ErrorCode, len(*in))
 		copy(*out, *in)
 	}
+	if in.LastUpdateTime != nil {
+		in, out := &in.LastUpdateTime, &out.LastUpdateTime
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -390,6 +390,10 @@ func (in *LastError) DeepCopyInto(out *LastError) {
 		*out = make([]ErrorCode, len(*in))
 		copy(*out, *in)
 	}
+	if in.LastUpdateTime != nil {
+		in, out := &in.LastUpdateTime, &out.LastUpdateTime
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/controllermanager/controller/shoot/shoot_utils.go
+++ b/pkg/controllermanager/controller/shoot/shoot_utils.go
@@ -66,12 +66,6 @@ func (s Status) OrWorse(other Status) Status {
 	return s
 }
 
-func formatError(message string, err error) *gardencorev1alpha1.LastError {
-	return &gardencorev1alpha1.LastError{
-		Description: fmt.Sprintf("%s (%s)", message, err.Error()),
-	}
-}
-
 // StatusLabelTransform transforms the shoot labels depending on the given Status.
 func StatusLabelTransform(status Status) func(*gardenv1beta1.Shoot) (*gardenv1beta1.Shoot, error) {
 	return func(shoot *gardenv1beta1.Shoot) (*gardenv1beta1.Shoot, error) {

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1012,10 +1012,18 @@ func schema_pkg_apis_core_v1alpha1_LastError(ref common.ReferenceCallback) commo
 							},
 						},
 					},
+					"lastUpdateTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Last time the error was reported",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
 				},
 				Required: []string{"description"},
 			},
 		},
+		Dependencies: []string{
+			"k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Extends the `LastError` with timestamp when was actually the last error reported.
**Which issue(s) this PR fixes**:
Fixes #1055 

**Special notes for your reviewer**:
The following CRDs also has a `lastError` field:
- `operatingsystemconfigs.extensions.gardener.cloud`
- `extensions.extensions.gardener.cloud`
- `controlplanes.extensions.gardener.cloud`

Do I have to extend them as well ?

/cc @ialidzhikov 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement user
The `.status.lastError` section in the shoot status does now contain a new field `lastUpdateTime` that indicates when the section has been updated the last time.
```
