### PR TITLE
fix OpenStack shoot to allow only 1 network

### DIFF
--- a/pkg/apis/garden/validation/validation.go
+++ b/pkg/apis/garden/validation/validation.go
@@ -1315,6 +1315,10 @@ func validateCloud(cloud garden.Cloud, kubernetes garden.Kubernetes, fldPath *fi
 		nodes, _, _, networkErrors := transformK8SNetworks(openStack.Networks.K8SNetworks, openStackPath.Child("networks"))
 		allErrs = append(allErrs, networkErrors...)
 
+		if len(openStack.Networks.Workers) > 1 {
+			allErrs = append(allErrs, field.Invalid(openStackPath.Child("networks", "workers"), openStack.Networks.Workers, "must specify only one worker cidr"))
+		}
+
 		workerCIDRs := make([]cidrvalidation.CIDR, 0, len(openStack.Networks.Workers))
 		for i, cidr := range openStack.Networks.Workers {
 			workerCIDR := cidrvalidation.NewCIDR(cidr, openStackPath.Child("networks", "workers").Index(i))

--- a/pkg/apis/garden/validation/validation_test.go
+++ b/pkg/apis/garden/validation/validation_test.go
@@ -2296,15 +2296,14 @@ var _ = Describe("validation", func() {
 	})
 
 	Describe("#ValidateSeed, #ValidateSeedUpdate", func() {
-		var(
-			 seed *garden.Seed
-			 backup *garden.BackupProfile
+		var (
+			seed   *garden.Seed
+			backup *garden.BackupProfile
 		)
-
 
 		BeforeEach(func() {
 			region := "some-region"
-			backup=&garden.BackupProfile{
+			backup = &garden.BackupProfile{
 				Provider: garden.CloudProviderAWS,
 				Region:   &region,
 				SecretRef: corev1.SecretReference{
@@ -2404,17 +2403,17 @@ var _ = Describe("validation", func() {
 			}, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
 				"Field": Equal("spec.networks.services"),
-			},Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("spec.backup.provider"),
+			}, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("spec.backup.provider"),
 				"Detail": Equal(`must provide a backup cloud provider name`),
-			},Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("spec.backup.secretRef.name"),
+			}, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("spec.backup.secretRef.name"),
 				"Detail": Equal(`must provide a name`),
-			},Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("spec.backup.secretRef.namespace"),
+			}, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("spec.backup.secretRef.namespace"),
 				"Detail": Equal(`must provide a namespace`),
 			}))
 		})
@@ -2453,8 +2452,8 @@ var _ = Describe("validation", func() {
 				Services: gardencore.CIDR("10.3.1.64/26"),
 			}
 			otherRegion := "other-region"
-			newSeed.Spec.Backup.Provider="other-provider"
-			newSeed.Spec.Backup.Region=    &otherRegion
+			newSeed.Spec.Backup.Provider = "other-provider"
+			newSeed.Spec.Backup.Region = &otherRegion
 
 			errorList := ValidateSeedUpdate(newSeed, seed)
 
@@ -2462,18 +2461,18 @@ var _ = Describe("validation", func() {
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("spec.networks"),
 				"Detail": Equal(`field is immutable`),
-			},Fields{
+			}, Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("spec.backup.region"),
 				"Detail": Equal(`field is immutable`),
-			},Fields{
+			}, Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("spec.backup.provider"),
 				"Detail": Equal(`field is immutable`),
 			}))
 		})
 
