### PR TITLE
Adapt v1beta1 api to support Azure zones and ServiceEndpoints

### DIFF
--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -6996,5 +6996,5 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>51504b4f</code>.
+on git commit <code>77713c395</code>.
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -3186,5 +3186,5 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>51504b4f</code>.
+on git commit <code>77713c395</code>.
 </em></p>

--- a/hack/api-reference/garden.md
+++ b/hack/api-reference/garden.md
@@ -2118,6 +2118,18 @@ AzureResourceGroup
 <p>Workers is a list of worker groups.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>zones</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Zones is a list of availability zones to deploy the Shoot cluster to.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="garden.sapcloud.io/v1beta1.AzureConstraints">AzureConstraints
@@ -2201,6 +2213,20 @@ KubernetesConstraints
 </td>
 <td>
 <p>VolumeTypes contains constraints regarding allowed values for volume types in the &lsquo;workers&rsquo; block in the Shoot specification.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>zones</code></br>
+<em>
+<a href="#garden.sapcloud.io/v1beta1.Zone">
+[]Zone
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Zones contains constraints regarding allowed values for &lsquo;zones&rsquo; block in the Shoot specification.</p>
 </td>
 </tr>
 </tbody>
@@ -2300,6 +2326,18 @@ string
 </td>
 <td>
 <p>Workers is a CIDR of a worker subnet (private) to create (used for the VMs).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceEndpoints</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceEndpoints is a list of Azure ServiceEndpoints which should be associated with the worker subnet.</p>
 </td>
 </tr>
 </tbody>
@@ -2487,196 +2525,6 @@ string
 </td>
 <td>
 <p>VolumeSize is the size of the root volume.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="garden.sapcloud.io/v1beta1.BackupInfrastructure">BackupInfrastructure
-</h3>
-<p>
-<p>BackupInfrastructure holds details about backup infrastructure</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Standard object metadata.</p>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#garden.sapcloud.io/v1beta1.BackupInfrastructureSpec">
-BackupInfrastructureSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Specification of the Backup Infrastructure.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>seed</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Seed is the name of a Seed object.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>shootUID</code></br>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/types#UID">
-k8s.io/apimachinery/pkg/types.UID
-</a>
-</em>
-</td>
-<td>
-<p>ShootUID is a unique identifier for the Shoot cluster for which the BackupInfrastructure object is created.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#garden.sapcloud.io/v1beta1.BackupInfrastructureStatus">
-BackupInfrastructureStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Most recently observed status of the Backup Infrastructure.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="garden.sapcloud.io/v1beta1.BackupInfrastructureSpec">BackupInfrastructureSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#garden.sapcloud.io/v1beta1.BackupInfrastructure">BackupInfrastructure</a>)
-</p>
-<p>
-<p>BackupInfrastructureSpec is the specification of a Backup Infrastructure.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>seed</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Seed is the name of a Seed object.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>shootUID</code></br>
-<em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/types#UID">
-k8s.io/apimachinery/pkg/types.UID
-</a>
-</em>
-</td>
-<td>
-<p>ShootUID is a unique identifier for the Shoot cluster for which the BackupInfrastructure object is created.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="garden.sapcloud.io/v1beta1.BackupInfrastructureStatus">BackupInfrastructureStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#garden.sapcloud.io/v1beta1.BackupInfrastructure">BackupInfrastructure</a>)
-</p>
-<p>
-<p>BackupInfrastructureStatus holds the most recently observed status of the Backup Infrastructure.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>lastOperation</code></br>
-<em>
-<a href="../core#core.gardener.cloud/v1alpha1.LastOperation">
-github.com/gardener/gardener/pkg/apis/core/v1alpha1.LastOperation
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>LastOperation holds information about the last operation on the BackupInfrastructure.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lastError</code></br>
-<em>
-<a href="../core#core.gardener.cloud/v1alpha1.LastError">
-github.com/gardener/gardener/pkg/apis/core/v1alpha1.LastError
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>LastError holds information about the last occurred error during an operation.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>observedGeneration</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ObservedGeneration is the most recent generation observed for this BackupInfrastructure. It corresponds to the
-BackupInfrastructure&rsquo;s generation, which is updated on mutation by the API Server.</p>
 </td>
 </tr>
 </tbody>
