### PR TITLE
Need to check storageclass name in alicloud when deleting

### DIFF
--- a/pkg/operation/cloudbotanist/alicloudbotanist/addons.go
+++ b/pkg/operation/cloudbotanist/alicloudbotanist/addons.go
@@ -54,7 +54,7 @@ func (b *AlicloudBotanist) GenerateStorageClassesConfig() (map[string]interface{
 		return nil, err
 	}
 	for _, sc := range storageclassList.Items {
-		if sc.Provisioner == "diskplugin.csi.alibabacloud.com" {
+		if sc.Provisioner == "diskplugin.csi.alibabacloud.com" && (sc.Name == "default" || sc.Name == "gardener.cloud-fast") {
 			if _, ok := sc.Parameters["encrypted"]; !ok {
 				if deleteErr := b.Operation.K8sShootClient.Kubernetes().StorageV1().StorageClasses().Delete(sc.Name, &metav1.DeleteOptions{}); deleteErr != nil {
 					return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Continue to #1199 , avoid to delete customer's storageclasses by accident.