### PR TITLE
Unique global monitoring secret name

### DIFF
--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -276,7 +276,7 @@ func BootstrapCluster(k8sGardenClient kubernetes.Interface, gardenNamespace stri
 
 func generateMonitoringSecret(k8sGardenClient kubernetes.Interface, gardenNamespace string) (*corev1.Secret, error) {
 	basicAuthSecret := &secretutils.BasicAuthSecretConfig{
-		Name:   "seed-monitoring-ingress-credentials",
+		Name:   "monitoring-ingress-credentials",
 		Format: secretutils.BasicAuthFormatNormal,
 
 		Username:       "admin",

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -271,7 +271,7 @@ func BootstrapCluster(seed *Seed, config *config.ControllerManagerConfiguration,
 			secret := secrets[key]
 			secretObj := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      secret.Name,
+					Name:      fmt.Sprintf("%s-%s", "seed", secret.Name),
 					Namespace: "garden",
 				},
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
If the garden cluster is also a seed cluster, the secret names from #1405 will clash. This PR will ensure that the secret in the garden cluster has a unique name.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
