### PR TITLE
Support for Kubernetes v1.15

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
@@ -53,7 +53,11 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - /hyperkube
+        {{- if semverCompare "< 1.15" .Values.kubernetesVersion }}
         - apiserver
+        {{- else }}
+        - kube-apiserver
+        {{- end }}
         - --enable-admission-plugins={{ include "kube-apiserver.admissionPlugins" . | trimSuffix "," }}
         {{- if .Values.enableCSI }}
         # Needed due to https://github.com/kubernetes/kubernetes/pull/73102

--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -61,7 +61,11 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - /hyperkube
+        {{- if semverCompare "< 1.15" .Values.kubernetesVersion }}
         - controller-manager
+        {{- else }}
+        - kube-controller-manager
+        {{- end }}
         - --allocate-node-cidrs=true
         - --attach-detach-reconcile-sync-period=1m0s
         - --controllers=*,bootstrapsigner,tokencleaner

--- a/charts/seed-controlplane/charts/kube-scheduler/templates/kube-scheduler.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/templates/kube-scheduler.yaml
@@ -57,7 +57,11 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - /hyperkube
+        {{- if semverCompare "< 1.15" .Values.kubernetesVersion }}
         - scheduler
+        {{- else }}
+        - kube-scheduler
+        {{- end }}
         - --config=/var/lib/kube-scheduler-config/config.yaml
         {{- if semverCompare ">= 1.13" .Values.kubernetesVersion }}
         - --authentication-kubeconfig=/var/lib/kube-scheduler/kubeconfig

--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet-config-file
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet-config-file
@@ -67,12 +67,14 @@ kubeReserved:
   cpu: 80m
   memory: 1Gi
 hairpinMode: promiscuous-bridge
+{{- if semverCompare "< 1.15" .Values.kubernetes.version }}
 hostNetworkSources:
 - "*"
 hostPIDSources:
 - "*"
 hostIPCSources:
 - "*"
+{{- end }}
 httpCheckFrequency: 20s
 maxOpenFiles: 1000000
 maxPods: 110

--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.flags
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.flags
@@ -1,39 +1,45 @@
 {{- define "kubelet-flags" -}}
---allow-privileged=true \
---bootstrap-kubeconfig=/var/lib/kubelet/kubeconfig-bootstrap \
+{{- if semverCompare "< 1.15" .Values.kubernetes.version }}
+--allow-privileged=true
+{{- end }}
+--bootstrap-kubeconfig=/var/lib/kubelet/kubeconfig-bootstrap
 {{- if .Values.kubernetes.kubelet.providerIDProvided }}
---provider-id=${PROVIDER_ID} \
+--provider-id=${PROVIDER_ID}
 {{- end }}
 {{- if .Values.kubernetes.kubelet.enableCSI }}
---cloud-provider=external \
---enable-controller-attach-detach=true \
+--cloud-provider=external
+--enable-controller-attach-detach=true
 {{- else }}
---cloud-provider={{ .Values.cloudProvider.name }} \
+--cloud-provider={{ .Values.cloudProvider.name }}
 {{- if .Values.cloudProvider.config }}
---cloud-config=/var/lib/kubelet/cloudprovider.conf \
+--cloud-config=/var/lib/kubelet/cloudprovider.conf
 {{- end }}
 {{- end }}
---config=/var/lib/kubelet/config/kubelet \
---cni-bin-dir=/opt/cni/bin/ \
---cni-conf-dir=/etc/cni/net.d/ \
+--config=/var/lib/kubelet/config/kubelet
+--cni-bin-dir=/opt/cni/bin/
+--cni-conf-dir=/etc/cni/net.d/
 {{- if semverCompare "< 1.12" .Values.kubernetes.version }}
---cadvisor-port=0 \
+--cadvisor-port=0
 {{- end }}
 {{- if semverCompare "< 1.11" .Values.kubernetes.version }}
---feature-gates=PodPriority=true \
+--feature-gates=PodPriority=true
 {{- end }}
 {{- if semverCompare "< 1.14" .Values.kubernetes.version }}
---feature-gates=SupportPodPidsLimit=true \
+--feature-gates=SupportPodPidsLimit=true
 {{- end }}
