### PR TITLE
Adapt container requests based on VPA recommendations

### DIFF
--- a/charts/seed-controlplane/charts/gardener-resource-manager/values.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/values.yaml
@@ -3,8 +3,8 @@ images:
 
 resources:
   requests:
-    cpu: 100m
-    memory: 32Mi
+    cpu: 23m
+    memory: 47Mi
   limits:
     cpu: 400m
     memory: 512Mi

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
@@ -181,8 +181,8 @@ spec:
           protocol: TCP
         resources:
           requests:
-            cpu: 100m
-            memory: 128Mi
+            cpu: 11m
+            memory: 16Mi
           limits:
             cpu: 300m
             memory: 512Mi

--- a/charts/seed-controlplane/charts/kube-scheduler/values.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/values.yaml
@@ -8,8 +8,8 @@ images:
   hyperkube: image-repository
 resources:
   requests:
-    cpu: 100m
-    memory: 32Mi
+    cpu: 23m
+    memory: 64Mi
   limits:
     cpu: 400m
     memory: 512Mi

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -115,8 +115,8 @@ spec:
           protocol: TCP
         resources:
           requests:
-            cpu: 30m
-            memory: 500Mi
+            cpu: 50m
+            memory: 350Mi
         volumeMounts:
         - mountPath: /srv/kubernetes/prometheus-kubelet
           name: prometheus-kubelet
@@ -148,8 +148,8 @@ spec:
           protocol: TCP
         resources:
           requests:
-            cpu: 100m
-            memory: 128Mi
+            cpu: 11m
+            memory: 16Mi
           limits:
             cpu: 300m
             memory: 512Mi
@@ -180,7 +180,7 @@ spec:
         resources:
           requests:
             cpu: 5m
-            memory: 16Mi
+            memory: 35Mi
           limits:
             cpu: 50m
             memory: 128Mi


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to better utilize the Seed nodes and thus also save costs, the pods of the Shoot control plane should only request the resources they really need.
Based on the evaluation of the VPA recommendations for all Shoots on our Canary and Live landscape over a few weeks, the new values reflects the average CPU and memory recommendations for the gardener-resource-manager, kube-apiserver/vpn-seed, kube-scheduler and prometheus pods/containers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```NONE```
