### PR TITLE
Improve messaging around svc/kube-apiserver deployment

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_reconcile.go
@@ -110,12 +110,12 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation, operationType
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
 		deployKubeAPIServerService = g.Add(flow.Task{
-			Name:         "Deploying Kubernetes API server service",
+			Name:         "Deploying Kubernetes API server service in the Seed cluster",
 			Fn:           flow.SimpleTaskFn(botanist.DeployKubeAPIServerService).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
 		waitUntilKubeAPIServerServiceIsReady = g.Add(flow.Task{
-			Name:         "Waiting until Kubernetes API server service has reported readiness",
+			Name:         "Waiting until Kubernetes API server service in the Seed cluster has reported readiness",
 			Fn:           flow.TaskFn(botanist.WaitUntilKubeAPIServerServiceIsReady),
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServerService),
 		})

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -44,9 +44,9 @@ func (b *Botanist) WaitUntilKubeAPIServerServiceIsReady(ctx context.Context) err
 	return retry.Until(ctx, 5*time.Second, func(ctx context.Context) (done bool, err error) {
 		loadBalancerIngress, err := kutil.GetLoadBalancerIngress(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, v1alpha1constants.DeploymentNameKubeAPIServer)
 		if err != nil {
-			b.Logger.Info("Waiting until the kube-apiserver service is ready...")
+			b.Logger.Info("Waiting until the kube-apiserver service deployed in the Seed cluster is ready...")
 			// TODO(AC): This is a quite optimistic check / we should differentiate here
-			return retry.MinorError(fmt.Errorf("kube-apiserver service is not ready: %v", err))
+			return retry.MinorError(fmt.Errorf("kube-apiserver service deployed in the Seed cluster is not ready: %v", err))
 		}
 		b.Operation.APIServerAddress = loadBalancerIngress
 		return retry.Ok()

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -188,7 +188,7 @@ func GetLoadBalancerIngress(ctx context.Context, client client.Client, namespace
 
 	switch {
 	case length == 0:
-		return "", errors.New("`.status.loadBalancer.ingress[]` has no elements yet, i.e. external load balancer has not been created (is your quota limit exceeded/reached?)")
+		return "", errors.New("`.status.loadBalancer.ingress[]` has no elements yet, i.e. external load balancer has not been created")
 	case serviceStatusIngress[length-1].IP != "":
 		return serviceStatusIngress[length-1].IP, nil
 	case serviceStatusIngress[length-1].Hostname != "":

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -784,7 +784,7 @@ var _ = Describe("kubernetes", func() {
 
 			_, err := GetLoadBalancerIngress(ctx, c, namespace, name)
 
-			Expect(err).To(MatchError("`.status.loadBalancer.ingress[]` has no elements yet, i.e. external load balancer has not been created (is your quota limit exceeded/reached?)"))
+			Expect(err).To(MatchError("`.status.loadBalancer.ingress[]` has no elements yet, i.e. external load balancer has not been created"))
 		})
 
 		It("should return an ip address", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve messaging around service kube-apiserver deployment in the Seed cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
