### PR TITLE
Enable tainting seeds to disable DNS

### DIFF
--- a/charts/shoot-addons/charts/nginx-ingress/values.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/values.yaml
@@ -15,8 +15,8 @@ controller:
     use-proxy-protocol: "false"
     worker-processes: "2"
 
-  customConfig: {}
-  # large-client-header-buffers: "4 32k"
+# customConfig: {}
+#   large-client-header-buffers: "4 32k"
 
   # Required for use with CNI based kubernetes installations (such as ones set up by kubeadm),
   # since CNI and hostport don't mix yet. Can be deprecated once https://github.com/kubernetes/kubernetes/issues/23920

--- a/charts/shoot-core/components/charts/kube-proxy/values.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/values.yaml
@@ -2,9 +2,9 @@ global:
   podNetwork: 1.2.3.4/24
 kubeconfig: dummy-b64-data-here
 kubernetesVersion: 1.11.2
-featureGates: {}
-  # CustomResourceValidation: true
-  # RotateKubeletServerCertificate: false
+#featureGates: {}
+#  CustomResourceValidation: true
+#  RotateKubeletServerCertificate: false
 images:
   hyperkube: image-repository
   alpine: image-repository

--- a/charts/shoot-core/components/values.yaml
+++ b/charts/shoot-core/components/values.yaml
@@ -5,7 +5,7 @@ cluster-autoscaler:
   enabled: false
 kube-proxy:
   kubeconfig: dummy-add-the-data-of-a-kubernetes-secret
-  featureGates: {}
+# featureGates: {}
   podAnnotations: {}
   images:
     hyperkube: image-repository

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -48,6 +48,9 @@ When the `gardener-controller-manager` starts it scans the `garden` namespace of
   * Not every end-user/stakeholder/customer has its own domain, however, Gardener needs to create a DNS record for every shoot cluster.
   * As landscape operator you might want to define a default domain owned and controlled by you that is used for all shoot clusters that don't specify their own domain.
 
