### PR TITLE
Alerts for missed ETCD [delta and full] backups

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
@@ -21,6 +21,16 @@ tests:
   # KubeEtcd3HighNumberOfFailedProposals
   - series: 'etcd_server_proposals_failed_total{job="kube-etcd3", pod="etcd"}'
     values: '0+1x81 81+0x39'
+  # KubeEtcdDeltaBackupFailed
+  - series: 'etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",kind="Incr"}'
+    values: '0+0x30'
+  - series: 'etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",kind="Incr",succeeded="true"}'
+    values: '0+0x30'
+  # KubeEtcdFullBackupFailed
+  - series: 'etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",kind="Full"}'
+    values: '0+0x3000'
+  - series: 'etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",kind="Full",succeeded="true"}'
+    values: '0+0x3000'
   alert_rule_test:
   - eval_time: 5m
     alertname: KubeEtcdMainDown
@@ -77,6 +87,31 @@ tests:
         pod: etcd
         job: kube-etcd3
       exp_annotations:
-        description: Etcd3 pod etcd has seen 81 proposal failures
-          within the last hour.
+        description: Etcd3 pod etcd has seen 81 proposal failures within the last hour.
         summary: High number of failed etcd proposals
+  - eval_time: 15m
+    alertname: KubeEtcdDeltaBackupFailed
+    exp_alerts:
+    - exp_labels:
+        service: etcd
+        severity: critical
+        type: seed
+        kind: Incr
+        job: kube-etcd3-backup-restore  
+        visibility: operator
+      exp_annotations:
+        description: No delta snapshot for the past 15 minutes.
+        summary: Etcd delta snapshot failure.     
+  - eval_time: 1455m
+    alertname: KubeEtcdFullBackupFailed
+    exp_alerts:
+    - exp_labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+        kind: Full
+        job: kube-etcd3-backup-restore
+      exp_annotations:
+        description: No full snapshot for the past 24 hours 15minutes.
+        summary: Etcd full snapshot failure.     

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -65,6 +65,30 @@ groups:
       description: Etcd3 pod {{ $labels.pod }} has seen {{ $value }} proposal failures
         within the last hour.
       summary: High number of failed etcd proposals
-
+  
   - record: shoot:etcd_object_counts:sum_by_resource
     expr: sum(etcd_object_counts) by (resource)
+  
+  # etcd backup failure alerts
+  - alert: KubeEtcdDeltaBackupFailed
+    expr: changes(etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",kind="Incr"}[15m]) < 1 and ON(job,kind) changes(etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",kind="Incr",succeeded="true"}[15m]) < 1
+    labels:
+      service: etcd
+      severity: critical
+      type: seed
+      visibility: operator
+    annotations:
+      description: No delta snapshot for the past 15 minutes.
+      summary: Etcd delta snapshot failure.
+  - alert: KubeEtcdFullBackupFailed
+    expr: changes(etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",kind="Full"}[1455m]) < 1 and ON(job,kind) changes(etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",kind="Full",succeeded="true"}[1455m]) < 1
+    labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+    annotations:
+        description: No full snapshot for the past 24 hours 15minutes.
+        summary: Etcd full snapshot failure.
+
+  


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements alert rules for missed etcd backups. Alert is raised if,

- delta snapshot is missed consecutively for 3 times
- full snapshot is missed [frequency is 1 day]

**Which issue(s) this PR fixes**:
Partially fixes [#97](https://github.com/gardener/etcd-backup-restore/issues/97) 

**Special notes for your reviewer**:
- Alerts for failed restores is yet to be added

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Defined alert rules for missed etcd backups [both delta and full backups]
```
