### PR TITLE
Always sync provider credentials in shoot deletion

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_control_delete.go
+++ b/pkg/controllermanager/controller/shoot/shoot_control_delete.go
@@ -188,7 +188,7 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation, errorContext *er
 		// existing machine class secrets.
 		deployCloudProviderSecret = g.Add(flow.Task{
 			Name:         "Deploying cloud provider account secret",
-			Fn:           flow.TaskFn(botanist.DeployCloudProviderSecret).DoIf(cleanupShootResources && !shootNamespaceInDeletion),
+			Fn:           flow.TaskFn(botanist.DeployCloudProviderSecret).SkipIf(shootNamespaceInDeletion),
 			Dependencies: flow.NewTaskIDs(syncClusterResourceToSeed),
 		})
 		deploySecrets = g.Add(flow.Task{


### PR DESCRIPTION
**What this PR does / why we need it**:
Always sync the provider credentials if the shoot namespace is not terminating in the shoot deletion flow.

**Which issue(s) this PR fixes**:
Fixes #1542

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
An issue that caused shoots from getting stuck during deletion flow when the cloud provider credentials have been refreshed has been fixed.
```
