### PR TITLE
Enable extensions to contribute conditions to shoot health status conditions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,54 +1,14 @@
 # Documentation Index
 
+## Overview
+
 * [General architecture](https://github.com/gardener/documentation/wiki/Architecture)
 * [Gardener landing page `gardener.cloud`](https://gardener.cloud/)
 * ["Gardener, the Kubernetes Botanist" blog on kubernetes.io](https://kubernetes.io/blog/2018/05/17/gardener/)
 
-## Development
-
-* [Setting up a local development environment](development/local_setup.md)
-* [Unit Testing and Dependency Management](development/testing_and_dependencies.md)
-* [Integration Testing](testing/integration_tests.md)
-* [Features, Releases and Hotfixes](development/process.md)
-* [Adding New Cloud Providers](development/new-cloud-provider.md)
-* [Extending the Monitoring Stack](development/monitoring-stack.md)
-
-## Testing
-
-* [Integration Testing Manual](testing/integration_tests.md)
-
 ## Concepts
 
 * [Gardener Scheduler](concepts/scheduler.md)
-
-## Extensions
-
-* [Extensibility overview](extensions/overview.md)
-* [Extension controller registration](extensions/controllerregistration.md)
-* [`Cluster` resource](extensions/cluster.md)
-* Extension points
-  * [General conventions](extensions/conventions.md)
-  * [Trigger for reconcile operations](extensions/reconcile-trigger.md)
-  * [Deploy resources into the shoot cluster](extensions/managedresources.md)
-  * [Shoot resource customization webhooks](extensions/shoot-webhooks.md)
-  * [Logging and Monitoring configuration](extensions/logging-and-monitoring.md)
-  * DNS providers
-    * [`DNSProvider` and `DNSEntry` resources](extensions/dns.md)
-  * IaaS/Cloud providers
-    * [Control plane customization webhooks](extensions/controlplane-webhooks.md)
-    * [`ControlPlane` resource](extensions/controlplane.md)
-    * [`Infrastructure` resource](extensions/infrastructure.md)
-    * [`Worker` resource](extensions/worker.md)
-  * Operating systems
-    * [`OperatingSystemConfig` resource](extensions/operatingsystemconfig.md)
-  * Other extensions
-    * [`Extension` resource](extensions/extension.md)
-
-## Deployment
-
-* [Deploying the Gardener into a Kubernetes cluster](deployment/kubernetes.md)
-* [Deploying the Gardener and a Seed into an AKS cluster](deployment/aks.md)
-* [Overwrite image vector](deployment/image_vector.md)
 
 ## Usage
 
@@ -65,3 +25,52 @@
 * [GEP-2: `BackupInfrastructure` CRD and Controller Redesign](proposals/02-backupinfra.md)
 * [GEP-3: Network extensibility](proposals/03-networking-extensibility.md)
 * [GEP-4: New `core.gardener.cloud/v1alpha1` APIs required to extract cloud-specific/OS-specific knowledge out of Gardener core](proposals/04-new-core-gardener-cloud-apis.md)
+
+## Development
+
+* [Setting up a local development environment](development/local_setup.md)
+* [Unit Testing and Dependency Management](development/testing_and_dependencies.md)
+* [Integration Testing](testing/integration_tests.md)
+* [Features, Releases and Hotfixes](development/process.md)
+* [Adding New Cloud Providers](development/new-cloud-provider.md)
+* [Extending the Monitoring Stack](development/monitoring-stack.md)
+
+## Extensions
+
+* [Extensibility overview](extensions/overview.md)
+* [Extension controller registration](extensions/controllerregistration.md)
+* [`Cluster` resource](extensions/cluster.md)
+* Extension points
+  * [General conventions](extensions/conventions.md)
+  * [Trigger for reconcile operations](extensions/reconcile-trigger.md)
+  * [Deploy resources into the shoot cluster](extensions/managedresources.md)
+  * [Shoot resource customization webhooks](extensions/shoot-webhooks.md)
+  * [Logging and Monitoring configuration](extensions/logging-and-monitoring.md)
+  * [Contributing to shoot health status conditions](extensions/shoot-health-status-conditions.md)
+  * Blob storage providers
+    * [`BackupBucket` resource](extensions/backupbucket.md)
+    * [`BackupEntry` resource](extensions/backupentry.md)
+  * DNS providers
+    * [`DNSProvider` and `DNSEntry` resources](extensions/dns.md)
+  * IaaS/Cloud providers
+    * [Control plane customization webhooks](extensions/controlplane-webhooks.md)
+    * [`ControlPlane` resource](extensions/controlplane.md)
+    * [`ControlPlane` exposure resource](extensions/controlplane-exposure.md)
+    * [`Infrastructure` resource](extensions/infrastructure.md)
+    * [`Worker` resource](extensions/worker.md)
+  * Network plugin providers
+    * `Network` resource (to-be-written)
+  * Operating systems
+    * [`OperatingSystemConfig` resource](extensions/operatingsystemconfig.md)
+  * Generic (non-essential) extensions
+    * [`Extension` resource](extensions/extension.md)
+
+## Testing
+
+* [Integration Testing Manual](testing/integration_tests.md)
+
+## Deployment
+
+* [Deploying the Gardener into a Kubernetes cluster](deployment/kubernetes.md)
+* [Deploying the Gardener and a Seed into an AKS cluster](deployment/aks.md)
+* [Overwrite image vector](deployment/image_vector.md)

--- a/docs/extensions/backupbucket.md
+++ b/docs/extensions/backupbucket.md
@@ -11,9 +11,10 @@ A bucket will be provisioned per `Seed`. So, backup of every `Shoot` created on 
 For the backup of the `Shoot` rescheduled on different `Seed` it will continue to use the same bucket.
 
 ## What is the lifespan of `BackupBucket`?
+
 The bucket associated with `BackupBucket` will be created at creation of `Seed`. And as per current implementation, it will be deleted on deletion of `Seed` and there isn't any `BackupEntry` resource associated with it.
 
-In the future, we plan to introduce schedule for `BackupBucket` the deletion logic for `BackupBucket` resource, which will reschedule the it on different available `seed`, on deletion or failure of health check for current associated `seed`. In that case, `BackupBucket` will be deleted only if there isn't any schedulable `Seed` available and there isn't any associated `BackupEntry` resource.
+In the future, we plan to introduce schedule for `BackupBucket` the deletion logic for `BackupBucket` resource, which will reschedule the it on different available `Seed`, on deletion or failure of health check for current associated `seed`. In that case, `BackupBucket` will be deleted only if there isn't any schedulable `Seed` available and there isn't any associated `BackupEntry` resource.
 
 ## What needs to be implemented to support a new infrastructure provider?
 
@@ -34,7 +35,7 @@ spec:
 ```
 
 The `.spec.secretRef` contains a reference to the provider secret pointing to the account that shall be used to create the needed resources. This provider secret will be configured
-by Gardener operator in the `seed` resource and propagated over there by seed controller.
+by Gardener operator in the `Seed` resource and propagated over there by seed controller.
 
 After your controller has created the required bucket, if required it generates the secret to access the objects in buckets and put reference to it in `status`. This secret is
 supposed to be used by Gardener or eventually `BackupEntry` resource and etcd-backup-restore component to backup the etcd.

--- a/docs/extensions/backupentry.md
+++ b/docs/extensions/backupentry.md
@@ -6,6 +6,7 @@ Before introducing the `BackupEntry` extension resource Gardener was using Terra
 Now, Gardener commissions an external, provider-specific controller to take over this task. You can also refer to backupInfra proposal documentation to get idea about how the transition was done and understand the resource in broader scope.
 
 ## What is the lifespan of `BackupEntry`?
+
 The bucket associated with `BackupEntry` will be created at using `BackupBucket` resource. The `BackupEntry` resource will be created as a part of a `Shoot` creation. But resource continue to exists post deletion of a `Shoot`. The  `deletionGracePeriod` of a `BackupEntry` resource i.e. time after the shoot deletion
 is configurable globally for Gardener via gardener-controller-manager component config. You can find the configuration option in reference.
 

--- a/docs/extensions/shoot-health-status-conditions.md
+++ b/docs/extensions/shoot-health-status-conditions.md
@@ -1,0 +1,84 @@
+# Contributing to shoot health status conditions
+
+Gardener checks regularly (every minute by default) the health status of all shoot clusters.
+It categorizes its checks into four different types:
+
+* `APIServerAvailable`: This type indicates whether the shoot's kube-apiserver is available or not.
+* `ControlPlaneHealthy`: This type indicates whether all the control plane components deployed to the shoot's namespace in the seed do exist and are running fine.
+* `EveryNodeReady`: This type indicates whether all `Node`s and all `Machine` objects report healthiness.
+* `SystemComponentsHealthy`: This type indicates whether all system components deployed to the `kube-system` namespace in the shoot do exist and are running fine.
+
+Every `Shoot` resource has a `status.conditions[]` list that contains the mentioned types, together with a `status` (`True`/`False`) and a descriptive message/explanation of the `status`.
+
+Most extension controllers are deploying components and resources as part of their reconciliation flows into the seed or shoot cluster.
+A prominent example for this is the `ControlPlane` controller that usually deploys a cloud-controller-manager or CSI controllers as part of the shoot control plane.
+Now that the extensions deploy resources into the cluster, especially resources that are essential for the functionality of the cluster, they might want to contribute to Gardener's checks mentioned above.
+
+## What can extensions do to contribute to Gardener's health checks?
+
+Every extension resource in Gardener's `extensions.gardener.cloud/v1alpha1` API group also has a `status.conditions[]` list (like the `Shoot`).
+Extension controllers can write conditions to the resource they are acting on and use a type that also exist in the shoot's conditions.
+One exception is that `APIServerAvailable` can't be used as the Gardener clearly can identify the status of this condition and it doesn't make sense for extensions to try to contribute/modify it.
+
+As an example for the `ControlPlane` controller let's take a look at the following resource:
+
+```yaml
+apiVersion: extensions.gardener.cloud/v1alpha1
+kind: ControlPlane
+metadata:
+  name: control-plane
+  namespace: shoot--foo--bar
+spec:
+  ...
+status:
+  conditions:
+  - type: ControlPlaneHealthy
+    status: "False"
+    reason: DeploymentUnhealthy
+    message: 'Deployment cloud-controller-manager is unhealthy: condition "Available" has
+      invalid status False (expected True) due to MinimumReplicasUnavailable: Deployment
+      does not have minimum availability.'
+    lastUpdateTime: "2014-05-25T12:44:27Z"
+  - type: ConfigComputedSuccessfully
+    status: "True"
+    reason: ConfigCreated
+    message: The cloud-provider-config has been successfully computed.
+    lastUpdateTime: "2014-05-25T12:43:27Z"
+```
+
+The extension controller has declared in its extension resource that one of the deployments it is responsible for is unhealthy.
+Also, it has written a second condition using a type that is unknown by Gardener.
+
+Gardener will pick the list of conditions and recognize that the there is one with a type `ControlPlaneHealthy`.
+It will merge it with its own `ControlPlaneHealthy` condition and report it back to the `Shoot`'s status:
+
+```yaml
+apiVersion: core.gardener.cloud/v1alpha1
+kind: Shoot
+metadata:
+  labels:
+    shoot.garden.sapcloud.io/status: unhealthy
+    shoot.garden.sapcloud.io/unhealthy: "true"
+  name: some-shoot
+  namespace: garden-core
+spec:
+status:
+  conditions:
+  - type: APIServerAvailable
+    status: "True"
+    reason: HealthzRequestSucceeded
+    message: API server /healthz endpoint responded with success status code. [response_time:31ms]
+    lastUpdateTime: "2014-05-23T08:26:52Z"
+    lastTransitionTime: "2014-05-25T12:45:13Z"
+  - type: ControlPlaneHealthy
+    status: "False"
+    reason: ControlPlaneUnhealthyReport
+    message: 'Deployment cloud-controller-manager is unhealthy: condition "Available" has
+      invalid status False (expected True) due to MinimumReplicasUnavailable: Deployment
+      does not have minimum availability.'
+    lastUpdateTime: "2014-05-25T12:45:13Z"
+    lastTransitionTime: "2014-05-25T12:45:13Z"
+  ...
+```
+
+Hence, the only duty extensions have is to maintain the health status of their components in the extension resource they are managing.

--- a/pkg/api/extensions/accessor.go
+++ b/pkg/api/extensions/accessor.go
@@ -17,11 +17,10 @@ package extensions
 import (
 	"fmt"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
-
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -141,6 +140,21 @@ func (u unstructuredLastOperationAccessor) GetType() gardencorev1alpha1.LastOper
 // GetExtensionType implements Spec.
 func (u unstructuredSpecAccessor) GetExtensionType() string {
 	return nestedString(u.UnstructuredContent(), "spec", "type")
+}
+
+// GetConditions implements Status.
+func (u unstructuredStatusAccessor) GetConditions() []gardencorev1alpha1.Condition {
+	val, ok, err := unstructured.NestedFieldNoCopy(u.UnstructuredContent(), "status", "conditions")
+	if err != nil || !ok {
+		return nil
+	}
+
+	conditions, ok2 := val.([]gardencorev1alpha1.Condition)
+	if !ok2 {
+		return nil
+	}
+
+	return conditions
 }
 
 // GetLastOperation implements Status.

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -872,14 +872,12 @@ const (
 )
 
 const (
+	// ShootAPIServerAvailable is a constant for a condition type indicating that the Shoot cluster's API server is available.
+	ShootAPIServerAvailable ConditionType = "APIServerAvailable"
 	// ShootControlPlaneHealthy is a constant for a condition type indicating the control plane health.
 	ShootControlPlaneHealthy ConditionType = "ControlPlaneHealthy"
 	// ShootEveryNodeReady is a constant for a condition type indicating the node health.
 	ShootEveryNodeReady ConditionType = "EveryNodeReady"
 	// ShootSystemComponentsHealthy is a constant for a condition type indicating the system components health.
 	ShootSystemComponentsHealthy ConditionType = "SystemComponentsHealthy"
-	// ShootAlertsInactive is a constant for a condition type indicating the Shoot cluster alert states.
-	ShootAlertsInactive ConditionType = "AlertsInactive"
-	// ShootAPIServerAvailable is a constant for a condition type indicating that the Shoot clusters API server is available.
-	ShootAPIServerAvailable ConditionType = "APIServerAvailable"
 )

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -21,6 +21,9 @@ import (
 
 // Status is the status of an Object.
 type Status interface {
+	// GetConditions retrieves the Conditions of a status.
+	// Conditions may be nil.
+	GetConditions() []gardencorev1alpha1.Condition
 	// GetLastOperation retrieves the LastOperation of a status.
 	// LastOperation may be nil.
 	GetLastOperation() LastOperation

--- a/pkg/apis/extensions/v1alpha1/types_defaults.go
+++ b/pkg/apis/extensions/v1alpha1/types_defaults.go
@@ -44,6 +44,11 @@ type DefaultStatus struct {
 	State string `json:"state,omitempty"`
 }
 
+// GetConditions implements Status.
+func (d *DefaultStatus) GetConditions() []gardencorev1alpha1.Condition {
+	return d.Conditions
+}
+
 // GetLastOperation implements Status.
 func (d *DefaultStatus) GetLastOperation() LastOperation {
 	if d.LastOperation == nil {

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -1876,8 +1876,6 @@ const (
 	ShootEveryNodeReady gardencorev1alpha1.ConditionType = "EveryNodeReady"
 	// ShootSystemComponentsHealthy is a constant for a condition type indicating the system components health.
 	ShootSystemComponentsHealthy gardencorev1alpha1.ConditionType = "SystemComponentsHealthy"
-	// ShootAlertsInactive is a constant for a condition type indicating the Shoot cluster alert states.
-	ShootAlertsInactive gardencorev1alpha1.ConditionType = "AlertsInactive"
 	// ShootAPIServerAvailable is a constant for a condition type indicating that the Shoot clusters API server is available.
 	ShootAPIServerAvailable gardencorev1alpha1.ConditionType = "APIServerAvailable"
 )

--- a/pkg/utils/kubernetes/health/health.go
+++ b/pkg/utils/kubernetes/health/health.go
@@ -410,5 +410,5 @@ func CheckAPIServerAvailability(condition gardencorev1alpha1.Condition, restClie
 	}
 
 	message := fmt.Sprintf("API server /healthz endpoint responded with success status code. %s", responseDurationText)
-	return helper.UpdatedCondition(condition, gardencorev1alpha1.ConditionTrue, "HealthzRequestFailed", message)
+	return helper.UpdatedCondition(condition, gardencorev1alpha1.ConditionTrue, "HealthzRequestSucceeded", message)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable extensions to contribute conditions to shoot health status conditions

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
It is now possible for extension controllers to contribute to the shoot health status conditions. Take a look at [this document](https://github.com/gardener/gardener/blob/master/docs/extensions/shoot-health-status-conditions.md) for further instructions and information.
```