---pod-infra-container-image={{ index .Values.images "pause-container" }} \
---kubeconfig=/var/lib/kubelet/kubeconfig-real \
---network-plugin=cni \
---node-labels="kubernetes.io/role=node,node-role.kubernetes.io/node=,worker.garden.sapcloud.io/group={{ required "worker.name is required" .Values.worker.name }}" \
+--pod-infra-container-image={{ index .Values.images "pause-container" }}
+--kubeconfig=/var/lib/kubelet/kubeconfig-real
+--network-plugin=cni
+{{- if semverCompare "< 1.15" .Values.kubernetes.version }}
+--node-labels="kubernetes.io/role=node,node-role.kubernetes.io/node=,worker.garden.sapcloud.io/group={{ required "worker.name is required" .Values.worker.name }},worker.gardener.cloud/pool={{ required "worker.name is required" .Values.worker.name }}"
+{{- else }}
+--node-labels="node.kubernetes.io/role=node,worker.garden.sapcloud.io/group={{ required "worker.name is required" .Values.worker.name }},worker.gardener.cloud/pool={{ required "worker.name is required" .Values.worker.name }}"
+{{- end }}
 {{- if semverCompare "< 1.11" .Values.kubernetes.version }}
---rotate-certificates=true \
+--rotate-certificates=true
 {{- end }}
 {{- range $index, $param := .Values.kubernetes.kubelet.parameters }}
-{{ $param }} \
+{{ $param }}
 {{- end }}
 --v=2 $KUBELET_EXTRA_ARGS
 {{- end -}}

--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.service
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.service
@@ -20,5 +20,5 @@
     ExecStartPre=/bin/sh -c 'hostnamectl set-hostname $(cat /etc/hostname | cut -d '.' -f 1)'
 {{- end }}
     ExecStart=/opt/bin/hyperkube kubelet \
-{{ include "kubelet-flags" . | indent 8 }}
+{{ include "kubelet-flags" . | trim | replace "\n" " \\\n" | indent 8 }}
 {{- end -}}

--- a/charts/shoot-core/charts/coredns/values.yaml
+++ b/charts/shoot-core/charts/coredns/values.yaml
@@ -45,6 +45,7 @@ configmap:
         pods insecure
         upstream
         fallthrough in-addr.arpa ip6.arpa
+        ttl 30
     - name: prometheus
       parameters: 0.0.0.0:9153
     - name: forward

--- a/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -65,7 +65,11 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - /hyperkube
+        {{- if semverCompare "< 1.15" .Values.kubernetesVersion }}
         - proxy
+        {{- else }}
+        - kube-proxy
+        {{- end }}
         - --config=/var/lib/kube-proxy-config/config.yaml
         - --v=2
         securityContext:

--- a/docs/usage/supported_k8s_versions.md
+++ b/docs/usage/supported_k8s_versions.md
@@ -14,11 +14,11 @@ The reason for that is that we require CRD status subresources for the extension
 
 ## Shoot cluster versions
 
-| Cloud provider | Kubernetes 1.10 | Kubernetes 1.11 | Kubernetes 1.12 | Kubernetes 1.13 | Kubernetes 1.14 |
-| -------------- | --------------- | --------------- | --------------- | --------------- | --------------- |
-| AWS            | 1.10.0+         | 1.11.0+         | 1.12.1+         | 1.13.0+         | 1.14.0+         |
-| Azure          | 1.10.1+         | 1.11.0+         | 1.12.1+         | 1.13.0+         | 1.14.0+         |
-| GCP            | 1.10.0+         | 1.11.0+         | 1.12.1+         | 1.13.0+         | 1.14.0+         |
-| OpenStack      | 1.10.1+         | 1.11.0+         | 1.12.1+         | 1.13.0+         | 1.14.0+         |
-| Alicloud       | unsupported     | unsupported     | unsupported     | 1.13.0+         | 1.14.0+         |
-| Packet         | unsupported     | unsupported     | unsupported     | 1.13.0+         | 1.14.0+         |
+| Cloud provider | Kubernetes 1.10 | Kubernetes 1.11 | Kubernetes 1.12 | Kubernetes 1.13 | Kubernetes 1.14 | Kubernetes 1.15 |
+| -------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- |
+| AWS            | 1.10.0+         | 1.11.0+         | 1.12.1+         | 1.13.0+         | 1.14.0+         | 1.15.0+         |
+| Azure          | 1.10.1+         | 1.11.0+         | 1.12.1+         | 1.13.0+         | 1.14.0+         | 1.15.0+         |
+| GCP            | 1.10.0+         | 1.11.0+         | 1.12.1+         | 1.13.0+         | 1.14.0+         | 1.15.0+         |
+| OpenStack      | 1.10.1+         | 1.11.0+         | 1.12.1+         | 1.13.0+         | 1.14.0+         | 1.15.0+         |
+| Alicloud       | unsupported     | unsupported     | unsupported     | 1.13.0+         | 1.14.0+         | 1.15.0+         |
+| Packet         | unsupported     | unsupported     | unsupported     | 1.13.0+         | 1.14.0+         | 1.15.0+         |

