### PR TITLE
Use feature gate to control hvpa for kube-apiserver and etcd of seed clusters

### DIFF
--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -86,3 +86,4 @@ shootBackup:
 featureGates:
   Logging: true
   HVPA: true
+  HVPAForShootedSeed: true

--- a/pkg/controllermanager/features/features.go
+++ b/pkg/controllermanager/features/features.go
@@ -23,8 +23,9 @@ var (
 	// FeatureGate is a shared global FeatureGate for Gardener Controller Manager flags.
 	FeatureGate  = utilfeature.NewFeatureGate()
 	featureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
-		features.Logging: {Default: false, PreRelease: utilfeature.Alpha},
-		features.HVPA:    {Default: false, PreRelease: utilfeature.Alpha},
+		features.Logging:            {Default: false, PreRelease: utilfeature.Alpha},
+		features.HVPA:               {Default: false, PreRelease: utilfeature.Alpha},
+		features.HVPAForShootedSeed: {Default: false, PreRelease: utilfeature.Alpha},
 	}
 )
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -35,4 +35,9 @@ const (
 	// owner @ggaurav10, @amshuman-kr
 	// alpha: v0.1.0
 	HVPA utilfeature.Feature = "HVPA"
+
+	// HVPAForShootedSeed enables simultaneous horizontal and vertical in Soil Clusters.
+	// owner @ggaurav10, @amshuman-kr
+	// alpha: v0.1.0
+	HVPAForShootedSeed utilfeature.Feature = "HVPA-For-ShootedSeed"
 )

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -31,13 +31,13 @@ const (
 	// alpha: v0.13.0
 	Logging utilfeature.Feature = "Logging"
 
-	// HVPA enables simultaneous horizontal and vertical in Seed Clusters.
+	// HVPA enables simultaneous horizontal and vertical scaling in Seed Clusters.
 	// owner @ggaurav10, @amshuman-kr
 	// alpha: v0.1.0
 	HVPA utilfeature.Feature = "HVPA"
 
-	// HVPAForShootedSeed enables simultaneous horizontal and vertical in Soil Clusters.
+	// HVPAForShootedSeed enables simultaneous horizontal and vertical scaling in shooted seed Clusters.
 	// owner @ggaurav10, @amshuman-kr
 	// alpha: v0.1.0
-	HVPAForShootedSeed utilfeature.Feature = "HVPA-For-ShootedSeed"
+	HVPAForShootedSeed utilfeature.Feature = "HVPAForShootedSeed"
 )

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -1127,7 +1127,7 @@ func (b *Botanist) DeployETCD(ctx context.Context) error {
 				Version: "v1alpha1",
 				Kind:    "Hvpa",
 			})
