### PR TITLE
Improve the audit related alert rule description

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-apiserver.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-apiserver.rules.test.yaml
@@ -96,5 +96,5 @@ tests:
         job: kube-apiserver
         visibility: operator
       exp_annotations:
-        description: 'The API server reached 0.03333333333333333% failures to log audit events.'
+        description: 'The API servers cumulative failure rate in logging audit events is 0.03%. This may be caused by an unavailable/unreachable audisink(s) and/or improper API server audit configuration.'
         summary: 'The API server has too many failed attempts to log audit events'

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-apiserver.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-apiserver.rules.yaml
@@ -81,5 +81,5 @@ groups:
       job: kube-apiserver
       visibility: operator
     annotations:
-      description: 'The API server reached {{ $value }}% failures to log audit events.'
-      summary: 'The API server has too many failed attempts to log audit events'
+        description: 'The API servers cumulative failure rate in logging audit events is {{ printf "%0.2f" $value }}%. This may be caused by an unavailable/unreachable audisink(s) and/or improper API server audit configuration.'
+        summary: 'The API server has too many failed attempts to log audit events'


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor adjustments to the audit related alert description. 
- Previously, the precision of the reported value was not controlled resulting in numbers such as `0.03333333333333333%`. The proposed change rounds the floats precision to 2 resulting in more reasonable numbers such as `0.03%`.
- The wording improved. Suggestions for the  possible cause added.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```
NONE
```
