### PR TITLE
Missed backup alerts raised only for etcd-main

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
@@ -22,14 +22,14 @@ tests:
   - series: 'etcd_server_proposals_failed_total{job="kube-etcd3", pod="etcd"}'
     values: '0+1x81 81+0x39'
   # KubeEtcdDeltaBackupFailed
-  - series: 'etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",kind="Incr"}'
-    values: '0+0x30'
-  - series: 'etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",kind="Incr",succeeded="true"}'
+  - series: 'etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",role="main",kind="Incr"}'
+    values: '0+1x30'
+  - series: 'etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",kind="Incr",succeeded="true"}'
     values: '0+0x30'
   # KubeEtcdFullBackupFailed
-  - series: 'etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",kind="Full"}'
-    values: '0+0x3000'
-  - series: 'etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",kind="Full",succeeded="true"}'
+  - series: 'etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",role="main",kind="Full"}'
+    values: '0+1x3000'
+  - series: 'etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",kind="Full",succeeded="true"}'
     values: '0+0x3000'
   alert_rule_test:
   - eval_time: 5m
@@ -96,6 +96,7 @@ tests:
         service: etcd
         severity: critical
         type: seed
+        role: main
         kind: Incr
         job: kube-etcd3-backup-restore  
         visibility: operator
@@ -109,6 +110,7 @@ tests:
         service: etcd
         severity: critical
         type: seed
+        role: main
         visibility: operator
         kind: Full
         job: kube-etcd3-backup-restore

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -71,7 +71,7 @@ groups:
   
   # etcd backup failure alerts
   - alert: KubeEtcdDeltaBackupFailed
-    expr: changes(etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",role="main",kind="Incr"}[15m]) > 1 and ON(job,role,kind) changes(etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",kind="Incr",succeeded="true"}[15m]) < 1
+    expr: changes(etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",role="main",kind="Incr"}[15m]) >= 1 and ON(job,role,kind) changes(etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",kind="Incr",succeeded="true"}[15m]) < 1
     labels:
       service: etcd
       severity: critical
@@ -81,7 +81,7 @@ groups:
       description: No delta snapshot for the past 15 minutes.
       summary: Etcd delta snapshot failure.
   - alert: KubeEtcdFullBackupFailed
-    expr: changes(etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",role="main",kind="Full"}[1455m]) > 1 and ON(job,role,kind) changes(etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",kind="Full",succeeded="true"}[1455m]) < 1
+    expr: changes(etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",role="main",kind="Full"}[1455m]) >= 1 and ON(job,role,kind) changes(etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",kind="Full",succeeded="true"}[1455m]) < 1
     labels:
         service: etcd
         severity: critical

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -71,7 +71,7 @@ groups:
   
   # etcd backup failure alerts
   - alert: KubeEtcdDeltaBackupFailed
-    expr: changes(etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",kind="Incr"}[15m]) < 1 and ON(job,kind) changes(etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",kind="Incr",succeeded="true"}[15m]) < 1
+    expr: changes(etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",role="main",kind="Incr"}[15m]) > 1 and ON(job,role,kind) changes(etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",kind="Incr",succeeded="true"}[15m]) < 1
     labels:
       service: etcd
       severity: critical
@@ -81,7 +81,7 @@ groups:
       description: No delta snapshot for the past 15 minutes.
       summary: Etcd delta snapshot failure.
   - alert: KubeEtcdFullBackupFailed
-    expr: changes(etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",kind="Full"}[1455m]) < 1 and ON(job,kind) changes(etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",kind="Full",succeeded="true"}[1455m]) < 1
+    expr: changes(etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",role="main",kind="Full"}[1455m]) > 1 and ON(job,role,kind) changes(etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",kind="Full",succeeded="true"}[1455m]) < 1
     labels:
         service: etcd
         severity: critical


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures that the alerts for missed backups is only for **etcd-main**. There are no backups for **etcd-events** and hence alerts are not required.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**: 
This PR **should** go together with [#1355](https://github.com/gardener/gardener/pull/1355)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
