### PR TITLE
Reduce timeouts while waiting for extension resources

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -344,7 +344,7 @@ func (b *Botanist) HibernateControlPlane(ctx context.Context) error {
 
 // ControlPlaneDefaultTimeout is the default timeout and defines how long Gardener should wait
 // for a successful reconciliation of a control plane resource.
-const ControlPlaneDefaultTimeout = 10 * time.Minute
+const ControlPlaneDefaultTimeout = 3 * time.Minute
 
 // DeployControlPlane creates the `ControlPlane` extension resource in the shoot namespace in the seed
 // cluster. Gardener waits until an external controller did reconcile the cluster successfully.

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -19,18 +19,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
-
-	"github.com/gardener/gardener/pkg/utils/retry"
-
-	"github.com/gardener/gardener/pkg/operation/common"
-
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	controllerutils "github.com/gardener/gardener/pkg/controllermanager/controller/utils"
 	"github.com/gardener/gardener/pkg/migration"
+	"github.com/gardener/gardener/pkg/operation/common"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
 	corev1 "k8s.io/api/core/v1"
@@ -42,7 +39,7 @@ import (
 
 // InfrastructureDefaultTimeout is the default timeout and defines how long Gardener should wait
 // for a successful reconciliation of an infrastructure resource.
-const InfrastructureDefaultTimeout = 10 * time.Minute
+const InfrastructureDefaultTimeout = 5 * time.Minute
 
 // DeployInfrastructure creates the `Infrastructure` extension resource in the shoot namespace in the seed
 // cluster. Gardener waits until an external controller did reconcile the cluster successfully.

--- a/pkg/operation/botanist/network.go
+++ b/pkg/operation/botanist/network.go
@@ -33,7 +33,7 @@ import (
 
 // NetworkDefaultTimeout is the default timeout and defines how long Gardener should wait
 // for a successful reconciliation of a network resource.
-const NetworkDefaultTimeout = 10 * time.Minute
+const NetworkDefaultTimeout = 3 * time.Minute
 
 // DeployNetwork creates the `Network` extension resource in the shoot namespace in the seed
 // cluster. Gardener waits until an external controller did reconcile the cluster successfully.

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -19,14 +19,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
-
-	"github.com/gardener/gardener/pkg/utils/retry"
-
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
 	corev1 "k8s.io/api/core/v1"
@@ -38,7 +36,7 @@ import (
 
 // WorkerDefaultTimeout is the default timeout and defines how long Gardener should wait
 // for a successful reconciliation of a worker resource.
-const WorkerDefaultTimeout = 30 * time.Minute
+const WorkerDefaultTimeout = 5 * time.Minute
 
 // DeployWorker creates the `Worker` extension resource in the shoot namespace in the seed
 // cluster. Gardener waits until an external controller did reconcile the resource successfully.
@@ -115,7 +113,7 @@ func (b *Botanist) DeployWorker(ctx context.Context) error {
 }
 
 // DestroyWorker deletes the `Worker` extension resource in the shoot namespace in the seed cluster,
-// and it waits for a maximum of 30m until it is deleted.
+// and it waits for a maximum of 5m until it is deleted.
 func (b *Botanist) DestroyWorker(ctx context.Context) error {
 	if err := b.K8sSeedClient.Client().Delete(ctx, &extensionsv1alpha1.Worker{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: b.Shoot.Info.Name}}); err != nil && !apierrors.IsNotFound(err) {
 		return err

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -20,8 +20,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver"
-
 	corev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -35,9 +33,9 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
+	"github.com/Masterminds/semver"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -419,7 +417,7 @@ func ConstructExternalDomain(ctx context.Context, client client.Client, shoot *g
 
 // ExtensionDefaultTimeout is the default timeout and defines how long Gardener should wait
 // for a successful reconciliation of this extension resource.
-const ExtensionDefaultTimeout = 10 * time.Minute
+const ExtensionDefaultTimeout = 3 * time.Minute
 
 // MergeExtensions merges the given controller registrations with the given extensions, expecting that each type in extensions is also represented in the registration.
 func MergeExtensions(registrations []corev1alpha1.ControllerRegistration, extensions []gardenv1beta1.Extension, namespace string) (map[string]Extension, error) {

--- a/pkg/operation/terraformer/config.go
+++ b/pkg/operation/terraformer/config.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	corev1 "k8s.io/api/core/v1"
@@ -41,6 +42,36 @@ const (
 // SetVariablesEnvironment sets the provided <tfvarsEnvironment> on the Terraformer object.
 func (t *Terraformer) SetVariablesEnvironment(tfvarsEnvironment map[string]string) *Terraformer {
 	t.variablesEnvironment = tfvarsEnvironment
+	return t
+}
+
+// SetJobBackoffLimit configures the backoff limit for the Terraformer job.
+func (t *Terraformer) SetJobBackoffLimit(limit int32) *Terraformer {
+	t.jobBackoffLimit = limit
+	return t
+}
+
+// SetActiveDeadlineSeconds configures the active deadline seconds for the Terraformer pod and job.
+func (t *Terraformer) SetActiveDeadlineSeconds(adl int64) *Terraformer {
+	t.activeDeadlineSeconds = adl
+	return t
+}
+
+// SetDeadlineCleaning configures the deadline while waiting for a clean environment.
+func (t *Terraformer) SetDeadlineCleaning(d time.Duration) *Terraformer {
+	t.deadlineCleaning = d
+	return t
+}
+
+// SetDeadlinePod configures the deadline while waiting for a the Terraformer pod.
+func (t *Terraformer) SetDeadlinePod(d time.Duration) *Terraformer {
+	t.deadlinePod = d
+	return t
+}
+
+// SetDeadlineJob configures the deadline while waiting for a the Terraformer job.
+func (t *Terraformer) SetDeadlineJob(d time.Duration) *Terraformer {
+	t.deadlineJob = d
 	return t
 }
 

--- a/pkg/operation/terraformer/state.go
+++ b/pkg/operation/terraformer/state.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	corev1 "k8s.io/api/core/v1"
 
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 )

--- a/pkg/operation/terraformer/types.go
+++ b/pkg/operation/terraformer/types.go
@@ -15,6 +15,8 @@
 package terraformer
 
 import (
+	"time"
+
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -51,6 +53,13 @@ type Terraformer struct {
 	jobName              string
 	variablesEnvironment map[string]string
 	configurationDefined bool
+
+	jobBackoffLimit       int32
+	activeDeadlineSeconds int64
+
+	deadlineCleaning time.Duration
+	deadlinePod      time.Duration
+	deadlineJob      time.Duration
 }
 
 const numberOfConfigResources = 3

--- a/pkg/operation/terraformer/waiter.go
+++ b/pkg/operation/terraformer/waiter.go
@@ -30,7 +30,7 @@ import (
 // waitForCleanEnvironment waits until no Terraform Job and Pod(s) exist for the current instance
 // of the Terraformer.
 func (t *Terraformer) waitForCleanEnvironment(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, t.deadlineCleaning)
 	defer cancel()
 
 	return retry.Until(ctx, 5*time.Second, func(ctx context.Context) (done bool, err error) {
@@ -63,7 +63,7 @@ func (t *Terraformer) waitForPod(ctx context.Context) int32 {
 	// If we can't read the terminated state of the container we simply force that the Terraform
 	// job gets created.
 	var exitCode int32 = 2
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, t.deadlinePod)
 	defer cancel()
 
 	if err := retry.Until(ctx, 5*time.Second, func(ctx context.Context) (done bool, err error) {
@@ -102,7 +102,7 @@ func (t *Terraformer) waitForPod(ctx context.Context) int32 {
 // waitForJob waits for the Terraform Job to be completed (either successful or failed). It checks the
 // Job status field to identify the state.
 func (t *Terraformer) waitForJob(ctx context.Context) bool {
-	ctx, cancel := context.WithTimeout(ctx, 20*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, t.deadlineJob)
 	defer cancel()
 
 	var succeeded = false


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduce the timeouts while waiting for extension resources to display errors provided by extension controllers faster.

**Special notes for your reviewer**:
/cc @ggaurav10 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The shoot flow does now propagate errors provided by extension controllers faster to the end-user (via the `Shoot`'s `.status` fields).
```
