### PR TITLE
Handling case when deleting HVPA resource, but the CRD itself is missing

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -919,8 +919,10 @@ func (b *Botanist) DeployKubeAPIServer() error {
 			Version: "v1alpha1",
 			Kind:    "Hvpa",
 		})
-		if err := b.K8sSeedClient.Client().Delete(context.TODO(), u); client.IgnoreNotFound(err) != nil {
-			return err
+		if err := b.K8sSeedClient.Client().Delete(context.TODO(), u); err != nil {
+			if !apierrors.IsNotFound(err) && !metaerrors.IsNoMatchError(err) {
+				return err
+			}
 		}
 	}
 
@@ -1127,8 +1129,10 @@ func (b *Botanist) DeployETCD(ctx context.Context) error {
 				Version: "v1alpha1",
 				Kind:    "Hvpa",
 			})
-			if err := b.K8sSeedClient.Client().Delete(ctx, u); client.IgnoreNotFound(err) != nil {
-				return err
+			if err := b.K8sSeedClient.Client().Delete(ctx, u); err != nil {
+				if !apierrors.IsNotFound(err) && !metaerrors.IsNoMatchError(err) {
+					return err
+				}
 			}
 		}
 		if err := b.ApplyChartSeed(filepath.Join(chartPathControlPlane, "etcd"), b.Shoot.SeedNamespace, fmt.Sprintf("etcd-%s", role), nil, etcd); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
In case the HVPA feature gate is off, GCM tries to delete any existing HVPA resource. However, if the CRD is not already installed, the error returned was not handled. With this PR, the error handling is added.

**Which issue(s) this PR fixes**:
Fixes #1674

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Adds error handling when HVPA CRD is not already installed, but a delete operation is attempted
```
