### PR TITLE
Fix accessor last operation typed nil pointer

### DIFF
--- a/pkg/apis/extensions/v1alpha1/types_defaults.go
+++ b/pkg/apis/extensions/v1alpha1/types_defaults.go
@@ -46,5 +46,8 @@ type DefaultStatus struct {
 
 // GetLastOperation implements Status.
 func (d *DefaultStatus) GetLastOperation() LastOperation {
+	if d.LastOperation == nil {
+		return nil
+	}
 	return d.LastOperation
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue with a typed nil pointer being handed out for the `LastOperation` accessor causing it to never 'really' be `nil`.

**Special notes for your reviewer**:
cc @timuthy 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
