### PR TITLE
Enhance retry logic for shootapp test

### DIFF
--- a/test/integration/framework/garden_operation.go
+++ b/test/integration/framework/garden_operation.go
@@ -322,11 +322,11 @@ func (o *GardenerTestOperation) WaitUntilDeploymentsWithLabelsIsReady(ctx contex
 
 // WaitUntilGuestbookAppIsAvailable waits until the guestbook app is available and ready to serve requests
 func (o *GardenerTestOperation) WaitUntilGuestbookAppIsAvailable(ctx context.Context, guestbookAppUrls []string) error {
-	return retry.Until(ctx, defaultPollInterval, func(ctx context.Context) (done bool, err error) {
+	return retry.UntilTimeout(ctx, defaultPollInterval, 5*time.Minute, func(ctx context.Context) (done bool, err error) {
 		for _, guestbookAppURL := range guestbookAppUrls {
 			response, err := o.HTTPGet(ctx, guestbookAppURL)
 			if err != nil {
-				return retry.SevereError(err)
+				return retry.MinorError(err)
 			}
 
 			if response.StatusCode != http.StatusOK {


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhance retry logic of the shootapp test by retrying the guestbook app availability even when the initial request errors.
This should fix problems when loadbalancers take to long to route traffic correctly or we temporarily run into a lb timeout.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
