### PR TITLE
add enabling of the systemd units

### DIFF
--- a/charts/shoot-cloud-config/templates/scripts/_cloud-config-script.sh
+++ b/charts/shoot-cloud-config/templates/scripts/_cloud-config-script.sh
@@ -70,7 +70,7 @@ if ! diff "$PATH_CLOUDCONFIG" "$PATH_CLOUDCONFIG_OLD" >/dev/null; then
     systemctl daemon-reload
 {{- range $name := (required ".worker.units is required" .worker.units) }}
 {{- if ne $name "docker.service" }}
-    systemctl restart {{ $name }}
+    systemctl enable {{ $name }} && systemctl restart {{ $name }}
 {{- end }}
 {{- end }}
     echo "Successfully restarted all units referenced in the cloud config."


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request add enabling of the systemd unit which we add via operationsystemconfig.
We need this because "runcmd" section of the cloud-init script is not run after the first boot, so all of  the systemd unit which we add with original cloud-init аре not enabled. Prior this change after reboot of a node the kubelet service under ubuntu OS does not run and the node can't join the shoot cluster

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The `cloud-config-downloader` running on every shoot worker nodes is now enabling all the systemd units before starting them.
```
