### PR TITLE
Use metrics-server 0.3.1 for 1.10.x clusters

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -68,6 +68,12 @@ images:
   sourceRepository: github.com/kubernetes-incubator/metrics-server
   repository: k8s.gcr.io/metrics-server-amd64
   tag: v0.3.3
+  targetVersion: ">= 1.11"
+- name: metrics-server
+  sourceRepository: github.com/kubernetes-incubator/metrics-server
+  repository: k8s.gcr.io/metrics-server-amd64
+  tag: v0.3.1
+  targetVersion: 1.10.x
 
 # Shoot core addons
 - name: vpn-shoot


### PR DESCRIPTION
**What this PR does / why we need it**:
Issues haven been faced when using `v0.3.3` of the `metrics-server` in kubernetes `1.10.x` clusters because the `openapi/v2` spec is changed in a way that isn't interpretable by older client (e.g. `kubectl 1.10.x`). So we switch back to `v0.3.1` for `1.10.x` clusters. 

**Special notes for your reviewer**:
/cc @zanetworker @schrodit @OlegLoewen @dguendisch @wyb1

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue has been fixed that caused different `kubectl` commands to not work properly on Kubernetes clusters of version `1.10.x`. Therefore, Gardener rolls back the `metric-server` to `v0.3.1` for those clusters.
```
