### PR TITLE
Remove VPA Feature Gate

### DIFF
--- a/charts/seed-bootstrap/requirements.yaml
+++ b/charts/seed-bootstrap/requirements.yaml
@@ -12,7 +12,6 @@ dependencies:
 - name: vpa
   repository: http://localhost:10191
   version: 0.1.0
-  condition: vpa.enabled
 - name: global-network-policies
   repository: http://localhost:10191
   version: 0.1.0

--- a/charts/seed-bootstrap/templates/prometheus/prometheus-vpa.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/prometheus-vpa.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.vpa.enabled }}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
@@ -11,4 +10,3 @@ spec:
     name: prometheus
   updatePolicy:
     updateMode: "Auto"
-{{ end }}

--- a/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
@@ -60,13 +60,9 @@ spec:
           successThreshold: 1
           timeoutSeconds: 3
         resources:
-{{- if .Values.vpa.enabled }}
           requests:
             cpu: 30m
             memory: 500Mi
-{{- else }}
-{{- include "util-templates.resource-quantity" .Values.prometheus | indent 10 -}}
-{{ end }}
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -90,8 +90,5 @@ alertmanager:
   emailConfigs: []
   storage: 1Gi
 
-vpa:
-  enabled: true
-
 global-network-policies:
   denyAll: false

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-vpa.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-vpa.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.vpa.enabled }}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
@@ -11,4 +10,3 @@ spec:
     name: etcd-{{ .Values.role }}
   updatePolicy:
     updateMode: "Off"
-{{ end }}

--- a/charts/seed-controlplane/charts/etcd/values.yaml
+++ b/charts/seed-controlplane/charts/etcd/values.yaml
@@ -14,8 +14,5 @@ servicePorts:
   server: 2380
   backuprestore: 8080
 
-vpa:
-  enabled: true
-
 metrics: basic
 

--- a/charts/seed-controlplane/charts/gardener-resource-manager/templates/vpa.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/templates/vpa.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.vpa.enabled }}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
@@ -14,4 +13,3 @@ spec:
     name: gardener-resource-manager
   updatePolicy:
     updateMode: "Off"
-{{ end }}

--- a/charts/seed-controlplane/charts/gardener-resource-manager/values.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/values.yaml
@@ -9,9 +9,6 @@ resources:
     cpu: 400m
     memory: 512Mi
 
-vpa:
-  enabled: true
-
 replicas: 1
 syncPeriod: 1m0s
 concurrentSyncs: 20

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-vpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-vpa.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.vpa.enabled }}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
@@ -11,4 +10,3 @@ spec:
     name: kube-apiserver
   updatePolicy:
     updateMode: "Off"
-{{ end }}

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -77,6 +77,3 @@ targetAverageUtilization: 80
 
 auditConfig:
   auditPolicy: ""
-
-vpa:
-  enabled: true

--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager-vpa.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager-vpa.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.vpa.enabled }}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
@@ -11,4 +10,3 @@ spec:
     name: kube-controller-manager
   updatePolicy:
     updateMode: "Off"
-{{ end }}

--- a/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
@@ -42,6 +42,3 @@ resources:
       perObject: 50
       weight: 5
       unit: Mi
-
-vpa:
-  enabled: true

--- a/charts/seed-controlplane/charts/kube-scheduler/templates/kube-scheduler-vpa.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/templates/kube-scheduler-vpa.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.vpa.enabled }}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
@@ -11,4 +10,3 @@ spec:
     name: kube-scheduler
   updatePolicy:
     updateMode: "Off"
-{{ end }}

--- a/charts/seed-controlplane/charts/kube-scheduler/values.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/values.yaml
@@ -13,6 +13,3 @@ resources:
   limits:
     cpu: 400m
     memory: 512Mi
-
-vpa:
-  enabled: true

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-seed/templates/kube-state-metrics.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-seed/templates/kube-state-metrics.yaml
@@ -45,7 +45,6 @@ spec:
     component: kube-state-metrics
     type: seed
 ---
-{{ if .Values.vpa.enabled }}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
@@ -58,7 +57,6 @@ spec:
     name: kube-state-metrics-seed
   updatePolicy:
     updateMode: "Auto"
-{{ end }}
 ---
 apiVersion: {{ include "deploymentversion" . }}
 kind: Deployment
@@ -118,8 +116,3 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-{{ if not .Values.vpa.enabled }}
-          limits:
-            cpu: 50m
-            memory: 64Mi
-{{ end }}

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-seed/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-seed/values.yaml
@@ -1,5 +1,3 @@
 images:
   kube-state-metrics: image-repository:image-tag
 replicas: 1
-vpa:
-  enabled: true

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/kube-state-metrics.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/kube-state-metrics.yaml
@@ -17,7 +17,6 @@ spec:
     component: kube-state-metrics
     type: shoot
 ---
-{{ if .Values.vpa.enabled }}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
@@ -30,7 +29,6 @@ spec:
     name: kube-state-metrics
   updatePolicy:
     updateMode: "Auto"
