### PR TITLE
Make Pod executor a separate package

### DIFF
--- a/pkg/client/kubernetes/pods.go
+++ b/pkg/client/kubernetes/pods.go
@@ -15,82 +15,19 @@
 package kubernetes
 
 import (
-	"bytes"
-	"context"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gardener/gardener/pkg/utils"
-
 	corev1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
-	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/transport/spdy"
 )
-
-// NewPodExecutor returns a podExecutor
-func NewPodExecutor(config *rest.Config) PodExecutor {
-	return &podExecutor{
-		config: config,
-	}
-}
-
-// PodExecutor is the pod executor interface
-type PodExecutor interface {
-	Execute(ctx context.Context, namespace, name, containerName, command string) (io.Reader, error)
-}
-
-type podExecutor struct {
-	config *rest.Config
-}
-
-// Execute executes a command on a pod
-func (p *podExecutor) Execute(ctx context.Context, namespace, name, containerName, command string) (io.Reader, error) {
-	client, err := corev1client.NewForConfig(p.config)
-	if err != nil {
-		return nil, err
-	}
-
-	var stdout, stderr bytes.Buffer
-	request := client.RESTClient().
-		Post().
-		Resource("pods").
-		Name(name).
-		Namespace(namespace).
-		SubResource("exec").
-		Param("container", containerName).
-		Param("command", "/bin/sh").
-		Param("stdin", "true").
-		Param("stdout", "true").
-		Param("stderr", "true").
-		Param("tty", "false").
-		Context(ctx)
-
-	executor, err := remotecommand.NewSPDYExecutor(p.config, http.MethodPost, request.URL())
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialized the command exector: %v", err)
-	}
-
-	err = executor.Stream(remotecommand.StreamOptions{
-		Stdin:  strings.NewReader(command),
-		Stdout: &stdout,
-		Stderr: &stderr,
-		Tty:    false,
-	})
-	if err != nil {
-		return &stderr, err
-	}
-
-	return &stdout, nil
-}
 
 // GetPodLogs retrieves the pod logs of the pod of the given name with the given options.
 func GetPodLogs(podInterface corev1client.PodInterface, name string, options *corev1.PodLogOptions) ([]byte, error) {

--- a/test/integration/framework/executor/framework.go
+++ b/test/integration/framework/executor/framework.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// Executor allows for execution of commands in containers.
+type Executor interface {
+	ExecCommandInContainerWithFullOutput(ctx context.Context, namespace, podName, containerName string, cmd ...string) (stdout, stderr string, err error)
+	ExecCommandInContainer(ctx context.Context, namespace, podName, containerName string, cmd ...string) (stdout string)
+	ExecShellInContainer(ctx context.Context, namespace, podName, containerName string, cmd string) (stdout string)
+}
+
+// ExecOptions passed to ExecWithOptions
+type ExecOptions struct {
+	Client        kubernetes.Interface
+	Command       []string
+	Namespace     string
+	PodName       string
+	ContainerName string
+	Stdin         io.Reader
+	CaptureStdout bool
+	CaptureStderr bool
+	// If false, whitespace in std{err,out} will be removed.
+	PreserveWhitespace bool
+}
+
+type defaultExecutor struct {
+	client kubernetes.Interface
+}
+
+// NewExecutor creates a new instance of Executor for a specific
+// Kubernetes client.
+func NewExecutor(client kubernetes.Interface) Executor {
+	return &defaultExecutor{client: client}
+}
+
+// ExecWithOptions executes a command in the specified container,
+// returning stdout, stderr and error. `options` allowed for
+// additional parameters to be passed.
+func ExecWithOptions(ctx context.Context, options ExecOptions) (stdout, stderr string, err error) {
+	const tty = false
+	req := options.Client.Kubernetes().CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(options.PodName).
+		Namespace(options.Namespace).
+		SubResource("exec").
+		Param("container", options.ContainerName).
+		Context(ctx)
+	req.VersionedParams(&v1.PodExecOptions{
+		Container: options.ContainerName,
+		Command:   options.Command,
+		Stdin:     options.Stdin != nil,
+		Stdout:    options.CaptureStdout,
+		Stderr:    options.CaptureStderr,
+		TTY:       tty,
+	}, scheme.ParameterCodec)
+
+	var stdoutBuff, stderrBuff bytes.Buffer
+	err = execute("POST", req.URL(), options.Client.RESTConfig(), options.Stdin, &stdoutBuff, &stderrBuff, tty)
+
+	if options.PreserveWhitespace {
+		return stdoutBuff.String(), stderrBuff.String(), err
+	}
+	return strings.TrimSpace(stdoutBuff.String()), strings.TrimSpace(stderrBuff.String()), err
+}
+
+// ExecCommandInContainerWithFullOutput executes a command in the
+// specified container and return stdout, stderr and error
+func (e *defaultExecutor) ExecCommandInContainerWithFullOutput(ctx context.Context, namespace, podName, containerName string, cmd ...string) (stdout, stderr string, err error) {
+	return ExecWithOptions(ctx, ExecOptions{
+		Client:             e.client,
+		Command:            cmd,
+		Namespace:          namespace,
+		PodName:            podName,
+		ContainerName:      containerName,
+		Stdin:              nil,
+		CaptureStdout:      true,
+		CaptureStderr:      true,
+		PreserveWhitespace: false,
+	})
+}
+
+// ExecCommandInContainer executes a command in the specified container.
+// Command is expect to succeed.
+func (e *defaultExecutor) ExecCommandInContainer(ctx context.Context, namespace, podName, containerName string, cmd ...string) (stdout string) {
+	stdout, stderr, err := e.ExecCommandInContainerWithFullOutput(ctx, namespace, podName, containerName, cmd...)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), `failed to execute command %in pod "%s/%s", container %s: %s`, podName, containerName, stderr)
+	return stdout
+}
+
+// ExecShellInContainer executes the specified command on the pod's container.
+func (e *defaultExecutor) ExecShellInContainer(ctx context.Context, namespace, podName, containerName string, cmd string) (stdout string) {
+	return e.ExecCommandInContainer(ctx, namespace, podName, containerName, "/bin/sh", "-c", cmd)
+}
+
+func execute(method string, url *url.URL, config *restclient.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {
+	exec, err := remotecommand.NewSPDYExecutor(config, method, url)
+	if err != nil {
+		return err
+	}
+	return exec.Stream(remotecommand.StreamOptions{
+		Stdin:  stdin,
+		Stdout: stdout,
+		Stderr: stderr,
+		Tty:    tty,
+	})
+}

--- a/test/integration/framework/networkpolicies/agnostic.go
+++ b/test/integration/framework/networkpolicies/agnostic.go
@@ -303,6 +303,7 @@ var (
 		}),
 		ExpectedPolicies: sets.NewString(
 			"allow-to-dns",
+			"allow-to-seed-apiserver",
 			"allow-to-shoot-apiserver",
 			"deny-all",
 		),

