### PR TITLE
Increase timeout of delete test

### DIFF
--- a/test/integration/shoots/creation/create_test.go
+++ b/test/integration/shoots/creation/create_test.go
@@ -83,7 +83,7 @@ var (
 )
 
 const (
-	CreateAndReconcileTimeout = 7200 * time.Second
+	CreateAndReconcileTimeout = 2 * time.Hour
 	InitializationTimeout     = 20 * time.Second
 )
 

--- a/test/integration/shoots/deletion/delete_test.go
+++ b/test/integration/shoots/deletion/delete_test.go
@@ -91,5 +91,5 @@ var _ = Describe("Shoot deletion testing", func() {
 			gardenerTestOperations.DumpState(ctx)
 			testLogger.Fatalf("Cannot delete shoot %s: %s", *shootName, err.Error())
 		}
-	}, 1800*time.Second)
+	}, 1*time.Hour)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase the timeout for deleting a shoot to 1 hour.
cc @dguendisch 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
