### PR TITLE
Add backup extension resource documentation

### DIFF
--- a/docs/extensions/backupbucket.md
+++ b/docs/extensions/backupbucket.md
@@ -1,0 +1,49 @@
+# Contract: `BackupBucket` resource
+
+The Gardener project features a sub-project called [etcd-backup-restore](https://github.com/gardener/etcd-backup-restore) to take periodic backups of etcd backing Shoot clusters. It demands the bucket (or its equivalent in different object store providers) to be created and configured externally with appropriate credentials. The `BackupBucket` resource takes this responsibility in Gardener.
+
+Before introducing the `BackupBucket` extension resource Gardener was using Terraform in order to create and manage these provider-specific resources (e.g., see [here](https://github.com/gardener/gardener/tree/0.27.0/charts/seed-terraformer/charts/aws-backup)).
+Now, Gardener commissions an external, provider-specific controller to take over this task. You can also refer to backupInfra proposal documentation to get idea about how the transition was done and understand the resource in broader scope.
+
+## What is the scope of bucket?
+
+A bucket will be provisioned per `Seed`. So, backup of every `Shoot` created on that `Seed` will be stored under different shoot specific prefix under the bucket.
+For the backup of the `Shoot` rescheduled on different `Seed` it will continue to use the same bucket.
+
+## What is the lifespan of `BackupBucket`?
+The bucket associated with `BackupBucket` will be created at creation of `Seed`. And as per current implementation, it will be deleted on deletion of `Seed` and there isn't any `BackupEntry` resource associated with it.
+
+Eventually, in future the the deletion logic will be changed such that on deletion of `Seed` if there isn't anu schedulable `Seed` available and there isn't any associated `BackupEntry` resource.
+
+## What needs to be implemented to support a new infrastructure provider?
+
+As part of the seed flow Gardener will create a special CRD in the seed cluster that needs to be reconciled by an extension controller, for example:
+
+```yaml
+---
+apiVersion: extensions.gardener.cloud/v1alpha1
+kind: BackupBucket
+metadata:
+  name: foo
+spec:
+  type: azure
+  region: eu-west-1
+  secretRef:
+    name: backupprovider
+    namespace: shoot--foo--bar
+```
+
+The `.spec.secretRef` contains a reference to the provider secret pointing to the account that shall be used to create the needed resources. This provider secret will be configured
+by Gardener operator in `seed` resource and propagated over here by seed controller.
+
+After your controller has created the required bucket, if required it needs generate the secret to access the objects in buckets and put reference to it in `status`. This secret is
+supposed to be used by Gardener or eventually `BackupEntry` resource and etcd-backup-restore component to backup the etcd.
+
+In order to support a new infrastructure provider you need to write a controller that watches all `BackupBucket`s with `.spec.type=<my-provider-name>`. You can take a look at the below referenced example implementation for the Azure provider.
+
+## References and additional resources
+
+* [`BackupBucket` API Reference](https://gardener.cloud/api-reference/extensions/#extensions.gardener.cloud/v1alpha1.BackupBucket)
+* [Exemplary implementation for the Azure provider](https://github.com/gardener/gardener-extensions/tree/master/controllers/provider-azure/pkg/controller/backupbucket)
+* [`BackupEntry` resource documentation](./backupentry.md)
+* [Shared bucket proposal](../proposals/02-backupinfra.md)

--- a/docs/extensions/backupbucket.md
+++ b/docs/extensions/backupbucket.md
@@ -13,7 +13,7 @@ For the backup of the `Shoot` rescheduled on different `Seed` it will continue t
 ## What is the lifespan of `BackupBucket`?
 The bucket associated with `BackupBucket` will be created at creation of `Seed`. And as per current implementation, it will be deleted on deletion of `Seed` and there isn't any `BackupEntry` resource associated with it.
 
-Eventually, in future the the deletion logic will be changed such that on deletion of `Seed` if there isn't anu schedulable `Seed` available and there isn't any associated `BackupEntry` resource.
+In the future, we plan to introduce schedule for `BackupBucket` the deletion logic for `BackupBucket` resource, which will reschedule the it on different available `seed`, on deletion or failure of health check for current associated `seed`. In that case, `BackupBucket` will be deleted only if there isn't any schedulable `Seed` available and there isn't any associated `BackupEntry` resource.
 
 ## What needs to be implemented to support a new infrastructure provider?
 
@@ -34,9 +34,9 @@ spec:
 ```
 
 The `.spec.secretRef` contains a reference to the provider secret pointing to the account that shall be used to create the needed resources. This provider secret will be configured
-by Gardener operator in `seed` resource and propagated over here by seed controller.
+by Gardener operator in the `seed` resource and propagated over there by seed controller.
 
-After your controller has created the required bucket, if required it needs generate the secret to access the objects in buckets and put reference to it in `status`. This secret is
+After your controller has created the required bucket, if required it generates the secret to access the objects in buckets and put reference to it in `status`. This secret is
 supposed to be used by Gardener or eventually `BackupEntry` resource and etcd-backup-restore component to backup the etcd.
 
 In order to support a new infrastructure provider you need to write a controller that watches all `BackupBucket`s with `.spec.type=<my-provider-name>`. You can take a look at the below referenced example implementation for the Azure provider.

--- a/docs/extensions/backupentry.md
+++ b/docs/extensions/backupentry.md
@@ -1,0 +1,43 @@
+# Contract: `BackupEntry` resource
+
+The Gardener project features a sub-project called [etcd-backup-restore](https://github.com/gardener/etcd-backup-restore) to take periodic backups of etcd backing Shoot clusters. It demands the bucket (or its equivalent in different object store providers) access credentials to be created and configured externally with appropriate credentials. The `BackupEntry` resource takes this responsibility in Gardener to provide this information by creating secret specific to the component. Said that, core motivation for introducing this resource was to support retention  of backups post deletion of `Shoot`. The etcd-backup-restore components takes responsibility of garbage collecting old backups out of define period. Once shoot is deleted, we need to persist the backups for few days. Hence, Gardener uses the BackupEntry resource for this housekeeping work post deletion of `Shoot`. The `BackupEntry` resource is responsible for shoot specific prefix under referred bucket.
+
+Before introducing the `BackupEntry` extension resource Gardener was using Terraform in order to create and manage these provider-specific resources (e.g., see [here](https://github.com/gardener/gardener/tree/0.27.0/charts/seed-terraformer/charts/aws-backup)).
+Now, Gardener commissions an external, provider-specific controller to take over this task. You can also refer to backupInfra proposal documentation to get idea about how the transition was done and understand the resource in broader scope.
+
+## What is the lifespan of `BackupEntry`?
+The bucket associated with `BackupEntry` will be created at using `BackupBucket` resource. The `BackupEntry` resource will be created as a part of `Shoot` creation. But resource continue to exists post deletion of `Shoot`. The  `deletionGracePeriod` of `BackupEntry` resource i.e. time after the shoot deletion
+is configurable globally for Gardener via gardener-controller-manager component config. You can find the configuration option in reference.
+
+## What needs to be implemented to support a new infrastructure provider?
+
+As part of the shoot flow Gardener will create a special CRD in the seed cluster that needs to be reconciled by an extension controller, for example:
+
+```yaml
+---
+apiVersion: extensions.gardener.cloud/v1alpha1
+kind: BackupEntry
+metadata:
+  name: shoot--foo--bar
+spec:
+  type: azure
+  region: eu-west-1
+  bucketName: foo
+  secretRef:
+    name: backupprovider
+    namespace: shoot--foo--bar
+```
+
+The `.spec.secretRef` contains a reference to the provider secret pointing to the account that shall be used to create the needed resources. This provider secret will be propagated from `BackupBucket` resource by Shoot controller.
+
+Your controller is supposed to create the `etcd-backup` secret in control-plane namespace for shoot. This secret is supposed to be used by Gardener or eventually etcd-backup-restore component to backup the etcd. The controller implementation should cleanup the objects created under shoot specific prefix in bucket equivalent to name of `BackupEntry` resource.
+
+In order to support a new infrastructure provider you need to write a controller that watches all `BackupBucket`s with `.spec.type=<my-provider-name>`. You can take a look at the below referenced example implementation for the Azure provider.
+
+## References and additional resources
+
+* [`BackupEntry` API Reference](https://gardener.cloud/api-reference/extensions/#extensions.gardener.cloud/v1alpha1.BackupBucket)
+* [Exemplary implementation for the Azure provider](https://github.com/gardener/gardener-extensions/tree/master/controllers/provider-azure/pkg/controller/backupentry)
+* [`BackupBucket` resource documentation](./backupbucket.md)
+* [Shared bucket proposal](../proposals/02-backupinfra.md)
+* [Gardener-controller-manager-component-config API specification](https://github.com/gardener/gardener/blob/master/pkg/controllermanager/apis/config/types.go)

--- a/docs/extensions/backupentry.md
+++ b/docs/extensions/backupentry.md
@@ -1,12 +1,12 @@
 # Contract: `BackupEntry` resource
 
-The Gardener project features a sub-project called [etcd-backup-restore](https://github.com/gardener/etcd-backup-restore) to take periodic backups of etcd backing Shoot clusters. It demands the bucket (or its equivalent in different object store providers) access credentials to be created and configured externally with appropriate credentials. The `BackupEntry` resource takes this responsibility in Gardener to provide this information by creating secret specific to the component. Said that, core motivation for introducing this resource was to support retention  of backups post deletion of `Shoot`. The etcd-backup-restore components takes responsibility of garbage collecting old backups out of define period. Once shoot is deleted, we need to persist the backups for few days. Hence, Gardener uses the BackupEntry resource for this housekeeping work post deletion of `Shoot`. The `BackupEntry` resource is responsible for shoot specific prefix under referred bucket.
+The Gardener project features a sub-project called [etcd-backup-restore](https://github.com/gardener/etcd-backup-restore) to take periodic backups of etcd backing Shoot clusters. It demands the bucket (or its equivalent in different object store providers) access credentials to be created and configured externally with appropriate credentials. The `BackupEntry` resource takes this responsibility in Gardener to provide this information by creating a secret specific to the component. Said that, the core motivation for introducing this resource was to support retention  of backups post deletion of `Shoot`. The etcd-backup-restore components takes responsibility of garbage collecting old backups out of the defined period. Once a shoot is deleted, we need to persist the backups for few days. Hence, Gardener uses the `BackupEntry` resource for this housekeeping work post deletion of a `Shoot`. The `BackupEntry` resource is responsible for shoot specific prefix under referred bucket.
 
 Before introducing the `BackupEntry` extension resource Gardener was using Terraform in order to create and manage these provider-specific resources (e.g., see [here](https://github.com/gardener/gardener/tree/0.27.0/charts/seed-terraformer/charts/aws-backup)).
 Now, Gardener commissions an external, provider-specific controller to take over this task. You can also refer to backupInfra proposal documentation to get idea about how the transition was done and understand the resource in broader scope.
 
 ## What is the lifespan of `BackupEntry`?
-The bucket associated with `BackupEntry` will be created at using `BackupBucket` resource. The `BackupEntry` resource will be created as a part of `Shoot` creation. But resource continue to exists post deletion of `Shoot`. The  `deletionGracePeriod` of `BackupEntry` resource i.e. time after the shoot deletion
+The bucket associated with `BackupEntry` will be created at using `BackupBucket` resource. The `BackupEntry` resource will be created as a part of a `Shoot` creation. But resource continue to exists post deletion of a `Shoot`. The  `deletionGracePeriod` of a `BackupEntry` resource i.e. time after the shoot deletion
 is configurable globally for Gardener via gardener-controller-manager component config. You can find the configuration option in reference.
 
 ## What needs to be implemented to support a new infrastructure provider?
@@ -30,7 +30,7 @@ spec:
 
 The `.spec.secretRef` contains a reference to the provider secret pointing to the account that shall be used to create the needed resources. This provider secret will be propagated from `BackupBucket` resource by Shoot controller.
 
-Your controller is supposed to create the `etcd-backup` secret in control-plane namespace for shoot. This secret is supposed to be used by Gardener or eventually etcd-backup-restore component to backup the etcd. The controller implementation should cleanup the objects created under shoot specific prefix in bucket equivalent to name of `BackupEntry` resource.
+Your controller is supposed to create the `etcd-backup` secret in control-plane namespace of a shoot. This secret is supposed to be used by Gardener or eventually the etcd-backup-restore component to backup the etcd. The controller implementation should cleanup the objects created under shoot specific prefix in bucket equivalent to name of `BackupEntry` resource.
 
 In order to support a new infrastructure provider you need to write a controller that watches all `BackupBucket`s with `.spec.type=<my-provider-name>`. You can take a look at the below referenced example implementation for the Azure provider.
 
@@ -40,4 +40,4 @@ In order to support a new infrastructure provider you need to write a controller
 * [Exemplary implementation for the Azure provider](https://github.com/gardener/gardener-extensions/tree/master/controllers/provider-azure/pkg/controller/backupentry)
 * [`BackupBucket` resource documentation](./backupbucket.md)
 * [Shared bucket proposal](../proposals/02-backupinfra.md)
-* [Gardener-controller-manager-component-config API specification](https://github.com/gardener/gardener/blob/master/pkg/controllermanager/apis/config/types.go)
+* [Gardener-controller-manager-component-config API specification](https://github.com/gardener/gardener/blob/master/pkg/controllermanager/apis/config/types.go#L101-#L107)


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**What this PR does / why we need it**:
This PR adds the documentation for extension BackupBucket and BackupEntry resources.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
