### PR TITLE
Restrict validity of browser certs to 2 years

### DIFF
--- a/charts/seed-monitoring/charts/grafana/templates/grafana-ingress.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     role: {{ .Values.role }}
 spec:
   tls:
-  - secretName: grafana-{{ .Values.role }}-tls
+  - secretName: grafana-tls
     hosts:
     - {{ .Values.ingress.host }}
   rules:

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"time"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
@@ -34,6 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -92,6 +94,8 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 		kubeSchedulerCertDNSNames         = dnsNamesForService("kube-scheduler", b.Shoot.SeedNamespace)
 
 		etcdCertDNSNames = dnsNamesForEtcd(b.Shoot.SeedNamespace)
+
+		endUserCrtValidity = 730 * 24 * time.Hour // ~2 years
 	)
 
 	if len(certificateAuthorities) != len(wantedCertificateAuthorities) {
@@ -497,6 +501,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			CertType:  secrets.ServerCert,
 			SigningCA: certificateAuthorities[v1alpha1constants.SecretNameCACluster],
+			Validity:  &endUserCrtValidity,
 		},
 
 		// Secret definition for prometheus (ingress)
@@ -510,6 +515,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			CertType:  secrets.ServerCert,
 			SigningCA: certificateAuthorities[v1alpha1constants.SecretNameCACluster],
+			Validity:  &endUserCrtValidity,
 		},
 	}
 
@@ -551,6 +557,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 				CertType:  secrets.ServerCert,
 				SigningCA: certificateAuthorities[v1alpha1constants.SecretNameCACluster],
+				Validity:  &endUserCrtValidity,
 			},
 			// Secret for elasticsearch
 			&secrets.CertificateSecretConfig{
@@ -625,7 +632,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 }
 
 // DeploySecrets creates a CA certificate for the Shoot cluster and uses it to sign the server certificate
-// used by the kube-apiserver, and all client certificates used for communcation. It also creates RSA key
+// used by the kube-apiserver, and all client certificates used for communication. It also creates RSA key
 // pairs for SSH connections to the nodes/VMs and for the VPN tunnel. Moreover, basic authentication
 // credentials are computed which will be used to secure the Ingress resources and the kube-apiserver itself.
 // Server certificates for the exposed monitoring endpoints (via Ingress) are generated as well.
@@ -707,8 +714,39 @@ func (b *Botanist) DeploySecrets(ctx context.Context) error {
 		return err
 	}
 
+	// Only necessary to renew certificates for Grafana, Kibana, Prometheus
+	// TODO: (timuthy) remove in future version.
+	var (
+		renewedLabel = "cert.gardener.cloud/renewed"
+		browserCerts = sets.NewString("grafana-tls", "kibana-tls", "prometheus-tls")
+	)
+	for name, secret := range existingSecretsMap {
+		_, ok := secret.Labels[renewedLabel]
+		if browserCerts.Has(name) && !ok {
+			if err := b.K8sSeedClient.Client().Delete(ctx, secret); client.IgnoreNotFound(err) != nil {
+				return err
+			}
+			delete(existingSecretsMap, name)
+		}
+	}
+
 	if err := b.generateShootSecrets(ctx, existingSecretsMap, wantedSecretsList); err != nil {
 		return err
+	}
+
+	// Only necessary to renew certificates for Grafana, Kibana, Prometheus
+	// TODO: (timuthy) remove in future version.
+	for name, secret := range b.Secrets {
+		_, ok := secret.Labels[renewedLabel]
+		if browserCerts.Has(name) && !ok {
+			if secret.Labels == nil {
+				secret.Labels = make(map[string]string)
+			}
+			secret.Labels[renewedLabel] = "true"
+			if err := b.K8sSeedClient.Client().Update(ctx, secret); err != nil {
+				return err
+			}
+		}
 	}
 
 	b.mutex.Lock()

--- a/pkg/utils/secrets/generate.go
+++ b/pkg/utils/secrets/generate.go
@@ -89,7 +89,7 @@ func GenerateClusterSecrets(ctx context.Context, k8sClusterClient kubernetes.Int
 		deployedClusterSecrets[out.secret.Name] = out.secret
 	}
 
-	// Wait and check wether an error occurred during the parallel processing of the Secret creation.
+	// Wait and check whether an error occurred during the parallel processing of the Secret creation.
 	if len(errorList) > 0 {
 		return deployedClusterSecrets, fmt.Errorf("Errors occurred during shoot secrets generation: %+v", errorList)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes Gardener to restrict the validity of certificates for the following service to 2 years:
- Garfana (operator / user)
- Prometheus
- Kibana

This is especially required since Apple's announcement:
https://support.apple.com/en-us/HT210176

**Special notes for your reviewer**:
Follow up item: #1684

/cc @dguendisch 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Server certificates for Grafana (operator / user), Prometheus and Kibana endpoints of Shoots are now created with a validity of 2 years (unlike 10 years previously). 
```

```improvement operator
A bug has been fixed which caused the Grafana ingresses of shoots to serve the Kubernetes Fake Certificate instead of a certificate signed by the cluster CA. 
```
