### PR TITLE
Adding Status.SetConditions() to extensions.v1alpha1 Status interface

### DIFF
--- a/pkg/api/extensions/accessor_test.go
+++ b/pkg/api/extensions/accessor_test.go
@@ -150,6 +150,42 @@ var _ = Describe("Accessor", func() {
 						Expect(acc.GetType()).To(Equal(t))
 					})
 				})
+				Describe("#Get Conditions", func() {
+					It("should get the conditions", func() {
+						var (
+							conditions = []gardencorev1alpha1.Condition{
+								{
+									Type:    "ABC",
+									Status:  gardencorev1alpha1.ConditionTrue,
+									Reason:  "reason",
+									Message: "message",
+								},
+							}
+							acc = mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{Conditions: conditions})
+						)
+						getConditions := acc.GetConditions()
+						Expect(getConditions).To(Equal(conditions))
+					})
+				})
+
+				Describe("#Set Conditions", func() {
+					It("should set the conditions", func() {
+						var (
+							acc        = mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{})
+							conditions = []gardencorev1alpha1.Condition{
+								{
+									Type:    "ABC",
+									Status:  gardencorev1alpha1.ConditionTrue,
+									Reason:  "reason",
+									Message: "message",
+								},
+							}
+						)
+						acc.SetConditions(conditions)
+						getConditions := acc.GetConditions()
+						Expect(getConditions).To(Equal(conditions))
+					})
+				})
 			})
 		})
 	})

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -24,6 +24,8 @@ type Status interface {
 	// GetConditions retrieves the Conditions of a status.
 	// Conditions may be nil.
 	GetConditions() []gardencorev1alpha1.Condition
+	// SetConditions sets the Conditions of a status.
+	SetConditions([]gardencorev1alpha1.Condition)
 	// GetLastOperation retrieves the LastOperation of a status.
 	// LastOperation may be nil.
 	GetLastOperation() LastOperation

--- a/pkg/apis/extensions/v1alpha1/types_defaults.go
+++ b/pkg/apis/extensions/v1alpha1/types_defaults.go
@@ -48,6 +48,10 @@ type DefaultStatus struct {
 func (d *DefaultStatus) GetConditions() []gardencorev1alpha1.Condition {
 	return d.Conditions
 }
+// SetConditions implements Status.
+func (d *DefaultStatus) SetConditions(c []gardencorev1alpha1.Condition) {
+	d.Conditions = c
+}
 
 // GetLastOperation implements Status.
 func (d *DefaultStatus) GetLastOperation() LastOperation {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding Status.SetConditions() to extensions.v1alpha1 Status interface - that is needed for the generic health check controller that will be implemented in the Extensions.
The Controller will use it to set Conditions containing the Health Status on extensions.

Known issue: GetConditions() in the unstructured Accessor will change the v1.time type fields in condition. Currently the unstructured accessor GetConditions() is not being used & for the health controller, that issue is not a problem - it needs to update the LastTransitionTime anyways and it does not matter if the value is slightly altered (couple ns). 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- current implementation of GetConditions() with the unstructured accessor using a [type cast does not work here](https://github.com/golang/go/wiki/InterfaceSlice). There was also no test that would have detected it.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
