### PR TITLE
Replace poll with retry methods with proper errors

### DIFF
--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -21,6 +21,8 @@ import (
 	"sort"
 	"strings"
 
+	errors2 "github.com/pkg/errors"
+
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -151,6 +153,13 @@ func (b *Botanist) RegisterAsSeed(protected, visible *bool, minimumVolumeSize *s
 		_, err = b.K8sGardenClient.Garden().GardenV1beta1().Seeds().Update(seed)
 	}
 	return err
+}
+
+func wrapWithLastError(err error, lastError *gardencorev1alpha1.LastError) error {
+	if err == nil || lastError == nil {
+		return err
+	}
+	return errors2.Wrapf(err, "last error: %s", lastError.Description)
 }
 
 // UnregisterAsSeed unregisters a Shoot cluster as a Seed in the Garden cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes some issues with the poll methods & gives us better errors in case a retrying operation fails.

**Special notes for your reviewer**:
cc @rfranzke 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
