### PR TITLE
Improve kind node name check for hack/dev-setup

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -199,7 +199,7 @@ $ sed -i -e 's/Logging: true/Logging: false/g' dev/20-componentconfig-gardener-c
 
 The Gardener exposes the API servers of Shoot clusters via Kubernetes services of type `LoadBalancer`. In order to establish stable endpoints (robust against changes of the load balancer address), it creates DNS records pointing to these load balancer addresses. They are used internally and by all cluster components to communicate.
 You need to have control over a domain (or subdomain) for which these records will be created.
-Please provide an *internal domain secret* (see [this](../../example/10-secret-internal-domain.yaml) for an example) which contains credentials with the proper privileges. Further information can be found [here](../deployment/configuration.md).
+Please provide an *internal domain secret* (see [this](../../example/10-secret-internal-domain.yaml) for an example) which contains credentials with the proper privileges. Further information can be found [here](../concepts/configuration.md).
 
 ```bash
 $ kubectl apply -f example/10-secret-internal-domain-unmanaged.yaml

--- a/hack/common
+++ b/hack/common
@@ -19,6 +19,7 @@ set -e
 DOCKER_FOR_DESKTOP="docker-for-desktop"
 MINIKUBE="minikube"
 KIND="kind"
+KIND_NODE_NAME_SUFFIX="-control-plane"
 
 API_SERVER_SECURE_PORT="${API_SERVER_SECURE_PORT:-8443}"
 
@@ -37,7 +38,7 @@ k8s_env() {
         echo "$MINIKUBE"
         return
     fi
-    if [[ "$node_name" == "$KIND"* ]]; then
+    if [[ "$node_name" == *"$KIND_NODE_NAME_SUFFIX" ]]; then
         echo "$KIND"
         return
     fi


### PR DESCRIPTION
**What this PR does / why we need it**:
- Improve kind node name check for `hack/dev-setup`.
- Fix broken link.

**Which issue(s) this PR fixes**:
Fixes #1219

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
