### PR TITLE
Provide ip range parameter for vpn-seed pull filter

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
@@ -196,6 +196,12 @@ spec:
           value: "true"
         - name: OPENVPN_PORT
           value: "4314"
+        - name: SERVICE_NETWORK
+          value: {{ .Values.shootNetworks.service }}
+        - name: POD_NETWORK
+          value: {{ .Values.shootNetworks.pod }}
+        - name: NODE_NETWORK
+          value: {{ .Values.shootNetworks.node }}
         ports:
         - name: tcp-tunnel
           containerPort: 1194

--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -247,6 +247,8 @@ func (b *HybridBotanist) DeployKubeAPIServer() error {
 		"kubernetesVersion": b.Shoot.Info.Spec.Kubernetes.Version,
 		"shootNetworks": map[string]interface{}{
 			"service": b.Shoot.GetServiceNetwork(),
+			"pod":     b.Shoot.GetPodNetwork(),
+			"node":    b.Shoot.GetNodeNetwork(),
 		},
 		"seedNetworks": map[string]interface{}{
 			"service": b.Seed.Info.Spec.Networks.Services,


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request provides the service, pod and node network range parameter for the vpn-seed chart.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `kube-apiserver` deployment does now have the requirement environment variables for the latest VPN version.
```
