### PR TITLE
Implement Extension accessor

### DIFF
--- a/pkg/api/extensions/accessor.go
+++ b/pkg/api/extensions/accessor.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Accessor tries to create an extensionsv1alpha1.Object from the given runtime.Object.
+//
+// If the given object already implements object, it is returned as-is.
+// If the object is unstructured, an unstructured accessor is returned that retrieves values
+// on a best-effort basis.
+// Otherwise, an error with the type of the object is returned.
+func Accessor(obj runtime.Object) (extensionsv1alpha1.Object, error) {
+	switch v := obj.(type) {
+	case extensionsv1alpha1.Object:
+		return v, nil
+	case *unstructured.Unstructured:
+		return UnstructuredAccessor(v), nil
+	default:
+		return nil, fmt.Errorf("value of type %T does not implement Object", obj)
+	}
+}
+
+// UnstructuredAccessor is an Object that retrieves values on a best-effort basis.
+// If values don't exist, it usually returns the zero value of them.
+func UnstructuredAccessor(u *unstructured.Unstructured) extensionsv1alpha1.Object {
+	return unstructuredAccessor{u}
+}
+
+type unstructuredAccessor struct {
+	*unstructured.Unstructured
+}
+
+type unstructuredStatusAccessor struct {
+	*unstructured.Unstructured
+}
+
+type unstructuredLastOperationAccessor struct {
+	*unstructured.Unstructured
+}
+
+type unstructuredSpecAccessor struct {
+	*unstructured.Unstructured
+}
+
+func nestedString(obj map[string]interface{}, fields ...string) string {
+	v, ok, err := unstructured.NestedString(obj, fields...)
+	if err != nil || !ok {
+		return ""
+	}
+	return v
+}
+
+func nestedInt(obj map[string]interface{}, fields ...string) int {
+	v, ok, err := unstructured.NestedFieldNoCopy(obj, fields...)
+	if err != nil || !ok {
+		return 0
+	}
+
+	switch x := v.(type) {
+	case int64:
+		return int(x)
+	case int32:
+		return int(x)
+	case int:
+		return x
+	default:
+		return 0
+	}
+}
+
+// GetDescription implements LastOperation.
+func (u unstructuredLastOperationAccessor) GetDescription() string {
+	return nestedString(u.UnstructuredContent(), "status", "lastOperation", "description")
+}
+
+// GetLastUpdateTime implements LastOperation.
+func (u unstructuredLastOperationAccessor) GetLastUpdateTime() metav1.Time {
+	var timestamp metav1.Time
+	_ = timestamp.UnmarshalQueryParameter(nestedString(u.UnstructuredContent(), "status", "lastOperation", "lastUpdateTime"))
+	return timestamp
+}
+
+// GetProgress implements LastOperation.
+func (u unstructuredLastOperationAccessor) GetProgress() int {
+	return nestedInt(u.UnstructuredContent(), "status", "lastOperation", "progress")
+}
+
+// GetState implements LastOperation.
+func (u unstructuredLastOperationAccessor) GetState() gardencorev1alpha1.LastOperationState {
+	return gardencorev1alpha1.LastOperationState(nestedString(u.UnstructuredContent(), "status", "lastOperation", "state"))
+}
+
+// GetType implements LastOperation.
+func (u unstructuredLastOperationAccessor) GetType() gardencorev1alpha1.LastOperationType {
+	return gardencorev1alpha1.LastOperationType(nestedString(u.UnstructuredContent(), "status", "lastOperation", "type"))
+}
+
+// GetExtensionType implements Spec.
+func (u unstructuredSpecAccessor) GetExtensionType() string {
+	return nestedString(u.UnstructuredContent(), "spec", "type")
+}
+
+// GetLastOperation implements Status.
+func (u unstructuredStatusAccessor) GetLastOperation() extensionsv1alpha1.LastOperation {
+	if _, ok, err := unstructured.NestedFieldNoCopy(u.UnstructuredContent(), "status", "lastOperation"); err != nil || !ok {
+		return nil
+	}
+	return unstructuredLastOperationAccessor{u.Unstructured}
+}
+
+// GetExtensionStatus implements Object.
+func (u unstructuredAccessor) GetExtensionStatus() extensionsv1alpha1.Status {
+	return unstructuredStatusAccessor{u.Unstructured}
+}
+
+// GetExtensionSpec implements Object.
+func (u unstructuredAccessor) GetExtensionSpec() extensionsv1alpha1.Spec {
+	return unstructuredSpecAccessor{u.Unstructured}
+}

