### PR TITLE
Add DeployInfrastructure task on updates

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -30,6 +30,7 @@ import (
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	informers "github.com/gardener/gardener/pkg/client/garden/informers/internalversion"
 	listers "github.com/gardener/gardener/pkg/client/garden/listers/garden/internalversion"
+	controllerutils "github.com/gardener/gardener/pkg/controllermanager/controller/utils"
 	"github.com/gardener/gardener/pkg/operation/common"
 	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
 
@@ -516,6 +517,13 @@ func (v *ValidateShoot) Admit(a admission.Attributes, o admission.ObjectInterfac
 		}
 
 		allErrs = validateAlicloud(validationContext)
+	}
+
+	if !reflect.DeepEqual(oldShoot.Spec.Provider.InfrastructureConfig, shoot.Spec.Provider.InfrastructureConfig) {
+		if shoot.ObjectMeta.Annotations == nil {
+			shoot.ObjectMeta.Annotations = make(map[string]string)
+		}
+		controllerutils.AddTasks(shoot.ObjectMeta.Annotations, common.ShootTaskDeployInfrastructure)
 	}
 
 	for idx, worker := range shoot.Spec.Provider.Workers {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the `shoot` admission plugin add the `deployInfrastructure` task if it detects `InfrastructureConfig` updates.

**Which issue(s) this PR fixes**:
Fixes #1653

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Gardener now triggers infrastructure related changes on shoots immediately, instead of only during the maintenance time window.
```
