### PR TITLE
Finalizers are written by gardener-controller-manager not gardener-apiserver

### DIFF
--- a/pkg/controllermanager/controller/cloudprofile/cloudprofile_control.go
+++ b/pkg/controllermanager/controller/cloudprofile/cloudprofile_control.go
@@ -149,6 +149,18 @@ func (c *defaultControl) ReconcileCloudProfile(obj *gardenv1beta1.CloudProfile, 
 		cloudProfileLogger.Info(message)
 		return errors.New("CloudProfile still has references")
 	}
+
+	finalizers := sets.NewString(cloudProfile.Finalizers...)
+	if !finalizers.Has(gardenv1beta1.GardenerName) {
+		finalizers.Insert(gardenv1beta1.GardenerName)
+		cloudProfile.Finalizers = finalizers.UnsortedList()
+
+		if _, err := c.k8sGardenClient.Garden().GardenV1beta1().CloudProfiles().Update(cloudProfile); err != nil {
+			logger.Logger.Errorf("Could not add finalizer to CloudProfile: %s", err.Error())
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/registry/garden/cloudprofile/strategy.go
+++ b/pkg/registry/garden/cloudprofile/strategy.go
@@ -19,10 +19,8 @@ import (
 
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/garden"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/garden/validation"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/storage/names"
 )
@@ -40,13 +38,6 @@ func (cloudProfileStrategy) NamespaceScoped() bool {
 }
 
 func (cloudProfileStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
-	cloudprofile := obj.(*garden.CloudProfile)
-
-	finalizers := sets.NewString(cloudprofile.Finalizers...)
-	if !finalizers.Has(gardenv1beta1.GardenerName) {
-		finalizers.Insert(gardenv1beta1.GardenerName)
-	}
-	cloudprofile.Finalizers = finalizers.UnsortedList()
 }
 
 func (cloudProfileStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/garden/project/strategy.go
+++ b/pkg/registry/garden/project/strategy.go
@@ -19,11 +19,9 @@ import (
 
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/garden"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/garden/validation"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/storage/names"
 )
@@ -45,12 +43,6 @@ func (projectStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object)
 
 	project.Generation = 1
 	project.Status = garden.ProjectStatus{}
-
-	finalizers := sets.NewString(project.Finalizers...)
-	if !finalizers.Has(gardenv1beta1.GardenerName) {
-		finalizers.Insert(gardenv1beta1.GardenerName)
-	}
-	project.Finalizers = finalizers.UnsortedList()
 }
 
 func (projectStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {

--- a/pkg/registry/garden/quota/strategy.go
+++ b/pkg/registry/garden/quota/strategy.go
@@ -19,10 +19,8 @@ import (
 
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/garden"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/garden/validation"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/storage/names"
 )
@@ -40,13 +38,6 @@ func (quotaStrategy) NamespaceScoped() bool {
 }
 
 func (quotaStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
-	quota := obj.(*garden.Quota)
-
-	finalizers := sets.NewString(quota.Finalizers...)
-	if !finalizers.Has(gardenv1beta1.GardenerName) {
-		finalizers.Insert(gardenv1beta1.GardenerName)
-	}
-	quota.Finalizers = finalizers.UnsortedList()
 }
 
 func (quotaStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/garden/secretbinding/strategy.go
+++ b/pkg/registry/garden/secretbinding/strategy.go
@@ -19,10 +19,8 @@ import (
 
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/garden"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/garden/validation"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/storage/names"
 )
@@ -40,13 +38,6 @@ func (secretBindingStrategy) NamespaceScoped() bool {
 }
 
 func (secretBindingStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
-	binding := obj.(*garden.SecretBinding)
-
-	finalizers := sets.NewString(binding.Finalizers...)
-	if !finalizers.Has(gardenv1beta1.GardenerName) {
-		finalizers.Insert(gardenv1beta1.GardenerName)
-	}
-	binding.Finalizers = finalizers.UnsortedList()
 }
 
 func (secretBindingStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/garden/seed/strategy.go
+++ b/pkg/registry/garden/seed/strategy.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/garden"
 	"github.com/gardener/gardener/pkg/apis/garden/helper"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/garden/validation"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -30,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
@@ -113,12 +111,6 @@ func (s Strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 
 	seed.Generation = 1
 	seed.Status = garden.SeedStatus{}
-
-	finalizers := sets.NewString(seed.Finalizers...)
-	if !finalizers.Has(gardenv1beta1.GardenerName) {
-		finalizers.Insert(gardenv1beta1.GardenerName)
-	}
-	seed.Finalizers = finalizers.UnsortedList()
 }
 
 // PrepareForUpdate is invoked on update before validation to normalize

--- a/pkg/registry/garden/shoot/strategy.go
+++ b/pkg/registry/garden/shoot/strategy.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gardener/gardener/pkg/api"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	"github.com/gardener/gardener/pkg/apis/garden"
-	gardenv1beta1 "github.com/gardener/gardener/pkg/apis/garden/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/garden/validation"
 	"github.com/gardener/gardener/pkg/operation/common"
 
@@ -29,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -57,13 +55,6 @@ func (shootStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 
 	shoot.Generation = 1
 	shoot.Status = garden.ShootStatus{}
-
-	finalizers := sets.NewString(shoot.Finalizers...)
-	if !finalizers.Has(gardenv1beta1.GardenerName) {
-		finalizers.Insert(gardenv1beta1.GardenerName)
-	}
-	shoot.Finalizers = finalizers.UnsortedList()
-
 }
 
 func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Finalizers are not written by gardener-apiserver anymore.
Instead gardener-controller-manager sets the gardener finalizer at the start of the reconciliation logic.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
- Please check if the finalizers are written in the correct position in code.

```improvement user
Finalizers for resources of the Gardener APIs are no longer written during creation by the `gardener-apiserver`. Instead, the `gardener-controller-manager` writes them once it starts reconciliation.
```