### PR TITLE
trouble shooting guide: dealing with dnsentries "already busy for owner"

### DIFF
--- a/docs/usage/trouble_shooting_guide.md
+++ b/docs/usage/trouble_shooting_guide.md
@@ -28,3 +28,42 @@ This guide records the issues that are quite possible across upgrade of Gardener
 3. Find out the latest full snapshot and delta snapshot from old backup bucket. The old backup bucket name is same as the backupInfra resource associated with Shoot in Garden cluster.
 4. Move them manually to new backup bucket.
 5. Enable the Gardener reconciliation for shoot by removing annotation `shoot.garden.sapcloud.io/ignore=true`.
+
+### After upgrading/restarting a local Gardener setup, the DNSEntries on the seeds show the error "... already busy for owner ..."
+
+#### Issue
+- custom resources DNSEntries on the seeds show the error "dns name "api.myshoot.mygarden.internal.dev.k8s.ondemand.com" already busy for owner "seed.gardener.cloud/a1234567-XXXX-XXXX-XXXX-025000000001/aws"
+- API server is not available via DNS name
+
+#### Environment
+- Gardener version: 0.20.0+
+
+#### Root Cause
+
+DNS records created by Gardener's dns-controller-manager are stored together with meta data, especially
+with an owner identifier. In this way the dns-controller-manager knows which records belong to it.
+It never changes records which are not owned by it.
+The owner identifier is unique for every seed and computed from the Gardener identity and the seed identity.
+The Gardener identity is the UUID of the garden namespace of the Gardener cluster.
+Especially if you have a local Gardener setup, there are situations where the Kubernetes cluster and therefore the garden namespace have to be recreated.
+For example, on updating docker-desktop all containers may have been deleted and are recreated.
+
+#### Action
+
+On each seed, you have to tell the dns-controller-manager, that it is also responsible for secondary owner
+identifiers. For this purpose create a custom resource `DNSOwner` and set the attribute `ownerId` to the old
+owner identifier shown in the error message of the DNS entries, e.g.
+
+```yaml
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSOwner
+metadata:
+  name: old-owner
+  namespace: default
+spec:
+  ownerId: seed.gardener.cloud/a1234567-XXXX-XXXX-XXXX-025000000001/aws
+  active: true
+```
+
+Currently the dns-controller-manager has to be restarted (i.e. delete its current pod) to make it known of
+the secondary owner identifier.


### PR DESCRIPTION
**What this PR does / why we need it**:
Several developer have already run into the problem that their local Gardener setup stops working
after upgrading Docker. The visible issue is an "already busy for owner" error of DNSEntries of the dns-controller-manager. As the root cause is not easy to understand, a section is added to the trouble shooting guide.
