### PR TITLE
Adjusting gardener scheduler test definitions for the test machinery

### DIFF
--- a/.test-defs/SchedulerTest.yaml
+++ b/.test-defs/SchedulerTest.yaml
@@ -6,7 +6,8 @@ spec:
   description: Tests the scheduler.
 
   activeDeadlineSeconds: 5400
-
+  behavior:
+  - serial
   config:
   - name: GO111MODULE
     value: "on"

--- a/.test-defs/cmd/scheduler/main.go
+++ b/.test-defs/cmd/scheduler/main.go
@@ -55,9 +55,9 @@ var (
 func init() {
 	testLogger = logger.NewLogger("debug")
 
-	shootName = os.Getenv("SHOOT_NAME_SCHEDULER")
+	shootName = os.Getenv("SHOOT_NAME")
 	if shootName == "" {
-		testLogger.Fatalf("EnvVar 'SHOOT_NAME_SCHEDULER' needs to be specified")
+		testLogger.Fatalf("EnvVar 'SHOOT_NAME' needs to be specified")
 	}
 	projectNamespace = os.Getenv("PROJECT_NAMESPACE")
 	if projectNamespace == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Gardener Scheduler Integration tests should be run for new landscape deployments.
Changes: 
- Test needs to run in serial (create shoot, change gardener-scheduler config map, restart scheduler)
- use common env Variable name for the Shoot's name.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Integration into new TM setup will be done by @schrodit  & @OlegLoewen 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
