### PR TITLE
Remove calculation of resource allocations for prometheus

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -341,31 +341,10 @@ alerting:
 
 ignoreAlerts: false
 
-# object can be any object you want to scale Prometheus on:
-# - number of Pods
-# - number of Nodes
-# - total Foos
-objectCount: 4
 resources:
   requests:
-    cpu:
-      base: 200
-      perObject: 6
-      weight: 5
-      unit: m
-    memory:
-      base: 360
-      perObject: 35
-      weight: 5
-      unit: Mi
+    cpu: 200m
+    memory: 360Mi
   limits:
-    cpu:
-      base: 350
-      perObject: 12
-      weight: 5
-      unit: m
-    memory:
-      base: 760
-      perObject: 60
-      weight: 5
-      unit: Mi
+    cpu: 350m
+    memory: 760Mi

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -86,7 +86,6 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 			"namespace": map[string]interface{}{
 				"uid": b.SeedNamespaceObject.UID,
 			},
-			"objectCount": b.Shoot.GetNodeCount(),
 			"podAnnotations": map[string]interface{}{
 				"checksum/secret-prometheus":       b.CheckSums["prometheus"],
 				"checksum/secret-vpn-seed":         b.CheckSums["vpn-seed"],


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove calculation of resource allocations for prometheus since VPA is already deployed for it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
