### PR TITLE
Fix KubernetesVersion Maintenance

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -243,7 +243,11 @@ func shouldKubernetesVersionBeUpdated(shoot *gardenv1beta1.Shoot, profile *garde
 		return false, err
 	}
 
-	return !versionExistsInCloudProfile || shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion || ExpirationDateExpired(offeredVersion.ExpirationDate), nil
+	if !versionExistsInCloudProfile && !shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion {
+		return false, nil
+	}
+
+	return shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion || ExpirationDateExpired(offeredVersion.ExpirationDate), nil
 }
 
 func mustMaintainNow(shoot *gardenv1beta1.Shoot) bool {

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_test.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_test.go
@@ -291,7 +291,7 @@ var _ = Describe("Shoot Maintenance", func() {
 
 		It("should determine that the shootKubernetes version must be maintained - cloud profile has no matching kubernetes version defined (the shoots kubernetes version has been deleted from the cloudProfile) -> update to latest kubernetes patch version with same minor", func() {
 			cloudProfile.Spec.GCP.Constraints.Kubernetes.OfferedVersions = kubernetesConstraints.OfferedVersions[:2]
-			shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion = falseVar
+			shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion = true
 
 			shoot.Spec.Kubernetes = gardenv1beta1.Kubernetes{Version: "1.0.0"}
 			version, err := MaintainKubernetesVersion(shoot, cloudProfile)
@@ -299,6 +299,17 @@ var _ = Describe("Shoot Maintenance", func() {
 			Expect(err).To(BeNil())
 			Expect(version).NotTo(BeNil())
 			Expect(*version).To(Equal("1.0.2"))
+		})
+
+		It("should determine that the shootKubernetes version must NOT be maintained - cloud profile has no matching kubernetes version defined & autoUpdate == false", func() {
+			cloudProfile.Spec.GCP.Constraints.Kubernetes.OfferedVersions = kubernetesConstraints.OfferedVersions[:2]
+			shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion = false
+
+			shoot.Spec.Kubernetes = gardenv1beta1.Kubernetes{Version: "1.0.0"}
+			version, err := MaintainKubernetesVersion(shoot, cloudProfile)
+
+			Expect(err).To(BeNil())
+			Expect(version).To(BeNil())
 		})
 
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the maintenance controller responsible for the kubernetes version update of the shoot.

Behaviour (shoot k8 version < latest) :
- K8 Version expired -> autoUpdate to latest patch version from CloudProfile
- k8 Version not expired & autoUpdate == true -> update to latest patch version
- k8 Version not expired & autoUpdate == false -> don't do anything
- **FIXED**  k8 Version not in CloudProfile & autoUpdate == false -> don't do anything
- k8 Version not in CloudProfile & autoUpdate == true -> update to latest patch version

**Which issue(s) this PR fixes**:
Fixes #1419

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fix bug in maintenance-controller not respecting `spec.maintenance.autoUpdate.kubernetesVersion: false` in the Shoot when the Kubernetes version does not exist in the CloudProfile.
```
