### PR TITLE
Add first version of gardener integration tests

### DIFF
--- a/.ci/get_latest_release_component_descriptor
+++ b/.ci/get_latest_release_component_descriptor
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+#
+# Copyright 2019 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import util
+import os
+import version
+import yaml
+import ctx
+from product.util import (
+    ComponentDescriptor,
+    ComponentDescriptorResolver,
+)
+from github.util import (
+    GitHubRepositoryHelper,
+    find_greatest_github_release_version,
+)
+
+gardener_component="github.com/gardener/gardener"
+gardensetup_component="github.com/gardener/garden-setup"
+
+
+cd_path = os.getenv("OUT_PATH")
+if not cd_path:
+    cd_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../component_descriptor_dir")
+
+descriptor_path = os.path.join(cd_path, "previous_component_descriptor.yaml")
+
+github_cfg_name = "github_com"
+github_cfg = ctx.cfg_factory().github(github_cfg_name)
+component_resolver = ComponentDescriptorResolver(ctx.cfg_factory())
+
+def get_releases(github_repository_owner: str, github_repository_name: str):
+    github_helper = GitHubRepositoryHelper(
+        owner=github_repository_owner,
+        name=github_repository_name,
+        github_cfg=github_cfg,
+    )
+
+    releases = github_helper.repository.releases()
+    release_versions = [
+        release.name for release in releases if release.name and "draft" not in release.name
+    ]
+    return release_versions
+
+def supports_component(component_descriptor: ComponentDescriptor, name: str, version: str):
+    for component in component_descriptor.raw["components"]:
+        if component["name"] == name:
+            return component["version"] == version
+    return False
+
+latest_gardener_release = version.find_latest_version(get_releases("gardener", "gardener"))
+if latest_gardener_release:
+    print("No latest gardener version found")
+    exit(1)
+
+print("Found latest gardener version {}".format(latest_gardener_release))
+
+gardensetup_releases = get_releases("gardener", "garden-setup")
+supported_releases = []
+for release in gardensetup_releases:
+    try:
+        component_descriptor = component_resolver.retrieve_descriptor((gardensetup_component, release))
+        if supports_component(component_descriptor, gardener_component, latest_gardener_release):
+            supported_releases.append(release)
+    except:
+        pass
+
+if supported_releases:
+    print("No supported garden-setup versions found")
+    exit(1)
+
+latest_supported_gardensetup = version.find_latest_version(supported_releases)
+
+print("Use garden-setup version {}".format(latest_supported_gardensetup))
+
+component_descriptor = component_resolver.retrieve_descriptor((gardensetup_component, latest_supported_gardensetup))
+raw_component_descriptor = yaml.dump(component_descriptor.raw)
+with open(descriptor_path, "w+") as file:
+    file.write(raw_component_descriptor)
+
+print("component_descriptor written to {}".format(descriptor_path))
+print(raw_component_descriptor)

--- a/.ci/testruns/default/Chart.yaml
+++ b/.ci/testruns/default/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: testruns
+version: 0.1.0

