### PR TITLE
Deploy Gardener-Resource-Manager for seed

### DIFF
--- a/charts/seed-bootstrap/templates/extensions/crd-managedresources.yaml
+++ b/charts/seed-bootstrap/templates/extensions/crd-managedresources.yaml
@@ -21,5 +21,9 @@ spec:
   - name: Age
     type: date
     JSONPath: .metadata.creationTimestamp
+  - name: Class
+    type: string
+    description: The class identifies which resource manager is responsible for this ManagedResource.
+    JSONPath: .spec.class
   subresources:
     status: {}

--- a/charts/seed-bootstrap/templates/gardener-resource-manager/deployment.yaml
+++ b/charts/seed-bootstrap/templates/gardener-resource-manager/deployment.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: {{ include "deploymentversion" . }}
+kind: Deployment
+metadata:
+  name: gardener-resource-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: gardener-resource-manager
+spec:
+  revisionHistoryLimit: 0
+  replicas: {{ .Values.gardenerResourceManager.replicas }}
+  selector:
+    matchLabels:
+      app: gardener-resource-manager
+  template:
+    metadata:
+      {{- if .Values.gardenerResourceManager.podAnnotations }}
+      annotations:
+{{ toYaml .Values.gardenerResourceManager.podAnnotations | indent 8 }}
+{{- end }}
+      labels:
+        app: gardener-resource-manager
+    spec:
+      serviceAccountName: gardener-resource-manager
+      containers:
+      - name: gardener-resource-manager
+        image: {{ index .Values.global.images "gardener-resource-manager" }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /gardener-resource-manager
+        - --leader-election=true
+        - --leader-election-namespace={{ .Release.Namespace }}
+        - --max-concurrent-workers={{ .Values.gardenerResourceManager.concurrentSyncs }}
+        - --resource-class={{ .Values.gardenerResourceManager.resourceClass }}
+        - --sync-period={{ .Values.gardenerResourceManager.syncPeriod }}
+        {{- if .Values.gardenerResourceManager.resources }}
+        resources:
+{{ toYaml .Values.gardenerResourceManager.resources | indent 10 }}
+        {{- end }}

--- a/charts/seed-bootstrap/templates/gardener-resource-manager/rbac.yaml
+++ b/charts/seed-bootstrap/templates/gardener-resource-manager/rbac.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: gardener-resource-manager-seed
+  labels:
+    app: gardener-resource-manager
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: gardener-resource-manager-seed
+  labels:
+    app: gardener-resource-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gardener-resource-manager-seed
+subjects:
+- kind: ServiceAccount
+  name: gardener-resource-manager
+  namespace: {{ .Release.Namespace }}

--- a/charts/seed-bootstrap/templates/gardener-resource-manager/serviceaccount.yaml
+++ b/charts/seed-bootstrap/templates/gardener-resource-manager/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gardener-resource-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: gardener-resource-manager

--- a/charts/seed-bootstrap/templates/gardener-resource-manager/vpa.yaml
+++ b/charts/seed-bootstrap/templates/gardener-resource-manager/vpa.yaml
@@ -1,0 +1,14 @@
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: gardener-resource-manager-vpa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: gardener-resource-manager
+spec:
+  targetRef:
+    apiVersion: {{ include "deploymentversion" . }}
+    kind: Deployment
+    name: gardener-resource-manager
+  updatePolicy:
+    updateMode: "Auto"

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -43,6 +43,7 @@ global:
     elasticsearch-oss: image-repository:image-tag
     elasticsearch-searchguard-oss: image-repository:image-tag
     fluentd-es: image-repository:image-tag
+    gardener-resource-manager: image-repository:image-tag
     kibana-oss: image-repository:image-tag
     pause-container: image-repository:image-tag
     prometheus: image-repository:image-tag
@@ -70,3 +71,17 @@ alertmanager:
 
 global-network-policies:
   denyAll: false
+
+gardenerResourceManager:
+  resources:
+    requests:
+      cpu: 23m
+      memory: 47Mi
+    limits:
+      cpu: 400m
+      memory: 512Mi
+  replicas: 1
+  resourceClass: seed
+  syncPeriod: 1m0s
+  concurrentSyncs: 20
+  podAnnotations: {}

--- a/pkg/apis/core/v1alpha1/types_constants.go
+++ b/pkg/apis/core/v1alpha1/types_constants.go
@@ -109,6 +109,10 @@ const (
 	// GardenRoleExtension is a constant for a label that describes the 'extensions' role.
 	GardenRoleExtension = "extension"
 
+	// SeedResourceManagerClass is the resource-class managed by the Gardener-Resource-Manager
+	// instance in the garden namespace on the seeds.
+	SeedResourceManagerClass = "seed"
+
 	// BackupProvider is used to identify the backup provider.
 	BackupProvider = "backup.gardener.cloud/provider"
 	// SeedProvider is used to identify the seed provider.

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+
 	"github.com/gardener/gardener/pkg/apis/garden"
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
@@ -246,6 +248,7 @@ func BootstrapCluster(seed *Seed, secrets map[string]*corev1.Secret, imageVector
 			common.ElasticsearchMetricsExporterImageName,
 			common.FluentBitImageName,
 			common.FluentdEsImageName,
+			common.GardenerResourceManagerImageName,
 			common.KibanaImageName,
 			common.PauseContainerImageName,
 			common.PrometheusImageName,
@@ -459,6 +462,9 @@ func BootstrapCluster(seed *Seed, secrets map[string]*corev1.Secret, imageVector
 			// "metadataService": "169.254.169.254/32"
 			"denyAll":         false,
 			"privateNetworks": privateNetworks,
+		},
+		"gardenerResourceManager": map[string]interface{}{
+			"resourceClass": v1alpha1.SeedResourceManagerClass,
 		},
 	}, applierOptions)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Deploy the Gardener-Resource-Manager to the `garden` namespace on the seed. With this instance, manifests in a `ManagedResource` can be applied / removed on the same seed cluster.

/cc @mandelsoft @MartinWeindel
 
**Special notes for your reviewer**:

Test scenario: Seed `Gardener-Resource-Manager` was deployed on seed with another `Gardener-Resource-Manager` for the shoot. The creation and deletion of `ManagedResources` for both seed and shoot didn't interfere each other.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
Every seed cluster now gets a [`gardener-resource-manager`](https://github.com/gardener/gardener-resource-manager) deployment in its `garden` namespace. This instance manages `ManagedResources` with `.spec.class=seed` for which contained manifests are applied to or removed from the very same seed cluster. Extension controllers might be interested in using this feature to let the `gardener-resource-manager` handle resources that need to be deployed to the seed.
```
