### PR TITLE
Add state dump to create and delete shoot

### DIFF
--- a/test/integration/gardener/rbac/gardener_rbac_test.go
+++ b/test/integration/gardener/rbac/gardener_rbac_test.go
@@ -81,7 +81,7 @@ var _ = Describe("RBAC testing", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		testLogger := logger.AddWriter(logger.NewLogger(*logLevel), GinkgoWriter)
-		gardenerTestOperation, err = framework.NewGardenTestOperation(ctx, gardenClient, testLogger, nil)
+		gardenerTestOperation, err = framework.NewGardenTestOperation(ctx, gardenClient, testLogger)
 		Expect(err).ToNot(HaveOccurred())
 
 	}, InitializationTimeout)

--- a/test/integration/gardener/reconcile/gardener_reconcile_test.go
+++ b/test/integration/gardener/reconcile/gardener_reconcile_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Shoot reconciliation testing", func() {
 		)
 		Expect(err).ToNot(HaveOccurred())
 
-		gardenerTestOperation, err = framework.NewGardenTestOperation(ctx, gardenClient, testLogger, nil)
+		gardenerTestOperation, err = framework.NewGardenTestOperation(ctx, gardenClient, testLogger)
 		Expect(err).ToNot(HaveOccurred())
 
 	}, InitializationTimeout)

--- a/test/integration/plants/plant_test.go
+++ b/test/integration/plants/plant_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Plant testing", func() {
 			plantTest, err = NewPlantTest(*kubeconfigPath, *kubeconfigPathExternalCluster, plantObject, plantTestLogger)
 			Expect(err).NotTo(HaveOccurred())
 
-			gardenerTestOperation, err = NewGardenTestOperation(ctx, plantTest.GardenClient, plantTestLogger, nil)
+			gardenerTestOperation, err = NewGardenTestOperation(ctx, plantTest.GardenClient, plantTestLogger)
 			Expect(err).ToNot(HaveOccurred())
 		}
 

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Scheduler testing", func() {
 		Expect(err).NotTo(HaveOccurred())
 		schedulerGardenerTest.ShootGardenerTest.Shoot.Namespace = *schedulerTestNamespace
 
-		gardenerTestOperation, err = NewGardenTestOperation(ctx, schedulerGardenerTest.ShootGardenerTest.GardenClient, schedulerOperationsTestLogger, nil)
+		gardenerTestOperation, err = NewGardenTestOperationWithShoot(ctx, schedulerGardenerTest.ShootGardenerTest.GardenClient, schedulerOperationsTestLogger, nil)
 		Expect(err).ToNot(HaveOccurred())
 	}, InitializationTimeout)
 

--- a/test/integration/seeds/logging/seed_log_test.go
+++ b/test/integration/seeds/logging/seed_log_test.go
@@ -156,13 +156,13 @@ var _ = Describe("Seed logging testing", func() {
 			targetTestShoot, err := shootGardenerTest.CreateShoot(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
-			gardenTestOperation, err = NewGardenTestOperation(ctx, shootGardenerTest.GardenClient, seedLogTestLogger, targetTestShoot)
+			gardenTestOperation, err = NewGardenTestOperationWithShoot(ctx, shootGardenerTest.GardenClient, seedLogTestLogger, targetTestShoot)
 			Expect(err).NotTo(HaveOccurred())
 		}
 
 		if StringSet(*shootName) {
 			shoot := &v1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Namespace: *shootNamespace, Name: *shootName}}
-			gardenTestOperation, err = NewGardenTestOperation(ctx, k8sGardenClient, seedLogTestLogger, shoot)
+			gardenTestOperation, err = NewGardenTestOperationWithShoot(ctx, k8sGardenClient, seedLogTestLogger, shoot)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking for required logging resources")

--- a/test/integration/shoots/applications/shoot_app_test.go
+++ b/test/integration/shoots/applications/shoot_app_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Shoot application testing", func() {
 			targetTestShoot, err = shootGardenerTest.CreateShoot(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
-			shootTestOperations, err = NewGardenTestOperation(ctx, shootGardenerTest.GardenClient, shootAppTestLogger, targetTestShoot)
+			shootTestOperations, err = NewGardenTestOperationWithShoot(ctx, shootGardenerTest.GardenClient, shootAppTestLogger, targetTestShoot)
 			Expect(err).NotTo(HaveOccurred())
 		}
 
@@ -145,7 +145,7 @@ var _ = Describe("Shoot application testing", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			shoot := &v1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Namespace: *shootNamespace, Name: *shootName}}
-			shootTestOperations, err = NewGardenTestOperation(ctx, shootGardenerTest.GardenClient, shootAppTestLogger, shoot)
+			shootTestOperations, err = NewGardenTestOperationWithShoot(ctx, shootGardenerTest.GardenClient, shootAppTestLogger, shoot)
 			Expect(err).NotTo(HaveOccurred())
 		}
 		var err error

