### PR TITLE
Add project name and shoot name to prometheus external labels

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -18,6 +18,8 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: {{ .Release.Namespace }}
+        project: {{ .Values.shoot.project }}
+        shoot_name: {{ .Values.shoot.name }}
         seed_api: {{ .Values.seed.apiserver }}
         seed_region: {{ .Values.seed.region }}
         seed_provider: {{ .Values.seed.provider }}

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -112,6 +112,8 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 			"shoot": map[string]interface{}{
 				"apiserver": fmt.Sprintf("https://%s", common.GetAPIServerDomain(b.Shoot.InternalClusterDomain)),
 				"provider":  b.Shoot.Info.Spec.Provider.Type,
+				"name":      b.Shoot.Info.Name,
+				"project":   b.Garden.Project.Name,
 			},
 			"ignoreAlerts": b.Shoot.IgnoreAlerts,
 			"extensions": map[string]interface{}{


### PR DESCRIPTION
**What this PR does / why we need it**:
Each shoot prometheus will get 2 new external labels for the shoot name and project. This is needed for the monitoring aggregation.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
