### PR TITLE
Fix backup bucket reconciliation

### DIFF
--- a/charts/gardener/charts/runtime/templates/controller-manager/configmap-componentconfig.yaml
+++ b/charts/gardener/charts/runtime/templates/controller-manager/configmap-componentconfig.yaml
@@ -112,10 +112,8 @@ data:
         {{- end }}
       backupBucket:
         concurrentSyncs: {{ required ".Values.global.controller.config.controllers.backupBucket.concurrentSyncs is required" .Values.global.controller.config.controllers.backupBucket.concurrentSyncs }}
-        syncPeriod: {{ required ".Values.global.controller.config.controllers.backupBucket.syncPeriod is required" .Values.global.controller.config.controllers.backupBucket.syncPeriod }}
       backupEntry:
         concurrentSyncs: {{ required ".Values.global.controller.config.controllers.backupEntry.concurrentSyncs is required" .Values.global.controller.config.controllers.backupEntry.concurrentSyncs }}
-        syncPeriod: {{ required ".Values.global.controller.config.controllers.backupEntry.syncPeriod is required" .Values.global.controller.config.controllers.backupEntry.syncPeriod }}
         {{- if .Values.global.controller.config.controllers.backupEntry.deletionGracePeriodHours }}
         deletionGracePeriodHours: {{ .Values.global.controller.config.controllers.backupEntry.deletionGracePeriodHours }}
         {{- end }}

--- a/charts/gardener/values.yaml
+++ b/charts/gardener/values.yaml
@@ -197,10 +197,8 @@ global:
           syncPeriod: 24h
         backupBucket:
           concurrentSyncs: 20
-          syncPeriod: 10m
         backupEntry:
           concurrentSyncs: 20
-          syncPeriod: 10m
           deletionGracePeriodHours: 0
         seed:
           concurrentSyncs: 5

--- a/cmd/utils/miscellaneous.go
+++ b/cmd/utils/miscellaneous.go
@@ -16,7 +16,11 @@ package utils
 
 import (
 	"context"
+
+	coreinstall "github.com/gardener/gardener/pkg/apis/core/install"
+	gardeninstall "github.com/gardener/gardener/pkg/apis/garden/install"
 	"github.com/gardener/gardener/pkg/logger"
+
 	corev1 "k8s.io/api/core/v1"
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -26,10 +30,14 @@ import (
 
 // CreateRecorder creates a record.EventRecorder that is not limited to a namespace having a specific eventSourceName
 func CreateRecorder(kubeClient k8s.Interface, eventSourceName string) record.EventRecorder {
+	scheme := scheme.Scheme
+	gardeninstall.Install(scheme)
+	coreinstall.Install(scheme)
+
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(logger.Logger.Debugf)
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: typedcorev1.New(kubeClient.CoreV1().RESTClient()).Events("")})
-	return eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: eventSourceName})
+	return eventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: eventSourceName})
 }
 
 // ContextFromStopChannel creates a new context from a given stop channel.

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -49,10 +49,8 @@ controllers:
     deletionGracePeriodHours: 0
   backupBucket:
     concurrentSyncs: 20
-    syncPeriod: 10m
   backupEntry:
     concurrentSyncs: 20
-    syncPeriod: 10m
     deletionGracePeriodHours: 0
 leaderElection:
   leaderElect: true

--- a/pkg/controllermanager/controller/backupbucket/backup_bucket_reconciler.go
+++ b/pkg/controllermanager/controller/backupbucket/backup_bucket_reconciler.go
@@ -133,11 +133,6 @@ func (r *reconciler) reconcileBackupBucket(backupBucket *gardencorev1alpha1.Back
 		return reconcile.Result{}, updateErr
 	}
 
-	if updateErr := controllerutils.RemoveGardenerOperationAnnotation(r.ctx, retry.DefaultBackoff, r.client, backupBucket); updateErr != nil {
-		backupBucketLogger.Errorf("Could not remove %q annotation: %+v", gardencorev1alpha1.GardenerOperation, updateErr)
-		return reconcile.Result{}, updateErr
-	}
-
 	return reconcile.Result{}, nil
 }
 
