### PR TITLE
[release-0.31] Fix create shoot with VolumeTypes regression

### DIFF
--- a/.test-defs/DeleteShoot.yaml
+++ b/.test-defs/DeleteShoot.yaml
@@ -4,7 +4,7 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the deletion of a shoot.
-  activeDeadlineSeconds: 1800
+  activeDeadlineSeconds: 3600
 
   command: [bash, -c]
   args:

--- a/test/integration/framework/common.go
+++ b/test/integration/framework/common.go
@@ -240,7 +240,7 @@ func AddWorker(shoot *gardencorev1alpha1.Shoot, cloudProfile *gardencorev1alpha1
 	})
 
 	if machineType.Storage == nil {
-		if len(cloudProfile.Spec.VolumeTypes) != 0 {
+		if len(cloudProfile.Spec.VolumeTypes) == 0 {
 			return fmt.Errorf("no VolumeTypes configured in the Cloudprofile '%s'", cloudProfile.Name)
 		}
 		shoot.Spec.Provider.Workers[0].Volume = &gardencorev1alpha1.Volume{


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry pick regression in create shoot (ref #1623) and increase timeout of delete shoot tests to 1h.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