-{{ end }}
 ---
 apiVersion: {{ include "deploymentversion" . }}
 kind: Deployment
@@ -95,11 +93,6 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
-{{ if not .Values.vpa.enabled }}
-          limits:
-            cpu: 50m
-            memory: 64Mi
-{{ end }}
       volumes:
       - name: kubeconfig
         secret:

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/values.yaml
@@ -1,5 +1,3 @@
 images:
   kube-state-metrics: image-repository:image-tag
 replicas: 1
-vpa:
-  enabled: true

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.vpa.enabled }}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
@@ -11,4 +10,3 @@ spec:
     name: prometheus
   updatePolicy:
     updateMode: "Auto"
-{{ end }}

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -114,13 +114,9 @@ spec:
           containerPort: 9090
           protocol: TCP
         resources:
-{{- if .Values.vpa.enabled }}
           requests:
             cpu: 30m
             memory: 500Mi
-{{- else }}
-{{- include "util-templates.resource-quantity" .Values | indent 10 -}}
-{{ end }}
         volumeMounts:
         - mountPath: /srv/kubernetes/prometheus-kubelet
           name: prometheus-kubelet

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -282,6 +282,3 @@ resources:
       perObject: 60
       weight: 5
       unit: Mi
-
-vpa:
-  enabled: true

--- a/charts/seed-monitoring/charts/core/values.yaml
+++ b/charts/seed-monitoring/charts/core/values.yaml
@@ -12,8 +12,6 @@ prometheus:
     prometheus: image-repository:image-tag
     configmap-reloader: image-repository:image-tag
     vpn-seed: image-repository:image-tag
-  vpa:
-    enabled: false
 kube-state-metrics-seed:
   replicas: 1
   images:

--- a/charts/seed-monitoring/values.yaml
+++ b/charts/seed-monitoring/values.yaml
@@ -12,8 +12,6 @@ prometheus:
     prometheus: image-repository:image-tag
     configmap-reloader: image-repository:image-tag
     vpn-seed: image-repository:image-tag
-  vpa:
-    enabled: false
 grafana:
   replicas: 1
   images:

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -74,4 +74,3 @@ shootBackup:
   schedule: "0 */24 * * *"
 featureGates:
   Logging: true
-  VPA: true

--- a/pkg/controllermanager/features/features.go
+++ b/pkg/controllermanager/features/features.go
@@ -24,7 +24,6 @@ var (
 	FeatureGate  = utilfeature.NewFeatureGate()
 	featureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
 		features.Logging: {Default: false, PreRelease: utilfeature.Alpha},
-		features.VPA:     {Default: false, PreRelease: utilfeature.Alpha},
 	}
 )
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -30,9 +30,4 @@ const (
 	// owner @mvladev, @ialidzhikov
 	// alpha: v0.13.0
 	Logging utilfeature.Feature = "Logging"
-
-	// VPA enables vertical pod autoscaling in Seed clusters.
-	// owner @wyb1
-	// alpha: v0.1.0
-	VPA utilfeature.Feature = "VPA"
 )

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -346,22 +346,13 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 				"apiserver": fmt.Sprintf("https://%s", b.Shoot.InternalClusterDomain),
 				"provider":  b.Shoot.CloudProvider,
 			},
