### PR TITLE
Fix NetworkPolciies for Seed clusters with v.1.10.x

### DIFF
--- a/charts/global-network-policies/templates/_private.tpl
+++ b/charts/global-network-policies/templates/_private.tpl
@@ -1,5 +1,10 @@
-{{- define "global-network-policies.except-networks" -}}
+{{- define "global-network-policies.except-to-networks" -}}
+{{- /*
+TODO (mvladev): Remove this extra -to block once Gardener stops supporting
+Kubernetes 1.10 for Seed clusters.
+*/ -}}
 {{- range $i, $network := $ }}
+  - to:
     - ipBlock:
         cidr: {{ required ".network.cidr is required" $network.network }}
 {{- if $network.except }}

--- a/charts/global-network-policies/templates/allow-to-private-networks.yaml
+++ b/charts/global-network-policies/templates/allow-to-private-networks.yaml
@@ -14,9 +14,12 @@ spec:
   podSelector:
     matchLabels:
       networking.gardener.cloud/to-private-networks: allowed
+{{- if .Values.clusterNetworks }}
   egress:
-  - to:
-{{ template "global-network-policies.except-networks" .Values.privateNetworks }}
+{{ template "global-network-policies.except-to-networks" .Values.clusterNetworks }}
+{{- else }}
+  egress: []
+{{- end }}
   policyTypes:
   - Egress
   ingress: []

--- a/charts/global-network-policies/templates/allow-to-seed-apiserver.yaml
+++ b/charts/global-network-policies/templates/allow-to-seed-apiserver.yaml
@@ -32,7 +32,7 @@ spec:
         - {{ $address }}
 {{- end }}
 {{- end }}
-{{ template "global-network-policies.except-networks" .Values.privateNetworks }}
+{{ template "global-network-policies.except-to-networks" .Values.privateNetworks }}
   # TODO (mvladev): discover ports on every Seed cluster dynamically.
   # ports:
   # - protocol: TCP

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/allow-elasticsearch-network-policy.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/allow-elasticsearch-network-policy.yaml
@@ -23,6 +23,11 @@ spec:
       namespaceSelector:
         matchLabels:
           role: garden
+    ports:
+    - protocol: TCP
+      port: {{ .Values.global.elasticsearchPorts.db }}
+  # TODO (mvladev): Remove this extra -from block once Gardener stops supporting Kubernetes 1.10 for Seed clusters.
+  - from:
     - podSelector:
         matchLabels:
           networking.gardener.cloud/to-elasticsearch: allowed

--- a/charts/seed-controlplane/charts/etcd/templates/allow-from-apiserver-network-policy.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/allow-from-apiserver-network-policy.yaml
@@ -18,6 +18,13 @@ spec:
           app: kubernetes
           garden.sapcloud.io/role: controlplane
           role: apiserver
+    ports:
+    - protocol: TCP
+      port: {{ .Values.servicePorts.client }}
+    - protocol: TCP
+      port: {{ .Values.servicePorts.backuprestore }}
+  # TODO (mvladev): Remove this extra -from block once Gardener stops supporting Kubernetes 1.10 for Seed clusters.
+  - from:
     - podSelector:
         matchLabels:
           app: prometheus

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/allow-kube-apiserver-policy.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/allow-kube-apiserver-policy.yaml
@@ -28,6 +28,11 @@ spec:
   - from:
     # allow all other Pods in the Seed cluster to access it.
     - podSelector: {}
+    ports:
+    - protocol: TCP
+      port: {{ required ".securePort is required" .Values.securePort }}
+  # TODO (mvladev): Remove this extra -from block once Gardener stops supporting Kubernetes 1.10 for Seed clusters.
+  - from:
     # kube-apiserver can be accessed from anywhere using the LoadBalancer.
     - ipBlock:
         cidr: 0.0.0.0/0

--- a/charts/seed-controlplane/charts/network-policies/templates/allow-to-shoot-networks.yaml
+++ b/charts/seed-controlplane/charts/network-policies/templates/allow-to-shoot-networks.yaml
@@ -14,9 +14,12 @@ spec:
   podSelector:
     matchLabels:
       networking.gardener.cloud/to-shoot-networks: allowed
+{{- if .Values.clusterNetworks }}
   egress:
-  - to:
-{{ template "global-network-policies.except-networks" .Values.clusterNetworks }}
+{{ template "global-network-policies.except-to-networks" .Values.clusterNetworks }}
+{{- else }}
+  egress: []
+{{- end }}
   policyTypes:
   - Egress
   ingress: []

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-prometheus-network-policy.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-prometheus-network-policy.yaml
@@ -17,10 +17,14 @@ spec:
     - podSelector:
         matchLabels:
           networking.gardener.cloud/from-prometheus: allowed
+  # TODO (mvladev): Remove this extra -to block once Gardener stops supporting Kubernetes 1.10 for Seed clusters.
+  - to:
     - podSelector:
         matchLabels:
           app: etcd-statefulset
           garden.sapcloud.io/role: controlplane
+  # TODO (mvladev): Remove this extra -to block once Gardener stops supporting Kubernetes 1.10 for Seed clusters.
+  - to:
     - podSelector:
         matchLabels:
           app: prometheus
@@ -28,6 +32,8 @@ spec:
       namespaceSelector:
         matchLabels:
           role: garden
+  # TODO (mvladev): Remove this extra -to block once Gardener stops supporting Kubernetes 1.10 for Seed clusters.
+  - to:
     - podSelector:
         matchLabels:
           component: alertmanager
@@ -36,6 +42,8 @@ spec:
       namespaceSelector:
         matchLabels:
           role: garden
+  # TODO (mvladev): Remove this extra -to block once Gardener stops supporting Kubernetes 1.10 for Seed clusters.
+  - to:
     - podSelector:
         matchLabels:
           app: vpa-exporter
@@ -49,6 +57,8 @@ spec:
         matchLabels:
           component: grafana
           garden.sapcloud.io/role: monitoring
+  # TODO (mvladev): Remove this extra -from block once Gardener stops supporting Kubernetes 1.10 for Seed clusters.
+  - from:
     - podSelector:
         matchLabels:
           app: nginx-ingress


### PR DESCRIPTION
In K8S `v1.10.x` there are validation checks which prevent having multiple `to` and `from` items:

https://github.com/kubernetes/kubernetes/blob/fc32d2f3698e36b93322a3465f63a14e9f0eaead/pkg/apis/networking/validation/validation.go#L120-L122
https://github.com/kubernetes/kubernetes/blob/fc32d2f3698e36b93322a3465f63a14e9f0eaead/pkg/apis/networking/validation/validation.go#L78-L80

Those checks are removed in 1.11

**What this PR does / why we need it**:

Network policies are broken on `v1.10.x` `Seed` clusters with:

```
'NetworkPolicy.extensions "allow-elasticsearch" is invalid: spec.ingress[0].from[0]:
      Forbidden: may not specify more than 1 from type'
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fix `NetworkPolicies` for `v1.10.x` Seed clusters.
```
