### PR TITLE
remove storage class upgrade logic

### DIFF
--- a/pkg/operation/cloudbotanist/alicloudbotanist/addons.go
+++ b/pkg/operation/cloudbotanist/alicloudbotanist/addons.go
@@ -16,8 +16,6 @@ package alicloudbotanist
 
 import (
 	"github.com/gardener/gardener/pkg/operation/common"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // DeployKube2IAMResources - Not needed on Alicloud
@@ -48,21 +46,6 @@ func (b *AlicloudBotanist) GenerateNginxIngressConfig() (map[string]interface{},
 
 // GenerateStorageClassesConfig generates values which are required to render the chart shoot-storageclasses properly.
 func (b *AlicloudBotanist) GenerateStorageClassesConfig() (map[string]interface{}, error) {
-	//TODO Delete in next release. Add encrypted flag in storge class
-	storageclassList, err := b.Operation.K8sShootClient.Kubernetes().StorageV1().StorageClasses().List(metav1.ListOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, err
-	}
-	for _, sc := range storageclassList.Items {
-		if sc.Provisioner == "diskplugin.csi.alibabacloud.com" && (sc.Name == "default" || sc.Name == "gardener.cloud-fast") {
-			if _, ok := sc.Parameters["encrypted"]; !ok {
-				if deleteErr := b.Operation.K8sShootClient.Kubernetes().StorageV1().StorageClasses().Delete(sc.Name, &metav1.DeleteOptions{}); deleteErr != nil {
-					return nil, err
-				}
-			}
-		}
-	}
-
 	return map[string]interface{}{
 		"StorageClasses": []map[string]interface{}{
 			{

--- a/test/integration/gardener/reconcile/gardener_reconcile_test.go
+++ b/test/integration/gardener/reconcile/gardener_reconcile_test.go
@@ -64,7 +64,7 @@ func validateFlags() {
 var _ = Describe("Shoot reconciliation testing", func() {
 	var (
 		gardenClient kubernetes.Interface
-		testLogger *logrus.Logger
+		testLogger   *logrus.Logger
 	)
 
 	CBeforeSuite(func(ctx context.Context) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a follow up of #201

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
As #201 is a previous version  has been deployed in all landscapes and the default/etcd storageclasses have already flagged with encryption option. We could remove the upgrading code in this release.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
