### PR TITLE
Fix kube-proxy PodSecurityPolicy to use hostPort

### DIFF
--- a/charts/shoot-core/components/charts/kube-proxy/templates/psp/kube-proxy-psp.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/psp/kube-proxy-psp.yaml
@@ -9,6 +9,9 @@ spec:
   - secret
   - configMap
   hostNetwork: true
+  hostPorts:
+  - min: {{ .Values.ports.metrics }}
+    max: {{ .Values.ports.metrics }}
   allowedHostPaths:
   - pathPrefix: /usr/share/ca-certificates
   - pathPrefix: /var/run/dbus/system_bus_socket


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix kube-proxy PodSecurityPolicy to use hostPort.

**Which issue(s) this PR fixes**:
Fixes gardener/gardener-extensions#479

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue preventing Shoot with `.spec.kubernetes.allowPrivilegedContainers=false` to be created is now fixed.
```
