### PR TITLE
Ignore conflict errors when deleting namespaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
-	github.com/ugorji/go/codec v1.1.7 // indirect
+	github.com/ugorji/go v1.1.7 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.etcd.io/bbolt v1.3.3 // indirect

--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -149,6 +150,9 @@ var (
 
 	// PersistentVolumeClaimCleanOptions is the delete selector for PersistentVolumeClaims.
 	PersistentVolumeClaimCleanOptions = utilclient.DeleteWith(utilclient.CollectionMatching(client.UseListOptions(&NoCleanupPreventionListOptions)))
+
+	// NamespaceErrorToleration are the errors to be tolerated during deletion.
+	NamespaceErrorToleration = utilclient.TolerateErrors(apierrors.IsConflict)
 )
 
 func cleanResourceFn(c client.Client, list runtime.Object, opts ...utilclient.CleanOptionFunc) flow.TaskFn {
@@ -198,7 +202,7 @@ func (b *Botanist) CleanKubernetesResources(ctx context.Context) error {
 		cleanResourceFn(c, &appsv1.DeploymentList{}, DeploymentCleanOptions, ZeroGracePeriod, FinalizeAfterFiveMinutes),
 		cleanResourceFn(c, &extensionsv1beta1.IngressList{}, IngressCleanOptions, ZeroGracePeriod, FinalizeAfterFiveMinutes),
 		cleanResourceFn(c, &batchv1.JobList{}, JobCleanOptions, ZeroGracePeriod, FinalizeAfterFiveMinutes),
-		cleanResourceFn(c, &corev1.NamespaceList{}, NamespaceCleanOptions, ZeroGracePeriod, FinalizeAfterFiveMinutes),
+		cleanResourceFn(c, &corev1.NamespaceList{}, NamespaceCleanOptions, ZeroGracePeriod, FinalizeAfterFiveMinutes, NamespaceErrorToleration),
 		cleanResourceFn(c, &corev1.PodList{}, PodCleanOptions, ZeroGracePeriod, FinalizeAfterFiveMinutes),
 		cleanResourceFn(c, &appsv1.ReplicaSetList{}, ReplicaSetCleanOptions, ZeroGracePeriod, FinalizeAfterFiveMinutes),
 		cleanResourceFn(c, &corev1.ReplicationControllerList{}, ReplicationControllerCleanOptions, ZeroGracePeriod, FinalizeAfterFiveMinutes),


### PR DESCRIPTION
**What this PR does / why we need it**:
When Gardener tries to clean up Kubernetes resources in the shoot, the deletion is retried as long as the resource isn't gone. However, calling `delete` on `Namespaces` which carry `finalizers` causes a `conflict error`. To prevent an abortion of the entire shoot deletion flow,  Gardener should tolerate the well known `conflict error` for `Namespaces`.

**Special notes for your reviewer**:
/cc @rfranzke @adracus 

Log extract:

```
encountered task errors: [task \\\"Cleaning kubernetes resources\\\" failed: 8 errors occurred:\\n\\t* Operation cannot be fulfilled on namespaces \\\"xyz\\\": The system is ensuring all content is removed from this namespace. Upon completion, this namespace will automatically be purged by the system.\\n\\t* Operation cannot be fulfilled on namespaces
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixes an issue for which led to an abortion of the shoot deletion flow in case Gardener tried to clean up namespaces in the shoot.
```
