### PR TITLE
Add spec.seedName fieldSelector for v1alpha1 Shoot

### DIFF
--- a/pkg/apis/core/v1alpha1/conversions.go
+++ b/pkg/apis/core/v1alpha1/conversions.go
@@ -16,6 +16,7 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
@@ -41,6 +42,19 @@ import (
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
+	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Shoot"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name", "metadata.namespace", garden.ShootSeedName, garden.ShootCloudProfileName:
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		},
+	); err != nil {
+		return err
+	}
+
 	// Add non-generated conversion functions
 	return scheme.AddConversionFuncs(
 		Convert_v1alpha1_Seed_To_garden_Seed,

--- a/pkg/apis/core/v1alpha1/register.go
+++ b/pkg/apis/core/v1alpha1/register.go
@@ -38,7 +38,7 @@ func Resource(resource string) schema.GroupResource {
 
 var (
 	// SchemeBuilder is a new Scheme Builder which registers our API.
-	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes, addDefaultingFuncs)
+	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes, addDefaultingFuncs, addConversionFuncs)
 	localSchemeBuilder = &SchemeBuilder
 	// AddToScheme is a reference to the Scheme Builder's AddToScheme function.
 	AddToScheme = SchemeBuilder.AddToScheme

--- a/pkg/apis/garden/field_constants.go
+++ b/pkg/apis/garden/field_constants.go
@@ -18,7 +18,16 @@ package garden
 // representation.
 const (
 
+	// ShootSeedNameDeprecated is the field selector path for finding
+	// the Seed cluster of a garden.sapcloud.io/v1beta1 Shoot.
+	// +deprecated
+	ShootSeedNameDeprecated = "spec.cloud.seed"
+
 	// ShootSeedName is the field selector path for finding
-	// the Seed cluster of a Shoot.
-	ShootSeedName = "spec.cloud.seed"
+	// the Seed cluster of a core.gardener.cloud/v1alpha1 Shoot.
+	ShootSeedName = "spec.seedName"
+
+	// ShootCloudProfileName is the field selector path for finding
+	// the CloudProfile name of a core.gardener.cloud/v1alpha1 Shoot.
+	ShootCloudProfileName = "spec.cloudProfileName"
 )

--- a/pkg/apis/garden/v1beta1/conversions.go
+++ b/pkg/apis/garden/v1beta1/conversions.go
@@ -136,7 +136,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	return scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Shoot"),
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "metadata.name", "metadata.namespace", garden.ShootSeedName:
+			case "metadata.name", "metadata.namespace", garden.ShootSeedNameDeprecated:
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)

--- a/pkg/registry/garden/shoot/storage/storage.go
+++ b/pkg/registry/garden/shoot/storage/storage.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
@@ -62,7 +63,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 
 		TableConvertor: newTableConvertor(),
 	}
-	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: shoot.GetAttrs, TriggerFunc: shoot.SeedTriggerFunc}
+	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: shoot.GetAttrs, TriggerFunc: shoot.TriggerFunc}
 	if err := store.CompleteWithOptions(options); err != nil {
 		panic(err)
 	}

--- a/pkg/registry/garden/shoot/strategy_test.go
+++ b/pkg/registry/garden/shoot/strategy_test.go
@@ -38,9 +38,13 @@ var _ = Describe("ToSelectableFields", func() {
 	It("should return correct fields", func() {
 		result := strategy.ToSelectableFields(newShoot("foo"))
 
-		Expect(result).To(HaveLen(3))
+		Expect(result).To(HaveLen(5))
+		Expect(result.Has(garden.ShootSeedNameDeprecated)).To(BeTrue())
+		Expect(result.Get(garden.ShootSeedNameDeprecated)).To(Equal("foo"))
 		Expect(result.Has(garden.ShootSeedName)).To(BeTrue())
 		Expect(result.Get(garden.ShootSeedName)).To(Equal("foo"))
+		Expect(result.Has(garden.ShootCloudProfileName)).To(BeTrue())
+		Expect(result.Get(garden.ShootCloudProfileName)).To(Equal("baz"))
 	})
 })
 
@@ -55,16 +59,21 @@ var _ = Describe("GetAttrs", func() {
 
 		Expect(ls).To(HaveLen(1))
 		Expect(ls.Get("foo")).To(Equal("bar"))
+		Expect(fs.Get(garden.ShootSeedNameDeprecated)).To(Equal("foo"))
 		Expect(fs.Get(garden.ShootSeedName)).To(Equal("foo"))
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
 
-var _ = Describe("SeedTriggerFunc", func() {
+var _ = Describe("TriggerFunc", func() {
 	It("should return correct matching values", func() {
-		expected := []storage.MatchValue{{IndexName: garden.ShootSeedName, Value: "foo"}}
+		expected := []storage.MatchValue{
+			{IndexName: garden.ShootSeedNameDeprecated, Value: "foo"},
+			{IndexName: garden.ShootSeedName, Value: "foo"},
+			{IndexName: garden.ShootCloudProfileName, Value: "baz"},
+		}
 
-		mv := strategy.SeedTriggerFunc(newShoot("foo"))
+		mv := strategy.TriggerFunc(newShoot("foo"))
 
 		Expect(mv).To(Equal(expected))
 
@@ -80,8 +89,7 @@ var _ = Describe("MatchShoot", func() {
 
 		Expect(result.Label).To(Equal(ls))
 		Expect(result.Field).To(Equal(fs))
-		Expect(result.IndexFields).To(ConsistOf(garden.ShootSeedName))
-
+		Expect(result.IndexFields).To(ConsistOf(garden.ShootSeedNameDeprecated, garden.ShootSeedName, garden.ShootCloudProfileName))
 	})
 })
 
@@ -135,9 +143,8 @@ func newShoot(seedName string) *garden.Shoot {
 			Labels:    map[string]string{"foo": "bar"},
 		},
 		Spec: garden.ShootSpec{
-			Cloud: garden.Cloud{
-				Seed: &seedName,
-			},
+			CloudProfileName: "baz",
+			SeedName:         &seedName,
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add spec.seedName fieldSelector for v1alpha1 Shoot
```
$ k get shoots.core.gardener.cloud --all-namespaces --field-selector spec.seedName=foo
```

- Preserve spec.cloud.seed fieldSelector got v1beta1 Shoot
```
$ k get shoots.garden.sapcloud.io --all-namespaces --field-selector spec.cloud.seed=foo
```

- Add spec.cloudProfileName fieldSelector for v1alpha1 Shoot
```
$ k get shoots.core.gardener.cloud --all-namespaces --field-selector spec.cloudProfileName=foo
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
`core.gardener.cloud/v1alpha1.Shoot` does now support field selector by `spec.seedName` and `spec.cloudProfileName`.
```
