### PR TITLE
Remove unused metrics

### DIFF
--- a/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
@@ -46,6 +46,8 @@ data:
         - '{__name__="ALERTS"}'
         - '{__name__="prometheus_tsdb_lowest_timestamp"}'
         - '{__name__="prometheus_tsdb_storage_blocks_bytes"}'
+        - '{__name__="kubeproxy_network_latency:quantile"}'
+        - '{__name__="kubeproxy_sync_proxy:quantile"}'
       kubernetes_sd_configs:
       - role: endpoints
       relabel_configs:

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -26,7 +26,6 @@ allowedMetrics:
   - container_fs_usage_bytes
   - container_last_seen
   - container_memory_working_set_bytes
-  - container_memory_usage_bytes
   - container_network_receive_bytes_total
   - container_network_transmit_bytes_total
 
@@ -34,25 +33,8 @@ allowedMetrics:
   - kubelet_volume_stats_available_bytes
   - kubelet_volume_stats_capacity_bytes
 
-  fluentd:
-  - fluentd_output_status_buffer_queue_length
-  - fluentd_output_status_buffer_total_bytes
-  - fluentd_output_status_retry_count
-  - fluentd_output_status_num_errors
-  - fluentd_output_status_emit_count
-  - fluentd_output_status_retry_wait
-  - fluentd_output_status_emit_records
-  - fluentd_output_status_write_count
-  - fluentd_output_status_rollback_count
-
-  fluentbit:
-  - fluentbit_input_records_total
-  - fluentbit_input_bytes_total
-  - fluentbit_output_proc_records_total
-  - fluentbit_output_proc_bytes_total
-  - fluentbit_output_errors_total
-  - fluentbit_output_retries_total
-  - fluentbit_output_retries_failed_total
+  fluentd: []
+  fluentbit: []
 
   elasticsearch:
   - elasticsearch_cluster_health_active_primary_shards

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-apiserver.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-apiserver.rules.yaml
@@ -41,7 +41,7 @@ groups:
     expr: histogram_quantile(0.99, rate(apiserver_request_latencies_bucket[5m])) / 1e+06
     labels:
       quantile: "0.99"
-  - record: apiserver_latency:quantile_seconds
+  - record: apiserver_latency:quantile
     expr: histogram_quantile(0.9, rate(apiserver_request_latencies_bucket[5m])) / 1e+06
     labels:
       quantile: "0.9"

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-proxy.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-proxy.rules.yaml
@@ -1,0 +1,27 @@
+groups:
+- name: kube-proxy.rules
+  rules:
+  - record: kubeproxy_network_latency:quantile
+    expr: histogram_quantile(0.99, sum(rate(kubeproxy_network_programming_duration_seconds_bucket[10m])) by (le))
+    labels:
+      quantile: "0.99"
+  - record: kubeproxy_network_latency:quantile
+    expr: histogram_quantile(0.9, sum(rate(kubeproxy_network_programming_duration_seconds_bucket[10m])) by (le))
+    labels:
+      quantile: "0.9"
+  - record: kubeproxy_network_latency:quantile
+    expr: histogram_quantile(0.5, sum(rate(kubeproxy_network_programming_duration_seconds_bucket[10m])) by (le))
+    labels:
+      quantile: "0.5"
+  - record: kubeproxy_sync_proxy:quantile
+    expr: histogram_quantile(0.99, sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket[10m])) by (le))
+    labels:
+      quantile: "0.99"
+  - record: kubeproxy_sync_proxy:quantile
+    expr: histogram_quantile(0.9, sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket[10m])) by (le))
+    labels:
+      quantile: "0.9"
+  - record: kubeproxy_sync_proxy:quantile
+    expr: histogram_quantile(0.5, sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket[10m])) by (le))
+    labels:
+      quantile: "0.5"

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -45,7 +45,6 @@ allowedMetrics:
   - container_fs_usage_bytes
   - container_last_seen
   - container_memory_working_set_bytes
-  - container_memory_usage_bytes
   - container_network_receive_bytes_total
   - container_network_transmit_bytes_total
   coredns:
@@ -101,9 +100,6 @@ allowedMetrics:
   - etcd_server_proposals_pending
   - grpc_server_handled_total
   - grpc_server_started_total
-  - grpc_server_handling_seconds_count
-  - grpc_server_handling_seconds_sum
-  - grpc_server_handling_seconds_bucket
   - process_max_fds
   - process_open_fds
   - process_resident_memory_bytes
@@ -128,8 +124,12 @@ allowedMetrics:
   - etcdbr_validation_duration_seconds_sum
   - process_resident_memory_bytes
   kubeProxy:
-  - kubeproxy_network_programming_duration_seconds_(.+)
-  - kubeproxy_sync_proxy_rules_(.+)
+  - kubeproxy_network_programming_duration_seconds_bucket
+  - kubeproxy_network_programming_duration_seconds_count
+  - kubeproxy_network_programming_duration_seconds_sum
+  - kubeproxy_sync_proxy_rules_duration_seconds_bucket
+  - kubeproxy_sync_proxy_rules_duration_seconds_count
+  - kubeproxy_sync_proxy_rules_duration_seconds_sum
   kubeScheduler:
   - scheduler_binding_latency_microseconds_bucket
   - scheduler_e2e_scheduling_latency_microseconds_bucket
@@ -179,16 +179,6 @@ allowedMetrics:
   - kube_statefulset_status_replicas_ready
   - kube_statefulset_status_replicas_updated
   machineControllerManager:
-  - mcm_cloud_api_requests_failed_total
-  - mcm_cloud_api_requests_total
-  - mcm_machine_controller_frozen
-  - mcm_machine_current_status_phase
-  - mcm_machine_deployment_failed_machines
-  - mcm_machine_items_total
-  - mcm_machine_set_failed_machines
-  - mcm_machinedeployment_items_total
-  - mcm_machineset_items_total
-  - mcm_scrape_failure_total
   - machine_adds
   - machine_depth
   - machine_queue_latency
@@ -219,18 +209,27 @@ allowedMetrics:
   - machineset_queue_latency
   - machineset_retries
   - machineset_work_duration
+  - mcm_cloud_api_requests_failed_total
+  - mcm_cloud_api_requests_total
+  - mcm_machine_controller_frozen
+  - mcm_machine_deployment_failed_machines
+  - mcm_machine_items_total
+  - mcm_machine_set_failed_machines
+  - mcm_machinedeployment_items_total
+  - mcm_machineset_items_total
+  - mcm_scrape_failure_total
   - node_adds
   - node_depth
   - node_queue_latency
   - node_retries
   - node_work_duration
+  - process_max_fds
+  - process_open_fds
   - secret_adds
   - secret_depth
   - secret_queue_latency
   - secret_retries
   - secret_work_duration
-  - process_max_fds
-  - process_open_fds
   nodeExporter:
   - node_cpu_seconds_total
   - node_filesystem_avail_bytes


### PR DESCRIPTION
**What this PR does / why we need it**:
Prometheus is scraping many metrics that are not used in any dashboards or aggregated. This PR removes these unused metrics.

@ggaurav10 @KristianZH @swapnilgm please review and check if any of the metrics are indeed needed. If this is the case then the metrics should be incorporated into a dashboard.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
