### PR TITLE
Enable CoreDNS Customization

### DIFF
--- a/charts/shoot-core/components/charts/coredns/templates/coredns-configmap.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-configmap.yaml
@@ -15,6 +15,7 @@ data:
         }{{ end }}
       {{- end }}
     }
+    import custom/*.server
     {{ end }}
   {{- range .Values.configmap.zoneFiles }}
   {{ .filename }}: {{ toYaml .contents | indent 4 }}

--- a/charts/shoot-core/components/charts/coredns/templates/coredns-custom-configmap.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-custom-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace:  kube-system
+  annotations:
+    resources.gardener.cloud/ignore: "true"

--- a/charts/shoot-core/components/charts/coredns/templates/coredns-deployment.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-deployment.yaml
@@ -47,6 +47,9 @@ spec:
         - name: config-volume
           mountPath: /etc/coredns
           readOnly: true
+        - mountPath: /etc/coredns/custom
+          name: custom-config-volume
+          readOnly: true
         ports:
         - containerPort: {{ .Values.deployment.spec.containers.ports.dns }}
           name: dns-udp
@@ -85,3 +88,8 @@ spec:
             items:
             - key: Corefile
               path: Corefile
+        - name: custom-config-volume
+          configMap:
+            defaultMode: 420
+            name: coredns-custom
+            optional: true

--- a/charts/shoot-core/components/charts/coredns/values.yaml
+++ b/charts/shoot-core/components/charts/coredns/values.yaml
@@ -57,6 +57,8 @@ configmap:
     - name: reload
     - name: loadbalance
       parameters: round_robin
+    - name: import
+      parameters: custom/*.override
   zoneFiles: []  # configure custom zone files as per https://coredns.io/2017/05/08/custom-dns-entries-for-kubernetes/
   #  - filename: example.db
   #    domain: example.com

--- a/docs/usage/custom-dns.md
+++ b/docs/usage/custom-dns.md
@@ -1,0 +1,60 @@
+# Custom DNS Configuration
+
+Gardener provides Kubernetes-Clusters-As-A-Service where all the system components (e.g., kube-proxy, networking, dns, ...) are managed. 
+As a result, Gardener needs to ensure and auto-correct additional configuration to those system components to avoid unnecaessary down-time. 
+
+In some cases, auto-correcting system components can prevent users from deploying applications on top of the cluster that requires bits of customization, DNS configuration can be a good example. 
+
+To allow for customizations for DNS configuration (that could potentially lead to downtime) while having the option to "undo", we utilize the `import` plugin from CoreDNS [1].
+which enables in-line configuration changes. 
+
+## How to use
+To customize your CoreDNS cluster config, you can simply edit a `configmap` named `custom-dns` in the `kube-system`
+namespace. By editing, this `configmap`, you are modifying CoreDNS configuration, therefore care is advised. 
+
+For example, to apply new config to CoreDNS that would point all `.global` DNS requests to another DNS pod, simply edit the configuration as follows: 
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  istio.server: |
+    global:8053 {
+            errors
+            cache 30
+            forward . 1.2.3.4
+        }
+   Corefile.override: | 
+         # <some-plugin> <some-plugin-config> 
+         debug
+         whoami
+```
+
+It is important to have the `configmap` keys ending with `*.server` (if you would like to add a new server) or `*.override` 
+if you want to customize the current server configuration (it is optional setting both).
+
+Once this `configmap` is applied, you can roll-out your CoreDNS deployment using: 
+
+```bash
+$ kubectl -n kube-system rollout restart deploy coredns
+```
+
+This will reload the config into CoreDNS. 
+
+The approach we follow here was inspired by AKS's approach [2]. 
+
+## Anti-Pattern 
+Applying a configuration that is in-compatible with the running version of CoreDNS is an anti-pattern (sometimes plugin configuration changes,
+simply applying a configuration can break DNS).
+ 
+If incompatible changes are applied by mistake, simply delete the content of the `configmap` 
+and re-apply. This should bring the cluster DNS back to functioning state.  
+
+
+
+## References
+
+- [1] [Import plugin](https://github.com/coredns/coredns/tree/master/plugin/import) 
+- [2] [AKS Custom DNS](https://docs.microsoft.com/en-us/azure/aks/coredns-custom)


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable customizing CoreDNS configuration via the `import` plugin. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/1115

**Special notes for your reviewer**:
This PR depends on https://github.com/gardener/gardener-resource-manager/pull/18 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
CoreDNS now supports custom configuration via an external config-map called `custom-dns` in the kube-system namespace. More documentation can be found [here](https://github.com/gardener/gardener/blob/master/docs/usage/custom-dns.md)
```
