### PR TITLE
Add networking provider label in Gardener

### DIFF
--- a/pkg/apis/core/v1alpha1/types_constants.go
+++ b/pkg/apis/core/v1alpha1/types_constants.go
@@ -115,6 +115,8 @@ const (
 	SeedProvider = "seed.gardener.cloud/provider"
 	// ShootProvider is used to identify the shoot provider.
 	ShootProvider = "shoot.gardener.cloud/provider"
+	// NetworkingProvider is used to identify the networking provider for the cni plugin.
+	NetworkingProvider = "networking.shoot.gardener.cloud/provider"
 
 	// LabelNetworkPolicyToBlockedCIDRs allows Egress from pods labeled with 'networking.gardener.cloud/to-blocked-cidrs=allowed'.
 	LabelNetworkPolicyToBlockedCIDRs = "networking.gardener.cloud/to-blocked-cidrs"


### PR DESCRIPTION
**What this PR does / why we need it**:
Add networking provider label as a constant in Gardener. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
None
```
