### PR TITLE
Bootstrap nodes with CA cert

### DIFF
--- a/charts/seed-operatingsystemconfig/original/templates/osc.yaml
+++ b/charts/seed-operatingsystemconfig/original/templates/osc.yaml
@@ -10,24 +10,24 @@ spec:
   type: {{ required ".osc.type is required" .Values.osc.type }}
   purpose: {{ required ".osc.purpose is required" .Values.osc.purpose }}
   {{- if .Values.osc.providerConfig }}
-  providerConfig: 
+  providerConfig:
 {{ .Values.osc.providerConfig | indent 4 }}
   {{- end }}
   reloadConfigFilePath: {{ required ".osc.reloadConfigFilePath is required" .Values.osc.reloadConfigFilePath }}
   units:
+{{ include "update-ca-certs" . | indent 2 }}
 {{ include "docker-logrotate" . | indent 2 }}
 {{ include "docker-logrotate-timer" . | indent 2 }}
 {{ include "docker-monitor" . | indent 2 }}
 {{ include "kubelet" . | indent 2 }}
 {{ include "kubelet-monitor" . | indent 2 }}
-{{ include "update-ca-certs" . | indent 2 }}
 {{ include "systemd-sysctl" . | indent 2 }}
 {{ include "gardener-user" . | indent 2 }}
   files:
+{{ include "root-certs" . | indent 2 }}
 {{ include "docker-logrotate-config" . | indent 2 }}
 {{ include "journald-config" . | indent 2 }}
 {{ include "kubelet-binary" . | indent 2 }}
-{{ include "root-certs" . | indent 2 }}
 {{ include "kernel-config" . | indent 2 }}
 {{ include "health-monitor" . | indent 2 }}
 {{ include "gardener-user-script" . | indent 2 }}

--- a/charts/seed-operatingsystemconfig/original/templates/ssl/_root-certs
+++ b/charts/seed-operatingsystemconfig/original/templates/ssl/_root-certs
@@ -6,5 +6,11 @@
     inline:
       encoding: b64
       data: {{ .Values.caBundle | b64enc }}
+- path: /etc/pki/trust/anchors/ROOTcerts.pem
+  permissions: 0644
+  content:
+    inline:
+      encoding: b64
+      data: {{ .Values.caBundle | b64enc }}
 {{- end -}}
 {{- end -}}

--- a/charts/seed-operatingsystemconfig/original/templates/ssl/_update-ca-certs.service
+++ b/charts/seed-operatingsystemconfig/original/templates/ssl/_update-ca-certs.service
@@ -11,11 +11,12 @@
     After=systemd-tmpfiles-setup.service clean-ca-certificates.service
     Before=sysinit.target
     ConditionPathIsReadWrite=/etc/ssl/certs
-    ConditionPathExists=/etc/ssl/certs/ROOTcerts.pem
-    # Do nothing if update-ca-certificates has never been run before
+    ConditionPathExists=!/var/lib/kubelet/kubeconfig-real
     [Service]
     Type=oneshot
     ExecStart=/usr/sbin/update-ca-certificates
-    ExecStartPost=/usr/bin/systemctl restart docker
+    ExecStartPost=/bin/systemctl restart docker
+    [Install]
+    WantedBy=kubelet.service
 {{- end -}}
 {{- end -}}

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -140,10 +140,14 @@ func (b *Botanist) generateOriginalConfig() (map[string]interface{}, error) {
 			},
 		}
 	)
-
-	if caBundle := b.Shoot.CloudProfile.Spec.CABundle; caBundle != nil {
-		originalConfig["caBundle"] = *caBundle
+	caBundle := ""
+	if cloudProfileCaBundle := b.Shoot.CloudProfile.Spec.CABundle; cloudProfileCaBundle != nil {
+		caBundle = fmt.Sprintf("%s", *cloudProfileCaBundle)
 	}
+	if caCert, ok := b.Secrets[v1alpha1constants.SecretNameCACluster].Data[secrets.DataKeyCertificateCA]; ok && len(caCert) != 0 {
+		caBundle = fmt.Sprintf("%s\n%s", caBundle, caCert)
+	}
+	originalConfig["caBundle"] = caBundle
 
 	return b.InjectShootShootImages(originalConfig, common.HyperkubeImageName, common.PauseContainerImageName)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The shoot nodes are now provisioned with CA cert of the cluster.

**Which issue(s) this PR fixes**:
Fixes #1515 

**Special notes for your reviewer**:
@phil9909 
The output of the test script is
```bash
$ ./test.sh 
namespace/test-6d79174edacf created
run `kubectl delete "namespace/test-6d79174edacf" "csr/docker-hub-proxy.test-6d79174edacf"` to clean up
service/docker-hub-proxy created
Generating a 2048 bit RSA private key
.....................................+++
................+++
writing new private key to 'cert.key'
-----
certificatesigningrequest.certificates.k8s.io/docker-hub-proxy.test-6d79174edacf created
certificatesigningrequest.certificates.k8s.io/docker-hub-proxy.test-6d79174edacf approved
secret/nginx-tls created
deployment.apps/nginx created
configmap/nginx created
Waiting for deployment "nginx" rollout to finish: 0 of 1 updated replicas are available...
deployment "nginx" successfully rolled out
deployment.apps/test created
Waiting for deployment "test" rollout to finish: 0 of 1 updated replicas are available...
deployment "test" successfully rolled out

Test passed. Starting cleanup
namespace "test-6d79174edacf" deleted
certificatesigningrequest.certificates.k8s.io "docker-hub-proxy.test-6d79174edacf" deleted
```


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The shoot cluster CA certificate is now installed only the freshly created nodes. If this feature is required on all nodes of the cluster, new workers have to be rolled-out.
```
```noteworthy operator
From now on changes in the `cloudprofile.spec.caBundle` will be applied only to newly created nodes.
```
