### PR TITLE
reject shoots having non-canonicalized cidrs

### DIFF
--- a/pkg/scheduler/controller/scheduler_control.go
+++ b/pkg/scheduler/controller/scheduler_control.go
@@ -190,7 +190,7 @@ func determineBestSeedCandidate(shoot *gardenv1beta1.Shoot, shootList []*gardenv
 	case config.MinimalDistance:
 		candidates = determineCandidatesWithMinimalDistanceStrategy(seedList, shoot, candidates)
 	default:
-		return nil, fmt.Errorf("unknown seed determination strategy configured in seed admission plugin. Strategy: '%s' does not exist. Valid strategies are: %v", strategy, config.Strategies)
+		return nil, fmt.Errorf("unknown seed determination strategy configured. Strategy: '%s' does not exist. Valid strategies are: %v", strategy, config.Strategies)
 	}
 
 	if candidates == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
CIDR 10.0.0.5/24 is a valid CIDR, but the canonical way of using such CIDRs in the context of gardener is 10.0.0.0/24.

Reject Shoots with non-canonicalized cidrs.

based on [PR](https://github.com/gardener/gardener/pull/1365)

**Which issue(s) this PR fixes**:
Fixes  https://github.com/gardener/gardener/pull/567#issuecomment-524184692

**Special notes for your reviewer**:
- Shoots already created with invalid CIDR Ranges must be deleted -> Shoots could not be reconciled before this PR  anyways so only deleting non-functional shoots

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Shoot's that use non-canonicalized CIDRs are now rejected by the Gardener API server. Always use CIDRs in their canonical form.
```
