### PR TITLE
Adapt Network extension API

### DIFF
--- a/pkg/apis/extensions/v1alpha1/types_network.go
+++ b/pkg/apis/extensions/v1alpha1/types_network.go
@@ -48,10 +48,8 @@ type NetworkList struct {
 type NetworkSpec struct {
 	// DefaultSpec is a structure containing common fields used by all extension resources.
 	DefaultSpec `json:",inline"`
-	// CloudProvider is the type of the cloud provider (e.g., aws, azure, gcp,...)
-	CloudProvider string `json:"cloudProvider,omitempty"`
-	// ClusterCIDR defines the CIDR that will be used for pods.
-	ClusterCIDR string `json:"clusterCIDR"`
+	// PodCIDR defines the CIDR that will be used for pods.
+	PodCIDR string `json:"podCIDR"`
 	// ServiceCIDR defines the CIDR that will be used for services.
 	ServiceCIDR string `json:"serviceNetworkCIDR"`
 	// ProviderConfig contains plugin-specific configuration.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adapt the network extension API to be cloud provider agnostic, also rename clusterCIDR to podCIDR.
