### PR TITLE
Adapt gardener-scheduler to work with `core.gardener.cloud/v1alpha1` resources

### DIFF
--- a/pkg/apis/core/v1alpha1/helper/helper.go
+++ b/pkg/apis/core/v1alpha1/helper/helper.go
@@ -173,3 +173,13 @@ func NetworksIntersect(cidr1, cidr2 string) bool {
 	_, net2, err2 := net.ParseCIDR(cidr2)
 	return err1 != nil || err2 != nil || net2.Contains(net1.IP) || net1.Contains(net2.IP)
 }
+
+// TaintsHave returns true if the given key is part of the taints list.
+func TaintsHave(taints []gardencorev1alpha1.SeedTaint, key string) bool {
+	for _, taint := range taints {
+		if taint.Key == key {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/apis/core/v1alpha1/helper/helpers_test.go
+++ b/pkg/apis/core/v1alpha1/helper/helpers_test.go
@@ -232,5 +232,13 @@ var _ = Describe("helper", func() {
 				false,
 			),
 		)
+
+		DescribeTable("#TaintsHave",
+			func(taints []gardencorev1alpha1.SeedTaint, key string, expectation bool) {
+				Expect(TaintsHave(taints, key)).To(Equal(expectation))
+			},
+			Entry("taint exists", []gardencorev1alpha1.SeedTaint{{Key: "foo"}}, "foo", true),
+			Entry("taint does not exist", []gardencorev1alpha1.SeedTaint{{Key: "foo"}}, "bar", false),
+		)
 	})
 })

--- a/pkg/scheduler/apis/config/install/install.go
+++ b/pkg/scheduler/apis/config/install/install.go
@@ -15,19 +15,17 @@
 package install
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/scheduler/apis/config"
 	"github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var (
 	schemeBuilder = runtime.NewSchemeBuilder(
 		v1alpha1.AddToScheme,
 		config.AddToScheme,
-		gardenv1beta1.AddToScheme,
 		setVersionPriority,
 	)
 

--- a/pkg/scheduler/controller/shoot/scheduler.go
+++ b/pkg/scheduler/controller/shoot/scheduler.go
@@ -19,34 +19,37 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/workqueue"
-
-	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/externalversions"
-	gardenlisters "github.com/gardener/gardener/pkg/client/garden/listers/garden/v1beta1"
+	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	controllerutils "github.com/gardener/gardener/pkg/controllermanager/controller/utils"
 	gardenmetrics "github.com/gardener/gardener/pkg/controllermanager/metrics"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/scheduler/apis/config"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
 )
 
 // SchedulerController controls Seeds.
 type SchedulerController struct {
-	k8sGardenClient    kubernetes.Interface
-	k8sGardenInformers gardeninformers.SharedInformerFactory
+	k8sGardenClient        kubernetes.Interface
+	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory
 
 	config *config.SchedulerConfiguration
 
 	control  SchedulerInterface
 	recorder record.EventRecorder
 
-	seedLister gardenlisters.SeedLister
+	cloudProfileLister gardencorelisters.CloudProfileLister
+	cloudProfileSynced cache.InformerSynced
+
+	seedLister gardencorelisters.SeedLister
 	seedSynced cache.InformerSynced
 
-	shootLister gardenlisters.ShootLister
+	shootLister gardencorelisters.ShootLister
 	shootSynced cache.InformerSynced
 	shootQueue  workqueue.RateLimitingInterface
 
@@ -56,33 +59,37 @@ type SchedulerController struct {
 
 // NewGardenerScheduler takes a Kubernetes client for the Garden clusters <k8sGardenClient>, a <sharedInformerFactory>, a struct containing the scheduler configuration and a <recorder> for
 // event recording. It creates a new NewGardenerScheduler.
-func NewGardenerScheduler(k8sGardenClient kubernetes.Interface, gardenInformerFactory gardeninformers.SharedInformerFactory, config *config.SchedulerConfiguration, recorder record.EventRecorder) *SchedulerController {
+func NewGardenerScheduler(k8sGardenClient kubernetes.Interface, gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory, config *config.SchedulerConfiguration, recorder record.EventRecorder) *SchedulerController {
 	var (
-		gardenv1beta1Informer = gardenInformerFactory.Garden().V1beta1()
+		coreV1Alpha1Informer = gardenCoreInformerFactory.Core().V1alpha1()
 
-		seedLister    = gardenv1beta1Informer.Seeds().Lister()
-		shootInformer = gardenv1beta1Informer.Shoots()
-		seedInformer  = gardenv1beta1Informer.Seeds()
-		shootLister   = shootInformer.Lister()
-		shootQueue    = workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(config.Schedulers.Shoot.RetrySyncPeriod.Duration, 12*time.Hour), "gardener-shoot-scheduler")
+		shootInformer        = coreV1Alpha1Informer.Shoots()
+		shootLister          = shootInformer.Lister()
+		seedInformer         = coreV1Alpha1Informer.Seeds()
+		seedLister           = seedInformer.Lister()
+		cloudProfileInformer = coreV1Alpha1Informer.CloudProfiles()
+		cloudProfileLister   = cloudProfileInformer.Lister()
+		shootQueue           = workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(config.Schedulers.Shoot.RetrySyncPeriod.Duration, 12*time.Hour), "gardener-shoot-scheduler")
 	)
 
 	schedulerController := &SchedulerController{
-		k8sGardenClient:    k8sGardenClient,
-		k8sGardenInformers: gardenInformerFactory,
-		control:            NewDefaultControl(k8sGardenClient, gardenInformerFactory, recorder, config, shootLister, seedLister),
-		config:             config,
-		recorder:           recorder,
-		seedLister:         seedLister,
-		shootQueue:         shootQueue,
-		shootLister:        shootLister,
-		workerCh:           make(chan int),
+		k8sGardenClient:        k8sGardenClient,
+		k8sGardenCoreInformers: gardenCoreInformerFactory,
+		control:                NewDefaultControl(k8sGardenClient, gardenCoreInformerFactory, recorder, config, shootLister, seedLister, cloudProfileLister),
+		config:                 config,
+		recorder:               recorder,
+		cloudProfileLister:     cloudProfileLister,
+		seedLister:             seedLister,
+		shootQueue:             shootQueue,
+		shootLister:            shootLister,
+		workerCh:               make(chan int),
 	}
 
 	shootInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    schedulerController.shootAdd,
 		UpdateFunc: schedulerController.shootUpdate,
 	})
