### PR TITLE
Integrate node-problem-detector

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -84,6 +84,10 @@ images:
   sourceRepository: github.com/coredns/coredns
   repository: coredns/coredns
   tag: "1.6.3"
+- name: node-problem-detector
+  sourceRepository: github.com/kubernetes/node-problem-detector
+  repository: k8s.gcr.io/node-problem-detector
+  tag: "v0.7.1"
 
 # Shoot optional addons
 - name: kubernetes-dashboard

--- a/charts/shoot-core/components/charts/node-problem-detector/Chart.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/Chart.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+name: node-problem-detector
+version: "1.6.1"
+appVersion: v0.7.1
+home: https://github.com/kubernetes/node-problem-detector
+description: Installs the node-problem-detector daemonset for monitoring extra attributes on nodes
+icon: https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png
+keywords:
+- node
+- problem
+- detector
+- monitoring
+sources:
+- https://github.com/kubernetes/charts/stable/node-problem-detector
+- https://github.com/kubernetes/node-problem-detector
+- https://kubernetes.io/docs/concepts/architecture/nodes/#condition
+maintainers:
+- name: max-rocket-internet
+  email: max.williams@deliveryhero.com
+- name: Random-Liu
+  email: lantaol@google.com
+- name: andyxning
+  email: andy.xning@gmail.com
+- name: wangzhen127
+  email: zhenw@google.com
+engine: gotpl

