### PR TITLE
Remove backup infrastructure mitigation from tests

### DIFF
--- a/.test-defs/cmd/create-shoot/main.go
+++ b/.test-defs/cmd/create-shoot/main.go
@@ -17,9 +17,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/ghodss/yaml"
 	"os"
 	"strconv"
+
+	"github.com/ghodss/yaml"
 
 	helper "github.com/gardener/gardener/.test-defs/cmd"
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
@@ -173,15 +174,6 @@ func main() {
 
 	if err := gardenerTestOperation.AddShoot(ctx, shootObject); err != nil {
 		testLogger.Fatalf("Cannot add shoot %s to test operation: %s", shootName, err.Error())
-	}
-
-	backupInfrastructure, err := helper.GetBackupInfrastructureOfShoot(ctx, shootGardenerTest, shootObject)
-	if err != nil {
-		testLogger.Fatal(err)
-	}
-	helper.UpdateBackupInfrastructureAnnotations(backupInfrastructure)
-	if err := shootGardenerTest.GardenClient.Client().Update(ctx, backupInfrastructure); err != nil {
-		testLogger.Fatalf("Cannot update annotation of backupinfrastructure %s: %s", backupInfrastructure.Name, err.Error())
 	}
 
 	err = gardenerTestOperation.DownloadKubeconfig(ctx, gardenerTestOperation.SeedClient, gardenerTestOperation.ShootSeedNamespace(), gardenv1beta1.GardenerName, fmt.Sprintf("%s/shoot.config", kubeconfigPath))

--- a/.test-defs/cmd/helper.go
+++ b/.test-defs/cmd/helper.go
@@ -15,13 +15,10 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/operation/common"
-	"github.com/gardener/gardener/test/integration/framework"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // UpdateWorkerZone updates the zone of the workers.
@@ -162,27 +159,4 @@ func UpdateAnnotations(shoot *gardenv1beta1.Shoot) {
 		shoot.Annotations = map[string]string{}
 	}
 	shoot.Annotations[common.GardenIgnoreAlerts] = "true"
-}
-
-// UpdateBackupInfrastructureAnnotations adds default annotations that should be present on any backupinfrastructure created.
-func UpdateBackupInfrastructureAnnotations(backup *gardenv1beta1.BackupInfrastructure) {
-	if backup.Annotations == nil {
-		backup.Annotations = map[string]string{}
-	}
-	backup.Annotations[common.BackupInfrastructureForceDeletion] = "true"
-}
-
-// GetBackupInfrastructureOfShoot returns the BackupInfrastructure object of the shoot
-func GetBackupInfrastructureOfShoot(ctx context.Context, shootGardenerTest *framework.ShootGardenerTest, shootObject *gardenv1beta1.Shoot) (*gardenv1beta1.BackupInfrastructure, error) {
-	backups := &gardenv1beta1.BackupInfrastructureList{}
-	err := shootGardenerTest.GardenClient.Client().List(ctx, backups, client.InNamespace(shootObject.Namespace))
-	if err != nil {
-		return nil, err
-	}
-	for _, backup := range backups.Items {
-		if backup.Spec.ShootUID == shootObject.GetUID() {
-			return &backup, nil
-		}
-	}
-	return nil, fmt.Errorf("cannot find backup infrastructure for shoot with uid %s", shootObject.GetUID())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove backup infrastructure mitigation due to removal of in-tree support (https://github.com/gardener/gardener/pull/1128)
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@swapnilgm as we now have shared backup buckets we do not need to adjust this mitigation to the new extensions?
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
