### PR TITLE
[hotfix] Add purpose-based deletion grace period for backup infrastructure

### DIFF
--- a/charts/gardener/charts/runtime/templates/configmap-controller-manager.yaml
+++ b/charts/gardener/charts/runtime/templates/configmap-controller-manager.yaml
@@ -100,8 +100,11 @@ data:
       backupInfrastructure:
         concurrentSyncs: {{ required ".Values.global.controller.config.controllers.backupInfrastructure.concurrentSyncs is required" .Values.global.controller.config.controllers.backupInfrastructure.concurrentSyncs }}
         syncPeriod: {{ required ".Values.global.controller.config.controllers.backupInfrastructure.syncPeriod is required" .Values.global.controller.config.controllers.backupInfrastructure.syncPeriod }}
-        {{- if .Values.global.controller.config.controllers.backupInfrastructure.deletionGracePeriodDays }}
-        deletionGracePeriodDays: {{ .Values.global.controller.config.controllers.backupInfrastructure.deletionGracePeriodDays }}
+        {{- if .Values.global.controller.config.controllers.backupInfrastructure.deletionGracePeriodHours }}
+        deletionGracePeriodHours: {{ .Values.global.controller.config.controllers.backupInfrastructure.deletionGracePeriodHours }}
+        {{- end }}
+        {{- if .Values.global.controller.config.controllers.backupInfrastructure.deletionGracePeriodHoursByPurpose }}
+        deletionGracePeriodHoursByPurpose: {{ .Values.global.controller.config.controllers.backupInfrastructure.deletionGracePeriodHoursByPurpose }}
         {{- end }}
     leaderElection:
       leaderElect: {{ required ".Values.global.controller.config.leaderElection.leaderElect is required" .Values.global.controller.config.leaderElection.leaderElect }}

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -46,7 +46,7 @@ controllers:
   backupInfrastructure:
     concurrentSyncs: 20
     syncPeriod: 24h
-    deletionGracePeriodDays: 0
+    deletionGracePeriodHours: 0
 leaderElection:
   leaderElect: true
   leaseDuration: 15s

--- a/pkg/controllermanager/apis/config/types.go
+++ b/pkg/controllermanager/apis/config/types.go
@@ -244,10 +244,13 @@ type BackupInfrastructureControllerConfiguration struct {
 	ConcurrentSyncs int
 	// SyncPeriod is the duration how often the existing resources are reconciled.
 	SyncPeriod metav1.Duration
-	// DeletionGracePeriodDays holds the period in number of days to delete the Backup Infrastructure after deletion timestamp is set.
+	// DeletionGracePeriodHours holds the period in number of hours to delete the Backup Infrastructure after deletion timestamp is set.
 	// If value is set to 0 then the BackupInfrastructureController will trigger deletion immediately.
 	// +optional
-	DeletionGracePeriodDays *int
+	DeletionGracePeriodHours *int
+	// DeletionGracePeriodHoursByPurpose holds various shoot purposes mapped to the respective deletion grace periods in hours for the backup infrastructure associated with the shoot
+	// +optional
+	DeletionGracePeriodHoursByPurpose map[string]int
 }
 
 // DiscoveryConfiguration defines the configuration of how to discover API groups.

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -120,9 +120,9 @@ func SetDefaults_ControllerManagerConfiguration(obj *ControllerManagerConfigurat
 		obj.Controllers.Shoot.RetrySyncPeriod = &durationVar
 	}
 
