### PR TITLE
Allow custom configuration for nginx-ingress addon

### DIFF
--- a/charts/shoot-addons/charts/nginx-ingress/templates/controller-configmap.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/controller-configmap.yaml
@@ -11,6 +11,8 @@ metadata:
   namespace: kube-system
 data:
   enable-vts-status: "{{ .Values.controller.stats.enabled }}"
-{{- if .Values.controller.config }}
+{{- if .Values.controller.customConfig }}
+{{ toYaml (merge .Values.controller.customConfig .Values.controller.config) | indent 2 }}
+{{- else }}
 {{ toYaml .Values.controller.config | indent 2 }}
 {{- end }}

--- a/charts/shoot-addons/charts/nginx-ingress/values.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/values.yaml
@@ -15,6 +15,9 @@ controller:
     use-proxy-protocol: "false"
     worker-processes: "2"
 
+  customConfig: {}
+  # large-client-header-buffers: "4 32k"
+
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920
   # is merged

--- a/example/90-deprecated-shoot-alicloud.yaml
+++ b/example/90-deprecated-shoot-alicloud.yaml
@@ -179,6 +179,8 @@ spec:
     nginx-ingress:
       enabled: false
       loadBalancerSourceRanges: []
+    # config:
+    #   enable-access-log-for-default-backend: "false"
     kubernetes-dashboard:
       enabled: true
     # authenticationMode: basic # allowed values: basic,token

--- a/example/90-deprecated-shoot-aws.yaml
+++ b/example/90-deprecated-shoot-aws.yaml
@@ -181,6 +181,8 @@ spec:
     nginx-ingress:
       enabled: false
       loadBalancerSourceRanges: []
+    # config:
+    #   enable-access-log-for-default-backend: "false"
     kubernetes-dashboard:
       enabled: true
     # authenticationMode: basic # allowed values: basic,token

--- a/example/90-deprecated-shoot-azure.yaml
+++ b/example/90-deprecated-shoot-azure.yaml
@@ -180,6 +180,8 @@ spec:
     nginx-ingress:
       enabled: false
       loadBalancerSourceRanges: []
+    # config:
+    #   enable-access-log-for-default-backend: "false"
     kubernetes-dashboard:
       enabled: true
     # authenticationMode: basic # allowed values: basic,token

--- a/example/90-deprecated-shoot-gcp.yaml
+++ b/example/90-deprecated-shoot-gcp.yaml
@@ -179,6 +179,8 @@ spec:
     nginx-ingress:
       enabled: false
       loadBalancerSourceRanges: []
+    # config:
+    #   enable-access-log-for-default-backend: "false"
     kubernetes-dashboard:
       enabled: true
     # authenticationMode: basic # allowed values: basic,token

--- a/example/90-deprecated-shoot-openstack.yaml
+++ b/example/90-deprecated-shoot-openstack.yaml
@@ -178,6 +178,8 @@ spec:
     nginx-ingress:
       enabled: false
       loadBalancerSourceRanges: []
+    # config:
+    #   enable-access-log-for-default-backend: "false"
     kubernetes-dashboard:
       enabled: true
     # authenticationMode: basic # allowed values: basic,token

--- a/example/90-deprecated-shoot-packet.yaml
+++ b/example/90-deprecated-shoot-packet.yaml
@@ -174,6 +174,8 @@ spec:
     nginx-ingress:
       enabled: false
       loadBalancerSourceRanges: []
+    # config:
+    #   enable-access-log-for-default-backend: "false"
     kubernetes-dashboard:
       enabled: true
     # authenticationMode: basic # allowed values: basic,token

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -243,6 +243,8 @@ spec:
     nginx-ingress:
       enabled: false
     # loadBalancerSourceRanges: []
+    # config:
+    #   enable-access-log-for-default-backend: "false"
     kubernetes-dashboard:
       enabled: true
     # authenticationMode: basic # allowed values: basic,token

--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -1431,6 +1431,20 @@ operations should be performed.</p>
 </tr>
 <tr>
 <td>
