### PR TITLE
Revert "without the install section, at least ubuntu does not automat…

### DIFF
--- a/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
+++ b/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
@@ -28,8 +28,6 @@ spec:
       RestartSec=30
       EnvironmentFile=/etc/environment
       ExecStart=/var/lib/cloud-config-downloader/download-cloud-config.sh
-      [Install]
-      WantedBy=multi-user.target
   files:
   - path: /var/lib/cloud-config-downloader/credentials/server
     permissions: 0644


### PR DESCRIPTION
…ically start this service even if enabled, coreos on the other side also specifies this section in all of their services, see https://coreos.com/os/docs/latest/using-systemd-drop-in-units.html"

This reverts commit 9c5fa19eb63c2a48c8fc684afaf3e5f4ac5a7543.

**What this PR does / why we need it**:
As discussed, we want to implement further improvements for rolling out changes in the downloader script. Hence, we revert it for now and ship it in the next release.

**Special notes for your reviewer**:
/cc @Gerrit91 @majst01

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
