### PR TITLE
Emit events on deletion of referenced gardener resources

### DIFF
--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -252,4 +252,8 @@ const (
 
 	// ControllerRegistrationName is the key of a label on extension namespaces that indicates the controller registration name.
 	LabelControllerRegistrationName = "controllerregistration.core.gardener.cloud/name"
+
+	// EventResourceReferenced indicates that the resource deletion is in waiting mode because the resource is still
+	// being referenced by at least one other resource (e.g. a SecretBinding is still referenced by a Shoot)
+	EventResourceReferenced = "ResourceReferenced"
 )

--- a/pkg/controllermanager/controller/backupbucket/backup_bucket_reconciler.go
+++ b/pkg/controllermanager/controller/backupbucket/backup_bucket_reconciler.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	controllerutils "github.com/gardener/gardener/pkg/controllermanager/controller/utils"
@@ -161,9 +162,10 @@ func (r *reconciler) deleteBackupBucket(backupBucket *gardencorev1alpha1.BackupB
 	}
 
 	if len(associatedBackupEntries) != 0 {
-		message := "Can't delete BackupBucket, because BackupEntries are still referencing it."
-		message += fmt.Sprintf(" BackupEntries: %+v", associatedBackupEntries)
+		message := fmt.Sprintf("Can't delete BackupBucket, because the following BackupEntries are still referencing it: %+v", associatedBackupEntries)
 		backupBucketLogger.Info(message)
+		r.recorder.Event(backupBucket, corev1.EventTypeNormal, v1alpha1constants.EventResourceReferenced, message)
+
 		return reconcile.Result{}, fmt.Errorf("BackupBucket %s still has references", backupBucket.Name)
 	}
 

