### PR TITLE
remove runtimeVersion (>= 1.14.x) specification for alicloud

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -152,7 +152,6 @@ images:
   sourceRepository: https://github.com/kubernetes-csi/node-driver-registrar
   repository: quay.io/k8scsi/csi-node-driver-registrar
   tag: v1.1.0
-  runtimeVersion: 1.14.x
 - name: csi-plugin-alicloud
   sourceRepository: https://github.com/AliyunContainerService/csi-plugin
   repository: registry.eu-central-1.aliyuncs.com/gardener-de/csi-plugin-alicloud


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove runtimeVersion specification in image lists of alicloud where runtimeVersion is not 1.13.x. Doing this avoids adding new specifically versioned items in images.yaml at the time of version update (every version shares the same image specification if it does not require a specific version of image).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This refer to PR in Gardener-extension repo: https://github.com/gardener/gardener-extensions/pull/198

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Gardener does now support support shoot clusters with Kubernetes version 1.15 on Alicloud. 
```
