### PR TITLE
fix GCP shoot validation to allow only 1 network

### DIFF
--- a/pkg/apis/garden/validation/validation.go
+++ b/pkg/apis/garden/validation/validation.go
@@ -1208,8 +1208,8 @@ func validateCloud(cloud garden.Cloud, kubernetes garden.Kubernetes, fldPath *fi
 		nodes, pods, services, networkErrors := transformK8SNetworks(gcp.Networks.K8SNetworks, gcpPath.Child("networks"))
 		allErrs = append(allErrs, networkErrors...)
 
-		if len(gcp.Networks.Workers) != zoneCount {
-			allErrs = append(allErrs, field.Invalid(gcpPath.Child("networks", "workers"), gcp.Networks.Workers, "must specify as many workers networks as zones"))
+		if len(gcp.Networks.Workers) > 1 {
+			allErrs = append(allErrs, field.Invalid(gcpPath.Child("networks", "workers"), gcp.Networks.Workers, "must specify only one worker cidr"))
 		}
 
 		workerCIDRs := make([]cidrvalidation.CIDR, 0, len(gcp.Networks.Workers))

--- a/pkg/apis/garden/validation/validation_test.go
+++ b/pkg/apis/garden/validation/validation_test.go
@@ -4500,6 +4500,18 @@ var _ = Describe("validation", func() {
 			})
 
 			Context("CIDR", func() {
+				It("should forbid more than one CIDR", func() {
+					shoot.Spec.Cloud.GCP.Networks.Workers = []gardencore.CIDR{"10.250.0.1/32", "10.250.0.2/32"}
+
+					errorList := ValidateShoot(shoot)
+
+					Expect(errorList).To(ConsistOfFields(Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.cloud.gcp.networks.workers"),
+						"Detail": Equal("must specify only one worker cidr"),
+					}))
+				})
+
 				It("should forbid invalid workers CIDR", func() {
 					shoot.Spec.Cloud.GCP.Networks.Workers = []gardencore.CIDR{invalidCIDR}
 

--- a/pkg/registry/garden/shoot/strategy_test.go
+++ b/pkg/registry/garden/shoot/strategy_test.go
@@ -15,8 +15,10 @@
 package shoot_test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/garden"
 	strategy "github.com/gardener/gardener/pkg/registry/garden/shoot"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,6 +83,30 @@ var _ = Describe("MatchShoot", func() {
 		Expect(result.Field).To(Equal(fs))
 		Expect(result.IndexFields).To(ConsistOf(garden.ShootSeedName))
 
+	})
+})
+
+var _ = Describe("Strategy", func() {
+
+	Context("PrepareForUpdate", func() {
+		Context("invalid GCP network CIRDs", func() {
+			It("should remove more than one GCP networks", func() {
+				shoot := newShoot("foo")
+
+				shoot.Spec.Cloud.GCP = &garden.GCPCloud{
+					Networks: garden.GCPNetworks{
+						Workers: []core.CIDR{"1.1.1.1/32", "1.1.1.2/32"},
+					},
+				}
+				oldShoot := newShoot("foo")
+				oldShoot.Spec.Cloud.GCP = shoot.Spec.Cloud.GCP.DeepCopy()
+
+				strategy.Strategy.PrepareForUpdate(context.TODO(), shoot, oldShoot)
+
+				Expect(shoot.Spec.Cloud.GCP.Networks.Workers).To(ConsistOf(core.CIDR("1.1.1.1/32")))
+				Expect(oldShoot.Spec.Cloud.GCP.Networks.Workers).To(ConsistOf(core.CIDR("1.1.1.1/32")))
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
**What this PR does / why we need it**:

On GCP we use only [one network for nodes ](https://github.com/gardener/gardener-extensions/blob/68668b0d1518f8e695ec09049931a4409e965906/controllers/provider-gcp/charts/internal/gcp-infra/templates/main.tf#L27-L32). The current GCP worker network validation falsely allows more than one CIDR.

To ensure not breaking existing invalid GCP Shoots, on update we drop the extra worker values.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Due to faulty validation, multi-zone GCP shoot clusters containing more than one CIDR in `spec.cloud.gcp.networks.workers[]` could be created (which is not a valid behavior). To ensure that those clusters are going to be safely reconciled with this update, on the next `Shoot` `UPDATE` request only the first `spec.cloud.gcp.networks.workers[0]` is going to be persisted.
Rollback to previous Gardener versions is not supported.
```
```action user
Creation of multi-zone GCP clusters now require exactly one CIDR in `spec.cloud.gcp.networks.workers[]`. 
Gardener will automatically patch existing multi-zone GCP `Shoot`s which are failing by removing the additional CIDRs (if they exist). Please update your `Shoot` manifests for future compatibility.
```
