### PR TITLE
Increase bcrypt cost

### DIFF
--- a/pkg/utils/secrets/basic_auth.go
+++ b/pkg/utils/secrets/basic_auth.go
@@ -90,7 +90,7 @@ func (s *BasicAuthSecretConfig) GenerateBasicAuth() (*BasicAuth, error) {
 	}
 
 	if s.BcryptPasswordHashRequest != false {
-		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), 12)
+		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), 16)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Increases bcrypt cost for more secure passwords that are used by Searchguard
 
**Which issue(s) this PR fixes**:
Fixes #1112

**Special notes for your reviewer**:
@rfranzke 

```improvement operator
NONE
```
