### PR TITLE
change the type of DefaultState struct's field State to *runtime.RawE…

### DIFF
--- a/charts/seed-bootstrap/templates/extensions/crd-controlplane.yaml
+++ b/charts/seed-bootstrap/templates/extensions/crd-controlplane.yaml
@@ -145,7 +145,7 @@ spec:
             state:
               description: State can be filled by the operating controller with what
                 ever data it needs.
-              type: string
+              type: object
             providerStatus:
               description: Provider-specific output for this control plane
               type: object

--- a/charts/seed-bootstrap/templates/extensions/crd-extension.yaml
+++ b/charts/seed-bootstrap/templates/extensions/crd-extension.yaml
@@ -118,7 +118,7 @@ spec:
             state:
               description: State can be filled by the operating controller with what
                 ever data it needs.
-              type: string
+              type: object
             providerStatus:
               description: Provider-specific output for this control plane
               type: object

--- a/charts/seed-bootstrap/templates/extensions/crd-infrastructure.yaml
+++ b/charts/seed-bootstrap/templates/extensions/crd-infrastructure.yaml
@@ -119,7 +119,7 @@ spec:
             state:
               description: State can be filled by the operating controller with what
                 ever data it needs.
-              type: string
+              type: object
           type: object
       required:
         - spec

--- a/charts/seed-bootstrap/templates/extensions/crd-network.yaml
+++ b/charts/seed-bootstrap/templates/extensions/crd-network.yaml
@@ -69,5 +69,9 @@ spec:
               description: ProviderStatus contains plugin-specific output.
               type: object
           type: object
+          state:
+            description: State can be filled by the operating controller with what
+                ever data it needs.
+            type: object
       required:
       - spec

--- a/charts/seed-bootstrap/templates/extensions/crd-operatingsystemconfig.yaml
+++ b/charts/seed-bootstrap/templates/extensions/crd-operatingsystemconfig.yaml
@@ -241,7 +241,7 @@ spec:
             state:
               description: State can be filled by the operating controller with what
                 ever data it needs.
-              type: string
+              type: object
             units:
               description: Units is a list of systemd unit names that are part of
                 the generated Cloud Config and shall be restarted when a new version

--- a/charts/seed-bootstrap/templates/extensions/crd-worker.yaml
+++ b/charts/seed-bootstrap/templates/extensions/crd-worker.yaml
@@ -220,7 +220,7 @@ spec:
             state:
               description: State can be filled by the operating controller with what
                 ever data it needs.
-              type: string
+              type: object
           type: object
       required:
         - spec

--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -7139,5 +7139,5 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>486dac1fc</code>.
+on git commit <code>27b4aaf7</code>.
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -1796,10 +1796,13 @@ int64
 <td>
 <code>state</code></br>
 <em>
-string
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime#RawExtension">
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>State can be filled by the operating controller with what ever data it needs.</p>
 </td>
 </tr>
@@ -3187,5 +3190,5 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>486dac1fc</code>.
+on git commit <code>27b4aaf7</code>.
 </em></p>

--- a/hack/api-reference/garden.md
+++ b/hack/api-reference/garden.md
@@ -8176,5 +8176,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>486dac1fc</code>.
+on git commit <code>27b4aaf7</code>.
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,5 +555,5 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>486dac1fc</code>.
+on git commit <code>27b4aaf7</code>.
 </em></p>

--- a/pkg/apis/extensions/v1alpha1/types_defaults.go
+++ b/pkg/apis/extensions/v1alpha1/types_defaults.go
@@ -14,7 +14,10 @@
 
 package v1alpha1
 
-import gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+import (
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+)
 
 // DefaultSpec contains common status fields for every extension resource.
 type DefaultSpec struct {
@@ -41,7 +44,8 @@ type DefaultStatus struct {
 	// ObservedGeneration is the most recent generation observed for this resource.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// State can be filled by the operating controller with what ever data it needs.
-	State string `json:"state,omitempty"`
+	// +optional
+	State *runtime.RawExtension `json:"state,omitempty"`
 }
 
 // GetConditions implements Status.

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -471,6 +471,11 @@ func (in *DefaultStatus) DeepCopyInto(out *DefaultStatus) {
 		*out = new(corev1alpha1.LastOperation)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.State != nil {
+		in, out := &in.State, &out.State
+		*out = new(runtime.RawExtension)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 


### PR DESCRIPTION
Change the type of DefaultState struct's field State to *runtime.RawExtension

**What this PR does / why we need it**:
Changing the State type to RawExtension makes much easier to store(serialize) and retrieve(deserialize) a custom resource.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
extensions v1alpha1.DefaultStatus.State type changes from String to *runtime.RawExtension
Status.State of the following CRDs  ControlPlane, Extension,  Infrastructure, Network, OperatingSystemConfig and Worker change its type to *runtime.RawExtension
```
