### PR TITLE
[hotfix]Fix the template for backupInfrastructure deletionGracePeriodHoursByPurpose in gardener chart

### DIFF
--- a/charts/gardener/charts/runtime/templates/configmap-controller-manager.yaml
+++ b/charts/gardener/charts/runtime/templates/configmap-controller-manager.yaml
@@ -104,7 +104,8 @@ data:
         deletionGracePeriodHours: {{ .Values.global.controller.config.controllers.backupInfrastructure.deletionGracePeriodHours }}
         {{- end }}
         {{- if .Values.global.controller.config.controllers.backupInfrastructure.deletionGracePeriodHoursByPurpose }}
-        deletionGracePeriodHoursByPurpose: {{ .Values.global.controller.config.controllers.backupInfrastructure.deletionGracePeriodHoursByPurpose }}
+        deletionGracePeriodHoursByPurpose:
+{{ toYaml .Values.global.controller.config.controllers.backupInfrastructure.deletionGracePeriodHoursByPurpose | indent 10 }}
         {{- end }}
     leaderElection:
       leaderElect: {{ required ".Values.global.controller.config.leaderElection.leaderElect is required" .Values.global.controller.config.leaderElection.leaderElect }}


### PR DESCRIPTION

Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
This PR fixes the template for backupInfrastructure deletionGracePeriodHoursByPurpose in gardener chart.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Please checkout the Garedner chart rendering using `helm template`
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixed the template for backupInfrastructure deletionGracePeriodHoursByPurpose in gardener chart
```
