### PR TITLE
Fix resource creation while namespace in deletion issue

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_control_delete.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_delete.go
@@ -88,6 +88,11 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation) *gardencorev1alp
 		return gardencorev1alpha1helper.LastError(fmt.Sprintf("Failed to retrieve the Shoot namespace in the Seed cluster (%s)", err.Error()))
 	}
 
+	shootNamespaceInDeletion, err := kutil.HasDeletionTimestamp(namespace)
+	if err != nil {
+		return gardencorev1alpha1helper.LastError(fmt.Sprintf("Failed to check the deletion timestamp for the Shoot namespace (%s)", err.Error()))
+	}
+
 	seedCloudBotanist, err := cloudbotanistpkg.New(o, common.CloudPurposeSeed)
 	if err != nil {
 		return gardencorev1alpha1helper.LastError(fmt.Sprintf("Failed to create a Seed CloudBotanist (%s)", err.Error()))
@@ -148,12 +153,12 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation) *gardencorev1alp
 		// existing machine class secrets.
 		deployCloudProviderSecret = g.Add(flow.Task{
 			Name:         "Deploying cloud provider account secret",
-			Fn:           flow.TaskFn(botanist.DeployCloudProviderSecret).DoIf(cleanupShootResources),
+			Fn:           flow.TaskFn(botanist.DeployCloudProviderSecret).DoIf(cleanupShootResources && !shootNamespaceInDeletion),
 			Dependencies: flow.NewTaskIDs(syncClusterResourceToSeed),
 		})
 		deploySecrets = g.Add(flow.Task{
 			Name: "Deploying Shoot certificates / keys",
-			Fn:   flow.SimpleTaskFn(botanist.DeploySecrets),
+			Fn:   flow.SimpleTaskFn(botanist.DeploySecrets).DoIf(!shootNamespaceInDeletion),
 		})
 
 		wakeUpControlPlane = g.Add(flow.Task{
@@ -171,7 +176,7 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation) *gardencorev1alp
 		// Redeploy the custom control plane to make sure cloud-controller-manager is restarted if the cloud provider secret changes.
 		deployControlPlane = g.Add(flow.Task{
 			Name:         "Deploying Shoot control plane",
-			Fn:           flow.TaskFn(botanist.DeployControlPlane).RetryUntilTimeout(defaultInterval, defaultTimeout).DoIf(cleanupShootResources && controlPlaneDeploymentNeeded),
+			Fn:           flow.TaskFn(botanist.DeployControlPlane).RetryUntilTimeout(defaultInterval, defaultTimeout).DoIf(cleanupShootResources && controlPlaneDeploymentNeeded && !shootNamespaceInDeletion),
 			Dependencies: flow.NewTaskIDs(deploySecrets, deployCloudProviderSecret),
 		})
 		waitUntilControlPlaneReady = g.Add(flow.Task{
@@ -183,7 +188,7 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation) *gardencorev1alp
 		// Redeploy the kube-controller-manager to make sure that it's restarted if the cloud provider secret changes.
 		deployKubeControllerManager = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes controller manager",
-			Fn:           flow.SimpleTaskFn(hybridBotanist.DeployKubeControllerManager).DoIf(cleanupShootResources && kubeControllerManagerDeploymentFound).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.SimpleTaskFn(hybridBotanist.DeployKubeControllerManager).DoIf(cleanupShootResources && kubeControllerManagerDeploymentFound && !shootNamespaceInDeletion).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deploySecrets, deployCloudProviderSecret, initializeShootClients),
 		})
 

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -17,6 +17,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"time"
 
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -40,6 +41,15 @@ func SetMetaDataLabel(meta *metav1.ObjectMeta, key, value string) {
 func HasMetaDataAnnotation(meta *metav1.ObjectMeta, key, value string) bool {
 	val, ok := meta.Annotations[key]
 	return ok && val == value
+}
+
+// HasDeletionTimestamp checks if an object has a deletion timestamp
+func HasDeletionTimestamp(obj runtime.Object) (bool, error) {
+	metadata, err  := meta.Accessor(obj)
+	if err != nil {
+		return false, err
+	}
+	return metadata.GetDeletionTimestamp() != nil, nil
 }
 
 // CreateOrUpdate creates or updates the object. Optionally, it executes a transformation function before the

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -97,6 +97,27 @@ var _ = Describe("kubernetes", func() {
 		})
 	})
 
+	Describe("#HasDeletionTimestamp", func() {
+		var namespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		}
+		It("should return false if no deletion timestamp is set", func() {
+		  result, err := HasDeletionTimestamp(namespace)
+		  Expect(err).NotTo(HaveOccurred())
+		  Expect(result).To(BeFalse())
+		})
+
+		It("should return true if timestamp is set", func() {
+			now := metav1.Now()
+			namespace.ObjectMeta.DeletionTimestamp = &now
+			result, err := HasDeletionTimestamp(namespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+	})
+
 	Describe("#CreateOrUpdate", func() {
 		const (
 			namespace = "foo"


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently after namespace is marked for deletion, the deletion flow would still try create resources for the sake of validation, this results in a dead-lock since resources can not be created or updated while namespace is in deletion. This PR fixes this issue. 


