### PR TITLE
Move BackupProfilie to Seed spec

### DIFF
--- a/charts/seed-bootstrap/templates/extensions/crd-backupbucket.yaml
+++ b/charts/seed-bootstrap/templates/extensions/crd-backupbucket.yaml
@@ -27,7 +27,7 @@ spec:
     JSONPath: .spec.region
   - name: State
     type: string
-    JSONPath: .status.lastOperation.status
+    JSONPath: .status.lastOperation.state
   - name: Age
     type: date
     JSONPath: .metadata.creationTimestamp

--- a/charts/seed-bootstrap/templates/extensions/crd-backupentry.yaml
+++ b/charts/seed-bootstrap/templates/extensions/crd-backupentry.yaml
@@ -31,7 +31,7 @@ spec:
     JSONPath: .spec.bucketName
   - name: State
     type: string
-    JSONPath: .status.lastOperation.status
+    JSONPath: .status.lastOperation.state
   - name: Age
     type: date
     JSONPath: .metadata.creationTimestamp

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -72,11 +72,6 @@ type CloudProfileSpec struct {
 	Packet *PacketProfile
 	// CABundle is a certificate bundle which will be installed onto every host machine of the Shoot cluster.
 	CABundle *string
-	// Backup holds the object store configuration for the backups of shoot(currently only etcd).
-	// If it is not specified, then there won't be any backups taken for Shoots associated with this CloudProfile.
-	// If backup field is present in CloudProfile, then backups of the etcd from Shoot controlplane will be stored under the
-	// configured object store.
-	Backup *BackupProfile
 }
 
 // AWSProfile defines certain constraints and definitions for the AWS cloud.
@@ -471,6 +466,11 @@ type SeedSpec struct {
 	Visible *bool
 	// Protected prevent that the Seed Cluster can be used for regular Shoot cluster control planes.
 	Protected *bool
+	// Backup holds the object store configuration for the backups of shoot(currently only etcd).
+	// If it is not specified, then there won't be any backups taken for Shoots associated with this Seed.
+	// If backup field is present in Seed, then backups of the etcd from Shoot controlplane will be stored under the
+	// configured object store.
+	Backup *BackupProfile
 }
 
 // SeedStatus holds the most recently observed status of the Seed cluster.

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -83,12 +83,6 @@ type CloudProfileSpec struct {
 	// CABundle is a certificate bundle which will be installed onto every host machine of the Shoot cluster.
 	// +optional
 	CABundle *string `json:"caBundle,omitempty"`
-	// Backup holds the object store configuration for the backups of shoot(currently only etcd).
-	// If it is not specified, then there won't be any backups taken for Shoots associated with this CloudProfile.
-	// If backup field is present in CloudProfile, then backups of the etcd from Shoot controlplane will be stored under the
-	// configured object store.
-	// +optional
-	Backup *BackupProfile `json:"backup,omitempty"`
 }
 
 // AWSProfile defines certain constraints and definitions for the AWS cloud.
@@ -509,6 +503,12 @@ type SeedSpec struct {
 	// Protected prevent that the Seed Cluster can be used for regular Shoot cluster control planes.
 	// +optional
 	Protected *bool `json:"protected,omitempty"`
+	// Backup holds the object store configuration for the backups of shoot(currently only etcd).
+	// If it is not specified, then there won't be any backups taken for Shoots associated with this Seed.
+	// If backup field is present in Seed, then backups of the etcd from Shoot controlplane will be stored under the
+	// configured object store.
+	// +optional
+	Backup *BackupProfile `json:"backup,omitempty"`
 }
 
 // SeedStatus holds the most recently observed status of the Seed cluster.

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -2565,7 +2565,6 @@ func autoConvert_v1beta1_CloudProfileSpec_To_garden_CloudProfileSpec(in *CloudPr
 		out.Packet = nil
 	}
 	out.CABundle = (*string)(unsafe.Pointer(in.CABundle))
-	out.Backup = (*garden.BackupProfile)(unsafe.Pointer(in.Backup))
 	return nil
 }
 
@@ -2630,7 +2629,6 @@ func autoConvert_garden_CloudProfileSpec_To_v1beta1_CloudProfileSpec(in *garden.
 		out.Packet = nil
 	}
 	out.CABundle = (*string)(unsafe.Pointer(in.CABundle))
-	out.Backup = (*BackupProfile)(unsafe.Pointer(in.Backup))
 	return nil
 }
 