--- a/charts/shoot-core/components/charts/node-problem-detector/README.md
+++ b/charts/shoot-core/components/charts/node-problem-detector/README.md
@@ -1,0 +1,66 @@
+# Kubernetes Node Problem Detector
+
+This chart installs a [node-problem-detector](https://github.com/kubernetes/node-problem-detector) daemonset. This tool aims to make various node problems visible to the upstream layers in cluster management stack. It is a daemon which runs on each node, detects node problems and reports them to apiserver.
+
+## TL;DR;
+
+```console
+$ helm install stable/node-problem-detector
+```
+
+## Prerequisites
+
+- Kubernetes 1.9+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release` and default configuration:
+
+```console
+$ helm install --name my-release stable/node-problem-detector
+```
+
+## Uninstalling the Chart
+
+To delete the chart:
+
+```console
+$ helm delete my-release
+```
+
+## Configuration
+
+Custom System log monitor config files can be created, see [here](https://github.com/kubernetes/node-problem-detector/tree/master/config) for examples.
+
+The following table lists the configurable parameters for this chart and their default values.
+
+| Parameter                             | Description                                | Default                                                      |
+|---------------------------------------|--------------------------------------------|--------------------------------------------------------------|
+| `affinity`                            | Map of node/pod affinities                 | `{}`                                                         |
+| `annotations`                         | Optional daemonset annotations             | `{}`                                                         |
+| `fullnameOverride`                    | Override the fullname of the chart         | `nil`                                                        |
+| `image.pullPolicy`                    | Image pull policy                          | `IfNotPresent`                                               |
+| `image.repository`                    | Image                                      | `k8s.gcr.io/node-problem-detector`                           |
+| `image.tag`                           | Image tag                                  | `v0.6.3`                                                     |
+| `nameOverride`                        | Override the name of the chart             | `nil`                                                        |
+| `rbac.create`                         | RBAC                                       | `true`                                                       |
+| `rbac.pspEnabled`                     | PodSecuritypolicy                          | `false`                                                      |
+| `hostNetwork`                         | Run pod on host network                    | `false`                                                      |
+| `priorityClassName`                   | Priority class name                        | `""`                                                         |
+| `resources`                           | Pod resource requests and limits           | `{}`                                                         |
+| `settings.custom_monitor_definitions` | User-specified custom monitor definitions  | `{}`                                                         |
+| `settings.log_monitors`               | System log monitor config files            | `/config/kernel-monitor.json`, `/config/docker-monitor.json` |
+| `settings.custom_plugin_monitors`     | Custom plugin monitor config files         | `[]`                                                         |
+| `settings.prometheus_address`         | Prometheus exporter address                | `0.0.0.0`                                                    |
+| `settings.prometheus_port`            | Prometheus exporter port                   | `20257`                                                      |
+| `serviceAccount.create`               | Whether a ServiceAccount should be created | `true`                                                       |
+| `serviceAccount.name`                 | Name of the ServiceAccount to create       | Generated value from template                                |
+| `tolerations`                         | Optional daemonset tolerations             | `[]`                                                         |
+| `nodeSelector`                        | Optional daemonset nodeSelector            | `{}`                                                         |
+| `env`                                 | Optional daemonset environment variables   | `[]`                                                         |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` or provide a YAML file containing the values for the above parameters:
+
+```console
+$ helm install --name my-release stable/node-problem-detector --values values.yaml
+```

--- a/charts/shoot-core/components/charts/node-problem-detector/charts/util-templates
+++ b/charts/shoot-core/components/charts/node-problem-detector/charts/util-templates
@@ -1,0 +1,1 @@
+../../../../../utils-templates

--- a/charts/shoot-core/components/charts/node-problem-detector/templates/_helpers.tpl
+++ b/charts/shoot-core/components/charts/node-problem-detector/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "node-problem-detector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "node-problem-detector.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "node-problem-detector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Create the name of the service account to use */}}
+{{- define "node-problem-detector.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{ default (include "node-problem-detector.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+{{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the configmap for storing custom monitor definitions
+*/}}
+{{- define "node-problem-detector.customConfig" -}}
+{{- $fullname := include "node-problem-detector.fullname" . -}}
+{{- printf "%s-custom-config" $fullname | replace "+" "_" | trunc 63 -}}
+{{- end -}}

--- a/charts/shoot-core/components/charts/node-problem-detector/templates/clusterrole.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/templates/clusterrole.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRole
+apiVersion: {{ include "rbacversion" . }}
+metadata:
+  name: node-problem-detector
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+{{- end -}}

--- a/charts/shoot-core/components/charts/node-problem-detector/templates/clusterrolebinding.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/templates/clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRoleBinding
+apiVersion: {{ include "rbacversion" . }}
+metadata:
+  name: node-problem-detector
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: node-problem-detector
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: node-problem-detector
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/shoot-core/components/charts/node-problem-detector/templates/custom-config-configmap.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/templates/custom-config-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+{{ .Values.settings.custom_monitor_definitions | toYaml | indent 2 }}
+kind: ConfigMap
+metadata:
+  name: node-problem-detector-custom-config
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  namespace: kube-system

--- a/charts/shoot-core/components/charts/node-problem-detector/templates/daemonset.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/templates/daemonset.yaml
@@ -1,0 +1,93 @@
+apiVersion: {{ include "daemonsetversion" . }}
+kind: DaemonSet
+metadata:
+  name: node-problem-detector
+  labels:
+    garden.sapcloud.io/role: system-component
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    origin: gardener
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app: {{ include "node-problem-detector.name" . }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app: {{ include "node-problem-detector.name" . }}
+        garden.sapcloud.io/role: system-component
+        origin: gardener
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/custom-config-configmap.yaml") . | sha256sum }}
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+{{- if .Values.annotations }}
+{{ toYaml .Values.annotations | indent 8 }}
+{{- end }}
+    spec:
+      serviceAccountName: node-problem-detector
+      hostNetwork: {{ .Values.hostNetwork }}
+      terminationGracePeriodSeconds: 30
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image:  {{ index .Values.images "node-problem-detector" }} 
+          imagePullPolicy: {{ .Values.images.pullPolicy | default "IfNotPresent" | quote }}
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "exec /node-problem-detector --logtostderr --config.system-log-monitor={{- range $index, $monitor := .Values.settings.log_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} .. {{- if .Values.settings.custom_plugin_monitors }} --config.custom-plugin-monitor={{- range $index, $monitor := .Values.settings.custom_plugin_monitors }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- end }} .. {{- if .Values.settings.system_stats_monitor }} --config.system-stats-monitor={{- range $index, $monitor := .Values.settings.system_stats_monitor }}{{if ne $index 0}},{{end}}{{ $monitor }}{{- end }} {{- end }} --prometheus-address={{ .Values.settings.prometheus_address }} --prometheus-port={{ .Values.settings.prometheus_port }}"
+          securityContext:
+            privileged: true
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+{{- if .Values.env }}
+{{ toYaml .Values.env | indent 12 }}
+{{- end }}
+          volumeMounts:
+            - name: log
+              mountPath: /var/log
+            - name: localtime
+              mountPath: /etc/localtime
+              readOnly: true
+            - name: custom-config
+              mountPath: /custom-config
+              readOnly: true
+          ports:
+            - containerPort: {{ .Values.settings.prometheus_port }}
+              name: exporter
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+      volumes:
+        - name: log
+          hostPath:
+            path: {{ .Values.hostpath.logdir }}
+        - name: localtime
+          hostPath:
+            path: /etc/localtime
+            type: "FileOrCreate"
+        - name: custom-config
+          configMap:
+            name: node-problem-detector-custom-config

--- a/charts/shoot-core/components/charts/node-problem-detector/templates/psp-clusterrole.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/templates/psp-clusterrole.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.pspEnabled }}
+kind: ClusterRole
+apiVersion: {{ include "rbacversion" . }}
+metadata:
+  name: node-problem-detector-psp
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - node-problem-detector
+{{- end }}

--- a/charts/shoot-core/components/charts/node-problem-detector/templates/psp-clusterrolebinding.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: node-problem-detector-psp
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-problem-detector-psp
+subjects:
+- kind: ServiceAccount
+  name: node-problem-detector
+  namespace: kube-system
+{{- end }}

--- a/charts/shoot-core/components/charts/node-problem-detector/templates/psp.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/templates/psp.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: {{ include "podsecuritypolicyversion" .}}
+kind: PodSecurityPolicy
+metadata:
+  name: node-problem-detector
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - 'configMap'
+  - 'emptyDir'
+  - 'projected'
+  - 'secret'
+  - 'downwardAPI'
+  - 'hostPath'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  allowedHostPaths:
+  - pathPrefix: /etc/localtime
+  - pathPrefix: /var/log
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+{{- end }}

--- a/charts/shoot-core/components/charts/node-problem-detector/templates/serviceaccount.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-problem-detector
+  labels:
+    app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
+    helm.sh/chart: {{ include "node-problem-detector.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  namespace: kube-system

--- a/charts/shoot-core/components/charts/node-problem-detector/values.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/values.yaml
@@ -1,0 +1,102 @@
+settings:
+  # Custom monitor definitions to add to Node Problem Detector - to be
+  # mounted at /custom-config. These are in addition to pre-packaged monitor
+  # definitions provided within the default docker image available at /config:
+  # https://github.com/kubernetes/node-problem-detector/tree/master/config
+  custom_monitor_definitions: {}
+    # docker-monitor-filelog.json: |
+    #   {
+    #     "plugin": "filelog",
+    #     "pluginConfig": {
+    #       "timestamp": "^time=\"(\\S*)\"",
+    #       "message": "msg=\"([^\n]*)\"",
+    #       "timestampFormat": "2006-01-02T15:04:05.999999999-07:00"
+    #     },
+    #     "logPath": "/var/log/docker.log",
+    #     "lookback": "5m",
+    #     "bufferSize": 10,
+    #     "source": "docker-monitor",
+    #     "conditions": [],
+    #     "rules": [
+    #       {
+    #         "type": "temporary",
+    #         "reason": "CorruptDockerImage",
+    #         "pattern": "Error trying v2 registry: failed to register layer: rename /var/lib/docker/image/(.+) /var/lib/docker/image/(.+): directory not empty.*"
+    #       }
+    #     ]
+    #   }
+  log_monitors:
+    - /config/kernel-monitor.json
+    - /config/docker-monitor.json
+    - /config/systemd-monitor.json
+    # An example of activating a custom log monitor definition in
+    # Node Problem Detector
+    # - /custom-config/docker-monitor-filelog.json
+  custom_plugin_monitors: 
+    - /config/kernel-monitor-counter.json
+    - /config/systemd-monitor-counter.json
+  system_stats_monitor:
+    - /config/system-stats-monitor.json
+  prometheus_address: 0.0.0.0
+  prometheus_port: 20257
+
+hostpath:
+  logdir: /var/log/
+
+# image:
+#   repository: k8s.gcr.io/node-problem-detector
+#   tag: v0.7.1
+#   pullPolicy: IfNotPresent
+
+images:
+  node-problem-detector: image-repository:image-tag
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+rbac:
+  create: true
+  pspEnabled: true
+# Flag to run Node Problem Detector on the host's network. This is typically
+# not recommended, but may be useful for certain use cases.
+hostNetwork: false
+
+priorityClassName: ""
+
+resources: 
+  limits:
+    cpu: "200m"
+    memory: "100Mi"
+  requests:
+    cpu: "20m"
+    memory: "20Mi"
+
+annotations: {}
+
+tolerations: 
+  - effect: NoSchedule
+    operator: Exists
+  - key: CriticalAddonsOnly
+    operator: Exists
+  - effect: NoExecute
+    operator: Exists
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+affinity: {}
+
+nodeSelector: {}
+
+env:
+#  - name: FOO
+#    value: BAR
+#  - name: POD_NAME
+#    valueFrom:
+#      fieldRef:
+#        fieldPath: metadata.name

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -233,8 +233,9 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 				"checksum/secret-vpn-shoot": b.CheckSums["vpn-shoot"],
 			},
 		}
-		nodeExporterConfig     = map[string]interface{}{}
-		blackboxExporterConfig = map[string]interface{}{}
+		nodeExporterConfig        = map[string]interface{}{}
+		blackboxExporterConfig    = map[string]interface{}{}
+		nodeProblemDetectorConfig = map[string]interface{}{}
 	)
 
 	proxyConfig := b.Shoot.Info.Spec.Kubernetes.KubeProxy
@@ -247,6 +248,11 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 	}
 
 	coreDNS, err := b.InjectShootShootImages(coreDNSConfig, common.CoreDNSImageName)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeProblemDetector, err := b.InjectShootShootImages(nodeProblemDetectorConfig, common.NodeProblemDetectorImageName)
 	if err != nil {
 		return nil, err
 	}