--- a/.ci/testruns/default/templates/testrun-default.yaml
+++ b/.ci/testruns/default/templates/testrun-default.yaml
@@ -1,0 +1,406 @@
+{{- $prefix := (randAlpha 5 | lower) -}}
+apiVersion: testmachinery.sapcloud.io/v1beta1
+kind: Testrun
+metadata:
+  name: {{ .Values.testrunName }}
+  namespace: default
+  annotations:
+    purpose: full-gardener
+spec:
+
+  ttlSecondsAfterFinished: 172800 # 2 days
+
+  locationSets:
+  - name: default
+    default: true
+    locations: []
+
+  - name: upgraded
+    locations:
+    - type: git
+      repo: https://github.com/gardener/garden-setup.git
+      revision: master
+
+  - name: tm
+    locations:
+    - type: git
+      repo: https://github.com/gardener/test-infra.git
+      revision: master
+
+
+  # Global config available to every test task in all phases (testFlow and onExit)
+  config:
+  - name: GARDENER_PREFIX
+    type: env
+    value: {{ $prefix }}
+  - name: PROJECT_NAMESPACE
+    type: env
+    value: garden-core
+
+  # the execution flow:
+  testflow:
+  - name: prepare-host
+    definition:
+      name: tm-scheduler-lock-gke
+      locationSet: tm
+
+  - name: create-garden
+    dependsOn: [ prepare-host ]
+    annotations:
+      purpose: beta
+    definition:
+      name: create-garden
+      location: default
+      config:
+{{ toYaml .Values.garden.credentials.config | indent 6 }}
+
+  - name: create-shoot-gcp
+    dependsOn: [ create-garden ]
+    definition:
+      name: create-shoot
+      locationSet: default
+      config:
+      - name: SHOOT_NAME
+        type: env
+        value: gcp-14-{{ $prefix }}
+      - name: K8S_VERSION
+        type: env
+        value: {{ .Values.shoot.k8sVersion }}
+      - name: CLOUDPROVIDER
+        type: env
+        value: gcp
+      - name: CLOUDPROFILE
+        type: env
+        value: gcp
+      - name: SECRET_BINDING
+        type: env
+        value: core-gcp-gcp
+      - name: REGION
+        type: env
+        value: europe-west1
+      - name: ZONE
+        type: env
+        value: europe-west1-b
+
+  - name: create-shoot-aws
+    dependsOn: [ create-garden ]
+    definition:
+      name: create-shoot
+      locationSet: default
+      config:
+      - name: SHOOT_NAME
+        type: env
+        value: aws-14-{{ $prefix }}
+      - name: CLOUDPROVIDER
+        type: env
+        value: aws
+      - name: K8S_VERSION
+        type: env
+        value: {{ .Values.shoot.k8sVersion }}
+      - name: SEED
+        type: env
+        value: gcp
+      - name: CLOUDPROFILE
+        type: env
+        value: aws
+      - name: SECRET_BINDING
+        type: env
+        value: core-aws-aws
+      - name: REGION
+        type: env
+        value: eu-west-1
+      - name: ZONE
+        type: env
+        value: eu-west-1b
+
+  - name: create-shoot-az
+    dependsOn: [ create-garden ]
+    definition:
+      name: create-shoot
+      locationSet: default
+      config:
+      - name: SEED
+        type: env
+        value: gcp
+      - name: SHOOT_NAME
+        type: env
+        value: az-14-{{ $prefix }}
+      - name: K8S_VERSION
+        type: env
+        value: {{ .Values.shoot.k8sVersion }}
+      - name: CLOUDPROVIDER
+        type: env
+        value: azure
+      - name: CLOUDPROFILE
+        type: env
+        value: azure
+      - name: SECRET_BINDING
+        type: env
+        value: core-azure-azure
+      - name: REGION
+        type: env
+        value: westeurope
+
+  - name: upgrade-garden
+    dependsOn: [ create-shoot-gcp, create-shoot-aws, create-shoot-az ]
+    definition:
+      name: upgrade-garden
+      locationSet: upgraded
+      config:
+      - name: GARDENER_IMAGE_TAG
+        type: env
+        value: {{ .Values.gardener.upgraded.tag }}
+      - name: GARDENER_COMMIT
+        type: env
+        value: {{ .Values.gardener.upgraded.commit }}
+{{ toYaml .Values.garden.credentials.config | indent 6 }}
+
+  - name: reconcile-shoots
+    dependsOn: [ upgrade-garden ]
+    definition:
+      name: reconcile-shoots
+      locationSet: upgraded
+      config:
+      - name: GARDENER_VERSION
+        type: env
+        value: {{ .Values.gardener.upgraded.tag }}
+
+  - name: tests-aws
+    dependsOn: [ reconcile-shoots ]
+    artifactsFrom: create-shoot-aws
+    definition:
+      label: default
+      locationSet: upgraded
+      continueOnError: true
+      config:
+      - name: K8S_VERSION
+        type: env
+        value: {{ .Values.shoot.k8sVersion }}
+      - name: SHOOT_NAME
+        type: env
+        value: aws-14-{{ $prefix }}
+
+  - name: delete-shoot-aws
+    dependsOn: [ tests-aws ]
+    definition:
+      name: delete-shoot
+      locationSet: upgraded
+      config:
+      - name: SHOOT_NAME
+        type: env
+        value: aws-14-{{ $prefix }}
+
+  - name: tests-gcp
+    dependsOn: [ reconcile-shoots ]
+    definition:
+      label: default
+      locationSet: upgraded
+      continueOnError: true
+      config:
+      - name: K8S_VERSION
+        type: env
+        value: {{ .Values.shoot.k8sVersion }}
+      - name: SHOOT_NAME
+        type: env
+        value: gcp-14-{{ $prefix }}
+  - name: delete-shoot-gcp
+    dependsOn: [ tests-gcp ]
+    definition:
+      name: delete-shoot
+      locationSet: default
+      config:
+      - name: SHOOT_NAME
+        type: env
+        value: gcp-14-{{ $prefix }}
+
+  - name: tests-az
+    dependsOn: [ reconcile-shoots ]
+    artifactsFrom: create-shoot-az
+    definition:
+      label: default
+      locationSet: upgraded
+      continueOnError: true
+      config:
+      - name: K8S_VERSION
+        type: env
+        value: {{ .Values.shoot.k8sVersion }}
+      - name: SHOOT_NAME
+        type: env
+        value: az-14-{{ $prefix }}
+
+  - name: delete-shoot-az
+    dependsOn: [ tests-az ]
+    definition:
+      name: delete-shoot
+      locationSet: upgraded
+      config:
+      - name: SHOOT_NAME
+        type: env
+        value: az-14-{{ $prefix }}
+
+  - name: create-shoot-gcp-upgrade
+    dependsOn: [ reconcile-shoots ]
+    definition:
+      name: create-shoot
+      locationSet: upgraded
+      config:
+      - name: SHOOT_NAME
+        type: env
+        value: gcp-14-{{ randAlpha 5 | lower }}
+      - name: K8S_VERSION
+        type: env
+        value: {{ .Values.shoot.k8sVersion }}
+      - name: CLOUDPROVIDER
+        type: env
+        value: gcp
+      - name: CLOUDPROFILE
+        type: env
+        value: gcp
+      - name: SECRET_BINDING
+        type: env
+        value: core-gcp-gcp
+      - name: REGION
+        type: env
+        value: europe-west1
+      - name: ZONE
+        type: env
+        value: europe-west1-b
+  - name: tests-gcp-upgrade
+    dependsOn: [ create-shoot-gcp-upgrade ]
+    definition:
+      label: default
+      locationSet: upgraded
+      continueOnError: true
+  - name: delete-shoot-gcp-upgraded
+    dependsOn: [ tests-gcp-upgrade ]
+    definition:
+      name: delete-shoot
+      locationSet: upgraded
+
+  - name: create-shoot-aws-upgraded
+    dependsOn: [ reconcile-shoots ]
+    definition:
+      name: create-shoot
+      locationSet: default
+      config:
+      - name: SHOOT_NAME
+        type: env
+        value: aws-14-{{ randAlpha 5 | lower }}
+      - name: CLOUDPROVIDER
+        type: env
+        value: aws
+      - name: K8S_VERSION
+        type: env
+        value: {{ .Values.shoot.k8sVersion }}
+      - name: SEED
+        type: env
+        value: gcp
+      - name: CLOUDPROFILE
+        type: env
+        value: aws
+      - name: SECRET_BINDING
+        type: env
+        value: core-aws-aws
+      - name: REGION
+        type: env
+        value: eu-west-1
+      - name: ZONE
+        type: env
+        value: eu-west-1b
+  - name: tests-aws-upgraded
+    dependsOn: [ create-shoot-aws-upgraded ]
+    definition:
+      label: default
+      locationSet: upgraded
+      continueOnError: true
+  - name: delete-shoot-aws-upgraded
+    dependsOn: [ tests-aws-upgraded ]
+    definition:
+      name: delete-shoot
+      locationSet: upgraded
+
+  - name: create-shoot-az-upgraded
+    dependsOn: [ reconcile-shoots ]
+    definition:
+      name: create-shoot
+      locationSet: default
+      config:
+      - name: SEED
+        type: env
+        value: gcp
+      - name: SHOOT_NAME
+        type: env
+        value: az-14-{{ randAlpha 5 | lower }}
+      - name: K8S_VERSION
+        type: env
+        value: {{ .Values.shoot.k8sVersion }}
+      - name: CLOUDPROVIDER
+        type: env
+        value: azure
+      - name: CLOUDPROFILE
+        type: env
+        value: azure
+      - name: SECRET_BINDING
+        type: env
+        value: core-azure-azure
+      - name: REGION
+        type: env
+        value: westeurope
+  - name: tests-az-upgraded
+    dependsOn: [ create-shoot-az-upgraded ]
+    definition:
+      label: default
+      locationSet: upgraded
+      continueOnError: true
+  - name: delete-shoot-az-upgraded
+    dependsOn: [ tests-az-upgraded ]
+    definition:
+      name: delete-shoot
+      locationSet: upgraded
+
+  - name: delete-garden
+    dependsOn: [ delete-shoot-aws, delete-shoot-gcp, delete-shoot-az, delete-shoot-gcp-upgraded, delete-shoot-aws-upgraded, delete-shoot-az-upgraded ]
+    definition:
+      name: delete-garden
+      locationSet: upgraded
+      config:
+{{ toYaml .Values.garden.credentials.config | indent 6 }}
+
+  - name: reset-host
+    dependsOn: [ delete-garden ]
+    definition:
+      name: tm-scheduler-release-gke
+      locationSet: tm
+      config:
+      - name: CLEAN
+        type: env
+        value: "false"
+
+  onExit:
+  - name: clean-gardener
+    useGlobalArtifacts: true
+    definition:
+      name: clean-gardener
+      locationSet: tm
+      condition: error
+
+  - name: delete-garden
+    dependsOn: [ clean-gardener ]
+    useGlobalArtifacts: true
+    definition:
+      name: delete-garden
+      condition: error
+      config:
+{{ toYaml .Values.garden.credentials.config | indent 6 }}
+
+  - name: reset-host
+    dependsOn: [ delete-garden ]
+    useGlobalArtifacts: true
+    definition:
+      name: tm-scheduler-release-gke
+      locationSet: tm
+      condition: error
+      config:
+      - name: CLEAN
+        type: env
+        value: "true"

