### PR TITLE
Unregister shoot as seed when it was annotated and gets deleted

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_control_delete.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_delete.go
@@ -106,6 +106,13 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation) *gardencorev1alp
 		return gardencorev1alpha1helper.LastError(fmt.Sprintf("Failed to create a HybridBotanist (%s)", err.Error()))
 	}
 
+	// Unregister the Shoot as Seed cluster if it was annotated to be a seed and is in the garden namespace
+	if o.Shoot.Info.Namespace == common.GardenNamespace && o.ShootedSeed != nil {
+		if err := botanist.UnregisterAsSeed(); err != nil {
+			return gardencorev1alpha1helper.LastError(fmt.Sprintf("Could not unregister Shoot %q as Seed: %+v", o.Shoot.Info.Name, err))
+		}
+	}
+
 	// We check whether the kube-apiserver deployment exists in the shoot namespace. If it does not, then we assume
 	// that it has never been deployed successfully, or that we have deleted it in a previous run because we already
 	// cleaned up. We follow that no (more) resources can have been deployed in the shoot cluster, thus there is nothing


### PR DESCRIPTION
**What this PR does / why we need it**:
When a shoot that is annotated to be a shooted seed is deleted we should remove the automatically created `Seed` object and seed secret.

**Which issue(s) this PR fixes**:
Fixes #1155 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Shooted seed clusters that get deleted will now also cause automatic deletion of the corresponding `Seed` object and seed secret.
```
