### PR TITLE
Forbid hibernating shoots with problematic webhooks

### DIFF
--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -6677,6 +6677,20 @@ string
 </tr>
 <tr>
 <td>
+<code>constraints</code></br>
+<em>
+<a href="#core.gardener.cloud/v1alpha1.Condition">
+[]Condition
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Constraints represents conditions of a Shoot&rsquo;s current state that constraint some operations on it.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>gardener</code></br>
 <em>
 <a href="#core.gardener.cloud/v1alpha1.Gardener">
@@ -7139,5 +7153,5 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>27b4aaf7</code>.
+on git commit <code>6d4b8494</code>.
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -3190,5 +3190,5 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>27b4aaf7</code>.
+on git commit <code>6d4b8494</code>.
 </em></p>

--- a/hack/api-reference/garden.md
+++ b/hack/api-reference/garden.md
@@ -7761,6 +7761,20 @@ Monitoring
 </tr>
 <tr>
 <td>
+<code>constraints</code></br>
+<em>
+<a href="../core#core.gardener.cloud/v1alpha1.Condition">
+[]github.com/gardener/gardener/pkg/apis/core/v1alpha1.Condition
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Constraints represents conditions of a Shoot&rsquo;s current state that constraint some operations on it.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>gardener</code></br>
 <em>
 <a href="#garden.sapcloud.io/v1beta1.Gardener">
@@ -8168,6 +8182,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Names is a list of availability zone names in this region.</p>
 </td>
 </tr>
