### PR TITLE
Add reconcile annotation for extensions

### DIFF
--- a/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
+++ b/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
@@ -9,6 +9,8 @@ kind: OperatingSystemConfig
 metadata:
   name: {{ required "secretName is required" .Values.secretName }}-downloader
   namespace: {{ .Release.Namespace }}
+  annotations:
+    gardener.cloud/operation: reconcile
 spec:
   type: {{ required "type is required" .Values.type }}
   purpose: {{ required "purpose is required" .Values.purpose }}

--- a/charts/seed-operatingsystemconfig/original/templates/osc.yaml
+++ b/charts/seed-operatingsystemconfig/original/templates/osc.yaml
@@ -4,6 +4,8 @@ kind: OperatingSystemConfig
 metadata:
   name: {{ required ".osc.secretName is required" .Values.osc.secretName }}-original
   namespace: {{ .Release.Namespace }}
+  annotations:
+    gardener.cloud/operation: reconcile
 spec:
   type: {{ required ".osc.type is required" .Values.osc.type }}
   purpose: {{ required ".osc.purpose is required" .Values.osc.purpose }}

--- a/docs/extensions/conventions.md
+++ b/docs/extensions/conventions.md
@@ -1,5 +1,7 @@
 # General conventions
 
+Gardener dictates the time of reconciliation for resources of the API group `extensions.gardener.cloud`. It does that by annotating the respected resource with `gardener.cloud/operation: reconcile`. Extension controllers react to this annotation and start reconciling the resource. They have to remove this annotation as soon as they begin with their reconcile operation and maintain the `status` of the extension resource accordingly.
+
 All the extensions that are registered to Gardener are deployed to the seed clusters (at the moment, every extension is installed to every seed cluster, however, in the future Gardener will be more smart to determine which extensions needs to be placed into which seed).
 
 Some of these extensions might need to create global resources in the seed (e.g., `ClusterRole`s), i.e., it's important to have a naming scheme to avoid conflicts as it cannot be checked or validated upfront that two extensions don't use the same names.

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -42,6 +42,21 @@ type LastError struct {
 	LastUpdateTime *metav1.Time `json:"lastUpdateTime,omitempty"`
 }
 
+// GetDescription implements LastError.
+func (l *LastError) GetDescription() string {
+	return l.Description
+}
+
+// GetCodes implements LastError.
+func (l *LastError) GetCodes() []ErrorCode {
+	return l.Codes
+}
+
+// GetLastUpdateTime implements LastError.
+func (l *LastError) GetLastUpdateTime() *metav1.Time {
+	return l.LastUpdateTime
+}
+
 // LastOperationType is a string alias.
 type LastOperationType string
 

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -24,6 +24,11 @@ type Status interface {
 	// GetLastOperation retrieves the LastOperation of a status.
 	// LastOperation may be nil.
 	GetLastOperation() LastOperation
+	// GetObservedGeneration retrieves the last generation observed by the extension controller.
+	GetObservedGeneration() int64
+	// GetLastError retrieves the LastError of a status.
+	// LastError may be nil.
+	GetLastError() LastError
 }
 
 // LastOperation is the last operation on an object.
@@ -40,6 +45,16 @@ type LastOperation interface {
 	GetType() gardencorev1alpha1.LastOperationType
 }
 
