### PR TITLE
Update Plant test to be gardener default

### DIFF
--- a/.test-defs/PlantTest.yaml
+++ b/.test-defs/PlantTest.yaml
@@ -6,7 +6,7 @@ spec:
   description: Tests the creation of a plant.
 
   activeDeadlineSeconds: 600
-  labels: ["default"]
+  labels: ["gardener","default"]
 
   command: [bash, -c]
   args:


### PR DESCRIPTION
**What this PR does / why we need it**:
Make the plant test a gardener test to not be duplicated for each shoot test

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
