### PR TITLE
Enhance dump logic during shoot failures

### DIFF
--- a/test/integration/framework/garden_operation.go
+++ b/test/integration/framework/garden_operation.go
@@ -138,6 +138,12 @@ func (o *GardenerTestOperation) AddShoot(ctx context.Context, shoot *v1beta1.Sho
 		return errors.Wrap(err, "could not construct Seed client")
 	}
 
+	o.SeedClient = seedClient
+	o.Shoot = shoot
+	o.Seed = seed
+	o.SeedCloudProfile = seedCloudProfile
+	o.Project = project
+
 	shootScheme := runtime.NewScheme()
 	shootSchemeBuilder := runtime.NewSchemeBuilder(
 		corescheme.AddToScheme,
@@ -156,13 +162,7 @@ func (o *GardenerTestOperation) AddShoot(ctx context.Context, shoot *v1beta1.Sho
 		return errors.Wrap(err, "could not construct Shoot client")
 	}
 
-	o.SeedClient = seedClient
 	o.ShootClient = shootClient
-
-	o.Shoot = shoot
-	o.Seed = seed
-	o.SeedCloudProfile = seedCloudProfile
-	o.Project = project
 
 	return nil
 }
@@ -433,12 +433,12 @@ func (o *GardenerTestOperation) DumpState(ctx context.Context) {
 		if err := o.dumpNodes(ctx, ctxIdentifier, o.ShootClient); err != nil {
 			o.Logger.Errorf("unable to dump information of nodes from shoot %s: %s", o.Shoot.Name, err.Error())
 		}
+	}
 
-		// dump controlplane in the shootnamespace
-		if o.Seed != nil && o.SeedClient != nil {
-			if err := o.dumpControlplaneInSeed(ctx, o.SeedClient, o.Seed, o.ShootSeedNamespace()); err != nil {
-				o.Logger.Errorf("unable to dump controlplane of %s in seed %s: %v", o.Shoot.Name, o.Seed.Name, err)
-			}
+	// dump controlplane in the shootnamespace
+	if o.Seed != nil && o.SeedClient != nil {
+		if err := o.dumpControlplaneInSeed(ctx, o.SeedClient, o.Seed, o.ShootSeedNamespace()); err != nil {
+			o.Logger.Errorf("unable to dump controlplane of %s in seed %s: %v", o.Shoot.Name, o.Seed.Name, err)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enhances the dump logic if a shoot is in failing state.
Currently no shoot relevant information (controlplane) is printed if the shoot client cannot be initialized. This initialization error can happens if the shoot is in failed state and its api server is down.

This behaviour is now changed so that the shoot's controlplane in the seed is still dumped to also debug such errors.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
