### PR TITLE
Add --no-block flag to systemd service restart command in cloud config.

### DIFF
--- a/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
+++ b/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
@@ -28,6 +28,8 @@ spec:
       RestartSec=30
       EnvironmentFile=/etc/environment
       ExecStart=/var/lib/cloud-config-downloader/download-cloud-config.sh
+      [Install]
+      WantedBy=multi-user.target
   files:
   - path: /var/lib/cloud-config-downloader/credentials/server
     permissions: 0644

--- a/charts/shoot-cloud-config/templates/scripts/_cloud-config-script.sh
+++ b/charts/shoot-cloud-config/templates/scripts/_cloud-config-script.sh
@@ -70,7 +70,7 @@ if ! diff "$PATH_CLOUDCONFIG" "$PATH_CLOUDCONFIG_OLD" >/dev/null; then
     systemctl daemon-reload
 {{- range $name := (required ".worker.units is required" .worker.units) }}
 {{- if ne $name "docker.service" }}
-    systemctl enable {{ $name }} && systemctl restart {{ $name }}
+    systemctl enable {{ $name }} && systemctl restart --no-block {{ $name }}
 {{- end }}
 {{- end }}
     echo "Successfully restarted all units referenced in the cloud config."


### PR DESCRIPTION
**What this PR does / why we need it**:

We use Ubuntu as our operating system for the worker nodes instead of the Gardener default coreOS. We see different behavior on `systemctl` in the cloud config script, where the cloud-config-downloader and the kubelet will not start without adding the `--no-block` argument to the `systemctl restart` command. There is no need to wait for the subsequent services to be restarted as all services are implemented as idempotent.

**Special notes for your reviewer**:

From our opinion, this should not affect the coreOS cluster join mechanism. However, we are not able to test that this in our environment with coreOS. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
