### PR TITLE
Aggregate prometheus tsdb metrics

### DIFF
--- a/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
@@ -43,6 +43,8 @@ data:
         - '{__name__="probe_success", job="blackbox-exporter-k8s-service-check"}'
         - '{__name__=~"shoot:(.+):(.+)"}'
         - '{__name__="ALERTS"}'
+        - '{__name__="prometheus_tsdb_lowest_timestamp"}'
+        - '{__name__="prometheus_tsdb_storage_blocks_bytes"}'
       kubernetes_sd_configs:
       - role: endpoints
       relabel_configs:
@@ -52,6 +54,11 @@ data:
         - __meta_kubernetes_endpoint_port_name
         regex: shoot-(.+);prometheus-web;metrics
         action: keep
+      metric_relable_configs:
+      - source_labels:
+        - exported_job
+        - exported_instance
+        action: drop
 
     - job_name: prometheus
       metrics_path: /federate

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -256,8 +256,10 @@ allowedMetrics:
   - prometheus_tsdb_head_gc_duration_seconds_count
   - prometheus_tsdb_head_samples_appended_total
   - prometheus_tsdb_head_series
+  - prometheus_tsdb_lowest_timestamp
   - prometheus_tsdb_reloads_failures_total
   - prometheus_tsdb_reloads_total
+  - prometheus_tsdb_storage_blocks_bytes
   - prometheus_tsdb_wal_corruptions_total
   blackboxExporter:
   - probe_duration_seconds


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds and aggregates prometheus metrics to view prometheus storage over time. The exported_job and exported_instance labels are also dropped from aggregated metrics because they are unnecessary. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
