### PR TITLE
Don't set failBelowRevision for etcd-events

### DIFF
--- a/pkg/operation/hybridbotanist/controlplane.go
+++ b/pkg/operation/hybridbotanist/controlplane.go
@@ -543,7 +543,6 @@ func (b *HybridBotanist) DeployETCD(ctx context.Context) error {
 				if err := b.Botanist.DeleteBackupInfrastructure(); err != nil {
 					return err
 				}
-				delete(etcd, "failBelowRevision")
 			}
 
 			// Restore the replica count from capture statefulset state.
@@ -553,6 +552,8 @@ func (b *HybridBotanist) DeployETCD(ctx context.Context) error {
 				etcd["replicas"] = *statefulset.Spec.Replicas
 			}
 		}
+
+		delete(etcd, "failBelowRevision")
 
 		if err := b.ApplyChartSeed(filepath.Join(chartPathControlPlane, "etcd"), b.Shoot.SeedNamespace, fmt.Sprintf("etcd-%s", role), nil, etcd); err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
