### PR TITLE
Add gardener.cloud "dashboard" API group

### DIFF
--- a/charts/gardener/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/charts/application/templates/rbac-user.yaml
@@ -10,6 +10,7 @@ rules:
 - apiGroups:
   - garden.sapcloud.io
   - core.gardener.cloud
+  - dashboard.gardener.cloud
   resources:
   - '*'
   verbs:


### PR DESCRIPTION
**What this PR does / why we need it**:
For the gardener dashboard webterminal feature we have introduced a new [gardener.cloud "dashboard"](https://github.com/gardener/terminal-controller-manager/blob/master/api/v1alpha1/groupversion_info.go#L28) API group under which the dashboard creates `terminal` resources. As of now only available for operators, hence we need to add it to the `garden.sapcloud.io:admin` cluster role

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `garden.sapcloud.io:admin` cluster role now includes the `dashboard.gardener.cloud` API Group
```