+<code>monitoring</code></br>
+<em>
+<a href="#core.gardener.cloud/v1alpha1.Monitoring">
+Monitoring
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Monitoring contains information about custom monitoring configurations for the shoot.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>provider</code></br>
 <em>
 <a href="#core.gardener.cloud/v1alpha1.Provider">
@@ -1614,6 +1628,37 @@ ProviderConfig
 <td>
 <em>(Optional)</em>
 <p>Config is the configuration of the plugin.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="core.gardener.cloud/v1alpha1.Alerting">Alerting
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#core.gardener.cloud/v1alpha1.Monitoring">Monitoring</a>)
+</p>
+<p>
+<p>Alerting contains information about how alerting will be done (i.e. who will receive alerts and how).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>emailReceivers</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MonitoringEmailReceivers is a list of recipients for alerts</p>
 </td>
 </tr>
 </tbody>
@@ -4672,6 +4717,17 @@ bool
 <tbody>
 <tr>
 <td>
+<code>class</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Class is the class of the storage type.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>size</code></br>
 <em>
 <a href="https://godoc.org/k8s.io/apimachinery/pkg/api/resource#Quantity">
@@ -4828,6 +4884,39 @@ If not present, the value will be computed based on the &ldquo;Begin&rdquo; valu
 </tr>
 </tbody>
 </table>
+<h3 id="core.gardener.cloud/v1alpha1.Monitoring">Monitoring
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#core.gardener.cloud/v1alpha1.ShootSpec">ShootSpec</a>)
+</p>
+<p>
+<p>Monitoring contains information about the monitoring configuration for the shoot.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>alerting</code></br>
+<em>
+<a href="#core.gardener.cloud/v1alpha1.Alerting">
+Alerting
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Alerting contains information about the alerting configuration for the shoot cluster.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="core.gardener.cloud/v1alpha1.Networking">Networking
 </h3>
 <p>
@@ -4949,6 +5038,19 @@ Addon
 <td>
 <em>(Optional)</em>
 <p>LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>config</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Config contains custom configuration for the nginx-ingress-controller configuration.
+See <a href="https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options">https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options</a></p>
 </td>
 </tr>
 </tbody>
@@ -6468,6 +6570,20 @@ operations should be performed.</p>
 </tr>
 <tr>
 <td>
+<code>monitoring</code></br>
+<em>
+<a href="#core.gardener.cloud/v1alpha1.Monitoring">
+Monitoring
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Monitoring contains information about custom monitoring configurations for the shoot.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>provider</code></br>
 <em>
 <a href="#core.gardener.cloud/v1alpha1.Provider">
@@ -6693,6 +6809,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Type is the machine type of the worker group.</p>
 </td>
 </tr>
@@ -6996,5 +7113,5 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>77713c395</code>.
+on git commit <code>e8637b838</code>.
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -2811,6 +2811,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Type is the type of the volume.</p>
 </td>
 </tr>
@@ -3186,5 +3187,5 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>77713c395</code>.
+on git commit <code>e8637b838</code>.
 </em></p>

--- a/hack/api-reference/garden.md
+++ b/hack/api-reference/garden.md
@@ -893,6 +893,20 @@ Maintenance
 operations should be performed.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>monitoring</code></br>
+<em>
+<a href="#garden.sapcloud.io/v1beta1.Monitoring">
+Monitoring
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Monitoring contains information about custom monitoring configurations for the shoot.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -1527,6 +1541,37 @@ github.com/gardener/gardener/pkg/apis/core/v1alpha1.ProviderConfig
 <td>
 <em>(Optional)</em>
 <p>Config is the configuration of the plugin.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="garden.sapcloud.io/v1beta1.Alerting">Alerting
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#garden.sapcloud.io/v1beta1.Monitoring">Monitoring</a>)
+</p>
+<p>
+<p>Alerting contains information about how alerting will be done (i.e. who will receive alerts and how).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>emailReceivers</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MonitoringEmailReceivers is a list of recipients for alerts</p>
 </td>
 </tr>
 </tbody>
