### PR TITLE
Add ControlPlane purpose field

### DIFF
--- a/pkg/apis/extensions/v1alpha1/types_controlplane.go
+++ b/pkg/apis/extensions/v1alpha1/types_controlplane.go
@@ -63,6 +63,9 @@ type ControlPlaneSpec struct {
 	// DefaultSpec is a structure containing common fields used by all extension resources.
 	DefaultSpec `json:",inline"`
 
+	// Purpose contains the data if a cloud provider needs additional components in order to expose the control plane.
+	// +optional
+	Purpose *Purpose `json:"purpose,omitempty"`
 	// ProviderConfig contains provider-specific configuration for this control plane.
 	// +optional
 	ProviderConfig *runtime.RawExtension `json:"providerConfig,omitempty"`
@@ -85,3 +88,13 @@ type ControlPlaneStatus struct {
 	// +optional
 	ProviderStatus *runtime.RawExtension `json:"providerStatus,omitempty"`
 }
+
+// Purpose is a string alias.
+type Purpose string
+
+const (
+	// Normal triggers the ControlPlane controllers for the shoot provider.
+	Normal Purpose = "normal"
+	// Exposure triggers the ControlPlane controllers for the exposure settings.
+	Exposure Purpose = "exposure"
+)

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -379,6 +379,11 @@ func (in *ControlPlaneList) DeepCopyObject() runtime.Object {
 func (in *ControlPlaneSpec) DeepCopyInto(out *ControlPlaneSpec) {
 	*out = *in
 	out.DefaultSpec = in.DefaultSpec
+	if in.Purpose != nil {
+		in, out := &in.Purpose, &out.Purpose
+		*out = new(Purpose)
+		**out = **in
+	}
 	if in.ProviderConfig != nil {
 		in, out := &in.ProviderConfig, &out.ProviderConfig
 		*out = new(runtime.RawExtension)


### PR DESCRIPTION
**What this PR does / why we need it**:
A `ControlPlane` CRD was introduced. It's purpose is to install any provider-specific components into the seed (or shoot) that are required to make the cluster functional.

Some providers have additional needs: They might need to deploy components that are required to expose the control plane. The `kube-apiserver` of a shoot is exposed via a load balancer in the seed. The seed provider might be different from the shoot provider (for example, you can create an AWS shoot whose control plane is running on a GCP seed). Examples for those components are the `aws-lb-readvertiser`.

This PR enhances the current ControlPlane resource with a new .spec.purpose field.
The purpose: `normal` should trigger the ControlPlane controllers for the shoot provider, i.e., the currently implemented control plane controllers.
The purpose: `exposure` should trigger the new control plane controllers for the exposure settings.

**Which issue(s) this PR fixes**:
https://github.com/gardener/gardener-extensions/issues/233

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
The `ControlPlane` extension CRD does now have an optional `.spec.purpose` field. The default purpose will be `normal`. Another purpose is `exposure` which can be used to trigger the deployment of components that are required for exposing a shoot control plane. As the shoot control plane is running in the seed cluster this is specific to the seed provider.
```
