### PR TITLE
Remove cleanup code from old grafana deployment

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -391,11 +391,6 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		return err
 	}
 
-	// TODO: Cleanup logic. Remove once all old grafana artifacts have been removed from all landscapes
-	if err := common.DeleteOldGrafanaStack(b.K8sSeedClient, b.Shoot.SeedNamespace); err != nil {
-		return err
-	}
-
 	if err := b.deployGrafanaCharts("operators", basicAuth, common.GrafanaOperatorsPrefix); err != nil {
 		return err
 	}

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -400,46 +400,6 @@ func DeleteGrafanaByRole(k8sClient kubernetes.Interface, namespace, role string)
 	return nil
 }
 
-// TODO: Remove later
-
-// DeleteOldGrafanaStack deletes all left over grafana objects.
-func DeleteOldGrafanaStack(k8sClient kubernetes.Interface, namespace string) error {
-	if k8sClient == nil {
-		return fmt.Errorf("require kubernetes client")
-	}
-
-	configMaps := []string{"grafana-dashboards", "grafana-dashboard-providers", "grafana-datasources"}
-
-	for _, configMap := range configMaps {
-		if err := k8sClient.Kubernetes().CoreV1().ConfigMaps(namespace).Delete(configMap,
-			&metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-	}
-
-	if err := k8sClient.Kubernetes().AppsV1().Deployments(namespace).Delete("grafana",
-		&metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	if err := k8sClient.Kubernetes().CoreV1().Secrets(namespace).Delete("grafana-basic-auth",
-		&metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	if err := k8sClient.Kubernetes().ExtensionsV1beta1().Ingresses(namespace).Delete("grafana",
-		&metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	if err := k8sClient.Kubernetes().CoreV1().Services(namespace).Delete("grafana",
-		&metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	return nil
-}
-
 // GetDomainInfoFromAnnotations returns the provider and the domain that is specified in the give annotations.
 func GetDomainInfoFromAnnotations(annotations map[string]string) (provider string, domain string, err error) {
 	if annotations == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes old cleanup logic for grafana. All old grafana deployments have been removed and it is now safe to remove this logic.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator

```
