### PR TITLE
Write audit policy resource version by admission

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
@@ -25,9 +25,9 @@ import (
 	"github.com/gardener/gardener/pkg/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/operation/botanist"
 	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/errors"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/errors"
 	utilretry "github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/pkg/version"
 

--- a/pkg/utils/kubernetes/patch.go
+++ b/pkg/utils/kubernetes/patch.go
@@ -15,13 +15,17 @@
 package kubernetes
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
 
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var json = jsoniter.ConfigFastest
@@ -66,4 +70,9 @@ func IsEmptyPatch(patch []byte) bool {
 	}
 
 	return len(m) == 0
+}
+
+// SubmitEmptyPatch submits an empty patch to the given `obj` with the given `client` instance.
+func SubmitEmptyPatch(ctx context.Context, c client.Client, obj runtime.Object) error {
+	return c.Patch(ctx, obj, client.ConstantPatch(types.StrategicMergePatchType, []byte("{}")))
 }

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -370,10 +370,13 @@ func (r *ReferenceManager) ensureShootReferences(shoot *garden.Shoot) error {
 		return err
 	}
 
-	if hasAuditPolicy(shoot.Spec.Kubernetes.KubeAPIServer) {
-		if _, err := r.configMapLister.ConfigMaps(shoot.Namespace).Get(shoot.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name); err != nil {
+	kubeAPIServer := shoot.Spec.Kubernetes.KubeAPIServer
+	if hasAuditPolicy(kubeAPIServer) {
+		auditPolicy, err := r.configMapLister.ConfigMaps(shoot.Namespace).Get(shoot.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name)
+		if err != nil {
 			return err
 		}
+		kubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.ResourceVersion = auditPolicy.ResourceVersion
 	}
 
 	return nil

--- a/plugin/pkg/global/resourcereferencemanager/admission_test.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission_test.go
@@ -69,6 +69,7 @@ var _ = Describe("resourcereferencemanager", func() {
 			shootName        = "shoot-1"
 			projectName      = "project-1"
 			allowedUser      = "allowed-user"
+			resourceVersion  = "123456"
 			finalizers       = []string{garden.GardenerName}
 
 			defaultUserName = "test-user"
@@ -84,9 +85,10 @@ var _ = Describe("resourcereferencemanager", func() {
 
 			configMap = corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       configMapName,
-					Namespace:  namespace,
-					Finalizers: finalizers,
+					Name:            configMapName,
+					Namespace:       namespace,
+					Finalizers:      finalizers,
+					ResourceVersion: resourceVersion,
 				},
 			}
 
@@ -424,6 +426,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				err := admissionHandler.Admit(attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
+				Expect(shoot.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.ResourceVersion).To(Equal(resourceVersion))
 			})
 
 			It("should reject because the referenced cloud profile does not exist", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the `ResourceReferenceManager` admission plugin set the `.spec.kubernetes.kubeAPIServer.auditConfig.auditPolicy.configMapRef.resourceVersion` field of shoots when an audit policy `ConfigMap` is referenced.

**Special notes for your reviewer**:
A part of storing the resource version was already addressed in https://github.com/gardener/gardener/commit/a063e96b8c2ad9c9a1b6bc76a45a5714eaf6cf61 but the `resourceVersion` can still be removed/modified when shoots are updated.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Gardener now makes sure that the `.spec.kubernetes.kubeAPIServer.auditConfig.auditPolicy.configMapRef.resourceVersion` of shoot resources is set when an audit policy `ConfigMap` is referenced.
```
