### PR TITLE
Configure aggregate-prometheus to sends metrics to the alertmanager

### DIFF
--- a/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
@@ -14,7 +14,27 @@ data:
 
     rule_files:
     - /etc/prometheus/rules/*.yaml
-
+    alerting:
+      alertmanagers:
+      - kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names: 
+            - garden
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_service_label_component ]
+          action: keep
+          regex: alertmanager
+        - source_labels: [ __meta_kubernetes_service_label_role ]
+          action: keep
+          regex: monitoring
+        - source_labels: [ __meta_kubernetes_endpoint_port_name ]
+          action: keep
+          regex: metrics
+      alert_relabel_configs:
+      - source_labels: [ ignoreAlerts ]
+        regex: true
+        action: drop
     scrape_configs:
     - job_name: shoot-prometheus
       metrics_path: /federate


### PR DESCRIPTION
**What this PR does / why we need it**:

Configure the Prometheus to push alerts to the central Alertmanager.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@dkistner @wyb1 

**Release note**:

```improvement operator
NONE
```
