### PR TITLE
Fix Extension deletion for ControllerInstallation

### DIFF
--- a/pkg/controllermanager/controller/controllerinstallation/controllerinstallation_control.go
+++ b/pkg/controllermanager/controller/controllerinstallation/controllerinstallation_control.go
@@ -449,13 +449,13 @@ func (c *defaultControllerInstallationControl) cleanOldExtensions(ctx context.Co
 			}
 
 			relevantExtension = append(relevantExtension, item)
+			del := &extensionsv1alpha1.Extension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      item.GetName(),
+					Namespace: item.GetNamespace(),
+				},
+			}
 			fns = append(fns, func(ctx context.Context) error {
-				del := &extensionsv1alpha1.Extension{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      item.GetName(),
-						Namespace: item.GetNamespace(),
-					},
-				}
 				return seedClient.Delete(ctx, del)
 			})
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Delete the correct extension type if a corresponding ControllerInstallation is deleted.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