--- a/pkg/api/extensions/accessor_test.go
+++ b/pkg/api/extensions/accessor_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	"time"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	extensionsinstall "github.com/gardener/gardener/pkg/apis/extensions/install"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	scheme *runtime.Scheme
+)
+
+func init() {
+	scheme = runtime.NewScheme()
+	extensionsinstall.Install(scheme)
+}
+
+func mkUnstructuredAccessor(obj extensionsv1alpha1.Object) extensionsv1alpha1.Object {
+	u := &unstructured.Unstructured{}
+	Expect(scheme.Convert(obj, u, nil)).To(Succeed())
+	return UnstructuredAccessor(u)
+}
+
+func mkUnstructuredAccessorWithSpec(spec extensionsv1alpha1.DefaultSpec) extensionsv1alpha1.Spec {
+	return mkUnstructuredAccessor(&extensionsv1alpha1.Infrastructure{Spec: extensionsv1alpha1.InfrastructureSpec{DefaultSpec: spec}}).GetExtensionSpec()
+}
+
+func mkUnstructuredAccessorWithStatus(status extensionsv1alpha1.DefaultStatus) extensionsv1alpha1.Status {
+	return mkUnstructuredAccessor(&extensionsv1alpha1.Infrastructure{Status: extensionsv1alpha1.InfrastructureStatus{DefaultStatus: status}}).GetExtensionStatus()
+}
+
+func mkUnstructuredAccessorWithLastOperation(lastOperation *gardencorev1alpha1.LastOperation) extensionsv1alpha1.LastOperation {
+	return mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{LastOperation: lastOperation}).GetLastOperation()
+}
+
+var _ = Describe("Accessor", func() {
+	Describe("#Accessor", func() {
+		It("should create an accessor for extensions", func() {
+			extension := &extensionsv1alpha1.Infrastructure{}
+			acc, err := Accessor(extension)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(acc).To(BeIdenticalTo(extension))
+		})
+
+		It("should create an unstructured accessor for unstructures", func() {
+			u := &unstructured.Unstructured{}
+			acc, err := Accessor(u)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(acc).To(Equal(UnstructuredAccessor(u)))
+		})
+
+		It("should error for other objects", func() {
+			_, err := Accessor(&corev1.ConfigMap{})
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("#UnstructuredAccessor", func() {
+		Context("#GetExtensionSpec", func() {
+			Describe("#GetExtensionType", func() {
+				It("should get the extension type", func() {
+					var (
+						t   = "foo"
+						acc = mkUnstructuredAccessorWithSpec(extensionsv1alpha1.DefaultSpec{Type: t})
+					)
+
+					Expect(acc.GetExtensionType()).To(Equal(t))
+				})
+			})
+		})
+
+		Context("#GetExtensionStatus", func() {
+			Context("#GetLastOperation", func() {
+				Describe("#GetDescription", func() {
+					It("should get the description", func() {
+						var (
+							desc = "desc"
+							acc  = mkUnstructuredAccessorWithLastOperation(&gardencorev1alpha1.LastOperation{Description: desc})
+						)
+
+						Expect(acc.GetDescription()).To(Equal(desc))
+					})
+				})
+
+				Describe("#GetLastUpdateTime", func() {
+					It("should get the last update time", func() {
+						var (
+							t   = metav1.NewTime(time.Unix(50, 0))
+							acc = mkUnstructuredAccessorWithLastOperation(&gardencorev1alpha1.LastOperation{LastUpdateTime: t})
+						)
+
+						Expect(acc.GetLastUpdateTime()).To(Equal(t))
+					})
+				})
+
+				Describe("#GetProgress", func() {
+					It("should get the progress", func() {
+						var (
+							progress = 10
+							acc      = mkUnstructuredAccessorWithLastOperation(&gardencorev1alpha1.LastOperation{Progress: progress})
+						)
+
+						Expect(acc.GetProgress()).To(Equal(progress))
+					})
+				})
+
+				Describe("#GetState", func() {
+					It("should get the state", func() {
+						var (
+							state = gardencorev1alpha1.LastOperationStateSucceeded
+							acc   = mkUnstructuredAccessorWithLastOperation(&gardencorev1alpha1.LastOperation{State: state})
+						)
+
+						Expect(acc.GetState()).To(Equal(state))
+					})
+				})
+
+				Describe("#GetType", func() {
+					It("should get the type", func() {
+						var (
+							t   = gardencorev1alpha1.LastOperationTypeReconcile
+							acc = mkUnstructuredAccessorWithLastOperation(&gardencorev1alpha1.LastOperation{Type: t})
+						)
+
+						Expect(acc.GetType()).To(Equal(t))
+					})
+				})
+			})
+		})
+	})
+})

--- a/pkg/api/extensions/extensions_suite_test.go
+++ b/pkg/api/extensions/extensions_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestExtensions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Extensions Suite")
+}

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -86,3 +86,28 @@ type LastOperation struct {
 	// Type of the last operation, one of Create, Reconcile, Delete.
 	Type LastOperationType `json:"type"`
 }
+
+// GetDescription implements LastOperation.
+func (l *LastOperation) GetDescription() string {
+	return l.Description
+}
+
+// GetLastUpdateTime implements LastOperation.
+func (l *LastOperation) GetLastUpdateTime() metav1.Time {
+	return l.LastUpdateTime
+}
+
+// GetProgress implements LastOperation.
+func (l *LastOperation) GetProgress() int {
+	return l.Progress
+}
+
+// GetState implements LastOperation.
+func (l *LastOperation) GetState() LastOperationState {
+	return l.State
+}
+
+// GetType implements LastOperation.
+func (l *LastOperation) GetType() LastOperationType {
+	return l.Type
+}

--- a/pkg/apis/extensions/install/install.go
+++ b/pkg/apis/extensions/install/install.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+var (
+	schemeBuilder = runtime.NewSchemeBuilder(
+		v1alpha1.AddToScheme,
+	)
+
+	// AddToScheme adds all extension types to the given Scheme.
+	AddToScheme = schemeBuilder.AddToScheme
+)
+
+// Install installs all extension types into the given Scheme. It panics if there is an error.
+func Install(scheme *runtime.Scheme) {
+	utilruntime.Must(AddToScheme(scheme))
+}

--- a/pkg/apis/extensions/v1alpha1/register.go
+++ b/pkg/apis/extensions/v1alpha1/register.go
@@ -65,8 +65,3 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }
-
-// ExtensionType is an interface for Gardener extensions API types.
-type ExtensionType interface {
-	GetExtensionType() string
-}

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Status is the status of an Object.
+type Status interface {
+	// GetLastOperation retrieves the LastOperation of a status.
+	// LastOperation may be nil.
+	GetLastOperation() LastOperation
+}
+
+// LastOperation is the last operation on an object.
+type LastOperation interface {
+	// GetDescription returns the description of the last operation.
+	GetDescription() string
+	// GetLastUpdateTime returns the last update time of the last operation.
+	GetLastUpdateTime() metav1.Time
+	// GetProgress returns progress of the last operation.
+	GetProgress() int
+	// GetState returns the LastOperationState of the last operation.
+	GetState() gardencorev1alpha1.LastOperationState
+	// GetType returns the LastOperationType of the last operation.
+	GetType() gardencorev1alpha1.LastOperationType
+}
+
+// Spec is the spec section of an Object.
+type Spec interface {
+	// GetExtensionType retrieves the extension type.
+	GetExtensionType() string
+}
+
+// Object is an extension object resource.
+type Object interface {
+	// GetExtensionStatus retrieves the object's status.
+	GetExtensionStatus() Status
+	// GetExtensionSpec retrieves the object's spec.
+	GetExtensionSpec() Spec
+}

--- a/pkg/apis/extensions/v1alpha1/types_backupbucket.go
+++ b/pkg/apis/extensions/v1alpha1/types_backupbucket.go
@@ -19,6 +19,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var _ Object = (*BackupBucket)(nil)
+
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -33,9 +35,14 @@ type BackupBucket struct {
 	Status BackupBucketStatus `json:"status"`
 }
 
-// GetExtensionType returns the type of this BackupBucket resource.
-func (i *BackupBucket) GetExtensionType() string {
-	return i.Spec.Type
+// GetExtensionSpec implements Object.
+func (i *BackupBucket) GetExtensionSpec() Spec {
+	return &i.Spec
+}
+
+// GetExtensionStatus implements Object.
+func (i *BackupBucket) GetExtensionStatus() Status {
+	return &i.Status
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/extensions/v1alpha1/types_backupentry.go
+++ b/pkg/apis/extensions/v1alpha1/types_backupentry.go
@@ -19,6 +19,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var _ Object = (*BackupEntry)(nil)
+
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -33,9 +35,14 @@ type BackupEntry struct {
 	Status BackupEntryStatus `json:"status"`
 }
 
-// GetExtensionType returns the type of this BackupEntry resource.
-func (i *BackupEntry) GetExtensionType() string {
-	return i.Spec.Type
+// GetExtensionSpec implements Object.
+func (i *BackupEntry) GetExtensionSpec() Spec {
+	return &i.Spec
+}
+
+// GetExtensionStatus implements Object.
+func (i *BackupEntry) GetExtensionStatus() Status {
+	return &i.Status
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/extensions/v1alpha1/types_controlplane.go
+++ b/pkg/apis/extensions/v1alpha1/types_controlplane.go
@@ -20,6 +20,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+var _ Object = (*ControlPlane)(nil)
+
 // ControlPlaneResource is a constant for the name of the ControlPlane resource.
 const ControlPlaneResource = "ControlPlane"
 
@@ -33,6 +35,16 @@ type ControlPlane struct {
 
 	Spec   ControlPlaneSpec   `json:"spec"`
 	Status ControlPlaneStatus `json:"status"`
+}
+
+// GetExtensionSpec implements Object.
+func (i *ControlPlane) GetExtensionSpec() Spec {
+	return &i.Spec
+}
+
+// GetExtensionStatus implements Object.
+func (i *ControlPlane) GetExtensionStatus() Status {
+	return &i.Status
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/extensions/v1alpha1/types_defaults.go
+++ b/pkg/apis/extensions/v1alpha1/types_defaults.go
@@ -22,6 +22,11 @@ type DefaultSpec struct {
 	Type string `json:"type"`
 }
 
+// GetExtensionType implements Spec.
+func (d *DefaultSpec) GetExtensionType() string {
+	return d.Type
+}
+
 // DefaultStatus contains common status fields for every extension resource.
 type DefaultStatus struct {
 	// Conditions represents the latest available observations of a Seed's current state.
@@ -37,4 +42,9 @@ type DefaultStatus struct {
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// State can be filled by the operating controller with what ever data it needs.
 	State string `json:"state,omitempty"`
+}
+
+// GetLastOperation implements Status.
+func (d *DefaultStatus) GetLastOperation() LastOperation {
+	return d.LastOperation
 }

--- a/pkg/apis/extensions/v1alpha1/types_extension.go
+++ b/pkg/apis/extensions/v1alpha1/types_extension.go
@@ -19,6 +19,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+var _ Object = (*Extension)(nil)
+
 // ExtensionResource is a constant for the name of the Extension resource.
 const ExtensionResource = "Extension"
 
@@ -35,9 +37,14 @@ type Extension struct {
 	Status ExtensionStatus `json:"status"`
 }
 
-// GetExtensionType returns the type of this Extension resource.
-func (g *Extension) GetExtensionType() string {
-	return g.Spec.Type
+// GetExtensionSpec implements Object.
+func (i *Extension) GetExtensionSpec() Spec {
+	return &i.Spec
+}
+
+// GetExtensionStatus implements Object.
+func (i *Extension) GetExtensionStatus() Status {
+	return &i.Status
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/extensions/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/extensions/v1alpha1/types_infrastructure.go
@@ -20,6 +20,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+var _ Object = (*Infrastructure)(nil)
+
 // InfrastructureResource is a constant for the name of the Infrastructure resource.
 const InfrastructureResource = "Infrastructure"
 
@@ -36,9 +38,14 @@ type Infrastructure struct {
 	Status InfrastructureStatus `json:"status"`
 }
 
-// GetExtensionType returns the type of this Infrastructure resource.
-func (i *Infrastructure) GetExtensionType() string {
-	return i.Spec.Type
+// GetExtensionSpec implements Object.
+func (i *Infrastructure) GetExtensionSpec() Spec {
+	return &i.Spec
+}
+
+// GetExtensionStatus implements Object.
+func (i *Infrastructure) GetExtensionStatus() Status {
+	return &i.Status
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/extensions/v1alpha1/types_network.go
+++ b/pkg/apis/extensions/v1alpha1/types_network.go
@@ -19,6 +19,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+var _ Object = (*Network)(nil)
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -30,6 +32,16 @@ type Network struct {
 
 	Spec   NetworkSpec   `json:"spec"`
 	Status NetworkStatus `json:"status"`
+}
+
+// GetExtensionSpec implements Object.
+func (i *Network) GetExtensionSpec() Spec {
+	return &i.Spec
+}
+
+// GetExtensionStatus implements Object.
+func (i *Network) GetExtensionStatus() Status {
+	return &i.Status
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -19,6 +19,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var _ Object = (*OperatingSystemConfig)(nil)
+
 // OperatingSystemConfigResource is a constant for the name of the OperatingSystemConfig resource.
 const OperatingSystemConfigResource = "OperatingSystemConfig"
 
@@ -35,9 +37,14 @@ type OperatingSystemConfig struct {
 	Status OperatingSystemConfigStatus `json:"status"`
 }
 
-// GetExtensionType returns the type of this OperatingSystemConfig resource.
-func (o *OperatingSystemConfig) GetExtensionType() string {
-	return o.Spec.Type
+// GetExtensionSpec implements Object.
+func (o *OperatingSystemConfig) GetExtensionSpec() Spec {
+	return &o.Spec
+}
+
+// GetExtensionStatus implements Object.
+func (o *OperatingSystemConfig) GetExtensionStatus() Status {
+	return &o.Status
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -21,6 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+var _ Object = (*Worker)(nil)
+
 // WorkerResource is a constant for the name of the Worker resource.
 const WorkerResource = "Worker"
 
@@ -37,9 +39,14 @@ type Worker struct {
 	Status WorkerStatus `json:"status"`
 }
 
-// GetExtensionType returns the type of this Worker resource.
-func (w *Worker) GetExtensionType() string {
-	return w.Spec.Type
+// GetExtensionSpec implements Object.
+func (i *Worker) GetExtensionSpec() Spec {
+	return &i.Spec
+}
+
+// GetExtensionStatus implements Object.
+func (i *Worker) GetExtensionStatus() Status {
+	return &i.Status
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controllermanager/controller/controllerinstallation/controllerinstallation_control.go
+++ b/pkg/controllermanager/controller/controllerinstallation/controllerinstallation_control.go
@@ -433,7 +433,7 @@ func (c *defaultControllerInstallationControl) cleanOldExtensions(ctx context.Co
 			continue
 		}
 		for _, item := range objList.Items {
-			if res.Type != item.GetExtensionType() {
+			if res.Type != item.Spec.Type {
 				continue
 			}
 			delFunc := func(ctx context.Context) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Implement an extension object accessor that can be used to define common operations over all extensions.

**Special notes for your reviewer**:
cc @rfranzke @timuthy 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