-	if obj.Controllers.BackupInfrastructure.DeletionGracePeriodDays == nil || *obj.Controllers.BackupInfrastructure.DeletionGracePeriodDays < 0 {
-		var defaultBackupInfrastructureDeletionGracePeriodDays = DefaultBackupInfrastructureDeletionGracePeriodDays
-		obj.Controllers.BackupInfrastructure.DeletionGracePeriodDays = &defaultBackupInfrastructureDeletionGracePeriodDays
+	if obj.Controllers.BackupInfrastructure.DeletionGracePeriodHours == nil || *obj.Controllers.BackupInfrastructure.DeletionGracePeriodHours < 0 {
+		var defaultBackupInfrastructureDeletionGracePeriodHours = DefaultBackupInfrastructureDeletionGracePeriodHours
+		obj.Controllers.BackupInfrastructure.DeletionGracePeriodHours = &defaultBackupInfrastructureDeletionGracePeriodHours
 	}
 
 	if obj.Controllers.Plant == nil {

--- a/pkg/controllermanager/apis/config/v1alpha1/types.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/types.go
@@ -248,10 +248,13 @@ type BackupInfrastructureControllerConfiguration struct {
 	ConcurrentSyncs int `json:"concurrentSyncs"`
 	// SyncPeriod is the duration how often the existing resources are reconciled.
 	SyncPeriod metav1.Duration `json:"syncPeriod"`
-	// DeletionGracePeriodDays holds the period in number of days to delete the Backup Infrastructure after deletion timestamp is set.
-	// If value is set to 0 then the BackupInfrastructureController will trigger deletion immediately..
+	// DeletionGracePeriodHours holds the period in number of hours to delete the Backup Infrastructure after deletion timestamp is set.
+	// If value is set to 0 then the BackupInfrastructureController will trigger deletion immediately.
 	// +optional
-	DeletionGracePeriodDays *int `json:"deletionGracePeriodDays,omitempty"`
+	DeletionGracePeriodHours *int `json:"deletionGracePeriodHours,omitempty"`
+	// DeletionGracePeriodHoursByPurpose holds various shoot purposes mapped to the respective deletion grace periods in hours for the backup infrastructure associated with the shoot
+	// +optional
+	DeletionGracePeriodHoursByPurpose map[string]int `json:"deletionGracePeriodHoursByPurpose,omitempty"`
 }
 
 // DiscoveryConfiguration defines the configuration of how to discover API groups.
@@ -325,9 +328,9 @@ const (
 	// ControllerManagerDefaultLockObjectName is the default lock name for leader election.
 	ControllerManagerDefaultLockObjectName = "gardener-controller-manager-leader-election"
 
-	// DefaultBackupInfrastructureDeletionGracePeriodDays is a constant for the default number of days the Backup Infrastructure should be kept after shoot is deleted.
+	// DefaultBackupInfrastructureDeletionGracePeriodHours is a constant for the default number of hours the Backup Infrastructure should be kept after shoot is deleted.
 	// By default we set this to 0 so that then BackupInfrastructureController will trigger deletion immediately.
-	DefaultBackupInfrastructureDeletionGracePeriodDays = 0
+	DefaultBackupInfrastructureDeletionGracePeriodHours = 0
 
 	// DefaultETCDBackupSchedule is a constant for the default schedule to take backups of a Shoot cluster (daily).
 	DefaultETCDBackupSchedule = "0 */24 * * *"

--- a/pkg/controllermanager/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/zz_generated.conversion.go
@@ -284,7 +284,8 @@ func RegisterConversions(s *runtime.Scheme) error {
 func autoConvert_v1alpha1_BackupInfrastructureControllerConfiguration_To_config_BackupInfrastructureControllerConfiguration(in *BackupInfrastructureControllerConfiguration, out *config.BackupInfrastructureControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = in.ConcurrentSyncs
 	out.SyncPeriod = in.SyncPeriod
-	out.DeletionGracePeriodDays = (*int)(unsafe.Pointer(in.DeletionGracePeriodDays))
+	out.DeletionGracePeriodHours = (*int)(unsafe.Pointer(in.DeletionGracePeriodHours))
+	out.DeletionGracePeriodHoursByPurpose = *(*map[string]int)(unsafe.Pointer(&in.DeletionGracePeriodHoursByPurpose))
 	return nil
 }
 
@@ -296,7 +297,8 @@ func Convert_v1alpha1_BackupInfrastructureControllerConfiguration_To_config_Back
 func autoConvert_config_BackupInfrastructureControllerConfiguration_To_v1alpha1_BackupInfrastructureControllerConfiguration(in *config.BackupInfrastructureControllerConfiguration, out *BackupInfrastructureControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = in.ConcurrentSyncs
 	out.SyncPeriod = in.SyncPeriod
-	out.DeletionGracePeriodDays = (*int)(unsafe.Pointer(in.DeletionGracePeriodDays))
+	out.DeletionGracePeriodHours = (*int)(unsafe.Pointer(in.DeletionGracePeriodHours))
+	out.DeletionGracePeriodHoursByPurpose = *(*map[string]int)(unsafe.Pointer(&in.DeletionGracePeriodHoursByPurpose))
 	return nil
 }
 

--- a/pkg/controllermanager/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -29,10 +29,17 @@ import (
 func (in *BackupInfrastructureControllerConfiguration) DeepCopyInto(out *BackupInfrastructureControllerConfiguration) {
 	*out = *in
 	out.SyncPeriod = in.SyncPeriod
-	if in.DeletionGracePeriodDays != nil {
-		in, out := &in.DeletionGracePeriodDays, &out.DeletionGracePeriodDays
+	if in.DeletionGracePeriodHours != nil {
+		in, out := &in.DeletionGracePeriodHours, &out.DeletionGracePeriodHours
 		*out = new(int)
 		**out = **in
+	}
+	if in.DeletionGracePeriodHoursByPurpose != nil {
+		in, out := &in.DeletionGracePeriodHoursByPurpose, &out.DeletionGracePeriodHoursByPurpose
+		*out = make(map[string]int, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	return
 }

--- a/pkg/controllermanager/apis/config/zz_generated.deepcopy.go
+++ b/pkg/controllermanager/apis/config/zz_generated.deepcopy.go
@@ -29,10 +29,17 @@ import (
 func (in *BackupInfrastructureControllerConfiguration) DeepCopyInto(out *BackupInfrastructureControllerConfiguration) {
 	*out = *in
 	out.SyncPeriod = in.SyncPeriod
-	if in.DeletionGracePeriodDays != nil {
-		in, out := &in.DeletionGracePeriodDays, &out.DeletionGracePeriodDays
+	if in.DeletionGracePeriodHours != nil {
+		in, out := &in.DeletionGracePeriodHours, &out.DeletionGracePeriodHours
 		*out = new(int)
 		**out = **in
+	}
+	if in.DeletionGracePeriodHoursByPurpose != nil {
+		in, out := &in.DeletionGracePeriodHoursByPurpose, &out.DeletionGracePeriodHoursByPurpose
+		*out = make(map[string]int, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	return
 }

--- a/pkg/registry/garden/backupinfrastructure/strategy.go
+++ b/pkg/registry/garden/backupinfrastructure/strategy.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 
 	"github.com/gardener/gardener/pkg/api"
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/garden"
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/garden/validation"
@@ -66,6 +67,10 @@ func (backupInfrastructureStrategy) PrepareForUpdate(ctx context.Context, obj, o
 }
 
 func mustIncreaseGeneration(oldBackupInfrastructure, newBackupInfrastructure *garden.BackupInfrastructure) bool {
+	var (
+		oldPurpose, newPurpose string
+	)
+
 	// The BackupInfrastructure specification changes.
 	if !apiequality.Semantic.DeepEqual(oldBackupInfrastructure.Spec, newBackupInfrastructure.Spec) {
 		return true
@@ -79,6 +84,12 @@ func mustIncreaseGeneration(oldBackupInfrastructure, newBackupInfrastructure *ga
 	oldPresent, _ := strconv.ParseBool(oldBackupInfrastructure.ObjectMeta.Annotations[common.BackupInfrastructureForceDeletion])
 	newPresent, _ := strconv.ParseBool(newBackupInfrastructure.ObjectMeta.Annotations[common.BackupInfrastructureForceDeletion])
 	if oldPresent != newPresent && newPresent {
+		return true
+	}
+
+	oldPurpose = oldBackupInfrastructure.ObjectMeta.Annotations[gardencorev1alpha1.GardenPurpose]
+	newPurpose = newBackupInfrastructure.ObjectMeta.Annotations[gardencorev1alpha1.GardenPurpose]
+	if oldPurpose != newPurpose {
 		return true
 	}
 

--- a/pkg/registry/garden/shoot/strategy.go
+++ b/pkg/registry/garden/shoot/strategy.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/api"
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/garden"
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/garden/validation"
@@ -72,6 +73,10 @@ func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Obje
 }
 
 func mustIncreaseGeneration(oldShoot, newShoot *garden.Shoot) bool {
+	var (
+		oldPurpose, newPurpose string
+	)
+
 	// The Shoot specification changes.
 	if !apiequality.Semantic.DeepEqual(oldShoot.Spec, newShoot.Spec) {
 		return true
@@ -102,6 +107,12 @@ func mustIncreaseGeneration(oldShoot, newShoot *garden.Shoot) bool {
 			delete(newShoot.Annotations, common.ShootOperation)
 			return true
 		}
+	}
+
+	oldPurpose = oldShoot.ObjectMeta.Annotations[gardencorev1alpha1.GardenPurpose]
+	newPurpose = newShoot.ObjectMeta.Annotations[gardencorev1alpha1.GardenPurpose]
+	if oldPurpose != newPurpose {
+		return true
 	}
 
 	return false


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This PR adds support for setting the backup infrastructure deletion grace period per shoot purpose via controller manager config, via new field `deletionGracePeriodHoursByPurpose`. This PR also modifies the field `deletionGracePeriodDays` for backupInfrastructure controller to `deletionGracePeriodHours`, to provide more fine-grained control over backup bucket retention period.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This feature serves as a mitigation for the bucket quota limit issues on AWS.
@swapnilgm @adracus @zanetworker 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The field `deletionGracePeriodHoursByPurpose` is now introduced for the backupInfrastructure controller to specify different deletion grace period values per shoot purpose.
```