-			"vpa": map[string]interface{}{
-				"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
-			},
 			"ignoreAlerts": b.Shoot.IgnoreAlerts,
 		}
 		kubeStateMetricsSeedConfig = map[string]interface{}{
 			"replicas": b.Shoot.GetReplicas(1),
-			"vpa": map[string]interface{}{
-				"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
-			},
 		}
 		kubeStateMetricsShootConfig = map[string]interface{}{
 			"replicas": b.Shoot.GetReplicas(1),
-			"vpa": map[string]interface{}{
-				"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
-			},
 		}
 	)
 

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -162,9 +162,6 @@ const (
 	// GardenRoleBackup is the value of GardenRole key indicating type 'backup'.
 	GardenRoleBackup = "backup"
 
-	// GardenRoleVpa is the value of GardenRole key indicating type 'vpa'.
-	GardenRoleVpa = "vpa"
-
 	// GardenCreatedBy is the key for an annotation of a Shoot cluster whose value indicates contains the username
 	// of the user that created the resource.
 	GardenCreatedBy = "garden.sapcloud.io/createdBy"

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -262,68 +262,6 @@ func ShouldObjectBeRemoved(obj metav1.Object, gracePeriod time.Duration) bool {
 	return deletionTimestamp.Time.Before(time.Now().Add(-gracePeriod))
 }
 
-// DeleteVpa delete all resources required for the vertical pod autoscaler in the given namespace.
-func DeleteVpa(k8sClient kubernetes.Interface, namespace string) error {
-	if k8sClient == nil {
-		return fmt.Errorf("require kubernetes client")
-	}
-
-	listOptions := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", GardenRole, GardenRoleVpa),
-	}
-
-	// Delete all Crds with label "garden.sapcloud.io/role=vpa"
-	if err := k8sClient.APIExtension().ApiextensionsV1beta1().CustomResourceDefinitions().DeleteCollection(
-		&metav1.DeleteOptions{}, listOptions); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	// Delete all Deployments with label "garden.sapcloud.io/role=vpa"
-	deletePropagation := metav1.DeletePropagationForeground
-	if err := k8sClient.Kubernetes().AppsV1().Deployments(namespace).DeleteCollection(
-		&metav1.DeleteOptions{
-			PropagationPolicy: &deletePropagation,
-		}, listOptions); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	// Delete all ClusterRoles with label "garden.sapcloud.io/role=vpa"
-	if err := k8sClient.Kubernetes().RbacV1().ClusterRoles().DeleteCollection(
-		&metav1.DeleteOptions{}, listOptions); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	// Delete all ClusterRoleBindings with label "garden.sapcloud.io/role=vpa"
-	if err := k8sClient.Kubernetes().RbacV1().ClusterRoleBindings().DeleteCollection(
-		&metav1.DeleteOptions{}, listOptions); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	// Delete all ServiceAccounts with label "garden.sapcloud.io/role=vpa"
-	if err := k8sClient.Kubernetes().CoreV1().ServiceAccounts(namespace).DeleteCollection(
-		&metav1.DeleteOptions{}, listOptions); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	// Delete vpa-exporter service
-	if err := k8sClient.Kubernetes().CoreV1().Services(namespace).Delete("vpa-exporter",
-		&metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	// Delete Service
-	if err := k8sClient.Client().Delete(context.TODO(), &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "vpa-webhook"}}); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	// Delete Secret
-	if err := k8sClient.Client().Delete(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "vpa-tls-certs"}}); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	return nil
-}
-
 // DeleteLoggingStack deletes all resource of the EFK logging stack in the given namespace.
 func DeleteLoggingStack(ctx context.Context, k8sClient client.Client, namespace string) error {
 	if k8sClient == nil {

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -21,8 +21,6 @@ import (
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	controllermanagerfeatures "github.com/gardener/gardener/pkg/controllermanager/features"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -139,9 +137,6 @@ func (b *HybridBotanist) DeployETCD() error {
 			"checksum/secret-etcd-ca":         b.CheckSums[gardencorev1alpha1.SecretNameCAETCD],
 			"checksum/secret-etcd-server-tls": b.CheckSums["etcd-server-tls"],
 			"checksum/secret-etcd-client-tls": b.CheckSums["etcd-client-tls"],
-		},
-		"vpa": map[string]interface{}{
-			"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
 		},
 		"storageCapacity": b.Seed.GetValidVolumeSize("10Gi"),
 	}
@@ -275,9 +270,6 @@ func (b *HybridBotanist) DeployKubeAPIServer() error {
 			"checksum/secret-service-account-key":       b.CheckSums["service-account-key"],
 			"checksum/secret-etcd-ca":                   b.CheckSums[gardencorev1alpha1.SecretNameCAETCD],
 			"checksum/secret-etcd-client-tls":           b.CheckSums["etcd-client-tls"],
-		},
-		"vpa": map[string]interface{}{
-			"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
 		},
 	}
 
@@ -456,9 +448,6 @@ func (b *HybridBotanist) DeployKubeControllerManager() error {
 			"checksum/secret-service-account-key":            b.CheckSums["service-account-key"],
 		},
 		"objectCount": b.Shoot.GetNodeCount(),
-		"vpa": map[string]interface{}{
-			"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
-		},
 	}
 
 	if b.Shoot.IsHibernated {
@@ -494,9 +483,6 @@ func (b *HybridBotanist) DeployKubeScheduler() error {
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-kube-scheduler":        b.CheckSums[common.KubeSchedulerDeploymentName],
 			"checksum/secret-kube-scheduler-server": b.CheckSums[common.KubeSchedulerServerName],
-		},
-		"vpa": map[string]interface{}{
-			"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
 		},
 	}
 

--- a/pkg/operation/hybridbotanist/resource_manager.go
+++ b/pkg/operation/hybridbotanist/resource_manager.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"path/filepath"
 
-	controllermanagerfeatures "github.com/gardener/gardener/pkg/controllermanager/features"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/operation/common"
 )
 
@@ -33,9 +31,6 @@ func (b *HybridBotanist) DeployGardenerResourceManager(ctx context.Context) erro
 			"checksum/secret-" + name: b.CheckSums[name],
 		},
 		"replicas": b.Shoot.GetReplicas(1),
-		"vpa": map[string]interface{}{
-			"enabled": controllermanagerfeatures.FeatureGate.Enabled(features.VPA),
-		},
 	}
 
 	values, err := b.InjectSeedShootImages(defaultValues, common.GardenerResourceManagerImageName)


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the VPA feature gate. The vpa will now always be deployed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```action operator
The `VPA` feature gate has been entirely removed. `VPA` components will now always be deployed. You have to remove the `VPA` feature gate from your gardener-controller-manager configuration after upgrading Gardener.
```
