### PR TITLE
Fix conversion from garden.CloudProfile to v1beta1.CloudProfile

### DIFF
--- a/pkg/apis/garden/v1beta1/conversions.go
+++ b/pkg/apis/garden/v1beta1/conversions.go
@@ -1072,6 +1072,10 @@ func Convert_garden_CloudProfile_To_v1beta1_CloudProfile(in *garden.CloudProfile
 		return err
 	}
 
+	if out.Annotations == nil {
+		out.Annotations = make(map[string]string)
+	}
+
 	switch in.Spec.Type {
 	case "aws":
 		if dnsProviders, ok := in.Annotations[garden.MigrationCloudProfileDNSProviders]; ok {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a write to a nil annotations map in the conversion functions which causes a gardener-apiserver panic on a `PATCH` request to `v1beta1.CloudProfile`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
