### PR TITLE
Propagate client connection settings to k8s clients

### DIFF
--- a/cmd/gardener-controller-manager/app/gardener_controller_manager.go
+++ b/cmd/gardener-controller-manager/app/gardener_controller_manager.go
@@ -285,10 +285,14 @@ func NewGardener(cfg *config.ControllerManagerConfiguration) (*Gardener, error) 
 		return nil, err
 	}
 
-	k8sGardenClient, err := kubernetes.NewForConfig(restCfg, client.Options{
-		Mapper: restmapper.NewDeferredDiscoveryRESTMapper(disc),
-		Scheme: kubernetes.GardenScheme,
-	})
+	k8sGardenClient, err := kubernetes.NewWithConfig(
+		kubernetes.WithRESTConfig(restCfg),
+		kubernetes.WithClientOptions(
+			client.Options{
+				Mapper: restmapper.NewDeferredDiscoveryRESTMapper(disc),
+				Scheme: kubernetes.GardenScheme,
+			}),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gardener-scheduler/app/gardener_scheduler.go
+++ b/cmd/gardener-scheduler/app/gardener_scheduler.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"k8s.io/client-go/discovery"
 	"os"
 	"time"
+
+	"k8s.io/client-go/discovery"
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
@@ -178,13 +179,18 @@ func NewGardenerScheduler(cfg *config.SchedulerConfiguration) (*GardenerSchedule
 		return nil, err
 	}
 
-	k8sGardenClient, err := kubernetes.NewForConfig(restCfg, client.Options{
-		Mapper: restmapper.NewDeferredDiscoveryRESTMapper(disc),
-		Scheme: kubernetes.GardenScheme,
-	})
+	k8sGardenClient, err := kubernetes.NewWithConfig(
+		kubernetes.WithRESTConfig(restCfg),
+		kubernetes.WithClientOptions(
+			client.Options{
+				Mapper: restmapper.NewDeferredDiscoveryRESTMapper(disc),
+				Scheme: kubernetes.GardenScheme,
+			}),
+	)
 	if err != nil {
 		return nil, err
 	}
+
 	k8sGardenClientLeaderElection, err := k8s.NewForConfig(restCfg)
 	if err != nil {
 		return nil, err

--- a/pkg/client/kubernetes/apply.go
+++ b/pkg/client/kubernetes/apply.go
@@ -46,10 +46,6 @@ var NewControllerClient = newControllerClient
 
 // NewApplierInternal constructs a new Applier from the given config and DiscoveryInterface.
 // This method should only be used for testing.
-// TODO(AC): Once https://github.com/kubernetes/kubernetes/issues/68865 is resolved,
-// this should be adapted to use the updated RESTMapper (https://github.com/kubernetes/kubernetes/issues/75383)
-// and not do the invalidation / checks on its own (depending on whether the controller-runtime/client might even automatically
-// use this updated mapper then).
 func NewApplierInternal(config *rest.Config, discoveryClient discovery.CachedDiscoveryInterface) (*Applier, error) {
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
 	c, err := NewControllerClient(config, client.Options{Mapper: mapper})
@@ -57,7 +53,7 @@ func NewApplierInternal(config *rest.Config, discoveryClient discovery.CachedDis
 		return nil, err
 	}
 
-	return &Applier{client: c, discovery: discoveryClient}, nil
+	return &Applier{client: c, restMapper: mapper}, nil
 }
 
 // NewApplierForConfig creates and returns a new Applier for the given rest.Config.
@@ -89,7 +85,7 @@ func (c *Applier) applyObject(ctx context.Context, desired *unstructured.Unstruc
 	current.SetGroupVersionKind(desired.GroupVersionKind())
 	err = c.client.Get(ctx, key, current)
 	if meta.IsNoMatchError(err) {
-		c.discovery.Invalidate()
+		c.restMapper.Reset()
 		err = c.client.Get(ctx, key, current)
 	}
 	if err != nil {

--- a/pkg/client/kubernetes/options.go
+++ b/pkg/client/kubernetes/options.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"errors"
+
+	"k8s.io/client-go/rest"
+	baseconfig "k8s.io/component-base/config"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type config struct {
+	clientOptions client.Options
+	restConfig    *rest.Config
+}
+
+// ConfigFunc is a function that mutates a Config struct.
+// It implements the functional options pattern. See
+// https://github.com/tmrts/go-patterns/blob/master/idiom/functional-options.md.
+type ConfigFunc func(config *config) error
+
+// WithRESTConfig returns a ConfigFunc that sets the passed rest.Config on the config object.
+func WithRESTConfig(restConfig *rest.Config) ConfigFunc {
+	return func(config *config) error {
+		config.restConfig = restConfig
+		return nil
+	}
+}
+
+// WithClientConnectionOptions returns a ConfigFunc that transfers settings from
+// the passed ClientConnectionConfiguration.
+// The kubeconfig location in ClientConnectionConfiguration is disregarded, though!
+func WithClientConnectionOptions(cfg baseconfig.ClientConnectionConfiguration) ConfigFunc {
+	return func(config *config) error {
+		if config.restConfig == nil {
+			return errors.New("REST config must be set before setting connection options")
+		}
+		config.restConfig.Burst = int(cfg.Burst)
+		config.restConfig.QPS = cfg.QPS
+		config.restConfig.AcceptContentTypes = cfg.AcceptContentTypes
+		config.restConfig.ContentType = cfg.ContentType
+		return nil
+	}
+}
+
+// WithClientOptions returns a ConfigFunc that sets the passed Options on the config object.
+func WithClientOptions(opt client.Options) ConfigFunc {
+	return func(config *config) error {
+		config.clientOptions = opt
+		return nil
+	}
+}

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -36,10 +36,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/discovery"
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	corescheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	apiregistrationclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	apiregistrationscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -173,8 +173,8 @@ type Clientset struct {
 // by first checking whether they exist and then either creating / updating them (update happens
 // with a predefined merge logic).
 type Applier struct {
-	client    client.Client
-	discovery discovery.CachedDiscoveryInterface
+	client     client.Client
+	restMapper *restmapper.DeferredDiscoveryRESTMapper
 }
 
 // MergeFunc determines how oldOj is merged into new oldObj.

--- a/pkg/controllermanager/controller/backupinfrastructure/backup_infrastructure_control.go
+++ b/pkg/controllermanager/controller/backupinfrastructure/backup_infrastructure_control.go
@@ -183,7 +183,7 @@ func (c *defaultControl) ReconcileBackupInfrastructure(obj *gardenv1beta1.Backup
 	backupInfrastructureJSON, _ := json.Marshal(backupInfrastructure)
 	backupInfrastructureLogger.Debugf(string(backupInfrastructureJSON))
 
-	op, err := operation.NewWithBackupInfrastructure(backupInfrastructure, backupInfrastructureLogger, c.k8sGardenClient, c.k8sGardenInformers, c.identity, c.secrets, c.imageVector)
+	op, err := operation.NewWithBackupInfrastructure(backupInfrastructure, c.config, backupInfrastructureLogger, c.k8sGardenClient, c.k8sGardenInformers, c.identity, c.secrets, c.imageVector)
 	if err != nil {
 		backupInfrastructureLogger.Errorf("Could not initialize a new operation: %s", err.Error())
 		return false, err

--- a/pkg/controllermanager/controller/controllerinstallation/controllerinstallation_control.go
+++ b/pkg/controllermanager/controller/controllerinstallation/controllerinstallation_control.go
@@ -196,9 +196,13 @@ func (c *defaultControllerInstallationControl) reconcile(controllerInstallation 
 		return err
 	}
 
-	k8sSeedClient, err := kubernetes.NewClientFromSecret(c.k8sGardenClient, seed.Spec.SecretRef.Namespace, seed.Spec.SecretRef.Name, client.Options{
-		Scheme: kubernetes.SeedScheme,
-	})
+	k8sSeedClient, err := kubernetes.NewClientFromSecret(c.k8sGardenClient, seed.Spec.SecretRef.Namespace, seed.Spec.SecretRef.Name,
+		kubernetes.WithClientConnectionOptions(c.config.ClientConnection),
+		kubernetes.WithClientOptions(
+			client.Options{
+				Scheme: kubernetes.SeedScheme,
+			}),
+	)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			conditionValid = helper.UpdatedCondition(conditionValid, gardencorev1alpha1.ConditionFalse, "SeedNotFound", fmt.Sprintf("Referenced Seed does not exist: %+v", err))
@@ -342,9 +346,13 @@ func (c *defaultControllerInstallationControl) delete(controllerInstallation *ga
 		return err
 	}
 
-	k8sSeedClient, err := kubernetes.NewClientFromSecret(c.k8sGardenClient, seed.Spec.SecretRef.Namespace, seed.Spec.SecretRef.Name, client.Options{
-		Scheme: kubernetes.SeedScheme,
-	})
+	k8sSeedClient, err := kubernetes.NewClientFromSecret(c.k8sGardenClient, seed.Spec.SecretRef.Namespace, seed.Spec.SecretRef.Name,
+		kubernetes.WithClientConnectionOptions(c.config.ClientConnection),
+		kubernetes.WithClientOptions(
+			client.Options{
+				Scheme: kubernetes.SeedScheme,
+			}),
+	)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			conditionValid = helper.UpdatedCondition(conditionValid, gardencorev1alpha1.ConditionFalse, "SeedNotFound", fmt.Sprintf("Referenced Seed does not exist: %+v", err))

--- a/pkg/controllermanager/controller/plant/plant_control.go
+++ b/pkg/controllermanager/controller/plant/plant_control.go
@@ -301,9 +301,13 @@ func (c *defaultPlantControl) initializePlantClients(plant *gardencorev1alpha1.P
 		return nil, nil, fmt.Errorf("%v:%v", "invalid kubconfig supplied resulted in: ", err)
 	}
 
-	plantClusterClient, err := kubernetes.NewRuntimeClientForConfig(config, client.Options{
-		Scheme: kubernetes.PlantScheme,
-	})
+	plantClusterClient, err := kubernetes.NewRuntimeClientForConfig(
+		kubernetes.WithRESTConfig(config),
+		kubernetes.WithClientOptions(
+			client.Options{
+				Scheme: kubernetes.PlantScheme,
+			}),
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/controllermanager/controller/seed/seed_control.go
+++ b/pkg/controllermanager/controller/seed/seed_control.go
@@ -275,7 +275,7 @@ func (c *defaultControl) ReconcileSeed(obj *gardenv1beta1.Seed, key string) erro
 	if c.config.Controllers.Seed.ReserveExcessCapacity != nil {
 		seedObj.MustReserveExcessCapacity(*c.config.Controllers.Seed.ReserveExcessCapacity)
 	}
-	if err := seedpkg.BootstrapCluster(seedObj, c.secrets, c.imageVector, len(associatedShoots)); err != nil {
+	if err := seedpkg.BootstrapCluster(seedObj, c.config, c.secrets, c.imageVector, len(associatedShoots)); err != nil {
 		conditionSeedAvailable = gardencorev1alpha1helper.UpdatedCondition(conditionSeedAvailable, gardencorev1alpha1.ConditionFalse, "BootstrappingFailed", err.Error())
 		c.updateSeedStatus(seed, conditionSeedAvailable)
 		seedLogger.Error(err.Error())

--- a/pkg/controllermanager/controller/shoot/shoot_care_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_care_control.go
@@ -126,7 +126,7 @@ func (c *defaultCareControl) Care(shootObj *gardenv1beta1.Shoot, key string) err
 
 	shootLogger.Debugf("[SHOOT CARE] %s", key)
 
-	operation, err := operation.New(shoot, shootLogger, c.k8sGardenClient, c.k8sGardenInformers, c.identity, c.secrets, c.imageVector, nil)
+	operation, err := operation.New(shoot, c.config, shootLogger, c.k8sGardenClient, c.k8sGardenInformers, c.identity, c.secrets, c.imageVector, nil)
 	if err != nil {
 		shootLogger.Errorf("could not initialize a new operation: %s", err.Error())
 		return nil // We do not want to run in the exponential backoff for the condition checks.

--- a/pkg/controllermanager/controller/shoot/shoot_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control.go
@@ -129,7 +129,7 @@ func (c *Controller) reconcileShootRequest(req reconcile.Request) (reconcile.Res
 		return reconcile.Result{}, err
 	}
 
-	o, err := operation.New(shoot, log, c.k8sGardenClient, c.k8sGardenInformers.Garden().V1beta1(), c.identity, c.secrets, c.imageVector, c.config.ShootBackup)
+	o, err := operation.New(shoot, c.config, log, c.k8sGardenClient, c.k8sGardenInformers.Garden().V1beta1(), c.identity, c.secrets, c.imageVector, c.config.ShootBackup)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
 	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/externalversions/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	controllerutils "github.com/gardener/gardener/pkg/controllermanager/controller/utils"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
@@ -152,7 +153,7 @@ func (c *defaultMaintenanceControl) Maintain(shootObj *gardenv1beta1.Shoot, key 
 
 	shootLogger.Infof("[SHOOT MAINTENANCE] %s", key)
 
-	operation, err := operation.New(shoot, shootLogger, c.k8sGardenClient, c.k8sGardenInformers, c.identity, c.secrets, c.imageVector, nil)
+	operation, err := operation.New(shoot, &config.ControllerManagerConfiguration{}, shootLogger, c.k8sGardenClient, c.k8sGardenInformers, c.identity, c.secrets, c.imageVector, nil)
 	if err != nil {
 		handleError(fmt.Sprintf("Could not initialize a new operation: %s", err.Error()))
 		return nil

--- a/pkg/operation/types.go
+++ b/pkg/operation/types.go
@@ -39,6 +39,7 @@ import (
 
 // Operation contains all data required to perform an operation on a Shoot cluster.
 type Operation struct {
+	Config                    *config.ControllerManagerConfiguration
 	Logger                    *logrus.Entry
 	GardenerInfo              *gardenv1beta1.Gardener
 	Secrets                   map[string]*corev1.Secret

--- a/test/integration/framework/garden_operation.go
+++ b/test/integration/framework/garden_operation.go
@@ -104,9 +104,11 @@ func NewGardenTestOperation(ctx context.Context, k8sGardenClient kubernetes.Inte
 		}
 
 		seedSecretRef := seed.Spec.SecretRef
-		seedClient, err = kubernetes.NewClientFromSecret(k8sGardenClient, seedSecretRef.Namespace, seedSecretRef.Name, client.Options{
-			Scheme: kubernetes.SeedScheme,
-		})
+		seedClient, err = kubernetes.NewClientFromSecret(k8sGardenClient, seedSecretRef.Namespace, seedSecretRef.Name, kubernetes.WithClientOptions(
+			client.Options{
+				Scheme: kubernetes.SeedScheme,
+			}),
+		)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not construct Seed client")
 		}
@@ -122,9 +124,11 @@ func NewGardenTestOperation(ctx context.Context, k8sGardenClient kubernetes.Inte
 		if err != nil {
 			return nil, errors.Wrap(err, "could not add schemes to shoot scheme")
 		}
-		shootClient, err = kubernetes.NewClientFromSecret(seedClient, shootop.ComputeTechnicalID(project.Name, shoot), v1beta1.GardenerName, client.Options{
-			Scheme: shootScheme,
-		})
+		shootClient, err = kubernetes.NewClientFromSecret(seedClient, shootop.ComputeTechnicalID(project.Name, shoot), v1beta1.GardenerName, kubernetes.WithClientOptions(
+			client.Options{
+				Scheme: shootScheme,
+			}),
+		)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not construct Shoot client")
 		}

--- a/test/integration/framework/plant_operations.go
+++ b/test/integration/framework/plant_operations.go
@@ -23,7 +23,7 @@ import (
 
 	"k8s.io/client-go/util/retry"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 
@@ -47,9 +47,11 @@ func NewPlantTest(kubeconfig string, kubeconfigPathExternalCluster string, plant
 		return nil, fmt.Errorf("Please specify the kubeconfig path for the external cluster correctly")
 	}
 
-	k8sGardenClient, err := kubernetes.NewClientFromFile("", kubeconfig, client.Options{
-		Scheme: kubernetes.GardenScheme,
-	})
+	k8sGardenClient, err := kubernetes.NewClientFromFile("", kubeconfig, kubernetes.WithClientOptions(
+		client.Options{
+			Scheme: kubernetes.GardenScheme,
+		}),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/framework/scheduler_operations.go
+++ b/test/integration/framework/scheduler_operations.go
@@ -17,13 +17,14 @@ package framework
 import (
 	"context"
 	"fmt"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"time"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 
 	"github.com/gardener/gardener/pkg/utils/retry"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,9 +43,11 @@ const configurationFileName = "schedulerconfiguration.yaml"
 
 // NewGardenSchedulerTest creates a new SchedulerGardenerTest by retrieving the ConfigMap containing the Scheduler Configuration & parsing the Scheduler Configuration
 func NewGardenSchedulerTest(ctx context.Context, shootGardenTest *ShootGardenerTest, hostKubeconfigPath string) (*SchedulerGardenerTest, error) {
-	k8sHostClient, err := kubernetes.NewClientFromFile("", hostKubeconfigPath, client.Options{
-		Scheme: kubernetes.ShootScheme,
-	})
+	k8sHostClient, err := kubernetes.NewClientFromFile("", hostKubeconfigPath, kubernetes.WithClientOptions(
+		client.Options{
+			Scheme: kubernetes.ShootScheme,
+		}),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/framework/shoot_operations.go
+++ b/test/integration/framework/shoot_operations.go
@@ -39,9 +39,11 @@ func NewShootGardenerTest(kubeconfig string, shoot *v1beta1.Shoot, logger *logru
 		return nil, fmt.Errorf("please specify the kubeconfig path correctly")
 	}
 
-	k8sGardenClient, err := kubernetes.NewClientFromFile("", kubeconfig, client.Options{
-		Scheme: kubernetes.GardenScheme,
-	})
+	k8sGardenClient, err := kubernetes.NewClientFromFile("", kubeconfig, kubernetes.WithClientOptions(
+		client.Options{
+			Scheme: kubernetes.GardenScheme,
+		}),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/framework/utils.go
+++ b/test/integration/framework/utils.go
@@ -276,9 +276,13 @@ func NewClientFromServiceAccount(ctx context.Context, k8sClient kubernetes.Inter
 		BearerToken: string(secret.Data["token"]),
 	}
 
-	return kubernetes.NewForConfig(serviceAccountConfig, client.Options{
-		Scheme: kubernetes.GardenScheme,
-	})
+	return kubernetes.NewWithConfig(
+		kubernetes.WithRESTConfig(serviceAccountConfig),
+		kubernetes.WithClientOptions(
+			client.Options{
+				Scheme: kubernetes.GardenScheme,
+			}),
+	)
 }
 
 // GetDeploymentReplicas gets the spec.Replicas count from a deployment

--- a/test/integration/gardener/rbac/gardener_rbac_test.go
+++ b/test/integration/gardener/rbac/gardener_rbac_test.go
@@ -17,9 +17,10 @@ package gardener_rbac_test
 import (
 	"context"
 	"flag"
+	"time"
+
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils/retry"
-	"time"
 
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/test/integration/framework"
@@ -72,9 +73,11 @@ var _ = Describe("RBAC testing", func() {
 		validateFlags()
 
 		var err error
-		gardenClient, err = kubernetes.NewClientFromFile("", *kubeconfigPath, client.Options{
-			Scheme: kubernetes.GardenScheme,
-		})
+		gardenClient, err = kubernetes.NewClientFromFile("", *kubeconfigPath, kubernetes.WithClientOptions(
+			client.Options{
+				Scheme: kubernetes.GardenScheme,
+			}),
+		)
 		Expect(err).ToNot(HaveOccurred())
 
 		testLogger := logger.AddWriter(logger.NewLogger(*logLevel), GinkgoWriter)

--- a/test/integration/gardener/reconcile/gardener_reconcile_test.go
+++ b/test/integration/gardener/reconcile/gardener_reconcile_test.go
@@ -74,9 +74,11 @@ var _ = Describe("Shoot reconciliation testing", func() {
 		testLogger = logger.AddWriter(logger.NewLogger(*logLevel), GinkgoWriter)
 
 		var err error
-		gardenClient, err = kubernetes.NewClientFromFile("", *kubeconfigPath, client.Options{
-			Scheme: kubernetes.GardenScheme,
-		})
+		gardenClient, err = kubernetes.NewClientFromFile("", *kubeconfigPath, kubernetes.WithClientOptions(
+			client.Options{
+				Scheme: kubernetes.GardenScheme,
+			}),
+		)
 		Expect(err).ToNot(HaveOccurred())
 
 		gardenerTestOperation, err = framework.NewGardenTestOperation(ctx, gardenClient, testLogger, nil)

--- a/test/integration/seeds/logging/seed_log_test.go
+++ b/test/integration/seeds/logging/seed_log_test.go
@@ -101,9 +101,11 @@ var _ = Describe("Seed logging testing", func() {
 		validateFlags()
 
 		seedLogTestLogger = logger.AddWriter(logger.NewLogger(*logLevel), GinkgoWriter)
-		k8sGardenClient, err := kubernetes.NewClientFromFile("", *kubeconfig, client.Options{
-			Scheme: kubernetes.GardenScheme,
-		})
+		k8sGardenClient, err := kubernetes.NewClientFromFile("", *kubeconfig, kubernetes.WithClientOptions(
+			client.Options{
+				Scheme: kubernetes.GardenScheme,
+			}),
+		)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Checks whether required logging resources are present.
@@ -142,7 +144,7 @@ var _ = Describe("Seed logging testing", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			seedSecretRef := seed.Spec.SecretRef
-			seedClient, err := kubernetes.NewClientFromSecret(k8sGardenClient, seedSecretRef.Namespace, seedSecretRef.Name, client.Options{})
+			seedClient, err := kubernetes.NewClientFromSecret(k8sGardenClient, seedSecretRef.Namespace, seedSecretRef.Name)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking for required logging resources")


### PR DESCRIPTION
**What this PR does / why we need it**:
The `Gardener-Controller-Manager` allows to configure client [connection settings](https://github.com/gardener/gardener/blob/5f600a587269dc0443ce13850f6ea5d1a10e79c4/example/20-componentconfig-gardener-controller-manager.yaml#L5-L8) like `qps` and `burst` which can improve the performance of k8s clients massively. This PR propagates those settings also to the `shoot` and `seed` k8s clients used by the controller-manager.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Client connection settings for the `gardener-controller-manager` are now being propagated to every Kubernetes client used by Gardener. This improves the overall performance of the system, especially for `ControllerInstallation`, `Seed`, and `Shoot` reconciliations.
```
