### PR TITLE
Improve gardener create shoot test

### DIFF
--- a/test/integration/framework/utils.go
+++ b/test/integration/framework/utils.go
@@ -136,21 +136,24 @@ func getDeploymentListByLabels(ctx context.Context, labelsMap labels.Selector, n
 	return deploymentList, nil
 }
 
-func shootCreationCompleted(newStatus *v1beta1.ShootStatus) bool {
-	if len(newStatus.Conditions) == 0 && newStatus.LastOperation == nil {
+func shootCreationCompleted(newShoot *v1beta1.Shoot) bool {
+	if newShoot.Generation != newShoot.Status.ObservedGeneration {
+		return false
+	}
+	if len(newShoot.Status.Conditions) == 0 && newShoot.Status.LastOperation == nil {
 		return false
 	}
 
-	for _, condition := range newStatus.Conditions {
+	for _, condition := range newShoot.Status.Conditions {
 		if condition.Status != gardencorev1alpha1.ConditionTrue {
 			return false
 		}
 	}
 
-	if newStatus.LastOperation != nil {
-		if newStatus.LastOperation.Type == gardencorev1alpha1.LastOperationTypeCreate ||
-			newStatus.LastOperation.Type == gardencorev1alpha1.LastOperationTypeReconcile {
-			if newStatus.LastOperation.State != gardencorev1alpha1.LastOperationStateSucceeded {
+	if newShoot.Status.LastOperation != nil {
+		if newShoot.Status.LastOperation.Type == gardencorev1alpha1.LastOperationTypeCreate ||
+			newShoot.Status.LastOperation.Type == gardencorev1alpha1.LastOperationTypeReconcile {
+			if newShoot.Status.LastOperation.State != gardencorev1alpha1.LastOperationStateSucceeded {
 				return false
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds a retry for shoot creation and deletion functions to avoid the test to fail if gardener is unavailable for some minutes (e.g. after update).
- Check shoot generation and observed generation in the shoot completion function

**Special notes for your reviewer**:
@zanetworker 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
