### PR TITLE
fix signature of DeleteChart for chart renderer

### DIFF
--- a/pkg/client/kubernetes/chartapplier.go
+++ b/pkg/client/kubernetes/chartapplier.go
@@ -34,7 +34,7 @@ type ChartApplier interface {
 	ApplyChartInNamespaceWithOptions(ctx context.Context, chartPath, namespace, name string, defaultValues, additionalValues map[string]interface{}, options ApplierOptions) error
 	ApplyChartInNamespace(ctx context.Context, chartPath, namespace, name string, defaultValues, additionalValues map[string]interface{}) error
 
-	DeleteChart(ctx context.Context, chartPath, namespace, name string) error
+	DeleteChart(ctx context.Context, chartPath, namespace, name string, defaultValues, additionalValues map[string]interface{}) error
 }
 
 // chartApplier is a structure that contains a chart renderer and a manifest applier.
@@ -104,8 +104,8 @@ func (c *chartApplier) ApplyChartInNamespace(ctx context.Context, chartPath, nam
 // DeleteChart takes a path to a chart <chartPath>, name of the release <name>,
 // release's namespace <namespace> and renders the template.
 // The resulting manifest will be deleted from the cluster the Kubernetes client has been created for.
-func (c *chartApplier) DeleteChart(ctx context.Context, chartPath, namespace, name string) error {
-	manifestReader, err := c.manifestReader(chartPath, namespace, name, nil, nil)
+func (c *chartApplier) DeleteChart(ctx context.Context, chartPath, namespace, name string, defaultValues, additionalValues map[string]interface{}) error {
+	manifestReader, err := c.manifestReader(chartPath, namespace, name, defaultValues, additionalValues)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

`DeleteChart` uses only the default values for the chart rendering.
This does not work for the general case, it must be possible
to specify the correct dedicated values to get the correct set of
manifests to be deleted.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