@@ -5382,6 +5427,17 @@ k8s.io/apimachinery/pkg/api/resource.Quantity
 <tbody>
 <tr>
 <td>
+<code>class</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Class is the class of the storage type.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>size</code></br>
 <em>
 <a href="https://godoc.org/k8s.io/apimachinery/pkg/api/resource#Quantity">
@@ -5539,6 +5595,39 @@ If not present, the value will be computed based on the &ldquo;Begin&rdquo; valu
 </tr>
 </tbody>
 </table>
+<h3 id="garden.sapcloud.io/v1beta1.Monitoring">Monitoring
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#garden.sapcloud.io/v1beta1.ShootSpec">ShootSpec</a>)
+</p>
+<p>
+<p>Monitoring contains information about the monitoring configuration for the shoot.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>alerting</code></br>
+<em>
+<a href="#garden.sapcloud.io/v1beta1.Alerting">
+Alerting
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Alerting contains information about the alerting configuration for the shoot cluster.</p>
+</td>
+</tr>
+</tbody>
+</table>
 <h3 id="garden.sapcloud.io/v1beta1.Monocular">Monocular
 </h3>
 <p>
@@ -5674,6 +5763,19 @@ Addon
 <td>
 <em>(Optional)</em>
 <p>LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>config</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Config contains custom configuration for the nginx-ingress-controller configuration.
+See <a href="https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options">https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options</a></p>
 </td>
 </tr>
 </tbody>
@@ -7598,6 +7700,20 @@ Maintenance
 operations should be performed.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>monitoring</code></br>
+<em>
+<a href="#garden.sapcloud.io/v1beta1.Monitoring">
+Monitoring
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Monitoring contains information about custom monitoring configurations for the shoot.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="garden.sapcloud.io/v1beta1.ShootStatus">ShootStatus
@@ -8034,5 +8150,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>77713c395</code>.
+on git commit <code>e8637b838</code>.
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,5 +555,5 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>77713c395</code>.
+on git commit <code>e8637b838</code>.
 </em></p>

--- a/hack/templates/resources/90-deprecated-shoot.yaml.tpl
+++ b/hack/templates/resources/90-deprecated-shoot.yaml.tpl
@@ -664,6 +664,8 @@ spec:
     nginx-ingress:
       enabled: ${value("spec.addons.nginx-ingress.enabled", "false")}
       loadBalancerSourceRanges: ${value("spec.addons.nginx-ingress.loadBalancerSourceRanges", [])}
+    # config:
+    #   enable-access-log-for-default-backend: "false"
     kubernetes-dashboard:
       enabled: ${value("spec.addons.kubernetes-dashboard.enabled", "true")}
     # authenticationMode: basic # allowed values: basic,token

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -168,6 +168,10 @@ type NginxIngress struct {
 	// LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress
 	// +optional
 	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty"`
+	// Config contains custom configuration for the nginx-ingress-controller configuration.
+	// See https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options
+	// +optional
+	Config map[string]string `json:"config,omitempty"`
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/pkg/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.conversion.go
@@ -3042,6 +3042,7 @@ func autoConvert_v1alpha1_NginxIngress_To_garden_NginxIngress(in *NginxIngress, 
 		return err
 	}
 	out.LoadBalancerSourceRanges = *(*[]string)(unsafe.Pointer(&in.LoadBalancerSourceRanges))
+	out.Config = *(*map[string]string)(unsafe.Pointer(&in.Config))
 	return nil
 }
 
@@ -3055,6 +3056,7 @@ func autoConvert_garden_NginxIngress_To_v1alpha1_NginxIngress(in *garden.NginxIn
 		return err
 	}
 	out.LoadBalancerSourceRanges = *(*[]string)(unsafe.Pointer(&in.LoadBalancerSourceRanges))
