### PR TITLE
respecting global machine image for v1beta1

### DIFF
--- a/pkg/apis/garden/v1beta1/defaults.go
+++ b/pkg/apis/garden/v1beta1/defaults.go
@@ -63,6 +63,13 @@ func SetDefaults_Shoot(obj *Shoot) {
 		if obj.Spec.Kubernetes.KubeControllerManager == nil || obj.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize == nil {
 			SetNodeCIDRMaskSize(&obj.Spec.Kubernetes, CalculateDefaultNodeCIDRMaskSize(&obj.Spec.Kubernetes, getShootCloudProviderWorkers(CloudProviderAWS, obj)))
 		}
+		if obj.Spec.Cloud.AWS.MachineImage != nil {
+			for i, worker := range obj.Spec.Cloud.AWS.Workers {
+				if worker.MachineImage == nil {
+					obj.Spec.Cloud.AWS.Workers[i].MachineImage = obj.Spec.Cloud.AWS.MachineImage
+				}
+			}
+		}
 	}
 
 	if cloud.Azure != nil {
@@ -75,6 +82,13 @@ func SetDefaults_Shoot(obj *Shoot) {
 		if obj.Spec.Kubernetes.KubeControllerManager == nil || obj.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize == nil {
 			SetNodeCIDRMaskSize(&obj.Spec.Kubernetes, CalculateDefaultNodeCIDRMaskSize(&obj.Spec.Kubernetes, getShootCloudProviderWorkers(CloudProviderAzure, obj)))
 		}
+		if obj.Spec.Cloud.Azure.MachineImage != nil {
+			for i, worker := range obj.Spec.Cloud.Azure.Workers {
+				if worker.MachineImage == nil {
+					obj.Spec.Cloud.Azure.Workers[i].MachineImage = obj.Spec.Cloud.Azure.MachineImage
+				}
+			}
+		}
 	}
 
 	if cloud.GCP != nil {
@@ -86,6 +100,13 @@ func SetDefaults_Shoot(obj *Shoot) {
 		}
 		if obj.Spec.Kubernetes.KubeControllerManager == nil || obj.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize == nil {
 			SetNodeCIDRMaskSize(&obj.Spec.Kubernetes, CalculateDefaultNodeCIDRMaskSize(&obj.Spec.Kubernetes, getShootCloudProviderWorkers(CloudProviderGCP, obj)))
+		}
+		if obj.Spec.Cloud.GCP.MachineImage != nil {
+			for i, worker := range obj.Spec.Cloud.GCP.Workers {
+				if worker.MachineImage == nil {
+					obj.Spec.Cloud.GCP.Workers[i].MachineImage = obj.Spec.Cloud.GCP.MachineImage
+				}
+			}
 		}
 	}
 
@@ -106,6 +127,13 @@ func SetDefaults_Shoot(obj *Shoot) {
 		if obj.Spec.Kubernetes.KubeControllerManager == nil || obj.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize == nil {
 			SetNodeCIDRMaskSize(&obj.Spec.Kubernetes, CalculateDefaultNodeCIDRMaskSize(&obj.Spec.Kubernetes, getShootCloudProviderWorkers(CloudProviderAlicloud, obj)))
 		}
+		if obj.Spec.Cloud.Alicloud.MachineImage != nil {
+			for i, worker := range obj.Spec.Cloud.Alicloud.Workers {
+				if worker.MachineImage == nil {
+					obj.Spec.Cloud.Alicloud.Workers[i].MachineImage = obj.Spec.Cloud.Alicloud.MachineImage
+				}
+			}
+		}
 	}
 
 	if cloud.OpenStack != nil {
@@ -118,11 +146,25 @@ func SetDefaults_Shoot(obj *Shoot) {
 		if obj.Spec.Kubernetes.KubeControllerManager == nil || obj.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize == nil {
 			SetNodeCIDRMaskSize(&obj.Spec.Kubernetes, CalculateDefaultNodeCIDRMaskSize(&obj.Spec.Kubernetes, getShootCloudProviderWorkers(CloudProviderOpenStack, obj)))
 		}
+		if obj.Spec.Cloud.OpenStack.MachineImage != nil {
+			for i, worker := range obj.Spec.Cloud.OpenStack.Workers {
+				if worker.MachineImage == nil {
+					obj.Spec.Cloud.OpenStack.Workers[i].MachineImage = obj.Spec.Cloud.OpenStack.MachineImage
+				}
+			}
+		}
 	}
 
 	if cloud.Packet != nil {
 		if obj.Spec.Kubernetes.KubeControllerManager == nil || obj.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize == nil {
 			SetNodeCIDRMaskSize(&obj.Spec.Kubernetes, CalculateDefaultNodeCIDRMaskSize(&obj.Spec.Kubernetes, getShootCloudProviderWorkers(CloudProviderPacket, obj)))
+		}
+		if obj.Spec.Cloud.Packet.MachineImage != nil {
+			for i, worker := range obj.Spec.Cloud.Packet.Workers {
+				if worker.MachineImage == nil {
+					obj.Spec.Cloud.Packet.Workers[i].MachineImage = obj.Spec.Cloud.Packet.MachineImage
+				}
+			}
 		}
 	}
 

--- a/pkg/apis/garden/v1beta1/defaults_test.go
+++ b/pkg/apis/garden/v1beta1/defaults_test.go
@@ -153,6 +153,38 @@ var _ = Describe("#SetDefaults_Shoot", func() {
 							Expect(shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize).To(Equal(&expectedSize))
 						})
 					})
