### PR TITLE
Fix a panic in the deletion step if the shoot is not successfully created

### DIFF
--- a/test/integration/shoots/deletion/delete_test.go
+++ b/test/integration/shoots/deletion/delete_test.go
@@ -75,15 +75,19 @@ var _ = Describe("Shoot deletion testing", func() {
 		gardenerTestOperations, err := NewGardenTestOperation(shootGardenerTest.GardenClient, testLogger)
 		Expect(err).To(BeNil())
 
-		err = gardenerTestOperations.AddShoot(ctx, shoot)
-		Expect(err).To(BeNil())
-
 		// Dump gardener state if delete shoot is in exit handler
 		if os.Getenv("TM_PHASE") == "Exit" {
+			if err := gardenerTestOperations.AddShoot(ctx, shoot); err != nil {
+				testLogger.Error(err.Error())
+				gardenerTestOperations.Shoot = shoot
+			}
 			gardenerTestOperations.DumpState(ctx)
 		}
 
 		if err := shootGardenerTest.DeleteShootAndWaitForDeletion(ctx); err != nil && !errors.IsNotFound(err) {
+			if err := gardenerTestOperations.AddShoot(ctx, shoot); err != nil {
+				testLogger.Error(err.Error())
+			}
 			gardenerTestOperations.DumpState(ctx)
 			testLogger.Fatalf("Cannot delete shoot %s: %s", *shootName, err.Error())
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes n issue in the deletion step of a shoot that causes the test to panic and leak shoots.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
