### PR TITLE
Add apiserver audit to monitoring

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-apiserver.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-apiserver.rules.test.yaml
@@ -22,6 +22,11 @@ tests:
     values: '100+0x60'
   - series: 'apiserver_request_latencies_bucket{verb="POST", le="+Inf"}'
     values: '100+0x60'
+  # KubeApiServerTooManyAuditlogFailures
+  - series: 'apiserver_audit_error_total{plugin="webhook", job="kube-apiserver"}'
+    values: '1+1x31'
+  - series: 'apiserver_audit_event_total{job="kube-apiserver"}'
+    values: '0+30x31'
   alert_rule_test:
   - eval_time: 5m
     alertname: ApiServerNotReachable
@@ -82,4 +87,14 @@ tests:
       exp_annotations:
         description: Kube API server latency for verb POST is high. This could be because the shoot workers and the control plane are in different regions. 99th percentile of request latency is greater than 3 second.
         summary: Kubernetes API server latency is high
-
+  - eval_time: 16m
+    alertname: KubeApiServerTooManyAuditlogFailures
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        type: seed
+        job: kube-apiserver
+        visibility: operator
+      exp_annotations:
+        description: 'The API server reached 0.03333333333333333% failures to log audit events.'
+        summary: 'The API server has too many failed attempts to log audit events'

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-apiserver.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-apiserver.rules.yaml
@@ -71,3 +71,15 @@ groups:
     annotations:
       description: 'The API server ({{ $labels.instance }}) is using {{ $value }}% of the available file/socket descriptors.'
       summary: 'The API server has too many open file descriptors'
+  ### API auditlog ###
+  - alert: KubeApiServerTooManyAuditlogFailures
+    expr: sum(rate (apiserver_audit_error_total{plugin="webhook"} [5m])) by (app ,role) / ignoring(plugin) sum(rate(apiserver_audit_event_total [5m])) by (app, role) > 0.02
+    for: 15m
+    labels:
+      severity: critical
+      type: seed
+      job: kube-apiserver
+      visibility: operator
+    annotations:
+      description: 'The API server reached {{ $value }}% failures to log audit events.'
+      summary: 'The API server has too many failed attempts to log audit events'

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -58,6 +58,8 @@ allowedMetrics:
   - etcd_object_counts
   - process_max_fds
   - process_open_fds
+  - apiserver_audit_event_total
+  - apiserver_audit_error_total
   kubeControllerManager:
   - process_max_fds
   - process_open_fds

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-cluster-health-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-cluster-health-dashboard.json
@@ -1449,6 +1449,93 @@
         }
       ],
       "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#73BF69",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "description": "",
+      "format": "percentunit",
+      "gauge": {
+        "maxValue": 0.06,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 13
+      },
+      "id": 26,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "pluginVersion": "6.2.0",
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(rate (apiserver_audit_error_total{plugin=\"webhook\"} [5m])) by (app ,role) / ignoring(plugin) sum(rate(apiserver_audit_event_total [5m])) by (app, role)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{app}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "0.01,0.02",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Auditlog Failures Ratio",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current",
+      "options": {}
     }
   ],
   "refresh": "10s",


### PR DESCRIPTION
**What this PR does / why we need it**:
Provides insight into the apiserver audit mechanism health. In productive environments where compliance is essential the health of the audit log is essential to committing to sufficient compliance level. Especially in distributed setups such as apiserver with a remote webhook for logging audit events.

This PR includes:
- Grafana dashboard panel for operators for the audit failure ratio (percentage of failed attempts to log audit event from all attempts). Green to yellow threshold: 0.01%. Yellow to red threshold: 0.02%.
- Alert for reaching the threshold for failed audit event log attempts (>0.02%) for 10 minutes
In this change, the feature is exposed (dashboards, alerts) to *operators* only.

Preview:
![image](https://user-images.githubusercontent.com/4983982/60015888-3e392b80-968d-11e9-8e3a-97bf856e0009.png)

**Which issue(s) this PR fixes**:
none

**Special notes for your reviewer**:
Check the numbers (sliding window minutes, thresholds, alert's `for`) too. See [comment](https://github.com/gardener/gardener/pull/1131#issuecomment-505438117)

**Release note**:
```improvement operator
Monitoring and alerts for apiserver audit health
```
