### PR TITLE
Increase terraformer memory limit

### DIFF
--- a/pkg/operation/terraformer/config.go
+++ b/pkg/operation/terraformer/config.go
@@ -139,11 +139,16 @@ func CreateOrUpdateConfigurationConfigMap(ctx context.Context, c client.Client, 
 	})
 }
 
-// CreateOrUpdateStateConfigMap creates or updates the Terraformer state ConfigMap with the given state.
-func CreateOrUpdateStateConfigMap(ctx context.Context, c client.Client, namespace, name, state string) (*corev1.ConfigMap, error) {
-	return createOrUpdateConfigMap(ctx, c, namespace, name, map[string]string{
-		StateKey: state,
-	})
+// CreateStateConfigMap creates the Terraformer state ConfigMap with the given state.
+func CreateStateConfigMap(ctx context.Context, c client.Client, namespace, name, state string) error {
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Data: map[string]string{
+			StateKey: state,
+		},
+	}
+
+	return c.Create(ctx, configMap)
 }
 
 // CreateOrUpdateTFVarsSecret creates or updates the Terraformer variables Secret with the given tfvars.
@@ -172,7 +177,7 @@ func DefaultInitializer(c client.Client, main, variables string, tfvars []byte) 
 		}
 
 		if config.InitializeState {
-			if _, err := CreateOrUpdateStateConfigMap(ctx, c, config.Namespace, config.StateName, ""); err != nil {
+			if err := CreateStateConfigMap(ctx, c, config.Namespace, config.StateName, ""); err != nil && !apierrors.IsAlreadyExists(err) {
 				return err
 			}
 		}

--- a/pkg/operation/terraformer/terraformer.go
+++ b/pkg/operation/terraformer/terraformer.go
@@ -393,12 +393,12 @@ func (t *Terraformer) podSpec(scriptName string) *corev1.PodSpec {
 				},
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceCPU:    resource.MustParse("100m"),
 						corev1.ResourceMemory: resource.MustParse("200Mi"),
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("200m"),
-						corev1.ResourceMemory: resource.MustParse("512Mi"),
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("1.5Gi"),
 					},
 				},
 				Env: t.env(),


### PR DESCRIPTION
**What this PR does / why we need it**:
- Increase terraformer memory limit as we observe terraformer Pods which are `OOMKilled`
- Modify InitializeState to only create (without update)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
terraformer memory limit is set to `1.5Gi`.
```
