### PR TITLE
[WIP] Wait for managed resources to be cleaned up before deleting k8s api server

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_control_delete.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_delete.go
@@ -261,7 +261,7 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation) *gardencorev1alp
 		deleteKubeAPIServer = g.Add(flow.Task{
 			Name:         "Deleting Kubernetes API server",
 			Fn:           flow.TaskFn(botanist.DeleteKubeAPIServer).Retry(defaultInterval),
-			Dependencies: flow.NewTaskIDs(syncPointCleaned, waitUntilWorkerDeleted),
+			Dependencies: flow.NewTaskIDs(syncPointCleaned, waitUntilManagedResourcesDeleted),
 		})
 		destroyControlPlane = g.Add(flow.Task{
 			Name:         "Destroying Shoot control plane",


### PR DESCRIPTION
**What this PR does / why we need it**:

gardener should wait for managed resources to be removed before removing the kube api server

**Which issue(s) this PR fixes**:
Fixes #1154