+// LastError is the last error on an object.
+type LastError interface {
+	// GetDescription gets the description of the last occurred error.
+	GetDescription() string
+	// GetCodes gets the error codes of the last error.
+	GetCodes() []gardencorev1alpha1.ErrorCode
+	// GetLastUpdateTime retrieves the last time the error was updated.
+	GetLastUpdateTime() *metav1.Time
+}
+
 // Spec is the spec section of an Object.
 type Spec interface {
 	// GetExtensionType retrieves the extension type.
@@ -48,6 +63,7 @@ type Spec interface {
 
 // Object is an extension object resource.
 type Object interface {
+	metav1.Object
 	// GetExtensionStatus retrieves the object's status.
 	GetExtensionStatus() Status
 	// GetExtensionSpec retrieves the object's spec.

--- a/pkg/apis/extensions/v1alpha1/types_defaults.go
+++ b/pkg/apis/extensions/v1alpha1/types_defaults.go
@@ -51,3 +51,16 @@ func (d *DefaultStatus) GetLastOperation() LastOperation {
 	}
 	return d.LastOperation
 }
+
+// GetLastError implements Status.
+func (d *DefaultStatus) GetLastError() LastError {
+	if d.LastError == nil {
+		return nil
+	}
+	return d.LastError
+}
+
+// GetObservedGeneration implements Status.
+func (d *DefaultStatus) GetObservedGeneration() int64 {
+	return d.ObservedGeneration
+}

--- a/pkg/utils/flow/flow.go
+++ b/pkg/utils/flow/flow.go
@@ -244,7 +244,7 @@ func (e *execution) reportProgress() {
 
 func (e *execution) run(ctx context.Context) error {
 	defer close(e.done)
-	e.log.Infof("Starting flow")
+	e.log.Info("Starting")
 	e.reportProgress()
 
 	var (
@@ -272,7 +272,7 @@ func (e *execution) run(ctx context.Context) error {
 		e.reportProgress()
 	}
 
-	e.log.Infof("Finished flow")
+	e.log.Info("Finished")
 	return e.result(cancelErr)
 }
 

--- a/pkg/utils/kubernetes/health/health.go
+++ b/pkg/utils/kubernetes/health/health.go
@@ -19,6 +19,8 @@ import (
 	"net/http"
 	"time"
 
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
@@ -312,6 +314,38 @@ func CheckSeed(seed *gardenv1beta1.Seed, identity *gardenv1beta1.Gardener) error
 		}
 	}
 
+	return nil
+}
+
+// CheckExtensionObject checks if an extension Object is healthy or not.
+// An extension object is healthy if
+// * Its observed generation is up-to-date
+// * No gardener.cloud/operation is set
+// * No lastError is in the status
+// * A last operation is state succeeded is present
+func CheckExtensionObject(obj extensionsv1alpha1.Object) error {
+	status := obj.GetExtensionStatus()
+	if status.GetObservedGeneration() != obj.GetGeneration() {
+		return fmt.Errorf("observed generation outdated (%d/%d)", status.GetObservedGeneration(), obj.GetGeneration())
+	}
+
+	op, ok := obj.GetAnnotations()[gardencorev1alpha1.GardenerOperation]
+	if ok {
+		return fmt.Errorf("gardener operation %q is not yet picked up by extension controller", op)
+	}
+
+	if lastErr := status.GetLastError(); lastErr != nil {
+		return fmt.Errorf("extension encountered error during reconciliation: %s", lastErr.GetDescription())
+	}
+
+	lastOp := status.GetLastOperation()
+	if lastOp == nil {
+		return fmt.Errorf("extension did not record a last operation yet")
+	}
+
+	if lastOp.GetState() != gardencorev1alpha1.LastOperationStateSucceeded {
+		return fmt.Errorf("extension state is not succeeded but %v", lastOp.GetState())
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes Gardener add `gardener.cloud/operation: reconcile` for the following resources:
- controlplane
- extension
- infrastructure
- operatingsystemconfig
- worker

Extension controllers are supposed to only reconcile when `gardener.cloud/operation: reconcile` is set on the affected resource. With that in place, Gardener still controls the reconciliation of each piece in the Shoot control flow.

:warning: For local development you need to update your provider extension charts and use at least version `0.8.0-dev-a80ef643c64b327677572bf30398551d73f3468b`. We'll create a new release of the gardener-extensions repository before releasing gardener.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```action developer
In order to give Gardener control over *when* to reconcile shoot clusters it now annotates `ControlPlane`, `Extension`, `Infrastructure`, `OperatingSystemConfig` and `Worker` extension resources with `gardener.cloud/operation=reconcile`. Extension controllers must only react/reconcile their resources if this annotation is set. After they have picked up the event they should update the status to `Reconcile Processing` and remove the annotation. This only applies for extension resources that have to be reconciled. Those that are newly created or marked for deletion shall be operated on independent of the annotation set by Gardener. Also, you might want to take a look at [gardener/gardener-extensions#178](https://github.com/gardener/gardener-extensions/pull/178) or [this document](https://github.com/gardener/gardener/blob/master/docs/extensions/conventions.md).
```
```noteworthy operator
Gardener now instructs extension controllers when they are supposed to reconcile `ControlPlane`, `Extension`, `Infrastructure`, `OperatingSystemConfig` and `Worker` resources by annotating them with `gardener.cloud/operation=reconcile`.
```
