### PR TITLE
Add shoot infra to alerts

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -21,6 +21,7 @@ data:
         seed_api: {{ .Values.seed.apiserver }}
         seed_region: {{ .Values.seed.region }}
         seed_profile: {{ .Values.seed.profile }}
+        shoot_infra: {{ .Values.shoot.provider }}
         ignoreAlerts: {{ .Values.ignoreAlerts }}
     rule_files:
     - /etc/prometheus/rules/*.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the infrastructure of the shoot to alerts.

**Which issue(s) this PR fixes**:
Fixes #169 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Shoot infrastructure provider is now included in alerts.
```