--- a/example/30-cloudprofile-alicloud.yaml
+++ b/example/30-cloudprofile-alicloud.yaml
@@ -15,6 +15,7 @@ spec:
       - name: unmanaged
       kubernetes:
         versions:
+        - 1.15.0
         - 1.14.3
         - 1.13.7
       machineImages:

--- a/example/30-cloudprofile-aws.yaml
+++ b/example/30-cloudprofile-aws.yaml
@@ -14,6 +14,7 @@ spec:
       - name: unmanaged
       kubernetes:
         versions:
+        - 1.15.0
         - 1.14.3
         - 1.13.7
         - 1.12.9

--- a/example/30-cloudprofile-azure.yaml
+++ b/example/30-cloudprofile-azure.yaml
@@ -14,6 +14,7 @@ spec:
       - name: unmanaged
       kubernetes:
         versions:
+        - 1.15.0
         - 1.14.3
         - 1.13.7
         - 1.12.9

--- a/example/30-cloudprofile-gcp.yaml
+++ b/example/30-cloudprofile-gcp.yaml
@@ -14,6 +14,7 @@ spec:
       - name: unmanaged
       kubernetes:
         versions:
+        - 1.15.0
         - 1.14.3
         - 1.13.7
         - 1.12.9

--- a/example/30-cloudprofile-openstack.yaml
+++ b/example/30-cloudprofile-openstack.yaml
@@ -16,6 +16,7 @@ spec:
       - name: MY-FLOATING-POOL
       kubernetes:
         versions:
+        - 1.15.0
         - 1.14.3
         - 1.13.7
         - 1.12.9

--- a/example/30-cloudprofile-packet.yaml
+++ b/example/30-cloudprofile-packet.yaml
@@ -15,6 +15,7 @@ spec:
       - name: unmanaged
       kubernetes:
         versions:
+        - 1.15.0
         - 1.14.3
         - 1.13.7
       machineImages:

--- a/example/90-shoot-alicloud.yaml
+++ b/example/90-shoot-alicloud.yaml
@@ -42,7 +42,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.14.3
+    version: 1.15.0
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   featureGates:

--- a/example/90-shoot-aws.yaml
+++ b/example/90-shoot-aws.yaml
@@ -44,7 +44,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.14.3
+    version: 1.15.0
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   featureGates:

--- a/example/90-shoot-azure.yaml
+++ b/example/90-shoot-azure.yaml
@@ -43,7 +43,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.14.3
+    version: 1.15.0
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   featureGates:

--- a/example/90-shoot-gcp.yaml
+++ b/example/90-shoot-gcp.yaml
@@ -42,7 +42,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.14.3
+    version: 1.15.0
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   featureGates:

--- a/example/90-shoot-openstack.yaml
+++ b/example/90-shoot-openstack.yaml
@@ -41,7 +41,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.14.3
+    version: 1.15.0
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   featureGates:

--- a/example/90-shoot-packet.yaml
+++ b/example/90-shoot-packet.yaml
@@ -37,7 +37,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.14.3
+    version: 1.15.0
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   featureGates:

--- a/hack/templates/resources/30-cloudprofile.yaml.tpl
+++ b/hack/templates/resources/30-cloudprofile.yaml.tpl
@@ -68,6 +68,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % if kubernetesVersions != []:
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
+        - 1.15.0
         - 1.14.3
         - 1.13.7
         - 1.12.9