@@ -301,6 +307,7 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 			"node-exporter":     nodeExporter,
 			"blackbox-exporter": blackboxExporter,
 		},
+		"node-problem-detector": nodeProblemDetector,
 	})
 }
 

--- a/pkg/operation/botanist/botanist_suite_test.go
+++ b/pkg/operation/botanist/botanist_suite_test.go
@@ -246,12 +246,14 @@ var _ = Describe("health check", func() {
 		}
 
 		// system component daemon sets
-		calicoNodeDaemonSet = newDaemonSet(shootNamespace, common.CalicoNodeDaemonSetName, v1alpha1constants.GardenRoleSystemComponent, true)
-		kubeProxyDaemonSet  = newDaemonSet(shootNamespace, common.KubeProxyDaemonSetName, v1alpha1constants.GardenRoleSystemComponent, true)
+		calicoNodeDaemonSet          = newDaemonSet(shootNamespace, common.CalicoNodeDaemonSetName, v1alpha1constants.GardenRoleSystemComponent, true)
+		kubeProxyDaemonSet           = newDaemonSet(shootNamespace, common.KubeProxyDaemonSetName, v1alpha1constants.GardenRoleSystemComponent, true)
+		nodeProblemDetectorDaemonSet = newDaemonSet(shootNamespace, common.NodeProblemDetectorDaemonSetName, v1alpha1constants.GardenRoleSystemComponent, true)
 
 		requiredSystemComponentDaemonSets = []*appsv1.DaemonSet{
 			calicoNodeDaemonSet,
 			kubeProxyDaemonSet,
+			nodeProblemDetectorDaemonSet,
 		}
 
 		nodeExporterDaemonSet = newDaemonSet(shootNamespace, common.NodeExporterDaemonSetName, v1alpha1constants.GardenRoleMonitoring, true)

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -204,6 +204,9 @@ const (
 	// KubeProxyDaemonSetName is the name of the kube-proxy daemon set.
 	KubeProxyDaemonSetName = "kube-proxy"
 
+	// NodeProblemDetectorDaemonSetName is the name of the node-problem-detector daemon set.
+	NodeProblemDetectorDaemonSetName = "node-problem-detector"
+
 	// NodeExporterDaemonSetName is the name of the node-exporter daemon set.
 	NodeExporterDaemonSetName = "node-exporter"
 
@@ -337,6 +340,9 @@ const (
 
 	// CoreDNSImageName is the name of the CoreDNS image.
 	CoreDNSImageName = "coredns"
+
+	// NodeProblemDetectorImageName is the name of the node-problem-detector image.
+	NodeProblemDetectorImageName = "node-problem-detector"
 
 	// HyperkubeImageName is the name of the Hyperkube image.
 	HyperkubeImageName = "hyperkube"
@@ -491,6 +497,7 @@ var (
 	RequiredSystemComponentDaemonSets = sets.NewString(
 		CalicoNodeDaemonSetName,
 		KubeProxyDaemonSetName,
+		NodeProblemDetectorDaemonSetName,
 	)
 
 	// RequiredMonitoringSeedDeployments is a set of the required seed monitoring deployments.


### PR DESCRIPTION
**What this PR does / why we need it**: This PR integrates node-problem-detector in Gardener as a shoot-core addon. The chart is inspired by the following references:
- https://github.com/helm/charts/tree/master/stable/node-problem-detector
- https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/node-problem-detector

**Which issue(s) this PR fixes**:
Fixes #[312](https://github.com/gardener/machine-controller-manager/issues/312)

**Special notes for your reviewer**: As it's a new component, please have a special eye on labels and other metadata to maintain homogeneity.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Node-problem-detector is integrated into Gardener. Certain problems occured in nodes will be visible as part of `NodeConditions` or `Event`. Refer [NPD](https://github.com/kubernetes/node-problem-detector) doc for more info.
```
