### PR TITLE
Remove volume type conversion for OpenStack cloud profiles

### DIFF
--- a/pkg/apis/core/v1alpha1/conversions.go
+++ b/pkg/apis/core/v1alpha1/conversions.go
@@ -431,8 +431,9 @@ func Convert_v1alpha1_CloudProfile_To_garden_CloudProfile(in *CloudProfile, out 
 				t := garden.OpenStackMachineType{MachineType: o}
 				if machineType.Storage != nil {
 					t.Storage = &garden.MachineTypeStorage{
-						Size: machineType.Storage.Size,
-						Type: machineType.Storage.Type,
+						Class: machineType.Storage.Class,
+						Size:  machineType.Storage.Size,
+						Type:  machineType.Storage.Type,
 					}
 					t.VolumeSize = machineType.Storage.Size
 					t.VolumeType = machineType.Storage.Type
@@ -724,6 +725,7 @@ func Convert_garden_CloudProfile_To_v1alpha1_CloudProfile(in *garden.CloudProfil
 		} else {
 			delete(out.Annotations, garden.MigrationCloudProfileDNSProviders)
 		}
+		out.Spec.VolumeTypes = nil
 
 	case in.Spec.Alicloud != nil:
 		out.Spec.Type = "alicloud"

--- a/pkg/apis/core/v1alpha1/types_cloudprofile.go
+++ b/pkg/apis/core/v1alpha1/types_cloudprofile.go
@@ -119,6 +119,8 @@ type MachineType struct {
 
 // MachineTypeStorage is the amount of storage associated with the root volume of this machine type.
 type MachineTypeStorage struct {
+	// Class is the class of the storage type.
+	Class string `json:"class"`
 	// Size is the storage size.
 	Size resource.Quantity `json:"size"`
 	// Type is the type of the storage.

--- a/pkg/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2880,6 +2880,7 @@ func Convert_garden_MachineType_To_v1alpha1_MachineType(in *garden.MachineType, 
 }
 
 func autoConvert_v1alpha1_MachineTypeStorage_To_garden_MachineTypeStorage(in *MachineTypeStorage, out *garden.MachineTypeStorage, s conversion.Scope) error {
+	out.Class = in.Class
 	out.Size = in.Size
 	out.Type = in.Type
 	return nil
@@ -2891,6 +2892,7 @@ func Convert_v1alpha1_MachineTypeStorage_To_garden_MachineTypeStorage(in *Machin
 }
 
 func autoConvert_garden_MachineTypeStorage_To_v1alpha1_MachineTypeStorage(in *garden.MachineTypeStorage, out *MachineTypeStorage, s conversion.Scope) error {
+	out.Class = in.Class
 	out.Size = in.Size
 	out.Type = in.Type
 	return nil

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -368,6 +368,8 @@ type MachineType struct {
 
 // MachineTypeStorage is the amount of storage associated with the root volume of this machine type.
 type MachineTypeStorage struct {
+	// Class is the class of the storage type.
+	Class string
 	// Size is the storage size.
 	Size resource.Quantity
 	// Type is the type of the storage.

--- a/pkg/apis/garden/v1beta1/conversions.go
+++ b/pkg/apis/garden/v1beta1/conversions.go
@@ -737,19 +737,12 @@ func Convert_v1beta1_CloudProfile_To_garden_CloudProfile(in *CloudProfile, out *
 			if err := autoConvert_v1beta1_MachineType_To_garden_MachineType(&machineType.MachineType, &o, s); err != nil {
 				return err
 			}
-			o.Storage = &garden.MachineTypeStorage{
-				Size: machineType.VolumeSize,
-				Type: machineType.VolumeType,
+			if o.Storage == nil {
+				o.Storage = &garden.MachineTypeStorage{}
 			}
+			o.Storage.Size = machineType.VolumeSize
+			o.Storage.Type = machineType.VolumeType
 			out.Spec.MachineTypes = append(out.Spec.MachineTypes, o)
-
-			if !volumeTypesHaveName(out.Spec.VolumeTypes, machineType.Name) {
-				out.Spec.VolumeTypes = append(out.Spec.VolumeTypes, garden.VolumeType{
-					Name:   machineType.Name,
-					Class:  machineType.VolumeType,
-					Usable: machineType.Usable,
-				})
-			}
 		}
 
 		for _, zone := range in.Spec.OpenStack.Constraints.Zones {

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -347,6 +347,8 @@ type MachineType struct {
 
 // MachineTypeStorage is the amount of storage associated with the root volume of this machine type.
 type MachineTypeStorage struct {
+	// Class is the class of the storage type.
+	Class string `json:"class"`
 	// Size is the storage size.
 	Size resource.Quantity `json:"size"`
 	// Type is the type of the storage.

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -3527,6 +3527,7 @@ func Convert_garden_MachineType_To_v1beta1_MachineType(in *garden.MachineType, o
 }
 
 func autoConvert_v1beta1_MachineTypeStorage_To_garden_MachineTypeStorage(in *MachineTypeStorage, out *garden.MachineTypeStorage, s conversion.Scope) error {
+	out.Class = in.Class
 	out.Size = in.Size
 	out.Type = in.Type
 	return nil
@@ -3538,6 +3539,7 @@ func Convert_v1beta1_MachineTypeStorage_To_garden_MachineTypeStorage(in *Machine
 }
 
 func autoConvert_garden_MachineTypeStorage_To_v1beta1_MachineTypeStorage(in *garden.MachineTypeStorage, out *MachineTypeStorage, s conversion.Scope) error {
+	out.Class = in.Class
 	out.Size = in.Size
 	out.Type = in.Type
 	return nil

--- a/pkg/apis/roundtrip_cloudprofile_migration_test.go
+++ b/pkg/apis/roundtrip_cloudprofile_migration_test.go
@@ -538,6 +538,7 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 			var (
 				machineType1VolumeSize, _ = resource.ParseQuantity("20Gi")
 				machineType1VolumeType    = "hdd"
+				machineType1StorageClass  = "premium"
 
 				floatingPool1Name                      = "fip1"
 				floatingPool1LBClass1Name              = "fip1classname"
@@ -612,8 +613,9 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 								Name:   machineType1Name,
 								Usable: &machineType1Usable,
 								Storage: &gardencorev1alpha1.MachineTypeStorage{
-									Size: machineType1VolumeSize,
-									Type: machineType1VolumeType,
+									Class: machineType1StorageClass,
+									Size:  machineType1VolumeSize,
+									Type:  machineType1VolumeType,
 								},
 							},
 						},
@@ -630,18 +632,6 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 						},
 						SeedSelector: &seedSelector,
 						Type:         providerType,
-						VolumeTypes: []gardencorev1alpha1.VolumeType{
-							{
-								Class:  volumeType1Class,
-								Name:   volumeType1Name,
-								Usable: &volumeType1Usable,
-							},
-							{
-								Class:  machineType1VolumeType,
-								Name:   machineType1Name,
-								Usable: &machineType1Usable,
-							},
-						},
 					},
 				}
 
@@ -702,8 +692,9 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 											Name:   machineType1Name,
 											Usable: &machineType1Usable,
 											Storage: &gardenv1beta1.MachineTypeStorage{
-												Size: machineType1VolumeSize,
-												Type: machineType1VolumeType,
+												Class: machineType1StorageClass,
+												Size:  machineType1VolumeSize,
+												Type:  machineType1VolumeType,
 											},
 										},
 										VolumeSize: machineType1VolumeSize,
@@ -730,8 +721,6 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 				out1 := &garden.CloudProfile{}
 				Expect(scheme.Convert(in, out1, nil)).To(BeNil())
 
-				volumeTypesJSON, _ := json.Marshal(out1.Spec.VolumeTypes)
-				expectedOut.Annotations[garden.MigrationCloudProfileVolumeTypes] = string(volumeTypesJSON)
 				out2 := &gardenv1beta1.CloudProfile{}
 				Expect(scheme.Convert(out1, out2, nil)).To(BeNil())
 				Expect(out2).To(Equal(expectedOut))
@@ -1806,18 +1795,6 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 						},
 						SeedSelector: &seedSelector,
 						Type:         providerType,
-						VolumeTypes: []gardencorev1alpha1.VolumeType{
-							{
-								Class:  volumeType1Class,
-								Name:   volumeType1Name,
-								Usable: &volumeType1Usable,
-							},
-							{
-								Class:  machineType1VolumeType,
-								Name:   machineType1Name,
-								Usable: &machineType1Usable,
-							},
-						},
 					},
 				}
 			)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3005,6 +3005,13 @@ func schema_pkg_apis_core_v1alpha1_MachineTypeStorage(ref common.ReferenceCallba
 				Description: "MachineTypeStorage is the amount of storage associated with the root volume of this machine type.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"class": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Class is the class of the storage type.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"size": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Size is the storage size.",
@@ -3019,7 +3026,7 @@ func schema_pkg_apis_core_v1alpha1_MachineTypeStorage(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"size", "type"},
+				Required: []string{"class", "size", "type"},
 			},
 		},
 		Dependencies: []string{
@@ -8668,6 +8675,13 @@ func schema_pkg_apis_garden_v1beta1_MachineTypeStorage(ref common.ReferenceCallb
 				Description: "MachineTypeStorage is the amount of storage associated with the root volume of this machine type.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"class": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Class is the class of the storage type.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"size": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Size is the storage size.",
@@ -8682,7 +8696,7 @@ func schema_pkg_apis_garden_v1beta1_MachineTypeStorage(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"size", "type"},
+				Required: []string{"class", "size", "type"},
 			},
 		},
 		Dependencies: []string{

--- a/plugin/pkg/shoot/quotavalidator/admission.go
+++ b/plugin/pkg/shoot/quotavalidator/admission.go
@@ -392,11 +392,19 @@ func (q *QuotaValidator) getShootResources(shoot garden.Shoot) (corev1.ResourceL
 			return nil, fmt.Errorf("MachineType %s not found in CloudProfile %s", worker.Machine.Type, cloudProfile.Name)
 		}
 
-		// Get the proper VolumeType
-		for _, element := range volumeTypes {
-			if worker.Volume != nil && worker.Volume.Type != nil && element.Name == *worker.Volume.Type {
-				volumeType = &element
-				break
+		if worker.Volume != nil {
+			if machineType.Storage != nil {
+				volumeType = &garden.VolumeType{
+					Class: machineType.Storage.Class,
+				}
+			} else {
+				// Get the proper VolumeType
+				for _, element := range volumeTypes {
+					if worker.Volume.Type != nil && element.Name == *worker.Volume.Type {
+						volumeType = &element
+						break
+					}
+				}
 			}
 		}
 		if volumeType == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
OpenStack `CloudProfile`s should not have volume types because the storage/root disk of a VM is defined by the used machine type. The quota admission plugin has been adapted according to this change. Operators that want to offer trial/quotas for OpenStack environments should set the new `class` field in the `storage` definition of machine types.

**Special notes for your reviewer**:
/cc @grolu 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
There is a new field in the `core.gardener.cloud/v1alpha1.CloudProfile` resource: `.spec.machineTypes[].storage.class` can be used to indicate the storage class (`standard` or `premium`, similar to `.spec.volumeTypes[].class`) in case `Quota`s are used for environments in which the root disk of VMs is defined by the machine type and not separately (like OpenStack, for example).
```
