### PR TITLE
Add support for terraform state v4

### DIFF
--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -258,10 +258,6 @@ const (
 	// TerraformerJobSuffix is the suffix used for the name of the Job which executes the Terraform configuration.
 	TerraformerJobSuffix = ".tf-job"
 
-	// TerraformerPurposeInfraDeprecated is a constant for the complete Terraform setup with purpose 'infrastructure'.
-	// deprecated
-	TerraformerPurposeInfraDeprecated = "infra"
-
 	// TerraformerPurposeInternalDNSDeprecated is a constant for the complete Terraform setup with purpose 'internal cluster domain'
 	// deprecated
 	TerraformerPurposeInternalDNSDeprecated = "internal-dns"


### PR DESCRIPTION
**What this PR does / why we need it**:
Terraform v0.12 comes with a new `version: 4` for the state representation. This PR updates the terraformer package to be able to work also with the new version of terraform state.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The terraformer package is now able to work with version 4 of terraform state.
```
