### PR TITLE
Add gardener reconcilation test after update

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -2,7 +2,7 @@ kind: TestDefinition
 metadata:
   name: create-shoot
 spec:
-  owner: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+  owner: gardener-oq@listserv.sap.com
   description: Tests the creation of a shoot.
 
   activeDeadlineSeconds: 3600

--- a/.test-defs/DeleteShoot.yaml
+++ b/.test-defs/DeleteShoot.yaml
@@ -2,7 +2,7 @@ kind: TestDefinition
 metadata:
   name: delete-shoot
 spec:
-  owner: DL_5C5BE3E2970B9F404D0E2F50@sap.com # OutputQualification DL
+  owner: gardener-oq@listserv.sap.com
   description: Tests the deletion of a shoot.
 
   activeDeadlineSeconds: 1800

--- a/.test-defs/PlantTest.yaml
+++ b/.test-defs/PlantTest.yaml
@@ -2,7 +2,7 @@ kind: TestDefinition
 metadata:
   name: plant-test
 spec:
-  owner: DL_5C5BE3E2970B9F404D0E2F50@sap.com # OutputQualification DL
+  owner: gardener-oq@listserv.sap.com
   description: Tests the creation of a plant.
 
   activeDeadlineSeconds: 600

--- a/.test-defs/ReconcileShoots.yaml
+++ b/.test-defs/ReconcileShoots.yaml
@@ -1,0 +1,20 @@
+kind: TestDefinition
+metadata:
+  name: reconcile-shoots
+spec:
+  owner: gardener-oq@listserv.sap.com
+  description: Tests to wait and check if all shoots are successfully reconciled
+
+  activeDeadlineSeconds: 3600
+  labels: []
+
+  command: [bash, -c]
+  args:
+  - >-
+    /tm/setup github.com/gardener gardener &&
+    go test $GOPATH/src/github.com/gardener/gardener/test/integration/gardener/reconcile
+    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor --verbose=debug
+    -kubeconfig=$TM_KUBECONFIG_PATH/gardener.config
+    -version=$GARDENER_VERSION
+
+  image: eu.gcr.io/gardener-project/gardener/testmachinery/golang:0.42.0

--- a/.test-defs/SchedulerTest.yaml
+++ b/.test-defs/SchedulerTest.yaml
@@ -2,7 +2,7 @@ kind: TestDefinition
 metadata:
   name: scheduler-test
 spec:
-  owner: DL_5C5BE3E2970B9F404D0E2F50@sap.com
+  owner: gardener-oq@listserv.sap.com
   description: Tests the scheduler.
 
   activeDeadlineSeconds: 5400

--- a/.test-defs/SeedNetworkPoliciesTest.yaml
+++ b/.test-defs/SeedNetworkPoliciesTest.yaml
@@ -2,7 +2,7 @@ kind: TestDefinition
 metadata:
   name: seed-networkpolicies-test
 spec:
-  owner: DL_5C5BE3E2970B9F404D0E2F50@sap.com # OutputQualification DL
+  owner: gardener-oq@listserv.sap.com
   description: Tests NetworkPolicies between various components.
 
   activeDeadlineSeconds: 1800

--- a/.test-defs/ShootAppTest.yaml
+++ b/.test-defs/ShootAppTest.yaml
@@ -2,7 +2,7 @@ kind: TestDefinition
 metadata:
   name: shootapp-test
 spec:
-  owner: DL_5C5BE3E2970B9F404D0E2F50@sap.com # OutputQualification DL
+  owner: gardener-oq@listserv.sap.com
   description: Tests the deployment of a guestbook.
 
   activeDeadlineSeconds: 1800