@@ -8143,6 +7991,7 @@ string
 (<em>Appears on:</em>
 <a href="#garden.sapcloud.io/v1beta1.AWSConstraints">AWSConstraints</a>, 
 <a href="#garden.sapcloud.io/v1beta1.AlicloudConstraints">AlicloudConstraints</a>, 
+<a href="#garden.sapcloud.io/v1beta1.AzureConstraints">AzureConstraints</a>, 
 <a href="#garden.sapcloud.io/v1beta1.GCPConstraints">GCPConstraints</a>, 
 <a href="#garden.sapcloud.io/v1beta1.OpenStackConstraints">OpenStackConstraints</a>, 
 <a href="#garden.sapcloud.io/v1beta1.PacketConstraints">PacketConstraints</a>)
@@ -8185,5 +8034,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>51504b4f</code>.
+on git commit <code>77713c395</code>.
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,5 +555,5 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>51504b4f</code>.
+on git commit <code>77713c395</code>.
 </em></p>

--- a/pkg/apis/core/v1alpha1/conversions.go
+++ b/pkg/apis/core/v1alpha1/conversions.go
@@ -261,6 +261,15 @@ func Convert_v1alpha1_CloudProfile_To_garden_CloudProfile(in *CloudProfile, out 
 			}
 		}
 
+		for _, region := range in.Spec.Regions {
+			if !zonesHaveName(out.Spec.Azure.Constraints.Zones, region.Name) {
+				z := garden.Zone{Region: region.Name}
+				for _, zones := range region.Zones {
+					z.Names = append(z.Names, zones.Name)
+				}
+				out.Spec.Azure.Constraints.Zones = append(out.Spec.Azure.Constraints.Zones, z)
+			}
+		}
 		cloudProfileConfig := &azurev1alpha1.CloudProfileConfig{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: azurev1alpha1.SchemeGroupVersion.String(),
@@ -1056,6 +1065,7 @@ func Convert_v1alpha1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conv
 		out.Spec.Cloud.Azure.Networks.Workers = infrastructureConfig.Networks.Workers
 		out.Spec.Cloud.Azure.Networks.VNet.CIDR = infrastructureConfig.Networks.VNet.CIDR
 		out.Spec.Cloud.Azure.Networks.VNet.Name = infrastructureConfig.Networks.VNet.Name
+		out.Spec.Cloud.Azure.Networks.ServiceEndpoints = infrastructureConfig.Networks.ServiceEndpoints
 		out.Spec.Cloud.Azure.Networks.Pods = in.Spec.Networking.Pods
 		out.Spec.Cloud.Azure.Networks.Services = in.Spec.Networking.Services
 		out.Spec.Cloud.Azure.Networks.Nodes = &in.Spec.Networking.Nodes
@@ -1103,6 +1113,7 @@ func Convert_v1alpha1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conv
 			}
 		}
 
+		out.Spec.Cloud.Azure.Zones = nil
 		out.Spec.Cloud.Azure.Workers = nil
 		for _, worker := range in.Spec.Provider.Workers {
 			var o garden.Worker
@@ -1110,6 +1121,7 @@ func Convert_v1alpha1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conv
 				return err
 			}
 			out.Spec.Cloud.Azure.Workers = append(out.Spec.Cloud.Azure.Workers, o)
+			out.Spec.Cloud.Azure.Zones = o.Zones
 		}
 
 	case "gcp":

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -191,6 +191,8 @@ type AzureConstraints struct {
 	MachineTypes []MachineType
 	// VolumeTypes contains constraints regarding allowed values for volume types in the 'workers' block in the Shoot specification.
 	VolumeTypes []VolumeType
+	// Zones contains constraints regarding allowed values for 'zones' block in the Shoot specification.
+	Zones []Zone
 }
 
 // AzureDomainCount defines the region and the count for this domain count value.
@@ -1002,6 +1004,8 @@ type AzureCloud struct {
 	ResourceGroup *AzureResourceGroup
 	// Workers is a list of worker groups.
 	Workers []Worker
+	// Zones is a list of availability zones to deploy the Shoot cluster to.
+	Zones []string
 }
 
 // AzureResourceGroup indicates whether to use an existing resource group or create a new one.
