### PR TITLE
Adds functionality to "cancel" HandleErrors 

### DIFF
--- a/pkg/utils/errors/errors_test.go
+++ b/pkg/utils/errors/errors_test.go
@@ -154,6 +154,19 @@ var _ = Describe("Errors", func() {
 			Expect(err).To(Equal(expectedErr))
 		})
 
+		It("Should return a cancelError when manually canceled", func() {
+			errID := "x1"
+			err := utilerrors.HandleErrors(errorContext,
+				nil,
+				nil,
+				utilerrors.ToExecute(errID, func() error {
+					return utilerrors.Cancel()
+				}),
+			)
+
+			Expect(utilerrors.WasCanceled(errors.Cause(err))).To(BeTrue())
+		})
+
 		It("Should stop execution on error", func() {
 			expectedErr := fmt.Errorf("Err1")
 			f1 := errorsmock.NewMockTaskFunc(ctrl)


### PR DESCRIPTION
**What this PR does / why we need it**:
Task functions called from `HandleErrors` can now return a special type of error - `cancelError` which can be used by the code which called `HandleErrors` to decide to stop further execution and not return an error.

The configured SuccessHandler is called if a task function returns `cancelError`.

**Which issue(s) this PR fixes**:
Fixes #1590 

**Special notes for your reviewer**:
None
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Task functions executed by HandleErrors can now return a special type of error which can be checked by the calling code and decide whether to stop execution and return nil or return an error.
```
