### PR TITLE
Add worker configuration from file

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -25,6 +25,7 @@ spec:
     -infrastructure-provider-config-filepath=$INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
     -controlplane-provider-config-filepath=$CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
     -networking-provider-config-filepath=$NETWORKING_PROVIDER_CONFIG_FILEPATH
+    -workers-config-filepath=$WORKERS_CONFIG_FILEPATH
     -worker-zone=$ZONE
     -networking-pods=$NETWORKING_PODS
     -networking-services=$NETWORKING_SERVICES

--- a/.test-defs/WorkerTest.yaml
+++ b/.test-defs/WorkerTest.yaml
@@ -31,6 +31,7 @@ spec:
     -infrastructure-provider-config-filepath=$INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
     -controlplane-provider-config-filepath=$CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
     -networking-provider-config-filepath=$NETWORKING_PROVIDER_CONFIG_FILEPATH
+    -workers-config-filepath=$WORKERS_CONFIG_FILEPATH
 #    -external-domain=
 
   image: golang:1.13.0

--- a/test/integration/shoots/update/shoot_update_test.go
+++ b/test/integration/shoots/update/shoot_update_test.go
@@ -99,9 +99,12 @@ var _ = Describe("Shoot update testing", func() {
 		shootTestOperations.AfterEach(ctx)
 	}, DumpStateTimeout)
 
-	CIt("should update the kubernetes version of the shoot to the next available minor version", func(ctx context.Context) {
+	CIt("should update the kubernetes version of the shoot to the next version", func(ctx context.Context) {
 		currentVersion := shootTestOperations.Shoot.Spec.Kubernetes.Version
 		newVersion := *kubernetesVersion
+		if currentVersion == newVersion {
+			Skip("shoot already has the desired kubernetes version")
+		}
 		if newVersion == "" {
 			var (
 				err error

--- a/test/integration/shoots/worker/worker_test.go
+++ b/test/integration/shoots/worker/worker_test.go
@@ -75,6 +75,7 @@ var (
 	infrastructureProviderConfig = flag.String("infrastructure-provider-config-filepath", "", "filepath to the provider specific infrastructure config")
 	controlPlaneProviderConfig   = flag.String("controlplane-provider-config-filepath", "", "filepath to the provider specific infrastructure config")
 	networkingProviderConfig     = flag.String("networking-provider-config-filepath", "", "filepath to the provider specific infrastructure config")
+	workersConfig                = flag.String("workers-config-filepath", "", "filepath to the workers config.")
 
 	// other
 	shootYamlPath       = "/example/90-shoot.yaml"
@@ -140,8 +141,10 @@ var _ = Describe("Worker Suite", func() {
 		workerGardenerTest, err = NewWorkerGardenerTest(shootGardenerTest)
 		Expect(err).NotTo(HaveOccurred())
 
-		workerGardenerTest.SetupShootWorkers(shootMachineImageName, shootMachineImageName2, workerZone)
-		Expect(err).NotTo(HaveOccurred())
+		if len(*workersConfig) == 0 {
+			err := workerGardenerTest.SetupShootWorkers(shootMachineImageName, shootMachineImageName2, workerZone)
+			Expect(err).NotTo(HaveOccurred())
+		}
 
 		shootObject, err := shootGardenerTest.CreateShoot(ctx)
 		if err != nil {
@@ -225,7 +228,7 @@ func prepareShoot() *gardencorev1alpha1.Shoot {
 	}
 
 	// set ProviderConfigs
-	err = SetProviderConfigsFromFilepath(shootObject, infrastructureProviderConfig, controlPlaneProviderConfig, networkingProviderConfig)
+	err = SetProviderConfigsFromFilepath(shootObject, infrastructureProviderConfig, controlPlaneProviderConfig, networkingProviderConfig, workersConfig)
 	Expect(err).To(BeNil())
 	return shootObject
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support to specify a raw worker configuration in shoot creation tests

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