+	out.Config = *(*map[string]string)(unsafe.Pointer(&in.Config))
 	return nil
 }
 

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1866,6 +1866,13 @@ func (in *NginxIngress) DeepCopyInto(out *NginxIngress) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Config != nil {
+		in, out := &in.Config, &out.Config
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -1129,7 +1129,6 @@ type Addons struct {
 	// KubernetesDashboard holds configuration settings for the kubernetes dashboard addon.
 	KubernetesDashboard *KubernetesDashboard
 	// NginxIngress holds configuration settings for the nginx-ingress addon.
-	// DEPRECATED: This field will be removed in a future version.
 	NginxIngress *NginxIngress
 
 	// ClusterAutoscaler holds configuration settings for the cluster autoscaler addon.
@@ -1189,6 +1188,9 @@ type NginxIngress struct {
 	Addon
 	// LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress
 	LoadBalancerSourceRanges []string
+	// Config contains custom configuration for the nginx-ingress-controller configuration.
+	// See https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options
+	Config map[string]string
 }
 
 // Monocular describes configuration values for the monocular addon.

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -1225,6 +1225,10 @@ type NginxIngress struct {
 	// LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress
 	// +optional
 	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty"`
+	// Config contains custom configuration for the nginx-ingress-controller configuration.
+	// See https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options
+	// +optional
+	Config map[string]string `json:"config,omitempty"`
 }
 
 // Monocular describes configuration values for the monocular addon.

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -3681,6 +3681,7 @@ func autoConvert_v1beta1_NginxIngress_To_garden_NginxIngress(in *NginxIngress, o
 		return err
 	}
 	out.LoadBalancerSourceRanges = *(*[]string)(unsafe.Pointer(&in.LoadBalancerSourceRanges))
+	out.Config = *(*map[string]string)(unsafe.Pointer(&in.Config))
 	return nil
 }
 
@@ -3694,6 +3695,7 @@ func autoConvert_garden_NginxIngress_To_v1beta1_NginxIngress(in *garden.NginxIng
 		return err
 	}
 	out.LoadBalancerSourceRanges = *(*[]string)(unsafe.Pointer(&in.LoadBalancerSourceRanges))
+	out.Config = *(*map[string]string)(unsafe.Pointer(&in.Config))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -2245,6 +2245,13 @@ func (in *NginxIngress) DeepCopyInto(out *NginxIngress) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Config != nil {
+		in, out := &in.Config, &out.Config
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -2393,6 +2393,13 @@ func (in *NginxIngress) DeepCopyInto(out *NginxIngress) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Config != nil {
+		in, out := &in.Config, &out.Config
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3216,6 +3216,21 @@ func schema_pkg_apis_core_v1alpha1_NginxIngress(ref common.ReferenceCallback) co
 							},
 						},
 					},
+					"config": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Config contains custom configuration for the nginx-ingress-controller configuration. See https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"enabled"},
 			},
@@ -8898,6 +8913,21 @@ func schema_pkg_apis_garden_v1beta1_NginxIngress(ref common.ReferenceCallback) c
 							Description: "LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"config": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Config contains custom configuration for the nginx-ingress-controller configuration. See https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Type:   []string{"string"},

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -93,6 +93,7 @@ func (b *Botanist) GenerateNginxIngressConfig() (map[string]interface{}, error) 
 	if enabled {
 		values = map[string]interface{}{
 			"controller": map[string]interface{}{
+				"customConfig": b.Shoot.Info.Spec.Addons.NginxIngress.Config,
 				"service": map[string]interface{}{
 					"loadBalancerSourceRanges": b.Shoot.Info.Spec.Addons.NginxIngress.LoadBalancerSourceRanges,
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow custom configuration for nginx-ingress addon

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
It is now possible to provide custom configuration for the standard `nginx-ingress` addon provided by Gardener using the `.spec.addons.nginx-ingress.config` map.
:warning: Be aware that you cannot control the version of the ingress controller, hence, it is not recommended to use this field as Gardener can update the version anytime, potentially conflicting with your custom configuration. Deploy your own ingress controller instead.
```