--- a/test/integration/shoots/ts/shoot_app_test.go
+++ b/test/integration/shoots/ts/shoot_app_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Shoot application testing", func() {
 			targetTestShoot, err = shootGardenerTest.CreateShoot(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
-			shootTestOperations, err = NewGardenTestOperation(ctx, shootGardenerTest.GardenClient, shootAppTestLogger, targetTestShoot)
+			shootTestOperations, err = NewGardenTestOperationWithShoot(ctx, shootGardenerTest.GardenClient, shootAppTestLogger, targetTestShoot)
 			Expect(err).NotTo(HaveOccurred())
 		}
 
@@ -144,7 +144,7 @@ var _ = Describe("Shoot application testing", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			shoot := &v1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Namespace: *shootNamespace, Name: *shootName}}
-			shootTestOperations, err = NewGardenTestOperation(ctx, shootGardenerTest.GardenClient, shootAppTestLogger, shoot)
+			shootTestOperations, err = NewGardenTestOperationWithShoot(ctx, shootGardenerTest.GardenClient, shootAppTestLogger, shoot)
 			Expect(err).NotTo(HaveOccurred())
 		}
 		var err error

--- a/test/integration/shoots/update/shoot_update_test.go
+++ b/test/integration/shoots/update/shoot_update_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Shoot update testing", func() {
 			targetTestShoot, err := shootGardenerTest.CreateShoot(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
-			shootTestOperations, err = NewGardenTestOperation(ctx, shootGardenerTest.GardenClient, shootTestLogger, targetTestShoot)
+			shootTestOperations, err = NewGardenTestOperationWithShoot(ctx, shootGardenerTest.GardenClient, shootTestLogger, targetTestShoot)
 			Expect(err).NotTo(HaveOccurred())
 		}
 
@@ -108,7 +108,7 @@ var _ = Describe("Shoot update testing", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			shoot := &v1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Namespace: *shootNamespace, Name: *shootName}}
-			shootTestOperations, err = NewGardenTestOperation(ctx, shootGardenerTest.GardenClient, shootTestLogger, shoot)
+			shootTestOperations, err = NewGardenTestOperationWithShoot(ctx, shootGardenerTest.GardenClient, shootTestLogger, shoot)
 			Expect(err).NotTo(HaveOccurred())
 		}
 

--- a/test/integration/shoots/worker/worker_test.go
+++ b/test/integration/shoots/worker/worker_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Worker Suite", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}
 
-		gardenTestOperation, err = NewGardenTestOperation(ctx, shootGardenerTest.GardenClient, workerTestLogger, shoot)
+		gardenTestOperation, err = NewGardenTestOperationWithShoot(ctx, shootGardenerTest.GardenClient, workerTestLogger, shoot)
 		Expect(err).NotTo(HaveOccurred())
 
 		workerGardenerTest, err = NewWorkerGardenerTest(ctx, shootGardenerTest, gardenTestOperation.ShootClient)


### PR DESCRIPTION
**What this PR does / why we need it**:
Add state dump to `create-shoot` and `delete-shoot`.
The `delete-shoot` test prints the dump also when it runs as cleanup test (`os.Getenv("TM_PHASE") == "Exit"`).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
