### PR TITLE
Allow to filter by target version for image vector

### DIFF
--- a/pkg/utils/imagevector/imagevector_suite_test.go
+++ b/pkg/utils/imagevector/imagevector_suite_test.go
@@ -15,10 +15,10 @@
 package imagevector_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestOperation(t *testing.T) {

--- a/pkg/utils/imagevector/types.go
+++ b/pkg/utils/imagevector/types.go
@@ -15,11 +15,16 @@
 package imagevector
 
 // ImageSource contains the repository and the tag of a Docker container image. If the respective
-// image is only valid for a specific Kubernetes version, then it must also contain the 'versions'
-// field describing for which versions it can be used.
+// image is only valid for a specific Kubernetes runtime version, then it must also contain the
+// 'runtimeVersion' field describing for which versions it can be used. Similarly, if it is only
+// valid for a specific Kubernetes version to operate on, then it must also contain the 'targetVersion'
+// field describing for which versions it can be used. Examples of these are CSI controllers that run
+// in the seed cluster and act on the shoot cluster. Different versions might be used depending on the
+// seed and the shoot version.
 type ImageSource struct {
 	Name           string  `json:"name" yaml:"name"`
 	RuntimeVersion *string `json:"runtimeVersion,omitempty" yaml:"runtimeVersion,omitempty"`
+	TargetVersion  *string `json:"targetVersion,omitempty" yaml:"targetVersion,omitempty"`
 
 	Repository string  `json:"repository" yaml:"repository"`
 	Tag        *string `json:"tag,omitempty" yaml:"tag,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Especially needed for controllers running in the seed and targetting the shoot in different versions (for example: CSI conttrollers).

**Special notes for your reviewer**:
Resolves the workaround introduced by https://github.com/gardener/gardener-extensions/commit/c2da1605cfe8169375598f6df918e0e0d7717850

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The image vector does now allow to add runtime version constraints. This is especially helpful if components that are running in the seed cluster can only target specific shoot cluster versions.
```
