### PR TITLE
adding setCondition to unstructured accessor

### DIFF
--- a/pkg/api/extensions/accessor.go
+++ b/pkg/api/extensions/accessor.go
@@ -148,13 +148,34 @@ func (u unstructuredStatusAccessor) GetConditions() []gardencorev1alpha1.Conditi
 	if err != nil || !ok {
 		return nil
 	}
-
-	conditions, ok2 := val.([]gardencorev1alpha1.Condition)
-	if !ok2 {
-		return nil
+	var conditions []gardencorev1alpha1.Condition
+	interfaceConditionSlice := val.([]interface{})
+	for _, interfaceCondition := range interfaceConditionSlice {
+		new := interfaceCondition.(map[string]interface{})
+		condition := &gardencorev1alpha1.Condition{}
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(new, condition)
+		if err != nil {
+			return nil
+		}
+		conditions = append(conditions, *condition)
 	}
-
 	return conditions
+}
+
+// SetConditions implements Status.
+func (u unstructuredStatusAccessor) SetConditions(conditions []gardencorev1alpha1.Condition) {
+	var interfaceSlice = make([]interface{}, len(conditions))
+	for i, d := range conditions {
+		unstrc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&d)
+		if err != nil {
+			return
+		}
+		interfaceSlice[i] = unstrc
+	}
+	err := unstructured.SetNestedSlice(u.UnstructuredContent(), interfaceSlice, "status", "conditions")
+	if err != nil {
+		return
+	}
 }
 
 // GetLastOperation implements Status.

--- a/pkg/api/extensions/accessor_test.go
+++ b/pkg/api/extensions/accessor_test.go
@@ -150,6 +150,44 @@ var _ = Describe("Accessor", func() {
 						Expect(acc.GetType()).To(Equal(t))
 					})
 				})
+				Describe("#Get Conditions", func() {
+					It("should get the conditions", func() {
+						var (
+							conditions = []gardencorev1alpha1.Condition{
+								{
+									Type:           "ABC",
+									Status:         gardencorev1alpha1.ConditionTrue,
+									Reason:         "reason",
+									Message:        "message",
+									LastUpdateTime: metav1.NewTime(metav1.Now().Round(time.Second)),
+								},
+							}
+							acc = mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{Conditions: conditions})
+						)
+						getConditions := acc.GetConditions()
+						Expect(getConditions).To(Equal(conditions))
+					})
+				})
+
+				Describe("#Set Conditions", func() {
+					It("should set the conditions", func() {
+						var (
+							acc        = mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{})
+							conditions = []gardencorev1alpha1.Condition{
+								{
+									Type:           "ABC",
+									Status:         gardencorev1alpha1.ConditionTrue,
+									Reason:         "reason",
+									Message:        "message",
+									LastUpdateTime: metav1.NewTime(metav1.Now().Round(time.Second)),
+								},
+							}
+						)
+						acc.SetConditions(conditions)
+						getConditions := acc.GetConditions()
+						Expect(getConditions).To(Equal(conditions))
+					})
+				})
 			})
 		})
 	})

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -24,6 +24,8 @@ type Status interface {
 	// GetConditions retrieves the Conditions of a status.
 	// Conditions may be nil.
 	GetConditions() []gardencorev1alpha1.Condition
+	// SetConditions sets the Conditions of a status.
+	SetConditions([]gardencorev1alpha1.Condition)
 	// GetLastOperation retrieves the LastOperation of a status.
 	// LastOperation may be nil.
 	GetLastOperation() LastOperation

--- a/pkg/apis/extensions/v1alpha1/types_defaults.go
+++ b/pkg/apis/extensions/v1alpha1/types_defaults.go
@@ -49,6 +49,11 @@ func (d *DefaultStatus) GetConditions() []gardencorev1alpha1.Condition {
 	return d.Conditions
 }
 
+// SetConditions implements Status.
+func (d *DefaultStatus) SetConditions(c []gardencorev1alpha1.Condition) {
+	d.Conditions = c
+}
+
 // GetLastOperation implements Status.
 func (d *DefaultStatus) GetLastOperation() LastOperation {
 	if d.LastOperation == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up to #1600

Adding Status.SetConditions() to extensions.v1alpha1 Status interface - that is needed for the generic health check controller that will be implemented in the Extensions.
The Controller will use it to set Conditions containing the Health Status on extensions.

The issue with converting a metav1.time  to Unstructured is solved. 
Go [json.Marshal does a round(0) on time.Time](https://github.com/golang/go/issues/22957) leading to a slightly different time when unmarshalling. 
This is not a problem for us, as the apiserver or client-go/controller-runtime also rely on the json.Marshal function. 

So when converting to unstructured and vice versa we only round the time.Time fields that will be rounded anyways either in the kube-apiserver or already on client side.

The API Objects all have rounded times - e.g in condition.LastTransition time.
See:

![image](https://user-images.githubusercontent.com/33809186/69435522-fe5f9880-0d3f-11ea-9dae-0a5e7a8b9b4b.png)



I have adjusted the tests accordingly.



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
