### PR TITLE
Stabilize client initialization in tests and fix shootapp redis statefulset

### DIFF
--- a/test/integration/shoots/applications/shoot_app_test.go
+++ b/test/integration/shoots/applications/shoot_app_test.go
@@ -44,10 +44,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 
-	apiextensions "k8s.io/api/extensions/v1beta1"
-	"k8s.io/apimachinery/pkg/labels"
-
 	. "github.com/gardener/gardener/test/integration/shoots"
+	apiextensions "k8s.io/api/extensions/v1beta1"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 
@@ -281,12 +279,7 @@ var _ = Describe("Shoot application testing", func() {
 		err = shootTestOperations.WaitUntilStatefulSetIsRunning(ctx, "redis-master", helmDeployNamespace, shootTestOperations.ShootClient)
 		Expect(err).NotTo(HaveOccurred())
 
-		redisSlaveLabelSelector := labels.SelectorFromSet(labels.Set(map[string]string{
-			"app":  "redis",
-			"role": "slave",
-		}))
-
-		err = shootTestOperations.WaitUntilDeploymentsWithLabelsIsReady(ctx, redisSlaveLabelSelector, helmDeployNamespace, shootTestOperations.ShootClient)
+		err = shootTestOperations.WaitUntilStatefulSetIsRunning(ctx, "redis-slave", helmDeployNamespace, shootTestOperations.ShootClient)
 		Expect(err).NotTo(HaveOccurred())
 
 		guestBookParams := struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Retry the initialization of shoot clients 
- redis slave is now a sts not a deployment therefore we wait for the sts to be ready

**Special notes for your reviewer**:

cc @dguendisch 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
