### PR TITLE
Increse requests and limits for the VPN-shoot componenet

### DIFF
--- a/charts/shoot-core/charts/vpn-shoot/templates/deployment.yaml
+++ b/charts/shoot-core/charts/vpn-shoot/templates/deployment.yaml
@@ -70,11 +70,11 @@ spec:
             - NET_ADMIN
         resources:
           requests:
-            cpu: 50m
-            memory: 50Mi
-          limits:
             cpu: 100m
             memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
         volumeMounts:
         - mountPath: /srv/secrets/vpn-shoot
           name: vpn-shoot


### PR DESCRIPTION
**What this PR does / why we need it**:
The VPN pod can become a bottle neck for high demand traffic (e.g., file transfer). This can result in lower throughput and other networking issues. This PR increases the requests and limits to avoid the throttle.

** Related ** 
https://github.com/gardener/gardener/issues/1241