### PR TITLE
Update g/gardener-resource-manager to 0.5.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -25,7 +25,7 @@ images:
 - name: gardener-resource-manager
   sourceRepository: github.com/gardener/gardener-resource-manager
   repository: eu.gcr.io/gardener-project/gardener/gardener-resource-manager
-  tag: "0.4.0"
+  tag: "0.5.0"
 - name: vpn-seed
   sourceRepository: github.com/gardener/vpn
   repository: eu.gcr.io/gardener-project/gardener/vpn-seed

--- a/charts/seed-controlplane/charts/gardener-resource-manager/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/templates/deployment.yaml
@@ -39,9 +39,11 @@ spec:
         - /gardener-resource-manager
         - --leader-election=true
         - --leader-election-namespace={{ .Release.Namespace }}
-        - --max-concurrent-workers={{ .Values.concurrentSyncs }}
+        - --sync-period={{ .Values.controllers.managedResource.syncPeriod }}
+        - --max-concurrent-workers={{ .Values.controllers.managedResource.concurrentSyncs }}
+        - --health-sync-period={{ .Values.controllers.managedResourceHealth.syncPeriod }}
+        - --health-max-concurrent-workers={{ .Values.controllers.managedResourceHealth.concurrentSyncs }}
         - --namespace={{ .Release.Namespace }}
-        - --sync-period={{ .Values.syncPeriod }}
         - --target-kubeconfig=/etc/gardener-resource-manager/kubeconfig
         {{- if .Values.resources }}
         resources:

--- a/charts/seed-controlplane/charts/gardener-resource-manager/values.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/values.yaml
@@ -10,7 +10,13 @@ resources:
     memory: 512Mi
 
 replicas: 1
-syncPeriod: 1m0s
-concurrentSyncs: 20
+
+controllers:
+  managedResource:
+    syncPeriod: 1m0s
+    concurrentSyncs: 20
+  managedResourceHealth:
+    syncPeriod: 1m0s
+    concurrentSyncs: 10
 
 podAnnotations: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Update g/gardener-resource-manager to 0.5.0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->

``` improvement operator github.com/gardener/gardener-resource-manager #14 @timuthy
An issue has been resolved which caused the Gardener-Resource-Manage to throw errors for `Kinds` belonging to a recently deployed CRD.
```

``` improvement developer github.com/gardener/gardener-resource-manager #12 @ialidzhikov
The golang version has been updated to 1.13. Please upgrade your local go installation to 1.13.
```

``` improvement operator github.com/gardener/gardener-resource-manager #11 @ialidzhikov
ManagedResource status is now enriched with two conditions - `ResourcesApplied` and `ResourcesHealthy`.
```

``` improvement operator github.com/gardener/gardener-resource-manager #8 @timuthy
Fixes an issue which left resources in the `target` cluster even though they were supposed to be deleted through a change or removal of the `ManagedResource`.
```