+:warning: Please note that the mentioned domain secrets are only needed if you have at least one seed cluster that is not tainted with `seed.gardener.cloud/disable-dns`.
+Seeds with this taint don't create any DNS records for shoots scheduled on it, hence, if you only have such seeds, you don't need to create the domain secrets.
+
 * **Alerting secrets** (optional), contain the alerting configuration and credentials for the [Alertmanager](https://prometheus.io/docs/alerting/alertmanager/) to send email alerts. It is also possible to configure the monitoring stack to send alerts to an alertmanager not deployed by Gardener to handle alerting. Please see [this](../../example/10-secret-alerting.yaml) for an example.
   * If email alerting is configured:
     * An Alertmanager is deployed into each seed cluster that handles the alerting for all shoots on the seed cluster.

--- a/example/50-seed.yaml
+++ b/example/50-seed.yaml
@@ -31,8 +31,9 @@ spec:
   blockCIDRs:
   - 169.254.169.254/32
 # taints:
-# - key: seed.gardener.cloud/protected  # only shoots in the `garden` namespace can use this seed
-# - key: seed.gardener.cloud/invisible  # the gardener-scheduler won't consider this seed for shoots
+# - key: seed.gardener.cloud/disable-dns # all shoots on this seed won't use any DNS, just the plain IPs/hostnames
+# - key: seed.gardener.cloud/protected   # only shoots in the `garden` namespace can use this seed
+# - key: seed.gardener.cloud/invisible   # the gardener-scheduler won't consider this seed for shoots
 # volume:
 #  minimumSize: 20Gi
 #  providers:

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,7 @@ github.com/gardener/controller-manager-library v0.0.0-20191022090355-2f744b5822c
 github.com/gardener/etcd-backup-restore v0.0.0-20190807103447-4c8bc2972b60/go.mod h1:w55uXFfKnGZFpcfl18L1yFtd2ZhRt1NpA7bxkAAHeKg=
 github.com/gardener/external-dns-management v0.0.0-20190220100540-b4bbb5832a03 h1:7fpVS/PBb93mtR+i97JszSO0jkw9dIFNuV0AZd6FEg4=
 github.com/gardener/external-dns-management v0.0.0-20190220100540-b4bbb5832a03/go.mod h1:Y3om11E865x4aQ7cmcHjknb8RMgCO153huRb/SvP+9o=
+github.com/gardener/external-dns-management v0.0.0-20191105152640-6ab503392c02 h1:8YX7RxiRMdCyn/42ryWnZ46SU8pnBnokZzkKFuf+TxY=
 github.com/gardener/gardener v0.0.0-20190913144920-5b4adb9f114d/go.mod h1:8LOLWzproKzfww5LdDo0/7FyVQR7gR1QA5LQc5buDzQ=
 github.com/gardener/gardener v0.0.0-20191028054636-32cb0027c126/go.mod h1:Ow7vOXQYgQeHTRFn2HdbEIptelrSB5NLmVFIt2rgNeY=
 github.com/gardener/gardener-extensions v0.0.0-20191028142629-438a3dcf5eca h1:MhPDRJz6djMpOBxlxvTG/St47cfoi4e0JRo2t9LpkVk=

--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -321,7 +321,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>CABundle is a certificate bundle which will be installed onto every host machine of shoot cluster targetting this profile.</p>
+<p>CABundle is a certificate bundle which will be installed onto every host machine of shoot cluster targeting this profile.</p>
 </td>
 </tr>
 <tr>
@@ -2223,7 +2223,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>CABundle is a certificate bundle which will be installed onto every host machine of shoot cluster targetting this profile.</p>
+<p>CABundle is a certificate bundle which will be installed onto every host machine of shoot cluster targeting this profile.</p>
 </td>
 </tr>
 <tr>
@@ -7409,5 +7409,5 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>722e44a70</code>.
+on git commit <code>4a68c44a2</code>.
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -3190,5 +3190,5 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>722e44a70</code>.
+on git commit <code>4a68c44a2</code>.
 </em></p>

--- a/hack/api-reference/garden.md
+++ b/hack/api-reference/garden.md
@@ -821,6 +821,7 @@ DNS
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>DNS contains information about the DNS settings of the Shoot.</p>
 </td>
 </tr>
@@ -7655,6 +7656,7 @@ DNS
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>DNS contains information about the DNS settings of the Shoot.</p>
 </td>
 </tr>
@@ -8206,5 +8208,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>722e44a70</code>.
+on git commit <code>4a68c44a2</code>.
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,5 +555,5 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>722e44a70</code>.
+on git commit <code>4a68c44a2</code>.
 </em></p>

--- a/pkg/apis/core/v1alpha1/conversions_test.go
+++ b/pkg/apis/core/v1alpha1/conversions_test.go
@@ -90,6 +90,9 @@ var _ = Describe("Conversion", func() {
 						BlockCIDRs: []string{blockCIDR},
 						Taints: []SeedTaint{
 							{
+								Key: SeedTaintDisableDNS,
+							},
+							{
 								Key: SeedTaintProtected,
 							},
 							{
@@ -140,6 +143,9 @@ var _ = Describe("Conversion", func() {
 						},
 						BlockCIDRs: []string{blockCIDR},
 						Taints: []garden.SeedTaint{
+							{
+								Key: SeedTaintDisableDNS,
+							},
 							{
 								Key: SeedTaintProtected,
 							},
@@ -196,6 +202,9 @@ var _ = Describe("Conversion", func() {
 						},
 						Taints: []garden.SeedTaint{
 							{
+								Key: SeedTaintDisableDNS,
+							},
+							{
 								Key: SeedTaintProtected,
 							},
 							{
@@ -245,6 +254,9 @@ var _ = Describe("Conversion", func() {
 						},
 						BlockCIDRs: []string{blockCIDR},
 						Taints: []SeedTaint{
+							{
+								Key: SeedTaintDisableDNS,
+							},
 							{
 								Key: SeedTaintProtected,
 							},

--- a/pkg/apis/core/v1alpha1/helper/helper.go
+++ b/pkg/apis/core/v1alpha1/helper/helper.go
@@ -16,10 +16,11 @@ package helper
 
 import (
 	"fmt"
-	"github.com/gardener/gardener/pkg/logger"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/gardener/gardener/pkg/logger"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
@@ -185,6 +186,7 @@ func TaintsHave(taints []gardencorev1alpha1.SeedTaint, key string) bool {
 }
 
 type ShootedSeed struct {
+	DisableDNS        *bool
 	Protected         *bool
 	Visible           *bool
 	MinimumVolumeSize *string
@@ -265,6 +267,9 @@ func parseShootedSeed(annotation string) (*ShootedSeed, error) {
 		shootedSeed.MinimumVolumeSize = &size
 	}
 
+	if _, ok := flags["disable-dns"]; ok {
+		shootedSeed.DisableDNS = &trueVar
+	}
 	if _, ok := flags["protected"]; ok {
 		shootedSeed.Protected = &trueVar
 	}
@@ -543,6 +548,11 @@ func ShootWantsBasicAuthentication(shoot *gardencorev1alpha1.Shoot) bool {
 		return true
 	}
 	return *kubeAPIServerConfig.EnableBasicAuthentication
+}
+
+// ShootUsesUnmanagedDNS returns true if the shoot's DNS section is marked as 'unmanaged'.
+func ShootUsesUnmanagedDNS(shoot *gardencorev1alpha1.Shoot) bool {
+	return shoot.Spec.DNS != nil && len(shoot.Spec.DNS.Providers) > 0 && shoot.Spec.DNS.Providers[0].Type != nil && *shoot.Spec.DNS.Providers[0].Type == "unmanaged"
 }
 
 // DetermineMachineImageForName finds the cloud specific machine images in the <cloudProfile> for the given <name> and

--- a/pkg/apis/core/v1alpha1/helper/helpers_test.go
+++ b/pkg/apis/core/v1alpha1/helper/helpers_test.go
@@ -533,6 +533,28 @@ var _ = Describe("helper", func() {
 		})
 	})
 
+	var (
+		unmanagedType = "unmanaged"
+		differentType = "foo"
+	)
+
+	DescribeTable("#ShootUsesUnmanagedDNS",
+		func(dns *gardencorev1alpha1.DNS, expectation bool) {
+			shoot := &gardencorev1alpha1.Shoot{
+				Spec: gardencorev1alpha1.ShootSpec{
+					DNS: dns,
+				},
+			}
+			Expect(ShootUsesUnmanagedDNS(shoot)).To(Equal(expectation))
+		},
+
+		Entry("no dns", nil, false),
+		Entry("no dns providers", &gardencorev1alpha1.DNS{}, false),
+		Entry("dns providers but no type", &gardencorev1alpha1.DNS{Providers: []gardencorev1alpha1.DNSProvider{{}}}, false),
+		Entry("dns providers but different type", &gardencorev1alpha1.DNS{Providers: []gardencorev1alpha1.DNSProvider{{Type: &differentType}}}, false),
+		Entry("dns providers and unmanaged type", &gardencorev1alpha1.DNS{Providers: []gardencorev1alpha1.DNSProvider{{Type: &unmanagedType}}}, true),
+	)
+
 	Describe("#GetShootMachineImageFromLatestMachineImageVersion", func() {
 		It("should return the Machine Image containing only the latest machine image version", func() {
 			latestVersion := "1.0.0"

--- a/pkg/apis/core/v1alpha1/types_seed.go
+++ b/pkg/apis/core/v1alpha1/types_seed.go
@@ -152,6 +152,10 @@ type SeedTaint struct {
 }
 
 const (
+	// SeedTaintDisableDNS is a constant for a taint key on a seed that marks it for disabling DNS. All shoots
+	// using this seed won't get any DNS providers, DNS records, and no DNS extension controller is required to
+	// be installed here. This is useful for environment where DNS is not required.
+	SeedTaintDisableDNS = "seed.gardener.cloud/disable-dns"
 	// SeedTaintProtected is a constant for a taint key on a seed that marks it as protected. Protected seeds
 	// may only be used by shoots in the `garden` namespace.
 	SeedTaintProtected = "seed.gardener.cloud/protected"

--- a/pkg/apis/garden/helper/helpers.go
+++ b/pkg/apis/garden/helper/helpers.go
@@ -223,6 +223,11 @@ func ShootWantsBasicAuthentication(kubeAPIServerConfig *garden.KubeAPIServerConf
 	return *kubeAPIServerConfig.EnableBasicAuthentication
 }
 
+// ShootUsesUnmanagedDNS returns true if the shoot's DNS section is marked as 'unmanaged'.
+func ShootUsesUnmanagedDNS(shoot *garden.Shoot) bool {
+	return shoot.Spec.DNS != nil && len(shoot.Spec.DNS.Providers) > 0 && shoot.Spec.DNS.Providers[0].Type != nil && *shoot.Spec.DNS.Providers[0].Type == garden.DNSUnmanaged
+}
+
 // GetConditionIndex returns the index of the condition with the given <conditionType> out of the list of <conditions>.
 // In case the required type could not be found, it returns -1.
 func GetConditionIndex(conditions []garden.Condition, conditionType garden.ConditionType) int {

--- a/pkg/apis/garden/helper/helpers_test.go
+++ b/pkg/apis/garden/helper/helpers_test.go
@@ -297,4 +297,26 @@ var _ = Describe("helper", func() {
 		Entry("secret", "v1", "Secret", "secret", BeNil()),
 		Entry("unknown", "v2", "Foo", "", HaveOccurred()),
 	)
+
+	var (
+		unmanagedType = garden.DNSUnmanaged
+		differentType = "foo"
+	)
+
+	DescribeTable("#ShootUsesUnmanagedDNS",
+		func(dns *garden.DNS, expectation bool) {
+			shoot := &garden.Shoot{
+				Spec: garden.ShootSpec{
+					DNS: dns,
+				},
+			}
+			Expect(ShootUsesUnmanagedDNS(shoot)).To(Equal(expectation))
+		},
+
+		Entry("no dns", nil, false),
+		Entry("no dns providers", &garden.DNS{}, false),
+		Entry("dns providers but no type", &garden.DNS{Providers: []garden.DNSProvider{{}}}, false),
+		Entry("dns providers but different type", &garden.DNS{Providers: []garden.DNSProvider{{Type: &differentType}}}, false),
+		Entry("dns providers and unmanaged type", &garden.DNS{Providers: []garden.DNSProvider{{Type: &unmanagedType}}}, true),
+	)
 })

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -662,6 +662,10 @@ type SeedTaint struct {
 }
 
 const (
+	// SeedTaintDisableDNS is a constant for a taint key on a seed that marks it for disabling DNS. All shoots
+	// using this seed won't get any DNS providers, DNS records, and no DNS extension controller is required to
+	// be installed here. This is useful for environment where DNS is not required.
+	SeedTaintDisableDNS = "seed.gardener.cloud/disable-dns"
 	// SeedTaintProtected is a constant for a taint key on a seed that marks it as protected. Protected seeds
 	// may only be used by shoots in the `garden` namespace.
 	SeedTaintProtected = "seed.gardener.cloud/protected"

--- a/pkg/apis/garden/v1beta1/conversion_test.go
+++ b/pkg/apis/garden/v1beta1/conversion_test.go
@@ -194,7 +194,7 @@ var _ = Describe("Machine Image Conversion", func() {
 					garden.MigrationSeedVolumeProviders:               `[{"Purpose":"` + volumeProviderPurpose2 + `","Name":"` + volumeProviderName2 + `"}]`,
 					"persistentvolume.garden.sapcloud.io/minimumSize": minimumVolumeSize,
 					"persistentvolume.garden.sapcloud.io/provider":    volumeProviderName1,
-					garden.MigrationSeedTaints:                        fmt.Sprintf("%s,%s,%s,%s", garden.SeedTaintProtected, garden.SeedTaintInvisible, taintKeyOtherOne, taintKeyOtherTwo),
+					garden.MigrationSeedTaints:                        fmt.Sprintf("%s,%s,%s,%s,%s", garden.SeedTaintDisableDNS, garden.SeedTaintProtected, garden.SeedTaintInvisible, taintKeyOtherOne, taintKeyOtherTwo),
 				}
 
 				out = &garden.Seed{}
@@ -251,6 +251,7 @@ var _ = Describe("Machine Image Conversion", func() {
 						},
 						BlockCIDRs: []string{blockCIDR},
 						Taints: []garden.SeedTaint{
+							{Key: garden.SeedTaintDisableDNS},
 							{Key: garden.SeedTaintProtected},
 							{Key: garden.SeedTaintInvisible},
 							{Key: taintKeyOtherOne},

--- a/pkg/apis/garden/v1beta1/conversions.go
+++ b/pkg/apis/garden/v1beta1/conversions.go
@@ -1288,51 +1288,53 @@ func Convert_v1beta1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conve
 	}
 	out.Spec.Networking = networking
 
-	var dns garden.DNS
-	if err := autoConvert_v1beta1_DNS_To_garden_DNS(&in.Spec.DNS, &dns, s); err != nil {
-		return err
-	}
-
-	var provider garden.DNSProvider
-	if in.Spec.DNS.ExcludeDomains != nil || in.Spec.DNS.ExcludeZones != nil || in.Spec.DNS.IncludeDomains != nil || in.Spec.DNS.IncludeZones != nil || in.Spec.DNS.Provider != nil || in.Spec.DNS.SecretName != nil {
-		provider.SecretName = in.Spec.DNS.SecretName
-		provider.Type = in.Spec.DNS.Provider
-
-		var domains *garden.DNSIncludeExclude
-		if in.Spec.DNS.IncludeDomains != nil || in.Spec.DNS.ExcludeDomains != nil {
-			domains = &garden.DNSIncludeExclude{}
-			for _, val := range in.Spec.DNS.IncludeDomains {
-				domains.Include = append(domains.Include, val)
-			}
-			for _, val := range in.Spec.DNS.ExcludeDomains {
-				domains.Exclude = append(domains.Exclude, val)
-			}
-		}
-		provider.Domains = domains
-
-		var zones *garden.DNSIncludeExclude
-		if in.Spec.DNS.IncludeZones != nil || in.Spec.DNS.ExcludeZones != nil {
-			zones = &garden.DNSIncludeExclude{}
-			for _, val := range in.Spec.DNS.IncludeZones {
-				zones.Include = append(zones.Include, val)
-			}
-			for _, val := range in.Spec.DNS.ExcludeZones {
-				zones.Exclude = append(zones.Exclude, val)
-			}
-		}
-		provider.Zones = zones
-
-		dns.Providers = append(dns.Providers, provider)
-	}
-
-	if additionalProviders, ok := in.Annotations[garden.MigrationShootDNSProviders]; ok {
-		var providers []garden.DNSProvider
-		if err := json.Unmarshal([]byte(additionalProviders), &providers); err != nil {
+	if in.Spec.DNS != nil {
+		var dns garden.DNS
+		if err := autoConvert_v1beta1_DNS_To_garden_DNS(in.Spec.DNS, &dns, s); err != nil {
 			return err
 		}
-		dns.Providers = append(dns.Providers, providers...)
+
+		var provider garden.DNSProvider
+		if in.Spec.DNS != nil && (in.Spec.DNS.ExcludeDomains != nil || in.Spec.DNS.ExcludeZones != nil || in.Spec.DNS.IncludeDomains != nil || in.Spec.DNS.IncludeZones != nil || in.Spec.DNS.Provider != nil || in.Spec.DNS.SecretName != nil) {
+			provider.SecretName = in.Spec.DNS.SecretName
+			provider.Type = in.Spec.DNS.Provider
+
+			var domains *garden.DNSIncludeExclude
+			if in.Spec.DNS.IncludeDomains != nil || in.Spec.DNS.ExcludeDomains != nil {
+				domains = &garden.DNSIncludeExclude{}
+				for _, val := range in.Spec.DNS.IncludeDomains {
+					domains.Include = append(domains.Include, val)
+				}
+				for _, val := range in.Spec.DNS.ExcludeDomains {
+					domains.Exclude = append(domains.Exclude, val)
+				}
+			}
+			provider.Domains = domains
+
+			var zones *garden.DNSIncludeExclude
+			if in.Spec.DNS.IncludeZones != nil || in.Spec.DNS.ExcludeZones != nil {
+				zones = &garden.DNSIncludeExclude{}
+				for _, val := range in.Spec.DNS.IncludeZones {
+					zones.Include = append(zones.Include, val)
+				}
+				for _, val := range in.Spec.DNS.ExcludeZones {
+					zones.Exclude = append(zones.Exclude, val)
+				}
+			}
+			provider.Zones = zones
+
+			dns.Providers = append(dns.Providers, provider)
+		}
+
+		if additionalProviders, ok := in.Annotations[garden.MigrationShootDNSProviders]; ok {
+			var providers []garden.DNSProvider
+			if err := json.Unmarshal([]byte(additionalProviders), &providers); err != nil {
+				return err
+			}
+			dns.Providers = append(dns.Providers, providers...)
+		}
+		out.Spec.DNS = &dns
 	}
-	out.Spec.DNS = &dns
 
 	var workerMigrationInfo garden.WorkerMigrationInfo
 	if data, ok := in.Annotations[garden.MigrationShootWorkers]; ok {
@@ -2167,9 +2169,10 @@ func Convert_garden_Shoot_To_v1beta1_Shoot(in *garden.Shoot, out *Shoot, s conve
 	}
 	out.Spec.Networking = networking
 
-	var dns DNS
+	var dns *DNS
 	if in.Spec.DNS != nil {
-		if err := autoConvert_garden_DNS_To_v1beta1_DNS(in.Spec.DNS, &dns, s); err != nil {
+		dns = &DNS{}
+		if err := autoConvert_garden_DNS_To_v1beta1_DNS(in.Spec.DNS, dns, s); err != nil {
 			return err
 		}
 

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -788,7 +788,8 @@ type ShootSpec struct {
 	// Cloud contains information about the cloud environment and their specific settings.
 	Cloud Cloud `json:"cloud"`
 	// DNS contains information about the DNS settings of the Shoot.
-	DNS DNS `json:"dns"`
+	// +optional
+	DNS *DNS `json:"dns,omitempty"`
 	// Extensions contain type and provider information for Shoot extensions.
 	// +optional
 	Extensions []Extension `json:"extensions,omitempty"`

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -4795,7 +4795,15 @@ func autoConvert_v1beta1_ShootSpec_To_garden_ShootSpec(in *ShootSpec, out *garde
 	if err := Convert_v1beta1_Cloud_To_garden_Cloud(&in.Cloud, &out.Cloud, s); err != nil {
 		return err
 	}
-	// WARNING: in.DNS requires manual conversion: inconvertible types (github.com/gardener/gardener/pkg/apis/garden/v1beta1.DNS vs *github.com/gardener/gardener/pkg/apis/garden.DNS)
+	if in.DNS != nil {
+		in, out := &in.DNS, &out.DNS
+		*out = new(garden.DNS)
+		if err := Convert_v1beta1_DNS_To_garden_DNS(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.DNS = nil
+	}
 	out.Extensions = *(*[]garden.Extension)(unsafe.Pointer(&in.Extensions))
 	out.Hibernation = (*garden.Hibernation)(unsafe.Pointer(in.Hibernation))
 	if err := Convert_v1beta1_Kubernetes_To_garden_Kubernetes(&in.Kubernetes, &out.Kubernetes, s); err != nil {
@@ -4813,7 +4821,15 @@ func autoConvert_garden_ShootSpec_To_v1beta1_ShootSpec(in *garden.ShootSpec, out
 		return err
 	}
 	// WARNING: in.CloudProfileName requires manual conversion: does not exist in peer-type
-	// WARNING: in.DNS requires manual conversion: inconvertible types (*github.com/gardener/gardener/pkg/apis/garden.DNS vs github.com/gardener/gardener/pkg/apis/garden/v1beta1.DNS)
+	if in.DNS != nil {
+		in, out := &in.DNS, &out.DNS
+		*out = new(DNS)
+		if err := Convert_garden_DNS_To_v1beta1_DNS(*in, *out, s); err != nil {
+			return err
+		}
+	} else {
+		out.DNS = nil
+	}
 	out.Extensions = *(*[]Extension)(unsafe.Pointer(&in.Extensions))
 	out.Hibernation = (*Hibernation)(unsafe.Pointer(in.Hibernation))
 	if err := Convert_garden_Kubernetes_To_v1beta1_Kubernetes(&in.Kubernetes, &out.Kubernetes, s); err != nil {

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -3367,7 +3367,11 @@ func (in *ShootSpec) DeepCopyInto(out *ShootSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Cloud.DeepCopyInto(&out.Cloud)
-	in.DNS.DeepCopyInto(&out.DNS)
+	if in.DNS != nil {
+		in, out := &in.DNS, &out.DNS
+		*out = new(DNS)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Extensions != nil {
 		in, out := &in.Extensions, &out.Extensions
 		*out = make([]Extension, len(*in))

--- a/pkg/apis/roundtrip_seed_migration_test.go
+++ b/pkg/apis/roundtrip_seed_migration_test.go
@@ -99,6 +99,9 @@ var _ = Describe("roundtripper seed migration", func() {
 					BlockCIDRs: []string{blockCIDR},
 					Taints: []gardencorev1alpha1.SeedTaint{
 						{
+							Key: gardencorev1alpha1.SeedTaintDisableDNS,
+						},
+						{
 							Key: gardencorev1alpha1.SeedTaintProtected,
 						},
 						{
@@ -131,7 +134,7 @@ var _ = Describe("roundtripper seed migration", func() {
 						garden.MigrationSeedCloudRegion:                   regionName,
 						garden.MigrationSeedProviderType:                  providerName,
 						garden.MigrationSeedProviderRegion:                regionName,
-						garden.MigrationSeedTaints:                        fmt.Sprintf("%s,%s", garden.SeedTaintProtected, garden.SeedTaintInvisible),
+						garden.MigrationSeedTaints:                        fmt.Sprintf("%s,%s,%s", garden.SeedTaintDisableDNS, garden.SeedTaintProtected, garden.SeedTaintInvisible),
 					},
 				},
 				Spec: gardenv1beta1.SeedSpec{
@@ -179,7 +182,7 @@ var _ = Describe("roundtripper seed migration", func() {
 			expectedOutAfterRoundTrip.Annotations[garden.MigrationSeedVolumeMinimumSize] = minimumVolumeSize
 			expectedOutAfterRoundTrip.Annotations[garden.MigrationSeedProviderType] = providerName
 			expectedOutAfterRoundTrip.Annotations[garden.MigrationSeedProviderRegion] = regionName
-			expectedOutAfterRoundTrip.Annotations[garden.MigrationSeedTaints] = fmt.Sprintf("%s,%s", garden.SeedTaintProtected, garden.SeedTaintInvisible)
+			expectedOutAfterRoundTrip.Annotations[garden.MigrationSeedTaints] = fmt.Sprintf("%s,%s,%s", garden.SeedTaintDisableDNS, garden.SeedTaintProtected, garden.SeedTaintInvisible)
 			Expect(out4).To(Equal(expectedOutAfterRoundTrip))
 		})
 	})

--- a/pkg/apis/roundtrip_shoot_migration_test.go
+++ b/pkg/apis/roundtrip_shoot_migration_test.go
@@ -497,7 +497,7 @@ var _ = Describe("roundtripper cloudprofile migration", func() {
 					},
 					Seed: &seedName,
 				},
-				DNS: gardenv1beta1.DNS{
+				DNS: &gardenv1beta1.DNS{
 					Domain:         &dnsDomain,
 					SecretName:     &dnsProvider1SecretName,
 					Provider:       &dnsProvider1Type,

--- a/pkg/controllermanager/controller/controllerinstallation/controllerinstallation_control.go
+++ b/pkg/controllermanager/controller/controllerinstallation/controllerinstallation_control.go
@@ -250,6 +250,7 @@ func (c *defaultControllerInstallationControl) reconcile(controllerInstallation 
 				"blockCIDRs":      seed.Spec.BlockCIDRs,
 				"protected":       gardencorev1alpha1helper.TaintsHave(seed.Spec.Taints, gardencorev1alpha1.SeedTaintProtected),
 				"visible":         !gardencorev1alpha1helper.TaintsHave(seed.Spec.Taints, gardencorev1alpha1.SeedTaintInvisible),
+				"taints":          seed.Spec.Taints,
 				"networks":        seed.Spec.Networks,
 			},
 		},

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -11630,7 +11630,7 @@ func schema_pkg_apis_garden_v1beta1_ShootSpec(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				Required: []string{"cloud", "dns", "kubernetes"},
+				Required: []string{"cloud", "kubernetes"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -60,7 +60,7 @@ func (b *Botanist) DestroyInternalDomainDNSRecord(ctx context.Context) error {
 
 // DeployExternalDomainDNSRecord deploys the DNS record for the external cluster domain.
 func (b *Botanist) DeployExternalDomainDNSRecord(ctx context.Context) error {
-	if b.Shoot.Info.Spec.DNS.Domain == nil || b.Shoot.ExternalClusterDomain == nil || strings.HasSuffix(*b.Shoot.ExternalClusterDomain, ".nip.io") {
+	if b.Shoot.Info.Spec.DNS == nil || b.Shoot.Info.Spec.DNS.Domain == nil || b.Shoot.ExternalClusterDomain == nil || strings.HasSuffix(*b.Shoot.ExternalClusterDomain, ".nip.io") {
 		return nil
 	}
 

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -124,7 +124,7 @@ func (b *Botanist) generateDownloaderConfig(machineImageName string) map[string]
 	return map[string]interface{}{
 		"type":    machineImageName,
 		"purpose": extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
-		"server":  fmt.Sprintf("https://%s", b.Shoot.ComputeAPIServerURL(false, true)),
+		"server":  fmt.Sprintf("https://%s", b.Shoot.ComputeAPIServerURL(false, true, b.APIServerAddress)),
 	}
 }
 

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -98,6 +98,14 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 		endUserCrtValidity = 730 * 24 * time.Hour // ~2 years
 	)
 
+	if gardencorev1alpha1helper.TaintsHave(b.Seed.Info.Spec.Taints, gardencorev1alpha1.SeedTaintDisableDNS) {
+		if addr := net.ParseIP(b.APIServerAddress); addr != nil {
+			apiServerIPAddresses = append(apiServerIPAddresses, addr)
+		} else {
+			apiServerCertDNSNames = append(apiServerCertDNSNames, b.APIServerAddress)
+		}
+	}
+
 	if len(certificateAuthorities) != len(wantedCertificateAuthorities) {
 		return nil, fmt.Errorf("missing certificate authorities")
 	}
@@ -167,7 +175,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 			},
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false),
+				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false, b.APIServerAddress),
 			},
 		},
 
@@ -202,7 +210,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false),
+				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false, b.APIServerAddress),
 			},
 		},
 
@@ -237,7 +245,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false),
+				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false, b.APIServerAddress),
 			},
 		},
 
@@ -257,7 +265,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false),
+				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false, b.APIServerAddress),
 			},
 		},
 
@@ -277,7 +285,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(false, true),
+				APIServerURL: b.Shoot.ComputeAPIServerURL(false, true, b.APIServerAddress),
 			},
 		},
 
@@ -297,7 +305,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false),
+				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false, b.APIServerAddress),
 			},
 		},
 
@@ -317,7 +325,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false),
+				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false, b.APIServerAddress),
 			},
 		},
 
@@ -352,7 +360,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(false, true),
+				APIServerURL: b.Shoot.ComputeAPIServerURL(false, true, b.APIServerAddress),
 			},
 		},
 
@@ -372,7 +380,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(false, true),
+				APIServerURL: b.Shoot.ComputeAPIServerURL(false, true, b.APIServerAddress),
 			},
 		},
 
@@ -536,7 +544,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 		KubeConfigRequest: &secrets.KubeConfigRequest{
 			ClusterName:  b.Shoot.SeedNamespace,
-			APIServerURL: b.Shoot.ComputeAPIServerURL(false, false),
+			APIServerURL: b.Shoot.ComputeAPIServerURL(false, false, b.APIServerAddress),
 		},
 	})
 

--- a/pkg/operation/garden/garden_test.go
+++ b/pkg/operation/garden/garden_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Garden", func() {
 		It("should return an error due to incomplete secrets map", func() {
 			_, err := GetInternalDomain(map[string]*corev1.Secret{})
 
-			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should return an error", func() {

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -79,12 +79,16 @@ func newOperation(
 		return nil, err
 	}
 
-	var seedObj *seed.Seed
+	var (
+		seedObj    *seed.Seed
+		disableDNS bool
+	)
 	if seedName != nil {
 		seedObj, err = seed.NewFromName(k8sGardenClient, k8sGardenCoreInformers, *seedName)
 		if err != nil {
 			return nil, err
 		}
+		disableDNS = gardencorev1alpha1helper.TaintsHave(seedObj.Info.Spec.Taints, gardencorev1alpha1.SeedTaintDisableDNS)
 	}
 
 	renderer, err := chartrenderer.NewForConfig(k8sGardenClient.RESTConfig())
@@ -112,7 +116,7 @@ func newOperation(
 	}
 
 	if shoot != nil {
-		shootObj, err := shootpkg.New(k8sGardenClient, k8sGardenCoreInformers, shoot, gardenObj.Project.Name, gardenObj.InternalDomain.Domain, gardenObj.DefaultDomains)
+		shootObj, err := shootpkg.New(k8sGardenClient, k8sGardenCoreInformers, shoot, gardenObj.Project.Name, disableDNS, gardenObj.InternalDomain, gardenObj.DefaultDomains)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/operation/shoot/shoot_test.go
+++ b/pkg/operation/shoot/shoot_test.go
@@ -90,7 +90,7 @@ var _ = Describe("shoot", func() {
 
 		DescribeTable("#ConstructInternalClusterDomain",
 			func(shootName, shootProject, internalDomain, expected string) {
-				Expect(ConstructInternalClusterDomain(shootName, shootProject, internalDomain)).To(Equal(expected))
+				Expect(ConstructInternalClusterDomain(shootName, shootProject, &garden.Domain{Domain: internalDomain})).To(Equal(expected))
 			},
 
 			Entry("with internal domain key", "foo", "bar", "internal.nip.io", "foo.bar.internal.nip.io"),

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -33,6 +33,7 @@ type Shoot struct {
 	SeedNamespace               string
 	KubernetesMajorMinorVersion string
 
+	DisableDNS            bool
 	InternalClusterDomain string
 	ExternalClusterDomain *string
 	ExternalDomain        *garden.Domain

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -173,8 +173,8 @@ func WaitUntilResourceDeletedWithDefaults(ctx context.Context, c client.Client, 
 }
 
 // GetLoadBalancerIngress takes a context, a client, a namespace and a service name. It queries for a load balancer's technical name
-// (ip address or hostname). It returns the value of the technical name whereby it always prefers the IP address (if given)
-// over the hostname. It also returns the list of all load balancer ingresses.
+// (ip address or hostname). It returns the value of the technical name whereby it always prefers the hostname (if given)
+// over the IP address. It also returns the list of all load balancer ingresses.
 func GetLoadBalancerIngress(ctx context.Context, client client.Client, namespace, name string) (string, error) {
 	service := &corev1.Service{}
 	if err := client.Get(ctx, Key(namespace, name), service); err != nil {
@@ -189,10 +189,10 @@ func GetLoadBalancerIngress(ctx context.Context, client client.Client, namespace
 	switch {
 	case length == 0:
 		return "", errors.New("`.status.loadBalancer.ingress[]` has no elements yet, i.e. external load balancer has not been created")
-	case serviceStatusIngress[length-1].IP != "":
-		return serviceStatusIngress[length-1].IP, nil
 	case serviceStatusIngress[length-1].Hostname != "":
 		return serviceStatusIngress[length-1].Hostname, nil
+	case serviceStatusIngress[length-1].IP != "":
+		return serviceStatusIngress[length-1].IP, nil
 	}
 
 	return "", errors.New("`.status.loadBalancer.ingress[]` has an element which does neither contain `.ip` nor `.hostname`")


### PR DESCRIPTION
**What this PR does / why we need it**:
Some infrastructure providers don't need or support DNS, so we will now add the possibility to disable DNS entirely per seed cluster. This will cause all shoot clusters assigned to this seed to not use any DNS records for the kube-apiservers. Instead, the load balancer IP/hostname is used directly in all kubeconfigs for communication.

**Which issue(s) this PR fixes**:
Fixes #1615

**Special notes for your reviewer**:
/cc @stoyanr @mkoynov

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
It is now possible to taint seed clusters with the `seed.gardener.cloud/disable-dns` taint. This will cause all shoot clusters assigned to this seed to not use any DNS records for the kube-apiservers. Instead, the load balancer IP/hostname is used directly in all kubeconfigs for communication.
```
```noteworthy developer
The local development setup is now easier if all seeds are tainted with the `seed.gardener.cloud/disable-dns` taint. No internal or default domain secrets are required in this case.
```
```noteworthy operator
When a load balancer service does now output both `.status.ingress[].hostname` and `.status.ingress[].ip` then the provided hostname is now taken instead of the IP address.
```
