### PR TITLE
Project Viewer and Member are now aggregated

### DIFF
--- a/charts/gardener/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/charts/application/templates/rbac-user.yaml
@@ -104,6 +104,7 @@ rules:
 
 # Cluster role setting the permissions for a project member. It gets bound by a RoleBinding
 # in a respective project namespace.
+# It aggregates all ClusterRoles labeled with rbac.gardener.cloud/aggregate-to-project-member: "true"
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
@@ -111,6 +112,21 @@ metadata:
   name: garden.sapcloud.io:system:project-member
   labels:
     garden.sapcloud.io/role: project-member
+    app: gardener
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.gardener.cloud/aggregate-to-project-member: "true"
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: gardener.cloud:system:project-member
+  labels:
+    rbac.gardener.cloud/aggregate-to-project-member: "true"
     app: gardener
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
@@ -152,19 +168,6 @@ rules:
   - settings.gardener.cloud
   resources:
   - openidconnectpresets
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - dashboard.gardener.cloud
-  resources:
-  - terminals
   verbs:
   - create
   - delete
@@ -233,6 +236,7 @@ rules:
 
 # Cluster role setting the permissions for a project viewer. It gets bound by a RoleBinding
 # in a respective project namespace.
+# It aggregates all ClusterRoles labeled with rbac.gardener.cloud/aggregate-to-project-viewer: "true"
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
@@ -240,6 +244,21 @@ metadata:
   name: garden.sapcloud.io:system:project-viewer
   labels:
     garden.sapcloud.io/role: project-viewer
+    app: gardener
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.gardener.cloud/aggregate-to-project-viewer: "true"
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: gardener.cloud:system:project-viewer
+  labels:
+    rbac.gardener.cloud/aggregate-to-project-viewer: "true"
     app: gardener
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

The ClusterRoles `garden.sapcloud.io:system:project-member` and`garden.sapcloud.io:system:project-viewer` are now aggregated.

Gardener administrators can now use the `rbac.gardener.cloud/aggregate-to-project-member: "true"` and `rbac.gardener.cloud/aggregate-to-project-viewer: "true"` labels to add additional rules to the aggregated roles.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

I'll file a PR in the dashboard to add the removed rules there as well

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The ClusterRoles `garden.sapcloud.io:system:project-member` and`garden.sapcloud.io:system:project-viewer` are now aggregated.

Gardener administrators can now use the `rbac.gardener.cloud/aggregate-to-project-member: "true"` and `rbac.gardener.cloud/aggregate-to-project-viewer: "true"` labels to add additional rules to the aggregated roles.
```
