### PR TITLE
Add alert for failed etcd data restoration

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
@@ -31,6 +31,9 @@ tests:
     values: '0+0x2912'
   - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore",role="main",kind="Full"}'
     values: '1+0x2912'
+  # KubeEtcdRestorationFailed
+  - series: 'etcdbr_restoration_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",succeeded="false"}'
+    values: '0+0x7 1 2 2'
   alert_rule_test:
   - eval_time: 5m
     alertname: KubeEtcdMainDown
@@ -117,3 +120,17 @@ tests:
       exp_annotations:
         description: No full snapshot taken in the past day.
         summary: Etcd full snapshot failure.
+  - eval_time: 5m
+    alertname: KubeEtcdRestorationFailed
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-backup-restore
+        succeeded: false
+        role: main
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: Etcd data restoration was triggered, but has failed.
+        summary: Etcd data restoration failure.

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -93,4 +93,16 @@ groups:
         description: No full snapshot taken in the past day.
         summary: Etcd full snapshot failure.
 
+  # etcd data restoration failure alert
+  - alert: KubeEtcdRestorationFailed
+    expr: etcdbr_restoration_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",succeeded="false"} > 0
+    for: 1m
+    labels:
+      service: etcd
+      severity: critical
+      type: seed
+      visibility: operator
+    annotations:
+      description: Etcd data restoration was triggered, but has failed.
+      summary: Etcd data restoration failure.
 


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This PR adds alert for failed etcd data restoration.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/etcd-backup-restore/issues/97

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Add alert rule for failed etcd restorations.
```
