### PR TITLE
Update generate monitoring doc script to return 0 if there are no changes

### DIFF
--- a/.ci/generate_monitoring_docs
+++ b/.ci/generate_monitoring_docs
@@ -54,6 +54,10 @@ for file in rules/*.yaml; do
 done
 popd > /dev/null
 
-git add $SOURCE_PATH/docs/development/user_alerts.md
-git add $SOURCE_PATH/docs/development/operator_alerts.md
-git commit -m "Update alert documentation"
+if [ -n "$(git status --porcelain)" ]; then
+  git add $SOURCE_PATH/docs/development/user_alerts.md
+  git add $SOURCE_PATH/docs/development/operator_alerts.md
+  git commit -m "Update alert documentation"
+else
+  echo "no changes";
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
The `generate_monitoring_docs` script would return a nonzero value if there were no changes to be committed causing the job to fail. This should not be the case.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
/cc @AndreasBurger 