### PR TITLE
Change default volume-plugin dir for kubelet

### DIFF
--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.flags
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.flags
@@ -26,5 +26,6 @@
 {{- if semverCompare "< 1.11" .Values.kubernetes.version }}
 --rotate-certificates=true
 {{- end }}
+--volume-plugin-dir=/var/lib/kubelet/volumeplugins
 --v=2 $KUBELET_EXTRA_ARGS
 {{- end -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the default volume-plugin directory in the kubelet. This helps circumvent the issue mentioned [here](https://github.com/projectcalico/calico/issues/2712)

**Special notes for your reviewer**:
this PR works serves as a requirement for: https://github.com/gardener/gardener-extensions/pull/312


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Volume plugin directory on the kubelet is now statically configured to /var/lib/kubelet/volumeplugins, this is to support Calico versions >= 3.8 on CoreOS which does not have write access to the defaule volume-plugin-dir. 
```