### PR TITLE
Change prometheus retention to 30d

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -81,7 +81,8 @@ spec:
         - --config.file=/etc/prometheus/config/prometheus.yaml
         - --storage.tsdb.path=/var/prometheus/data
         - --storage.tsdb.no-lockfile
-        - --storage.tsdb.retention.time=180h
+        - --storage.tsdb.retention.time=30d
+        - --storage.tsdb.retention.size=15GB
         - --web.route-prefix=/
         - --web.enable-lifecycle
         - --web.listen-address=0.0.0.0:{{ .Values.port }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Increases the shoot prometheus retention to 30 days. Prometheus has 20GB of storage available. To prevent potential out of storage problems the flag `--storage.tsdb.retention.size=15GB` has been set. This gives prometheus a 5GB buffer for its wal. The largest shoot prometheus we have needs a wal of about 2GB, so this should give us plenty of buffer.

**Which issue(s) this PR fixes**:
Fixes #1356

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Increase shoot prometheus retention to 30d. Retention is guaranteed if prometheus exceeds 15GB of storage.
```