@@ -1017,6 +1021,8 @@ type AzureNetworks struct {
 	VNet AzureVNet
 	// Workers is a CIDR of a worker subnet (private) to create (used for the VMs).
 	Workers string
+	// ServiceEndpoints is a list of Azure ServiceEndpoints which should be associated with the worker subnet.
+	ServiceEndpoints []string
 }
 
 // AzureVNet indicates whether to use an existing VNet or create a new one.

--- a/pkg/apis/garden/v1beta1/helper/helpers.go
+++ b/pkg/apis/garden/v1beta1/helper/helpers.go
@@ -968,7 +968,10 @@ func GetZones(shoot gardenv1beta1.Shoot, cloudProfile *gardenv1beta1.CloudProfil
 	case gardenv1beta1.CloudProviderAWS:
 		return gardenv1beta1.CloudProviderAWS, cloudProfile.Spec.AWS.Constraints.Zones, nil
 	case gardenv1beta1.CloudProviderAzure:
-		// Azure instead of Zones, has AzureDomainCounts
+		if len(shoot.Spec.Cloud.Azure.Zones) > 0 {
+			return gardenv1beta1.CloudProviderAzure, cloudProfile.Spec.Azure.Constraints.Zones, nil
+		}
+		// If Shoot has no zones configred use instead AzureDomainCounts.
 		return gardenv1beta1.CloudProviderAzure, []gardenv1beta1.Zone{}, nil
 	case gardenv1beta1.CloudProviderGCP:
 		return gardenv1beta1.CloudProviderGCP, cloudProfile.Spec.GCP.Constraints.Zones, nil

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -154,6 +154,9 @@ type AzureConstraints struct {
 	MachineTypes []MachineType `json:"machineTypes"`
 	// VolumeTypes contains constraints regarding allowed values for volume types in the 'workers' block in the Shoot specification.
 	VolumeTypes []VolumeType `json:"volumeTypes"`
+	// Zones contains constraints regarding allowed values for 'zones' block in the Shoot specification.
+	// +optional
+	Zones []Zone `json:"zones,omitempty"`
 }
 
 // AzureDomainCount defines the region and the count for this domain count value.
@@ -944,6 +947,9 @@ type AzureCloud struct {
 	ResourceGroup *AzureResourceGroup `json:"resourceGroup,omitempty"`
 	// Workers is a list of worker groups.
 	Workers []AzureWorker `json:"workers"`
+	// Zones is a list of availability zones to deploy the Shoot cluster to.
+	// +optional
+	Zones []string `json:"zones,omitempty"`
 }
 
 // AzureResourceGroup indicates whether to use an existing resource group or create a new one.
@@ -959,6 +965,9 @@ type AzureNetworks struct {
 	VNet AzureVNet `json:"vnet"`
 	// Workers is a CIDR of a worker subnet (private) to create (used for the VMs).
 	Workers string `json:"workers"`
+	// ServiceEndpoints is a list of Azure ServiceEndpoints which should be associated with the worker subnet.
+	// +optional
+	ServiceEndpoints []string `json:"serviceEndpoints,omitempty"`
 }
 
 // AzureVNet indicates whether to use an existing VNet or create a new one.

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -1964,6 +1964,7 @@ func autoConvert_v1beta1_AzureCloud_To_garden_AzureCloud(in *AzureCloud, out *ga
 	} else {
 		out.Workers = nil
 	}
+	out.Zones = *(*[]string)(unsafe.Pointer(&in.Zones))
 	return nil
 }
 
@@ -1997,6 +1998,7 @@ func autoConvert_garden_AzureCloud_To_v1beta1_AzureCloud(in *garden.AzureCloud, 
 	} else {
 		out.Workers = nil
 	}
+	out.Zones = *(*[]string)(unsafe.Pointer(&in.Zones))
 	return nil
 }
 
@@ -2023,6 +2025,7 @@ func autoConvert_v1beta1_AzureConstraints_To_garden_AzureConstraints(in *AzureCo
 	}
 	out.MachineTypes = *(*[]garden.MachineType)(unsafe.Pointer(&in.MachineTypes))
 	out.VolumeTypes = *(*[]garden.VolumeType)(unsafe.Pointer(&in.VolumeTypes))
+	out.Zones = *(*[]garden.Zone)(unsafe.Pointer(&in.Zones))
 	return nil
 }
 
