### PR TITLE
Fix deletion of ControlPlane secrets

### DIFF
--- a/pkg/utils/secrets/secrets.go
+++ b/pkg/utils/secrets/secrets.go
@@ -86,9 +86,5 @@ func getSecrets(cs kubernetes.Interface, namespace string) (map[string]*corev1.S
 }
 
 func deleteSecret(cs kubernetes.Interface, namespace, name string) error {
-	err := cs.CoreV1().Secrets(namespace).Delete(name, &metav1.DeleteOptions{})
-	if err != nil {
-		return errors.Wrapf(err, "could not delete secret '%s/%s'", namespace, name)
-	}
-	return nil
+	return cs.CoreV1().Secrets(namespace).Delete(name, &metav1.DeleteOptions{})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the ControlPlane actuator uses `github.com/gardener/gardener/pkg/util/secrets` and tries to ignore not found errors with with `client.IgnoreNotFound(err) != nil`. 

Ref https://github.com/gardener/gardener-extensions/blob/0.13.2/pkg/controller/controlplane/genericactuator/actuator.go#L424

However currently `(s *Secrets) Delete` will never return an apierrors.NotFound. The PR adapts the deletion to return the appropriate error.
The PR fixes ControlPlane deletions with error like:
```
Error deleting controlplane: could not delete secrets for controlplane 'shoot--foo--bar'
```

/king bug

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @shturec 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