--- a/.ci/testruns/default/values.yaml
+++ b/.ci/testruns/default/values.yaml
@@ -1,0 +1,67 @@
+# Default values for testruns.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+
+testrunName: ""
+
+shoot:
+  k8sVersion: 1.14.3
+
+gardener:
+  upgraded:
+    commit: ""
+    tag: ""
+
+garden:
+  credentials:
+    config:
+    - name: gcloud
+      type: file
+      path: "/tmp/garden/gcloud.json"
+      valueFrom:
+        secretKeyRef:
+          name: garden-test
+          key: gcloud.json
+    - name: ACCESS_KEY_ID
+      type: env
+      private: true
+      valueFrom:
+        secretKeyRef:
+          name: garden-test
+          key: accessKeyID
+    - name: SECRET_ACCESS_KEY_ID
+      type: env
+      private: true
+      valueFrom:
+        secretKeyRef:
+          name: garden-test
+          key: secretAccessKey
+    - name: AZ_CLIENT_ID
+      type: env
+      private: true
+      valueFrom:
+        secretKeyRef:
+          name: garden-test
+          key: clientID
+    - name: AZ_CLIENT_SECRET
+      type: env
+      private: true
+      valueFrom:
+        secretKeyRef:
+          name: garden-test
+          key: clientSecret
+    - name: AZ_SUBSCRIPTION_ID
+      type: env
+      private: true
+      valueFrom:
+        secretKeyRef:
+          name: garden-test
+          key: subscriptionID
+    - name: AZ_TENANT_ID
+      type: env
+      private: true
+      valueFrom:
+        secretKeyRef:
+          name: garden-test
+          key: tenantID

