### PR TITLE
Add gardener user for SSH

### DIFF
--- a/charts/seed-operatingsystemconfig/original/templates/gardener-user/_gardener-user-script
+++ b/charts/seed-operatingsystemconfig/original/templates/gardener-user/_gardener-user-script
@@ -1,0 +1,8 @@
+{{- define "gardener-user-script" -}}
+- path: /var/lib/gardener-user/run.sh
+  permissions: 0755
+  content:
+    inline:
+      encoding: b64
+      data: "IyEvYmluL2Jhc2ggLWV1CgppZCBnYXJkZW5lciB8fCB1c2VyYWRkIGdhcmRlbmVyIC1tVQppZiBbICEgLWYgIi9ob21lL2dhcmRlbmVyLy5zc2gvYXV0aG9yaXplZF9rZXlzIiBdOyB0aGVuCiAgbWtkaXIgLXAgL2hvbWUvZ2FyZGVuZXIvLnNzaAogIGNwIC1mIC92YXIvbGliL2dhcmRlbmVyLXVzZXItc3NoLmtleSAvaG9tZS9nYXJkZW5lci8uc3NoL2F1dGhvcml6ZWRfa2V5cwogIGNob3duIGdhcmRlbmVyOmdhcmRlbmVyIC9ob21lL2dhcmRlbmVyLy5zc2gvYXV0aG9yaXplZF9rZXlzCmZpCmlmIFsgISAtZiAiL2V0Yy9zdWRvZXJzLmQvOTktZ2FyZGVuZXItdXNlciIgXTsgdGhlbgogIGVjaG8gImdhcmRlbmVyIEFMTD0oQUxMKSBOT1BBU1NXRDpBTEwiID4gL2V0Yy9zdWRvZXJzLmQvOTktZ2FyZGVuZXItdXNlcgpmaQo="
+{{- end -}}

--- a/charts/seed-operatingsystemconfig/original/templates/gardener-user/_gardener-user.service
+++ b/charts/seed-operatingsystemconfig/original/templates/gardener-user/_gardener-user.service
@@ -1,0 +1,12 @@
+{{ define "gardener-user" -}}
+- name: gardener-user.service
+  enable: true
+  content: |
+    [Unit]
+    Description=Configure gardener user
+    After=sshd.service
+    [Service]
+    Restart=on-failure
+    EnvironmentFile=/etc/environment
+    ExecStart=/var/lib/gardener-user/run.sh
+{{- end}}

--- a/charts/seed-operatingsystemconfig/original/templates/osc.yaml
+++ b/charts/seed-operatingsystemconfig/original/templates/osc.yaml
@@ -22,6 +22,7 @@ spec:
 {{ include "kubelet-monitor" . | indent 2 }}
 {{ include "update-ca-certs" . | indent 2 }}
 {{ include "systemd-sysctl" . | indent 2 }}
+{{ include "gardener-user" . | indent 2 }}
   files:
 {{ include "docker-logrotate-config" . | indent 2 }}
 {{ include "journald-config" . | indent 2 }}
@@ -29,3 +30,4 @@ spec:
 {{ include "root-certs" . | indent 2 }}
 {{ include "kernel-config" . | indent 2 }}
 {{ include "health-monitor" . | indent 2 }}
+{{ include "gardener-user-script" . | indent 2 }}

--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -232,6 +232,8 @@ const (
 
 	// OperatingSystemConfigUnitNameKubeletService is a constant for a unit in the operating system config that contains the kubelet service.
 	OperatingSystemConfigUnitNameKubeletService = "kubelet.service"
+	// OperatingSystemConfigUnitNameGardenerUserService is a constant for a unit in the operating system config that contains the gardener-user service.
+	OperatingSystemConfigUnitNameGardenerUserService = "gardener-user.service"
 	// OperatingSystemConfigFilePathKernelSettings is a constant for a path to a file in the operating system config that contains some general kernel settings.
 	OperatingSystemConfigFilePathKernelSettings = "/etc/sysctl.d/99-k8s-general.conf"
 	// OperatingSystemConfigFilePathKubeletConfig is a constant for a path to a file in the operating system config that contains the kubelet configuration.


### PR DESCRIPTION
What this PR does / why we need it:
Add new user on the VMs named gardener.
This is done to improve ssh-ing to the nodes, because every OS has different default user on the different cloud providers.

Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:
@vpnachev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A user named `gardener` is deployed on every shoot node to ease ssh access to it.
```