--- a/pkg/controllermanager/controller/cloudprofile/cloudprofile.go
+++ b/pkg/controllermanager/controller/cloudprofile/cloudprofile.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -50,7 +51,7 @@ type Controller struct {
 
 // NewCloudProfileController takes a Kubernetes client <k8sGardenClient> and a <k8sGardenCoreInformers> for the Garden clusters.
 // It creates and return a new Garden controller to control CloudProfiles.
-func NewCloudProfileController(k8sGardenClient kubernetes.Interface, k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory) *Controller {
+func NewCloudProfileController(k8sGardenClient kubernetes.Interface, k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory, recorder record.EventRecorder) *Controller {
 	var (
 		gardenCoreV1alpha1Informer = k8sGardenCoreInformers.Core().V1alpha1()
 		cloudProfileInformer       = gardenCoreV1alpha1Informer.CloudProfiles()
@@ -63,7 +64,7 @@ func NewCloudProfileController(k8sGardenClient kubernetes.Interface, k8sGardenCo
 		cloudProfileLister:     cloudProfileInformer.Lister(),
 		cloudProfileQueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cloudprofile"),
 		shootLister:            shootLister,
-		control:                NewDefaultControl(k8sGardenClient, shootLister),
+		control:                NewDefaultControl(k8sGardenClient, shootLister, recorder),
 		workerCh:               make(chan int),
 	}
 

--- a/pkg/controllermanager/controller/controllerregistration/seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed_control.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -27,7 +28,8 @@ import (
 	controllerutils "github.com/gardener/gardener/pkg/controllermanager/controller/utils"
 	"github.com/gardener/gardener/pkg/logger"
 
-	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-multierror"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -138,7 +140,9 @@ func (c *defaultSeedControl) Reconcile(obj *gardencorev1alpha1.Seed) error {
 
 		for _, controllerInstallation := range controllerInstallationList {
 			if controllerInstallation.Spec.SeedRef.Name == seed.Name {
-				return fmt.Errorf("ControllerInstallations for seed %q still pending, cannot release seed", seed.Name)
+				message := fmt.Sprintf("ControllerInstallations for seed %q still pending, cannot release seed", seed.Name)
+				c.recorder.Event(seed, corev1.EventTypeNormal, v1alpha1constants.EventResourceReferenced, message)
+				return fmt.Errorf(message)
 			}
 		}
 

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -128,7 +128,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) {
 	var (
 		backupBucketController           = backupbucketcontroller.NewBackupBucketController(f.k8sGardenClient, f.k8sGardenCoreInformers, f.cfg, f.recorder)
 		backupEntryController            = backupentrycontroller.NewBackupEntryController(f.k8sGardenClient, f.k8sGardenCoreInformers, f.cfg, f.gardenNamespace, f.recorder)
-		cloudProfileController           = cloudprofilecontroller.NewCloudProfileController(f.k8sGardenClient, f.k8sGardenCoreInformers)
+		cloudProfileController           = cloudprofilecontroller.NewCloudProfileController(f.k8sGardenClient, f.k8sGardenCoreInformers, f.recorder)
 		controllerRegistrationController = controllerregistrationcontroller.NewController(f.k8sGardenClient, f.k8sGardenCoreInformers, f.cfg, f.recorder)
 		controllerInstallationController = controllerinstallationcontroller.NewController(f.k8sGardenClient, f.k8sGardenCoreInformers, f.cfg, f.recorder, gardenNamespace)
 		quotaController                  = quotacontroller.NewQuotaController(f.k8sGardenClient, f.k8sGardenCoreInformers, f.recorder)

--- a/pkg/controllermanager/controller/quota/quota_control.go
+++ b/pkg/controllermanager/controller/quota/quota_control.go
@@ -21,12 +21,14 @@ import (
 	"time"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	controllerutils "github.com/gardener/gardener/pkg/controllermanager/controller/utils"
 	"github.com/gardener/gardener/pkg/logger"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
@@ -140,7 +142,11 @@ func (c *defaultControl) ReconcileQuota(obj *gardencorev1alpha1.Quota, key strin
 			}
 			return nil
 		}
-		quotaLogger.Infof("Can't delete Quota, because the following SecretBindings are still referencing it: %v", associatedSecretBindings)
+
+		message := fmt.Sprintf("Can't delete Quota, because the following SecretBindings are still referencing it: %v", associatedSecretBindings)
+		quotaLogger.Info(message)
+		c.recorder.Event(quota, corev1.EventTypeNormal, v1alpha1constants.EventResourceReferenced, message)
+
 		return errors.New("Quota still has references")
 	}
 

--- a/pkg/controllermanager/controller/secretbinding/secretbinding_control.go
+++ b/pkg/controllermanager/controller/secretbinding/secretbinding_control.go
@@ -21,12 +21,14 @@ import (
 	"time"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	controllerutils "github.com/gardener/gardener/pkg/controllermanager/controller/utils"
 	"github.com/gardener/gardener/pkg/logger"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kubecorev1listers "k8s.io/client-go/listers/core/v1"
@@ -158,7 +160,11 @@ func (c *defaultControl) ReconcileSecretBinding(obj *gardencorev1alpha1.SecretBi
 			}
 			return nil
 		}
-		secretBindingLogger.Infof("Can't delete SecretBinding, because the following Shoots are still referencing it: %v", associatedShoots)
+
+		message := fmt.Sprintf("Can't delete SecretBinding, because the following Shoots are still referencing it: %v", associatedShoots)
+		secretBindingLogger.Infof(message)
+		c.recorder.Event(secretBinding, corev1.EventTypeNormal, v1alpha1constants.EventResourceReferenced, message)
+
 		return errors.New("SecretBinding still has references")
 	}
 

--- a/pkg/controllermanager/controller/seed/seed_control.go
+++ b/pkg/controllermanager/controller/seed/seed_control.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1alpha1"
@@ -227,13 +228,18 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1alpha1.Seed, key string)
 			return nil
 		}
 
-		parentLogMessage := "Can't delete Seed, because the following objects are still referencing it: "
+		parentLogMessage := "Can't delete Seed, because the following objects are still referencing it:"
 		if len(associatedShoots) != 0 {
-			seedLogger.Infof("%s Shoots=%v", parentLogMessage, associatedShoots)
+			message := fmt.Sprintf("%s Shoots=%v", parentLogMessage, associatedShoots)
+			seedLogger.Info(message)
+			c.recorder.Event(seed, corev1.EventTypeNormal, v1alpha1constants.EventResourceReferenced, message)
 		}
 		if len(associatedBackupBuckets) != 0 {
-			seedLogger.Infof("%s BackupBuckets=%v", parentLogMessage, associatedBackupBuckets)
+			message := fmt.Sprintf("%s BackupBuckets=%v", parentLogMessage, associatedBackupBuckets)
+			seedLogger.Info(message)
+			c.recorder.Event(seed, corev1.EventTypeNormal, v1alpha1constants.EventResourceReferenced, message)
 		}
+
 		return errors.New("seed still has references")
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
gardener-controller-manager now emits Events, when the user tries to delete a resource which is still being referenced in another resource and the deletion is therefore blocked (for example a SecretBinding that is still referenced by a Shoot). This is done for the following resources:
- BackupBuckets
- CloudProfiles
- Quotas
- Seeds

**Which issue(s) this PR fixes**:
Fixes #1473

**Special notes for your reviewer**:
- Please check, if there are additional resources for which this functionality should be added
- Should I add test cases for this logic?
- I thought about adding an Event, when the user tries to delete a Secret that is still referenced by a SecretBinding or Seed. The problem is, that currently there is no controller where this logic can simply be added to. WDYT?

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