--- a/docs/testing/integration_tests.md
+++ b/docs/testing/integration_tests.md
@@ -308,3 +308,43 @@ ginkgo \
     --shootNamespace="garden-dev" \
     --cleanup=true
 ```
+
+## Gardener
+
+Currently the gardener tests consists of:
+
+- RBAC test
+- shoots reconcile test
+
+### Gardener RBAC test
+
+The gardener RBAC test is meant to test if RBAC is enabled on the gardener cluster.
+This is tested by:
+1. Check if the RBAC API-Resource is available
+2. Check if a service account in a project namespace can access the `garden` project.
+
+#### Example Run
+```console
+cd test/integration/gardener/rbac
+ginkgo \
+    --progress \
+    -v \
+    --noColor \
+    -kubeconfig=$HOME/.kube/config \
+    -project-namespace=garden-core
+```
+
+### Gardener reconcile test
+
+The gardener reconcile test checks if all shoots of a gardener cluster are successfully reconciled after the gardener version was updated.
+
+#### Example Run
+```console
+cd test/integration/gardener/rbac
+ginkgo \
+    --progress \
+    -v \
+    --noColor \
+    -kubeconfig=$HOME/.kube/config \
+    -version=0.26.4
+```

--- a/test/integration/framework/shoot_operations.go
+++ b/test/integration/framework/shoot_operations.go
@@ -182,7 +182,7 @@ func (s *ShootGardenerTest) WaitForShootToBeCreated(ctx context.Context) error {
 			s.Logger.Infof("Error while waiting for shoot to be created: %s", err.Error())
 			return retry.MinorError(err)
 		}
-		if shootCreationCompleted(shoot) {
+		if ShootCreationCompleted(shoot) {
 			return retry.Ok()
 		}
 		s.Logger.Infof("Waiting for shoot %s to be created", s.Shoot.Name)

--- a/test/integration/framework/utils.go
+++ b/test/integration/framework/utils.go
@@ -137,7 +137,8 @@ func getDeploymentListByLabels(ctx context.Context, labelsMap labels.Selector, n
 	return deploymentList, nil
 }
 
-func shootCreationCompleted(newShoot *v1beta1.Shoot) bool {
+// ShootCreationCompleted checks if a shoot is successfully reconciled.
+func ShootCreationCompleted(newShoot *v1beta1.Shoot) bool {
 	if newShoot.Generation != newShoot.Status.ObservedGeneration {
 		return false
 	}

--- a/test/integration/gardener/reconcile/gardener_reconcile_suite_test.go
+++ b/test/integration/gardener/reconcile/gardener_reconcile_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gardener_rbac_test
+package gardener_reconcile_test
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-func TestPlant(t *testing.T) {
+func TestReconcile(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "RBAC Test Suite")
+	RunSpecs(t, "Reconcile Test Suite")
 }

--- a/test/integration/gardener/reconcile/gardener_reconcile_test.go
+++ b/test/integration/gardener/reconcile/gardener_reconcile_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardener_reconcile_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	"github.com/gardener/gardener/test/integration/framework"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/gardener/gardener/test/integration/shoots"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	kubeconfigPath  = flag.String("kubeconfig", "", "the path to the kubeconfig path  of the garden cluster that will be used for integration tests")
+	gardenerVersion = flag.String("version", "", "current gardener version")
+	logLevel        = flag.String("verbose", "", "verbosity level, when set, logging level will be DEBUG")
+)
+
+const (
+	ReconcileShootsTimeout = 1 * time.Hour
+	InitializationTimeout  = 20 * time.Second
+)
+
+func validateFlags() {
+
+	if !StringSet(*kubeconfigPath) {
+		Fail("you need to specify the correct path for the kubeconfigpath")
+	}
+
+	if !FileExists(*kubeconfigPath) {
+		Fail("kubeconfigpath path does not exist")
+	}
+
+	if !StringSet(*gardenerVersion) {
+		Fail("you need to specify the current gardener version")
+	}
+}
+
+var _ = Describe("Shoot reconciliation testing", func() {
+	var (
+		gardenClient kubernetes.Interface
+		testLogger *logrus.Logger
+	)
+
+	CBeforeSuite(func(ctx context.Context) {
+		validateFlags()
+		testLogger = logger.AddWriter(logger.NewLogger(*logLevel), GinkgoWriter)
+
+		var err error
+		gardenClient, err = kubernetes.NewClientFromFile("", *kubeconfigPath, client.Options{
+			Scheme: kubernetes.GardenScheme,
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+	}, InitializationTimeout)
+
+	CIt("Should reconcile all shoots", func(ctx context.Context) {
+		err := retry.UntilTimeout(ctx, 30*time.Second, ReconcileShootsTimeout, func(ctx context.Context) (bool, error) {
+			shoots := &v1beta1.ShootList{}
+			err := gardenClient.Client().List(ctx, shoots)
+			if err != nil {
+				testLogger.Debug(err.Error())
+				return retry.MinorError(err)
+			}
+
+			reconciledShoots := 0
+			for _, shoot := range shoots.Items {
+				// check if the last acted gardener version is the current version,
+				// to determine if the updated gardener version reconciled the shoot.
+				if shoot.Status.Gardener.Version != *gardenerVersion {
+					testLogger.Debugf("last acted gardener version %s does not match current gardener version %s", shoot.Status.Gardener.Version, *gardenerVersion)
+					continue
+				}
+				if framework.ShootCreationCompleted(&shoot) {
+					reconciledShoots++
+				}
+			}
+
+			if reconciledShoots != len(shoots.Items) {
+				err := fmt.Errorf("Reconciled %d of %d shoots. Waiting ...", reconciledShoots, len(shoots.Items))
+				testLogger.Info(err.Error())
+				return retry.MinorError(err)
+			}
+
+			return retry.Ok()
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+	}, ReconcileShootsTimeout)
+
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
Added an test that checks if all shoots are successfully reconciled after an gardener update.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Added a test that checks if all shoots are successfully reconciled after an gardener update
```
