### PR TITLE
Allow multiple AZs in OpenStack w/o dedicated subnets

### DIFF
--- a/pkg/apis/garden/validation/validation.go
+++ b/pkg/apis/garden/validation/validation.go
@@ -1199,10 +1199,6 @@ func validateCloud(cloud garden.Cloud, fldPath *field.Path) field.ErrorList {
 		nodes, _, _, networkErrors := transformK8SNetworks(openStack.Networks.K8SNetworks, openStackPath.Child("networks"))
 		allErrs = append(allErrs, networkErrors...)
 
-		if len(openStack.Networks.Workers) != zoneCount {
-			allErrs = append(allErrs, field.Invalid(openStackPath.Child("networks", "workers"), openStack.Networks.Workers, "must specify as many workers networks as zones"))
-		}
-
 		workerCIDRs := make([]cidrvalidation.CIDR, 0, len(openStack.Networks.Workers))
 		for i, cidr := range openStack.Networks.Workers {
 			workerCIDR := cidrvalidation.NewCIDR(cidr, openStackPath.Child("networks", "workers").Index(i))


### PR DESCRIPTION
**What this PR does / why we need it**:

It allows to specify multiple availability zones for OpenStack environment without specifying multiple worker CIDRs.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extensions/issues/184

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
