### PR TITLE
Fetch scheduler configuration from host cluster

### DIFF
--- a/.test-defs/cmd/scheduler/main.go
+++ b/.test-defs/cmd/scheduler/main.go
@@ -122,6 +122,7 @@ func init() {
 func main() {
 	ctx := context.Background()
 	defer ctx.Done()
+	hostConfigPath := fmt.Sprintf("%s/host.config", kubeconfigPath)
 	gardenerConfigPath := fmt.Sprintf("%s/gardener.config", kubeconfigPath)
 
 	shootGardenerTest, err := framework.NewShootGardenerTest(gardenerConfigPath, nil, testLogger)
@@ -158,7 +159,7 @@ func main() {
 
 	shootGardenerTest.Shoot = shootObject
 
-	schedulerGardenerTest, err := framework.NewGardenSchedulerTest(ctx, shootGardenerTest)
+	schedulerGardenerTest, err := framework.NewGardenSchedulerTest(ctx, shootGardenerTest, hostConfigPath)
 	if err != nil {
 		testLogger.Fatalf("Failed to create an new Gardener Scheduler test '%v'", err)
 	}

--- a/test/integration/framework/scheduler_operations.go
+++ b/test/integration/framework/scheduler_operations.go
@@ -17,6 +17,7 @@ package framework
 import (
 	"context"
 	"fmt"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"time"
 
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -40,9 +41,16 @@ import (
 const configurationFileName = "schedulerconfiguration.yaml"
 
 // NewGardenSchedulerTest creates a new SchedulerGardenerTest by retrieving the ConfigMap containing the Scheduler Configuration & parsing the Scheduler Configuration
-func NewGardenSchedulerTest(ctx context.Context, shootGardenTest *ShootGardenerTest) (*SchedulerGardenerTest, error) {
+func NewGardenSchedulerTest(ctx context.Context, shootGardenTest *ShootGardenerTest, hostKubeconfigPath string) (*SchedulerGardenerTest, error) {
+	k8sHostClient, err := kubernetes.NewClientFromFile("", hostKubeconfigPath, client.Options{
+		Scheme: kubernetes.ShootScheme,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	schedulerConfigurationConfigMap := &corev1.ConfigMap{}
-	if err := shootGardenTest.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: schedulerconfigv1alpha1.SchedulerDefaultConfigurationConfigMapNamespace, Name: schedulerconfigv1alpha1.SchedulerDefaultConfigurationConfigMapName}, schedulerConfigurationConfigMap); err != nil {
+	if err := k8sHostClient.Client().Get(ctx, client.ObjectKey{Namespace: schedulerconfigv1alpha1.SchedulerDefaultConfigurationConfigMapNamespace, Name: schedulerconfigv1alpha1.SchedulerDefaultConfigurationConfigMapName}, schedulerConfigurationConfigMap); err != nil {
 		return nil, err
 	}
 

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Scheduler testing", func() {
 		shootGardenerTest, err := NewShootGardenerTest(*kubeconfig, shoot, schedulerOperationsTestLogger)
 		Expect(err).To(BeNil())
 
-		schedulerGardenerTest, err = NewGardenSchedulerTest(ctx, shootGardenerTest)
+		schedulerGardenerTest, err = NewGardenSchedulerTest(ctx, shootGardenerTest, *kubeconfig)
 		Expect(err).NotTo(HaveOccurred())
 		schedulerGardenerTest.ShootGardenerTest.Shoot.Namespace = *schedulerTestNamespace
 	}, InitializationTimeout)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the gardener scheduler that tries to fetch its configuration the virtual gardener cluster.
Instead it should fetch the configuration from the host cluster.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
