### PR TITLE
Moving imagevector related method to its package

### DIFF
--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -49,16 +49,6 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
-// ReadGlobalImageVectorWithEnvOverride reads the global image vector and applies the env override. Exposed for testing.
-func ReadGlobalImageVectorWithEnvOverride() (imagevector.ImageVector, error) {
-	imageVector, err := imagevector.ReadFile(filepath.Join(common.ChartPath, "images.yaml"))
-	if err != nil {
-		return nil, err
-	}
-
-	return imagevector.WithEnvOverride(imageVector)
-}
-
 // GardenControllerFactory contains information relevant to controllers for the Garden API group.
 type GardenControllerFactory struct {
 	cfg                    *config.ControllerManagerConfiguration
@@ -127,7 +117,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) {
 
 	runtime.Must(garden.VerifyInternalDomainSecret(f.k8sGardenClient, len(shootList), secrets[common.GardenRoleInternalDomain]))
 
-	imageVector, err := ReadGlobalImageVectorWithEnvOverride()
+	imageVector, err := imagevector.ReadGlobalImageVectorWithEnvOverride(filepath.Join(common.ChartPath, "images.yaml"))
 	runtime.Must(err)
 
 	gardenNamespace := &corev1.Namespace{}

--- a/pkg/controllermanager/controller/factory_test.go
+++ b/pkg/controllermanager/controller/factory_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Controller Manager", func() {
 			defer test.WithEnvVar(imagevector.OverrideEnv, "")()
 			defer test.WithWd("../../..")()
 
-			_, err := ReadGlobalImageVectorWithEnvOverride()
+			_, err := imagevector.ReadGlobalImageVectorWithEnvOverride("charts/images.yaml")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/pkg/utils/imagevector/imagevector.go
+++ b/pkg/utils/imagevector/imagevector.go
@@ -50,6 +50,16 @@ func ReadFile(name string) (ImageVector, error) {
 	return Read(file)
 }
 
+// ReadGlobalImageVectorWithEnvOverride reads the global image vector and applies the env override. Exposed for testing.
+func ReadGlobalImageVectorWithEnvOverride(filePath string) (ImageVector, error) {
+	imageVector, err := ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return WithEnvOverride(imageVector)
+}
+
 // mergeImageSources merges the two given ImageSources.
 //
 // If the tag of the override is non-empty, it immediately returns the override.


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves imagevector related method (ReadGlobalImageVectorWithEnvOverride) from the controller package to package (imagevector). In the current situation reusing the ReadGlobalImageVectorWithEnvOverride as a dependency in other project will drag the whole controller package into the client code.
Also the method signature is more generalised  in order to be more agile.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
`pkg/controllermanager/controller/factory.ReadGlobalImageVectorWithEnvOverride` has been moved to package `pkg/utils/imagevector`
```
