### PR TITLE
Fix version of k8s.io/code-generator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,7 @@ require (
 	k8s.io/apiserver v0.0.0-20190313205120-8b27c41bdbb1
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/cluster-bootstrap v0.0.0-20190314002537-50662da99b70
-	k8s.io/code-generator v0.0.0-00010101000000-000000000000
+	k8s.io/code-generator v0.0.0-20190311093542-50b561225d70
 	k8s.io/component-base v0.0.0-20190314000054-4a91899592f4
 	k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a
 	k8s.io/helm v2.7.2+incompatible
@@ -125,7 +125,7 @@ replace (
 	k8s.io/apiserver => k8s.io/apiserver v0.0.0-20190313205120-8b27c41bdbb1 // kubernetes-1.14.0
 	k8s.io/client-go => k8s.io/client-go v11.0.0+incompatible // kubernetes-1.14.0
 	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.0.0-20190314002537-50662da99b70 // kubernetes-1.14.0
-	k8s.io/code-generator => k8s.io/code-generator v0.0.0-20190311093542-50b561225d70 // kubernetes-1.14.0
+	k8s.io/code-generator => k8s.io/code-generator v0.0.0-20190311093542-50b561225d70 // kubernetes-1.14.4
 	k8s.io/component-base => k8s.io/component-base v0.0.0-20190314000054-4a91899592f4 // kubernetes-1.14.0
 	k8s.io/helm => k8s.io/helm v2.13.1+incompatible
 	k8s.io/klog => k8s.io/klog v0.1.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -418,10 +418,10 @@ k8s.io/api/apps/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1beta1
 k8s.io/api/policy/v1beta1
+k8s.io/api/autoscaling/v2beta1
 k8s.io/api/batch/v1
 k8s.io/api/batch/v1beta1
 k8s.io/api/extensions/v1beta1
-k8s.io/api/autoscaling/v2beta1
 k8s.io/api/networking/v1
 k8s.io/api/apps/v1beta1
 k8s.io/api/apps/v1beta2
@@ -809,7 +809,7 @@ k8s.io/client-go/listers/storage/v1beta1
 # k8s.io/cluster-bootstrap v0.0.0-20190314002537-50662da99b70 => k8s.io/cluster-bootstrap v0.0.0-20190314002537-50662da99b70
 k8s.io/cluster-bootstrap/token/api
 k8s.io/cluster-bootstrap/token/util
-# k8s.io/code-generator v0.0.0-00010101000000-000000000000 => k8s.io/code-generator v0.0.0-20190311093542-50b561225d70
+# k8s.io/code-generator v0.0.0-20190311093542-50b561225d70 => k8s.io/code-generator v0.0.0-20190311093542-50b561225d70
 k8s.io/code-generator/cmd/client-gen
 k8s.io/code-generator/cmd/conversion-gen
 k8s.io/code-generator/cmd/deepcopy-gen


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently trying to vendor `github.com/gardener/gardener@0.27.0` fails with:
```bash
$ mkdir foo && cd foo
$ go mod init github.com/me/foo
$ go get github.com/gardener/gardener@0.27.0
go: finding github.com/gardener/gardener 0.27.0
go: finding k8s.io/code-generator v0.0.0-00010101000000-000000000000
go: k8s.io/code-generator@v0.0.0-00010101000000-000000000000: unknown revision 000000000000
go: error loading module requirements
```

The PR fixes the `k8s.io/code-generator` version.

---

Test the fix:

```bash
$ mkdir bar && cd bar
$ go mod init github.com/me/bar
# get the revision of this PR
$ go get github.com/gardener/gardener@a27d833e57d323b73620c594c6f17f9f632bcfa8
```


/kind bug

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
gihtub.com/gardener/gardener can now properly be vendored with go modules.
```
