### PR TITLE
Added configurable nodeCIDRMaskSize flag to Shoot spec

### DIFF
--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -64,6 +64,9 @@ spec:
         - --allocate-node-cidrs=true
         - --attach-detach-reconcile-sync-period=1m0s
         - --controllers=*,bootstrapsigner,tokencleaner
+        {{- if .Values.nodeCIDRMaskSize }}
+        - --node-cidr-mask-size={{ .Values.nodeCIDRMaskSize }}
+        {{- end }}
         - --cluster-cidr={{ .Values.podNetwork }}
         - --cluster-name={{ .Values.clusterName }}
         - --cluster-signing-cert-file=/srv/kubernetes/ca/ca.crt

--- a/example/90-shoot-alicloud.yaml
+++ b/example/90-shoot-alicloud.yaml
@@ -87,6 +87,8 @@ spec:
   # kubeControllerManager:
   #   featureGates:
   #     SomeKubernetesFeature: true
+  # The NodeCIRDMaskSize field is immutable due to https://github.com/kubernetes/kubernetes/issues/70957
+  #   nodeCIDRMaskSize: 24
   #   horizontalPodAutoscaler:
   #     syncPeriod: 30s
   #     tolerance: 0.1

--- a/example/90-shoot-aws.yaml
+++ b/example/90-shoot-aws.yaml
@@ -89,6 +89,8 @@ spec:
   # kubeControllerManager:
   #   featureGates:
   #     SomeKubernetesFeature: true
+  # The NodeCIRDMaskSize field is immutable due to https://github.com/kubernetes/kubernetes/issues/70957
+  #   nodeCIDRMaskSize: 24
   #   horizontalPodAutoscaler:
   #     syncPeriod: 30s
   #     tolerance: 0.1

--- a/example/90-shoot-azure.yaml
+++ b/example/90-shoot-azure.yaml
@@ -88,6 +88,8 @@ spec:
   # kubeControllerManager:
   #   featureGates:
   #     SomeKubernetesFeature: true
+  # The NodeCIRDMaskSize field is immutable due to https://github.com/kubernetes/kubernetes/issues/70957
+  #   nodeCIDRMaskSize: 24
   #   horizontalPodAutoscaler:
   #     syncPeriod: 30s
   #     tolerance: 0.1

--- a/example/90-shoot-gcp.yaml
+++ b/example/90-shoot-gcp.yaml
@@ -87,6 +87,8 @@ spec:
   # kubeControllerManager:
   #   featureGates:
   #     SomeKubernetesFeature: true
+  # The NodeCIRDMaskSize field is immutable due to https://github.com/kubernetes/kubernetes/issues/70957
+  #   nodeCIDRMaskSize: 24
   #   horizontalPodAutoscaler:
   #     syncPeriod: 30s
   #     tolerance: 0.1

--- a/example/90-shoot-openstack.yaml
+++ b/example/90-shoot-openstack.yaml
@@ -86,6 +86,8 @@ spec:
   # kubeControllerManager:
   #   featureGates:
   #     SomeKubernetesFeature: true
+  # The NodeCIRDMaskSize field is immutable due to https://github.com/kubernetes/kubernetes/issues/70957
+  #   nodeCIDRMaskSize: 24
   #   horizontalPodAutoscaler:
   #     syncPeriod: 30s
   #     tolerance: 0.1

--- a/example/90-shoot-packet.yaml
+++ b/example/90-shoot-packet.yaml
@@ -82,6 +82,8 @@ spec:
   # kubeControllerManager:
   #   featureGates:
   #     SomeKubernetesFeature: true
+  # The NodeCIRDMaskSize field is immutable due to https://github.com/kubernetes/kubernetes/issues/70957
+  #   nodeCIDRMaskSize: 24
   #   horizontalPodAutoscaler:
   #     syncPeriod: 30s
   #     tolerance: 0.1

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -360,6 +360,8 @@ spec:
   # kubeControllerManager:
   #   featureGates:
   #     SomeKubernetesFeature: true
