### PR TITLE
Enable server side encryption of oss buckets on Alicloud

### DIFF
--- a/charts/seed-terraformer/charts/alicloud-backup/templates/_main.tf
+++ b/charts/seed-terraformer/charts/alicloud-backup/templates/_main.tf
@@ -12,13 +12,9 @@ provider "alicloud" {
 resource "alicloud_oss_bucket" "bucket" {
   bucket        = "{{ required "bucket.name is required" .Values.bucket.name }}"
   acl           = "private"
-}
 
-// Workaround: Providing a null-resource for letting Terraform think that there are
-// differences, enabling the Gardener to start an actual `terraform apply` job.
-resource "null_resource" "outputs" {
-  triggers = {
-    recompute = "outputs"
+  server_side_encryption_rule {
+    sse_algorithm = "KMS"
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to enable server side encryption of oss buckets on Alicloud.
**Which issue(s) this PR fixes**:
Fixes #
None
**Special notes for your reviewer**:
It will trigger a 'terraform apply' job on existed buckets. It will not affect snapshots already stored in buckets, but for snapshots uploaded after the change, they will be encrypted on server side.


```noteworthy operator
NONE
```