--- a/.ci/tm-test
+++ b/.ci/tm-test
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -e
+
+export SOURCE_PATH="$(readlink -f "$(dirname ${0})/..")"
+
+TESTRUN_CHART=""
+TM_LANDSCAPE="external"
+LANDSCAPE=""
+ARGUMENTS=""
+
+ARGOUI_ENDPOINT=""
+S3_ENDPOINT=""
+KIBANA_ENDPOINT=""
+
+
+for i in "$@"
+do
+echo $i
+case $i in
+        -tm-chart=*|--tm-chart=*)
+        TESTRUN_CHART="${i#*=}"
+        shift
+    ;;
+        -tm-landscape=*|--tm-landscape=*)
+        TM_LANDSCAPE="${i#*=}"
+        shift
+    ;;
+        -landscape=*|--landscape=*)
+        LANDSCAPE="${i#*=}"
+        shift
+    ;;
+        --)
+        ARGUMENTS="${@:2}"
+        break
+    ;;
+    *)
+        # unknown option
+        echo "Unknown option ${i#*=}"
+        exit 1
+    ;;
+esac
+done
+
+if [[ $TESTRUN_CHART == "" ]]; then
+    echo "Required parameter: -tm-chart"
+    exit 1
+fi
+if [[ $TM_LANDSCAPE == "" ]]; then
+    echo "Required parameter: -tm-landscape : external | internal"
+    exit 1
+fi
+if [[ $LANDSCAPE == "" ]]; then
+    echo "Required parameter: -landscape"
+    exit 1
+fi
+
+if [[ $TM_LANDSCAPE == "external" ]]; then
+    TM_CONFIG_NAME=testmachinery
+    S3_ENDPOINT="storage.googleapis.com"
+fi
+
+NEW_GARDENER_VERSION="$(cat $SOURCE_PATH/VERSION)"
+NEW_GARDENERT_COMMIT="$(git rev-parse HEAD)"
+
+echo "Testmachinery config name: ${TM_CONFIG_NAME}"
+echo "Testmachinery landscape: ${TM_LANDSCAPE}"
+echo "Arguments: ${ARGUMENTS}"
+echo "Gardener Version: ${NEW_GARDENER_VERSION}"
+echo "Gardener Commit: ${NEW_GARDENERT_COMMIT}"
+
+mkdir -p /tm
+TM_CLUSTER=/tm/kubeconfig
+/cc/utils/cli.py config attribute --cfg-type kubernetes --cfg-name $TM_CONFIG_NAME --key kubeconfig > $TM_CLUSTER
+
+TESTRUN_CHART_PATH="$SOURCE_PATH/.ci/testruns/$TESTRUN_CHART"
+COMPONENT_DESCRIPTOR_PATH="$COMPONENT_DESCRIPTOR_DIR/component_descriptor"
+
+export KUBECONFIG=$TM_CLUSTER
+kubectl cluster-info
+
+# timeout to 6h
+/testrunner run-full \
+    --tm-kubeconfig-path=$TM_CLUSTER \
+    --timeout=21600 \
+    --interval=60 \
+    --es-config-name=sap_internal \
+    --s3-endpoint=$S3_ENDPOINT \
+    --s3-ssl=true \
+    --testruns-chart-path=$TESTRUN_CHART_PATH \
+    --set=gardener.upgraded.commit=$NEW_GARDENERT_COMMIT,gardener.upgraded.tag=$NEW_GARDENER_VERSION \
+    --component-descriptor-path=$OUT_PATH/previous_component_descriptor.yaml \
+    --upgraded-component-descriptor-path=$COMPONENT_DESCRIPTOR_PATH \
+    $ARGUMENTS


### PR DESCRIPTION
**What this PR does / why we need it**:
Added a basic gardener integration test that tests the following flow:

1. get a gke cluster
2. setup gardener with the latest release version e.g 0.26.2 with its corresponding garden-setup version e.g. 1.6.0
3. create 3 shoots (aws, gcp and azure)
4. update gardener to the newest master version with the master garden-setup version
5. wait until all shoots of the gardener are successfully reconciled
6a. test the previously created shoot with all gardener integration tests
6b. delete the previously created shoots 
7a. create 3 new shoots (aws, gcp and azure)
7b. test the new created shoots with all gardener tests
7c. delete the newly created clusters.
8. delete the gardener
9. release the GKE cluster


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
e2e tests are currently skipped as of their time consuming execution time

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Added gardener integration tests to test a full gardener lifecycle with a specific commit.
```
