### PR TITLE
Add kubernetes version definition to update test

### DIFF
--- a/.test-defs/ShootKubernetesUpdateTest.yaml
+++ b/.test-defs/ShootKubernetesUpdateTest.yaml
@@ -16,4 +16,5 @@ spec:
     -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
     -shoot-name=$SHOOT_NAME
     -shoot-namespace=$PROJECT_NAMESPACE
+    -version=$K8S_VERSION
   image: golang:1.13.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Add version flag to update test so we can specify the version to upgrade.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
