### PR TITLE
Cleanup the code for etcd old pvc deletion

### DIFF
--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -16,7 +16,6 @@ package botanist
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/gardener/gardener/pkg/operation/common"
@@ -215,20 +214,4 @@ func (b *Botanist) CleanKubernetesResources(ctx context.Context) error {
 		cleanResourceFn(c, &appsv1.StatefulSetList{}, false, StatefulSetCleanOptions),
 		cleanResourceFn(c, &corev1.PersistentVolumeClaimList{}, false, PersistentVolumeClaimCleanOptions),
 	)(ctx)
-}
-
-// DeleteOrphanEtcdMainPVC delete the orphan PVC associated with old etcd-main statefulsets as a result of migration in Release 0.22.0 (https://github.com/gardener/gardener/releases/tag/0.22.0).
-func (b *Botanist) DeleteOrphanEtcdMainPVC(ctx context.Context) error {
-	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("etcd-%s-etcd-%s-0", common.EtcdRoleMain, common.EtcdRoleMain),
-			Namespace: b.Shoot.SeedNamespace,
-		},
-	}
-
-	// Since there isn't any further dependency on this PVC, we don't wait here until PVC
-	// and associated PV get deleted completely. Yes this won't report any error face while deleting
-	// PVC. But eventually at the time of shoot deletion we cleanup the seednamespace and all resource
-	// in it with proper error reporting. So, we can safely avoid waiting.
-	return client.IgnoreNotFound(b.K8sSeedClient.Client().Delete(ctx, pvc))
 }

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -86,22 +86,6 @@ func (b *Botanist) WaitUntilEtcdReady(ctx context.Context) error {
 	})
 }
 
-// WaitUntilEtcdStatefulsetDeleted waits until the etcd statefulsets get deleted.
-func (b *Botanist) WaitUntilEtcdStatefulsetDeleted(ctx context.Context, role string) error {
-	return retry.Until(ctx, 5*time.Second, func(ctx context.Context) (done bool, err error) {
-		b.Logger.Infof("Waiting until the etcd-%s statefulset get deleted...", role)
-		_, err = b.K8sSeedClient.Kubernetes().AppsV1().StatefulSets(b.Shoot.SeedNamespace).Get(fmt.Sprintf("etcd-%s", role), metav1.GetOptions{})
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return retry.Ok()
-			}
-			return retry.SevereError(err)
-		}
-
-		return retry.MinorError(fmt.Errorf("etcd-%s is still present", role))
-	})
-}
-
 // WaitUntilKubeAPIServerReady waits until the kube-apiserver pod(s) indicate readiness in their statuses.
 func (b *Botanist) WaitUntilKubeAPIServerReady(ctx context.Context) error {
 	return retry.UntilTimeout(ctx, 5*time.Second, 300*time.Second, func(ctx context.Context) (done bool, err error) {


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
This PR clean's up the code added for backward compatibility of etcd PVC storageclass migration.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
