### PR TITLE
support inject volume provider value during install controller

### DIFF
--- a/pkg/controllermanager/controller/controllerinstallation/controllerinstallation_control.go
+++ b/pkg/controllermanager/controller/controllerinstallation/controllerinstallation_control.go
@@ -20,8 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/gardener/gardener/pkg/utils/flow"
-
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	gardenextensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -36,6 +34,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/common"
 	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
 	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/flow"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	multierror "github.com/hashicorp/go-multierror"
@@ -236,14 +235,15 @@ func (c *defaultControllerInstallationControl) reconcile(controllerInstallation 
 				"identity": c.gardenNamespace.UID,
 			},
 			"seed": map[string]interface{}{
-				"identity":      seed.Name,
-				"provider":      seedCloudProvider,
-				"region":        seed.Spec.Cloud.Region,
-				"ingressDomain": seed.Spec.IngressDomain,
-				"blockCIDRs":    seed.Spec.BlockCIDRs,
-				"protected":     seed.Spec.Protected,
-				"visible":       seed.Spec.Visible,
-				"networks":      seed.Spec.Networks,
+				"identity":       seed.Name,
+				"provider":       seedCloudProvider,
+				"volumeProvider": common.GetPersistentVolumeProvider(seed),
+				"region":         seed.Spec.Cloud.Region,
+				"ingressDomain":  seed.Spec.IngressDomain,
+				"blockCIDRs":     seed.Spec.BlockCIDRs,
+				"protected":      seed.Spec.Protected,
+				"visible":        seed.Spec.Visible,
+				"networks":       seed.Spec.Networks,
 			},
 		},
 	}

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -638,3 +638,11 @@ func EffectiveShootMaintenanceTimeWindow(shoot *gardenv1beta1.Shoot) *utils.Main
 
 	return EffectiveMaintenanceTimeWindow(timeWindow)
 }
+
+// GetPersistentVolumeProvider gets the Persistent Volume Provider of seed cluster. If it is not specified, return ""
+func GetPersistentVolumeProvider(seed *gardenv1beta1.Seed) string {
+	if seed.Annotations == nil {
+		return ""
+	}
+	return seed.Annotations[AnnotatePersistentVolumeProvider]
+}

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -577,12 +577,3 @@ func (s *Seed) GetValidVolumeSize(size string) string {
 
 	return size
 }
-
-// GetPersistentVolumeProvider gets the Persistent Volume Provider of seed cluster. If it is not specified, return ""
-func (s *Seed) GetPersistentVolumeProvider() string {
-	if s.Info.Annotations == nil {
-		return ""
-	}
-
-	return s.Info.Annotations[common.AnnotatePersistentVolumeProvider]
-}


### PR DESCRIPTION
**What this PR does / why we need it**:
#1162

```improvement operator
The `ControllerInstallation` controller does now inject the volume provider name into the Helm charts for the respective seed if it was annotated with `persistentvolume.garden.sapcloud.io/provider=<name>`. The path of the value is `.gardener.seed.volumeProvider`.
```
 