### PR TITLE
Use seed name for external label

### DIFF
--- a/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
@@ -10,7 +10,7 @@ data:
       evaluation_interval: 30s
       scrape_interval: 30s
       external_labels:
-        seed: seed
+        seed: {{ .Values.aggregatePrometheus.seed }}
 
     rule_files:
     - /etc/prometheus/rules/*.yaml
@@ -19,7 +19,7 @@ data:
       - kubernetes_sd_configs:
         - role: endpoints
           namespaces:
-            names: 
+            names:
             - garden
         relabel_configs:
         - source_labels: [ __meta_kubernetes_service_label_component ]

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -7,6 +7,7 @@ prometheus:
 aggregatePrometheus:
   port: 9090
   storage: 20Gi
+  seed: seed
 
 allowedMetrics:
   alertmanager: []

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -442,6 +442,7 @@ func BootstrapCluster(seed *Seed, secrets map[string]*corev1.Secret, imageVector
 		},
 		"aggregatePrometheus": map[string]interface{}{
 			"storage": seed.GetValidVolumeSize("20Gi"),
+			"seed":    seed.Info.Name,
 		},
 		"elastic-kibana-curator": map[string]interface{}{
 			"enabled": loggingEnabled,


### PR DESCRIPTION
**What this PR does / why we need it**:
All `aggregate prometheus` instances had the external label `seed: seed` which is not correct. This PR sets the external label `seed` to its seed name. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