@@ -2049,6 +2052,7 @@ func autoConvert_garden_AzureConstraints_To_v1beta1_AzureConstraints(in *garden.
 	}
 	out.MachineTypes = *(*[]MachineType)(unsafe.Pointer(&in.MachineTypes))
 	out.VolumeTypes = *(*[]VolumeType)(unsafe.Pointer(&in.VolumeTypes))
+	out.Zones = *(*[]Zone)(unsafe.Pointer(&in.Zones))
 	return nil
 }
 
@@ -2087,6 +2091,7 @@ func autoConvert_v1beta1_AzureNetworks_To_garden_AzureNetworks(in *AzureNetworks
 		return err
 	}
 	out.Workers = in.Workers
+	out.ServiceEndpoints = *(*[]string)(unsafe.Pointer(&in.ServiceEndpoints))
 	return nil
 }
 
@@ -2103,6 +2108,7 @@ func autoConvert_garden_AzureNetworks_To_v1beta1_AzureNetworks(in *garden.AzureN
 		return err
 	}
 	out.Workers = in.Workers
+	out.ServiceEndpoints = *(*[]string)(unsafe.Pointer(&in.ServiceEndpoints))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -585,6 +585,11 @@ func (in *AzureCloud) DeepCopyInto(out *AzureCloud) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Zones != nil {
+		in, out := &in.Zones, &out.Zones
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -628,6 +633,13 @@ func (in *AzureConstraints) DeepCopyInto(out *AzureConstraints) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Zones != nil {
+		in, out := &in.Zones, &out.Zones
+		*out = make([]Zone, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 
@@ -662,6 +674,11 @@ func (in *AzureNetworks) DeepCopyInto(out *AzureNetworks) {
 	*out = *in
 	in.K8SNetworks.DeepCopyInto(&out.K8SNetworks)
 	in.VNet.DeepCopyInto(&out.VNet)
+	if in.ServiceEndpoints != nil {
+		in, out := &in.ServiceEndpoints, &out.ServiceEndpoints
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/garden/validation/validation_test.go
+++ b/pkg/apis/garden/validation/validation_test.go
@@ -4778,6 +4778,37 @@ var _ = Describe("validation", func() {
 				}))
 			})
 
+			Context("Zoned", func() {
+				var (
+					specField = "spec.cloud.azure.zones"
+					azZones   = []string{"1", "2"}
+				)
+				It("should forbid to move a zoned shoot into a non zoned shoot", func() {
+					shoot.Spec.Cloud.Azure.Zones = azZones
+					newShoot := prepareShootForUpdate(shoot)
+					newShoot.Spec.Cloud.Azure.Zones = []string{}
+
+					errorList := ValidateShootUpdate(newShoot, shoot)
+					Expect(errorList).To(ConsistOfFields(Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal(specField),
+						"Detail": ContainSubstring(`Can't move from zoned cluster to non zoned cluster`),
+					}))
+				})
+
+				It("should forbid to move a non zoned shoot into a zoned shoot", func() {
+					newShoot := prepareShootForUpdate(shoot)
+					newShoot.Spec.Cloud.Azure.Zones = azZones
+
+					errorList := ValidateShootUpdate(newShoot, shoot)
+					Expect(errorList).To(ConsistOfFields(Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal(specField),
+						"Detail": ContainSubstring(`Can't move from non zoned cluster to zoned cluster`),
+					}))
+				})
+			})
+
 			Context("CIDR", func() {
 
 				It("should forbid invalid VNet CIDRs", func() {

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -576,6 +576,11 @@ func (in *AzureCloud) DeepCopyInto(out *AzureCloud) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Zones != nil {
+		in, out := &in.Zones, &out.Zones
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -619,6 +624,13 @@ func (in *AzureConstraints) DeepCopyInto(out *AzureConstraints) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Zones != nil {
+		in, out := &in.Zones, &out.Zones
+		*out = make([]Zone, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 
@@ -653,6 +665,11 @@ func (in *AzureNetworks) DeepCopyInto(out *AzureNetworks) {
 	*out = *in
 	in.K8SNetworks.DeepCopyInto(&out.K8SNetworks)
 	in.VNet.DeepCopyInto(&out.VNet)
+	if in.ServiceEndpoints != nil {
+		in, out := &in.ServiceEndpoints, &out.ServiceEndpoints
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/roundtrip_cloudprofile_migration_test.go
+++ b/pkg/apis/roundtrip_cloudprofile_migration_test.go
@@ -349,6 +349,12 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 										Usable: &volumeType1Usable,
 									},
 								},
+								Zones: []gardenv1beta1.Zone{
+									{
+										Region: region1Name,
+										Names:  []string{region1Zone1},
+									},
+								},
 							},
 							CountUpdateDomains: []gardenv1beta1.AzureDomainCount{
 								{Region: countUpdateDomainRegion, Count: countUpdateDomain},
@@ -365,8 +371,6 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 				out1 := &garden.CloudProfile{}
 				Expect(scheme.Convert(in, out1, nil)).To(BeNil())
 
-				regionsJSON, _ := json.Marshal(out1.Spec.Regions)
-				expectedOut.Annotations[garden.MigrationCloudProfileRegions] = string(regionsJSON)
 				out2 := &gardenv1beta1.CloudProfile{}
 				Expect(scheme.Convert(out1, out2, nil)).To(BeNil())
 				Expect(out2).To(Equal(expectedOut))
@@ -380,7 +384,6 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 				expectedOutAfterRoundTrip := in.DeepCopy()
 				expectedOutAfterRoundTrip.Annotations[garden.MigrationCloudProfileProviderConfig] = string(providerConfigJSON)
 				expectedOutAfterRoundTrip.Annotations[garden.MigrationCloudProfileSeedSelector] = string(seedSelectorJSON)
-				expectedOutAfterRoundTrip.Annotations[garden.MigrationCloudProfileRegions] = string(regionsJSON)
 				Expect(out4).To(Equal(expectedOutAfterRoundTrip))
 			})
 		})
@@ -1382,6 +1385,12 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 										Class:  volumeType1Class,
 										Name:   volumeType1Name,
 										Usable: &volumeType1Usable,
+									},
+								},
+								Zones: []gardenv1beta1.Zone{
+									{
+										Region: region1Name,
+										Names:  []string{region1Zone1},
 									},
 								},
 							},

