### PR TITLE
Increase kubernetes update test timeout

### DIFF
--- a/.test-defs/ShootKubernetesUpdateTest.yaml
+++ b/.test-defs/ShootKubernetesUpdateTest.yaml
@@ -4,7 +4,7 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the kubernetes update of a shoot.
-  activeDeadlineSeconds: 1800
+  activeDeadlineSeconds: 3600
 
   labels: ["shoot"]
 

--- a/test/integration/shoots/update/shoot_update_test.go
+++ b/test/integration/shoots/update/shoot_update_test.go
@@ -49,13 +49,12 @@ var (
 	kubernetesVersion = flag.String("version", "", "the version to update the shoot")
 	shootName         = flag.String("shoot-name", "", "the name of the shoot we want to test")
 	shootNamespace    = flag.String("shoot-namespace", "", "the namespace name that the shoot resides in")
-	testShootsPrefix  = flag.String("prefix", "", "prefix to use for test shoots")
 	logLevel          = flag.String("verbose", "", "verbosity level, when set, logging level will be DEBUG")
 )
 
 const (
-	UpdateKubernetesVersionTimeout = 600 * time.Second
-	InitializationTimeout          = 600 * time.Second
+	UpdateKubernetesVersionTimeout = 45 * time.Minute
+	InitializationTimeout          = time.Minute
 	DumpStateTimeout               = 5 * time.Minute
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase the timeout for the kubernetes update test to 45 minutes.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Increase the timeout for kubernetes update tests to 45 minutes
```
