### PR TITLE
Fix deletion of unsuccessfully hibernated Shoot

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_control_delete.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_delete.go
@@ -195,7 +195,7 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation) *gardencorev1alp
 		})
 		wakeUpControlPlane = g.Add(flow.Task{
 			Name:         "Waking up control plane to ensure proper cleanup of resources",
-			Fn:           flow.TaskFn(botanist.WakeUpControlPlane).DoIf((o.Shoot.Info.Status.IsHibernated != nil && *o.Shoot.Info.Status.IsHibernated || o.Shoot.Info.Status.IsHibernated == nil && o.Shoot.HibernationEnabled) && cleanupShootResources),
+			Fn:           flow.TaskFn(botanist.WakeUpControlPlane).DoIf(((o.Shoot.Info.Status.IsHibernated != nil && *o.Shoot.Info.Status.IsHibernated) || o.Shoot.HibernationEnabled) && cleanupShootResources),
 			Dependencies: flow.NewTaskIDs(syncClusterResourceToSeed, waitUntilControlPlaneReady),
 		})
 		waitUntilKubeAPIServerIsReady = g.Add(flow.Task{


### PR DESCRIPTION
**What this PR does / why we need it**:
The gardener-controller-manager fails with nil pointer dereference trying to delete a Shoot which has `.spec.hibernation.enabled: true` and `.status.hibernated: false` and the kube-apiserver deployment exists and is scaled down to 0.
The PR forces controlplane wake up even in the above case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @vpnachev , @danielfoehrKn , @timuthy 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The deletion of unsuccessfully hibernated Shoot was improved to prevent nil pointer dereference in `gardener-controller-manager`.
```
