### PR TITLE
Fix custom worker config in the Shoot

### DIFF
--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -63,6 +63,13 @@ func (b *Botanist) DeployWorker(ctx context.Context) error {
 			}
 		}
 
+		var pConfig *runtime.RawExtension
+		if worker.ProviderConfig != nil {
+			pConfig = &runtime.RawExtension{
+				Raw: worker.ProviderConfig.Raw,
+			}
+		}
+
 		pools = append(pools, extensionsv1alpha1.WorkerPool{
 			Name:           worker.Name,
 			Minimum:        int(worker.Minimum),
@@ -80,6 +87,7 @@ func (b *Botanist) DeployWorker(ctx context.Context) error {
 			UserData: []byte(b.Shoot.OperatingSystemConfigsMap[worker.Name].Downloader.Data.Content),
 			Volume:   volume,
 			Zones:    worker.Zones,
+			ProviderConfig: pConfig,
 		})
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes sure the workers can use custom configuration.

**Special notes for your reviewer**:
Fixes the use of [this](https://github.com/gardener/gardener-extensions/blob/master/controllers/provider-aws/pkg/controller/worker/machines.go#L143-L145).

```improvement operator
NONE
```
