### PR TITLE
Adding vpa exporter vpa to prevent OOMKills for vpa-exporter.

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/templates/vpa-exporter-vpa.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/vpa-exporter-vpa.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.enabled }}
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: vpa-exporter-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRef:
+    apiVersion: {{ include "deploymentversion" . }}
+    kind: Deployment
+    name: vpa-exporter
+  updatePolicy:
+    updateMode: "Auto"
+{{ end }}

--- a/charts/seed-bootstrap/charts/vpa/templates/vpa-exporter.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/vpa-exporter.yaml
@@ -34,9 +34,11 @@ spec:
           requests:
             cpu: 50m
             memory: 200Mi
+{{ if not .Values.enabled }}
           limits:
             cpu: 500m
             memory: 1Gi
+{{ end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/seed-bootstrap/charts/vpa/templates/vpa-exporter.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/vpa-exporter.yaml
@@ -35,8 +35,8 @@ spec:
             cpu: 50m
             memory: 200Mi
           limits:
-            cpu: 200m
-            memory: 500Mi
+            cpu: 500m
+            memory: 1Gi
 ---
 apiVersion: v1
 kind: Service

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-seed/templates/kube-state-metrics.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-seed/templates/kube-state-metrics.yaml
@@ -44,9 +44,22 @@ spec:
   selector:
     component: kube-state-metrics
     type: seed
-
 ---
-
+{{ if .Values.vpa.enabled }}
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: kube-state-metrics-seed-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRef:
+    apiVersion: {{ include "deploymentversion" . }}
+    kind: Deployment
+    name: kube-state-metrics-seed
+  updatePolicy:
+    updateMode: "Auto"
+{{ end }}
+---
 apiVersion: {{ include "deploymentversion" . }}
 kind: Deployment
 metadata:
@@ -105,6 +118,8 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+{{ if not .Values.vpa.enabled }}
           limits:
             cpu: 50m
             memory: 64Mi
+{{ end }}

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-seed/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-seed/values.yaml
@@ -1,3 +1,5 @@
 images:
   kube-state-metrics: image-repository:image-tag
 replicas: 1
+vpa:
+  enabled: true

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/kube-state-metrics.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/kube-state-metrics.yaml
@@ -17,6 +17,21 @@ spec:
     component: kube-state-metrics
     type: shoot
 ---
+{{ if .Values.vpa.enabled }}
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: kube-state-metrics-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRef:
+    apiVersion: {{ include "deploymentversion" . }}
+    kind: Deployment
+    name: kube-state-metrics
+  updatePolicy:
+    updateMode: "Auto"
+{{ end }}
+---
 apiVersion: {{ include "deploymentversion" . }}
 kind: Deployment
 metadata:
@@ -80,9 +95,11 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+{{ if not .Values.vpa.enabled }}
           limits:
             cpu: 50m
             memory: 64Mi
+{{ end }}
       volumes:
       - name: kubeconfig
         secret:

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/values.yaml
@@ -1,3 +1,5 @@
 images:
   kube-state-metrics: image-repository:image-tag
 replicas: 1
+vpa:
+  enabled: true

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -353,9 +353,15 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		}
 		kubeStateMetricsSeedConfig = map[string]interface{}{
 			"replicas": b.Shoot.GetReplicas(1),
+			"vpa": map[string]interface{}{
+				"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
+			},
 		}
 		kubeStateMetricsShootConfig = map[string]interface{}{
 			"replicas": b.Shoot.GetReplicas(1),
+			"vpa": map[string]interface{}{
+				"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
+			},
 		}
 	)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables `vpa` for `vpa-exporter` to prevent OOMKill of the vpa-exporter. `vpa-exporter` scraps `vpa` metrics from vpa resources in the shoots for Prometheus to injest.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
vpa added for vpa-exporter to prevent OOMKill of vpa-exporter pod.
```
