### PR TITLE
Never remove VPA status when applying manifests

### DIFF
--- a/pkg/client/kubernetes/apply.go
+++ b/pkg/client/kubernetes/apply.go
@@ -20,20 +20,17 @@ import (
 	"fmt"
 	"io"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/discovery"
 	memcache "k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
-
-	corev1 "k8s.io/api/core/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -152,6 +149,10 @@ var DefaultApplierOptions = ApplierOptions{
 			// We do not want to overwrite a ServiceAccount's `.secrets[]` list or `.imagePullSecrets[]`.
 			newObj.Object["secrets"] = oldObj.Object["secrets"]
 			newObj.Object["imagePullSecrets"] = oldObj.Object["imagePullSecrets"]
+		},
+		schema.GroupKind{Group: "autoscaling.k8s.io", Kind: "VerticalPodAutoscaler"}: func(newObj, oldObj *unstructured.Unstructured) {
+			// Never override the status of VPA resources
+			newObj.Object["status"] = oldObj.Object["status"]
 		},
 	},
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Never remove VPA status when applying manifests

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Gardener's "Applier" does now keep the `status` of existing `VerticalPodAutoscaler` resources when applying manifests.
```
