### PR TITLE
Canonicalize CIDRs in Shoot specification

### DIFF
--- a/pkg/apis/core/types_utils.go
+++ b/pkg/apis/core/types_utils.go
@@ -69,6 +69,8 @@ const (
 // CIDR is a string alias.
 type CIDR string
 
+// Adding new CIDRs to the struct bellow must be kept in sync with pkg/registry/garden/shoot/canonicalize.go
+
 // K8SNetworks contains CIDRs for the pod, service and node networks of a Kubernetes cluster.
 type K8SNetworks struct {
 	// Nodes is the CIDR of the node network.

--- a/pkg/apis/core/v1alpha1/types_utils.go
+++ b/pkg/apis/core/v1alpha1/types_utils.go
@@ -75,6 +75,8 @@ const (
 // CIDR is a string alias.
 type CIDR string
 
+// Adding new CIDRs to the struct bellow must be kept in sync with pkg/registry/garden/shoot/canonicalize.go
+
 // K8SNetworks contains CIDRs for the pod, service and node networks of a Kubernetes cluster.
 type K8SNetworks struct {
 	// Nodes is the CIDR of the node network.

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -679,6 +679,8 @@ type ShootStatus struct {
 // CalicoNetworkType is a constant for the calico network type.
 const CalicoNetworkType = "calico"
 
+// Adding new CIDRs to the struct bellow must be kept in sync with pkg/registry/garden/shoot/canonicalize.go
+
 // Networking defines networking parameters for the shoot cluster.
 type Networking struct {
 	gardencore.K8SNetworks
@@ -727,6 +729,8 @@ type AWSCloud struct {
 	// Zones is a list of availability zones to deploy the Shoot cluster to.
 	Zones []string
 }
+
+// Adding new CIDRs to the struct bellow must be kept in sync with pkg/registry/garden/shoot/canonicalize.go
 
 // AWSNetworks holds information about the Kubernetes and infrastructure networks.
 type AWSNetworks struct {
@@ -780,6 +784,8 @@ type AlicloudVPC struct {
 	CIDR *gardencore.CIDR
 }
 
+// Adding new CIDRs to the struct bellow must be kept in sync with pkg/registry/garden/shoot/canonicalize.go
+
 // AlicloudNetworks holds information about the Kubernetes and infrastructure networks.
 type AlicloudNetworks struct {
 	gardencore.K8SNetworks
@@ -811,6 +817,8 @@ type PacketCloud struct {
 	// Zones is a list of availability zones to deploy the Shoot cluster to, currently, only one is supported.
 	Zones []string
 }
+
+// Adding new CIDRs to the struct bellow must be kept in sync with pkg/registry/garden/shoot/canonicalize.go
 
 // PacketNetworks holds information about the Kubernetes and infrastructure networks.
 type PacketNetworks struct {
@@ -845,6 +853,8 @@ type AzureResourceGroup struct {
 	// Name is the name of an existing resource group.
 	Name string
 }
+
+// Adding new CIDRs to the struct bellow must be kept in sync with pkg/registry/garden/shoot/canonicalize.go
 
 // AzureNetworks holds information about the Kubernetes and infrastructure networks.
 type AzureNetworks struct {
@@ -885,6 +895,8 @@ type GCPCloud struct {
 	// Zones is a list of availability zones to deploy the Shoot cluster to.
 	Zones []string
 }
+
+// Adding new CIDRs to the struct bellow must be kept in sync with pkg/registry/garden/shoot/canonicalize.go
 
 // GCPNetworks holds information about the Kubernetes and infrastructure networks.
 type GCPNetworks struct {
@@ -944,6 +956,8 @@ type OpenStackLoadBalancerClass struct {
 	// configuration is done.
 	SubnetID *string
 }
+
+// Adding new CIDRs to the struct bellow must be kept in sync with pkg/registry/garden/shoot/canonicalize.go
 
 // OpenStackNetworks holds information about the Kubernetes and infrastructure networks.
 type OpenStackNetworks struct {

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -727,6 +727,8 @@ type ShootStatus struct {
 // CalicoNetworkType is a constant for the calico network type.
 const CalicoNetworkType = "calico"
 
+// Adding new CIDRs to the struct bellow must be kept in sync with pkg/registry/garden/shoot/canonicalize.go
+
 // Networking defines networking parameters for the shoot cluster.
 type Networking struct {
 	gardencorev1alpha1.K8SNetworks `json:",inline"`
@@ -783,6 +785,8 @@ type AWSCloud struct {
 	// Zones is a list of availability zones to deploy the Shoot cluster to.
 	Zones []string `json:"zones"`
 }
+
+// Adding new CIDRs to the struct bellow must be kept in sync with pkg/registry/garden/shoot/canonicalize.go
 
 // AWSNetworks holds information about the Kubernetes and infrastructure networks.
 type AWSNetworks struct {
@@ -841,6 +845,8 @@ type AlicloudVPC struct {
 	CIDR *gardencorev1alpha1.CIDR `json:"cidr,omitempty"`
 }
 
+// Adding new CIDRs to the struct bellow must be kept in sync with pkg/registry/garden/shoot/canonicalize.go
+
 // AlicloudNetworks holds information about the Kubernetes and infrastructure networks.
 type AlicloudNetworks struct {
 	gardencorev1alpha1.K8SNetworks `json:",inline"`
@@ -873,6 +879,8 @@ type PacketCloud struct {
 	// Zones is a list of availability zones to deploy the Shoot cluster to, currently, only one is supported.
 	Zones []string `json:"zones"`
 }
+
+// Adding new CIDRs to the struct bellow must be kept in sync with pkg/registry/garden/shoot/canonicalize.go
 
 // PacketNetworks holds information about the Kubernetes and infrastructure networks.
 type PacketNetworks struct {
@@ -909,6 +917,8 @@ type AzureResourceGroup struct {
 	// Name is the name of an existing resource group.
 	Name string `json:"name"`
 }
+
+// Adding new CIDRs to the struct bellow must be kept in sync with pkg/registry/garden/shoot/canonicalize.go
 
 // AzureNetworks holds information about the Kubernetes and infrastructure networks.
 type AzureNetworks struct {
@@ -952,6 +962,8 @@ type GCPCloud struct {
 	// Zones is a list of availability zones to deploy the Shoot cluster to.
 	Zones []string `json:"zones"`
 }
+
+// Adding new CIDRs to the struct bellow must be kept in sync with pkg/registry/garden/shoot/canonicalize.go
 
 // GCPNetworks holds information about the Kubernetes and infrastructure networks.
 type GCPNetworks struct {
@@ -1018,6 +1030,8 @@ type OpenStackLoadBalancerClass struct {
 	// +optional
 	SubnetID *string `json:"subnetID,omitempty"`
 }
+
+// Adding new CIDRs to the struct bellow must be kept in sync with pkg/registry/garden/shoot/canonicalize.go
 
 // OpenStackNetworks holds information about the Kubernetes and infrastructure networks.
 type OpenStackNetworks struct {

--- a/pkg/registry/garden/shoot/canonicalize.go
+++ b/pkg/registry/garden/shoot/canonicalize.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot
+
+import (
+	"net"
+
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/garden"
+)
+
+// canonicalizeShootCIDRs tries to convert all CIDR address to their canonical form.
+// e.g "10.0.4.5/24" -> "10.0.4.0/24"
+// Parse errors are ignored and they should be picked by the valdiation.
+func canonicalizeShootCIDRs(spec *garden.ShootSpec) {
+	if spec == nil {
+		return
+	}
+
+	if networking := spec.Networking; networking != nil {
+		canonicalizeK8SNetworks(networking.K8SNetworks)
+	}
+
+	if aws := spec.Cloud.AWS; aws != nil {
+		networks := aws.Networks
+
+		canonicalizeK8SNetworks(networks.K8SNetworks)
+
+		canonicalizeCIDRs(networks.Internal)
+		canonicalizeCIDR(networks.VPC.CIDR)
+		canonicalizeCIDRs(networks.Public)
+		canonicalizeCIDRs(networks.Workers)
+	}
+
+	if azure := spec.Cloud.Azure; azure != nil {
+		networks := azure.Networks
+
+		canonicalizeK8SNetworks(networks.K8SNetworks)
+
+		canonicalizeCIDR(networks.VNet.CIDR)
+
+		workers := &networks.Workers
+		canonicalizeCIDR(&networks.Workers)
+		spec.Cloud.Azure.Networks.Workers = *workers
+	}
+
+	if gcp := spec.Cloud.GCP; gcp != nil {
+		networks := gcp.Networks
+
+		canonicalizeK8SNetworks(networks.K8SNetworks)
+
+		canonicalizeCIDR(networks.Internal)
+		canonicalizeCIDRs(networks.Workers)
+	}
+
+	if openstack := spec.Cloud.OpenStack; openstack != nil {
+		networks := openstack.Networks
+
+		canonicalizeK8SNetworks(networks.K8SNetworks)
+
+		canonicalizeCIDRs(networks.Workers)
+	}
+
+	if alicloud := spec.Cloud.Alicloud; alicloud != nil {
+		networks := alicloud.Networks
+
+		canonicalizeK8SNetworks(networks.K8SNetworks)
+
+		canonicalizeCIDR(networks.VPC.CIDR)
+		canonicalizeCIDRs(networks.Workers)
+	}
+
+	if packet := spec.Cloud.Packet; packet != nil {
+		canonicalizeK8SNetworks(packet.Networks.K8SNetworks)
+	}
+}
+
+func canonicalizeCIDR(cidr *gardencore.CIDR) {
+	if cidr == nil {
+		return
+	}
+	_, ipNet, _ := net.ParseCIDR(string(*cidr))
+	if ipNet != nil {
+		*cidr = gardencore.CIDR(ipNet.String())
+	}
+}
+
+func canonicalizeCIDRs(cidrs []gardencore.CIDR) {
+	for i, cidr := range cidrs {
+		cidr := &cidr
+		canonicalizeCIDR(cidr)
+		cidrs[i] = *cidr
+	}
+}
+
+func canonicalizeK8SNetworks(networks gardencore.K8SNetworks) {
+	canonicalizeCIDR(networks.Nodes)
+	canonicalizeCIDR(networks.Pods)
+	canonicalizeCIDR(networks.Services)
+}

--- a/pkg/registry/garden/shoot/strategy.go
+++ b/pkg/registry/garden/shoot/strategy.go
@@ -154,6 +154,8 @@ func (shootStrategy) Validate(ctx context.Context, obj runtime.Object) field.Err
 }
 
 func (shootStrategy) Canonicalize(obj runtime.Object) {
+	shoot := obj.(*garden.Shoot)
+	canonicalizeShootCIDRs(&shoot.Spec)
 }
 
 func (shootStrategy) AllowCreateOnUpdate() bool {

--- a/pkg/registry/garden/shoot/strategy_test.go
+++ b/pkg/registry/garden/shoot/strategy_test.go
@@ -108,6 +108,151 @@ var _ = Describe("Strategy", func() {
 			})
 		})
 	})
+
+	Context("Canonicalize", func() {
+		It("should convert all network entries to connonical reprentation", func() {
+
+			given := garden.Shoot{
+				Spec: garden.ShootSpec{
+					Networking: &garden.Networking{
+						K8SNetworks: core.K8SNetworks{
+							Nodes:    cidrPtr("10.0.0.2/24"),
+							Pods:     cidrPtr("10.0.1.3/24"),
+							Services: cidrPtr("10.0.2.4/24"),
+						},
+					},
+					Cloud: garden.Cloud{
+						AWS: &garden.AWSCloud{
+							Networks: garden.AWSNetworks{
+								K8SNetworks: core.K8SNetworks{
+									Nodes:    cidrPtr("10.0.3.2/24"),
+									Pods:     cidrPtr("10.0.4.3/24"),
+									Services: cidrPtr("10.0.5.4/24"),
+								},
+								VPC: garden.AWSVPC{
+									CIDR: cidrPtr("10.0.6.5/24"),
+								},
+								Internal: makeCIDRs("10.0.7.6/24", "10.0.8.7/24"),
+								Public:   makeCIDRs("10.0.8.7/24", "10.0.9.8/24"),
+								Workers:  makeCIDRs("10.0.9.8/24", "10.0.10.9/24"),
+							},
+						},
+						Azure: &garden.AzureCloud{
+							Networks: garden.AzureNetworks{
+								K8SNetworks: core.K8SNetworks{
+									Nodes:    cidrPtr("10.0.11.10/24"),
+									Pods:     cidrPtr("10.0.12.11/24"),
+									Services: cidrPtr("10.0.13.12/24"),
+								},
+								VNet: garden.AzureVNet{
+									CIDR: cidrPtr("10.0.14.13/24"),
+								},
+								Workers: core.CIDR("10.0.15.14/24"),
+							},
+						},
+
+						GCP: &garden.GCPCloud{
+							Networks: garden.GCPNetworks{
+								K8SNetworks: core.K8SNetworks{
+									Nodes:    cidrPtr("10.0.16.15/24"),
+									Pods:     cidrPtr("10.0.17.16/24"),
+									Services: cidrPtr("10.0.18.17/24"),
+								},
+								Internal: cidrPtr("10.0.19.18/24"),
+								Workers:  makeCIDRs("10.0.20.19/24", "10.0.21.20/24"),
+							},
+						},
+						OpenStack: &garden.OpenStackCloud{
+							Networks: garden.OpenStackNetworks{
+								K8SNetworks: core.K8SNetworks{
+									Nodes:    cidrPtr("10.0.22.21/24"),
+									Pods:     cidrPtr("10.0.23.22/24"),
+									Services: cidrPtr("10.0.24.23/24"),
+								},
+								Workers: makeCIDRs("10.0.25.24/24", "10.0.26.25/24"),
+							},
+						},
+
+						Alicloud: &garden.Alicloud{
+							Networks: garden.AlicloudNetworks{
+								K8SNetworks: core.K8SNetworks{
+									Nodes:    cidrPtr("10.0.27.26/24"),
+									Pods:     cidrPtr("10.0.28.27/24"),
+									Services: cidrPtr("10.0.29.28/24"),
+								},
+								VPC: garden.AlicloudVPC{
+									CIDR: cidrPtr("10.0.30.29/24"),
+								},
+								Workers: makeCIDRs("10.0.31.30/24", "10.0.32.31/24"),
+							},
+						},
+						Packet: &garden.PacketCloud{
+							Networks: garden.PacketNetworks{
+								K8SNetworks: core.K8SNetworks{
+									Nodes:    cidrPtr("10.0.33.32/24"),
+									Pods:     cidrPtr("10.0.34.33/24"),
+									Services: cidrPtr("10.0.35.34/24"),
+								},
+							},
+						},
+					},
+				},
+			}
+			expected := given.DeepCopy()
+
+			strategy.Strategy.Canonicalize(&given)
+
+			// spec.networks
+			expected.Spec.Networking.Nodes = cidrPtr("10.0.0.0/24")
+			expected.Spec.Networking.Pods = cidrPtr("10.0.1.0/24")
+			expected.Spec.Networking.Services = cidrPtr("10.0.2.0/24")
+
+			// spec.cloud.aws
+			expected.Spec.Cloud.AWS.Networks.Nodes = cidrPtr("10.0.3.0/24")
+			expected.Spec.Cloud.AWS.Networks.Pods = cidrPtr("10.0.4.0/24")
+			expected.Spec.Cloud.AWS.Networks.Services = cidrPtr("10.0.5.0/24")
+			expected.Spec.Cloud.AWS.Networks.VPC.CIDR = cidrPtr("10.0.6.0/24")
+			expected.Spec.Cloud.AWS.Networks.Internal = makeCIDRs("10.0.7.0/24", "10.0.8.0/24")
+			expected.Spec.Cloud.AWS.Networks.Public = makeCIDRs("10.0.8.0/24", "10.0.9.0/24")
+			expected.Spec.Cloud.AWS.Networks.Workers = makeCIDRs("10.0.9.0/24", "10.0.10.0/24")
+
+			// spec.cloud.azure
+			expected.Spec.Cloud.Azure.Networks.Nodes = cidrPtr("10.0.11.0/24")
+			expected.Spec.Cloud.Azure.Networks.Pods = cidrPtr("10.0.12.0/24")
+			expected.Spec.Cloud.Azure.Networks.Services = cidrPtr("10.0.13.0/24")
+			expected.Spec.Cloud.Azure.Networks.VNet.CIDR = cidrPtr("10.0.14.0/24")
+			expected.Spec.Cloud.Azure.Networks.Workers = core.CIDR("10.0.15.0/24")
+
+			// spec.cloud.gcp
+			expected.Spec.Cloud.GCP.Networks.Nodes = cidrPtr("10.0.16.0/24")
+			expected.Spec.Cloud.GCP.Networks.Pods = cidrPtr("10.0.17.0/24")
+			expected.Spec.Cloud.GCP.Networks.Services = cidrPtr("10.0.18.0/24")
+			expected.Spec.Cloud.GCP.Networks.Internal = cidrPtr("10.0.19.0/24")
+			expected.Spec.Cloud.GCP.Networks.Workers = makeCIDRs("10.0.20.0/24", "10.0.21.0/24")
+
+			// spec.cloud.openstack
+			expected.Spec.Cloud.OpenStack.Networks.Nodes = cidrPtr("10.0.22.0/24")
+			expected.Spec.Cloud.OpenStack.Networks.Pods = cidrPtr("10.0.23.0/24")
+			expected.Spec.Cloud.OpenStack.Networks.Services = cidrPtr("10.0.24.0/24")
+			expected.Spec.Cloud.OpenStack.Networks.Workers = makeCIDRs("10.0.25.0/24", "10.0.26.0/24")
+
+			// spec.cloud.alicloud
+			expected.Spec.Cloud.Alicloud.Networks.Nodes = cidrPtr("10.0.27.0/24")
+			expected.Spec.Cloud.Alicloud.Networks.Pods = cidrPtr("10.0.28.0/24")
+			expected.Spec.Cloud.Alicloud.Networks.Services = cidrPtr("10.0.29.0/24")
+			expected.Spec.Cloud.Alicloud.Networks.VPC.CIDR = cidrPtr("10.0.30.0/24")
+			expected.Spec.Cloud.Alicloud.Networks.Workers = makeCIDRs("10.0.31.0/24", "10.0.32.0/24")
+
+			// spec.cloud.packet
+			expected.Spec.Cloud.Packet.Networks.Nodes = cidrPtr("10.0.33.0/24")
+			expected.Spec.Cloud.Packet.Networks.Pods = cidrPtr("10.0.34.0/24")
+			expected.Spec.Cloud.Packet.Networks.Services = cidrPtr("10.0.35.0/24")
+
+			Expect(*expected).To(BeEquivalentTo(given))
+
+		})
+	})
+
 })
 
 func newShoot(seedName string) *garden.Shoot {
@@ -123,4 +268,17 @@ func newShoot(seedName string) *garden.Shoot {
 			},
 		},
 	}
+}
+
+func cidrPtr(cidr string) *core.CIDR {
+	c := core.CIDR(cidr)
+	return &c
+}
+
+func makeCIDRs(cidrs ...string) []core.CIDR {
+	converted := make([]core.CIDR, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		converted = append(converted, core.CIDR(cidr))
+	}
+	return converted
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

All CIDRs in the Shoot specification are stored in their canonical form on CREATE/UPDATE operation.

For example:

CIDR `10.0.0.5/24` is a valid CIDR, but the canonical way of using such CIDRs in the context of gardener is `10.0.0.0/24`.

End users are still able to use the non-canonical values, but it'll be overwritten in the backend.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/pull/567#issuecomment-524184692

**Special notes for your reviewer**:
This targets only the `Shoot` resource. `Seed` will be added as a separate PR.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
All CIDRs in the `Shoot` specification now use the canonical CIDR form. e.g. `10.0.4.5/24` -> `10.0.4.0/24` (network address + mask).

All valid CIDRs can still be send to the API server, but they'll be stored in their canonical form on `CREATE` / `UPDATE` operations.
```
