### PR TITLE
Improve dashboard for aggregate Prometheus

### DIFF
--- a/charts/seed-bootstrap/dashboards/alerts-dashboard.json
+++ b/charts/seed-bootstrap/dashboards/alerts-dashboard.json
@@ -5,7 +5,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1565958165910,
+  "iteration": 1566916324303,
   "links": [],
   "panels": [
     {
@@ -712,7 +712,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count(ALERTS{severity=~\"$Severity\", alertstate=~\"$AlertState\", cluster=~\"$Cluster\"}) by (cluster)",
+          "expr": "count(ALERTS{alertname=~\"$Alertname\", severity=~\"$Severity\", alertstate=~\"$AlertState\", cluster=~\"$Cluster\"}) by (cluster)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ cluster }}",
@@ -802,7 +802,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count(ALERTS{severity=~\"$Severity\", alertstate=~\"$AlertState\", cluster=~\"$Cluster\"}) by (alertname,cluster)",
+          "expr": "count(ALERTS{alertname=~\"$Alertname\", severity=~\"$Severity\", alertstate=~\"$AlertState\", cluster=~\"$Cluster\"}) by (alertname,cluster)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ alertname }}/{{ cluster }}",
@@ -864,10 +864,8 @@
       {
         "allValue": null,
         "current": {
-          "text": "shoot--d064864--shoot-aws1",
-          "value": [
-            "shoot--d064864--shoot-aws1"
-          ]
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": "prometheus",
         "definition": "label_values(cluster)",
@@ -959,6 +957,34 @@
         "name": "AlertState",
         "options": [],
         "query": "label_values(alertstate)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "prometheus",
+        "definition": "label_values(alertname)",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "Alertname",
+        "options": [],
+        "query": "label_values(alertname)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/charts/seed-bootstrap/dashboards/cluster-overview.json
+++ b/charts/seed-bootstrap/dashboards/cluster-overview.json
@@ -6,7 +6,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1565956128181,
+  "iteration": 1566913546161,
   "links": [],
   "panels": [
     {
@@ -365,28 +365,17 @@
     "list": [
       {
         "allValue": null,
-        "current": {
-          "tags": [],
-          "text": "shoot--d064864--shoot-aws1",
-          "value": "shoot--d064864--shoot-aws1"
-        },
         "datasource": "prometheus",
-        "definition": "label_values(seed:container_cpu_usage_seconds_total:sum_by_pod{namespace=~\"shoot(.+)\"},namespace)",
+        "definition": "label_values(namespace)",
         "hide": 0,
         "includeAll": false,
         "label": "Shoot",
         "multi": false,
         "name": "shoot",
-        "options": [
-          {
-            "selected": true,
-            "text": "shoot--d064864--shoot-aws1",
-            "value": "shoot--d064864--shoot-aws1"
-          }
-        ],
-        "query": "label_values(seed:container_cpu_usage_seconds_total:sum_by_pod{namespace=~\"shoot(.+)\"},namespace)",
-        "refresh": 0,
-        "regex": "",
+        "options": [],
+        "query": "label_values(namespace)",
+        "refresh": 1,
+        "regex": "((shoot-|shoot--)(\\w.+))",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the dashboards for the aggregate prometheus. 
* Operators can now filter by alert name on the Alerts dashboard
* Due to a bug it was not possible to select clusters on the cluster overview page. This PR fixes this.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```