### PR TITLE
Add more recording rules for aggregate prometheus

### DIFF
--- a/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
+++ b/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
@@ -1,6 +1,7 @@
 groups:
 - name: recording-rules.rules
   rules:
+  # Recording rules for pod usage
   - record: seed:container_cpu_usage_seconds_total:sum_by_pod
     expr: sum(rate(container_cpu_usage_seconds_total[5m])) by (pod_name, namespace)
 
@@ -12,3 +13,29 @@ groups:
 
   - record: seed:container_network_transmit_bytes_total:sum_by_pod
     expr: sum(rate(container_network_transmit_bytes_total[5m])) by (pod_name, namespace)
+
+  # Recording rules for the sum of the entire seed usage
+  - record: seed:container_cpu_usage_seconds_total:sum
+    expr: sum(seed:container_cpu_usage_seconds_total:sum_by_pod)
+
+  - record: seed:container_memory_working_set_bytes:sum
+    expr: sum(seed:container_memory_working_set_bytes:sum_by_pod)
+
+  - record: seed:container_network_receive_bytes_total:sum
+    expr: sum(seed:container_network_receive_bytes_total:sum_by_pod)
+
+  - record: seed:container_network_transmit_bytes_total:sum
+    expr: sum(seed:container_network_transmit_bytes_total:sum_by_pod)
+
+  # Recording rules for the sum of all control plane usage
+  - record: seed:container_cpu_usage_seconds_total:sum_cp
+    expr: sum(seed:container_cpu_usage_seconds_total:sum_by_pod{namespace=~"((shoot-|shoot--)(\\w.+))"})
+
+  - record: seed:container_memory_working_set_bytes:sum_cp
+    expr: sum(seed:container_memory_working_set_bytes:sum_by_pod{namespace=~"((shoot-|shoot--)(\\w.+))"})
+
+  - record: seed:container_network_receive_bytes_total:sum_cp
+    expr: sum(seed:container_network_receive_bytes_total:sum_by_pod{namespace=~"((shoot-|shoot--)(\\w.+))"})
+
+  - record: seed:container_network_transmit_bytes_total:sum_cp
+    expr: sum(seed:container_network_transmit_bytes_total:sum_by_pod{namespace=~"((shoot-|shoot--)(\\w.+))"})

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
@@ -41,8 +41,7 @@ data:
       params:
         'match[]':
         - '{__name__="probe_success", job="blackbox-exporter-k8s-service-check"}'
-        - '{__name__="shoot:kube_apiserver:sum_by_pod"}'
-        - '{__name__="shoot:kube_node_info:count"}'
+        - '{__name__=~"shoot:(.+):(.+)"}'
         - '{__name__="ALERTS"}'
       kubernetes_sd_configs:
       - role: endpoints
@@ -58,10 +57,7 @@ data:
       metrics_path: /federate
       params:
         'match[]':
-        - '{__name__="seed:container_cpu_usage_seconds_total:sum_by_pod"}'
-        - '{__name__="seed:container_memory_working_set_bytes:sum_by_pod"}'
-        - '{__name__="seed:container_network_receive_bytes_total:sum_by_pod"}'
-        - '{__name__="seed:container_network_transmit_bytes_total:sum_by_pod"}'
+        - '{__name__=~"seed:(.+):(.+)"}'
       kubernetes_sd_configs:
       - role: endpoints
       relabel_configs:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds some more recording rules. This will make it easier for a global prometheus to get information about the seed usage without having to get all of the pod metrics. Fetching all pod metrics would cause performance issues due to the high amount of churn (pods names change relatively often).
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
