### PR TITLE
[release-0.31] Revert "Use cluster autoscaler friendly scheduling algorithm"

### DIFF
--- a/charts/seed-controlplane/charts/kube-scheduler/templates/componentconfig.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/templates/componentconfig.yaml
@@ -13,7 +13,3 @@ data:
       kubeconfig: /var/lib/kube-scheduler/kubeconfig
     leaderElection:
       leaderElect: true
-{{- if .Values.config.algorithmSource.provider }}
-    algorithmSource:
-      provider: {{ .Values.config.algorithmSource.provider }}
-{{- end }}

--- a/charts/seed-controlplane/charts/kube-scheduler/values.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/values.yaml
@@ -13,6 +13,3 @@ resources:
   limits:
     cpu: 400m
     memory: 512Mi
-config:
-  algorithmSource:
-    provider: ClusterAutoscalerProvider

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -57,11 +57,6 @@ import (
 
 var chartPathControlPlane = filepath.Join(common.ChartPath, "seed-controlplane", "charts")
 
-const (
-	schedulerDefaultProvider           = "DefaultProvider"
-	schedulerClusterAutoscalerProvider = "ClusterAutoscalerProvider"
-)
-
 // DeployNamespace creates a namespace in the Seed cluster which is used to deploy all the control plane
 // components for the Shoot cluster. Moreover, the cloud provider configuration and all the secrets will be
 // stored as ConfigMaps/Secrets.
@@ -1006,11 +1001,6 @@ func (b *Botanist) DeployKubeScheduler() error {
 	defaultValues := map[string]interface{}{
 		"replicas":          b.Shoot.GetReplicas(1),
 		"kubernetesVersion": b.Shoot.Info.Spec.Kubernetes.Version,
-		"config": map[string]interface{}{
-			"algorithmSource": map[string]interface{}{
-				"provider": b.schedulerProvider(),
-			},
-		},
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-kube-scheduler":        b.CheckSums[v1alpha1constants.DeploymentNameKubeScheduler],
 			"checksum/secret-kube-scheduler-server": b.CheckSums[common.KubeSchedulerServerName],
@@ -1109,11 +1099,4 @@ func (b *Botanist) DeployETCD(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func (b *Botanist) schedulerProvider() string {
-	if b.Shoot.WantsClusterAutoscaler {
-		return schedulerClusterAutoscalerProvider
-	}
-	return schedulerDefaultProvider
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Reverts cluster autoscaler friendly scheduling algorithm gardener/gardener#1551.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
kube-scheduler no longer uses the ClusterAutoscaler-friendly scheduling algorithm when cluster-autoscaler is enabled as it can cause instability in the workloads.
```

```noteworthy user
When cluster autoscaler enabled (workers have different min / max values), `kube-scheduler` will no longer  use a ClusterAutoscaler-friendly scheduling algorithm as it can cause instability in the workloads.
```
