### PR TITLE
Added a 1s sleep while polling the etcd sidecar during startup.

### DIFF
--- a/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
@@ -42,10 +42,14 @@ data:
                   sleep 1;
                   continue;;
             "Failed")
+                 sleep 1;
                   continue;;
             "Successful")
                   start_managed_etcd
                   break
+                  ;;
+            *)
+                  sleep 1;
                   ;;
             esac;
           done


### PR DESCRIPTION
**What this PR does / why we need it**:
The bootstrap script for the etcd container now sleeps for 1s in each iteration polling for the etcd backup sidecar to be ready. Earlier, the wait before the next poll used to happen only if etcd backup sidecar was already started and a tight polling loop used to happen if the etcd container starts before the backup sidecar.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
The bootstrap script for the etcd container now sleeps for 1s in each iteration polling for the etcd backup sidecar to be ready. Earlier, the wait before the next poll used to happen only if etcd backup sidecar was already started and a tight polling loop used to happen if the etcd container starts before the backup sidecar.
```
