### PR TITLE
Allow to skip certain cleanup steps

### DIFF
--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -227,6 +227,9 @@ const (
 	// For example, if the shoot is annotated with <AnnotationShootCustom>key=value,
 	// then the namespace in the seed will be annotated with <AnnotationShootCustom>key=value, as well.
 	AnnotationShootCustom = "custom.shoot.sapcloud.io/"
+	// AnnotationShootSkipCleanup is a key for an annotation on a Shoot resource that declares that the clean up steps should be skipped when the
+	// cluster is deleted. Concretely, this will skip everything except the deletion of (load balancer) services and persistent volume resources.
+	AnnotationShootSkipCleanup = "shoot.gardener.cloud/skip-cleanup"
 
 	// OperatingSystemConfigUnitNameKubeletService is a constant for a unit in the operating system config that contains the kubelet service.
 	OperatingSystemConfigUnitNameKubeletService = "kubelet.service"

--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -220,6 +220,13 @@ func (b *Botanist) CleanKubernetesResources(ctx context.Context) error {
 		ops     = utilclient.NewCleanOps(utilclient.DefaultCleaner(), ensurer)
 	)
 
+	if metav1.HasAnnotation(b.Shoot.Info.ObjectMeta, v1alpha1constants.AnnotationShootSkipCleanup) {
+		return flow.Parallel(
+			cleanResourceFn(ops, c, &corev1.ServiceList{}, ServiceCleanOption, GracePeriodFiveMinutes, FinalizeAfterFiveMinutes),
+			cleanResourceFn(ops, c, &corev1.PersistentVolumeClaimList{}, PersistentVolumeClaimCleanOption, GracePeriodFiveMinutes, FinalizeAfterFiveMinutes),
+		)(ctx)
+	}
+
 	return flow.Parallel(
 		cleanResourceFn(ops, c, &batchv1beta1.CronJobList{}, CronJobCleanOption, GracePeriodFiveMinutes, FinalizeAfterFiveMinutes),
 		cleanResourceFn(ops, c, &appsv1.DaemonSetList{}, DaemonSetCleanOption, GracePeriodFiveMinutes, FinalizeAfterFiveMinutes),


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow skipping certain cleanup tasks that might be undesired for users.

**Special notes for your reviewer**:
/cc @vlerenc

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
It is now possible to instruct Gardener to skip certain cleanup tasks when deleting a `Shoot` cluster by annotating it with `shoot.gardener.cloud/skip-cleanup=true`. Please be careful using this as it might leave orphaned infrastructure resources. Services (of type load balancer) as well as persistent volume resources are still deleted even if this annotation is set.
```
