### PR TITLE
Add backupProvider label on seednamespace even if backup is not configured in seed

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -65,6 +65,7 @@ func (b *Botanist) DeployNamespace(ctx context.Context) error {
 			gardencorev1alpha1.LabelSeedProvider:       string(b.Seed.CloudProvider),
 			gardencorev1alpha1.LabelShootProvider:      string(b.Shoot.CloudProvider),
 			gardencorev1alpha1.LabelNetworkingProvider: string(b.Shoot.Info.Spec.Networking.Type),
+			gardencorev1alpha1.LabelBackupProvider:     string(b.Seed.CloudProvider),
 		}
 
 		if b.Seed.Info.Spec.Backup != nil {


### PR DESCRIPTION


Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