@@ -8176,5 +8191,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>27b4aaf7</code>.
+on git commit <code>6d4b8494</code>.
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,5 +555,5 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>27b4aaf7</code>.
+on git commit <code>6d4b8494</code>.
 </em></p>

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -97,6 +97,9 @@ type ShootStatus struct {
 	// Conditions represents the latest available observations of a Shoots's current state.
 	// +optional
 	Conditions []Condition `json:"conditions,omitempty"`
+	// Constraints represents conditions of a Shoot's current state that constraint some operations on it.
+	// +optional
+	Constraints []Condition `json:"constraints,omitempty"`
 	// Gardener holds information about the Gardener which last acted on the Shoot.
 	Gardener Gardener `json:"gardener"`
 	// IsHibernated indicates whether the Shoot is currently hibernated.
@@ -888,4 +891,6 @@ const (
 	ShootEveryNodeReady ConditionType = "EveryNodeReady"
 	// ShootSystemComponentsHealthy is a constant for a condition type indicating the system components health.
 	ShootSystemComponentsHealthy ConditionType = "SystemComponentsHealthy"
+	// ShootHibernationPossible is a constant for a condition type indicating whether the Shoot can be hibernated.
+	ShootHibernationPossible ConditionType = "HibernationPossible"
 )

--- a/pkg/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.conversion.go
@@ -4063,6 +4063,7 @@ func autoConvert_garden_ShootSpec_To_v1alpha1_ShootSpec(in *garden.ShootSpec, ou
 
 func autoConvert_v1alpha1_ShootStatus_To_garden_ShootStatus(in *ShootStatus, out *garden.ShootStatus, s conversion.Scope) error {
 	out.Conditions = *(*[]garden.Condition)(unsafe.Pointer(&in.Conditions))
+	out.Constraints = *(*[]garden.Condition)(unsafe.Pointer(&in.Constraints))
 	if err := Convert_v1alpha1_Gardener_To_garden_Gardener(&in.Gardener, &out.Gardener, s); err != nil {
 		return err
 	}
@@ -4082,6 +4083,7 @@ func autoConvert_v1alpha1_ShootStatus_To_garden_ShootStatus(in *ShootStatus, out
 
 func autoConvert_garden_ShootStatus_To_v1alpha1_ShootStatus(in *garden.ShootStatus, out *ShootStatus, s conversion.Scope) error {
 	out.Conditions = *(*[]Condition)(unsafe.Pointer(&in.Conditions))
+	out.Constraints = *(*[]Condition)(unsafe.Pointer(&in.Constraints))
 	if err := Convert_garden_Gardener_To_v1alpha1_Gardener(&in.Gardener, &out.Gardener, s); err != nil {
 		return err
 	}

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -2935,6 +2935,13 @@ func (in *ShootStatus) DeepCopyInto(out *ShootStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Constraints != nil {
+		in, out := &in.Constraints, &out.Constraints
+		*out = make([]Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	out.Gardener = in.Gardener
 	if in.LastOperation != nil {
 		in, out := &in.LastOperation, &out.LastOperation

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -839,6 +839,9 @@ const (
 type ShootStatus struct {
 	// Conditions represents the latest available observations of a Shoots's current state.
 	Conditions []Condition
+	// Constraints represents conditions of a Shoot's current state that constraint some operations on it.
+	// +optional
+	Constraints []Condition
 	// Gardener holds information about the Gardener which last acted on the Shoot.
 	Gardener Gardener
 	// LastOperation holds information about the last operation on the Shoot.
@@ -1788,4 +1791,6 @@ const (
 	ShootSystemComponentsHealthy ConditionType = "SystemComponentsHealthy"
 	// ShootAPIServerAvailable is a constant for a condition type indicating the api server is available.
 	ShootAPIServerAvailable ConditionType = "APIServerAvailable"
+	// ShootHibernationPossible is a constant for a condition type indicating whether the Shoot can be hibernated.
+	ShootHibernationPossible ConditionType = "HibernationPossible"
 )

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -741,6 +741,9 @@ type ShootStatus struct {
 	// Conditions represents the latest available observations of a Shoots's current state.
 	// +optional
 	Conditions []gardencorev1alpha1.Condition `json:"conditions,omitempty"`
+	// Constraints represents conditions of a Shoot's current state that constraint some operations on it.
+	// +optional
+	Constraints []gardencorev1alpha1.Condition `json:"constraints,omitempty"`
 	// Gardener holds information about the Gardener which last acted on the Shoot.
 	Gardener Gardener `json:"gardener"`
 	// LastOperation holds information about the last operation on the Shoot.
@@ -1891,6 +1894,8 @@ const (
 	ShootSystemComponentsHealthy gardencorev1alpha1.ConditionType = "SystemComponentsHealthy"
 	// ShootAPIServerAvailable is a constant for a condition type indicating that the Shoot clusters API server is available.
 	ShootAPIServerAvailable gardencorev1alpha1.ConditionType = "APIServerAvailable"
+	// ShootHibernationPossible is a constant for a condition type indicating whether the Shoot can be hibernated.
+	ShootHibernationPossible gardencorev1alpha1.ConditionType = "HibernationPossible"
 )
 
 const (

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -4829,6 +4829,7 @@ func autoConvert_garden_ShootSpec_To_v1beta1_ShootSpec(in *garden.ShootSpec, out
 
 func autoConvert_v1beta1_ShootStatus_To_garden_ShootStatus(in *ShootStatus, out *garden.ShootStatus, s conversion.Scope) error {
 	out.Conditions = *(*[]garden.Condition)(unsafe.Pointer(&in.Conditions))
+	out.Constraints = *(*[]garden.Condition)(unsafe.Pointer(&in.Constraints))
 	if err := Convert_v1beta1_Gardener_To_garden_Gardener(&in.Gardener, &out.Gardener, s); err != nil {
 		return err
 	}
@@ -4848,6 +4849,7 @@ func autoConvert_v1beta1_ShootStatus_To_garden_ShootStatus(in *ShootStatus, out 
 
 func autoConvert_garden_ShootStatus_To_v1beta1_ShootStatus(in *garden.ShootStatus, out *ShootStatus, s conversion.Scope) error {
 	out.Conditions = *(*[]v1alpha1.Condition)(unsafe.Pointer(&in.Conditions))
+	out.Constraints = *(*[]v1alpha1.Condition)(unsafe.Pointer(&in.Constraints))
 	if err := Convert_garden_Gardener_To_v1beta1_Gardener(&in.Gardener, &out.Gardener, s); err != nil {
 		return err
 	}

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -3414,6 +3414,13 @@ func (in *ShootStatus) DeepCopyInto(out *ShootStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Constraints != nil {
+		in, out := &in.Constraints, &out.Constraints
+		*out = make([]v1alpha1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	out.Gardener = in.Gardener
 	if in.LastOperation != nil {
 		in, out := &in.LastOperation, &out.LastOperation

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -3729,6 +3729,13 @@ func (in *ShootStatus) DeepCopyInto(out *ShootStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Constraints != nil {
+		in, out := &in.Constraints, &out.Constraints
+		*out = make([]Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	out.Gardener = in.Gardener
 	if in.LastOperation != nil {
 		in, out := &in.LastOperation, &out.LastOperation

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -4859,6 +4859,19 @@ func schema_pkg_apis_core_v1alpha1_ShootStatus(ref common.ReferenceCallback) com
 							},
 						},
 					},
+					"constraints": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Constraints represents conditions of a Shoot's current state that constraint some operations on it.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.Condition"),
+									},
+								},
+							},
+						},
+					},
 					"gardener": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Gardener holds information about the Gardener which last acted on the Shoot.",
@@ -11035,6 +11048,19 @@ func schema_pkg_apis_garden_v1beta1_ShootStatus(ref common.ReferenceCallback) co
 					"conditions": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Conditions represents the latest available observations of a Shoots's current state.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.Condition"),
+									},
+								},
+							},
+						},
+					},
+					"constraints": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Constraints represents conditions of a Shoot's current state that constraint some operations on it.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/operation/botanist/constraints_check.go
+++ b/pkg/operation/botanist/constraints_check.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist
+
+import (
+	"context"
+	"fmt"
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func shootHibernatedConstraint(condition gardencorev1alpha1.Condition) gardencorev1alpha1.Condition {
+	return gardencorev1alpha1helper.UpdatedCondition(condition, gardencorev1alpha1.ConditionTrue, "ConstraintNotChecked", "Shoot cluster has been hibernated.")
+}
+
+// ConstraintsChecks conducts the constraints checks on all the given constraints.
+func (b *Botanist) ConstraintsChecks(ctx context.Context, initializeShootClients func() error, hibernation gardencorev1alpha1.Condition) gardencorev1alpha1.Condition {
+	hibernationPossible := b.constraintsChecks(ctx, initializeShootClients, hibernation)
+	return b.pardonCondition(hibernationPossible)
+}
+
+func (b *Botanist) constraintsChecks(ctx context.Context, initializeShootClients func() error, hibernationConstraint gardencorev1alpha1.Condition) gardencorev1alpha1.Condition {
+	if b.Shoot.HibernationEnabled || b.Shoot.Info.Status.IsHibernated {
+		return shootHibernatedConstraint(hibernationConstraint)
+	}
+
+	if err := initializeShootClients(); err != nil {
+		message := fmt.Sprintf("Could not initialize Shoot client for constraints check: %+v", err)
+		b.Logger.Error(message)
+		hibernationConstraint = gardencorev1alpha1helper.UpdatedConditionUnknownErrorMessage(hibernationConstraint, message)
+
+		return hibernationConstraint
+	}
+
+	newHibernationConstraint, err := b.CheckHibernationPossible(ctx, hibernationConstraint)
+	hibernationConstraint = newConditionOrError(hibernationConstraint, newHibernationConstraint, err)
+
+	return hibernationConstraint
+}
+
+// CheckHibernationPossible checks the Shoot for problematic webhooks which could prevent wakeup after hibernation
+func (b *Botanist) CheckHibernationPossible(ctx context.Context, constraint gardencorev1alpha1.Condition) (*gardencorev1alpha1.Condition, error) {
+	validatingWebhookConfigs := &admissionregistrationv1beta1.ValidatingWebhookConfigurationList{}
+	if err := b.K8sShootClient.Client().List(ctx, validatingWebhookConfigs); err != nil {
+		return nil, fmt.Errorf("could not get ValidatingWebhookConfigurations of Shoot cluster to check if Shoot can be hibernated")
+	}
+
+	for _, webhookConfig := range validatingWebhookConfigs.Items {
+		for _, webhook := range webhookConfig.Webhooks {
+			if IsProblematicWebhook(webhook) {
+				failurePolicy := "nil"
+				if webhook.FailurePolicy != nil {
+					failurePolicy = string(*webhook.FailurePolicy)
+				}
+
+				c := gardencorev1alpha1helper.UpdatedCondition(constraint, gardencorev1alpha1.ConditionFalse, "ProblematicWebhooks",
+					fmt.Sprintf("Shoot cannot be hibernated because of ValidatingWebhookConfiguration \"%s\": webhook \"%s\" with failurePolicy \"%s\" will probably prevent the Shoot from being woken up again",
+						webhookConfig.Name, webhook.Name, failurePolicy))
+				return &c, nil
+			}
+		}
+	}
+
+	mutatingWebhookConfigs := &admissionregistrationv1beta1.MutatingWebhookConfigurationList{}
+	if err := b.K8sShootClient.Client().List(ctx, mutatingWebhookConfigs); err != nil {
+		return nil, fmt.Errorf("could not get MutatingWebhookConfigurations of Shoot cluster to check if Shoot can be hibernated")
+	}
+
+	for _, webhookConfig := range mutatingWebhookConfigs.Items {
+		for _, webhook := range webhookConfig.Webhooks {
+			if IsProblematicWebhook(webhook) {
+				failurePolicy := "nil"
+				if webhook.FailurePolicy != nil {
+					failurePolicy = string(*webhook.FailurePolicy)
+				}
+
+				c := gardencorev1alpha1helper.UpdatedCondition(constraint, gardencorev1alpha1.ConditionFalse, "ProblematicWebhooks",
+					fmt.Sprintf("Shoot cannot be hibernated because of MutatingWebhookConfiguration \"%s\": webhook \"%s\" with failurePolicy \"%s\" will probably prevent the Shoot from being woken up again",
+						webhookConfig.Name, webhook.Name, failurePolicy))
+				return &c, nil
+			}
+		}
+	}
+
+	c := gardencorev1alpha1helper.UpdatedCondition(constraint, gardencorev1alpha1.ConditionTrue, "NoProblematicWebhooks", "Shoot can be hibernated.")
+	return &c, nil
+}
+
+// IsProblematicWebhook checks if a single webhook of the Shoot Cluster is problematic and the Shoot should therefore
+// not be hibernated. Problematic webhooks are webhooks with rules for CREATE/UPDATE/* pods or nodes and
+// failurePolicy=Fail/nil. If the Shoot contains such a webhook, we can never wake up this shoot cluster again
+// as new nodes cannot get created/ready, or our system component pods cannot get created/ready
+// (because the webhook's backing pod is not yet running).
+func IsProblematicWebhook(webhook admissionregistrationv1beta1.Webhook) bool {
+	if webhook.FailurePolicy != nil && *webhook.FailurePolicy != admissionregistrationv1beta1.Fail {
+		// in admissionregistration.k8s.io/v1 FailurePolicy is defaulted to `Fail`
+		// see https://github.com/kubernetes/api/blob/release-1.16/admissionregistration/v1/types.go#L195
+		// and https://github.com/kubernetes/api/blob/release-1.16/admissionregistration/v1/types.go#L324
+		// therefore, webhook with FailurePolicy==nil is also considered problematic
+		return false
+	}
+
+	for _, rule := range webhook.Rules {
+		apiGroups := sets.NewString(rule.APIGroups...)
+		resources := sets.NewString(rule.Resources...)
+
+		if apiGroups.Has(corev1.GroupName) && resources.HasAny("pods", "nodes") {
+			for _, op := range rule.Operations {
+				if op == admissionregistrationv1beta1.Create || op == admissionregistrationv1beta1.Update || op == admissionregistrationv1beta1.OperationAll {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/operation/botanist/constraints_check_test.go
+++ b/pkg/operation/botanist/constraints_check_test.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist_test
+
+import (
+	"github.com/gardener/gardener/pkg/operation/botanist"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var _ = Describe("constraints checks", func() {
+	Context("HibernationPossible", func() {
+		type webhookTestCase struct {
+			failurePolicy *admissionregistrationv1beta1.FailurePolicyType
+			operationType admissionregistrationv1beta1.OperationType
+			groupResource schema.GroupResource
+		}
+
+		var (
+			failurePolicyIgnore = admissionregistrationv1beta1.Ignore
+			failurePolicyFail   = admissionregistrationv1beta1.Fail
+
+			operationCreate = admissionregistrationv1beta1.Create
+			operationUpdate = admissionregistrationv1beta1.Update
+			operationAll    = admissionregistrationv1beta1.OperationAll
+			operationDelete = admissionregistrationv1beta1.Delete
+
+			groupResourcePods  = corev1.Resource("pods")
+			groupResourceNodes = corev1.Resource("nodes")
+			groupResourceOther = corev1.Resource("other")
+
+			problematicWebhookTestCase = webhookTestCase{
+				failurePolicy: &failurePolicyFail,
+				operationType: operationCreate,
+				groupResource: groupResourcePods,
+			}
+		)
+
+		DescribeTable("#IsProblematicWebhook",
+			func(testCase webhookTestCase, expected bool) {
+				var (
+					webhook = admissionregistrationv1beta1.Webhook{
+						Name:          "foo-webhook",
+						FailurePolicy: testCase.failurePolicy,
+						Rules: []admissionregistrationv1beta1.RuleWithOperations{
+							{
+								Operations: []admissionregistrationv1beta1.OperationType{testCase.operationType},
+								Rule: admissionregistrationv1beta1.Rule{
+									APIGroups: []string{testCase.groupResource.Group},
+									Resources: []string{testCase.groupResource.Resource},
+								},
+							},
+						},
+					}
+				)
+
+				isProblematic := botanist.IsProblematicWebhook(webhook)
+				Expect(isProblematic).To(Equal(expected))
+			},
+			Entry("Problematic Webhook for CREATE pods",
+				problematicWebhookTestCase,
+				true,
+			),
+			Entry("Problematic Webhook with failurePolicy nil for CREATE pods",
+				webhookTestCase{
+					failurePolicy: nil,
+					operationType: problematicWebhookTestCase.operationType,
+					groupResource: problematicWebhookTestCase.groupResource,
+				},
+				true,
+			),
+			Entry("Problematic Webhook for UPDATE pods",
+				webhookTestCase{
+					failurePolicy: problematicWebhookTestCase.failurePolicy,
+					operationType: operationUpdate,
+					groupResource: problematicWebhookTestCase.groupResource,
+				},
+				true,
+			),
+			Entry("Problematic Webhook for * pods",
+				webhookTestCase{
+					failurePolicy: problematicWebhookTestCase.failurePolicy,
+					operationType: operationAll,
+					groupResource: problematicWebhookTestCase.groupResource,
+				},
+				true,
+			),
+			Entry("Problematic Webhook for CREATE nodes",
+				webhookTestCase{
+					failurePolicy: problematicWebhookTestCase.failurePolicy,
+					operationType: problematicWebhookTestCase.operationType,
+					groupResource: groupResourceNodes,
+				},
+				true,
+			),
+			Entry("Problematic Webhook for UPDATE nodes",
+				webhookTestCase{
+					failurePolicy: problematicWebhookTestCase.failurePolicy,
+					operationType: operationUpdate,
+					groupResource: groupResourceNodes,
+				},
+				true,
+			),
+			Entry("Problematic Webhook for * nodes",
+				webhookTestCase{
+					failurePolicy: problematicWebhookTestCase.failurePolicy,
+					operationType: operationAll,
+					groupResource: groupResourceNodes,
+				},
+				true,
+			),
+			Entry("Unproblematic Webhook because of failurePolicy 'Ignore'",
+				webhookTestCase{
+					failurePolicy: &failurePolicyIgnore,
+					operationType: problematicWebhookTestCase.operationType,
+					groupResource: problematicWebhookTestCase.groupResource,
+				},
+				false,
+			),
+			Entry("Unproblematic Webhook because of operationType 'DELETE'",
+				webhookTestCase{
+					failurePolicy: problematicWebhookTestCase.failurePolicy,
+					operationType: operationDelete,
+					groupResource: problematicWebhookTestCase.groupResource,
+				},
+				false,
+			),
+			Entry("Unproblematic Webhook because of resource 'other'",
+				webhookTestCase{
+					failurePolicy: problematicWebhookTestCase.failurePolicy,
+					operationType: problematicWebhookTestCase.operationType,
+					groupResource: groupResourceOther,
+				},
+				false,
+			),
+		)
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR Gardener forbids to hibernate Shoot clusters with problematic Webhooks (defined by the user, see #1575).
Therefore the Shoot care controller now checks all the Webhooks in the Shoot cluster and writes the Condition to the newly introduced `Shoot.status.constraints[]` array (type `[]Condition`).
The `gardener-apiserver` looks into the `constraints` section and forbids hibernation accordingly.

**Which issue(s) this PR fixes**:
Fixes #1575

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Gardener now forbids hibernating Shoots with problematic Webhooks that might prevent the Shoot from being woken up again. Problematic Webhooks are `MutatingWebhookConfigurations` and `ValidatingWebhookConfigurations` with `failurePolicy=Fail|nil` and rules for `CREATE|UPDATE|* for pods|nodes`.
```
