### PR TITLE
Finalize CRD & APIService after 1h

### DIFF
--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -69,7 +69,10 @@ func MustNewRequirement(key string, op selection.Operator, vals ...string) label
 
 var (
 	// FinalizeAfterFiveMinutes is an option to finalize resources after five minutes.
-	FinalizeAfterFiveMinutes = utilclient.FinalizeGracePeriod(5 * 60)
+	FinalizeAfterFiveMinutes = utilclient.FinalizeGracePeriodSeconds(5 * 60)
+
+	// FinalizeAfterOneHour is an option to finalize resources after one hour.
+	FinalizeAfterOneHour = utilclient.FinalizeGracePeriodSeconds(60 * 60)
 
 	// ZeroGracePeriod is an option to delete resources with no grace period.
 	ZeroGracePeriod = utilclient.DeleteWith(utilclient.GracePeriodSeconds(0))
@@ -184,8 +187,8 @@ func (b *Botanist) CleanExtendedAPIs(ctx context.Context) error {
 	c := b.K8sShootClient.Client()
 
 	return flow.Parallel(
-		cleanResourceFn(c, &apiregistrationv1beta1.APIServiceList{}, APIServiceCleanOptions, ZeroGracePeriod, FinalizeAfterFiveMinutes),
-		cleanResourceFn(c, &apiextensionsv1beta1.CustomResourceDefinitionList{}, CustomResourceDefinitionCleanOptions, ZeroGracePeriod, FinalizeAfterFiveMinutes),
+		cleanResourceFn(c, &apiregistrationv1beta1.APIServiceList{}, APIServiceCleanOptions, ZeroGracePeriod, FinalizeAfterOneHour),
+		cleanResourceFn(c, &apiextensionsv1beta1.CustomResourceDefinitionList{}, CustomResourceDefinitionCleanOptions, ZeroGracePeriod, FinalizeAfterOneHour),
 	)(ctx)
 }
 

--- a/pkg/utils/kubernetes/client/client_test.go
+++ b/pkg/utils/kubernetes/client/client_test.go
@@ -232,7 +232,7 @@ var _ = Describe("Cleaner", func() {
 					c.EXPECT().Patch(ctx, &cm2, client.MergeFrom(&cm2WithFinalizer)),
 				)
 
-				Expect(cleaner.Clean(ctx, c, &cm2, FinalizeGracePeriod(20))).To(Succeed())
+				Expect(cleaner.Clean(ctx, c, &cm2, FinalizeGracePeriodSeconds(20))).To(Succeed())
 			})
 
 			It("should delete the object if its deletion timestamp is not over the finalize grace period", func() {
@@ -251,7 +251,7 @@ var _ = Describe("Cleaner", func() {
 					c.EXPECT().Delete(ctx, &cm2, ClientDeleteOptionFuncProduces(client.DeleteOptions{})),
 				)
 
-				Expect(cleaner.Clean(ctx, c, &cm2, FinalizeGracePeriod(20))).To(Succeed())
+				Expect(cleaner.Clean(ctx, c, &cm2, FinalizeGracePeriodSeconds(20))).To(Succeed())
 			})
 
 			It("should delete the object if its deletion timestamp is over the finalize grace period and no finalizer is left", func() {
@@ -270,7 +270,7 @@ var _ = Describe("Cleaner", func() {
 					c.EXPECT().Delete(ctx, &cm2, ClientDeleteOptionFuncProduces(client.DeleteOptions{})),
 				)
 
-				Expect(cleaner.Clean(ctx, c, &cm2, FinalizeGracePeriod(10))).To(Succeed())
+				Expect(cleaner.Clean(ctx, c, &cm2, FinalizeGracePeriodSeconds(10))).To(Succeed())
 			})
 
 			It("should finalize the list if the object's deletion timestamps are over the finalize grace period", func() {
@@ -290,7 +290,7 @@ var _ = Describe("Cleaner", func() {
 					c.EXPECT().Patch(ctx, &cm2, client.MergeFrom(&cm2WithFinalizer)),
 				)
 
-				Expect(cleaner.Clean(ctx, c, list, FinalizeGracePeriod(20))).To(Succeed())
+				Expect(cleaner.Clean(ctx, c, list, FinalizeGracePeriodSeconds(20))).To(Succeed())
 			})
 
 			It("should delete the list if the object's deletion timestamps are not over the finalize grace period", func() {
@@ -310,7 +310,7 @@ var _ = Describe("Cleaner", func() {
 					c.EXPECT().Delete(ctx, &cm2WithFinalizer, ClientDeleteOptionFuncProduces(client.DeleteOptions{})),
 				)
 
-				Expect(cleaner.Clean(ctx, c, list, FinalizeGracePeriod(20))).To(Succeed())
+				Expect(cleaner.Clean(ctx, c, list, FinalizeGracePeriodSeconds(20))).To(Succeed())
 			})
 
 			It("should delete the list if the object's deletion timestamps is over the finalize grace period and no finalizers are left", func() {
@@ -330,7 +330,7 @@ var _ = Describe("Cleaner", func() {
 					c.EXPECT().Delete(ctx, &cm2, ClientDeleteOptionFuncProduces(client.DeleteOptions{})),
 				)
 
-				Expect(cleaner.Clean(ctx, c, list, FinalizeGracePeriod(10))).To(Succeed())
+				Expect(cleaner.Clean(ctx, c, list, FinalizeGracePeriodSeconds(10))).To(Succeed())
 			})
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase the time after which CRDs and APIService are being finalized to 1h.

**Special notes for your reviewer**:
cc @vlerenc 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
When deleting a shoot, registered `CustomResourceDefinition`s and `APIService`s now have `1h` time to cleanup before getting forcefully finalized.
```
