### PR TITLE
Synced etcd encryption secret now has ownerrefence to shoot

### DIFF
--- a/pkg/operation/botanist/etcdencryption.go
+++ b/pkg/operation/botanist/etcdencryption.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/operation/common"
 	encryptionconfiguration "github.com/gardener/gardener/pkg/operation/etcdencryption"
 	"github.com/gardener/gardener/pkg/utils"
@@ -111,6 +112,9 @@ func (b *Botanist) createOrUpdateEncryptionConfiguration(ctx context.Context) (*
 func (b *Botanist) syncEncryptionConfigurationToGarden(ctx context.Context, conf *apiserverconfigv1.EncryptionConfiguration) error {
 	secret := &corev1.Secret{ObjectMeta: kutil.ObjectMetaFromKey(common.GardenEtcdEncryptionSecretKey(b.Shoot.Info.Namespace, b.Shoot.Info.Name))}
 	_, err := controllerutil.CreateOrUpdate(ctx, b.K8sGardenClient.Client(), secret, func() error {
+		secret.OwnerReferences = []metav1.OwnerReference{
+			*metav1.NewControllerRef(b.Shoot.Info, gardenv1beta1.SchemeGroupVersion.WithKind("Shoot")),
+		}
 		return encryptionconfiguration.UpdateSecret(secret, conf)
 	})
 	return err


### PR DESCRIPTION
**What this PR does / why we need it**:
Add owner reference to `Shoot` for synced etcd encryption `Secret` in project namespace in the garden cluster.

**Special notes for your reviewer**:
/cc @schrodit, thanks for reporting!

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The etcd encryption `Secret` that is synced to the project namespace in the garden cluster does now have a owner reference to the `Shoot` (allows proper garbage collection after shoot deletion).
```