@@ -170,6 +171,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % if kubernetesVersions != []:
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
+        - 1.15.0
         - 1.14.3
         - 1.13.7
         - 1.12.9
@@ -269,6 +271,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % if kubernetesVersions != []:
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
+        - 1.15.0
         - 1.14.3
         - 1.13.7
         - 1.12.9
@@ -360,6 +363,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
         versions:
+        - 1.15.0
         - 1.14.3
         - 1.13.7
         % endif
@@ -443,6 +447,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
         versions:
+        - 1.15.0
         - 1.14.3
         - 1.13.7
         % endif
@@ -529,6 +534,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % if kubernetesVersions != []:
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
+        - 1.15.0
         - 1.14.3
         - 1.13.7
         - 1.12.9

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -25,22 +25,22 @@
   kubernetesVersion=""
   if cloud == "aws":
     region="eu-west-1"
-    kubernetesVersion="1.14.3"
+    kubernetesVersion="1.15.0"
   elif cloud == "azure" or cloud == "az":
     region="westeurope"
-    kubernetesVersion="1.14.3"
+    kubernetesVersion="1.15.0"
   elif cloud == "gcp":
     region="europe-west1"
-    kubernetesVersion="1.14.3"
+    kubernetesVersion="1.15.0"
   elif cloud == "alicloud":
     region="cn-beijing"
-    kubernetesVersion="1.14.3"
+    kubernetesVersion="1.15.0"
   elif cloud == "packet":
     region="ewr1"
-    kubernetesVersion="1.14.3"
+    kubernetesVersion="1.15.0"
   elif cloud == "openstack" or cloud == "os":
     region="europe-1"
-    kubernetesVersion="1.14.3"
+    kubernetesVersion="1.15.0"
 %>---
 apiVersion: garden.sapcloud.io/v1beta1
 kind: Shoot

--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -108,6 +108,7 @@ var supportedKubernetesVersions = []string{
 	"1.12",
 	"1.13",
 	"1.14",
+	"1.15",
 }
 
 func checkIfSupportedKubernetesVersion(gitVersion string) error {

--- a/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
@@ -206,7 +206,7 @@ func (c *defaultControl) reconcileShoot(o *operation.Operation, operationType ga
 		deployKubeControllerManager = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes controller manager",
 			Fn:           flow.SimpleTaskFn(hybridBotanist.DeployKubeControllerManager).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(deploySecrets, deployCloudProviderSecret, waitUntilKubeAPIServerIsReady, deployCloudProviderConfig, initializeShootClients),
+			Dependencies: flow.NewTaskIDs(deploySecrets, deployCloudProviderSecret, waitUntilKubeAPIServerIsReady, deployCloudProviderConfig),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Syncing shoot access credentials to project namespace in Garden",


### PR DESCRIPTION
**What this PR does / why we need it**:
Support for Kubernetes v1.15

**Which issue(s) this PR fixes**:
Fixes #1118 

**Special notes for your reviewer**:
I didn't vendor the `kubernetes-1.15` sources yet because we first want to fix the vendoring in gardener-extensions.

⚠️ Also, using 1.15 requires a newer version of the provider extensions (not yet released, you can use `0.6.7-dev-1.15-support` tag for testing, if you want.)

I have successfully validated the functionality for all cloud providers and all older versions:
- :white_check_mark: Reconcile old clusters in all versions (1.10, 1.11, 1.12, 1.13, 1.14) with this branch
- :white_check_mark: Create new clusters with versions < 1.15
- :white_check_mark: Create new clusters with version  = 1.15
- :white_check_mark: Upgrade old clusters from version 1.14 to version 1.15
- :white_check_mark: Delete clusters with versions < 1.15
- :white_check_mark: Delete clusters with version  = 1.15

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```action operator
In order to support Kubernetes 1.15 you must use at least v[`0.7.0`](https://github.com/gardener/gardener-extensions/releases/tag/0.7.0) of the provider extension controllers.
```
```noteworthy user
Gardener does now support shoot clusters with Kubernetes version 1.15. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.15.md) before upgrading to 1.15.
```
