### PR TITLE
Improvements for DNSProvider objects

### DIFF
--- a/charts/seed-dns/provider/templates/dnsprovider.yaml
+++ b/charts/seed-dns/provider/templates/dnsprovider.yaml
@@ -13,6 +13,10 @@ kind: DNSProvider
 metadata:
   name: {{ .Values.name }}
   namespace: {{ .Release.Namespace }}
+{{- if ne .Values.purpose "internal" }}
+  labels:
+    dns.gardener.cloud/realms: "{{ .Release.Namespace }},"
+{{- end }}
 spec:
   type: {{ .Values.provider }}
   secretRef:

--- a/charts/seed-dns/provider/values.yaml
+++ b/charts/seed-dns/provider/values.yaml
@@ -1,4 +1,5 @@
 name: internal
+purpose: internal
 provider: ""
 secretData: {}
 domains:

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -49,7 +49,7 @@ func (b *Botanist) DeployInternalDomainDNSRecord(ctx context.Context) error {
 	if err := b.deployDNSProvider(ctx, DNSPurposeInternal, b.Garden.InternalDomain.Provider, b.Garden.InternalDomain.SecretData, b.Shoot.InternalClusterDomain); err != nil {
 		return err
 	}
-	if err := b.deployDNSEntry(ctx, DNSPurposeInternal, b.Shoot.InternalClusterDomain, b.APIServerAddress); err != nil {
+	if err := b.deployDNSEntry(ctx, DNSPurposeInternal, common.GetAPIServerDomain(b.Shoot.InternalClusterDomain), b.APIServerAddress); err != nil {
 		return err
 	}
 	return b.deleteLegacyTerraformDNSResources(ctx, common.TerraformerPurposeInternalDNSDeprecated)
@@ -69,10 +69,10 @@ func (b *Botanist) DeployExternalDomainDNSRecord(ctx context.Context) error {
 		return nil
 	}
 
-	if err := b.deployDNSProvider(ctx, DNSPurposeExternal, b.Shoot.ExternalDomain.Provider, b.Shoot.ExternalDomain.SecretData, *b.Shoot.Info.Spec.DNS.Domain); err != nil {
+	if err := b.deployDNSProvider(ctx, DNSPurposeExternal, b.Shoot.ExternalDomain.Provider, b.Shoot.ExternalDomain.SecretData, *b.Shoot.ExternalClusterDomain); err != nil {
 		return err
 	}
-	if err := b.deployDNSEntry(ctx, DNSPurposeExternal, *b.Shoot.ExternalClusterDomain, b.Shoot.InternalClusterDomain); err != nil {
+	if err := b.deployDNSEntry(ctx, DNSPurposeExternal, common.GetAPIServerDomain(*b.Shoot.ExternalClusterDomain), common.GetAPIServerDomain(b.Shoot.InternalClusterDomain)); err != nil {
 		return err
 	}
 	return b.deleteLegacyTerraformDNSResources(ctx, common.TerraformerPurposeExternalDNSDeprecated)

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -89,6 +89,7 @@ func (b *Botanist) DestroyExternalDomainDNSRecord(ctx context.Context) error {
 func (b *Botanist) deployDNSProvider(ctx context.Context, name, provider string, secretData map[string][]byte, includedDomains ...string) error {
 	values := map[string]interface{}{
 		"name":       name,
+		"purpose":    name,
 		"provider":   provider,
 		"secretData": secretData,
 		"domains": map[string]interface{}{

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -85,7 +85,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 				},
 			},
 			"shoot": map[string]interface{}{
-				"apiserver": fmt.Sprintf("https://%s", b.Shoot.InternalClusterDomain),
+				"apiserver": fmt.Sprintf("https://%s", common.GetAPIServerDomain(b.Shoot.InternalClusterDomain)),
 				"provider":  b.Shoot.CloudProvider,
 			},
 			"ignoreAlerts": b.Shoot.IgnoreAlerts,

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -87,7 +87,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 			"kube-apiserver",
 			fmt.Sprintf("kube-apiserver.%s", b.Shoot.SeedNamespace),
 			fmt.Sprintf("kube-apiserver.%s.svc", b.Shoot.SeedNamespace),
-			b.Shoot.InternalClusterDomain,
+			common.GetAPIServerDomain(b.Shoot.InternalClusterDomain),
 		}, dnsNamesForService("kubernetes", "default")...)
 
 		kubeControllerManagerCertDNSNames = dnsNamesForService("kube-controller-manager", b.Shoot.SeedNamespace)
@@ -101,7 +101,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 	}
 
 	if b.Shoot.ExternalClusterDomain != nil {
-		apiServerCertDNSNames = append(apiServerCertDNSNames, *(b.Shoot.Info.Spec.DNS.Domain), *(b.Shoot.ExternalClusterDomain))
+		apiServerCertDNSNames = append(apiServerCertDNSNames, *(b.Shoot.Info.Spec.DNS.Domain), common.GetAPIServerDomain(*b.Shoot.ExternalClusterDomain))
 	}
 
 	secretList := []secrets.ConfigInterface{
@@ -946,9 +946,9 @@ type projectSecret struct {
 // the project namespace in the Garden cluster and the monitoring credentials for the
 // user-facing monitoring stack are also copied.
 func (b *Botanist) SyncShootCredentialsToGarden(ctx context.Context) error {
-	kubecfgURL := b.Shoot.InternalClusterDomain
+	kubecfgURL := common.GetAPIServerDomain(b.Shoot.InternalClusterDomain)
 	if b.Shoot.ExternalClusterDomain != nil {
-		kubecfgURL = *b.Shoot.ExternalClusterDomain
+		kubecfgURL = common.GetAPIServerDomain(*b.Shoot.ExternalClusterDomain)
 	}
 
 	projectSecrets := []projectSecret{

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -207,6 +207,11 @@ const (
 	// '*.<IngressPrefix>.cluster.example.com'.
 	IngressPrefix = "ingress"
 
+	// APIServerPrefix is the part of a FQDN which will be used to construct the domain name for the kube-apiserver of
+	// a Shoot cluster. For example, when a Shoot specifies domain 'cluster.example.com', the apiserver domain would be
+	// 'api.cluster.example.com'.
+	APIServerPrefix = "api"
+
 	// InternalDomainKey is a key which must be present in an internal domain constructed for a Shoot cluster. If the
 	// configured internal domain already contains it, it won't be added twice. If it does not contain it, it will be
 	// appended.

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -546,3 +546,9 @@ func GetServiceAccountSigningKeySecret(ctx context.Context, c client.Client, sho
 
 	return ReadServiceAccountSigningKeySecret(secret)
 }
+
+// GetAPIServerDomain returns the fully qualified domain name of for the api-server for the Shoot cluster. The
+// end result is 'api.<domain>'.
+func GetAPIServerDomain(domain string) string {
+	return fmt.Sprintf("%s.%s", APIServerPrefix, domain)
+}

--- a/pkg/operation/shoot/shoot_test.go
+++ b/pkg/operation/shoot/shoot_test.go
@@ -16,7 +16,6 @@ package shoot_test
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -97,8 +96,8 @@ var _ = Describe("shoot", func() {
 				Expect(ConstructInternalClusterDomain(shootName, shootProject, internalDomain)).To(Equal(expected))
 			},
 
-			Entry("with internal domain key", "foo", "bar", "internal.nip.io", "api.foo.bar.internal.nip.io"),
-			Entry("without internal domain key", "foo", "bar", "nip.io", "api.foo.bar.internal.nip.io"),
+			Entry("with internal domain key", "foo", "bar", "internal.nip.io", "foo.bar.internal.nip.io"),
+			Entry("without internal domain key", "foo", "bar", "nip.io", "foo.bar.internal.nip.io"),
 		)
 
 		Describe("#ConstructExternalClusterDomain", func() {
@@ -108,9 +107,8 @@ var _ = Describe("shoot", func() {
 
 			It("should return the constructed domain", func() {
 				var (
-					domain         = "foo.bar.com"
-					expectedDomain = fmt.Sprintf("api.%s", domain)
-					shoot          = &gardenv1beta1.Shoot{
+					domain = "foo.bar.com"
+					shoot  = &gardenv1beta1.Shoot{
 						Spec: gardenv1beta1.ShootSpec{
 							DNS: gardenv1beta1.DNS{
 								Domain: &domain,
@@ -119,7 +117,7 @@ var _ = Describe("shoot", func() {
 					}
 				)
 
-				Expect(ConstructExternalClusterDomain(shoot)).To(Equal(&expectedDomain))
+				Expect(ConstructExternalClusterDomain(shoot)).To(Equal(&domain))
 			})
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The `DNSProvider` objects should not include the `api.` prefix but only the cluster's base domain. This is now corrected. Also, purpose labels are added (`dns.gardener.cloud/realms="<shoot-namespace>,"`).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Gardener does now annotate `DNSProvider` objects for the external cluster domain(s) with `dns.gardener.cloud/realms="<shoot-namespace>,"`.
```
```improvement operator
The `DNSProvider`s for a shoot do now only include the shoot's base domain (without `api.` prefix).
```