### PR TITLE
Ignore err if the shoot cannot be added

### DIFF
--- a/.test-defs/cmd/delete-shoot/main.go
+++ b/.test-defs/cmd/delete-shoot/main.go
@@ -61,9 +61,12 @@ func main() {
 	if err != nil {
 		testLogger.Fatalf("Cannot create ShootGardenerTest %s", err.Error())
 	}
-	gardenerTestOperations, err := framework.NewGardenTestOperationWithShoot(ctx, shootGardenerTest.GardenClient, testLogger, shoot)
+	gardenerTestOperations, err := framework.NewGardenTestOperation(ctx, shootGardenerTest.GardenClient, testLogger)
 	if err != nil {
 		testLogger.Fatalf("Cannot create gardener test  %s: %s", shootName, err.Error())
+	}
+	if err := gardenerTestOperations.AddShoot(ctx, shoot); err != nil {
+		testLogger.Warnf("Cannot add shoot: %s", err.Error())
 	}
 
 	// Dump gardener state if delete shoot is in exit handler


### PR DESCRIPTION
**What this PR does / why we need it**:
If the shoot cannot be added to the operations framework for some reason(already cleared, unable to initialize kubernetes client, etc.) this error is ignored and the shoot deletion will proceed.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
