### PR TITLE
Fix Shoot resource finalization for Kubernetes < v1.14

### DIFF
--- a/pkg/utils/kubernetes/client/client.go
+++ b/pkg/utils/kubernetes/client/client.go
@@ -349,13 +349,16 @@ func (o *cleaner) doClean(ctx context.Context, c client.Client, obj runtime.Obje
 		}
 	}
 
-	if err := delete(ctx, c, obj, &cleanOptions.DeleteOptions); err != nil {
-		for _, tolerate := range cleanOptions.ErrorToleration {
-			if tolerate(err) {
-				return nil
+	// Ref: https://github.com/kubernetes/kubernetes/issues/83771
+	if acc.GetDeletionTimestamp().IsZero() {
+		if err := delete(ctx, c, obj, &cleanOptions.DeleteOptions); err != nil {
+			for _, tolerate := range cleanOptions.ErrorToleration {
+				if tolerate(err) {
+					return nil
+				}
 			}
+			return err
 		}
-		return err
 	}
 	return nil
 }

--- a/pkg/utils/kubernetes/client/client_test.go
+++ b/pkg/utils/kubernetes/client/client_test.go
@@ -268,7 +268,7 @@ var _ = Describe("Cleaner", func() {
 				Expect(cleaner.Clean(ctx, c, &nsWithFinalizer, FinalizeGracePeriodSeconds(20))).To(Succeed())
 			})
 
-			It("should delete the object if its deletion timestamp is not over the finalize grace period", func() {
+			It("should not delete the object if its deletion timestamp is not over the finalize grace period", func() {
 				var (
 					ctx               = context.TODO()
 					deletionTimestamp = metav1.NewTime(time.Unix(30, 0))
@@ -282,13 +282,12 @@ var _ = Describe("Cleaner", func() {
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, cm2Key, &cm2).SetArg(2, cm2WithFinalizer),
 					timeOps.EXPECT().Now().Return(now),
-					c.EXPECT().Delete(ctx, &cm2, ClientDeleteOptionFuncProduces(client.DeleteOptions{})),
 				)
 
 				Expect(cleaner.Clean(ctx, c, &cm2, FinalizeGracePeriodSeconds(20))).To(Succeed())
 			})
 
-			It("should delete the object if its deletion timestamp is over the finalize grace period and no finalizer is left", func() {
+			It("should not delete the object if its deletion timestamp is over the finalize grace period and no finalizer is left", func() {
 				var (
 					ctx               = context.TODO()
 					deletionTimestamp = metav1.NewTime(time.Unix(30, 0))
@@ -302,7 +301,6 @@ var _ = Describe("Cleaner", func() {
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, cm2Key, &cm2),
 					timeOps.EXPECT().Now().Return(now),
-					c.EXPECT().Delete(ctx, &cm2, ClientDeleteOptionFuncProduces(client.DeleteOptions{})),
 				)
 
 				Expect(cleaner.Clean(ctx, c, &cm2, FinalizeGracePeriodSeconds(10))).To(Succeed())
@@ -329,7 +327,7 @@ var _ = Describe("Cleaner", func() {
 				Expect(cleaner.Clean(ctx, c, list, FinalizeGracePeriodSeconds(20))).To(Succeed())
 			})
 
-			It("should delete the list if the object's deletion timestamps are not over the finalize grace period", func() {
+			It("should not delete the list if the object's deletion timestamp is not over the finalize grace period", func() {
 				var (
 					ctx               = context.TODO()
 					deletionTimestamp = metav1.NewTime(time.Unix(30, 0))
@@ -344,13 +342,12 @@ var _ = Describe("Cleaner", func() {
 				gomock.InOrder(
 					c.EXPECT().List(ctx, list, ClientListOptionFuncProduces(client.ListOptions{})).SetArg(1, corev1.ConfigMapList{Items: []corev1.ConfigMap{cm2WithFinalizer}}),
 					timeOps.EXPECT().Now().Return(now),
-					c.EXPECT().Delete(ctx, &cm2WithFinalizer, ClientDeleteOptionFuncProduces(client.DeleteOptions{})),
 				)
 
 				Expect(cleaner.Clean(ctx, c, list, FinalizeGracePeriodSeconds(20))).To(Succeed())
 			})
 
-			It("should delete the list if the object's deletion timestamps is over the finalize grace period and no finalizers are left", func() {
+			It("should not delete the list if the object's deletion timestamp is over the finalize grace period and no finalizers are left", func() {
 				var (
 					ctx               = context.TODO()
 					deletionTimestamp = metav1.NewTime(time.Unix(30, 0))
@@ -365,7 +362,6 @@ var _ = Describe("Cleaner", func() {
 				gomock.InOrder(
 					c.EXPECT().List(ctx, list, ClientListOptionFuncProduces(client.ListOptions{})).SetArg(1, corev1.ConfigMapList{Items: []corev1.ConfigMap{cm2}}),
 					timeOps.EXPECT().Now().Return(now),
-					c.EXPECT().Delete(ctx, &cm2, ClientDeleteOptionFuncProduces(client.DeleteOptions{})),
 				)
 
 				Expect(cleaner.Clean(ctx, c, list, FinalizeGracePeriodSeconds(10))).To(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:
For Kubernetes < v1.14 the `deletionTimestamp` is updated (moved to the future) in each DELETE request - ref kubernetes/kubernetes#83771. Our finalization logic uses the `deletionTimestamp` to check whether a finalizationGracePeriod is passed since the initial deletion and if yes - then finalize the resouces, otherwise delete the resources again. These subsequent deletions move the deletionTimestamp forward and in this way the finalizationCheck never becomes true.

Steps to reproduce:
1. Create a Shoot with Kubernetes version < 1.14 (for example 1.13.11)
1. Create a deployment with a finalizer in the Shoot.
1. Trigger Shoot deletion.
1. Ensure that the deployment deletionTimestamp is periodically moved forward and it cannot be finalized. I.e the Shoot deletion is blocked.

The PR prevents subsequent DELETE request if the resource already has `deletionTimestamp`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @vpnachev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue with unsuccessful finalization of Shoot resources for Kubernetes < v1.14 is now fixed. 
```
