### PR TITLE
Scrape kube-proxy metrics

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -448,6 +448,26 @@ data:
       metric_relabel_configs:
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.nodeExporter | indent 6 }}
 
+    - job_name: kube-proxy
+      honor_labels: false
+      kubernetes_sd_configs:
+      - role: endpoints
+        api_server: https://kube-apiserver:443
+        tls_config:
+{{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_endpoints_name
+        - __meta_kubernetes_endpoint_port_name
+        action: keep
+        regex: kube-proxy;metrics
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
+      - source_labels: [ __meta_kubernetes_pod_node_name ]
+        target_label: node
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.kubeProxy | indent 6 }}
+
     - job_name: vpn-connection
       honor_labels: false
       metrics_path: /probe

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -127,6 +127,9 @@ allowedMetrics:
   - etcdbr_validation_duration_seconds_count
   - etcdbr_validation_duration_seconds_sum
   - process_resident_memory_bytes
+  kubeProxy:
+  - kubeproxy_network_programming_duration_seconds_(.+)
+  - kubeproxy_sync_proxy_rules_(.+)
   kubeScheduler:
   - scheduler_binding_latency_microseconds_bucket
   - scheduler_e2e_scheduling_latency_microseconds_bucket

--- a/charts/shoot-core/components/charts/kube-proxy/templates/componentconfig.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/componentconfig.yaml
@@ -14,6 +14,7 @@ data:
 {{- if not .Values.enableIPVS }}
     clusterCIDR: {{ .Values.global.podNetwork }}
 {{- end }}
+    metricsBindAddress: 0.0.0.0:{{ .Values.ports.metrics }}
     mode: {{ include "kube-proxy.mode" . }}
     conntrack:
       maxPerCore: 524288

--- a/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -77,6 +77,11 @@ spec:
           requests:
             cpu: 20m
             memory: 64Mi
+        ports:
+        - containerPort: {{ .Values.ports.metrics }}
+          protocol: TCP
+          hostPort: {{ .Values.ports.metrics }}
+          name: metrics
         volumeMounts:
         - name: kubeconfig
           mountPath: /var/lib/kube-proxy

--- a/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-service.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-proxy
+  namespace: kube-system
+  labels:
+    app: kubernetes
+    role: proxy
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: {{ .Values.ports.metrics }}
+    protocol: TCP
+  selector:
+    app: kubernetes
+    role: proxy

--- a/charts/shoot-core/components/charts/kube-proxy/values.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/values.yaml
@@ -11,3 +11,6 @@ images:
 podAnnotations: {}
 
 enableIPVS: false
+
+ports:
+  metrics: 10249


### PR DESCRIPTION
**What this PR does / why we need it**:
Prometheus now scrapes metrics from `kube-proxy`. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Prometheus now scrapes kube-proxy metrics, especially (`kubeproxy_network_programming_duration_seconds` and `kubeproxy_sync_proxy_rules`). 
```
