### PR TITLE
Prevent panics due to potential invalid type conversion

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_hibernation_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_hibernation_control.go
@@ -133,7 +133,12 @@ func shootHasHibernationSchedules(shoot *gardenv1beta1.Shoot) bool {
 }
 
 func (c *Controller) shootHibernationAdd(obj interface{}) {
-	if shootHasHibernationSchedules(obj.(*gardenv1beta1.Shoot)) {
+	shoot, ok := obj.(*gardenv1beta1.Shoot)
+	if !ok {
+		return
+	}
+
+	if shootHasHibernationSchedules(shoot) {
 		key, err := cache.MetaNamespaceKeyFunc(obj)
 		if err != nil {
 			gardenlogger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
@@ -163,7 +168,12 @@ func (c *Controller) shootHibernationUpdate(oldObj, newObj interface{}) {
 }
 
 func (c *Controller) shootHibernationDelete(obj interface{}) {
-	if shootHasHibernationSchedules(obj.(*gardenv1beta1.Shoot)) {
+	shoot, ok := obj.(*gardenv1beta1.Shoot)
+	if !ok {
+		return
+	}
+
+	if shootHasHibernationSchedules(shoot) {
 		key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 		if err != nil {
 			gardenlogger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
We have seen panics due to invalid type conversion - we should always check whether the conversion is possible.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
