### PR TITLE
Improve shoot reconciliation decisions

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot.go
+++ b/pkg/controllermanager/controller/shoot/shoot.go
@@ -34,7 +34,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kubeinformers "k8s.io/client-go/informers"

--- a/pkg/controllermanager/controller/shoot/shoot_care_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_care_control.go
@@ -204,7 +204,7 @@ func (c *defaultCareControl) updateShootConditions(shoot *gardenv1beta1.Shoot, c
 }
 
 // garbageCollection cleans the Seed and the Shoot cluster from no longer required
-// objects. It receives a Garden object <garden> which stores the Shoot object.
+// objects. It receives a botanist object <botanist> which stores the Shoot object.
 func garbageCollection(initShootClients func() error, botanist *botanistpkg.Botanist) {
 	var (
 		qualifiedShootName = fmt.Sprintf("%s/%s", botanist.Shoot.Info.Namespace, botanist.Shoot.Info.Name)

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -75,3 +75,17 @@ type Extension struct {
 	extensionsv1alpha1.Extension
 	Timeout time.Duration
 }
+
+// IncompleteDNSConfigError is a custom error type.
+type IncompleteDNSConfigError struct{}
+
+// Error prints the error message of the IncompleteDNSConfigError error.
+func (e *IncompleteDNSConfigError) Error() string {
+	return "unable to figure out which secret should be used for dns"
+}
+
+// IsIncompleteDNSConfigError returns true if the error indicates that not the DNS config is incomplete.
+func IsIncompleteDNSConfigError(err error) bool {
+	_, ok := err.(*IncompleteDNSConfigError)
+	return ok
+}

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -106,8 +106,8 @@ func TimeElapsed(timestamp *metav1.Time, duration time.Duration) bool {
 	}
 
 	var (
-		end = metav1.NewTime(timestamp.Time.Add(duration))
-		now = metav1.Now()
+		end = metav1.NewTime(timestamp.Time.UTC().Add(duration))
+		now = metav1.NewTime(time.Now().UTC())
 	)
 	return !now.Before(&end)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
* All the times are converted to UTC before comparing.
* All unscheduled shoots and shoots that never were reconciled to be deleted immediately.
* Update `.status.retryCycleStartTime` if generation changed, status was `Failed`, Gardener version changed or no start time was set before (correctly indicate that a new retry cycle was started).
* If the DNS config is unknown and the shoot shall be deleted but was never reconciled then this error is ignored.

**Which issue(s) this PR fixes**:
Fixes #1295

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
It is now possible to delete `Shoot`s that were created with a wrong `.spec.dns.domain` field.
```
