### PR TITLE
Downgrade helm to v2.14.3

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -40,6 +40,7 @@ go install -mod=vendor ./vendor/golang.org/x/lint/golint
 
 # Install Helm (see https://docs.helm.sh/using_helm/#from-script).
 if ! which helm 1>/dev/null; then
+  export DESIRED_VERSION=v2.14.3
   echo -n "Installing helm... "
   install_helm_path="./get_helm.sh"
   curl https://raw.githubusercontent.com/helm/helm/master/scripts/get > "${install_helm_path}"


### PR DESCRIPTION
**What this PR does / why we need it**:
With helm v2.15.0 a regression has been introduced https://github.com/helm/helm/issues/6708 which breaks our CI builds. Thus downgrading to the previous version till a fix in helm is provided.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ccwienk @rfranzke 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
