### PR TITLE
Enable volume plugin dir configuration for kubelet

### DIFF
--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.flags
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.flags
@@ -26,6 +26,8 @@
 {{- if semverCompare "< 1.11" .Values.kubernetes.version }}
 --rotate-certificates=true
 {{- end }}
---volume-plugin-dir=/var/lib/kubelet/volumeplugins
+{{- if .Values.worker.kubelet.volumePluginDir }}
+--volume-plugin-dir={{ .Values.worker.kubelet.volumePluginDir }}
+{{- end }}
 --v=2 $KUBELET_EXTRA_ARGS
 {{- end -}}

--- a/charts/seed-operatingsystemconfig/original/values.yaml
+++ b/charts/seed-operatingsystemconfig/original/values.yaml
@@ -22,6 +22,7 @@ worker:
     cpuManagerPolicy: none
   # podPIDsLimit: 24
     maxPods: 110
+  # volumePluginDir: null
     evictionPressureTransitionPeriod: 4m0s
     evictionMaxPodGracePeriod: 90
     evictionHard:

--- a/example/90-deprecated-shoot-aws.yaml
+++ b/example/90-deprecated-shoot-aws.yaml
@@ -35,6 +35,7 @@ spec:
         # cpuManagerPolicy: none
         # podPidsLimit: 10
         # maxPods: 110
+        # volumePluginDir: null
         # evictionPressureTransitionPeriod: 4m0s
         # evictionMaxPodGracePeriod: 90
         # evictionHard:

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -58,6 +58,7 @@ spec:
     #     cpuManagerPolicy: none
     #     podPidsLimit: 10
     #     maxPods: 110
+    #     volumePluginDir: null
     #     evictionPressureTransitionPeriod: 4m0s
     #     evictionMaxPodGracePeriod: 90
     #     evictionHard:

--- a/hack/templates/resources/90-deprecated-shoot.yaml.tpl
+++ b/hack/templates/resources/90-deprecated-shoot.yaml.tpl
@@ -97,6 +97,7 @@ spec:
         # cpuManagerPolicy: none
         # podPidsLimit: 10
         # maxPods: 110
+        # volumePluginDir: null
         # evictionPressureTransitionPeriod: 4m0s
         # evictionMaxPodGracePeriod: 90
         # evictionHard:

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -609,6 +609,9 @@ type KubeletConfig struct {
 	// PodPIDsLimit is the maximum number of process IDs per pod allowed by the kubelet.
 	// +optional
 	PodPIDsLimit *int64 `json:"podPidsLimit,omitempty"`
+	// VolumePluginDir is the full path of the directory in which to search for additional third party volume plugins.
+	// +optional
+	VolumePluginDir *string `json:"volumePluginDir,omitempty"`
 }
 
 // KubeletConfigEviction contains kubelet eviction thresholds supporting either a resource.Quantity or a percentage based value.

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -1492,6 +1492,8 @@ const (
 // KubeletConfig contains configuration settings for the kubelet.
 type KubeletConfig struct {
 	KubernetesConfig
+	// VolumePluginDir is the full path of the directory in which to search for additional third party volume plugins.
+	VolumePluginDir *string
 	// PodPIDsLimit is the maximum number of process IDs per pod allowed by the kubelet.
 	PodPIDsLimit *int64
 	// CPUCFSQuota allows you to disable/enable CPU throttling for Pods.

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -1637,6 +1637,9 @@ const (
 // KubeletConfig contains configuration settings for the kubelet.
 type KubeletConfig struct {
 	KubernetesConfig `json:",inline"`
+	// VolumePluginDir is the full path of the directory in which to search for additional third party volume plugins.
+	// +optional
+	VolumePluginDir *string `json:"volumePluginDir,omitempty"`
 	// PodPIDsLimit is the maximum number of process IDs per pod allowed by the kubelet.
 	// +optional
 	PodPIDsLimit *int64 `json:"podPidsLimit,omitempty"`

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -289,6 +289,9 @@ func (b *Botanist) deployOperatingSystemConfigsForWorker(machineTypes []gardenco
 		if podPIDsLimit := kubeletConfig.PodPIDsLimit; podPIDsLimit != nil {
 			kubelet["podPIDsLimit"] = *podPIDsLimit
 		}
+		if volumePluginDir := kubeletConfig.VolumePluginDir; volumePluginDir != nil {
+			kubelet["volumePluginDir"] = *volumePluginDir
+		}
 		if cpuCFSQuota := kubeletConfig.CPUCFSQuota; cpuCFSQuota != nil {
 			kubelet["cpuCFSQuota"] = *cpuCFSQuota
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
End-users can now configure .spec.kubernetes.kubelet.volumePluginDir the directory in which to search for additional third party volume plugins.

**Which issue(s) this PR fixes**:
Fixes #725 

**Special notes for your reviewer**:
If possible I would also like to backport this to v0.28.0

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
It is now possible to set the directory in which to search for additional third party volume plugins by configuring `.spec.kubernetes.kubelet.volumePluginDir` in the `Shoot` specification.
```
