### PR TITLE
Add alerts for etcd DB size limits

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
@@ -21,6 +21,10 @@ tests:
   # KubeEtcd3HighNumberOfFailedProposals
   - series: 'etcd_server_proposals_failed_total{job="kube-etcd3", pod="etcd"}'
     values: '0+1x81 81+0x39'
+  # KubeEtcd3DbSizeLimitApproaching
+  # KubeEtcd3DbSizeLimitCrossed
+  - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3",role="main"}'
+    values: '966367641+107374182x20' # 0.9GB 1GB 1.1GB .. 1.9GB
   # KubeEtcdDeltaBackupFailed
   - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore",role="main",kind="Incr"}'
     values: '0+0x62'
@@ -92,6 +96,32 @@ tests:
       exp_annotations:
         description: Etcd3 pod etcd has seen 81 proposal failures within the last hour.
         summary: High number of failed etcd proposals
+  - eval_time: 5m
+    alertname: KubeEtcd3DbSizeLimitApproaching
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3
+        role: main
+        service: etcd
+        severity: warning
+        type: seed
+        visibility: all
+      exp_annotations:
+        description: Etcd3 main DB size is approaching its current practical limit of 2GB.
+        summary: Etcd3 main DB size is approaching its current practical limit.
+  - eval_time: 10m
+    alertname: KubeEtcd3DbSizeLimitCrossed
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3
+        role: main
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: all
+      exp_annotations:
+        description: Etcd3 main DB size has crossed its current practical limit of 2GB. Etcd might now require more memory to continue serving traffic with low latency, and might face request throttling.
+        summary: Etcd3 main DB size has crossed its current practical limit.
   - eval_time: 31m
     alertname: KubeEtcdDeltaBackupFailed
     exp_alerts:

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -69,6 +69,29 @@ groups:
   - record: shoot:etcd_object_counts:sum_by_resource
     expr: sum(etcd_object_counts) by (resource)
 
+  # etcd DB size alerts
+  - alert: KubeEtcd3DbSizeLimitApproaching
+    expr: (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"} > bool 1610612736) + (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"} <= bool 2147483648) == 2 # between 1.5GB and 2GB
+    labels:
+      service: etcd
+      severity: warning
+      type: seed
+      visibility: all
+    annotations:
+      description: Etcd3 {{ $labels.role }} DB size is approaching its current practical limit of 2GB.
+      summary: Etcd3 {{ $labels.role }} DB size is approaching its current practical limit.
+
+  - alert: KubeEtcd3DbSizeLimitCrossed
+    expr: etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"} > 2147483648 # above 2GB
+    labels:
+      service: etcd
+      severity: critical
+      type: seed
+      visibility: all
+    annotations:
+      description: Etcd3 {{ $labels.role }} DB size has crossed its current practical limit of 2GB. Etcd might now require more memory to continue serving traffic with low latency, and might face request throttling.
+      summary: Etcd3 {{ $labels.role }} DB size has crossed its current practical limit.
+
   # etcd backup failure alerts
   - alert: KubeEtcdDeltaBackupFailed
     expr: (time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore",kind="Incr",role="main"} > bool 900) + (etcdbr_snapshot_required{kind="Incr", role="main"} >= bool 1) == 2


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This PR adds alerts for approaching and crossed etcd DB size based on current practical limit of 2GB, with a warning at 1.5GB.

**Which issue(s) this PR fixes**:
Fixes #1026 

**Special notes for your reviewer**:
Limits are hard-coded at the moment, until we have dynamic limits based on HVPA.
cc @swapnilgm @amshuman-kr 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Add alerts for etcd DB size limits.
```
