### PR TITLE
Fix deletion for stale Extensions

### DIFF
--- a/pkg/operation/botanist/extension.go
+++ b/pkg/operation/botanist/extension.go
@@ -83,13 +83,13 @@ func (b *Botanist) DeleteStaleExtensionResources(ctx context.Context) error {
 	fns := make([]flow.TaskFn, 0, meta.LenList(deployedExtensions))
 	for _, deployedExtension := range deployedExtensions.Items {
 		if !wantedExtensions.Has(deployedExtension.Spec.Type) {
+			toDelete := &extensionsv1alpha1.Extension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      deployedExtension.Name,
+					Namespace: deployedExtension.Namespace,
+				},
+			}
 			fns = append(fns, func(ctx context.Context) error {
-				toDelete := &extensionsv1alpha1.Extension{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      deployedExtension.Name,
-						Namespace: deployedExtension.Namespace,
-					},
-				}
 				return client.IgnoreNotFound(b.K8sSeedClient.Client().Delete(ctx, toDelete, kubernetes.DefaultDeleteOptionFuncs...))
 			})
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements a fix when deleting stale `Extension` resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue has been fixed which removed a wrong extension from the cluster when an extension had been disabled.
```
