### PR TITLE
Upgrade VPA to 0.6.3

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -153,15 +153,15 @@ images:
 - name: vpa-admission-controller
   sourceRepository: github.com/kubernetes/autoscaler
   repository: k8s.gcr.io/vpa-admission-controller
-  tag: "0.5.0"
+  tag: "0.6.3"
 - name: vpa-recommender
   sourceRepository: github.com/kubernetes/autoscaler
   repository: k8s.gcr.io/vpa-recommender
-  tag: "0.5.0"
+  tag: "0.6.3"
 - name: vpa-updater
   sourceRepository: github.com/kubernetes/autoscaler
   repository: k8s.gcr.io/vpa-updater
-  tag: "0.5.0"
+  tag: "0.6.3"
 - name: vpa-exporter
   sourceRepository: github.com/gardener/vpa-exporter
   repository: eu.gcr.io/gardener-project/gardener/vpa-exporter

--- a/charts/seed-bootstrap/charts/vpa/templates/vpa-rbac.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/vpa-rbac.yaml
@@ -26,6 +26,7 @@ rules:
   resources:
   - pods
   - nodes
+  - limitranges
   verbs:
   - get
   - list
@@ -254,6 +255,7 @@ rules:
   - pods
   - configmaps
   - nodes
+  - limitranges
   verbs:
   - get
   - list


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrades VPA components from `0.5.0` to `0.6.3`. VPA can now set the limits of containers. See https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler#limits-control for more information.

/cc @RaphaelVogel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
VPA components are upgraded to version `0.6.3`. VPA can now increase the limits of containers proportionally, effectively enabling better auto-scaling of control plane components.
```
