### PR TITLE
Fix conversion of CloudProfile between APIs

### DIFF
--- a/pkg/apis/garden/v1beta1/conversions.go
+++ b/pkg/apis/garden/v1beta1/conversions.go
@@ -599,7 +599,7 @@ func Convert_v1beta1_CloudProfile_To_garden_CloudProfile(in *CloudProfile, out *
 		}
 		cloudProfileConfig.CountFaultDomains = nil
 		for _, c := range in.Spec.Azure.CountFaultDomains {
-			if !azureV1alpha1DomainCountsHaveRegion(cloudProfileConfig.CountUpdateDomains, c.Region) {
+			if !azureV1alpha1DomainCountsHaveRegion(cloudProfileConfig.CountFaultDomains, c.Region) {
 				cloudProfileConfig.CountFaultDomains = append(cloudProfileConfig.CountFaultDomains, azurev1alpha1.DomainCount{
 					Region: c.Region,
 					Count:  c.Count,
@@ -1056,12 +1056,14 @@ func Convert_v1beta1_CloudProfile_To_garden_CloudProfile(in *CloudProfile, out *
 		out.Spec.SeedSelector = nil
 	}
 
-	if providerConfigJSON, ok := in.Annotations[garden.MigrationCloudProfileProviderConfig]; ok {
-		var providerConfig garden.ProviderConfig
-		if err := json.Unmarshal([]byte(providerConfigJSON), &providerConfig); err != nil {
-			return err
+	if out.Spec.ProviderConfig == nil {
+		if providerConfigJSON, ok := in.Annotations[garden.MigrationCloudProfileProviderConfig]; ok {
+			providerConfig := &garden.ProviderConfig{}
+			if err := json.Unmarshal([]byte(providerConfigJSON), providerConfig); err != nil {
+				return err
+			}
+			out.Spec.ProviderConfig = providerConfig
 		}
-		out.Spec.ProviderConfig = &providerConfig
 	}
 
 	return nil

--- a/pkg/apis/roundtrip_cloudprofile_migration_test.go
+++ b/pkg/apis/roundtrip_cloudprofile_migration_test.go
@@ -233,6 +233,10 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 				countFaultDomain        = 8
 
 				providerConfig = &azurev1alpha1.CloudProfileConfig{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "azure.provider.extensions.gardener.cloud/v1alpha1",
+						Kind:       "CloudProfileConfig",
+					},
 					MachineImages: []azurev1alpha1.MachineImages{
 						{Name: "foo"},
 					},
@@ -243,6 +247,7 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 						{Region: countFaultDomainRegion, Count: countFaultDomain},
 					},
 				}
+
 				providerConfigJSON, _ = json.Marshal(providerConfig)
 				providerType          = "azure"
 
@@ -553,6 +558,10 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 				requestTimeout = "30s"
 
 				providerConfig = &openstackv1alpha1.CloudProfileConfig{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "openstack.provider.extensions.gardener.cloud/v1alpha1",
+						Kind:       "CloudProfileConfig",
+					},
 					Constraints: openstackv1alpha1.Constraints{
 						FloatingPools: []openstackv1alpha1.FloatingPool{
 							{
@@ -1312,6 +1321,10 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 				countFaultDomain        = 8
 
 				providerConfig = &azurev1alpha1.CloudProfileConfig{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "azure.provider.extensions.gardener.cloud/v1alpha1",
+						Kind:       "CloudProfileConfig",
+					},
 					MachineImages: []azurev1alpha1.MachineImages{
 						{Name: "foo"},
 					},
@@ -1631,6 +1644,10 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 				requestTimeout = "30s"
 
 				providerConfig = &openstackv1alpha1.CloudProfileConfig{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "openstack.provider.extensions.gardener.cloud/v1alpha1",
+						Kind:       "CloudProfileConfig",
+					},
 					Constraints: openstackv1alpha1.Constraints{
 						FloatingPools: []openstackv1alpha1.FloatingPool{
 							{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix `garden.sapcloud.io/v1beta1.CloudProfile` resource to be possible to be reconfigured with  `kubectl edit` or `kubectl apply`.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This fix has to be cherry picket to `release-0.31`, maybe to `release-0.30` as well.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fix conversion of `garden.sapcloud.io/v1beta1.CloudProfile`.
```