--- a/pkg/apis/roundtrip_shoot_migration_test.go
+++ b/pkg/apis/roundtrip_shoot_migration_test.go
@@ -893,111 +893,114 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 					},
 				}
 				controlPlaneConfigJSON, _ = json.Marshal(controlPlaneConfig)
+				worker1VolumeSize = "20Gi"
+				worker1VolumeType = "voltype"
+				workerMigrationJSON = "{\"worker1\":{\"ProviderConfig\":" + worker1ProviderConfig + ",\"Volume\":{\"Type\":\"" + worker1VolumeType + "\",\"Size\":\"" + worker1VolumeSize + "\"},\"Zones\":null}}"
 
-				worker1VolumeSize   = "20Gi"
-				worker1VolumeType   = "voltype"
-				worker1Zones        = []string{"zone1", "zone2"}
-				workerMigrationJSON = "{\"worker1\":{\"ProviderConfig\":" + worker1ProviderConfig + ",\"Volume\":{\"Type\":\"" + worker1VolumeType + "\",\"Size\":\"" + worker1VolumeSize + "\"},\"Zones\":[\"" + worker1Zones[0] + "\",\"" + worker1Zones[1] + "\"]}}"
-
-				in          = defaultCoreShoot.DeepCopy()
-				expectedOut = defaultGardenShoot.DeepCopy()
+				in          *gardencorev1alpha1.Shoot
+				expectedOut *gardenv1beta1.Shoot
 			)
 
