### PR TITLE
Remove default label from rbac test

### DIFF
--- a/.test-defs/RBACTest.yaml
+++ b/.test-defs/RBACTest.yaml
@@ -6,7 +6,7 @@ spec:
   description: Tests if rbac is enabled for the gardener and if a service acount has acccess to the garden ns
 
   activeDeadlineSeconds: 1800
-  labels: ["default", "release"]
+  labels: ["release"]
 
   config:
   - name: GO111MODULE


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove `default` label from rbac test as this test is only relevant for release jobs.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
