### PR TITLE
Add etcd encryption for gardener runtime chart

### DIFF
--- a/charts/gardener/charts/runtime/templates/apiserver/configmap-encryption-configuration.yaml
+++ b/charts/gardener/charts/runtime/templates/apiserver/configmap-encryption-configuration.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.global.apiserver.enabled .Values.global.apiserver.encryption.configuration }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gardener-encryption-config
+  namespace: garden
+  labels:
+    app: gardener
+    role: apiserver
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  encryption-configuration.yaml: |-
+{{ .Values.global.apiserver.encryption.configuration | indent 4 }}
+{{- end }}

--- a/charts/gardener/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/charts/runtime/templates/apiserver/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         {{- if .Values.global.apiserver.audit.policy }}
         checksum/configmap-gardener-audit-policy-config: {{ include (print $.Template.BasePath "/apiserver/configmap-audit-policy.yaml") . | sha256sum }}
         {{- end }}
+        {{- if .Values.global.apiserver.audit.policy }}
+        checksum/configmap-gardener-encryption-config: {{ include (print $.Template.BasePath "/apiserver/configmap-encryption-configuration.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.global.apiserver.audit.webhook.config }}
         checksum/secret-gardener-audit-webhook-config: {{ include (print $.Template.BasePath "/apiserver/secret-audit-webhook-config.yaml") . | sha256sum }}
         {{- end }}
@@ -60,6 +63,9 @@ spec:
         imagePullPolicy: {{ .Values.global.apiserver.image.pullPolicy }}
         command:
         - /gardener-apiserver
+        {{- if .Values.global.apiserver.encryption.configuration }}
+        - --encryption-provider-config=/etc/gardener-apiserver/encryption/encryption-configuration.yaml
+        {{- end }}
         {{- if .Values.global.apiserver.audit.dynamicConfiguration }}
         - --audit-dynamic-configuration={{ .Values.global.apiserver.audit.dynamicConfiguration }}
         {{- end }}
@@ -203,6 +209,10 @@ spec:
         - name: gardener-audit-webhook-config
           mountPath: /etc/gardener-apiserver/auditwebhook
         {{- end }}
+        {{- if .Values.global.apiserver.encryption.configuration }}
+        - name: gardener-encryption-config
+          mountPath: /etc/gardener-apiserver/encryption
+        {{- end }}
       {{- if .Values.global.apiserver.etcd.useSidecar }}
       - name: etcd
         image: quay.io/coreos/etcd:v3.3.12
@@ -253,6 +263,11 @@ spec:
       - name: gardener-audit-policy-config
         configMap:
           name: gardener-audit-policy-config
+      {{- end }}
+      {{- if .Values.global.apiserver.encryption.configuration }}
+      - name: gardener-encryption-config
+        configMap:
+          name: gardener-encryption-config
       {{- end }}
       {{- if .Values.global.apiserver.audit.webhook.config }}
       - name: gardener-audit-webhook-config

--- a/charts/gardener/values.yaml
+++ b/charts/gardener/values.yaml
@@ -16,6 +16,15 @@ global:
       limits:
         cpu: 300m
         memory: 256Mi
+    encryption:
+      configuration: |
+        apiVersion: apiserver.config.k8s.io/v1
+        kind: EncryptionConfiguration
+        resources:
+          - resources:
+            - secrets
+            providers:
+            - identity: {}
     etcd:
       useSidecar: false # only meant for development purposes. if this is set to true, other etcd config values are ignored
       servers: https://etcd:2379


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes it possible to add an encryption configuration for a virtual-garden API server setup. 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
For `virtual-garden` based setups, it is now possible to configure an etcd encryption configuration.
```