--- a/test/integration/framework/networkpolicies/alicloud.go
+++ b/test/integration/framework/networkpolicies/alicloud.go
@@ -33,9 +33,9 @@ var (
 		}),
 		ExpectedPolicies: sets.NewString(
 			"allow-from-prometheus",
-			"allow-to-shoot-apiserver",
 			"allow-to-dns",
 			"allow-to-public-networks",
+			"allow-to-shoot-apiserver",
 			"deny-all",
 		),
 	}
@@ -116,7 +116,7 @@ func (a *AlicloudNetworkPolicy) ToSources() []Rule {
 		a.newSource(ElasticSearchInfo).Build(),
 		a.newSource(GrafanaInfo).AllowPod(PrometheusInfo).Build(),
 		a.newSource(KibanaInfo).AllowTargetPod(ElasticSearchInfo.FromPort("http")).Build(),
-		a.newSource(AddonManagerInfo).AllowPod(KubeAPIServerInfo).Build(),
+		a.newSource(AddonManagerInfo).AllowPod(KubeAPIServerInfo).AllowHost(SeedKubeAPIServer, ExternalHost).Build(),
 		a.newSource(AlicloudKubeControllerManagerInfoSecured).AllowPod(KubeAPIServerInfo).Build(),
 		a.newSource(AlicloudKubeControllerManagerInfoNotSecured).AllowPod(KubeAPIServerInfo).Build(),
 		a.newSource(KubeSchedulerInfoNotSecured).AllowPod(KubeAPIServerInfo).Build(),

--- a/test/integration/framework/networkpolicies/aws.go
+++ b/test/integration/framework/networkpolicies/aws.go
@@ -67,7 +67,7 @@ func (a *AWSNetworkPolicy) ToSources() []Rule {
 		a.newSource(ElasticSearchInfo).Build(),
 		a.newSource(GrafanaInfo).AllowPod(PrometheusInfo).Build(),
 		a.newSource(KibanaInfo).AllowTargetPod(ElasticSearchInfo.FromPort("http")).Build(),
-		a.newSource(AddonManagerInfo).AllowPod(KubeAPIServerInfo).Build(),
+		a.newSource(AddonManagerInfo).AllowPod(KubeAPIServerInfo).AllowHost(SeedKubeAPIServer, ExternalHost).Build(),
 		a.newSource(KubeControllerManagerInfoNotSecured).AllowPod(KubeAPIServerInfo).AllowHost(AWSMetadataServiceHost, ExternalHost).Build(),
 		a.newSource(KubeControllerManagerInfoSecured).AllowPod(KubeAPIServerInfo).AllowHost(AWSMetadataServiceHost, ExternalHost).Build(),
 		a.newSource(KubeSchedulerInfoNotSecured).AllowPod(KubeAPIServerInfo).Build(),

--- a/test/integration/framework/networkpolicies/azure.go
+++ b/test/integration/framework/networkpolicies/azure.go
@@ -47,7 +47,7 @@ func (a *AzureNetworkPolicy) ToSources() []Rule {
 		a.newSource(ElasticSearchInfo).Build(),
 		a.newSource(GrafanaInfo).AllowPod(PrometheusInfo).Build(),
 		a.newSource(KibanaInfo).AllowTargetPod(ElasticSearchInfo.FromPort("http")).Build(),
-		a.newSource(AddonManagerInfo).AllowPod(KubeAPIServerInfo).Build(),
+		a.newSource(AddonManagerInfo).AllowPod(KubeAPIServerInfo).AllowHost(SeedKubeAPIServer, ExternalHost).Build(),
 		a.newSource(KubeControllerManagerInfoNotSecured).AllowPod(KubeAPIServerInfo).AllowHost(AzureMetadataServiceHost, ExternalHost).Build(),
 		a.newSource(KubeControllerManagerInfoSecured).AllowPod(KubeAPIServerInfo).AllowHost(AzureMetadataServiceHost, ExternalHost).Build(),
 		a.newSource(KubeSchedulerInfoNotSecured).AllowPod(KubeAPIServerInfo).Build(),

--- a/test/integration/framework/networkpolicies/gcp.go
+++ b/test/integration/framework/networkpolicies/gcp.go
@@ -47,7 +47,7 @@ func (a *GCPNetworkPolicy) ToSources() []Rule {
 		a.newSource(ElasticSearchInfo).Build(),
 		a.newSource(GrafanaInfo).AllowPod(PrometheusInfo).Build(),
 		a.newSource(KibanaInfo).AllowTargetPod(ElasticSearchInfo.FromPort("http")).Build(),
-		a.newSource(AddonManagerInfo).AllowPod(KubeAPIServerInfo).Build(),
+		a.newSource(AddonManagerInfo).AllowPod(KubeAPIServerInfo).AllowHost(SeedKubeAPIServer, ExternalHost).Build(),
 		a.newSource(KubeControllerManagerInfoNotSecured).AllowPod(KubeAPIServerInfo).AllowHost(GCPMetadataServiceHost, ExternalHost).Build(),
 		a.newSource(KubeControllerManagerInfoSecured).AllowPod(KubeAPIServerInfo).AllowHost(GCPMetadataServiceHost, ExternalHost).Build(),
 		a.newSource(KubeSchedulerInfoNotSecured).AllowPod(KubeAPIServerInfo).Build(),

--- a/test/integration/framework/networkpolicies/openstack.go
+++ b/test/integration/framework/networkpolicies/openstack.go
@@ -84,7 +84,7 @@ func (a *OpenStackNetworkPolicy) ToSources() []Rule {
 		a.newSource(ElasticSearchInfo).Build(),
 		a.newSource(GrafanaInfo).AllowPod(PrometheusInfo).Build(),
 		a.newSource(KibanaInfo).AllowTargetPod(ElasticSearchInfo.FromPort("http")).Build(),
-		a.newSource(AddonManagerInfo).AllowPod(KubeAPIServerInfo).Build(),
+		a.newSource(AddonManagerInfo).AllowPod(KubeAPIServerInfo).AllowHost(SeedKubeAPIServer, ExternalHost).Build(),
 		a.newSource(KubeControllerManagerInfoNotSecured).AllowPod(KubeAPIServerInfo).AllowHost(OpenStackMetadataServiceHost, ExternalHost).Build(),
 		a.newSource(KubeControllerManagerInfoSecured).AllowPod(KubeAPIServerInfo).AllowHost(OpenStackMetadataServiceHost, ExternalHost).Build(),
 		a.newSource(KubeSchedulerInfoNotSecured).AllowPod(KubeAPIServerInfo).Build(),

--- a/test/integration/seeds/networkpolicies/alicloud/networkpolicy_alicloud_test.go
+++ b/test/integration/seeds/networkpolicies/alicloud/networkpolicy_alicloud_test.go
@@ -23,8 +23,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
-	"io/ioutil"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,6 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/logger"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/test/integration/framework"
+	"github.com/gardener/gardener/test/integration/framework/executor"
 	networkpolicies "github.com/gardener/gardener/test/integration/framework/networkpolicies"
 	. "github.com/gardener/gardener/test/integration/shoots"
 	. "github.com/onsi/ginkgo"
@@ -118,7 +118,7 @@ var _ = Describe("Network Policy Testing", func() {
 			return trgPod
 		}
 
-		establishConnectionToHost = func(ctx context.Context, nsp *networkpolicies.NamespacedSourcePod, host string, port int32) (io.Reader, error) {
+		establishConnectionToHost = func(ctx context.Context, nsp *networkpolicies.NamespacedSourcePod, host string, port int32) (stdout, stderr string, err error) {
 			if !nsp.Pod.CheckVersion(shootTestOperations.Shoot) {
 				Skip("Source pod doesn't match Shoot version contstraints. Skipping.")
 			}
@@ -126,43 +126,35 @@ var _ = Describe("Network Policy Testing", func() {
 				Skip("Component doesn't match Seed Provider contstraints. Skipping.")
 			}
 			By(fmt.Sprintf("Checking for source Pod: %s is running", nsp.Pod.Name))
-			err := shootTestOperations.WaitUntilPodIsRunningWithLabels(ctx, nsp.Pod.Selector(), nsp.Namespace, shootTestOperations.SeedClient)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			ExpectWithOffset(1, shootTestOperations.WaitUntilPodIsRunningWithLabels(ctx, nsp.Pod.Selector(), nsp.Namespace, shootTestOperations.SeedClient)).NotTo(HaveOccurred())
 
-			By(fmt.Sprintf("Executing connectivity command from %s/%s to %s:%d", nsp.Namespace, nsp.Pod.Name, host, port))
-			command := fmt.Sprintf("nc -v -z -w 3 %s %d", host, port)
+			command := []string{"nc", "-vznw", "3", host, fmt.Sprint(port)}
+			By(fmt.Sprintf("Executing connectivity command in %s/%s to %s", nsp.Namespace, nsp.Pod.Name, strings.Join(command, " ")))
 
-			return shootTestOperations.PodExecByLabel(ctx, nsp.Pod.Selector(), "busybox-0", command, nsp.Namespace, shootTestOperations.SeedClient)
+			return executor.NewExecutor(shootTestOperations.SeedClient).
+				ExecCommandInContainerWithFullOutput(ctx, nsp.Namespace, nsp.Pod.Name, "busybox-0", command...)
 		}
 
 		assertCannotConnectToHost = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, host string, port int32) {
-			r, err := establishConnectionToHost(ctx, sourcePod, host, port)
+			_, stderr, err := establishConnectionToHost(ctx, sourcePod, host, port)
 			ExpectWithOffset(1, err).To(HaveOccurred())
-			bytes, err := ioutil.ReadAll(r)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
 			By("Connection message is timed out\n")
-			ExpectWithOffset(1, string(bytes)).To(SatisfyAny(ContainSubstring("Connection timed out"), ContainSubstring("nc: bad address")))
+			ExpectWithOffset(1, stderr).To(SatisfyAny(ContainSubstring("Connection timed out"), ContainSubstring("nc: bad address")))
+		}
+
+		assertConnectToHost = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, targetHost *networkpolicies.Host, allowed bool) {
+			_, stderr, err := establishConnectionToHost(ctx, sourcePod, targetHost.HostName, targetHost.Port)
+			if allowed {
+				ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			} else {
+				ExpectWithOffset(1, err).To(HaveOccurred())
+				ExpectWithOffset(1, stderr).To(SatisfyAny(BeEmpty(), ContainSubstring("Connection timed out"), ContainSubstring("nc: bad address")), "stderr has correct message")
+			}
 		}
 
 		assertCannotConnectToPod = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, targetPod *networkpolicies.NamespacedTargetPod) {
 			pod := getTargetPod(ctx, targetPod)
 			assertCannotConnectToHost(ctx, sourcePod, pod.Status.PodIP, targetPod.Port.Port)
-		}
-
-		assertConnectToHost = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, targetHost *networkpolicies.Host, allowed bool) {
-			r, err := establishConnectionToHost(ctx, sourcePod, targetHost.HostName, targetHost.Port)
-			if allowed {
-				ExpectWithOffset(1, err).NotTo(HaveOccurred())
-				ExpectWithOffset(1, r).NotTo(BeNil())
-			} else {
-				ExpectWithOffset(1, err).To(HaveOccurred())
-				bytes, err := ioutil.ReadAll(r)
-				ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-				By("Connection message is timed out\n")
-				ExpectWithOffset(1, string(bytes)).To(SatisfyAny(ContainSubstring("Connection timed out"), ContainSubstring("nc: bad address")))
-			}
 		}
 
 		assertConnectToPod = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, targetPod *networkpolicies.NamespacedTargetPod, allowed bool) {
@@ -382,6 +374,7 @@ var _ = Describe("Network Policy Testing", func() {
 			Ports: []networkpolicies.Port(nil),
 			ExpectedPolicies: sets.String{
 				"allow-to-dns":             sets.Empty{},
+				"allow-to-seed-apiserver":  sets.Empty{},
 				"allow-to-shoot-apiserver": sets.Empty{},
 				"deny-all":                 sets.Empty{}}}
 		GardenerResourceManager8080 = &networkpolicies.TargetPod{
@@ -1414,8 +1407,9 @@ var _ = Describe("Network Policy Testing", func() {
 			DefaultCIt(`should block connection to Pod "machine-controller-manager" at port 10258`, assertEgresssToMirroredPod(MachineControllerManager10258, false))
 			DefaultCIt(`should block connection to Pod "prometheus" at port 9090`, assertEgresssToMirroredPod(Prometheus9090, false))
 			DefaultCIt(`should block connection to "Metadata service" 100.100.100.200:80`, assertEgresssToHost(MetadataservicePort80, false))
-			DefaultCIt(`should block connection to "External host" 8.8.8.8:53`, assertEgresssToHost(ExternalhostPort53, false))
+			DefaultCIt(`should allow connection to "External host" 8.8.8.8:53`, assertEgresssToHost(ExternalhostPort53, true))
 			DefaultCIt(`should block connection to "Garden Prometheus" prometheus-web.garden:80`, assertEgresssToHost(GardenPrometheusPort80, false))
+			DefaultCIt(`should allow connection to "Seed Kube APIServer" kubernetes.default:443`, assertEgresssToHost(SeedKubeAPIServerPort443, true))
 		})
 
 		Context("kube-controller-manager-https", func() {

--- a/test/integration/seeds/networkpolicies/aws/networkpolicy_aws_test.go
+++ b/test/integration/seeds/networkpolicies/aws/networkpolicy_aws_test.go
@@ -23,8 +23,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
-	"io/ioutil"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,6 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/logger"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/test/integration/framework"
+	"github.com/gardener/gardener/test/integration/framework/executor"
 	networkpolicies "github.com/gardener/gardener/test/integration/framework/networkpolicies"
 	. "github.com/gardener/gardener/test/integration/shoots"
 	. "github.com/onsi/ginkgo"
@@ -118,7 +118,7 @@ var _ = Describe("Network Policy Testing", func() {
 			return trgPod
 		}
 
-		establishConnectionToHost = func(ctx context.Context, nsp *networkpolicies.NamespacedSourcePod, host string, port int32) (io.Reader, error) {
+		establishConnectionToHost = func(ctx context.Context, nsp *networkpolicies.NamespacedSourcePod, host string, port int32) (stdout, stderr string, err error) {
 			if !nsp.Pod.CheckVersion(shootTestOperations.Shoot) {
 				Skip("Source pod doesn't match Shoot version contstraints. Skipping.")
 			}
@@ -126,43 +126,35 @@ var _ = Describe("Network Policy Testing", func() {
 				Skip("Component doesn't match Seed Provider contstraints. Skipping.")
 			}
 			By(fmt.Sprintf("Checking for source Pod: %s is running", nsp.Pod.Name))
-			err := shootTestOperations.WaitUntilPodIsRunningWithLabels(ctx, nsp.Pod.Selector(), nsp.Namespace, shootTestOperations.SeedClient)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			ExpectWithOffset(1, shootTestOperations.WaitUntilPodIsRunningWithLabels(ctx, nsp.Pod.Selector(), nsp.Namespace, shootTestOperations.SeedClient)).NotTo(HaveOccurred())
 
-			By(fmt.Sprintf("Executing connectivity command from %s/%s to %s:%d", nsp.Namespace, nsp.Pod.Name, host, port))
-			command := fmt.Sprintf("nc -v -z -w 3 %s %d", host, port)
+			command := []string{"nc", "-vznw", "3", host, fmt.Sprint(port)}
+			By(fmt.Sprintf("Executing connectivity command in %s/%s to %s", nsp.Namespace, nsp.Pod.Name, strings.Join(command, " ")))
 
-			return shootTestOperations.PodExecByLabel(ctx, nsp.Pod.Selector(), "busybox-0", command, nsp.Namespace, shootTestOperations.SeedClient)
+			return executor.NewExecutor(shootTestOperations.SeedClient).
+				ExecCommandInContainerWithFullOutput(ctx, nsp.Namespace, nsp.Pod.Name, "busybox-0", command...)
 		}
 
 		assertCannotConnectToHost = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, host string, port int32) {
-			r, err := establishConnectionToHost(ctx, sourcePod, host, port)
+			_, stderr, err := establishConnectionToHost(ctx, sourcePod, host, port)
 			ExpectWithOffset(1, err).To(HaveOccurred())
-			bytes, err := ioutil.ReadAll(r)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
 			By("Connection message is timed out\n")
-			ExpectWithOffset(1, string(bytes)).To(SatisfyAny(ContainSubstring("Connection timed out"), ContainSubstring("nc: bad address")))
+			ExpectWithOffset(1, stderr).To(SatisfyAny(ContainSubstring("Connection timed out"), ContainSubstring("nc: bad address")))
+		}
+
+		assertConnectToHost = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, targetHost *networkpolicies.Host, allowed bool) {
+			_, stderr, err := establishConnectionToHost(ctx, sourcePod, targetHost.HostName, targetHost.Port)
+			if allowed {
+				ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			} else {
+				ExpectWithOffset(1, err).To(HaveOccurred())
+				ExpectWithOffset(1, stderr).To(SatisfyAny(BeEmpty(), ContainSubstring("Connection timed out"), ContainSubstring("nc: bad address")), "stderr has correct message")
+			}
 		}
 
 		assertCannotConnectToPod = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, targetPod *networkpolicies.NamespacedTargetPod) {
 			pod := getTargetPod(ctx, targetPod)
 			assertCannotConnectToHost(ctx, sourcePod, pod.Status.PodIP, targetPod.Port.Port)
-		}
-
-		assertConnectToHost = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, targetHost *networkpolicies.Host, allowed bool) {
-			r, err := establishConnectionToHost(ctx, sourcePod, targetHost.HostName, targetHost.Port)
-			if allowed {
-				ExpectWithOffset(1, err).NotTo(HaveOccurred())
-				ExpectWithOffset(1, r).NotTo(BeNil())
-			} else {
-				ExpectWithOffset(1, err).To(HaveOccurred())
-				bytes, err := ioutil.ReadAll(r)
-				ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-				By("Connection message is timed out\n")
-				ExpectWithOffset(1, string(bytes)).To(SatisfyAny(ContainSubstring("Connection timed out"), ContainSubstring("nc: bad address")))
-			}
 		}
 
 		assertConnectToPod = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, targetPod *networkpolicies.NamespacedTargetPod, allowed bool) {
@@ -410,6 +402,7 @@ var _ = Describe("Network Policy Testing", func() {
 			Ports: []networkpolicies.Port(nil),
 			ExpectedPolicies: sets.String{
 				"allow-to-dns":             sets.Empty{},
+				"allow-to-seed-apiserver":  sets.Empty{},
 				"allow-to-shoot-apiserver": sets.Empty{},
 				"deny-all":                 sets.Empty{}}}
 		GardenerResourceManager8080 = &networkpolicies.TargetPod{
@@ -1491,8 +1484,9 @@ var _ = Describe("Network Policy Testing", func() {
 			DefaultCIt(`should block connection to Pod "machine-controller-manager" at port 10258`, assertEgresssToMirroredPod(MachineControllerManager10258, false))
 			DefaultCIt(`should block connection to Pod "prometheus" at port 9090`, assertEgresssToMirroredPod(Prometheus9090, false))
 			DefaultCIt(`should block connection to "Metadata service" 169.254.169.254:80`, assertEgresssToHost(MetadataservicePort80, false))
-			DefaultCIt(`should block connection to "External host" 8.8.8.8:53`, assertEgresssToHost(ExternalhostPort53, false))
+			DefaultCIt(`should allow connection to "External host" 8.8.8.8:53`, assertEgresssToHost(ExternalhostPort53, true))
 			DefaultCIt(`should block connection to "Garden Prometheus" prometheus-web.garden:80`, assertEgresssToHost(GardenPrometheusPort80, false))
+			DefaultCIt(`should allow connection to "Seed Kube APIServer" kubernetes.default:443`, assertEgresssToHost(SeedKubeAPIServerPort443, true))
 		})
 
 		Context("kube-controller-manager-http", func() {

--- a/test/integration/seeds/networkpolicies/azure/networkpolicy_azure_test.go
+++ b/test/integration/seeds/networkpolicies/azure/networkpolicy_azure_test.go
@@ -23,8 +23,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
-	"io/ioutil"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,6 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/logger"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/test/integration/framework"
+	"github.com/gardener/gardener/test/integration/framework/executor"
 	networkpolicies "github.com/gardener/gardener/test/integration/framework/networkpolicies"
 	. "github.com/gardener/gardener/test/integration/shoots"
 	. "github.com/onsi/ginkgo"
@@ -118,7 +118,7 @@ var _ = Describe("Network Policy Testing", func() {
 			return trgPod
 		}
 
-		establishConnectionToHost = func(ctx context.Context, nsp *networkpolicies.NamespacedSourcePod, host string, port int32) (io.Reader, error) {
+		establishConnectionToHost = func(ctx context.Context, nsp *networkpolicies.NamespacedSourcePod, host string, port int32) (stdout, stderr string, err error) {
 			if !nsp.Pod.CheckVersion(shootTestOperations.Shoot) {
 				Skip("Source pod doesn't match Shoot version contstraints. Skipping.")
 			}
@@ -126,43 +126,35 @@ var _ = Describe("Network Policy Testing", func() {
 				Skip("Component doesn't match Seed Provider contstraints. Skipping.")
 			}
 			By(fmt.Sprintf("Checking for source Pod: %s is running", nsp.Pod.Name))
-			err := shootTestOperations.WaitUntilPodIsRunningWithLabels(ctx, nsp.Pod.Selector(), nsp.Namespace, shootTestOperations.SeedClient)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			ExpectWithOffset(1, shootTestOperations.WaitUntilPodIsRunningWithLabels(ctx, nsp.Pod.Selector(), nsp.Namespace, shootTestOperations.SeedClient)).NotTo(HaveOccurred())
 
-			By(fmt.Sprintf("Executing connectivity command from %s/%s to %s:%d", nsp.Namespace, nsp.Pod.Name, host, port))
-			command := fmt.Sprintf("nc -v -z -w 3 %s %d", host, port)
+			command := []string{"nc", "-vznw", "3", host, fmt.Sprint(port)}
+			By(fmt.Sprintf("Executing connectivity command in %s/%s to %s", nsp.Namespace, nsp.Pod.Name, strings.Join(command, " ")))
 
-			return shootTestOperations.PodExecByLabel(ctx, nsp.Pod.Selector(), "busybox-0", command, nsp.Namespace, shootTestOperations.SeedClient)
+			return executor.NewExecutor(shootTestOperations.SeedClient).
+				ExecCommandInContainerWithFullOutput(ctx, nsp.Namespace, nsp.Pod.Name, "busybox-0", command...)
 		}
 
 		assertCannotConnectToHost = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, host string, port int32) {
-			r, err := establishConnectionToHost(ctx, sourcePod, host, port)
+			_, stderr, err := establishConnectionToHost(ctx, sourcePod, host, port)
 			ExpectWithOffset(1, err).To(HaveOccurred())
-			bytes, err := ioutil.ReadAll(r)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
 			By("Connection message is timed out\n")
-			ExpectWithOffset(1, string(bytes)).To(SatisfyAny(ContainSubstring("Connection timed out"), ContainSubstring("nc: bad address")))
+			ExpectWithOffset(1, stderr).To(SatisfyAny(ContainSubstring("Connection timed out"), ContainSubstring("nc: bad address")))
+		}
+
+		assertConnectToHost = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, targetHost *networkpolicies.Host, allowed bool) {
+			_, stderr, err := establishConnectionToHost(ctx, sourcePod, targetHost.HostName, targetHost.Port)
+			if allowed {
+				ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			} else {
+				ExpectWithOffset(1, err).To(HaveOccurred())
+				ExpectWithOffset(1, stderr).To(SatisfyAny(BeEmpty(), ContainSubstring("Connection timed out"), ContainSubstring("nc: bad address")), "stderr has correct message")
+			}
 		}
 
 		assertCannotConnectToPod = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, targetPod *networkpolicies.NamespacedTargetPod) {
 			pod := getTargetPod(ctx, targetPod)
 			assertCannotConnectToHost(ctx, sourcePod, pod.Status.PodIP, targetPod.Port.Port)
-		}
-
-		assertConnectToHost = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, targetHost *networkpolicies.Host, allowed bool) {
-			r, err := establishConnectionToHost(ctx, sourcePod, targetHost.HostName, targetHost.Port)
-			if allowed {
-				ExpectWithOffset(1, err).NotTo(HaveOccurred())
-				ExpectWithOffset(1, r).NotTo(BeNil())
-			} else {
-				ExpectWithOffset(1, err).To(HaveOccurred())
-				bytes, err := ioutil.ReadAll(r)
-				ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-				By("Connection message is timed out\n")
-				ExpectWithOffset(1, string(bytes)).To(SatisfyAny(ContainSubstring("Connection timed out"), ContainSubstring("nc: bad address")))
-			}
 		}
 
 		assertConnectToPod = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, targetPod *networkpolicies.NamespacedTargetPod, allowed bool) {
@@ -383,6 +375,7 @@ var _ = Describe("Network Policy Testing", func() {
 			Ports: []networkpolicies.Port(nil),
 			ExpectedPolicies: sets.String{
 				"allow-to-dns":             sets.Empty{},
+				"allow-to-seed-apiserver":  sets.Empty{},
 				"allow-to-shoot-apiserver": sets.Empty{},
 				"deny-all":                 sets.Empty{}}}
 		GardenerResourceManager8080 = &networkpolicies.TargetPod{
@@ -1450,8 +1443,9 @@ var _ = Describe("Network Policy Testing", func() {
 			DefaultCIt(`should block connection to Pod "machine-controller-manager" at port 10258`, assertEgresssToMirroredPod(MachineControllerManager10258, false))
 			DefaultCIt(`should block connection to Pod "prometheus" at port 9090`, assertEgresssToMirroredPod(Prometheus9090, false))
 			DefaultCIt(`should block connection to "Metadata service" 169.254.169.254:80`, assertEgresssToHost(MetadataservicePort80, false))
-			DefaultCIt(`should block connection to "External host" 8.8.8.8:53`, assertEgresssToHost(ExternalhostPort53, false))
+			DefaultCIt(`should allow connection to "External host" 8.8.8.8:53`, assertEgresssToHost(ExternalhostPort53, true))
 			DefaultCIt(`should block connection to "Garden Prometheus" prometheus-web.garden:80`, assertEgresssToHost(GardenPrometheusPort80, false))
+			DefaultCIt(`should allow connection to "Seed Kube APIServer" kubernetes.default:443`, assertEgresssToHost(SeedKubeAPIServerPort443, true))
 		})
 
 		Context("kube-controller-manager-http", func() {

--- a/test/integration/seeds/networkpolicies/gcp/networkpolicy_gcp_test.go
+++ b/test/integration/seeds/networkpolicies/gcp/networkpolicy_gcp_test.go
@@ -23,8 +23,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
-	"io/ioutil"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,6 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/logger"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/test/integration/framework"
+	"github.com/gardener/gardener/test/integration/framework/executor"
 	networkpolicies "github.com/gardener/gardener/test/integration/framework/networkpolicies"
 	. "github.com/gardener/gardener/test/integration/shoots"
 	. "github.com/onsi/ginkgo"
@@ -118,7 +118,7 @@ var _ = Describe("Network Policy Testing", func() {
 			return trgPod
 		}
 
-		establishConnectionToHost = func(ctx context.Context, nsp *networkpolicies.NamespacedSourcePod, host string, port int32) (io.Reader, error) {
+		establishConnectionToHost = func(ctx context.Context, nsp *networkpolicies.NamespacedSourcePod, host string, port int32) (stdout, stderr string, err error) {
 			if !nsp.Pod.CheckVersion(shootTestOperations.Shoot) {
 				Skip("Source pod doesn't match Shoot version contstraints. Skipping.")
 			}
@@ -126,43 +126,35 @@ var _ = Describe("Network Policy Testing", func() {
 				Skip("Component doesn't match Seed Provider contstraints. Skipping.")
 			}
 			By(fmt.Sprintf("Checking for source Pod: %s is running", nsp.Pod.Name))
-			err := shootTestOperations.WaitUntilPodIsRunningWithLabels(ctx, nsp.Pod.Selector(), nsp.Namespace, shootTestOperations.SeedClient)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			ExpectWithOffset(1, shootTestOperations.WaitUntilPodIsRunningWithLabels(ctx, nsp.Pod.Selector(), nsp.Namespace, shootTestOperations.SeedClient)).NotTo(HaveOccurred())
 
-			By(fmt.Sprintf("Executing connectivity command from %s/%s to %s:%d", nsp.Namespace, nsp.Pod.Name, host, port))
-			command := fmt.Sprintf("nc -v -z -w 3 %s %d", host, port)
+			command := []string{"nc", "-vznw", "3", host, fmt.Sprint(port)}
+			By(fmt.Sprintf("Executing connectivity command in %s/%s to %s", nsp.Namespace, nsp.Pod.Name, strings.Join(command, " ")))
 
-			return shootTestOperations.PodExecByLabel(ctx, nsp.Pod.Selector(), "busybox-0", command, nsp.Namespace, shootTestOperations.SeedClient)
+			return executor.NewExecutor(shootTestOperations.SeedClient).
+				ExecCommandInContainerWithFullOutput(ctx, nsp.Namespace, nsp.Pod.Name, "busybox-0", command...)
 		}
 
 		assertCannotConnectToHost = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, host string, port int32) {
-			r, err := establishConnectionToHost(ctx, sourcePod, host, port)
+			_, stderr, err := establishConnectionToHost(ctx, sourcePod, host, port)
 			ExpectWithOffset(1, err).To(HaveOccurred())
-			bytes, err := ioutil.ReadAll(r)
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
 			By("Connection message is timed out\n")
-			ExpectWithOffset(1, string(bytes)).To(SatisfyAny(ContainSubstring("Connection timed out"), ContainSubstring("nc: bad address")))
+			ExpectWithOffset(1, stderr).To(SatisfyAny(ContainSubstring("Connection timed out"), ContainSubstring("nc: bad address")))
+		}
+
+		assertConnectToHost = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, targetHost *networkpolicies.Host, allowed bool) {
+			_, stderr, err := establishConnectionToHost(ctx, sourcePod, targetHost.HostName, targetHost.Port)
+			if allowed {
+				ExpectWithOffset(1, err).NotTo(HaveOccurred())
+			} else {
+				ExpectWithOffset(1, err).To(HaveOccurred())
+				ExpectWithOffset(1, stderr).To(SatisfyAny(BeEmpty(), ContainSubstring("Connection timed out"), ContainSubstring("nc: bad address")), "stderr has correct message")
+			}
 		}
 
 		assertCannotConnectToPod = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, targetPod *networkpolicies.NamespacedTargetPod) {
 			pod := getTargetPod(ctx, targetPod)
 			assertCannotConnectToHost(ctx, sourcePod, pod.Status.PodIP, targetPod.Port.Port)
-		}
-
-		assertConnectToHost = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, targetHost *networkpolicies.Host, allowed bool) {
-			r, err := establishConnectionToHost(ctx, sourcePod, targetHost.HostName, targetHost.Port)
-			if allowed {
-				ExpectWithOffset(1, err).NotTo(HaveOccurred())
-				ExpectWithOffset(1, r).NotTo(BeNil())
-			} else {
-				ExpectWithOffset(1, err).To(HaveOccurred())
-				bytes, err := ioutil.ReadAll(r)
-				ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-				By("Connection message is timed out\n")
-				ExpectWithOffset(1, string(bytes)).To(SatisfyAny(ContainSubstring("Connection timed out"), ContainSubstring("nc: bad address")))
-			}
 		}
 
 		assertConnectToPod = func(ctx context.Context, sourcePod *networkpolicies.NamespacedSourcePod, targetPod *networkpolicies.NamespacedTargetPod, allowed bool) {
@@ -383,6 +375,7 @@ var _ = Describe("Network Policy Testing", func() {
 			Ports: []networkpolicies.Port(nil),
 			ExpectedPolicies: sets.String{
 				"allow-to-dns":             sets.Empty{},
+				"allow-to-seed-apiserver":  sets.Empty{},
 				"allow-to-shoot-apiserver": sets.Empty{},
 				"deny-all":                 sets.Empty{}}}
 		GardenerResourceManager8080 = &networkpolicies.TargetPod{
@@ -1428,8 +1421,9 @@ var _ = Describe("Network Policy Testing", func() {
 			DefaultCIt(`should block connection to Pod "machine-controller-manager" at port 10258`, assertEgresssToMirroredPod(MachineControllerManager10258, false))
 			DefaultCIt(`should block connection to Pod "prometheus" at port 9090`, assertEgresssToMirroredPod(Prometheus9090, false))
 			DefaultCIt(`should block connection to "Metadata service" 169.254.169.254:80`, assertEgresssToHost(MetadataservicePort80, false))
-			DefaultCIt(`should block connection to "External host" 8.8.8.8:53`, assertEgresssToHost(ExternalhostPort53, false))
+			DefaultCIt(`should allow connection to "External host" 8.8.8.8:53`, assertEgresssToHost(ExternalhostPort53, true))
 			DefaultCIt(`should block connection to "Garden Prometheus" prometheus-web.garden:80`, assertEgresssToHost(GardenPrometheusPort80, false))
+			DefaultCIt(`should allow connection to "Seed Kube APIServer" kubernetes.default:443`, assertEgresssToHost(SeedKubeAPIServerPort443, true))
 		})
 
 		Context("kube-controller-manager-http", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes network policies and stdout and stdin are now separate

**Which issue(s) this PR fixes**:

Prerequisite for #1137

**Special notes for your reviewer**:
n/a 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
NONE
```