-			if err := b.K8sSeedClient.Client().Delete(context.TODO(), u); client.IgnoreNotFound(err) != nil {
+			if err := b.K8sSeedClient.Client().Delete(ctx, u); client.IgnoreNotFound(err) != nil {
 				return err
 			}
 		}

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -671,8 +671,14 @@ func (b *Botanist) DeployKubeAPIServerService() error {
 
 // DeployKubeAPIServer deploys kube-apiserver deployment.
 func (b *Botanist) DeployKubeAPIServer() error {
+	hvpaEnabled := controllermanagerfeatures.FeatureGate.Enabled(features.HVPA)
+
+	if b.ShootedSeed != nil {
+		// Override for shooted seeds
+		hvpaEnabled = controllermanagerfeatures.FeatureGate.Enabled(features.HVPAForShootedSeed)
+	}
+
 	var (
-		hvpaEnabled       = controllermanagerfeatures.FeatureGate.Enabled(features.HVPA)
 		minReplicas int32 = 1
 		maxReplicas int32 = 4
 
@@ -732,7 +738,7 @@ func (b *Botanist) DeployKubeAPIServer() error {
 		foundDeployment = false
 	}
 
-	if b.ShootedSeed != nil {
+	if b.ShootedSeed != nil && !hvpaEnabled {
 		var (
 			apiServer  = b.ShootedSeed.APIServer
 			autoscaler = apiServer.Autoscaler
@@ -741,29 +747,15 @@ func (b *Botanist) DeployKubeAPIServer() error {
 		minReplicas = *autoscaler.MinReplicas
 		maxReplicas = autoscaler.MaxReplicas
 
-		if hvpaEnabled {
-			// If HVPA is enabled, we can keep the limits very high
-			defaultValues["apiServerResources"] = map[string]interface{}{
-				"requests": map[string]interface{}{
-					"cpu":    "1750m",
-					"memory": "2Gi",
-				},
-				"limits": map[string]interface{}{
-					"cpu":    "8",
-					"memory": "16000M",
-				},
-			}
-		} else {
-			defaultValues["apiServerResources"] = map[string]interface{}{
-				"requests": map[string]interface{}{
-					"cpu":    "1750m",
-					"memory": "2Gi",
-				},
-				"limits": map[string]interface{}{
-					"cpu":    "4000m",
-					"memory": "8Gi",
-				},
-			}
+		defaultValues["apiServerResources"] = map[string]interface{}{
+			"requests": map[string]interface{}{
+				"cpu":    "1750m",
+				"memory": "2Gi",
+			},
+			"limits": map[string]interface{}{
+				"cpu":    "4000m",
+				"memory": "8Gi",
+			},
 		}
 	} else {
 		replicas := deployment.Spec.Replicas
@@ -917,6 +909,19 @@ func (b *Botanist) DeployKubeAPIServer() error {
 				return err
 			}
 		}
+	} else {
+		// If HVPA is disabled, delete any HVPA that was already deployed
+		u := &unstructured.Unstructured{}
+		u.SetName(v1alpha1constants.DeploymentNameKubeAPIServer)
+		u.SetNamespace(b.Shoot.SeedNamespace)
+		u.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "autoscaling.k8s.io",
+			Version: "v1alpha1",
+			Kind:    "Hvpa",
+		})
+		if err := b.K8sSeedClient.Client().Delete(context.TODO(), u); client.IgnoreNotFound(err) != nil {
+			return err
+		}
 	}
 
 	return b.ApplyChartSeed(filepath.Join(chartPathControlPlane, v1alpha1constants.DeploymentNameKubeAPIServer), b.Shoot.SeedNamespace, v1alpha1constants.DeploymentNameKubeAPIServer, values, nil)
@@ -1049,6 +1054,11 @@ func (b *Botanist) DeployKubeScheduler() error {
 func (b *Botanist) DeployETCD(ctx context.Context) error {
 	hvpaEnabled := controllermanagerfeatures.FeatureGate.Enabled(features.HVPA)
 
+	if b.ShootedSeed != nil {
+		// Override for shooted seeds
+		hvpaEnabled = controllermanagerfeatures.FeatureGate.Enabled(features.HVPAForShootedSeed)
+	}
+
 	etcdConfig := map[string]interface{}{
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-etcd-ca":         b.CheckSums[v1alpha1constants.SecretNameCAETCD],
@@ -1107,6 +1117,20 @@ func (b *Botanist) DeployETCD(ctx context.Context) error {
 			}
 		}
 
+		if !hvpaEnabled {
+			// If HVPA is disabled, delete any HVPA that was already deployed
+			u := &unstructured.Unstructured{}
+			u.SetName(fmt.Sprintf("etcd-%s", role))
+			u.SetNamespace(b.Shoot.SeedNamespace)
+			u.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "autoscaling.k8s.io",
+				Version: "v1alpha1",
+				Kind:    "Hvpa",
+			})
+			if err := b.K8sSeedClient.Client().Delete(context.TODO(), u); client.IgnoreNotFound(err) != nil {
+				return err
+			}
+		}
 		if err := b.ApplyChartSeed(filepath.Join(chartPathControlPlane, "etcd"), b.Shoot.SeedNamespace, fmt.Sprintf("etcd-%s", role), nil, etcd); err != nil {
 			return err
 		}


### PR DESCRIPTION
Use feature gate to control hvpa for kube-apiserver and etcd of seed clusters

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
To enable scaling of `kube-apiserver` and `etcd` of shooted seeds via HVPA, enable the feature gate `HVPAForShootedSeed`.
```
