### PR TITLE
Enable balance-similar-node-groups flag in cluster-autoscaler

### DIFF
--- a/charts/seed-controlplane/charts/cluster-autoscaler/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/cluster-autoscaler/templates/deployment.yaml
@@ -50,6 +50,7 @@ spec:
         - --skip-nodes-with-local-storage=false
         - --expander=least-waste
         - --expendable-pods-priority-cutoff=-10
+        - --balance-similar-node-groups=true
         {{- range $key, $flag := .Values.flags }}
         - --{{ $flag.name }}={{ $flag.value }}
         {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**: This PR enables the `--balance-similar-node-groups` flag in cluster-autoscaler. Refer to the [issue](https://github.com/gardener/machine-controller-manager/issues/234) for more info.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Cluster Autoscaler now balances similar worker-groups while scaling-up. Similar worker-groups are defined as those having nodes with the same resource capacities and exactly the same labels. Refer [doc](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#im-running-cluster-with-nodes-in-multiple-zones-for-ha-purposes-is-that-supported-by-cluster-autoscaler) for more info. 
```
