### PR TITLE
Add monitoring for seed

### DIFF
--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/allow-elasticsearch-network-policy.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/allow-elasticsearch-network-policy.yaml
@@ -25,10 +25,19 @@ spec:
           role: garden
     - podSelector:
         matchLabels:
+          app: aggregate-prometheus
+          role: monitoring
+      namespaceSelector:
+        matchLabels:
+          role: garden
+    - podSelector:
+        matchLabels:
           networking.gardener.cloud/to-elasticsearch: allowed
     ports:
     - protocol: TCP
       port: {{ .Values.global.elasticsearchPorts.db }}
+    - protocol: TCP
+      port: {{ .Values.global.elasticsearchPorts.metricsExporter }}
   policyTypes:
   - Ingress
   egress: []

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/allow-to-elasticsearch-network-policy.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/allow-to-elasticsearch-network-policy.yaml
@@ -21,6 +21,8 @@ spec:
     ports:
     - protocol: TCP
       port: {{ .Values.global.elasticsearchPorts.db }}
+    - protocol: TCP
+      port: {{ .Values.global.elasticsearchPorts.metricsExporter }}
   policyTypes:
   - Egress
   ingress: []

--- a/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
+++ b/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
@@ -1,0 +1,8 @@
+groups:
+- name: recording-rules.rules
+  rules:
+  - record: seed:container_cpu_usage_seconds_total:sum_rate_by_pod
+    expr: sum(rate(container_cpu_usage_seconds_total[5m])) by (pod_name)
+
+  - record: seed:container_memory_working_set_bytes:sum_by_pod
+    expr: sum(container_memory_working_set_bytes) by (pod_name)

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/_helpers.tpl
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/_helpers.tpl
@@ -1,0 +1,6 @@
+{{- define "prometheus.keep-metrics.metric-relabel-config" -}}
+- source_labels: [ __name__ ]
+  regex: ^({{ . | join "|" }})$
+  action: keep
+{{- end -}}
+

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/clusterrolebinding.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: aggregate-prometheus
+    role: monitoring
+  name: aggregate-prometheus
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: aggregate-prometheus
+    namespace: {{ .Release.Namespace }}

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aggregate-prometheus-config
+  namespace: {{ .Release.Namespace }}
+data:
+  prometheus.yaml: |
+
+    global:
+      evaluation_interval: 30s
+      scrape_interval: 30s
+      external_labels:
+        seed: seed
+
+    scrape_configs:
+    - job_name: shoot-prometheus
+      metrics_path: /federate
+      params:
+        'match[]':
+        - '{__name__="probe_success", job="blackbox-exporter-k8s-service-check"}'
+        - '{__name__="shoot:kube_apiserver:sum_by_pod"}'
+        - '{__name__="shoot:kube_node_info:count"}'
+        - '{__name__="ALERTS"}'
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_namespace
+        - __meta_kubernetes_endpoints_name
+        - __meta_kubernetes_endpoint_port_name
+        regex: shoot-(.+);prometheus-web;metrics
+        action: keep
+
+    - job_name: prometheus
+      metrics_path: /federate
+      params:
+        'match[]':
+        - '{__name__="seed:container_cpu_usage_seconds_total:sum_rate_by_pod"}'
+        - '{__name__="seed:container_memory_working_set_bytes:sum_by_pod"}'
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_namespace
+        - __meta_kubernetes_endpoints_name
+        - __meta_kubernetes_endpoint_port_name
+        regex: garden;prometheus-web;web
+        action: keep
+
+    - job_name: alertmanager
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [{{ .Release.Namespace }}]
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_endpoints_name
+        - __meta_kubernetes_endpoint_port_name
+        regex: alertmanager;cluster
+        action: keep
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.alertmanager | indent 6 }}
+      - source_labels: [ namespace ]
+        action: keep
+        regex: ^{{ .Release.Namespace }}$
+
+    - job_name: elasticsearch-logging
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [{{ .Release.Namespace }}]
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_endpoints_name
+        - __meta_kubernetes_endpoint_port_name
+        regex: elasticsearch-logging;metrics
+        action: keep
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.elasticsearch | indent 6 }}
+      - source_labels: [ namespace ]
+        action: keep
+        regex: ^{{ .Release.Namespace }}$

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/service.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: aggregate-prometheus-web
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: prometheus
+    role: monitoring
+spec:
+  ports:
+  - name: web
+    port: 80
+    protocol: TCP
+    targetPort: {{ .Values.prometheus.port }}
+  selector:
+    app: aggregate-prometheus
+    role: monitoring
+  type: ClusterIP

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/serviceaccount.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aggregate-prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: aggregate-prometheus
+    role: monitoring

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/statefulset.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/statefulset.yaml
@@ -1,41 +1,39 @@
 apiVersion: {{ include "statefulsetversion" . }}
 kind: StatefulSet
 metadata:
-  name: prometheus
+  name: aggregate-prometheus
   namespace: {{ .Release.Namespace }}
   labels:
-    app: prometheus
+    app: aggregate-prometheus
     role: monitoring
 spec:
   updateStrategy:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: prometheus
+      app: aggregate-prometheus
       role: monitoring
-  serviceName: prometheus
+  serviceName: aggregate-prometheus
   template:
     metadata:
       labels:
-        app: prometheus
+        app: aggregate-prometheus
         role: monitoring
     spec:
       # used to talk to Seed's API server.
-      serviceAccountName: prometheus
+      serviceAccountName: aggregate-prometheus
       containers:
       - name: prometheus
         image: {{ index .Values.global.images "prometheus" }}
         imagePullPolicy: IfNotPresent
-        command: ["/bin/sh","-c"]
         args:
-          - rm -rf /var/prometheus/data/*; /bin/prometheus
-            --config.file=/etc/prometheus/config/prometheus.yaml
-            --storage.tsdb.path=/var/prometheus/data
-            --storage.tsdb.no-lockfile
-            --storage.tsdb.retention.time=2h
-            --storage.tsdb.retention.size=1GB
-            --web.listen-address=0.0.0.0:{{ .Values.prometheus.port }}
-            --web.enable-lifecycle
+          - --config.file=/etc/prometheus/config/prometheus.yaml
+          - --storage.tsdb.path=/var/prometheus/data
+          - --storage.tsdb.no-lockfile
+          - --storage.tsdb.retention.time=2w
+          - --web.enable-admin-api
+          - --web.listen-address=0.0.0.0:{{ .Values.aggregatePrometheus.port }}
+          - --web.enable-lifecycle
         # Since v2.0.0-beta.3 prometheus runs as nobody user (fsGroup 65534/runAsUser 0)
         # data volume needs to be mounted with the same permissions,
         # otherwise we will have Permission denied problems
@@ -44,7 +42,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /-/healthy
-            port: {{ .Values.prometheus.port }}
+            port: {{ .Values.aggregatePrometheus.port }}
             scheme: HTTP
           failureThreshold: 60
           periodSeconds: 5
@@ -53,7 +51,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /-/ready
-            port: {{ .Values.prometheus.port }}
+            port: {{ .Values.aggregatePrometheus.port }}
             scheme: HTTP
           failureThreshold: 120
           periodSeconds: 5
@@ -67,9 +65,6 @@ spec:
         - mountPath: /etc/prometheus/config
           name: config
           readOnly: true
-        - mountPath: /etc/prometheus/rules
-          name: rules
-          readOnly: true
         - mountPath: /var/prometheus/data
           name: prometheus-db
           subPath: prometheus-
@@ -77,9 +72,8 @@ spec:
         image: {{ index .Values.global.images "configmap-reloader" }}
         imagePullPolicy: IfNotPresent
         args:
-        - -webhook-url=http://localhost:{{ .Values.prometheus.port }}/-/reload
+        - -webhook-url=http://localhost:{{ .Values.aggregatePrometheus.port }}/-/reload
         - -volume-dir=/etc/prometheus/config
-        - -volume-dir=/etc/prometheus/rules
         resources:
           requests:
             cpu: 5m
@@ -91,19 +85,12 @@ spec:
         - mountPath: /etc/prometheus/config
           name: config
           readOnly: true
-        - mountPath: /etc/prometheus/rules
-          name: rules
-          readOnly: true
       terminationGracePeriodSeconds: 300
       volumes:
       - name: config
         configMap:
           defaultMode: 420
-          name: prometheus-config
-      - name: rules
-        configMap:
-          defaultMode: 420
-          name: prometheus-rules
+          name: aggregate-prometheus-config
   volumeClaimTemplates:
   - metadata:
       name: prometheus-db
@@ -112,4 +99,4 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: {{ .Values.prometheus.storage }}
+          storage: {{ .Values.aggregatePrometheus.storage }}

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/vpa.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/vpa.yaml
@@ -1,0 +1,14 @@
+{{ if .Values.vpa.enabled }}
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: aggregate-prometheus-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRef:
+    apiVersion: {{ include "statefulsetversion" . }}
+    kind: StatefulSet
+    name: aggregate-prometheus
+  updatePolicy:
+    updateMode: "Auto"
+{{ end }}

--- a/charts/seed-bootstrap/templates/prometheus/rules.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/rules.yaml
@@ -3,4 +3,5 @@ kind: ConfigMap
 metadata:
   name: prometheus-rules
   namespace: {{ .Release.Namespace }}
-data: {}
+data:
+{{ (.Files.Glob "prometheus-rules/**").AsConfig | indent 2 }}

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -2,37 +2,14 @@ cloudProvider: aws
 
 prometheus:
   port: 9090
-  # object can be any object you want to scale Prometheus on:
-  # - number of Pods
-  # - number of Nodes
-  # - total Foos
-  objectCount: 4
   storage: 10Gi
-  resources:
-    requests:
-      cpu:
-        base: 100
-        perObject: 4
-        weight: 5
-        unit: m
-      memory:
-        base: 150
-        perObject: 18
-        weight: 5
-        unit: Mi
-    limits:
-      cpu:
-        base: 150
-        perObject: 8
-        weight: 5
-        unit: m
-      memory:
-        base: 200
-        perObject: 64
-        weight: 5
-        unit: Mi
+
+aggregatePrometheus:
+  port: 9090
+  storage: 20Gi
 
 allowedMetrics:
+  alertmanager: []
   cAdvisor:
   - container_cpu_cfs_periods_total
   - container_cpu_usage_seconds_total
@@ -45,6 +22,7 @@ allowedMetrics:
   - container_memory_working_set_bytes
   - container_network_receive_bytes_total
   - container_network_transmit_bytes_total
+  elasticsearch: []
   kubelet:
   - kubelet_volume_stats_available_bytes
   - kubelet_volume_stats_capacity_bytes

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/apiserver-connectivity-check.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/apiserver-connectivity-check.rules.yaml
@@ -1,14 +1,14 @@
 groups:
   - name: apiserver-connectivity-check.rules
     rules:
-      - alert: ApiServerUnreachableViaKubernetesService
-        expr: probe_success{job="blackbox-exporter-k8s-service-check"} != 1
-        for: 15m
-        labels:
-          service: apiserver-connectivity-check
-          severity: critical
-          type: shoot
-          visibility: all
-        annotations:
-          summary: Api server unreachable via the kubernetes service.
-          description: The Api server has been unreachable for 3 minutes via the kubernetes service in the shoot.
+    - alert: ApiServerUnreachableViaKubernetesService
+      expr: probe_success{job="blackbox-exporter-k8s-service-check"} != 1
+      for: 15m
+      labels:
+        service: apiserver-connectivity-check
+        severity: critical
+        type: shoot
+        visibility: all
+      annotations:
+        summary: Api server unreachable via the kubernetes service.
+        description: The Api server has been unreachable for 3 minutes via the kubernetes service in the shoot.

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-apiserver.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-apiserver.rules.yaml
@@ -83,3 +83,6 @@ groups:
     annotations:
         description: 'The API servers cumulative failure rate in logging audit events is {{ printf "%0.2f" $value }}%. This may be caused by an unavailable/unreachable audisink(s) and/or improper API server audit configuration.'
         summary: 'The API server has too many failed attempts to log audit events'
+
+  - record: shoot:kube_apiserver:sum_by_pod
+    expr: sum(up{job="kube-apiserver"}) by (pod)

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -65,3 +65,6 @@ groups:
       description: Etcd3 pod {{ $labels.pod }} has seen {{ $value }} proposal failures
         within the last hour.
       summary: High number of failed etcd proposals
+
+  - record: shoot:etcd_object_counts:sum_by_resource
+    expr: sum(etcd_object_counts) by (resource)

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
@@ -76,3 +76,6 @@ groups:
     annotations:
       description: The nf_conntrack table is {{ $value }}% full.
       summary: Number of tracked connections is near the limit
+
+  - record: shoot:kube_node_info:count
+    expr: count(kube_node_info{type="shoot"})

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-prometheus-network-policy.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-prometheus-network-policy.yaml
@@ -56,6 +56,13 @@ spec:
       namespaceSelector:
         matchLabels:
           role: kube-system
+    - podSelector:
+        matchLabels:
+          app: aggregate-prometheus
+          role: monitoring
+      namespaceSelector:
+        matchLabels:
+          role: garden
   policyTypes:
   - Egress
   - Ingress

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -411,8 +411,10 @@ func BootstrapCluster(seed *Seed, secrets map[string]*corev1.Secret, imageVector
 			"reserve-excess-capacity": DesiredExcessCapacity(numberOfAssociatedShoots),
 		},
 		"prometheus": map[string]interface{}{
-			"objectCount": nodeCount,
-			"storage":     seed.GetValidVolumeSize("10Gi"),
+			"storage": seed.GetValidVolumeSize("10Gi"),
+		},
+		"aggregatePrometheus": map[string]interface{}{
+			"storage": seed.GetValidVolumeSize("20Gi"),
 		},
 		"elastic-kibana-curator": map[string]interface{}{
 			"enabled": loggingEnabled,


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds monitoring for the seed cluster. Components running in the `garden` namespace can now be monitored using this new prometheus. Additionally, this new prometheus aggregates data from each shoot on the seed. The following data is aggregated:
* API Server availability
* Number of API Servers per shoot
* Number of nodes per shoot
* Alerts
* Control Plane CPU/Memory usage

This PR is the first step for a "global" aggregated view of the entire landscape.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
A second prometheus was added in the `garden` namespace instead of using the existing one because they have different roles. This will allow us to be more flexible in the future.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Components running in the `garden` namespace can now be monitored using the `seed-prometheus`.
```
```improvement operator
Shoot metrics are now aggregated in each seed in the `seed-prometheus`.
```
