### PR TITLE
Alertmanager only for users

### DIFF
--- a/charts/seed-monitoring/charts/alertmanager/templates/allow-alertmanager-network-policy.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/allow-alertmanager-network-policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: {{ include "networkpolicyversion" . }}
+kind: NetworkPolicy
+metadata:
+  annotations:
+    gardener.cloud/description: |
+      Allows Alertmanager to be reached from the ingress.
+  name: allow-alertmanager
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      component: alertmanager
+      garden.sapcloud.io/role: monitoring
+      role: monitoring
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: nginx-ingress
+          component: controller
+      namespaceSelector:
+        matchLabels:
+          role: kube-system
+  policyTypes:
+  - Ingress

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -162,8 +162,8 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 
 		alertManagerValues, err := b.InjectSeedShootImages(map[string]interface{}{
 			"ingress": map[string]interface{}{
-				"basicAuthSecret": basicAuth,
-				"host":            b.Seed.GetIngressFQDN("a", b.Shoot.Info.Name, b.Garden.Project.Name),
+				"basicAuthSecret": basicAuthUsers,
+				"host":            b.Seed.GetIngressFQDN("a-users", b.Shoot.Info.Name, b.Garden.Project.Name),
 			},
 			"replicas":     b.Shoot.GetReplicas(1),
 			"storage":      b.Seed.GetValidVolumeSize("1Gi"),

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -163,7 +163,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		alertManagerValues, err := b.InjectSeedShootImages(map[string]interface{}{
 			"ingress": map[string]interface{}{
 				"basicAuthSecret": basicAuthUsers,
-				"host":            b.Seed.GetIngressFQDN("a-users", b.Shoot.Info.Name, b.Garden.Project.Name),
+				"host":            b.Seed.GetIngressFQDN("au", b.Shoot.Info.Name, b.Garden.Project.Name),
 			},
 			"replicas":     b.Shoot.GetReplicas(1),
 			"storage":      b.Seed.GetValidVolumeSize("1Gi"),

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -209,10 +209,10 @@ const (
 	GardenIgnoreAlerts = "shoot.garden.sapcloud.io/ignore-alerts"
 
 	// GrafanaOperatorsPrefix is a constant for a prefix used for the operators Grafana instance.
-	GrafanaOperatorsPrefix = "g-operators"
+	GrafanaOperatorsPrefix = "go"
 
 	// GrafanaUsersPrefix is a constant for a prefix used for the users Grafana instance.
-	GrafanaUsersPrefix = "g-users"
+	GrafanaUsersPrefix = "gu"
 
 	// IngressPrefix is the part of a FQDN which will be used to construct the domain name for an ingress controller of
 	// a Shoot cluster. For example, when a Shoot specifies domain 'cluster.example.com', the ingress domain would be


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the alertmanager available to users if they configured their shoot to receive alerts. The alertmanager needed a new network policy to be reachable from nginx.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Users can now use an `Alertmanager` if they configured their shoot to receive alerts.
```
```action user
The subdomain for the the user monitoring has changed from `g-users` to `gu`.
```
```action operator
The subdomain for the the operator monitoring has changed from `g-operators` to `go`.
```
