### PR TITLE
Add VPA for gardener components

### DIFF
--- a/charts/gardener/charts/runtime/templates/apiserver/vpa.yaml
+++ b/charts/gardener/charts/runtime/templates/apiserver/vpa.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.global.apiserver.vpa }}
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: gardener-apiserver-vpa
+  namespace: garden
+spec:
+  targetRef:
+    apiVersion: {{ include "deploymentversion" . }}
+    kind: Deployment
+    name: gardener-apiserver
+  updatePolicy:
+    updateMode: Auto
+{{- end }}

--- a/charts/gardener/charts/runtime/templates/controller-manager/vpa.yaml
+++ b/charts/gardener/charts/runtime/templates/controller-manager/vpa.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.global.controller.vpa }}
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: gardener-controller-manager-vpa
+  namespace: garden
+spec:
+  targetRef:
+    apiVersion: {{ include "deploymentversion" . }}
+    kind: Deployment
+    name: gardener-controller-manager
+  updatePolicy:
+    updateMode: Auto
+{{- end }}

--- a/charts/gardener/charts/runtime/templates/scheduler/vpa.yaml
+++ b/charts/gardener/charts/runtime/templates/scheduler/vpa.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.global.scheduler.vpa }}
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: gardener-scheduler-vpa
+  namespace: garden
+spec:
+  targetRef:
+    apiVersion: {{ include "deploymentversion" . }}
+    kind: Deployment
+    name: gardener-scheduler
+  updatePolicy:
+    updateMode: Auto
+{{- end }}

--- a/charts/gardener/values.yaml
+++ b/charts/gardener/values.yaml
@@ -49,6 +49,7 @@ global:
         ...
         -----END RSA PRIVATE KEY-----
     featureGates: {}
+    vpa: false
     audit:
  #    dynamicConfiguration: false                             Enables dynamic audit configuration. This feature also requires the DynamicAuditing feature flag
       log:
@@ -159,6 +160,7 @@ global:
     additionalVolumes: []
     additionalVolumeMounts: []
     env: []
+    vpa: false
   # imageVectorOverwrite: |
   #  Please find documentation in docs/deployment/image_vector.md
     config:
@@ -264,6 +266,7 @@ global:
       limits:
         cpu: 300m
         memory: 256Mi
+    vpa: false
     config:
       clientConnection:
         acceptContentTypes: application/json


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds optional VPA objects to the gardener apiserver, controller, and scheduler.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Vertical pod autoscaling can be enabled for the `gardener-apiserver`, `gardener-controller-manager` and `gardener-scheduler`. To enable VPA for each component `global.apiserver.vpa`, `global.controller.vpa` and `global.scheduler.vpa` must be set to true respectively. 
```
