### PR TITLE
maintenance integration test running with scaled-down gardener scheduler

### DIFF
--- a/.test-defs/ShootMaintenanceTest.yaml
+++ b/.test-defs/ShootMaintenanceTest.yaml
@@ -5,12 +5,21 @@ spec:
   owner: DL_5C5BE3E2970B9F404D0E2F50@sap.com
   description: Tests the shoot machine image maintenance.
 
-  activeDeadlineSeconds: 5400
+  activeDeadlineSeconds: 600
+  behavior:
+    - serial
+
+  config:
+    - name: GO111MODULE
+      value: "on"
+      type: env
 
   command: [bash, -c]
   args:
-  - >-
-    /tm/setup github.com/gardener gardener &&
-    go run $GOPATH/src/github.com/gardener/gardener/.test-defs/cmd/shoot-maintenance
-
-  image: eu.gcr.io/gardener-project/gardener/testmachinery/golang:0.42.0
+    - >-
+      go test -mod=vendor ./test/integration/shoots/maintenance
+      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      -kubeconfig=$TM_KUBECONFIG_PATH/gardener.config
+      -shootName=$SHOOT_NAME
+      -shootNamespace=$PROJECT_NAMESPACE
+  image: golang:1.12.9

--- a/test/integration/shoots/maintenance/maintenance_test.go
+++ b/test/integration/shoots/maintenance/maintenance_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Shoot Maintenance testing", func() {
 		cloudProfileCleanupNeeded = true
 
 		// set integration test machineImage to shoot
-		updateImage := helper.UpdateMachineImages(shootMaintenanceTest.CloudProvider, []*gardenv1beta1.ShootMachineImage{&testMachineImage})
+		updateImage := helper.UpdateDefaultMachineImage(shootMaintenanceTest.CloudProvider, &testMachineImage)
 		Expect(updateImage).NotTo(BeNil())
 		updateImage(&shoot.Spec.Cloud)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The Gardener Maintenance Integration test creates a Shoot to test if the Shoot Images updates are correctly applied by the Gardener Controller Manager. 
The actual creation & reconciliation & deletion of a Shoot is already tested in other integration test and is consequently only significantly slowing down the test execution.

Maintenance Integration test 
- should run in serial
- scales down the Scheduler before execution
- scales up the Scheduler after execution

Goal: The maintenance integration tests should be ready to be executed by the test-machinery.

Also: fix bug due to multiple workers introduced
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

@schrodit can we sync on how I can test new integration tests with the test-machinery  in the future?

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
