### PR TITLE
Check shoot deletion timestamp when cleaning-up

### DIFF
--- a/pkg/utils/kubernetes/client/client_test.go
+++ b/pkg/utils/kubernetes/client/client_test.go
@@ -305,6 +305,91 @@ var _ = Describe("Cleaner", func() {
 		})
 	})
 
+	Describe("#EnsureGoneBefore", func() {
+		var (
+			before            = time.Now()
+			goneBeforeEnsurer = GoneBeforeEnsurer(before)
+		)
+
+		It("should ensure that the object is gone because it is not found", func() {
+			ctx := context.TODO()
+
+			c.EXPECT().Get(ctx, cm1Key, &cm1).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+
+			Expect(goneBeforeEnsurer.EnsureGone(ctx, c, &cm1)).To(Succeed())
+		})
+
+		It("should ensure that the object is gone because it has a greater deletion timestamp", func() {
+			ctx := context.TODO()
+			cm1.ObjectMeta.CreationTimestamp = metav1.NewTime(before.Add(time.Second))
+
+			c.EXPECT().Get(ctx, cm1Key, &cm1)
+
+			Expect(goneBeforeEnsurer.EnsureGone(ctx, c, &cm1)).To(Succeed())
+		})
+
+		It("should ensure that the list is gone because it is empty", func() {
+			var (
+				ctx  = context.TODO()
+				list = corev1.ConfigMapList{}
+			)
+
+			c.EXPECT().List(ctx, &list)
+
+			Expect(goneBeforeEnsurer.EnsureGone(ctx, c, &list)).To(Succeed())
+		})
+
+		It("should ensure that no error occurs because the element was created after shoot deletion", func() {
+			// move timestamp of configmap ahead of time marker
+			cm1.ObjectMeta.CreationTimestamp = metav1.NewTime(before.Add(time.Second))
+
+			var (
+				ctx  = context.TODO()
+				list = corev1.ConfigMapList{
+					Items: []corev1.ConfigMap{
+						cm1,
+					},
+				}
+			)
+
+			c.EXPECT().List(ctx, &list)
+
+			Expect(goneBeforeEnsurer.EnsureGone(ctx, c, &list)).To(Not(HaveOccurred()))
+		})
+
+		It("should ensure that an error occurs because one element in the list is not gone", func() {
+			// move timestamp of configmap ahead of time marker
+			cm1.ObjectMeta.CreationTimestamp = metav1.NewTime(before.Add(time.Second))
+
+			// move timestamp of configmap before of time marker
+			cm2.ObjectMeta.CreationTimestamp = metav1.NewTime(before.Add(-time.Second))
+
+			var (
+				ctx  = context.TODO()
+				list = corev1.ConfigMapList{
+					Items: []corev1.ConfigMap{
+						cm1,
+						cm2,
+					},
+				}
+			)
+
+			c.EXPECT().List(ctx, &list)
+
+			Expect(goneBeforeEnsurer.EnsureGone(ctx, c, &list)).To(
+				Equal(NewObjectsRemaining(&cm2)),
+			)
+		})
+
+		It("should error that the object is still present", func() {
+			ctx := context.TODO()
+
+			c.EXPECT().Get(ctx, cm1Key, &cm1)
+
+			Expect(goneBeforeEnsurer.EnsureGone(ctx, c, &cm1)).To(Equal(NewObjectsRemaining(&cm1)))
+		})
+	})
+
 	Context("#CleanOps", func() {
 		var (
 			cleaner *mockutilclient.MockCleaner


### PR DESCRIPTION
**What this PR does / why we need it**:
When cleaning up a cluster during shoot deletion, only check those resources to be gone which have a `creationTimestamp <= deletionTimestamp` of the shoot.

**Which issue(s) this PR fixes**:
Fixes #1639

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The clean-up check which is executed during a shoot deletion has been improved. Previously, the check failed when managed resources were re-created after their deletion.
```
