### PR TITLE
Cleanup the old backup infra resources

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
@@ -157,6 +157,16 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation, operationType
 			Fn:           flow.TaskFn(botanist.WaitUntilEtcdReady).SkipIf(o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(deployETCD),
 		})
+		deleteBackupInfrastructure = g.Add(flow.Task{
+			Name:         "Delete backup infrastructure resource",
+			Fn:           flow.SimpleTaskFn(botanist.DeleteBackupInfrastructure),
+			Dependencies: flow.NewTaskIDs(deployETCD),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Waiting until the backup infrastructure has been deleted",
+			Fn:           flow.TaskFn(botanist.WaitUntilBackupInfrastructureDeleted),
+			Dependencies: flow.NewTaskIDs(deleteBackupInfrastructure),
+		})
 		deployControlPlane = g.Add(flow.Task{
 			Name:         "Deploying shoot control plane components",
 			Fn:           flow.TaskFn(botanist.DeployControlPlane).RetryUntilTimeout(defaultInterval, defaultTimeout),


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
This PR removes the orphan backupInfra resources which are no longer needed post reconciliation of Shoot using gardener 0.29+. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The orphaned `BackupInfrastructure` resources post reconciliation of shoots using Gardener 0.29+ are now getting deleted.
:warning: For hibernated cluster it now guarantees only latest snapshot will be there on shared bucket. It doesn't migrate the old snapshots and hence break the policy of the configured deletion grace period. If you want to keep the old data you would need to download it manually from the buckets before upgrading to this Gardener version.
```
```action operator
The old `garden.sapcloud.io/v1beta1.BackupInfrastructure` resources are deprecated and will be removed in the next release. The `core.gardener.cloud/v1alpha1.BackupBucket` and `core.gardener.cloud/v1alpha1` are the replacement.
```