### PR TITLE
remove trivially used hostpath; add /lib/modules hostpath vol when iptables is used

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver.yaml
@@ -58,6 +58,9 @@ spec:
             add:
             - NET_ADMIN
           privileged: true
+        volumeMounts:
+        - name: modules
+          mountPath: /lib/modules
       containers:
       - name: kube-apiserver
         image: {{ index .Values.images "hyperkube" }}
@@ -211,12 +214,6 @@ spec:
         {{- end }}
         - name: kube-apiserver-admission-config
           mountPath: {{ include "kube-apiserver.admissionPluginConfigFileDir" . }}
-        - name: etcssl
-          mountPath: /etc/ssl
-          readOnly: true
-        - name: ssl-certs-hosts
-          mountPath: /usr/share/ca-certificates
-          readOnly: true
         {{- if .Values.enableEtcdEncryption }}
         - name: etcd-encryption-secret
           mountPath: /etc/kubernetes/etcd-encryption-secret
@@ -285,6 +282,9 @@ spec:
       schedulerName: default-scheduler
       terminationGracePeriodSeconds: 30
       volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
       - name: audit-policy-config
         configMap:
           name: audit-policy-config
@@ -341,12 +341,6 @@ spec:
       - name: vpn-seed-tlsauth
         secret:
           secretName: vpn-seed-tlsauth
-      - name: etcssl
-        hostPath:
-          path: /etc/ssl
-      - name: ssl-certs-hosts
-        hostPath:
-          path: /usr/share/ca-certificates
       - name: blackbox-exporter-config-apiserver
         configMap:
           name: blackbox-exporter-config-apiserver

--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -135,12 +135,6 @@ spec:
           mountPath: /var/lib/kube-controller-manager
         - name: kube-controller-manager-server
           mountPath: /var/lib/kube-controller-manager-server
-        - name: etcssl
-          mountPath: /etc/ssl
-          readOnly: true
-        - name: ssl-certs-hosts
-          mountPath: /usr/share/ca-certificates
-          readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -158,9 +152,3 @@ spec:
       - name: kube-controller-manager-server
         secret:
           secretName: kube-controller-manager-server
-      - name: etcssl
-        hostPath:
-          path: /etc/ssl
-      - name: ssl-certs-hosts
-        hostPath:
-          path: /usr/share/ca-certificates


### PR DESCRIPTION
**What this PR does / why we need it**:

- The hostPaths used in kube-apiserver and controller-manager are not used. On OSes that make /usr read-only, mkdir on these paths will fail.
- Separately, the initContainer in kube-apiserver needs to bind host's /lib/modules. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
