### PR TITLE
Fix redis slave persistence for alicloud tests

### DIFF
--- a/test/integration/shoots/applications/shoot_app_test.go
+++ b/test/integration/shoots/applications/shoot_app_test.go
@@ -265,11 +265,18 @@ var _ = Describe("Shoot application testing", func() {
 		By("Applying redis chart")
 		if shoot.Spec.Provider.Type == "alicloud" {
 			// AliCloud requires a minimum of 20 GB for its PVCs
-			err = shootTestOperations.DeployChart(ctx, helmDeployNamespace, chartRepo, "redis", map[string]interface{}{"master": map[string]interface{}{
-				"persistence": map[string]interface{}{
-					"size": "20Gi",
+			err = shootTestOperations.DeployChart(ctx, helmDeployNamespace, chartRepo, "redis", map[string]interface{}{
+				"master": map[string]interface{}{
+					"persistence": map[string]interface{}{
+						"size": "20Gi",
+					},
 				},
-			}})
+				"slave": map[string]interface{}{
+					"persistence": map[string]interface{}{
+						"size": "20Gi",
+					},
+				},
+			})
 			Expect(err).NotTo(HaveOccurred())
 		} else {
 			err = shootTestOperations.DeployChart(ctx, helmDeployNamespace, chartRepo, "redis", nil)


### PR DESCRIPTION
**What this PR does / why we need it**:

Use 20gb persistence storage for the redis slave

**Which issue(s) this PR fixes**:
cc @dguendisch @OlegLoewen 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