-			in.Spec.Provider = gardencorev1alpha1.Provider{
-				Type: providerType,
-				ControlPlaneConfig: &gardencorev1alpha1.ProviderConfig{
-					RawExtension: runtime.RawExtension{
-						Raw: controlPlaneConfigJSON,
-					},
-				},
-				InfrastructureConfig: &gardencorev1alpha1.ProviderConfig{
-					RawExtension: runtime.RawExtension{
-						Raw: infrastructureConfigJSON,
-					},
-				},
-				Workers: []gardencorev1alpha1.Worker{
-					{
-						Annotations: worker1Annotations,
-						CABundle:    &worker1CABundle,
-						Kubernetes:  workerKubernetes,
-						Labels:      worker1Labels,
-						Name:        worker1Name,
-						Machine: gardencorev1alpha1.Machine{
-							Type: worker1MachineType,
-							Image: &gardencorev1alpha1.ShootMachineImage{
-								Name:    worker1MachineImageName,
-								Version: worker1MachineImageVersion,
-							},
-						},
-						Maximum:        worker1Maximum,
-						Minimum:        worker1Minimum,
-						MaxSurge:       &worker1MaxSurge,
-						MaxUnavailable: &worker1MaxUnavailable,
-						ProviderConfig: &gardencorev1alpha1.ProviderConfig{
-							RawExtension: runtime.RawExtension{
-								Raw: []byte(worker1ProviderConfig),
-							},
-						},
-						Taints: worker1Taints,
-						Volume: &gardencorev1alpha1.Volume{
-							Size: worker1VolumeSize,
-							Type: worker1VolumeType,
-						},
-						Zones: worker1Zones,
-					},
-				},
-			}
+			BeforeEach(func() {
+				in = defaultCoreShoot.DeepCopy()
+				expectedOut = defaultGardenShoot.DeepCopy()
 
-			expectedOut.Annotations = map[string]string{
-				garden.MigrationShootDNSProviders: dnsProviderMigrationJSON,
-				garden.MigrationShootWorkers:      workerMigrationJSON,
-			}
-			expectedOut.Spec.Cloud.Azure = &gardenv1beta1.AzureCloud{
-				MachineImage: nil,
-				ResourceGroup: &gardenv1beta1.AzureResourceGroup{
-					Name: resourceGroupName,
-				},
-				Networks: gardenv1beta1.AzureNetworks{
-					K8SNetworks: gardenv1beta1.K8SNetworks{
-						Nodes:    &networkingNodesCIDR,
-						Pods:     &networkingPodsCIDR,
-						Services: &networkingServicesCIDR,
+				in.Spec.Provider = gardencorev1alpha1.Provider{
+					Type: providerType,
+					ControlPlaneConfig: &gardencorev1alpha1.ProviderConfig{
+						RawExtension: runtime.RawExtension{
+							Raw: controlPlaneConfigJSON,
+						},
 					},
-					VNet: gardenv1beta1.AzureVNet{
-						Name: &vnetName,
-						CIDR: &vnetCIDR,
+					InfrastructureConfig: &gardencorev1alpha1.ProviderConfig{
+						RawExtension: runtime.RawExtension{
+							Raw: infrastructureConfigJSON,
+						},
 					},
-					Workers: workerCIDR,
-				},
-				Workers: []gardenv1beta1.AzureWorker{
-					{
-						Worker: gardenv1beta1.Worker{
-							Annotations:   worker1Annotations,
-							AutoScalerMax: int(worker1Maximum),
-							AutoScalerMin: int(worker1Minimum),
-							CABundle:      &worker1CABundle,
-							Kubelet:       workerKubelet,
-							Labels:        worker1Labels,
-							Name:          worker1Name,
-							MachineType:   worker1MachineType,
-							MachineImage: &gardenv1beta1.ShootMachineImage{
-								Name:    worker1MachineImageName,
-								Version: worker1MachineImageVersion,
+					Workers: []gardencorev1alpha1.Worker{
+						{
+							Annotations: worker1Annotations,
+							CABundle:    &worker1CABundle,
+							Kubernetes:  workerKubernetes,
+							Labels:      worker1Labels,
+							Name:        worker1Name,
+							Machine: gardencorev1alpha1.Machine{
+								Type: worker1MachineType,
+								Image: &gardencorev1alpha1.ShootMachineImage{
+									Name:    worker1MachineImageName,
+									Version: worker1MachineImageVersion,
+								},
 							},
+							Maximum:        worker1Maximum,
+							Minimum:        worker1Minimum,
 							MaxSurge:       &worker1MaxSurge,
 							MaxUnavailable: &worker1MaxUnavailable,
-							Taints:         worker1Taints,
+							ProviderConfig: &gardencorev1alpha1.ProviderConfig{
+								RawExtension: runtime.RawExtension{
+									Raw: []byte(worker1ProviderConfig),
+								},
+							},
+							Taints: worker1Taints,
+							Volume: &gardencorev1alpha1.Volume{
+								Size: worker1VolumeSize,
+								Type: worker1VolumeType,
+							},
 						},
-						VolumeSize: worker1VolumeSize,
-						VolumeType: worker1VolumeType,
 					},
-				},
-			}
-			expectedOut.Spec.Kubernetes.CloudControllerManager = &gardenv1beta1.CloudControllerManagerConfig{
-				KubernetesConfig: gardenv1beta1.KubernetesConfig{
-					FeatureGates: cloudControllerManagerFeatureGates,
-				},
-			}
+				}
+
+				expectedOut.Annotations = map[string]string{
+					garden.MigrationShootDNSProviders: dnsProviderMigrationJSON,
+					garden.MigrationShootWorkers:      workerMigrationJSON,
+				}
+
+				expectedOut.Spec.Cloud.Azure = &gardenv1beta1.AzureCloud{
+					MachineImage: nil,
+					ResourceGroup: &gardenv1beta1.AzureResourceGroup{
+						Name: resourceGroupName,
+					},
+					Networks: gardenv1beta1.AzureNetworks{
+						K8SNetworks: gardenv1beta1.K8SNetworks{
+							Nodes:    &networkingNodesCIDR,
+							Pods:     &networkingPodsCIDR,
+							Services: &networkingServicesCIDR,
+						},
+						VNet: gardenv1beta1.AzureVNet{
+							Name: &vnetName,
+							CIDR: &vnetCIDR,
+						},
+						Workers: workerCIDR,
+					},
+					Workers: []gardenv1beta1.AzureWorker{
+						{
+							Worker: gardenv1beta1.Worker{
+								Annotations:   worker1Annotations,
+								AutoScalerMax: int(worker1Maximum),
+								AutoScalerMin: int(worker1Minimum),
+								CABundle:      &worker1CABundle,
+								Kubelet:       workerKubelet,
+								Labels:        worker1Labels,
+								Name:          worker1Name,
+								MachineType:   worker1MachineType,
+								MachineImage: &gardenv1beta1.ShootMachineImage{
+									Name:    worker1MachineImageName,
+									Version: worker1MachineImageVersion,
+								},
+								MaxSurge:       &worker1MaxSurge,
+								MaxUnavailable: &worker1MaxUnavailable,
+								Taints:         worker1Taints,
+							},
+							VolumeSize: worker1VolumeSize,
+							VolumeType: worker1VolumeType,
+						},
+					},
+				}
+				expectedOut.Spec.Kubernetes.CloudControllerManager = &gardenv1beta1.CloudControllerManagerConfig{
+					KubernetesConfig: gardenv1beta1.KubernetesConfig{
+						FeatureGates: cloudControllerManagerFeatureGates,
+					},
+				}
+			})
 
 			It("should correctly convert core.gardener.cloud/v1alpha1.Shoot -> garden.sapcloud.io/v1beta1.Shoot -> core.gardener.cloud/v1alpha1.Shoot", func() {
 				out1 := &garden.Shoot{}
@@ -1017,6 +1020,58 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 				expectedOutAfterRoundTrip.Annotations = out2.Annotations
 				Expect(out4).To(Equal(expectedOutAfterRoundTrip))
 			})
+
+			It("should correctly convert with zones and service endpoints from core.gardener.cloud/v1alpha1.Shoot -> garden.sapcloud.io/v1beta1.Shoot -> core.gardener.cloud/v1alpha1.Shoot", func() {
+				var (
+					worker1Zones     = []string{"1", "2"}
+					serviceEndpoints = []string{"Microsoft.Test"}
+
+					infrastructureConfig = &azurev1alpha1.InfrastructureConfig{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: azurev1alpha1.SchemeGroupVersion.String(),
+							Kind:       "InfrastructureConfig",
+						},
+						ResourceGroup: &azurev1alpha1.ResourceGroup{
+							Name: resourceGroupName,
+						},
+						Networks: azurev1alpha1.NetworkConfig{
+							VNet: azurev1alpha1.VNet{
+								Name: &vnetName,
+								CIDR: &vnetCIDR,
+							},
+							Workers:          workerCIDR,
+							ServiceEndpoints: serviceEndpoints,
+						},
+						Zoned: true,
+					}
+					infrastructureConfigJSON, _ = json.Marshal(infrastructureConfig)
+				)
+
+				in.Spec.Provider.InfrastructureConfig.RawExtension.Raw = infrastructureConfigJSON
+				in.Spec.Provider.Workers[0].Zones = worker1Zones
+
+				expectedOut.Annotations[garden.MigrationShootWorkers] = "{\"worker1\":{\"ProviderConfig\":" + worker1ProviderConfig + ",\"Volume\":{\"Type\":\"" + worker1VolumeType + "\",\"Size\":\"" + worker1VolumeSize + "\"},\"Zones\":[\"" + worker1Zones[0] + "\",\"" + worker1Zones[1] + "\"]}}"
+				expectedOut.Spec.Cloud.Azure.Zones = worker1Zones
+				expectedOut.Spec.Cloud.Azure.Networks.ServiceEndpoints = serviceEndpoints
+
+				out1 := &garden.Shoot{}
+				Expect(scheme.Convert(in, out1, nil)).To(BeNil())
+
+				out2 := &gardenv1beta1.Shoot{}
+				Expect(scheme.Convert(out1, out2, nil)).To(BeNil())
+				Expect(out2).To(Equal(expectedOut))
+
+				out3 := &garden.Shoot{}
+				Expect(scheme.Convert(out2, out3, nil)).To(BeNil())
+
+				out4 := &gardencorev1alpha1.Shoot{}
+				Expect(scheme.Convert(out3, out4, nil)).To(BeNil())
+
+				expectedOutAfterRoundTrip := in.DeepCopy()
+				expectedOutAfterRoundTrip.Annotations = out2.Annotations
+				Expect(out4).To(Equal(expectedOutAfterRoundTrip))
+			})
+
 		})
 
 		Context("GCP provider", func() {
@@ -1967,6 +2022,7 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 						},
 						Workers: workerCIDR,
 					},
+					Zoned: true,
 				}
 				infrastructureConfigJSON, _ = json.Marshal(infrastructureConfig)
 
@@ -2030,6 +2086,7 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 						VolumeType: worker1VolumeType,
 					},
 				},
