### PR TITLE
support shoot spec with <major>.<minor> Kubernetes version

### DIFF
--- a/example/90-shoot-alicloud.yaml
+++ b/example/90-shoot-alicloud.yaml
@@ -81,7 +81,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.15.2
+    version: 1.15.2 # specify "major.minor" to get latest patch version
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   featureGates:

--- a/example/90-shoot-aws.yaml
+++ b/example/90-shoot-aws.yaml
@@ -83,7 +83,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.15.2
+    version: 1.15.2 # specify "major.minor" to get latest patch version
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   featureGates:

--- a/example/90-shoot-azure.yaml
+++ b/example/90-shoot-azure.yaml
@@ -82,7 +82,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.15.2
+    version: 1.15.2 # specify "major.minor" to get latest patch version
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   featureGates:

--- a/example/90-shoot-gcp.yaml
+++ b/example/90-shoot-gcp.yaml
@@ -81,7 +81,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.15.2
+    version: 1.15.2 # specify "major.minor" to get latest patch version
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   featureGates:

--- a/example/90-shoot-openstack.yaml
+++ b/example/90-shoot-openstack.yaml
@@ -80,7 +80,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.15.2
+    version: 1.15.2 # specify "major.minor" to get latest patch version
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   featureGates:

--- a/example/90-shoot-packet.yaml
+++ b/example/90-shoot-packet.yaml
@@ -76,7 +76,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.15.2
+    version: 1.15.2 # specify "major.minor" to get latest patch version
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   featureGates:

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -538,7 +538,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: ${value("spec.kubernetes.version", kubernetesVersion)}<% kubeAPIServer=value("spec.kubernetes.kubeAPIServer", {}) %><% cloudControllerManager=value("spec.kubernetes.cloudControllerManager", {}) %><% kubeControllerManager=value("spec.kubernetes.kubeControllerManager", {}) %><% kubeScheduler=value("spec.kubernetes.kubeScheduler", {}) %><% kubeProxy=value("spec.kubernetes.kubeProxy", {}) %><% kubelet=value("spec.kubernetes.kubelet", {}) %>
+    version: ${value("spec.kubernetes.version", kubernetesVersion)}<% kubeAPIServer=value("spec.kubernetes.kubeAPIServer", {}) %><% cloudControllerManager=value("spec.kubernetes.cloudControllerManager", {}) %><% kubeControllerManager=value("spec.kubernetes.kubeControllerManager", {}) %><% kubeScheduler=value("spec.kubernetes.kubeScheduler", {}) %><% kubeProxy=value("spec.kubernetes.kubeProxy", {}) %><% kubelet=value("spec.kubernetes.kubelet", {}) %> # specify "major.minor" to get latest patch version
     allowPrivilegedContainers: ${value("spec.kubernetes.allowPrivilegedContainers", "true")} # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
     % if kubeAPIServer != {}:
     kubeAPIServer: ${yaml.dump(kubeAPIServer, width=10000, default_flow_style=None)}

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -17,6 +17,7 @@ package validator
 import (
 	"errors"
 	"fmt"
+	"github.com/Masterminds/semver"
 	"io"
 	"reflect"
 	"strings"
@@ -405,8 +406,11 @@ func validateAWS(c *validationContext) field.ErrorList {
 	if ok, validDNSProviders := validateDNSConstraints(c.cloudProfile.Spec.AWS.Constraints.DNSProviders, c.shoot.Spec.DNS.Provider, c.oldShoot.Spec.DNS.Provider); !ok {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec", "dns", "provider"), c.shoot.Spec.DNS.Provider, validDNSProviders))
 	}
-	if ok, validKubernetesVersions := validateKubernetesVersionConstraints(c.cloudProfile.Spec.AWS.Constraints.Kubernetes.Versions, c.shoot.Spec.Kubernetes.Version, c.oldShoot.Spec.Kubernetes.Version); !ok {
+	ok, validKubernetesVersions, versionDefault := validateKubernetesVersionConstraints(c.cloudProfile.Spec.AWS.Constraints.Kubernetes.Versions, c.shoot.Spec.Kubernetes.Version, c.oldShoot.Spec.Kubernetes.Version)
+	if !ok {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec", "kubernetes", "version"), c.shoot.Spec.Kubernetes.Version, validKubernetesVersions))
+	} else if versionDefault != nil {
+		c.shoot.Spec.Kubernetes.Version = versionDefault.String()
 	}
 	if ok, validMachineImages := validateMachineImagesConstraints(c.cloudProfile.Spec.AWS.Constraints.MachineImages, c.shoot.Spec.Cloud.AWS.MachineImage, c.oldShoot.Spec.Cloud.AWS.MachineImage); !ok {
 		allErrs = append(allErrs, field.NotSupported(path.Child("machineImage"), *c.shoot.Spec.Cloud.AWS.MachineImage, validMachineImages))
@@ -458,8 +462,11 @@ func validateAzure(c *validationContext) field.ErrorList {
 	if ok, validDNSProviders := validateDNSConstraints(c.cloudProfile.Spec.Azure.Constraints.DNSProviders, c.shoot.Spec.DNS.Provider, c.oldShoot.Spec.DNS.Provider); !ok {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec", "dns", "provider"), c.shoot.Spec.DNS.Provider, validDNSProviders))
 	}
-	if ok, validKubernetesVersions := validateKubernetesVersionConstraints(c.cloudProfile.Spec.Azure.Constraints.Kubernetes.Versions, c.shoot.Spec.Kubernetes.Version, c.oldShoot.Spec.Kubernetes.Version); !ok {
+	ok, validKubernetesVersions, versionDefault := validateKubernetesVersionConstraints(c.cloudProfile.Spec.Azure.Constraints.Kubernetes.Versions, c.shoot.Spec.Kubernetes.Version, c.oldShoot.Spec.Kubernetes.Version)
+	if !ok {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec", "kubernetes", "version"), c.shoot.Spec.Kubernetes.Version, validKubernetesVersions))
+	} else if versionDefault != nil {
+		c.shoot.Spec.Kubernetes.Version = versionDefault.String()
 	}
 	if ok, validMachineImages := validateMachineImagesConstraints(c.cloudProfile.Spec.Azure.Constraints.MachineImages, c.shoot.Spec.Cloud.Azure.MachineImage, c.oldShoot.Spec.Cloud.Azure.MachineImage); !ok {
 		allErrs = append(allErrs, field.NotSupported(path.Child("machineImage"), *c.shoot.Spec.Cloud.Azure.MachineImage, validMachineImages))
@@ -508,8 +515,11 @@ func validateGCP(c *validationContext) field.ErrorList {
 	if ok, validDNSProviders := validateDNSConstraints(c.cloudProfile.Spec.GCP.Constraints.DNSProviders, c.shoot.Spec.DNS.Provider, c.oldShoot.Spec.DNS.Provider); !ok {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec", "dns", "provider"), c.shoot.Spec.DNS.Provider, validDNSProviders))
 	}
-	if ok, validKubernetesVersions := validateKubernetesVersionConstraints(c.cloudProfile.Spec.GCP.Constraints.Kubernetes.Versions, c.shoot.Spec.Kubernetes.Version, c.oldShoot.Spec.Kubernetes.Version); !ok {
+	ok, validKubernetesVersions, versionDefault := validateKubernetesVersionConstraints(c.cloudProfile.Spec.GCP.Constraints.Kubernetes.Versions, c.shoot.Spec.Kubernetes.Version, c.oldShoot.Spec.Kubernetes.Version)
+	if !ok {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec", "kubernetes", "version"), c.shoot.Spec.Kubernetes.Version, validKubernetesVersions))
+	} else if versionDefault != nil {
+		c.shoot.Spec.Kubernetes.Version = versionDefault.String()
 	}
 	if ok, validMachineImages := validateMachineImagesConstraints(c.cloudProfile.Spec.GCP.Constraints.MachineImages, c.shoot.Spec.Cloud.GCP.MachineImage, c.oldShoot.Spec.Cloud.GCP.MachineImage); !ok {
 		allErrs = append(allErrs, field.NotSupported(path.Child("machineImage"), *c.shoot.Spec.Cloud.GCP.MachineImage, validMachineImages))
@@ -562,8 +572,11 @@ func validatePacket(c *validationContext) field.ErrorList {
 	if ok, validDNSProviders := validateDNSConstraints(c.cloudProfile.Spec.Packet.Constraints.DNSProviders, c.shoot.Spec.DNS.Provider, c.oldShoot.Spec.DNS.Provider); !ok {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec", "dns", "provider"), c.shoot.Spec.DNS.Provider, validDNSProviders))
 	}
-	if ok, validKubernetesVersions := validateKubernetesVersionConstraints(c.cloudProfile.Spec.Packet.Constraints.Kubernetes.Versions, c.shoot.Spec.Kubernetes.Version, c.oldShoot.Spec.Kubernetes.Version); !ok {
+	ok, validKubernetesVersions, versionDefault := validateKubernetesVersionConstraints(c.cloudProfile.Spec.Packet.Constraints.Kubernetes.Versions, c.shoot.Spec.Kubernetes.Version, c.oldShoot.Spec.Kubernetes.Version)
+	if !ok {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec", "kubernetes", "version"), c.shoot.Spec.Kubernetes.Version, validKubernetesVersions))
+	} else if versionDefault != nil {
+		c.shoot.Spec.Kubernetes.Version = versionDefault.String()
 	}
 	if ok, validMachineImages := validateMachineImagesConstraints(c.cloudProfile.Spec.Packet.Constraints.MachineImages, c.shoot.Spec.Cloud.Packet.MachineImage, c.oldShoot.Spec.Cloud.Packet.MachineImage); !ok {
 		allErrs = append(allErrs, field.NotSupported(path.Child("machineImage"), *c.shoot.Spec.Cloud.Packet.MachineImage, validMachineImages))
@@ -619,8 +632,11 @@ func validateOpenStack(c *validationContext) field.ErrorList {
 	if ok, validFloatingPools := validateFloatingPoolConstraints(c.cloudProfile.Spec.OpenStack.Constraints.FloatingPools, c.shoot.Spec.Cloud.OpenStack.FloatingPoolName, c.oldShoot.Spec.Cloud.OpenStack.FloatingPoolName); !ok {
 		allErrs = append(allErrs, field.NotSupported(path.Child("floatingPoolName"), c.shoot.Spec.Cloud.OpenStack.FloatingPoolName, validFloatingPools))
 	}
-	if ok, validKubernetesVersions := validateKubernetesVersionConstraints(c.cloudProfile.Spec.OpenStack.Constraints.Kubernetes.Versions, c.shoot.Spec.Kubernetes.Version, c.oldShoot.Spec.Kubernetes.Version); !ok {
+	ok, validKubernetesVersions, versionDefault := validateKubernetesVersionConstraints(c.cloudProfile.Spec.OpenStack.Constraints.Kubernetes.Versions, c.shoot.Spec.Kubernetes.Version, c.oldShoot.Spec.Kubernetes.Version)
+	if !ok {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec", "kubernetes", "version"), c.shoot.Spec.Kubernetes.Version, validKubernetesVersions))
+	} else if versionDefault != nil {
+		c.shoot.Spec.Kubernetes.Version = versionDefault.String()
 	}
 	if ok, validLoadBalancerProviders := validateLoadBalancerProviderConstraints(c.cloudProfile.Spec.OpenStack.Constraints.LoadBalancerProviders, c.shoot.Spec.Cloud.OpenStack.LoadBalancerProvider, c.oldShoot.Spec.Cloud.OpenStack.LoadBalancerProvider); !ok {
 		allErrs = append(allErrs, field.NotSupported(path.Child("floatingPoolName"), c.shoot.Spec.Cloud.OpenStack.LoadBalancerProvider, validLoadBalancerProviders))
@@ -673,8 +689,11 @@ func validateAlicloud(c *validationContext) field.ErrorList {
 	if ok, validDNSProviders := validateDNSConstraints(c.cloudProfile.Spec.Alicloud.Constraints.DNSProviders, c.shoot.Spec.DNS.Provider, c.oldShoot.Spec.DNS.Provider); !ok {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec", "dns", "provider"), c.shoot.Spec.DNS.Provider, validDNSProviders))
 	}
-	if ok, validKubernetesVersions := validateKubernetesVersionConstraints(c.cloudProfile.Spec.Alicloud.Constraints.Kubernetes.Versions, c.shoot.Spec.Kubernetes.Version, c.oldShoot.Spec.Kubernetes.Version); !ok {
+	ok, validKubernetesVersions, versionDefault := validateKubernetesVersionConstraints(c.cloudProfile.Spec.Alicloud.Constraints.Kubernetes.Versions, c.shoot.Spec.Kubernetes.Version, c.oldShoot.Spec.Kubernetes.Version)
+	if !ok {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("spec", "kubernetes", "version"), c.shoot.Spec.Kubernetes.Version, validKubernetesVersions))
+	} else if versionDefault != nil {
+		c.shoot.Spec.Kubernetes.Version = versionDefault.String()
 	}
 	if ok, validMachineImages := validateMachineImagesConstraints(c.cloudProfile.Spec.Alicloud.Constraints.MachineImages, c.shoot.Spec.Cloud.Alicloud.MachineImage, c.oldShoot.Spec.Cloud.Alicloud.MachineImage); !ok {
 		allErrs = append(allErrs, field.NotSupported(path.Child("machineImage"), *c.shoot.Spec.Cloud.Alicloud.MachineImage, validMachineImages))
@@ -805,21 +824,55 @@ func hasDomainIntersection(domainA, domainB string) bool {
 	return strings.HasSuffix(long, short)
 }
 
-func validateKubernetesVersionConstraints(constraints []string, version, oldVersion string) (bool, []string) {
-	if version == oldVersion {
-		return true, nil
+func validateKubernetesVersionConstraints(constraints []string, shootVersion, oldShootVersion string) (bool, []string, *semver.Version) {
+	if shootVersion == oldShootVersion {
+		return true, nil, nil
 	}
 
-	validValues := []string{}
-
-	for _, v := range constraints {
-		validValues = append(validValues, v)
-		if v == version {
-			return true, nil
+	shootVersionSplit := strings.Split(shootVersion, ".")
+	var (
+		shootVersionMajor, shootVersionMinor int64
+		getLatestPatchVersion                bool
+	)
+	if len(shootVersionSplit) == 2 {
+		// add a fake patch version to avoid manual parsing
+		fakeShootVersion := shootVersion + ".0"
+		version, err := semver.NewVersion(fakeShootVersion)
+		if err == nil {
+			getLatestPatchVersion = true
+			shootVersionMajor = version.Major()
+			shootVersionMinor = version.Minor()
 		}
 	}
 
-	return false, validValues
+	validValues := []string{}
+	var latestVersion *semver.Version
+	for _, versionConstraint := range constraints {
+		validValues = append(validValues, versionConstraint)
+
+		if versionConstraint == shootVersion {
+			return true, nil, nil
+		}
+
+		if getLatestPatchVersion {
+			// CloudProfile cannot contain invalid semVer shootVersion
+			cpVersion, _ := semver.NewVersion(versionConstraint)
+
+			if cpVersion.Major() != shootVersionMajor || cpVersion.Minor() != shootVersionMinor {
+				continue
+			}
+
+			if latestVersion == nil || cpVersion.GreaterThan(latestVersion) {
+				latestVersion = cpVersion
+			}
+		}
+	}
+
+	if latestVersion != nil {
+		return true, nil, latestVersion
+	}
+
+	return false, validValues, nil
 }
 
 func validateMachineTypes(constraints []garden.MachineType, machineType, oldMachineType string) (bool, []string) {

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -763,6 +763,38 @@ var _ = Describe("validator", func() {
 				Expect(apierrors.IsForbidden(err)).To(BeTrue())
 			})
 
+			It("should default a major.minor kubernetes version to latest patch version", func() {
+				shoot.Spec.Kubernetes.Version = "1.6"
+				highestPatchVersion := "1.6.6"
+				cloudProfile.Spec.AWS.Constraints.Kubernetes.Versions = append(cloudProfile.Spec.AWS.Constraints.Kubernetes.Versions, highestPatchVersion, "1.7.1", "1.7.2")
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
+
+				err := admissionHandler.Admit(attrs, nil)
+
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(shoot.Spec.Kubernetes.Version).To(Equal(highestPatchVersion))
+			})
+
+			It("should reject: default only exactly matching minor kubernetes version", func() {
+				shoot.Spec.Kubernetes.Version = "1.8"
+				highestPatchVersion := "1.81.5"
+				cloudProfile.Spec.AWS.Constraints.Kubernetes.Versions = append(cloudProfile.Spec.AWS.Constraints.Kubernetes.Versions, "1.81.0", highestPatchVersion)
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
+
+				err := admissionHandler.Admit(attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
 			It("should reject due to an invalid machine image", func() {
 				shoot.Spec.Cloud.AWS.MachineImage = &garden.ShootMachineImage{
 					Name:    "not-supported",
@@ -1077,6 +1109,38 @@ var _ = Describe("validator", func() {
 				Expect(apierrors.IsForbidden(err)).To(BeTrue())
 			})
 
+			It("should default a major.minor kubernetes version to latest patch version", func() {
+				shoot.Spec.Kubernetes.Version = "1.6"
+				highestPatchVersion := "1.6.6"
+				cloudProfile.Spec.Azure.Constraints.Kubernetes.Versions = append(cloudProfile.Spec.Azure.Constraints.Kubernetes.Versions, highestPatchVersion, "1.7.1", "1.7.2")
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
+
+				err := admissionHandler.Admit(attrs, nil)
+
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(shoot.Spec.Kubernetes.Version).To(Equal(highestPatchVersion))
+			})
+
+			It("should reject: default only exactly matching minor kubernetes version", func() {
+				shoot.Spec.Kubernetes.Version = "1.8"
+				highestPatchVersion := "1.81.5"
+				cloudProfile.Spec.Azure.Constraints.Kubernetes.Versions = append(cloudProfile.Spec.Azure.Constraints.Kubernetes.Versions, "1.81.0", highestPatchVersion)
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
+
+				err := admissionHandler.Admit(attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
 			It(" ", func() {
 				shoot.Spec.Cloud.Azure.MachineImage = &garden.ShootMachineImage{
 					Name:    "not-supported",
@@ -1358,6 +1422,38 @@ var _ = Describe("validator", func() {
 				Expect(apierrors.IsForbidden(err)).To(BeTrue())
 			})
 
+			It("should default a major.minor kubernetes version to latest patch version", func() {
+				shoot.Spec.Kubernetes.Version = "1.6"
+				highestPatchVersion := "1.6.6"
+				cloudProfile.Spec.GCP.Constraints.Kubernetes.Versions = append(cloudProfile.Spec.GCP.Constraints.Kubernetes.Versions, highestPatchVersion, "1.7.1", "1.7.2")
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
+
+				err := admissionHandler.Admit(attrs, nil)
+
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(shoot.Spec.Kubernetes.Version).To(Equal(highestPatchVersion))
+			})
+
+			It("should reject: default only exactly matching minor kubernetes version", func() {
+				shoot.Spec.Kubernetes.Version = "1.8"
+				highestPatchVersion := "1.81.5"
+				cloudProfile.Spec.GCP.Constraints.Kubernetes.Versions = append(cloudProfile.Spec.GCP.Constraints.Kubernetes.Versions, "1.81.0", highestPatchVersion)
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
+
+				err := admissionHandler.Admit(attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
 			It("should reject due to an invalid machine image", func() {
 				shoot.Spec.Cloud.GCP.MachineImage = &garden.ShootMachineImage{
 					Name:    "not-supported",
@@ -1599,6 +1695,38 @@ var _ = Describe("validator", func() {
 
 			It("should reject due to an invalid kubernetes version", func() {
 				shoot.Spec.Kubernetes.Version = "1.2.3"
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
+
+				err := admissionHandler.Admit(attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
+			It("should default a major.minor kubernetes version to latest patch version", func() {
+				shoot.Spec.Kubernetes.Version = "1.6"
+				highestPatchVersion := "1.6.6"
+				cloudProfile.Spec.Packet.Constraints.Kubernetes.Versions = append(cloudProfile.Spec.Packet.Constraints.Kubernetes.Versions, highestPatchVersion, "1.7.1", "1.7.2")
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
+
+				err := admissionHandler.Admit(attrs, nil)
+
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(shoot.Spec.Kubernetes.Version).To(Equal(highestPatchVersion))
+			})
+
+			It("should reject: default only exactly matching minor kubernetes version", func() {
+				shoot.Spec.Kubernetes.Version = "1.8"
+				highestPatchVersion := "1.81.5"
+				cloudProfile.Spec.Packet.Constraints.Kubernetes.Versions = append(cloudProfile.Spec.Packet.Constraints.Kubernetes.Versions, "1.81.0", highestPatchVersion)
 
 				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
 				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
@@ -1913,6 +2041,38 @@ var _ = Describe("validator", func() {
 				Expect(apierrors.IsForbidden(err)).To(BeTrue())
 			})
 
+			It("should default a major.minor kubernetes version to latest patch version", func() {
+				shoot.Spec.Kubernetes.Version = "1.6"
+				highestPatchVersion := "1.6.6"
+				cloudProfile.Spec.OpenStack.Constraints.Kubernetes.Versions = append(cloudProfile.Spec.OpenStack.Constraints.Kubernetes.Versions, highestPatchVersion, "1.7.1", "1.7.2")
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
+
+				err := admissionHandler.Admit(attrs, nil)
+
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(shoot.Spec.Kubernetes.Version).To(Equal(highestPatchVersion))
+			})
+
+			It("should reject: default only exactly matching minor kubernetes version", func() {
+				shoot.Spec.Kubernetes.Version = "1.8"
+				highestPatchVersion := "1.81.5"
+				cloudProfile.Spec.OpenStack.Constraints.Kubernetes.Versions = append(cloudProfile.Spec.OpenStack.Constraints.Kubernetes.Versions, "1.81.0", highestPatchVersion)
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
+
+				err := admissionHandler.Admit(attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
 			It("should reject due to an invalid load balancer provider", func() {
 				shoot.Spec.Cloud.OpenStack.LoadBalancerProvider = "invalid-provider"
 
@@ -2171,6 +2331,38 @@ var _ = Describe("validator", func() {
 
 			It("should reject due to an invalid kubernetes version", func() {
 				shoot.Spec.Kubernetes.Version = "1.2.3"
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
+
+				err := admissionHandler.Admit(attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
+			It("should default a major.minor kubernetes version to latest patch version", func() {
+				shoot.Spec.Kubernetes.Version = "1.6"
+				highestPatchVersion := "1.6.6"
+				cloudProfile.Spec.Alicloud.Constraints.Kubernetes.Versions = append(cloudProfile.Spec.Alicloud.Constraints.Kubernetes.Versions, highestPatchVersion, "1.7.1", "1.7.2")
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, false, nil)
+
+				err := admissionHandler.Admit(attrs, nil)
+
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(shoot.Spec.Kubernetes.Version).To(Equal(highestPatchVersion))
+			})
+
+			It("should reject: default only exactly matching minor kubernetes version", func() {
+				shoot.Spec.Kubernetes.Version = "1.8"
+				highestPatchVersion := "1.81.5"
+				cloudProfile.Spec.Alicloud.Constraints.Kubernetes.Versions = append(cloudProfile.Spec.Alicloud.Constraints.Kubernetes.Versions, "1.81.0", highestPatchVersion)
 
 				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
 				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)


### PR DESCRIPTION
**What this PR does / why we need it**:
Ability to specify only major & minor version in the shoot spec 
- default to the latest patch version of that major & minor combination

Note that in the shoot spec,  the kubernetes version must be within quotation marks to be recognized as a string during unmarshalling in the apiserver.

 So specify "1.15" instead of 1.15

**Which issue(s) this PR fixes**:
Fixes #1324

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
It is now possible to create or update `Shoot` resources by only specifying the `<major>.<minor>` parts of the desired Kubernetes version. Gardener will automatically try to pick the latest patch version offered by the referenced `CloudProfile`.
```
