### PR TITLE
increased delete-shoot test timeout from 30min to 60min

### DIFF
--- a/.test-defs/DeleteShoot.yaml
+++ b/.test-defs/DeleteShoot.yaml
@@ -4,7 +4,7 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the deletion of a shoot.
-  activeDeadlineSeconds: 1800
+  activeDeadlineSeconds: 3600
 
   command: [bash, -c]
   args:


### PR DESCRIPTION
**What this PR does / why we need it**:
Increased the timeout of the DeleteShoot tests from 30min to 60min, as azure sometimes crosses the 30min threshold.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```
