### PR TITLE
Always deploy gardener-resource-manager

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
@@ -217,7 +217,7 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation, operationType
 		})
 		deployGardenerResourceManager = g.Add(flow.Task{
 			Name:         "Deploying gardener-resource-manager",
-			Fn:           flow.TaskFn(hybridBotanist.DeployGardenerResourceManager).RetryUntilTimeout(defaultInterval, defaultTimeout).SkipIf(o.Shoot.IsHibernated),
+			Fn:           flow.TaskFn(hybridBotanist.DeployGardenerResourceManager).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, rewriteSecrets),
 		})
 		deployManagedResources = g.Add(flow.Task{


### PR DESCRIPTION
**What this PR does / why we need it**:
We should deploy the gardener-resource-manager always because it's an essential part of the control plane. This PR is doing the same (actually, it was never intended to skip this task when the shoot is hibernated).

**Which issue(s) this PR fixes**:
Fixes #1194

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The newly introduced `gardener-resource-manager` component is now always deployed (even if the shoot is hibernated (with `replicas=0`)). This allows waking it up again when a hibernated shoot shall be deleted.
```
