### PR TITLE
Clean up unused OperatingSystemConfigs

### DIFF
--- a/pkg/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/operatingsystemconfig_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist_test
+
+import (
+	"context"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	mock "github.com/gardener/gardener/pkg/mock/gardener/kubernetes"
+	"github.com/gardener/gardener/pkg/operation"
+	"github.com/gardener/gardener/pkg/operation/botanist"
+	"github.com/gardener/gardener/pkg/operation/shoot"
+
+	"github.com/golang/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("operatingsystemconfig", func() {
+	var (
+		ctrl                 *gomock.Controller
+		k8sSeedClient        *mock.MockInterface
+		k8sSeedRuntimeClient *mockclient.MockClient
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+
+		k8sSeedClient = mock.NewMockInterface(ctrl)
+		k8sSeedRuntimeClient = mockclient.NewMockClient(ctrl)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#CleanupOperatingSystemConfigs", func() {
+		It("should cleanup unused operating system configs", func() {
+			var (
+				ctx              = context.TODO()
+				newDownloaderOsc = extensionsv1alpha1.OperatingSystemConfig{ObjectMeta: metav1.ObjectMeta{Name: "cloud-config-new-worker-9f0e7-downloader"}}
+				newOriginalOsc   = extensionsv1alpha1.OperatingSystemConfig{ObjectMeta: metav1.ObjectMeta{Name: "cloud-config-new-worker-9f0e7-original"}}
+				oldDownloaderOsc = extensionsv1alpha1.OperatingSystemConfig{ObjectMeta: metav1.ObjectMeta{Name: "cloud-config-old-worker-9f0e7-downloader"}}
+				oldOriginalOsc   = extensionsv1alpha1.OperatingSystemConfig{ObjectMeta: metav1.ObjectMeta{Name: "cloud-config-old-worker-9f0e7-original"}}
+			)
+
+			k8sSeedClient.EXPECT().Client().Return(k8sSeedRuntimeClient)
+			k8sSeedRuntimeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, list *extensionsv1alpha1.OperatingSystemConfigList, _ ...client.ListOptionFunc) error {
+				list.Items = []extensionsv1alpha1.OperatingSystemConfig{newDownloaderOsc, newOriginalOsc, oldDownloaderOsc, oldOriginalOsc}
+				return nil
+			})
+
+			// Expect that the old OperatingSystemConfigs will be cleaned up
+			k8sSeedRuntimeClient.EXPECT().Delete(ctx, &oldDownloaderOsc)
+			k8sSeedRuntimeClient.EXPECT().Delete(ctx, &oldOriginalOsc)
+
+			op := &operation.Operation{
+				K8sSeedClient: k8sSeedClient,
+				Shoot: &shoot.Shoot{
+					SeedNamespace: "shoot--foo--bar",
+				},
+			}
+			botanist := botanist.Botanist{Operation: op}
+
+			usedOscNames := map[string]string{
+				newDownloaderOsc.Name: newDownloaderOsc.Name,
+				newOriginalOsc.Name:   newOriginalOsc.Name,
+			}
+			err := botanist.CleanupOperatingSystemConfigs(ctx, usedOscNames)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -86,7 +86,7 @@ func (b *Botanist) DeployWorker(ctx context.Context) error {
 				Name:    string(machineImage.Name),
 				Version: machineImage.Version,
 			},
-			UserData: []byte(b.Shoot.CloudConfigMap[worker.Name].Downloader.Content),
+			UserData: []byte(b.Shoot.OperatingSystemConfigsMap[worker.Name].Downloader.Data.Content),
 			Volume:   volume,
 			Zones:    b.Shoot.GetZones(),
 		})

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -85,7 +85,7 @@ func New(k8sGardenClient kubernetes.Interface, k8sGardenInformers gardeninformer
 
 		Extensions: extensions,
 	}
-	shootObj.CloudConfigMap = make(map[string]CloudConfig, len(shootObj.GetWorkerNames()))
+	shootObj.OperatingSystemConfigsMap = make(map[string]OperatingSystemConfigs, len(shootObj.GetWorkerNames()))
 
 	// Determine information about external domain for shoot cluster.
 	externalDomain, err := ConstructExternalDomain(context.TODO(), k8sGardenClient.Client(), shoot, secret, defaultDomains)

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -42,11 +42,11 @@ type Shoot struct {
 	IgnoreAlerts           bool
 	HibernationEnabled     bool
 
-	CloudConfigMap       map[string]CloudConfig
-	Extensions           map[string]Extension
-	InfrastructureStatus []byte
-	ControlPlaneStatus   []byte
-	MachineDeployments   []extensionsv1alpha1.MachineDeployment
+	OperatingSystemConfigsMap map[string]OperatingSystemConfigs
+	Extensions                map[string]Extension
+	InfrastructureStatus      []byte
+	ControlPlaneStatus        []byte
+	MachineDeployments        []extensionsv1alpha1.MachineDeployment
 }
 
 // ExternalDomain contains information for the used external shoot domain.
@@ -56,15 +56,21 @@ type ExternalDomain struct {
 	SecretData map[string][]byte
 }
 
-// CloudConfig contains a downloader script as well as the original cloud config.
-type CloudConfig struct {
-	Downloader CloudConfigData
-	Original   CloudConfigData
+// OperatingSystemConfigs contains operating system configs for the downloader script as well as for the original cloud config.
+type OperatingSystemConfigs struct {
+	Downloader OperatingSystemConfig
+	Original   OperatingSystemConfig
 }
 
-// CloudConfigData contains the actual content, a command to load it and all units that
+// OperatingSystemConfig contains the operating system config's name and data.
+type OperatingSystemConfig struct {
+	Name string
+	Data OperatingSystemConfigData
+}
+
+// OperatingSystemConfigData contains the actual content, a command to load it and all units that
 // shall be considered for restart on change.
-type CloudConfigData struct {
+type OperatingSystemConfigData struct {
 	Content string
 	Command *string
 	Units   []string


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR introduces an OperatingSystemConfigs cleanup during the `Computing operating system specific configuration for shoot workers` step. OSCs that are obsolete (no longer used) are now deleted.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
OperatingSystemConfigs that are obsolete (no longer used) are now cleaned up during reconciliation.
```
