### PR TITLE
Fix local dev setup

### DIFF
--- a/hack/dev-setup-register-gardener
+++ b/hack/dev-setup-register-gardener
@@ -188,6 +188,9 @@ webhooks:
     resources:
     - secrets
   failurePolicy: Fail
+  namespaceSelector:
+    matchLabels:
+      garden.sapcloud.io/role: project
   clientConfig:
     service:
       namespace: garden


### PR DESCRIPTION
**What this PR does / why we need it**:
Added namespaceSelector for project namespaces also to the `ValidatingWebhookConfiguration` in `hack/dev-setup-register-gardener`.
This fixes the issue, that you can't create domain secrets (e.g. internal domain secret) in the `garden` namespace without `gcm` running, but `gcm` actually panics at startup if no internal domain secret is present.

**Which issue(s) this PR fixes**:
Fixes #1531

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