-		Context("#validateBackupProfileUpdate",func(){
+		Context("#validateBackupProfileUpdate", func() {
 			It("should allow adding backup profile", func() {
 				seed.Spec.Backup = nil
 				newSeed := prepareSeedForUpdate(seed)
@@ -5848,6 +5847,18 @@ var _ = Describe("validation", func() {
 			})
 
 			Context("CIDR", func() {
+
+				It("should forbid more than one CIDR", func() {
+					shoot.Spec.Cloud.OpenStack.Networks.Workers = []gardencore.CIDR{"10.250.0.1/32", "10.250.0.2/32"}
+
+					errorList := ValidateShoot(shoot)
+
+					Expect(errorList).To(ConsistOfFields(Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.cloud.openstack.networks.workers"),
+						"Detail": Equal("must specify only one worker cidr"),
+					}))
+				})
 
 				It("should forbid invalid workers CIDR", func() {
 					shoot.Spec.Cloud.OpenStack.Networks.Workers = []gardencore.CIDR{invalidCIDR}

--- a/pkg/registry/garden/shoot/strategy.go
+++ b/pkg/registry/garden/shoot/strategy.go
@@ -76,7 +76,7 @@ func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Obje
 		newShoot.Generation = oldShoot.Generation + 1
 	}
 
-	// TODO: (mvladev) there was a bug in the verication of GCP
+	// TODO: (mvladev) there was a bug in the verication of GCP & openstack
 	// and clusters with more than one Worker network were allowed to
 	// be created.
 	// This is used to fix the broken Shoots on update.
@@ -90,6 +90,18 @@ func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Obje
 	if gcp := oldShoot.Spec.Cloud.GCP; gcp != nil {
 		if len(gcp.Networks.Workers) > 1 {
 			gcp.Networks.Workers = []gardencore.CIDR{gcp.Networks.Workers[0]}
+		}
+	}
+
+	if openstack := newShoot.Spec.Cloud.OpenStack; openstack != nil {
+		if len(openstack.Networks.Workers) > 1 {
+			openstack.Networks.Workers = []gardencore.CIDR{openstack.Networks.Workers[0]}
+		}
+	}
+
+	if openstack := oldShoot.Spec.Cloud.OpenStack; openstack != nil {
+		if len(openstack.Networks.Workers) > 1 {
+			openstack.Networks.Workers = []gardencore.CIDR{openstack.Networks.Workers[0]}
 		}
 	}
 

--- a/pkg/registry/garden/shoot/strategy_test.go
+++ b/pkg/registry/garden/shoot/strategy_test.go
@@ -107,6 +107,24 @@ var _ = Describe("Strategy", func() {
 				Expect(oldShoot.Spec.Cloud.GCP.Networks.Workers).To(ConsistOf(core.CIDR("1.1.1.1/32")))
 			})
 		})
+		Context("invalid Openstack network CIRDs", func() {
+			It("should remove more than one OpenStack networks", func() {
+				shoot := newShoot("foo")
+
+				shoot.Spec.Cloud.OpenStack = &garden.OpenStackCloud{
+					Networks: garden.OpenStackNetworks{
+						Workers: []core.CIDR{"1.1.1.1/32", "1.1.1.2/32"},
+					},
+				}
+				oldShoot := newShoot("foo")
+				oldShoot.Spec.Cloud.OpenStack = shoot.Spec.Cloud.OpenStack.DeepCopy()
+
+				strategy.Strategy.PrepareForUpdate(context.TODO(), shoot, oldShoot)
+
+				Expect(shoot.Spec.Cloud.OpenStack.Networks.Workers).To(ConsistOf(core.CIDR("1.1.1.1/32")))
+				Expect(oldShoot.Spec.Cloud.OpenStack.Networks.Workers).To(ConsistOf(core.CIDR("1.1.1.1/32")))
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
**What this PR does / why we need it**:

On Openstack we use only [one network for nodes ](https://github.com/gardener/gardener-extensions/blob/68668b0d1518f8e695ec09049931a4409e965906/controllers/provider-openstack/charts/internal/openstack-infra/templates/main.tf#L32-L42). The current OpenStack worker network validation falsely allows more than one CIDR.

To ensure not breaking existing invalid OpenStack Shoots, on update we drop the extra worker values.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

This is the OpenStack variant of https://github.com/gardener/gardener/pull/1346

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Due to faulty validation, multi-zone OpenStack shoot clusters containing more than one CIDR in `spec.cloud.gcp.networks.workers[]` could be created (which is not a valid behavior). To ensure that those clusters are going to be safely reconciled with this update, on the next `Shoot` `UPDATE` request only the first `spec.cloud.openstack.networks.workers[0]` is going to be persisted.
Rollback to previous Gardener versions is not supported.
```
```action user
Creation of multi-zone OpenStack clusters now require exactly one CIDR in `spec.cloud.openstack.networks.workers[]`. 
Gardener will automatically patch existing multi-zone OpenStack `Shoot`s which are failing by removing the additional CIDRs (if they exist). Please update your `Shoot` manifests for future compatibility.
```
