### PR TITLE
Support for Kubernetes v1.16

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -77,7 +77,7 @@ images:
 - name: coredns
   sourceRepository: github.com/coredns/coredns
   repository: coredns/coredns
-  tag: "1.4.0"
+  tag: "1.6.3"
 
 # Shoot optional addons
 - name: kubernetes-dashboard

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
@@ -113,6 +113,9 @@ spec:
         - --secure-port={{ required ".securePort is required" .Values.securePort }}
         - --service-cluster-ip-range={{ .Values.shootNetworks.service }}
         - --service-account-key-file=/srv/kubernetes/service-account-key/id_rsa
+        {{- if semverCompare ">= 1.16" .Values.kubernetesVersion }}
+        - --shutdown-delay-duration=20s
+        {{- end }}
         - --token-auth-file=/srv/kubernetes/token/static_tokens.csv
         - --tls-cert-file=/srv/kubernetes/apiserver/kube-apiserver.crt
         - --tls-private-key-file=/srv/kubernetes/apiserver/kube-apiserver.key

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
@@ -147,7 +147,11 @@ spec:
         readinessProbe:
           httpGet:
             scheme: HTTPS
+            {{- if semverCompare ">= 1.16" .Values.kubernetesVersion }}
+            path: /readyz
+            {{- else }}
             path: /healthz
+            {{- end }}
             port: {{ required ".securePort is required" .Values.securePort }}
             httpHeaders:
             - name: Authorization

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
@@ -99,6 +99,9 @@ spec:
         - --kubelet-client-key=/srv/kubernetes/apiserver-kubelet/kube-apiserver-kubelet.key
         - --insecure-port=0
         {{- include "kube-apiserver.oidcConfig" . | indent 8 }}
+        {{- if semverCompare ">= 1.16" .Values.kubernetesVersion }}
+        - --livez-grace-period=1m
+        {{- end }}
         - --profiling=false
         - --proxy-client-cert-file=/srv/kubernetes/aggregator/kube-aggregator.crt
         - --proxy-client-key-file=/srv/kubernetes/aggregator/kube-aggregator.key
@@ -127,7 +130,11 @@ spec:
         livenessProbe:
           httpGet:
             scheme: HTTPS
+            {{- if semverCompare ">= 1.16" .Values.kubernetesVersion }}
+            path: /livez
+            {{- else }}
             path: /healthz
+            {{- end }}
             port: {{ required ".securePort is required" .Values.securePort }}
             httpHeaders:
             - name: Authorization

--- a/charts/shoot-core/components/charts/coredns/templates/coredns-deployment.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-deployment.yaml
@@ -74,8 +74,8 @@ spec:
           failureThreshold: 5
         readinessProbe:
           httpGet:
-            path: /health
-            port: 8080
+            path: /ready
+            port: 8181
             scheme: HTTP
       dnsPolicy: Default
       volumes:

--- a/charts/shoot-core/components/charts/coredns/templates/coredns-rbac.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-rbac.yaml
@@ -13,6 +13,12 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding

--- a/charts/shoot-core/components/charts/coredns/values.yaml
+++ b/charts/shoot-core/components/charts/coredns/values.yaml
@@ -39,6 +39,7 @@ configmap:
       configBlock: |-
         class error
     - name: health
+    - name: ready
     - name: kubernetes
       parameters: cluster.local in-addr.arpa ip6.arpa
       configBlock: |-

--- a/docs/usage/supported_k8s_versions.md
+++ b/docs/usage/supported_k8s_versions.md
@@ -14,11 +14,11 @@ The reason for that is that we require CRD status subresources for the extension
 
 ## Shoot cluster versions
 
-| Cloud provider | Kubernetes 1.10 | Kubernetes 1.11 | Kubernetes 1.12 | Kubernetes 1.13 | Kubernetes 1.14 | Kubernetes 1.15 |
-| -------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- |
-| AWS            | 1.10.0+         | 1.11.0+         | 1.12.1+         | 1.13.0+         | 1.14.0+         | 1.15.0+         |
-| Azure          | 1.10.1+         | 1.11.0+         | 1.12.1+         | 1.13.0+         | 1.14.0+         | 1.15.0+         |
-| GCP            | 1.10.0+         | 1.11.0+         | 1.12.1+         | 1.13.0+         | 1.14.0+         | 1.15.0+         |
-| OpenStack      | 1.10.1+         | 1.11.0+         | 1.12.1+         | 1.13.0+         | 1.14.0+         | 1.15.0+         |
-| Alicloud       | unsupported     | unsupported     | unsupported     | 1.13.0+         | 1.14.0+         | 1.15.0+         |
-| Packet         | unsupported     | unsupported     | unsupported     | 1.13.0+         | 1.14.0+         | 1.15.0+         |
+| Cloud provider | Kubernetes 1.10 | Kubernetes 1.11 | Kubernetes 1.12 | Kubernetes 1.13 | Kubernetes 1.14 | Kubernetes 1.15 | Kubernetes 1.16 |
+| -------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- |
+| AWS            | 1.10.0+         | 1.11.0+         | 1.12.1+         | 1.13.0+         | 1.14.0+         | 1.15.0+         | 1.16.0+         |
+| Azure          | 1.10.1+         | 1.11.0+         | 1.12.1+         | 1.13.0+         | 1.14.0+         | 1.15.0+         | 1.16.0+         |
+| GCP            | 1.10.0+         | 1.11.0+         | 1.12.1+         | 1.13.0+         | 1.14.0+         | 1.15.0+         | 1.16.0+         |
+| OpenStack      | 1.10.1+         | 1.11.0+         | 1.12.1+         | 1.13.0+         | 1.14.0+         | 1.15.0+         | 1.16.0+         |
+| Alicloud       | unsupported     | unsupported     | unsupported     | 1.13.0+         | 1.14.0+         | 1.15.0+         | 1.16.0+         |
+| Packet         | unsupported     | unsupported     | unsupported     | 1.13.0+         | 1.14.0+         | 1.15.0+         | 1.16.0+         |

