### PR TITLE
Fix false positive Etcd alert

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
@@ -22,15 +22,15 @@ tests:
   - series: 'etcd_server_proposals_failed_total{job="kube-etcd3", pod="etcd"}'
     values: '0+1x81 81+0x39'
   # KubeEtcdDeltaBackupFailed
-  - series: 'etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",role="main",kind="Incr"}'
-    values: '0+1x30'
-  - series: 'etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",kind="Incr",succeeded="true"}'
-    values: '0+0x30'
+  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore",role="main",kind="Incr"}'
+    values: '0+0x62'
+  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore",role="main",kind="Incr"}'
+    values: '1+0x62'
   # KubeEtcdFullBackupFailed
-  - series: 'etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",role="main",kind="Full"}'
-    values: '0+1x3000'
-  - series: 'etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",kind="Full",succeeded="true"}'
-    values: '0+0x3000'
+  - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore",role="main",kind="Full"}'
+    values: '0+0x2912'
+  - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore",role="main",kind="Full"}'
+    values: '1+0x2912'
   alert_rule_test:
   - eval_time: 5m
     alertname: KubeEtcdMainDown
@@ -89,31 +89,31 @@ tests:
       exp_annotations:
         description: Etcd3 pod etcd has seen 81 proposal failures within the last hour.
         summary: High number of failed etcd proposals
-  - eval_time: 15m
+  - eval_time: 31m
     alertname: KubeEtcdDeltaBackupFailed
     exp_alerts:
     - exp_labels:
+        job: kube-etcd3-backup-restore
+        kind: Incr
+        role: main
         service: etcd
         severity: critical
         type: seed
-        role: main
-        kind: Incr
-        job: kube-etcd3-backup-restore  
         visibility: operator
       exp_annotations:
-        description: No delta snapshot for the past 15 minutes.
-        summary: Etcd delta snapshot failure.     
-  - eval_time: 1455m
+        description: No delta snapshot for the past at least 30 minutes.
+        summary: Etcd delta snapshot failure.
+  - eval_time: 1456m
     alertname: KubeEtcdFullBackupFailed
     exp_alerts:
     - exp_labels:
+        job: kube-etcd3-backup-restore
+        kind: Full
+        role: main
         service: etcd
         severity: critical
         type: seed
-        role: main
         visibility: operator
-        kind: Full
-        job: kube-etcd3-backup-restore
       exp_annotations:
-        description: No full snapshot for the past 24 hours 15minutes.
-        summary: Etcd full snapshot failure.     
+        description: No full snapshot taken in the past day.
+        summary: Etcd full snapshot failure.

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -65,30 +65,32 @@ groups:
       description: Etcd3 pod {{ $labels.pod }} has seen {{ $value }} proposal failures
         within the last hour.
       summary: High number of failed etcd proposals
-  
+
   - record: shoot:etcd_object_counts:sum_by_resource
     expr: sum(etcd_object_counts) by (resource)
-  
+
   # etcd backup failure alerts
   - alert: KubeEtcdDeltaBackupFailed
-    expr: changes(etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",role="main",kind="Incr"}[15m]) >= 1 and ON(job,role,kind) changes(etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",kind="Incr",succeeded="true"}[15m]) < 1
+    expr: (time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore",kind="Incr",role="main"} > bool 900) + (etcdbr_snapshot_required{kind="Incr", role="main"} >= bool 1) == 2
+    for: 15m
     labels:
       service: etcd
       severity: critical
       type: seed
       visibility: operator
     annotations:
-      description: No delta snapshot for the past 15 minutes.
+      description: No delta snapshot for the past at least 30 minutes.
       summary: Etcd delta snapshot failure.
   - alert: KubeEtcdFullBackupFailed
-    expr: changes(etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",role="main",kind="Full"}[1455m]) >= 1 and ON(job,role,kind) changes(etcdbr_snapshot_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",kind="Full",succeeded="true"}[1455m]) < 1
+    expr: (time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore",kind="Full",role="main"} > bool 86400) + (etcdbr_snapshot_required{kind="Full", role="main"} >= bool 1) == 2
+    for: 15m
     labels:
         service: etcd
         severity: critical
         type: seed
         visibility: operator
     annotations:
-        description: No full snapshot for the past 24 hours 15minutes.
+        description: No full snapshot taken in the past day.
         summary: Etcd full snapshot failure.
 
-  
+

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -103,23 +103,24 @@ allowedMetrics:
   - process_open_fds
   - process_resident_memory_bytes
   kubeETCD3BR:
-  - etcdbr_snapshot_gc_total
-  - etcdbr_snapshot_latest_revision
-  - etcdbr_snapshot_latest_timestamp
-  - etcdbr_snapshot_duration_seconds_bucket
-  - etcdbr_snapshot_duration_seconds_count
-  - etcdbr_snapshot_duration_seconds_sum
-  - etcdbr_validation_duration_seconds_bucket
-  - etcdbr_validation_duration_seconds_count
-  - etcdbr_validation_duration_seconds_sum
-  - etcdbr_restoration_duration_seconds_bucket
-  - etcdbr_restoration_duration_seconds_count
-  - etcdbr_restoration_duration_seconds_sum
   - etcdbr_defragmentation_duration_seconds_bucket
   - etcdbr_defragmentation_duration_seconds_count
   - etcdbr_defragmentation_duration_seconds_sum
-  - etcdbr_network_transmitted_bytes
   - etcdbr_network_received_bytes
+  - etcdbr_network_transmitted_bytes
+  - etcdbr_restoration_duration_seconds_bucket
+  - etcdbr_restoration_duration_seconds_count
+  - etcdbr_restoration_duration_seconds_sum
+  - etcdbr_snapshot_duration_seconds_bucket
+  - etcdbr_snapshot_duration_seconds_count
+  - etcdbr_snapshot_duration_seconds_sum
+  - etcdbr_snapshot_gc_total
+  - etcdbr_snapshot_latest_revision
+  - etcdbr_snapshot_latest_timestamp
+  - etcdbr_snapshot_required
+  - etcdbr_validation_duration_seconds_bucket
+  - etcdbr_validation_duration_seconds_count
+  - etcdbr_validation_duration_seconds_sum
   - process_resident_memory_bytes
   kubeScheduler:
   - scheduler_binding_latency_microseconds_bucket


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the false positive alert `KubeEtcdFullBackupFailed`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @PadmaB @shreyas-s-rao 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
The false positive `KubeEtcdFullBackupFailed` alert has been fixed. This requires at least version [0.12.0](https://github.com/gardener/gardener-extensions/releases/tag/0.12.0) of the `gardener-extensions` (containing [0.7.3](https://github.com/gardener/etcd-backup-restore/releases/tag/0.7.3) of `etcd-backup-restore`).
```