### PR TITLE
Fix monitoring regression

### DIFF
--- a/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
@@ -38,9 +38,10 @@ data:
     scrape_configs:
     - job_name: shoot-prometheus
       metrics_path: /federate
+      honor_labels: true
       params:
         'match[]':
-        - '{__name__="probe_success", job="blackbox-exporter-k8s-service-check"}'
+        - '{__name__="shoot:availability"}'
         - '{__name__=~"shoot:(.+):(.+)"}'
         - '{__name__="ALERTS"}'
         - '{__name__="prometheus_tsdb_lowest_timestamp"}'
@@ -54,11 +55,6 @@ data:
         - __meta_kubernetes_endpoint_port_name
         regex: shoot-(.+);prometheus-web;metrics
         action: keep
-      metric_relabel_configs:
-      - source_labels:
-        - exported_job
-        - exported_instance
-        action: drop
 
     - job_name: prometheus
       metrics_path: /federate

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/apiserver-connectivity-check.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/apiserver-connectivity-check.rules.yaml
@@ -1,14 +1,16 @@
 groups:
-  - name: apiserver-connectivity-check.rules
-    rules:
-    - alert: ApiServerUnreachableViaKubernetesService
-      expr: probe_success{job="blackbox-exporter-k8s-service-check"} != 1
-      for: 15m
-      labels:
-        service: apiserver-connectivity-check
-        severity: critical
-        type: shoot
-        visibility: all
-      annotations:
-        summary: Api server unreachable via the kubernetes service.
-        description: The Api server has been unreachable for 3 minutes via the kubernetes service in the shoot.
+- name: apiserver-connectivity-check.rules
+  rules:
+  - alert: ApiServerUnreachableViaKubernetesService
+    expr: probe_success{job="blackbox-exporter-k8s-service-check"} != 1
+    for: 15m
+    labels:
+      service: apiserver-connectivity-check
+      severity: critical
+      type: shoot
+      visibility: all
+    annotations:
+      summary: Api server unreachable via the kubernetes service.
+      description: The Api server has been unreachable for 3 minutes via the kubernetes service in the shoot.
+  - record: shoot:availability
+    expr: probe_success{job="blackbox-exporter-k8s-service-check"} == bool 1


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a regression that was added to the monitoring stack. We no longer drop important metrics for the monitoring aggregation and use `honor_labels: true` to prevent adding `exported_job` and `exported_instance` labels.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fix monitoring regression for aggregated monitoring
```
