### PR TITLE
Improved kube-apiserver availability during maintenance (rolling updates and scaling).

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
@@ -8,12 +8,18 @@ metadata:
     app: kubernetes
     role: apiserver
 spec:
+  minReadySeconds: 30
   revisionHistoryLimit: 0
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app: kubernetes
       role: apiserver
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 0
+    type: RollingUpdate
   template:
     metadata:
       annotations:
@@ -101,6 +107,13 @@ spec:
         - --tls-private-key-file=/srv/kubernetes/apiserver/kube-apiserver.key
         - --tls-cipher-suites={{ include "kubernetes.tlsCipherSuites" . | replace "\n" "," | trimPrefix "," }}
         - --v=2
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - sleep 5
         livenessProbe:
           httpGet:
             scheme: HTTPS


### PR DESCRIPTION
**What this PR does / why we need it**:
It improves the availability of `kube-apiserver` during maintenance activities such as a rolling update or scaling (say, by HPA) of the `kube-apiserver` `Deployment`.

* Changes to minReadSeconds and maxUnavailable
improve availability during rolling update.
* The delay in preStop help give the kube-proxies a chance to
propagate the changes to the iptables in all the nodes as noted [here](https://github.com/kubernetes/kubernetes/issues/43576).

**Which issue(s) this PR fixes**:
https://github.com/gardener/gardener/issues/1241

**Special notes for your reviewer**:
With these changes disruption to `kube-apiserver` requests is almost completely eliminated during maintenance except for `WATCH` requests which would continue to be disrupted.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Improvement of the availability of `kube-apiserver` during maintenance activities such as a rolling update or scaling (say, by HPA) of the `kube-apiserver` `Deployment`.
```