+	schedulerController.cloudProfileSynced = cloudProfileInformer.Informer().HasSynced
 	schedulerController.seedSynced = seedInformer.Informer().HasSynced
 	schedulerController.shootSynced = shootInformer.Informer().HasSynced
 
@@ -90,12 +97,12 @@ func NewGardenerScheduler(k8sGardenClient kubernetes.Interface, gardenInformerFa
 }
 
 // Run runs the SchedulerController until the given stop channel can be read from.
-func (c *SchedulerController) Run(ctx context.Context, k8sGardenInformers gardeninformers.SharedInformerFactory) {
+func (c *SchedulerController) Run(ctx context.Context, k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory) {
 	var waitGroup sync.WaitGroup
 
-	k8sGardenInformers.Start(ctx.Done())
+	k8sGardenCoreInformers.Start(ctx.Done())
 
-	if !cache.WaitForCacheSync(ctx.Done(), c.seedSynced, c.shootSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), c.cloudProfileSynced, c.seedSynced, c.shootSynced) {
 		logger.Logger.Error("Timed out waiting for caches to sync")
 		return
 	}

--- a/pkg/scheduler/controller/shoot/scheduler_suite_test.go
+++ b/pkg/scheduler/controller/shoot/scheduler_suite_test.go
@@ -15,13 +15,13 @@
 package shoot
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestScheduler(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Shoot scheduler Test Suite")
+	RunSpecs(t, "Shoot Scheduler Test Suite")
 }

--- a/test/integration/framework/scheduler_operations.go
+++ b/test/integration/framework/scheduler_operations.go
@@ -35,7 +35,6 @@ import (
 	"github.com/gardener/gardener/pkg/apis/garden/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/scheduler/apis/config"
 	schedulerconfigv1alpha1 "github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
-	shootscheduler "github.com/gardener/gardener/pkg/scheduler/controller/shoot"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -125,7 +124,8 @@ func (s *SchedulerGardenerTest) ScheduleShoot(ctx context.Context, shoot *garden
 		}
 		return nil
 	}
-	return shootscheduler.UpdateShootToBeScheduledOntoSeed(ctx, shoot, seed, executeSchedulingRequest)
+	shoot.Spec.Cloud.Seed = &seed.Name
+	return executeSchedulingRequest(ctx, shoot)
 }
 
 // ChooseRegionAndZoneWithNoSeed determines all available Zones from the Shoot and the CloudProfile and then delegates the choosing of a region were no seed is deployed


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR the `gardener-scheduler` is adapted to only work with the `core.gardener.cloud/v1alpha1` resources. 

**Special notes for your reviewer**:
* Part of #1376
* :warning: Depends on #1430 which should be merged first

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
The `gardener-scheduler` is now working only with `core.gardener.cloud/v1alpha1` instead of `garden.sapcloud.io/v1beta1` resources.
```
