### PR TITLE
Add logging configuration from provider specific components

### DIFF
--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
@@ -87,13 +87,6 @@ data:
 
     [FILTER]
         Name                parser
-        Match               kubernetes.cloud-controller-manager*cloud-controller-manager*
-        Key_Name            log
-        Parser              kubeapiserverParser
-        Reserve_Data        True
-
-    [FILTER]
-        Name                parser
         Match               kubernetes.kube-scheduler*cloud-kube-scheduler*
         Key_Name            log
         Parser              kubeapiserverParser
@@ -178,13 +171,6 @@ data:
 
     [FILTER]
         Name                parser
-        Match               kubernetes.machine-controller-manager*machine-controller-manager*
-        Key_Name            log
-        Parser              kubeapiserverParser
-        Reserve_Data        True
-
-    [FILTER]
-        Name                parser
         Match               kubernetes.vpn-shoot*vpn-shoot*
         Key_Name            log
         Parser              vpnshootParser
@@ -224,13 +210,6 @@ data:
         Match               kubernetes.prometheus*prometheus*
         Key_Name            log
         Parser              alermanagerParser
-        Reserve_Data        True
-
-    [FILTER]
-        Name                parser
-        Match               kubernetes.*lb-readvertiser*lb-readvertiser*
-        Key_Name            log
-        Parser              lbReadvertiserParser
         Reserve_Data        True
 
     [FILTER]
@@ -288,6 +267,10 @@ data:
         Match               kubernetes.*
         script              modify_severity.lua
         call                cb_modify
+
+{{ if .Values.fluentbit.extensions.filters }}
+{{- toString .Values.fluentbit.extensions.filters | indent 4 }}
+{{- end }}
 
   output-fluentd.conf: |
     [OUTPUT]
@@ -385,13 +368,6 @@ data:
         Time_Format %Y-%m-%dT%H:%M:%S.%L
 
     [PARSER]
-        Name        lbReadvertiserParser
-        Format      regex
-        Regex       ^time="(?<time>\d{4}-\d{2}-\d{2}T[^"]*)"\s+level=(?<severity>\w+)\smsg="(?<log>.*)"
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S%Z
-
-    [PARSER]
         Name        grafanaParser
         Format      regex
         Regex       ^t=(?<time>\d{4}-\d{2}-\d{2}T[^ ]*)\s+lvl=(?<severity>\w+)\smsg="(?<log>.*)"\s+logger=(?<source>.*)
@@ -402,6 +378,10 @@ data:
         Name        addonmanagerParser
         Format      regex
         Regex       ^(?<severity>[A-Z]+):\s(?<log>.*)
+
+{{ if .Values.fluentbit.extensions.parsers }}
+{{- toString .Values.fluentbit.extensions.parsers | indent 4 }}
+{{- end }}
 
   modify_severity.lua: |-
     function cb_modify(tag, timestamp, record)

--- a/charts/seed-bootstrap/charts/fluentd-es/values.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/values.yaml
@@ -30,3 +30,6 @@ fluentbit:
     role: logging
   ports:
     metrics: 2020
+  extensions:
+    filters: ""
+    parsers: ""

--- a/pkg/apis/core/v1alpha1/types_constants.go
+++ b/pkg/apis/core/v1alpha1/types_constants.go
@@ -120,6 +120,10 @@ const (
 	LabelShootProvider = "shoot.gardener.cloud/provider"
 	// LabelNetworkingProvider is used to identify the networking provider for the cni plugin.
 	LabelNetworkingProvider = "networking.shoot.gardener.cloud/provider"
+	// LabelExtensionConfiguration is used to identify the provider's configuration which will be added to Gardener configuration
+	LabelExtensionConfiguration = "extensions.gardener.cloud/configuration"
+	// LabelLogging is a constant for a label for logging stack configurations
+	LabelLogging = "logging"
 
 	// LabelNetworkPolicyToBlockedCIDRs allows Egress from pods labeled with 'networking.gardener.cloud/to-blocked-cidrs=allowed'.
 	LabelNetworkPolicyToBlockedCIDRs = "networking.gardener.cloud/to-blocked-cidrs"
@@ -172,6 +176,12 @@ const (
 	OperatingSystemConfigFilePathKernelSettings = "/etc/sysctl.d/99-k8s-general.conf"
 	// OperatingSystemConfigFilePathKubeletConfig is a constant for a path to a file in the operating system config that contains the kubelet configuration.
 	OperatingSystemConfigFilePathKubeletConfig = "/var/lib/kubelet/config/kubelet"
+
+
+	// FluentBitConfigMapKubernetesFilterConfig is a constant for the Fluent Bit ConfigMap's section regarding Kubernetes filters
+	FluentBitConfigMapKubernetesFilter = "filter-kubernetes.conf"
+	// FluentBitConfigMapParserConfig is a constant for the Fluent Bit ConfigMap's section regarding Parses for common container types
+	FluentBitConfigMapParser = "parsers.conf"
 
 	// ControllerRegistrationName is the key of a label on extension namespaces that indicates the controller registration name.
 	LabelControllerRegistrationName = "controllerregistration.core.gardener.cloud/name"


### PR DESCRIPTION
**What this PR does / why we need it**:
Every extension controller has deployed a ConfigMap into the garden namespace in the seed cluster. This ConfigMap contains the respective information for Gardener's logging stacks.

**Which issue(s) this PR fixes**:
Part 1 of #1351 

**Special notes for your reviewer**:
Depends on https://github.com/gardener/gardener-extensions/pull/286

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
Gardener does now read `ConfigMap`s labelled with `extensions.gardener.cloud/configuration=logging` and injects their data into the `fluent-bit` configuration. This allows extension controllers to define their provider-specific logging configuration for the components they deploy.
```
