### PR TITLE
Exit shoot admission early if spec is unchanged

### DIFF
--- a/plugin/pkg/shoot/quotavalidator/admission.go
+++ b/plugin/pkg/shoot/quotavalidator/admission.go
@@ -126,8 +126,8 @@ func (q *QuotaValidator) ValidateInitialization() error {
 	return nil
 }
 
-// Admit checks that the requested Shoot resources are within the quota limits.
-func (q *QuotaValidator) Admit(a admission.Attributes, o admission.ObjectInterfaces) error {
+// Validate checks that the requested Shoot resources do not exceed the quota limits.
+func (q *QuotaValidator) Validate(a admission.Attributes, o admission.ObjectInterfaces) error {
 	// Wait until the caches have been synced
 	if q.readyFunc == nil {
 		q.AssignReadyFunc(func() bool {

--- a/plugin/pkg/shoot/quotavalidator/admission_test.go
+++ b/plugin/pkg/shoot/quotavalidator/admission_test.go
@@ -229,7 +229,7 @@ var _ = Describe("quotavalidator", func() {
 			It("should pass because all quotas limits are sufficient", func() {
 				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
 
-				err := admissionHandler.Admit(attrs, nil)
+				err := admissionHandler.Validate(attrs, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -237,7 +237,7 @@ var _ = Describe("quotavalidator", func() {
 				shoot.Spec.Cloud.GCP.Workers[0].AutoScalerMax = 2
 				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
 
-				err := admissionHandler.Admit(attrs, nil)
+				err := admissionHandler.Validate(attrs, nil)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -248,7 +248,7 @@ var _ = Describe("quotavalidator", func() {
 
 				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
 
-				err := admissionHandler.Admit(attrs, nil)
+				err := admissionHandler.Validate(attrs, nil)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -256,7 +256,7 @@ var _ = Describe("quotavalidator", func() {
 				shoot.Spec.Cloud.GCP = &shootSpecCloudGCE2Worker
 				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
 
-				err := admissionHandler.Admit(attrs, nil)
+				err := admissionHandler.Validate(attrs, nil)
 				Expect(err).To(HaveOccurred())
 			})
 
@@ -268,7 +268,7 @@ var _ = Describe("quotavalidator", func() {
 				shoot.Spec.Kubernetes.Version = "1.1.1"
 				attrs := admission.NewAttributesRecord(&shoot, &oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, false, nil)
 
-				err := admissionHandler.Admit(attrs, nil)
+				err := admissionHandler.Validate(attrs, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -281,7 +281,7 @@ var _ = Describe("quotavalidator", func() {
 
 				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
 
-				err := admissionHandler.Admit(attrs, nil)
+				err := admissionHandler.Validate(attrs, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -290,7 +290,7 @@ var _ = Describe("quotavalidator", func() {
 				gardenInformerFactory.Garden().InternalVersion().SecretBindings().Informer().GetStore().Add(&secretBinding)
 				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
 
-				err := admissionHandler.Admit(attrs, nil)
+				err := admissionHandler.Validate(attrs, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -318,7 +318,7 @@ var _ = Describe("quotavalidator", func() {
 				gardenInformerFactory.Garden().InternalVersion().SecretBindings().Informer().GetStore().Add(&secretBinding)
 				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
 
-				err := admissionHandler.Admit(attrs, nil)
+				err := admissionHandler.Validate(attrs, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -366,7 +366,7 @@ var _ = Describe("quotavalidator", func() {
 			It("should pass because quota is sufficient", func() {
 				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
 
-				err := admissionHandler.Admit(attrs, nil)
+				err := admissionHandler.Validate(attrs, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -388,7 +388,7 @@ var _ = Describe("quotavalidator", func() {
 
 				attrs := admission.NewAttributesRecord(&shoot, &oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, false, nil)
 
-				err := admissionHandler.Admit(attrs, nil)
+				err := admissionHandler.Validate(attrs, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -396,7 +396,7 @@ var _ = Describe("quotavalidator", func() {
 				shoot.Annotations[common.ShootExpirationTimestamp] = "2018-01-02T00:00:00+00:00" // plus 1 day
 				attrs := admission.NewAttributesRecord(&shoot, &oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, false, nil)
 
-				err := admissionHandler.Admit(attrs, nil)
+				err := admissionHandler.Validate(attrs, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -404,7 +404,7 @@ var _ = Describe("quotavalidator", func() {
 				shoot.Annotations[common.ShootExpirationTimestamp] = "2018-01-09T00:00:00+00:00" // plus 8 days
 				attrs := admission.NewAttributesRecord(&shoot, &oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, false, nil)
 
-				err := admissionHandler.Admit(attrs, nil)
+				err := admissionHandler.Validate(attrs, nil)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -466,7 +466,7 @@ var _ = Describe("quotavalidator", func() {
 			It("should pass because quota is sufficient", func() {
 				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
 
-				err := admissionHandler.Admit(attrs, nil)
+				err := admissionHandler.Validate(attrs, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -478,7 +478,7 @@ var _ = Describe("quotavalidator", func() {
 				shoot.Spec.Kubernetes.Version = "1.1.1"
 				attrs := admission.NewAttributesRecord(&shoot, &oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, false, nil)
 
-				err := admissionHandler.Admit(attrs, nil)
+				err := admissionHandler.Validate(attrs, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a check to the shoot admission plugin that causes a premature exit in case the `spec` of a shoot is not changed.

Thus, newly introduced defaulting functionalities do not cause a `generation` increase by changing anything outside the `spec` section (e.g. adding a label).

**Special notes for your reviewer**:
The `quotavalidator` has been changed to a **validating** admission plugin.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The shoot validator admission plugin exits early in case of update operations that did not change the `.spec` field.
```