+  # The NodeCIRDMaskSize field is immutable due to https://github.com/kubernetes/kubernetes/issues/70957
+  #   nodeCIDRMaskSize: 24
   #   horizontalPodAutoscaler:
   #     syncPeriod: 30s
   #     tolerance: 0.1

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -1240,6 +1240,8 @@ type KubeControllerManagerConfig struct {
 	KubernetesConfig
 	// HorizontalPodAutoscalerConfig contains horizontal pod autoscaler configuration settings for the kube-controller-manager.
 	HorizontalPodAutoscalerConfig *HorizontalPodAutoscalerConfig
+	// NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24)
+	NodeCIDRMaskSize *int
 }
 
 // HorizontalPodAutoscalerConfig contains horizontal pod autoscaler configuration settings for the kube-controller-manager.

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -1380,6 +1380,9 @@ type KubeControllerManagerConfig struct {
 	// HorizontalPodAutoscalerConfig contains horizontal pod autoscaler configuration settings for the kube-controller-manager.
 	// +optional
 	HorizontalPodAutoscalerConfig *HorizontalPodAutoscalerConfig `json:"horizontalPodAutoscaler,omitempty"`
+	// NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24)
+	// +optional
+	NodeCIDRMaskSize *int `json:"nodeCIDRMaskSize,omitempty"`
 }
 
 // GardenerDuration is a workaround for missing OpenAPI functions on metav1.Duration struct.

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -3095,6 +3095,7 @@ func autoConvert_v1beta1_KubeControllerManagerConfig_To_garden_KubeControllerMan
 		return err
 	}
 	out.HorizontalPodAutoscalerConfig = (*garden.HorizontalPodAutoscalerConfig)(unsafe.Pointer(in.HorizontalPodAutoscalerConfig))
+	out.NodeCIDRMaskSize = (*int)(unsafe.Pointer(in.NodeCIDRMaskSize))
 	return nil
 }
 
@@ -3108,6 +3109,7 @@ func autoConvert_garden_KubeControllerManagerConfig_To_v1beta1_KubeControllerMan
 		return err
 	}
 	out.HorizontalPodAutoscalerConfig = (*HorizontalPodAutoscalerConfig)(unsafe.Pointer(in.HorizontalPodAutoscalerConfig))
+	out.NodeCIDRMaskSize = (*int)(unsafe.Pointer(in.NodeCIDRMaskSize))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -1609,6 +1609,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(HorizontalPodAutoscalerConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NodeCIDRMaskSize != nil {
+		in, out := &in.NodeCIDRMaskSize, &out.NodeCIDRMaskSize
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -1597,6 +1597,11 @@ func (in *KubeControllerManagerConfig) DeepCopyInto(out *KubeControllerManagerCo
 		*out = new(HorizontalPodAutoscalerConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NodeCIDRMaskSize != nil {
+		in, out := &in.NodeCIDRMaskSize, &out.NodeCIDRMaskSize
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -4058,6 +4058,13 @@ func schema_pkg_apis_garden_v1beta1_KubeControllerManagerConfig(ref common.Refer
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/garden/v1beta1.HorizontalPodAutoscalerConfig"),
 						},
 					},
+					"nodeCIDRMaskSize": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24)",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -455,6 +455,10 @@ func (b *HybridBotanist) DeployKubeControllerManager() error {
 		if controllerManagerConfig.HorizontalPodAutoscalerConfig != nil {
 			defaultValues["horizontalPodAutoscaler"] = controllerManagerConfig.HorizontalPodAutoscalerConfig
 		}
+
+		if controllerManagerConfig.NodeCIDRMaskSize != nil {
+			defaultValues["nodeCIDRMaskSize"] = *controllerManagerConfig.NodeCIDRMaskSize
+		}
 	}
 
 	values, err := b.InjectSeedShootImages(defaultValues, common.HyperkubeImageName)


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows to set the optional `--node-cidr-mask-size` flag on the `kube-controller-manager` which specifies how large the Pod CIDR range for a node can be (default is 24).

**Which issue(s) this PR fixes**:
Fixes #1107

**Special notes for your reviewer**:
/cc @KesavanKing

**Release note**:
```noteworthy user
It's now possible to configure the node CIDR mask size for the kube-controller-manager in the `.spec.kubernetes.kubeControllerManager.nodeCIDRMaskSize` flag in the `Shoot` resource.
```
