### PR TITLE
Use cluster autoscaler friendly scheduling algorithm

### DIFF
--- a/charts/seed-controlplane/charts/kube-scheduler/templates/componentconfig.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/templates/componentconfig.yaml
@@ -13,3 +13,7 @@ data:
       kubeconfig: /var/lib/kube-scheduler/kubeconfig
     leaderElection:
       leaderElect: true
+{{- if .Values.config.algorithmSource.provider }}
+    algorithmSource:
+      provider: {{ .Values.config.algorithmSource.provider }}
+{{- end }}

--- a/charts/seed-controlplane/charts/kube-scheduler/values.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/values.yaml
@@ -13,3 +13,6 @@ resources:
   limits:
     cpu: 400m
     memory: 512Mi
+config:
+  algorithmSource:
+    provider: ClusterAutoscalerProvider


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables cluster autoscaler friendly scheduling algorithm.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

For the actual implementation see: https://github.com/kubernetes/kubernetes/blob/1163a1d51ed007ff2c3cd6fe548f60fc0b175a24/pkg/scheduler/algorithmprovider/defaults/defaults.go#L93-L94

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
kube-scheduler now uses the ClusterAutoscaler-friendly scheduling algorithm when cluster-autoscaler is enabled.
```

```noteworthy user
When cluster autoscaler is enabled (workers have different min / max values), `kube-scheduler` will use a ClusterAutoscaler-friendly scheduling algorithm.

In practice this means that `kube-scheduler` will more likely prioritize nodes with higher resource usage for pod scheduling. This would lead to better resource usage and it will likely provision less nodes. All other scheduler priority configurations are not affected. 
```