@@ -209,7 +204,7 @@ func (r *reconciler) deleteBackupBucket(backupBucket *gardencorev1alpha1.BackupB
 	}
 
 	if err := controllerutils.RemoveFinalizer(r.ctx, r.client, secret, gardenv1beta1.ExternalGardenerName); err != nil {
-		backupBucketLogger.Errorf("Failed to ensure external gardener finalizer on referred secret: %+v", err)
+		backupBucketLogger.Errorf("Failed to remove external gardener finalizer on referred secret: %+v", err)
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controllermanager/controller/controllerregistration/seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed_control.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
-	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1alpha1"
@@ -29,19 +27,13 @@ import (
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	controllerutils "github.com/gardener/gardener/pkg/controllermanager/controller/utils"
 	"github.com/gardener/gardener/pkg/logger"
-	"github.com/gardener/gardener/pkg/operation/common"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/retry"
-	"github.com/sirupsen/logrus"
 
 	multierror "github.com/hashicorp/go-multierror"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (c *Controller) seedAdd(obj interface{}) {
@@ -141,12 +133,6 @@ func (c *defaultSeedControl) Reconcile(obj *gardenv1beta1.Seed) error {
 	}
 
 	if seed.DeletionTimestamp != nil {
-		if seed.Spec.Backup != nil {
-			if err := waitUntilBackupBucketDeleted(ctx, c.k8sGardenClient.Client(), seed, logger); err != nil {
-				return err
-			}
-		}
-
 		controllerInstallationList, err := c.controllerInstallationLister.List(labels.Everything())
 		if err != nil {
 			return err
@@ -162,39 +148,6 @@ func (c *defaultSeedControl) Reconcile(obj *gardenv1beta1.Seed) error {
 			logger.Errorf("Could not update the Seed specification: %s", err.Error())
 			return err
 		}
-	}
-
-	return nil
-}
-
-// waitUntilBackupBucketDeleted waits until backup bucket extension resource is deleted in gardener cluster.
-func waitUntilBackupBucketDeleted(ctx context.Context, gardenClient client.Client, seed *gardenv1beta1.Seed, logger *logrus.Entry) error {
-	var lastError *gardencorev1alpha1.LastError
-
-	if err := retry.UntilTimeout(ctx, time.Second, 30*time.Second, func(ctx context.Context) (bool, error) {
-		backupBucketName := string(seed.UID)
-		bb := &gardencorev1alpha1.BackupBucket{}
-
-		if err := gardenClient.Get(ctx, kutil.Key(backupBucketName), bb); err != nil {
-			if apierrors.IsNotFound(err) {
-				return retry.Ok()
-			}
-			return retry.SevereError(err)
-		}
-
-		if lastErr := bb.Status.LastError; lastErr != nil {
-			logger.Errorf("BackupBucket did not get deleted yet, lastError is: %s", lastErr.Description)
-			lastError = lastErr
-		}
-
-		logger.Infof("Waiting for backupBucket to be deleted...")
-		return retry.MinorError(common.WrapWithLastError(fmt.Errorf("worker is still present"), lastError))
-	}); err != nil {
-		message := fmt.Sprintf("Error while waiting for backupBucket object to be deleted")
-		if lastError != nil {
-			return gardencorev1alpha1helper.DetermineError(fmt.Sprintf("%s: %s", message, lastError.Description))
-		}
-		return gardencorev1alpha1helper.DetermineError(fmt.Sprintf("%s: %s", message, err.Error()))
 	}
 
 	return nil

--- a/pkg/controllermanager/controller/utils/finalizers.go
+++ b/pkg/controllermanager/controller/utils/finalizers.go
@@ -54,7 +54,7 @@ func RemoveFinalizer(ctx context.Context, c client.Client, obj kutil.Object, fin
 		finalizers.Delete(finalizer)
 		obj.SetFinalizers(finalizers.UnsortedList())
 		return nil
-	}); err != nil {
+	}); client.IgnoreNotFound(err) != nil {
 		return fmt.Errorf("could not remove %q finalizer: %+v", finalizer, err)
 	}
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -536,10 +536,7 @@ func (b *Botanist) DeployBackupEntryInGarden(ctx context.Context) error {
 	ownerRef.BlockOwnerDeletion = &blockOwnerDeletion
 
 	return kutil.CreateOrUpdate(ctx, b.K8sGardenClient.Client(), backupEntry, func() error {
-		if backupEntry.ObjectMeta.Annotations == nil {
-			backupEntry.ObjectMeta.Annotations = map[string]string{}
-		}
-		backupEntry.ObjectMeta.Annotations[gardencorev1alpha1.GardenerOperation] = gardencorev1alpha1.GardenerOperationReconcile
+		metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, gardencorev1alpha1.GardenerOperation, gardencorev1alpha1.GardenerOperationReconcile)
 		finalizers := sets.NewString(backupEntry.GetFinalizers()...)
 		finalizers.Insert(gardenv1beta1.GardenerName)
 		backupEntry.SetFinalizers(finalizers.UnsortedList())


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
This PR fixed removes the backup bucket reconciliation on every seed reconciliation. To reconcile backup bucket out of default schedule one has to manually put reconciliation annotation.
Also, it transfer the responsibility on 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