--- a/example/30-deprecated-cloudprofile-alicloud.yaml
+++ b/example/30-deprecated-cloudprofile-alicloud.yaml
@@ -15,6 +15,7 @@ spec:
       - name: unmanaged
       kubernetes:
         versions:
+        - 1.16.0
         - 1.15.2
         - 1.14.5
         - 1.13.9

--- a/example/30-deprecated-cloudprofile-aws.yaml
+++ b/example/30-deprecated-cloudprofile-aws.yaml
@@ -14,6 +14,7 @@ spec:
       - name: unmanaged
       kubernetes:
         versions:
+        - 1.16.0
         - 1.15.2
         - 1.14.5
         - 1.13.9

--- a/example/30-deprecated-cloudprofile-azure.yaml
+++ b/example/30-deprecated-cloudprofile-azure.yaml
@@ -14,6 +14,7 @@ spec:
       - name: unmanaged
       kubernetes:
         versions:
+        - 1.16.0
         - 1.15.2
         - 1.14.5
         - 1.13.9

--- a/example/30-deprecated-cloudprofile-gcp.yaml
+++ b/example/30-deprecated-cloudprofile-gcp.yaml
@@ -14,6 +14,7 @@ spec:
       - name: unmanaged
       kubernetes:
         versions:
+        - 1.16.0
         - 1.15.2
         - 1.14.5
         - 1.13.9

--- a/example/30-deprecated-cloudprofile-openstack.yaml
+++ b/example/30-deprecated-cloudprofile-openstack.yaml
@@ -16,6 +16,7 @@ spec:
       - name: MY-FLOATING-POOL
       kubernetes:
         versions:
+        - 1.16.0
         - 1.15.2
         - 1.14.5
         - 1.13.9

--- a/example/30-deprecated-cloudprofile-packet.yaml
+++ b/example/30-deprecated-cloudprofile-packet.yaml
@@ -15,6 +15,7 @@ spec:
       - name: unmanaged
       kubernetes:
         versions:
+        - 1.16.0
         - 1.15.2
         - 1.14.5
         - 1.13.9

--- a/example/90-shoot-alicloud.yaml
+++ b/example/90-shoot-alicloud.yaml
@@ -81,7 +81,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.15.2 # specify "major.minor" to get latest patch version
+    version: 1.16.0 # specify "major.minor" to get latest patch version
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   admissionPlugins:

--- a/example/90-shoot-aws.yaml
+++ b/example/90-shoot-aws.yaml
@@ -83,7 +83,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.15.2 # specify "major.minor" to get latest patch version
+    version: 1.16.0 # specify "major.minor" to get latest patch version
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   admissionPlugins:

--- a/example/90-shoot-azure.yaml
+++ b/example/90-shoot-azure.yaml
@@ -82,7 +82,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.15.2 # specify "major.minor" to get latest patch version
+    version: 1.16.0 # specify "major.minor" to get latest patch version
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   admissionPlugins:

--- a/example/90-shoot-gcp.yaml
+++ b/example/90-shoot-gcp.yaml
@@ -81,7 +81,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.15.2 # specify "major.minor" to get latest patch version
+    version: 1.16.0 # specify "major.minor" to get latest patch version
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   admissionPlugins:

--- a/example/90-shoot-openstack.yaml
+++ b/example/90-shoot-openstack.yaml
@@ -80,7 +80,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.15.2 # specify "major.minor" to get latest patch version
+    version: 1.16.0 # specify "major.minor" to get latest patch version
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   admissionPlugins:

--- a/example/90-shoot-packet.yaml
+++ b/example/90-shoot-packet.yaml
@@ -76,7 +76,7 @@ spec:
   #   scaleDownDelayAfterFailure: 10m
   #   scaleDownDelayAfterDelete: 10s
   #   scanInterval: 10s
-    version: 1.15.2 # specify "major.minor" to get latest patch version
+    version: 1.16.0 # specify "major.minor" to get latest patch version
     allowPrivilegedContainers: true # 'true' means that all authenticated users can use the "gardener.privileged" PodSecurityPolicy, allowing full unrestricted access to Pod features.
   # kubeAPIServer:
   #   admissionPlugins:

