### PR TITLE
Add OpenVPN Env Variables to Prometheus

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -142,6 +142,12 @@ spec:
         env:
         - name: OPENVPN_PORT
           value: "4314"
+        - name: SERVICE_NETWORK
+          value: {{ .Values.networks.services }}
+        - name: POD_NETWORK
+          value: {{ .Values.networks.pods }}
+        - name: NODE_NETWORK
+          value: {{ .Values.networks.nodes }}
         ports:
         - name: https
           containerPort: 1194


### PR DESCRIPTION
**What this PR does / why we need it**:
Add Nodes / Services / Pods CIDRs as env vars for the prometheus VPN side car in the seed. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `prometheus` stateful set does now have the requirement environment variables for the latest VPN version.
```
