### PR TITLE
Fix profile for example azure shoot

### DIFF
--- a/example/90-shoot-azure.yaml
+++ b/example/90-shoot-azure.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: garden-dev
 spec:
   cloud:
-    profile: azure
+    profile: az
     region: westeurope
     secretBindingRef:
       name: core-azure


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fix the profile for the azure shoot in the /example folder. The profile `azure` is not supported, it has to be `az`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```