@@ -4616,6 +4614,7 @@ func autoConvert_v1beta1_SeedSpec_To_garden_SeedSpec(in *SeedSpec, out *garden.S
 	out.BlockCIDRs = *(*[]core.CIDR)(unsafe.Pointer(&in.BlockCIDRs))
 	out.Visible = (*bool)(unsafe.Pointer(in.Visible))
 	out.Protected = (*bool)(unsafe.Pointer(in.Protected))
+	out.Backup = (*garden.BackupProfile)(unsafe.Pointer(in.Backup))
 	return nil
 }
 
@@ -4636,6 +4635,7 @@ func autoConvert_garden_SeedSpec_To_v1beta1_SeedSpec(in *garden.SeedSpec, out *S
 	out.BlockCIDRs = *(*[]v1alpha1.CIDR)(unsafe.Pointer(&in.BlockCIDRs))
 	out.Visible = (*bool)(unsafe.Pointer(in.Visible))
 	out.Protected = (*bool)(unsafe.Pointer(in.Protected))
+	out.Backup = (*BackupProfile)(unsafe.Pointer(in.Backup))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -1069,11 +1069,6 @@ func (in *CloudProfileSpec) DeepCopyInto(out *CloudProfileSpec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.Backup != nil {
-		in, out := &in.Backup, &out.Backup
-		*out = new(BackupProfile)
-		(*in).DeepCopyInto(*out)
-	}
 	return
 }
 
@@ -3096,6 +3091,11 @@ func (in *SeedSpec) DeepCopyInto(out *SeedSpec) {
 		in, out := &in.Protected, &out.Protected
 		*out = new(bool)
 		**out = **in
+	}
+	if in.Backup != nil {
+		in, out := &in.Backup, &out.Backup
+		*out = new(BackupProfile)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -1073,11 +1073,6 @@ func (in *CloudProfileSpec) DeepCopyInto(out *CloudProfileSpec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.Backup != nil {
-		in, out := &in.Backup, &out.Backup
-		*out = new(BackupProfile)
-		(*in).DeepCopyInto(*out)
-	}
 	return
 }
 
@@ -3084,6 +3079,11 @@ func (in *SeedSpec) DeepCopyInto(out *SeedSpec) {
 		in, out := &in.Protected, &out.Protected
 		*out = new(bool)
 		**out = **in
+	}
+	if in.Backup != nil {
+		in, out := &in.Backup, &out.Backup
+		*out = new(BackupProfile)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3215,17 +3215,11 @@ func schema_pkg_apis_garden_v1beta1_CloudProfileSpec(ref common.ReferenceCallbac
 							Format:      "",
 						},
 					},
-					"backup": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Backup holds the object store configuration for the backups of shoot(currently only etcd). If it is not specified, then there won't be any backups taken for Shoots associated with this CloudProfile. If backup field is present in CloudProfile, then backups of the etcd from Shoot controlplane will be stored under the configured object store.",
-							Ref:         ref("github.com/gardener/gardener/pkg/apis/garden/v1beta1.BackupProfile"),
-						},
-					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/gardener/gardener/pkg/apis/garden/v1beta1.AWSProfile", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.AlicloudProfile", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.AzureProfile", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.BackupProfile", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.GCPProfile", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.OpenStackProfile", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.PacketProfile"},
+			"github.com/gardener/gardener/pkg/apis/garden/v1beta1.AWSProfile", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.AlicloudProfile", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.AzureProfile", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.GCPProfile", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.OpenStackProfile", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.PacketProfile"},
 	}
 }
 
@@ -6621,12 +6615,18 @@ func schema_pkg_apis_garden_v1beta1_SeedSpec(ref common.ReferenceCallback) commo
 							Format:      "",
 						},
 					},
+					"backup": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Backup holds the object store configuration for the backups of shoot(currently only etcd). If it is not specified, then there won't be any backups taken for Shoots associated with this Seed. If backup field is present in Seed, then backups of the etcd from Shoot controlplane will be stored under the configured object store.",
+							Ref:         ref("github.com/gardener/gardener/pkg/apis/garden/v1beta1.BackupProfile"),
+						},
+					},
 				},
 				Required: []string{"cloud", "ingressDomain", "secretRef", "networks"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/gardener/gardener/pkg/apis/garden/v1beta1.SeedCloud", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.SeedNetworks", "k8s.io/api/core/v1.SecretReference"},
+			"github.com/gardener/gardener/pkg/apis/garden/v1beta1.BackupProfile", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.SeedCloud", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.SeedNetworks", "k8s.io/api/core/v1.SecretReference"},
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
This PR in context of shared bucket proposal, fix the location of `BackupProfile` as per [discussion](https://github.com/gardener/gardener/pull/1128/files#r313758309).
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
