### PR TITLE
adding health check library documentation

### DIFF
--- a/docs/extensions/shoot-health-status-conditions.md
+++ b/docs/extensions/shoot-health-status-conditions.md
@@ -82,3 +82,4 @@ status:
 ```
 
 Hence, the only duty extensions have is to maintain the health status of their components in the extension resource they are managing.
+This can be accomplished using the [health check library for extensions](https://github.com/gardener/gardener-extensions/blob/master/docs/healthcheck-library.md).


### PR DESCRIPTION
**What this PR does / why we need it**:
Connection two pieces of documentation - healthcheck conditions in Gardener and the healthcheck library in the extension repo.

Depends on [Extension Pull Request](https://github.com/gardener/gardener-extensions/pull/472)
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
