### PR TITLE
fix openstack conversion for volumes

### DIFF
--- a/pkg/apis/garden/v1beta1/conversions.go
+++ b/pkg/apis/garden/v1beta1/conversions.go
@@ -1861,6 +1861,7 @@ func Convert_v1beta1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conve
 			if data, ok := workerMigrationInfo[worker.Name]; ok {
 				w.ProviderConfig = data.ProviderConfig
 				w.Zones = data.Zones
+				w.Volume = data.Volume
 			}
 
 			if w.Zones == nil {
@@ -2195,6 +2196,7 @@ func Convert_garden_Shoot_To_v1beta1_Shoot(in *garden.Shoot, out *Shoot, s conve
 			workerMigrationInfo[worker.Name] = garden.WorkerMigrationData{
 				ProviderConfig: worker.ProviderConfig,
 				Zones:          worker.Zones,
+				Volume:         worker.Volume,
 			}
 		}
 		data, err := json.Marshal(workerMigrationInfo)

--- a/pkg/apis/roundtrip_shoot_migration_test.go
+++ b/pkg/apis/roundtrip_shoot_migration_test.go
@@ -733,7 +733,7 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 				worker1VolumeSize   = "20Gi"
 				worker1VolumeType   = "voltype"
 				worker1Zones        = []string{zone1Name, zone2Name}
-				workerMigrationJSON = "{\"worker1\":{\"ProviderConfig\":" + worker1ProviderConfig + ",\"Volume\":null,\"Zones\":[\"" + worker1Zones[0] + "\",\"" + worker1Zones[1] + "\"]}}"
+				workerMigrationJSON = "{\"worker1\":{\"ProviderConfig\":" + worker1ProviderConfig + ",\"Volume\":{\"Type\":\"" + worker1VolumeType + "\",\"Size\":\"" + worker1VolumeSize + "\"},\"Zones\":[\"" + worker1Zones[0] + "\",\"" + worker1Zones[1] + "\"]}}"
 
 				in          = defaultCoreShoot.DeepCopy()
 				expectedOut = defaultGardenShoot.DeepCopy()
@@ -897,7 +897,7 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 				worker1VolumeSize   = "20Gi"
 				worker1VolumeType   = "voltype"
 				worker1Zones        = []string{"zone1", "zone2"}
-				workerMigrationJSON = "{\"worker1\":{\"ProviderConfig\":" + worker1ProviderConfig + ",\"Volume\":null,\"Zones\":[\"" + worker1Zones[0] + "\",\"" + worker1Zones[1] + "\"]}}"
+				workerMigrationJSON = "{\"worker1\":{\"ProviderConfig\":" + worker1ProviderConfig + ",\"Volume\":{\"Type\":\"" + worker1VolumeType + "\",\"Size\":\"" + worker1VolumeSize + "\"},\"Zones\":[\"" + worker1Zones[0] + "\",\"" + worker1Zones[1] + "\"]}}"
 
 				in          = defaultCoreShoot.DeepCopy()
 				expectedOut = defaultGardenShoot.DeepCopy()
@@ -1060,7 +1060,7 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 				worker1VolumeSize   = "20Gi"
 				worker1VolumeType   = "voltype"
 				worker1Zones        = []string{zone1Name, zone2Name}
-				workerMigrationJSON = "{\"worker1\":{\"ProviderConfig\":" + worker1ProviderConfig + ",\"Volume\":null,\"Zones\":[\"" + worker1Zones[0] + "\",\"" + worker1Zones[1] + "\"]}}"
+				workerMigrationJSON = "{\"worker1\":{\"ProviderConfig\":" + worker1ProviderConfig + ",\"Volume\":{\"Type\":\"" + worker1VolumeType + "\",\"Size\":\"" + worker1VolumeSize + "\"},\"Zones\":[\"" + worker1Zones[0] + "\",\"" + worker1Zones[1] + "\"]}}"
 
 				in          = defaultCoreShoot.DeepCopy()
 				expectedOut = defaultGardenShoot.DeepCopy()
@@ -1407,7 +1407,7 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 				worker1VolumeSize   = "20Gi"
 				worker1VolumeType   = "voltype"
 				worker1Zones        = []string{zone1Name, zone2Name}
-				workerMigrationJSON = "{\"worker1\":{\"ProviderConfig\":" + worker1ProviderConfig + ",\"Volume\":null,\"Zones\":[\"" + worker1Zones[0] + "\",\"" + worker1Zones[1] + "\"]}}"
+				workerMigrationJSON = "{\"worker1\":{\"ProviderConfig\":" + worker1ProviderConfig + ",\"Volume\":{\"Type\":\"" + worker1VolumeType + "\",\"Size\":\"" + worker1VolumeSize + "\"},\"Zones\":[\"" + worker1Zones[0] + "\",\"" + worker1Zones[1] + "\"]}}"
 
 				in          = defaultCoreShoot.DeepCopy()
 				expectedOut = defaultGardenShoot.DeepCopy()
@@ -1553,7 +1553,7 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 				worker1VolumeSize   = "20Gi"
 				worker1VolumeType   = "voltype"
 				worker1Zones        = []string{zone1Name, zone2Name}
-				workerMigrationJSON = "{\"worker1\":{\"ProviderConfig\":" + worker1ProviderConfig + ",\"Volume\":null,\"Zones\":[\"" + worker1Zones[0] + "\",\"" + worker1Zones[1] + "\"]}}"
+				workerMigrationJSON = "{\"worker1\":{\"ProviderConfig\":" + worker1ProviderConfig + ",\"Volume\":{\"Type\":\"" + worker1VolumeType + "\",\"Size\":\"" + worker1VolumeSize + "\"},\"Zones\":[\"" + worker1Zones[0] + "\",\"" + worker1Zones[1] + "\"]}}"
 
 				in          = defaultCoreShoot.DeepCopy()
 				expectedOut = defaultGardenShoot.DeepCopy()

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -139,7 +139,7 @@ func (d *DNS) Admit(a admission.Attributes, o admission.ObjectInterfaces) error 
 	assignDefaultDomainIfNeeded(shoot, d.projectLister, d.secretLister)
 
 	// If the provider != unmanaged then we need a configured domain.
-	if shoot.Spec.DNS.Domain == nil {
+	if shoot.Spec.DNS == nil || shoot.Spec.DNS.Domain == nil {
 		return apierrors.NewBadRequest(fmt.Sprintf("shoot domain field .spec.dns.domain must be set if provider != %s", garden.DNSUnmanaged))
 	}
 

--- a/plugin/pkg/shoot/oidc/applier_test.go
+++ b/plugin/pkg/shoot/oidc/applier_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestAPI(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "oidc Suite")
+	RunSpecs(t, "Admission OpenIDConnectPreset Suite")
 }
 
 var _ = Describe("Applier", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Altering an openstack  shoot via v1beta1 version is not possible because 
- the conversion from internal -> v1beta1 did not set the volume information in the migration annotation (for no shoot- no its properly set)
- conversion from v1beta -> internal now sets the volume information from the migration annotation. 

This happened because Openstack is a special case & did not include Volume information in the v1beta1 Worker. Needs the information from the migration annotation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
An issue with the conversion for OpenStack shoots when `spec.workers[].volume` was stated has been fixed.
```