+				Zones: worker1Zones,
 			}
 			in.Spec.Kubernetes.CloudControllerManager = &gardenv1beta1.CloudControllerManagerConfig{
 				KubernetesConfig: gardenv1beta1.KubernetesConfig{

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -6172,6 +6172,20 @@ func schema_pkg_apis_garden_v1beta1_AzureCloud(ref common.ReferenceCallback) com
 							},
 						},
 					},
+					"zones": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Zones is a list of availability zones to deploy the Shoot cluster to.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"networks", "workers"},
 			},
@@ -6246,12 +6260,25 @@ func schema_pkg_apis_garden_v1beta1_AzureConstraints(ref common.ReferenceCallbac
 							},
 						},
 					},
+					"zones": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Zones contains constraints regarding allowed values for 'zones' block in the Shoot specification.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("github.com/gardener/gardener/pkg/apis/garden/v1beta1.Zone"),
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"kubernetes", "machineImages", "machineTypes", "volumeTypes"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/gardener/gardener/pkg/apis/garden/v1beta1.DNSProviderConstraint", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.KubernetesConstraints", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.MachineImage", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.MachineType", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.VolumeType"},
+			"github.com/gardener/gardener/pkg/apis/garden/v1beta1.DNSProviderConstraint", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.KubernetesConstraints", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.MachineImage", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.MachineType", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.VolumeType", "github.com/gardener/gardener/pkg/apis/garden/v1beta1.Zone"},
 	}
 }
 
@@ -6322,6 +6349,20 @@ func schema_pkg_apis_garden_v1beta1_AzureNetworks(ref common.ReferenceCallback) 
 							Description: "Workers is a CIDR of a worker subnet (private) to create (used for the VMs).",
 							Type:        []string{"string"},
 							Format:      "",
+						},
+					},
+					"serviceEndpoints": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ServiceEndpoints is a list of Azure ServiceEndpoints which should be associated with the worker subnet.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
 						},
 					},
 				},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -367,7 +367,7 @@ google.golang.org/appengine/internal/log
 google.golang.org/appengine/internal/remote_api
 google.golang.org/appengine/internal/urlfetch
 google.golang.org/appengine/urlfetch
-# google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64
+# google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55
 google.golang.org/genproto/googleapis/rpc/status
 # google.golang.org/grpc v1.22.1
 google.golang.org/grpc


### PR DESCRIPTION
**What this PR does / why we need it**:
To ensure backwards compatibility between the `v1alpha1` and the old `v1beta1` shoot api, we need to add also Azure zone and ServiceEndpoint support for the `v1beta1` api.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
The `garden.sapcloud.io/v1beta1.Shoot` resource does now support the configuration of availability zones and service endpoints for Azure shoot clusters.
```
