### PR TITLE
Add some duplication checks in CloudProfile validation

### DIFF
--- a/pkg/apis/garden/v1beta1/conversions.go
+++ b/pkg/apis/garden/v1beta1/conversions.go
@@ -95,13 +95,15 @@ func Convert_garden_MachineImage_To_v1beta1_MachineImage(in *garden.MachineImage
 func Convert_v1beta1_KubernetesConstraints_To_garden_KubernetesConstraints(in *KubernetesConstraints, out *garden.KubernetesConstraints, s conversion.Scope) error {
 	out.OfferedVersions = []garden.KubernetesVersion{}
 	duplicates := map[string]int{}
-	for index, externalVersion := range in.Versions {
+	index := 0
+	for _, externalVersion := range in.Versions {
 		internalVersion := &garden.KubernetesVersion{Version: externalVersion}
 		if _, exists := duplicates[externalVersion]; exists {
 			continue
 		}
 		out.OfferedVersions = append(out.OfferedVersions, *internalVersion)
 		duplicates[externalVersion] = index
+		index++
 	}
 	for _, externalVersion := range in.OfferedVersions {
 		internalVersion := &garden.KubernetesVersion{}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds some duplication checks to the CloudProfile validation to prevent duplicate Kubernetes versions, duplicate regions names and duplicate zone names.
It also fixes a bug in the CloudProfile conversion which could cause an index out of range panic.

**Which issue(s) this PR fixes**:
Fixes #1407

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
Gardener now checks duplicate Kubernetes versions, region names and zones names in the `CloudProfile` resource. Please make sure, that there are no duplicates in your existing `CloudProfile`s before upgrading gardener.
```
