### PR TITLE
Increase timeout of create shoot

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -4,7 +4,7 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the creation of a shoot.
-  activeDeadlineSeconds: 3600
+  activeDeadlineSeconds: 7200
 
   command: [bash, -c]
   args:


### PR DESCRIPTION
**What this PR does / why we need it**:
As agreed I will increase the timeout for now to 2h.
This should be only temporary before we are able to specify different timeouts per shootflavor.

**Special notes for your reviewer**:
cc @dguendisch @dkistner 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
