### PR TITLE
Add shoot kubernetes version update test

### DIFF
--- a/pkg/apis/garden/v1beta1/helper/helpers_test.go
+++ b/pkg/apis/garden/v1beta1/helper/helpers_test.go
@@ -197,6 +197,230 @@ var _ = Describe("helper", func() {
 		),
 	)
 
+	var (
+		kubernetesConstraint = gardenv1beta1.KubernetesConstraints{
+			Versions: []string{
+				"1.15.1",
+				"1.14.4",
+				"1.12.9",
+			},
+		}
+	)
+
+	DescribeTable("#DetermineLatestKubernetesPatchVersion",
+		func(cloudProfile gardenv1beta1.CloudProfile, currentVersion, expectedVersion string, expectVersion bool) {
+			ok, newVersion, err := DetermineLatestKubernetesPatchVersion(cloudProfile, currentVersion)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(Equal(expectVersion))
+			Expect(newVersion).To(Equal(expectedVersion))
+		},
+		Entry("version = 1.15.1",
+			gardenv1beta1.CloudProfile{
+				Spec: gardenv1beta1.CloudProfileSpec{
+					AWS: &gardenv1beta1.AWSProfile{
+						Constraints: gardenv1beta1.AWSConstraints{
+							Kubernetes: kubernetesConstraint,
+						},
+					},
+				},
+			},
+			"1.15.0",
+			"1.15.1",
+			true,
+		),
+		Entry("version = 1.12.9",
+			gardenv1beta1.CloudProfile{
+				Spec: gardenv1beta1.CloudProfileSpec{
+					AWS: &gardenv1beta1.AWSProfile{
+						Constraints: gardenv1beta1.AWSConstraints{
+							Kubernetes: kubernetesConstraint,
+						},
+					},
+				},
+			},
+			"1.12.4",
+			"1.12.9",
+			true,
+		),
+		Entry("no new version",
+			gardenv1beta1.CloudProfile{
+				Spec: gardenv1beta1.CloudProfileSpec{
+					AWS: &gardenv1beta1.AWSProfile{
+						Constraints: gardenv1beta1.AWSConstraints{
+							Kubernetes: kubernetesConstraint,
+						},
+					},
+				},
+			},
+			"1.15.1",
+			"",
+			false,
+		),
+		Entry("GCP",
+			gardenv1beta1.CloudProfile{
+				Spec: gardenv1beta1.CloudProfileSpec{
+					GCP: &gardenv1beta1.GCPProfile{
+						Constraints: gardenv1beta1.GCPConstraints{
+							Kubernetes: kubernetesConstraint,
+						},
+					},
+				},
+			},
+			"1.12.4",
+			"1.12.9",
+			true,
+		),
+		Entry("Azure",
+			gardenv1beta1.CloudProfile{
+				Spec: gardenv1beta1.CloudProfileSpec{
+					Azure: &gardenv1beta1.AzureProfile{
+						Constraints: gardenv1beta1.AzureConstraints{
+							Kubernetes: kubernetesConstraint,
+						},
+					},
+				},
+			},
+			"1.12.4",
+			"1.12.9",
+			true,
+		),
+		Entry("Openstack",
+			gardenv1beta1.CloudProfile{
+				Spec: gardenv1beta1.CloudProfileSpec{
+					OpenStack: &gardenv1beta1.OpenStackProfile{
+						Constraints: gardenv1beta1.OpenStackConstraints{
+							Kubernetes: kubernetesConstraint,
+						},
+					},
+				},
+			},
+			"1.12.4",
+			"1.12.9",
+			true,
+		),
+		Entry("Packet",
+			gardenv1beta1.CloudProfile{
+				Spec: gardenv1beta1.CloudProfileSpec{
+					Packet: &gardenv1beta1.PacketProfile{
+						Constraints: gardenv1beta1.PacketConstraints{
+							Kubernetes: kubernetesConstraint,
+						},
+					},
+				},
+			},
+			"1.12.4",
+			"1.12.9",
+			true,
+		),
+	)
+
+	DescribeTable("#DetermineNextKubernetesMinorVersion",
+		func(cloudProfile gardenv1beta1.CloudProfile, currentVersion, expectedVersion string, expectVersion bool) {
+			ok, newVersion, err := DetermineNextKubernetesMinorVersion(cloudProfile, currentVersion)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(Equal(expectVersion))
+			Expect(newVersion).To(Equal(expectedVersion))
+		},
+		Entry("version = 1.15.1",
+			gardenv1beta1.CloudProfile{
+				Spec: gardenv1beta1.CloudProfileSpec{
+					AWS: &gardenv1beta1.AWSProfile{
+						Constraints: gardenv1beta1.AWSConstraints{
+							Kubernetes: kubernetesConstraint,
+						},
+					},
+				},
+			},
+			"1.14.4",
+			"1.15.1",
+			true,
+		),
+		Entry("version = 1.12.9",
+			gardenv1beta1.CloudProfile{
+				Spec: gardenv1beta1.CloudProfileSpec{
+					AWS: &gardenv1beta1.AWSProfile{
+						Constraints: gardenv1beta1.AWSConstraints{
+							Kubernetes: kubernetesConstraint,
+						},
+					},
+				},
+			},
+			"1.11.0",
+			"1.12.9",
+			true,
+		),
+		Entry("no new version",
+			gardenv1beta1.CloudProfile{
+				Spec: gardenv1beta1.CloudProfileSpec{
+					AWS: &gardenv1beta1.AWSProfile{
+						Constraints: gardenv1beta1.AWSConstraints{
+							Kubernetes: kubernetesConstraint,
+						},
+					},
+				},
+			},
+			"1.15.1",
+			"",
+			false,
+		),
+		Entry("GCP",
+			gardenv1beta1.CloudProfile{
+				Spec: gardenv1beta1.CloudProfileSpec{
+					GCP: &gardenv1beta1.GCPProfile{
+						Constraints: gardenv1beta1.GCPConstraints{
+							Kubernetes: kubernetesConstraint,
+						},
+					},
+				},
+			},
+			"1.12.9",
+			"1.14.4",
+			true,
+		),
+		Entry("Azure",
+			gardenv1beta1.CloudProfile{
+				Spec: gardenv1beta1.CloudProfileSpec{
+					Azure: &gardenv1beta1.AzureProfile{
+						Constraints: gardenv1beta1.AzureConstraints{
+							Kubernetes: kubernetesConstraint,
+						},
+					},
+				},
+			},
+			"1.12.9",
+			"1.14.4",
+			true,
+		),
+		Entry("Openstack",
+			gardenv1beta1.CloudProfile{
+				Spec: gardenv1beta1.CloudProfileSpec{
+					OpenStack: &gardenv1beta1.OpenStackProfile{
+						Constraints: gardenv1beta1.OpenStackConstraints{
+							Kubernetes: kubernetesConstraint,
+						},
+					},
+				},
+			},
+			"1.12.9",
+			"1.14.4",
+			true,
+		),
+		Entry("Packet",
+			gardenv1beta1.CloudProfile{
+				Spec: gardenv1beta1.CloudProfileSpec{
+					Packet: &gardenv1beta1.PacketProfile{
+						Constraints: gardenv1beta1.PacketConstraints{
+							Kubernetes: kubernetesConstraint,
+						},
+					},
+				},
+			},
+			"1.12.9",
+			"1.14.4",
+			true,
+		),
+	)
+
 	DescribeTable("#ShootWantsClusterAutoscaler",
 		func(shoot *gardenv1beta1.Shoot, wantsAutoscaler bool) {
 			actualWantsAutoscaler, err := ShootWantsClusterAutoscaler(shoot)

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -176,7 +176,7 @@ func (c *defaultMaintenanceControl) Maintain(shootObj *gardenv1beta1.Shoot, key 
 	// Check if the CloudProfile contains a newer Kubernetes patch version.
 	var updateKubernetesVersion func(s *gardenv1beta1.Kubernetes)
 	if shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion {
-		newerPatchVersionFound, latestPatchVersion, err := helper.DetermineLatestKubernetesVersion(*operation.Shoot.CloudProfile, operation.Shoot.Info.Spec.Kubernetes.Version)
+		newerPatchVersionFound, latestPatchVersion, err := helper.DetermineLatestKubernetesPatchVersion(*operation.Shoot.CloudProfile, operation.Shoot.Info.Spec.Kubernetes.Version)
 		if err != nil {
 			handleError(fmt.Sprintf("Failure while determining the latest Kubernetes patch version in the CloudProfile: %s", err.Error()))
 			return nil

--- a/test/integration/shoots/update/shoot_update_test.go
+++ b/test/integration/shoots/update/shoot_update_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shootupdate
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
+	"time"
+
+	. "github.com/gardener/gardener/test/integration/shoots"
+
+	"github.com/gardener/gardener/pkg/apis/garden/v1beta1"
+	"github.com/gardener/gardener/pkg/logger"
+	. "github.com/gardener/gardener/test/integration/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	kubeconfig        = flag.String("kubeconfig", "", "the path to the kubeconfig  of the garden cluster that will be used for integration tests")
+	kubernetesVersion = flag.String("version", "", "the version to update the shoot")
+	shootName         = flag.String("shootName", "", "the name of the shoot we want to test")
+	shootNamespace    = flag.String("shootNamespace", "", "the namespace name that the shoot resides in")
+	testShootsPrefix  = flag.String("prefix", "", "prefix to use for test shoots")
+	logLevel          = flag.String("verbose", "", "verbosity level, when set, logging level will be DEBUG")
+	shootTestYamlPath = flag.String("shootpath", "", "the path to the shoot yaml that will be used for testing")
+	cleanup           = flag.Bool("cleanup", false, "deletes the newly created / existing test shoot after the test suite is done")
+)
+
+const (
+	UpdateKubernetesVersionTimeout = 600 * time.Second
+	InitializationTimeout          = 600 * time.Second
+)
+
+func validateFlags() {
+	if StringSet(*shootTestYamlPath) && StringSet(*shootName) {
+		Fail("You can set either the shoot YAML path or specify a shootName to test against")
+	}
+
+	if !StringSet(*shootTestYamlPath) && !StringSet(*shootName) {
+		Fail("You should either set the shoot YAML path or specify a shootName to test against")
+	}
+
+	if StringSet(*shootTestYamlPath) {
+		if !FileExists(*shootTestYamlPath) {
+			Fail("shoot yaml path is set but invalid")
+		}
+	}
+
+	if !StringSet(*kubeconfig) {
+		Fail("you need to specify the correct path for the kubeconfig")
+	}
+
+	if !FileExists(*kubeconfig) {
+		Fail("kubeconfig path does not exist")
+	}
+}
+
+var _ = Describe("Shoot update testing", func() {
+	var (
+		shootGardenerTest   *ShootGardenerTest
+		shootTestOperations *GardenerTestOperation
+		shootTestLogger     *logrus.Logger
+	)
+
+	CBeforeSuite(func(ctx context.Context) {
+		// validate flags
+		validateFlags()
+		shootTestLogger = logger.AddWriter(logger.NewLogger(*logLevel), GinkgoWriter)
+
+		// check if a shoot spec is provided, if yes create a shoot object from it and use it for testing
+		if StringSet(*shootTestYamlPath) {
+			*cleanup = true
+			// parse shoot yaml into shoot object and generate random test names for shoots
+			_, shootObject, err := CreateShootTestArtifacts(*shootTestYamlPath, *testShootsPrefix, true)
+			Expect(err).NotTo(HaveOccurred())
+
+			shootGardenerTest, err = NewShootGardenerTest(*kubeconfig, shootObject, shootTestLogger)
+			Expect(err).NotTo(HaveOccurred())
+
+			targetTestShoot, err := shootGardenerTest.CreateShoot(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			shootTestOperations, err = NewGardenTestOperation(ctx, shootGardenerTest.GardenClient, shootTestLogger, targetTestShoot)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		if StringSet(*shootName) {
+			var err error
+			shootGardenerTest, err = NewShootGardenerTest(*kubeconfig, nil, shootTestLogger)
+			Expect(err).NotTo(HaveOccurred())
+
+			shoot := &v1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Namespace: *shootNamespace, Name: *shootName}}
+			shootTestOperations, err = NewGardenTestOperation(ctx, shootGardenerTest.GardenClient, shootTestLogger, shoot)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+	}, InitializationTimeout)
+
+	CIt("should update the kubernetes version of the shoot to the next available minor version", func(ctx context.Context) {
+		currentVersion := shootTestOperations.Shoot.Spec.Kubernetes.Version
+		newVersion := *kubernetesVersion
+		if newVersion == "" {
+			var (
+				err error
+				ok  bool
+			)
+			cloudprofile := shootTestOperations.SeedCloudProfile
+			ok, newVersion, err = helper.DetermineNextKubernetesMinorVersion(*cloudprofile, currentVersion)
+			Expect(err).ToNot(HaveOccurred())
+			if !ok {
+				Skip("no new version found")
+			}
+		}
+
+		By(fmt.Sprintf("updating shoot %s to version %s", shootTestOperations.Shoot.Name, newVersion))
+		shootTestOperations.Shoot.Spec.Kubernetes.Version = newVersion
+
+		_, err := shootGardenerTest.UpdateShoot(ctx, shootTestOperations.Shoot)
+		Expect(err).ToNot(HaveOccurred())
+
+	}, UpdateKubernetesVersionTimeout)
+
+})

--- a/test/integration/shoots/update/shootupdate_suite_test.go
+++ b/test/integration/shoots/update/shootupdate_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shootupdate_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestUpdateShoot(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Shoot Update Integration Test Suite")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added an integration test that updates the kubernetes of a shoot to specified version or the next minor version.
After the kubernetes version is updated the test checks if the shoot successfully reconciles.

**Special notes for your reviewer**:
To specify the next minor version [this function](https://github.com/gardener/gardener/blob/5be4367561deac34871049a010470b925d7485dc/pkg/apis/garden/v1beta1/helper/helpers.go#L314) was copied to the test framework.
But the only difference of these functions is the semver compare operator. 
Should I refactor the Gardener helper method so that we have no duplicated code (for exmaple factor out common code and create two new function `DetermineLatestKubernetesPatchVersion` and `DetermineLatestKubernetesMinorVersion`)?


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Added an integration test to validate the successful reconciliation of a shoot after its kubernetes version is updated
```
