### PR TITLE
Add system-component label to calico-kube-controllers deployment

### DIFF
--- a/charts/shoot-core/charts/calico/templates/calico.yaml
+++ b/charts/shoot-core/charts/calico/templates/calico.yaml
@@ -393,6 +393,7 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
     k8s-app: calico-kube-controllers
+    garden.sapcloud.io/role: system-component
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
 spec:
@@ -409,6 +410,7 @@ spec:
       namespace: kube-system
       labels:
         k8s-app: calico-kube-controllers
+        garden.sapcloud.io/role: system-component
     spec:
       nodeSelector:
         beta.kubernetes.io/os: linux


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the gardener system-components label `garden.sapcloud.io/role: system-component` to the calico-kube-controllers deployment
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
