### PR TITLE
Allow project members to manage terminal resources

### DIFF
--- a/charts/gardener/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/charts/application/templates/rbac-user.yaml
@@ -161,6 +161,19 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - dashboard.gardener.cloud
+  resources:
+  - terminals
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 # ClusterRole defines the required permissions for the gardener-scheduler
 # Configmap: GET on gardener-scheduler-configmap to read the scheduler configuration & DELETE, GET, PATCH, UPDATE on gardener-scheduler-leader-election
 # Events: CREATE, PATCH, UPDATE to send scheduling events


### PR DESCRIPTION
**What this PR does / why we need it**:
For the upcoming web terminal feature in the dashboard, project members should be allowed to manage terminal resources

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
NONE
```