--- a/hack/templates/resources/30-deprecated-cloudprofile.yaml.tpl
+++ b/hack/templates/resources/30-deprecated-cloudprofile.yaml.tpl
@@ -68,6 +68,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % if kubernetesVersions != []:
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
+        - 1.16.0
         - 1.15.2
         - 1.14.5
         - 1.13.9
@@ -172,6 +173,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % if kubernetesVersions != []:
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
+        - 1.16.0
         - 1.15.2
         - 1.14.5
         - 1.13.9
@@ -273,6 +275,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % if kubernetesVersions != []:
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
+        - 1.16.0
         - 1.15.2
         - 1.14.5
         - 1.13.9
@@ -366,6 +369,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
         versions:
+        - 1.16.0
         - 1.15.2
         - 1.14.5
         - 1.13.9
@@ -451,6 +455,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
         versions:
+        - 1.16.0
         - 1.15.2
         - 1.14.5
         - 1.13.9
@@ -539,6 +544,7 @@ spec:<% caBundle=value("spec.caBundle", "") %>
         % if kubernetesVersions != []:
         ${yaml.dump(kubernetesVersions, width=10000, default_flow_style=None)}
         % else:
+        - 1.16.0
         - 1.15.2
         - 1.14.5
         - 1.13.9

--- a/hack/templates/resources/90-shoot.yaml.tpl
+++ b/hack/templates/resources/90-shoot.yaml.tpl
@@ -25,22 +25,22 @@
   kubernetesVersion=""
   if cloud == "aws":
     region="eu-west-1"
-    kubernetesVersion="1.15.2"
+    kubernetesVersion="1.16.0"
   elif cloud == "azure" or cloud == "az":
     region="westeurope"
-    kubernetesVersion="1.15.2"
+    kubernetesVersion="1.16.0"
   elif cloud == "gcp":
     region="europe-west1"
-    kubernetesVersion="1.15.2"
+    kubernetesVersion="1.16.0"
   elif cloud == "alicloud":
     region="cn-beijing"
-    kubernetesVersion="1.15.2"
+    kubernetesVersion="1.16.0"
   elif cloud == "packet":
     region="ewr1"
-    kubernetesVersion="1.15.2"
+    kubernetesVersion="1.16.0"
   elif cloud == "openstack" or cloud == "os":
     region="europe-1"
-    kubernetesVersion="1.15.2"
+    kubernetesVersion="1.16.0"
 %>---
 apiVersion: garden.sapcloud.io/v1beta1
 kind: Shoot

--- a/pkg/apis/garden/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.defaults.go
@@ -126,11 +126,6 @@ func SetObjectDefaults_SeedList(in *SeedList) {
 
 func SetObjectDefaults_Shoot(in *Shoot) {
 	SetDefaults_Shoot(in)
-	if in.Spec.Addons != nil {
-		if in.Spec.Addons.KubernetesDashboard != nil {
-			SetDefaults_KubernetesDashboard(in.Spec.Addons.KubernetesDashboard)
-		}
-	}
 	if in.Spec.Cloud.AWS != nil {
 		for i := range in.Spec.Cloud.AWS.Workers {
 			a := &in.Spec.Cloud.AWS.Workers[i]

--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -119,6 +119,7 @@ var supportedKubernetesVersions = []string{
 	"1.13",
 	"1.14",
 	"1.15",
+	"1.16",
 }
 
 func checkIfSupportedKubernetesVersion(gitVersion string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Support for Kubernetes v1.16

**Which issue(s) this PR fixes**:
Fixes #1376 

**Special notes for your reviewer**:
I didn't vendor the `kubernetes-1.16` sources yet because the controller-runtime is still using `kubenretes-1.14`.

⚠️ Also, using 1.16 requires a newer version of the provider extensions (not yet released, you can use `0.13.0-dev3-kubernetes-1.16` tag for testing, if you want.)

I have successfully validated the functionality for all cloud providers and all older versions:
- :white_check_mark: Create new clusters with versions < 1.16
- :white_check_mark: Create new clusters with version  = 1.16
- :white_check_mark: Upgrade old clusters from version 1.15 to version 1.16
- :white_check_mark: Delete clusters with versions < 1.16
- :white_check_mark: Delete clusters with version  = 1.16

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```action operator
In order to support Kubernetes 1.16 you must use at least v[`0.13.0`](https://github.com/gardener/gardener-extensions/releases/tag/0.13.0) of the provider extension controllers.
```
```noteworthy user
Gardener does now support shoot clusters with Kubernetes version 1.16. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md) before upgrading to 1.16.
```
```noteworthy user
The CoreDNS version for all shoots has been upgraded from `1.4.0` to `1.6.3`.
```
```action user
As the Kubernetes community is in the process of deprecating basic authentication for the kube-apiserver newly created 1.16 shoot clusters don't enable it by default anymore. Similarly, the default authentication mode for the `kubernetes-dashboard` addon is `token` instead of `basic`. You can still enable it manually, but you should consider migrating away from it. We will drop basic authentication support in a future release when Kubernetes doesn't support it anymore.
```