+
+					Context("global machine image", func() {
+						globalMachineImageName := "jeOs"
+						globalMachineImageVersion := "1.1"
+						BeforeEach(func() {
+							aws.MachineImage = &v1beta1.ShootMachineImage{
+								Name:    globalMachineImageName,
+								Version: globalMachineImageVersion,
+							}
+							aws.Workers = []v1beta1.AWSWorker{
+								{
+									Worker: v1beta1.Worker{
+										Name: "worker-default",
+									},
+								},
+								{
+									Worker: v1beta1.Worker{
+										MachineImage: &v1beta1.ShootMachineImage{
+											Name:    "coreos",
+											Version: "1.0",
+										},
+									},
+								},
+							}
+						})
+						It("should respect global machine image", func() {
+							Expect(shoot.Spec.Cloud.AWS.Workers[0].MachineImage).ToNot(BeNil())
+							Expect(shoot.Spec.Cloud.AWS.Workers[0].MachineImage.Name).To(Equal(globalMachineImageName))
+							Expect(shoot.Spec.Cloud.AWS.Workers[0].MachineImage.Version).To(Equal(globalMachineImageVersion))
+						})
+					})
+
 					Context("kubernetes.Kubelet global default max pod", func() {
 						BeforeEach(func() {
 							var (
@@ -281,6 +313,38 @@ var _ = Describe("#SetDefaults_Shoot", func() {
 							Expect(shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize).To(Equal(&expectedSize))
 						})
 					})
+
+					Context("global machine image", func() {
+						globalMachineImageName := "jeOs"
+						globalMachineImageVersion := "1.1"
+						BeforeEach(func() {
+							azure.MachineImage = &v1beta1.ShootMachineImage{
+								Name:    globalMachineImageName,
+								Version: globalMachineImageVersion,
+							}
+							azure.Workers = []v1beta1.AzureWorker{
+								{
+									Worker: v1beta1.Worker{
+										Name: "worker-default",
+									},
+								},
+								{
+									Worker: v1beta1.Worker{
+										MachineImage: &v1beta1.ShootMachineImage{
+											Name:    "coreos",
+											Version: "1.0",
+										},
+									},
+								},
+							}
+						})
+						It("should respect global machine image", func() {
+							Expect(shoot.Spec.Cloud.Azure.Workers[0].MachineImage).ToNot(BeNil())
+							Expect(shoot.Spec.Cloud.Azure.Workers[0].MachineImage.Name).To(Equal(globalMachineImageName))
+							Expect(shoot.Spec.Cloud.Azure.Workers[0].MachineImage.Version).To(Equal(globalMachineImageVersion))
+						})
+					})
+
 					Context("kubernetes.Kubelet global default max pod", func() {
 						BeforeEach(func() {
 							var (
@@ -425,6 +489,38 @@ var _ = Describe("#SetDefaults_Shoot", func() {
 							Expect(shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize).To(Equal(&expectedSize))
 						})
 					})
+
+					Context("global machine image", func() {
+						globalMachineImageName := "jeOs"
+						globalMachineImageVersion := "1.1"
+						BeforeEach(func() {
+							gcp.MachineImage = &v1beta1.ShootMachineImage{
+								Name:    globalMachineImageName,
+								Version: globalMachineImageVersion,
+							}
+							gcp.Workers = []v1beta1.GCPWorker{
+								{
+									Worker: v1beta1.Worker{
+										Name: "worker-default",
+									},
+								},
+								{
+									Worker: v1beta1.Worker{
+										MachineImage: &v1beta1.ShootMachineImage{
+											Name:    "coreos",
+											Version: "1.0",
+										},
+									},
+								},
+							}
+						})
+						It("should respect global machine image", func() {
+							Expect(shoot.Spec.Cloud.GCP.Workers[0].MachineImage).ToNot(BeNil())
+							Expect(shoot.Spec.Cloud.GCP.Workers[0].MachineImage.Name).To(Equal(globalMachineImageName))
+							Expect(shoot.Spec.Cloud.GCP.Workers[0].MachineImage.Version).To(Equal(globalMachineImageVersion))
+						})
+					})
+
 					Context("kubernetes.Kubelet global default max pod", func() {
 						BeforeEach(func() {
 							var (
@@ -583,6 +679,38 @@ var _ = Describe("#SetDefaults_Shoot", func() {
 							Expect(shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize).To(Equal(&expectedSize))
 						})
 					})
+
+					Context("global machine image", func() {
+						globalMachineImageName := "jeOs"
+						globalMachineImageVersion := "1.1"
+						BeforeEach(func() {
+							alicloud.MachineImage = &v1beta1.ShootMachineImage{
+								Name:    globalMachineImageName,
+								Version: globalMachineImageVersion,
+							}
+							alicloud.Workers = []v1beta1.AlicloudWorker{
+								{
+									Worker: v1beta1.Worker{
+										Name: "worker-default",
+									},
+								},
+								{
+									Worker: v1beta1.Worker{
+										MachineImage: &v1beta1.ShootMachineImage{
+											Name:    "coreos",
+											Version: "1.0",
+										},
+									},
+								},
+							}
+						})
+						It("should respect global machine image", func() {
+							Expect(shoot.Spec.Cloud.Alicloud.Workers[0].MachineImage).ToNot(BeNil())
+							Expect(shoot.Spec.Cloud.Alicloud.Workers[0].MachineImage.Name).To(Equal(globalMachineImageName))
+							Expect(shoot.Spec.Cloud.Alicloud.Workers[0].MachineImage.Version).To(Equal(globalMachineImageVersion))
+						})
+					})
+
 					Context("kubernetes.Kubelet global default max pod", func() {
 						BeforeEach(func() {
 							var (
@@ -728,6 +856,38 @@ var _ = Describe("#SetDefaults_Shoot", func() {
 							Expect(shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize).To(Equal(&expectedSize))
 						})
 					})
+
+					Context("global machine image", func() {
+						globalMachineImageName := "jeOs"
+						globalMachineImageVersion := "1.1"
+						BeforeEach(func() {
+							openstack.MachineImage = &v1beta1.ShootMachineImage{
+								Name:    globalMachineImageName,
+								Version: globalMachineImageVersion,
+							}
+							openstack.Workers = []v1beta1.OpenStackWorker{
+								{
+									Worker: v1beta1.Worker{
+										Name: "worker-default",
+									},
+								},
+								{
+									Worker: v1beta1.Worker{
+										MachineImage: &v1beta1.ShootMachineImage{
+											Name:    "coreos",
+											Version: "1.0",
+										},
+									},
+								},
+							}
+						})
+						It("should respect global machine image", func() {
+							Expect(shoot.Spec.Cloud.OpenStack.Workers[0].MachineImage).ToNot(BeNil())
+							Expect(shoot.Spec.Cloud.OpenStack.Workers[0].MachineImage.Name).To(Equal(globalMachineImageName))
+							Expect(shoot.Spec.Cloud.OpenStack.Workers[0].MachineImage.Version).To(Equal(globalMachineImageVersion))
+						})
+					})
+
 					Context("kubernetes.Kubelet global default max pod", func() {
 						BeforeEach(func() {
 							var (
@@ -841,6 +1001,38 @@ var _ = Describe("#SetDefaults_Shoot", func() {
 							Expect(shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize).To(Equal(&expectedSize))
 						})
 					})
+
+					Context("global machine image", func() {
+						globalMachineImageName := "jeOs"
+						globalMachineImageVersion := "1.1"
+						BeforeEach(func() {
+							packet.MachineImage = &v1beta1.ShootMachineImage{
+								Name:    globalMachineImageName,
+								Version: globalMachineImageVersion,
+							}
+							packet.Workers = []v1beta1.PacketWorker{
+								{
+									Worker: v1beta1.Worker{
+										Name: "worker-default",
+									},
+								},
+								{
+									Worker: v1beta1.Worker{
+										MachineImage: &v1beta1.ShootMachineImage{
+											Name:    "coreos",
+											Version: "1.0",
+										},
+									},
+								},
+							}
+						})
+						It("should respect global machine image", func() {
+							Expect(shoot.Spec.Cloud.Packet.Workers[0].MachineImage).ToNot(BeNil())
+							Expect(shoot.Spec.Cloud.Packet.Workers[0].MachineImage.Name).To(Equal(globalMachineImageName))
+							Expect(shoot.Spec.Cloud.Packet.Workers[0].MachineImage.Version).To(Equal(globalMachineImageVersion))
+						})
+					})
+
 					Context("kubernetes.Kubelet global default max pod", func() {
 						BeforeEach(func() {
 							var (


### PR DESCRIPTION
**What this PR does / why we need it**:

The admission plugin before the migration to v1alpha used to default machine images of workers
 - worker.image == nil -> set global machine image
 - if  worker.image == nil  && global machine image == nil  -> take default from CloudProfile

v1alpha1 does not have the concept of global machine images anymore, thus this logic was removed from the admissionplugin.

**This fix sets the global machine image in the v1beta1 defaulting of the shoot to replace the removed functionality in the admissionplugin.**


**Which issue(s) this PR fixes**:
Fixes #1496

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue has been fixed that didn't respect the global machine image for v1beta1 Shoots
```
