### PR TITLE
Increase nginx-ingress resource limits for shooted seeds

### DIFF
--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -105,8 +105,8 @@ func (b *Botanist) GenerateNginxIngressConfig() (map[string]interface{}, error) 
 				"controller": map[string]interface{}{
 					"resources": map[string]interface{}{
 						"limits": map[string]interface{}{
-							"cpu":    "500m",
-							"memory": "1024Mi",
+							"cpu":    "1000m",
+							"memory": "2048Mi",
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase nginx-ingress resource limits for shooted seeds

**Special notes for your reviewer**:
Until we have VPA/autoscaling for such components we have to increase the limits manually, unfortunately.
cc @amshuman-kr @georgekuruvillak @wyb1

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The resource limits for the `nginx-ingress` controller on shooted seeds have been increased to `1` CPU, `2Gi` memory.
```
