### PR TITLE
Add OS user gardener to the VMs

### DIFF
--- a/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
+++ b/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
@@ -28,6 +28,17 @@ spec:
       RestartSec=30
       EnvironmentFile=/etc/environment
       ExecStart=/var/lib/cloud-config-downloader/download-cloud-config.sh
+  - name: gardener-user.service
+    command: start
+    enable: true
+    content: |
+      [Unit]
+      Description=Configure gardener user
+      After=sshd.service
+      [Service]
+      Restart=on-failure
+      EnvironmentFile=/etc/environment
+      ExecStart=/var/lib/gardener-user/run.sh
   files:
   - path: /var/lib/cloud-config-downloader/credentials/server
     permissions: 0644
@@ -59,3 +70,9 @@ spec:
       inline:
         encoding: b64
         data: {{ include "seed-operatingsystemconfig.downloader.download-script" . | b64enc }}
+  - path: /var/lib/gardener-user/run.sh
+    permissions: 0744
+    content:
+      inline:
+        encoding: b64
+        data: {{ include "seed-operatingsystemconfig.gardener-user" . | b64enc }}

--- a/charts/seed-operatingsystemconfig/downloader/templates/scripts/_gardener-user.sh
+++ b/charts/seed-operatingsystemconfig/downloader/templates/scripts/_gardener-user.sh
@@ -1,0 +1,11 @@
+{{- define "seed-operatingsystemconfig.gardener-user" -}}
+#!/bin/bash -eu
+
+id gardener || useradd gardener -mU
+mkdir -p /home/gardener/.ssh
+find /home -name authorized_keys -not -path "/home/gardener/*" -exec cp -f {} /home/gardener/.ssh/authorized_keys \;
+chown gardener:gardener /home/gardener/.ssh/authorized_keys
+cat >/etc/sudoers.d/99-gardener-user <<EOF
+gardener ALL=(ALL) NOPASSWD:ALL
+EOF
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add new user on the VMs named `gardener`.
This is done to improve ssh-ing to the nodes, because every OS has different default user on the different cloud providers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@KristianZH  you might consider to change the `gardenctl ssh` not to use `<user>@...` but `gardener@...`.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
