### PR TITLE
Secret for global prom

### DIFF
--- a/charts/seed-bootstrap/templates/aggregate-prometheus/ingress-auth-secret.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/ingress-auth-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aggregate-prometheus-basic-auth
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  auth: {{ .Values.ingress.basicAuthSecret }}

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/ingress.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/ingress.yaml
@@ -4,20 +4,20 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
-    nginx.ingress.kubernetes.io/auth-secret: grafana-basic-auth
+    nginx.ingress.kubernetes.io/auth-secret: aggregate-prometheus-basic-auth
     nginx.ingress.kubernetes.io/auth-type: basic
-  name: grafana
+  name: aggregate-prometheus
   namespace: {{ .Release.Namespace }}
 spec:
   tls:
-  - secretName: grafana-tls
+  - secretName: aggregate-prometheus-tls
     hosts:
-    - {{ .Values.grafana.host }}
+    - {{ .Values.aggregatePrometheus.host }}
   rules:
-  - host: {{ .Values.grafana.host }}
+  - host: {{ .Values.aggregatePrometheus.host }}
     http:
       paths:
       - backend:
-          serviceName: grafana
-          servicePort: 3000
+          serviceName: aggregate-prometheus-web
+          servicePort: 80
         path: /

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -8,6 +8,10 @@ aggregatePrometheus:
   port: 9090
   storage: 20Gi
   seed: seed
+  host: p.seed-1.example.com
+
+grafana:
+  host: p.seed-1.example.com
 
 allowedMetrics:
   alertmanager: []
@@ -65,7 +69,6 @@ allowedMetrics:
 
 
 ingress:
-  host: p.seed-1.example.com
   # admin : admin base64 encoded
   basicAuthSecret: YWRtaW46JGFwcjEkSWRSaVM5c3MkR3U1MHMxaGUwL2Z6Tzh2elE4S1BEMQ==
 

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -166,6 +166,9 @@ const (
 	// GardenRoleMonitoring is the value of the GardenRole key indicating type 'monitoring'.
 	GardenRoleMonitoring = "monitoring"
 
+	// GardenRoleGlobalMonitoring is the vlaue of the GardenRole key indicating type 'global-monitoring'
+	GardenRoleGlobalMonitoring = "global-monitoring"
+
 	// GardenRoleOptionalAddon is the value of the GardenRole key indicating type 'optional-addon'.
 	GardenRoleOptionalAddon = "optional-addon"
 

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -164,12 +164,16 @@ func generateWantedSecrets(seed *Seed, certificateAuthorities map[string]*utilse
 			CertType:  utilsecrets.ServerCert,
 			SigningCA: certificateAuthorities[caSeed],
 		},
-		&utilsecrets.BasicAuthSecretConfig{
-			Name:   "seed-monitoring-ingress-credentials",
-			Format: utilsecrets.BasicAuthFormatNormal,
+		&utilsecrets.CertificateSecretConfig{
+			Name: "aggregate-prometheus-tls",
 
-			Username:       "admin",
-			PasswordLength: 32,
+			CommonName:   "prometheus",
+			Organization: []string{fmt.Sprintf("%s:monitoring:ingress", garden.GroupName)},
+			DNSNames:     []string{seed.GetIngressFQDN("p-seed", "", "garden")},
+			IPAddresses:  nil,
+
+			CertType:  utilsecrets.ServerCert,
+			SigningCA: certificateAuthorities[caSeed],
 		},
 	}
 
@@ -449,11 +453,12 @@ func BootstrapCluster(seed *Seed, config *config.ControllerManagerConfiguration,
 			// Apply status from old Object to retain status information
 			new.Object["status"] = old.Object["status"]
 		}
-		vpaGK              = schema.GroupKind{Group: "autoscaling.k8s.io", Kind: "VerticalPodAutoscaler"}
-		issuerGK           = schema.GroupKind{Group: "certmanager.k8s.io", Kind: "ClusterIssuer"}
-		grafanaHost        = seed.GetIngressFQDN("g-seed", "", "garden")
-		grafanaCredentials = existingSecretsMap["seed-monitoring-ingress-credentials"]
-		grafanaBasicAuth   = utils.CreateSHA1Secret(grafanaCredentials.Data[utilsecrets.DataKeyUserName], grafanaCredentials.Data[utilsecrets.DataKeyPassword])
+		vpaGK                 = schema.GroupKind{Group: "autoscaling.k8s.io", Kind: "VerticalPodAutoscaler"}
+		issuerGK              = schema.GroupKind{Group: "certmanager.k8s.io", Kind: "ClusterIssuer"}
+		grafanaHost           = seed.GetIngressFQDN("g-seed", "", "garden")
+		prometheusHost        = seed.GetIngressFQDN("p-seed", "", "garden")
+		monitoringCredentials = existingSecretsMap["seed-monitoring-ingress-credentials"]
+		monitoringBasicAuth   = utils.CreateSHA1Secret(monitoringCredentials.Data[utilsecrets.DataKeyUserName], monitoringCredentials.Data[utilsecrets.DataKeyPassword])
 	)
 
 	applierOptions.MergeFuncs[vpaGK] = retainStatusInformation
@@ -483,6 +488,10 @@ func BootstrapCluster(seed *Seed, config *config.ControllerManagerConfiguration,
 		"aggregatePrometheus": map[string]interface{}{
 			"storage": seed.GetValidVolumeSize("20Gi"),
 			"seed":    seed.Info.Name,
+			"host":    prometheusHost,
+		},
+		"grafana": map[string]interface{}{
+			"host": grafanaHost,
 		},
 		"elastic-kibana-curator": map[string]interface{}{
 			"enabled": loggingEnabled,
@@ -538,8 +547,7 @@ func BootstrapCluster(seed *Seed, config *config.ControllerManagerConfiguration,
 			"resourceClass": v1alpha1.SeedResourceManagerClass,
 		},
 		"ingress": map[string]interface{}{
-			"basicAuthSecret": grafanaBasicAuth,
-			"host":            grafanaHost,
+			"basicAuthSecret": monitoringBasicAuth,
 		},
 	}, applierOptions)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
A set of basic auth credentials are created in the garden cluster. This secret is synced to each seed and used to gain access to the aggregate monitoring components (aggregate prometheus and grafana in the garden namespace).
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Operators can now access all aggregate monitoring components using one set of basic auth credentials. The basic auth credentials are stored in the garden cluster in the secret `garden/seed-monitoring-ingress-credentials`.
```
