### PR TITLE
Explicitly set cluster autoscaler configuration

### DIFF
--- a/charts/seed-controlplane/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/cluster-autoscaler/templates/deployment.yaml
@@ -53,6 +53,24 @@ spec:
         {{- range $key, $flag := .Values.flags }}
         - --{{ $flag.name }}={{ $flag.value }}
         {{- end }}
+        {{- if .Values.scaleDownUtilizationThreshold }}
+        - --scale-down-utilization-threshold={{ .Values.scaleDownUtilizationThreshold }}
+        {{- end }}
+        {{- if .Values.scaleDownUnneededTime }}
+        - --scale-down-unneeded-time={{ .Values.scaleDownUnneededTime }}
+        {{- end }}
+        {{- if .Values.scaleDownDelayAfterAdd }}
+        - --scale-down-delay-after-add={{ .Values.scaleDownDelayAfterAdd }}
+        {{- end }}
+        {{- if .Values.scaleDownDelayAfterFailure }}
+        - --scale-down-delay-after-failure={{ .Values.scaleDownDelayAfterFailure }}
+        {{- end }}
+        {{- if .Values.scaleDownDelayAfterDelete }}
+        - --scale-down-delay-after-delete={{ .Values.scaleDownDelayAfterDelete }}
+        {{- end }}
+        {{- if .Values.scanInterval }}
+        - --scan-interval={{ .Values.scanInterval }}
+        {{- end }}
         - --v=2
         env:
         - name: CONTROL_NAMESPACE

--- a/charts/seed-controlplane/charts/cluster-autoscaler/values.yaml
+++ b/charts/seed-controlplane/charts/cluster-autoscaler/values.yaml
@@ -14,6 +14,9 @@ workerPools:
 
 metricsPort: 8085
 
-flags:
-- name: foo
-  value: bar
+scaleDownUnneededTime: 30m0s
+scaleDownDelayAfterAdd: 1h0m0s
+# scaleDownUtilizationThreshold: foo
+# scaleDownDelayAfterFailure: foo
+# scaleDownDelayAfterDelete: foo
+# scanInterval: foo


### PR DESCRIPTION
**What this PR does / why we need it**:
I've seen gardener-controller-manager crashing when a shoot was configured with
```
spec.kubernetes.clusterAutoscaler = {
  scaleDownDelayAfterAdd: 4m0s,
  scaleDownUnneededTime: 4m0s,
}
```

Let's renounce the strange reflection magic and rather configure the cluster-autoscaler explicitly (like we used to do for all other components).

```
panic: reflect: call of reflect.Value.Interface on zero Value

goroutine 285091 [running]:
reflect.valueInterface(0x0, 0x0, 0x0, 0x1, 0x0, 0x0)
        /usr/local/go/src/reflect/value.go:984 +0x1a1
reflect.Value.Interface(...)
        /usr/local/go/src/reflect/value.go:979
github.com/gardener/gardener/pkg/operation/botanist.marshalFlagValue(0x17066e0, 0x0, 0x0, 0x0)
        /go/src/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go:307 +0x14f
github.com/gardener/gardener/pkg/operation/botanist.mkFlag(...)
        /go/src/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go:296
github.com/gardener/gardener/pkg/operation/botanist.appendOrDefaultFlag(0x0, 0x0, 0x0, 0x1a5712c, 0x20, 0x17066e0, 0x0, 0x0, 0x0, 0xae0aad, ...)
        /go/src/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go:320 +0x49
github.com/gardener/gardener/pkg/operation/botanist.(*Botanist).DeployClusterAutoscaler(0xc004270a40, 0x1d5c8c0, 0xc021164ae0, 0x42bda1, 0xc002049c08)
        /go/src/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go:262 +0x112
github.com/gardener/gardener/pkg/utils/flow.TaskFn.RetryUntilTimeout.func1.1(0x1d5c8c0, 0xc021164ae0, 0xc013872e80, 0xc002049c58, 0x1240cf7)
        /go/src/github.com/gardener/gardener/pkg/utils/flow/taskfn.go:95 +0x39
github.com/gardener/gardener/pkg/utils/retry.UntilFor(0x1d5c8c0, 0xc021164ae0, 0xc021169000, 0x1d42dc0, 0xc013872e80, 0xc013872e70, 0x7f1132168008, 0x0)
        /go/src/github.com/gardener/gardener/pkg/utils/retry/retry.go:131 +0x3e
github.com/gardener/gardener/pkg/utils/retry.(*ops).Until(0xc0003fa1b0, 0x1d5c8c0, 0xc021164ae0, 0x12a05f200, 0xc013872e70, 0xc021164a01, 0xc013872e70)
        /go/src/github.com/gardener/gardener/pkg/utils/retry/retry.go:175 +0xa2
github.com/gardener/gardener/pkg/utils/flow.TaskFn.RetryUntilTimeout.func1(0x1d5c8c0, 0xc021164ae0, 0x0, 0x0)
        /go/src/github.com/gardener/gardener/pkg/utils/flow/taskfn.go:94 +0xed
github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode.func1(0xc005f6ecd0, 0x1a50057, 0x1c, 0x1d5c880, 0xc000048018)
        /go/src/github.com/gardener/gardener/pkg/utils/flow/flow.go:204 +0x1d6
created by github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode
        /go/src/github.com/gardener/gardener/pkg/utils/flow/flow.go:199 +0x13b
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
