### PR TITLE
Add network policies to shoot

### DIFF
--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         origin: gardener
         garden.sapcloud.io/role: system-component
         component: blackbox-exporter
+        networking.gardener.cloud/from-seed: allowed
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-public-networks: allowed
     spec:
       tolerations:
       - effect: NoSchedule

--- a/charts/shoot-core/components/charts/network-policies/Chart.yaml
+++ b/charts/shoot-core/components/charts/network-policies/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for networkpolicies that Gardener deploys into shoots.
+name: network-policies
+version: 0.1.0

--- a/charts/shoot-core/components/charts/network-policies/charts/utils-templates
+++ b/charts/shoot-core/components/charts/network-policies/charts/utils-templates
@@ -1,0 +1,1 @@
+../../../../../utils-templates

--- a/charts/shoot-core/components/charts/network-policies/templates/allow-from-seed.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-from-seed.yaml
@@ -1,0 +1,24 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  annotations:
+    gardener.cloud/description: |
+      Allows Ingress from the control plane to pods labeled with
+      'networking.gardener.cloud/from-seed=allowed'.
+  name: gardener.cloud--allow-from-seed
+  namespace: kube-system
+  labels:
+    origin: gardener
+spec:
+  podSelector:
+    matchLabels:
+      networking.gardener.cloud/from-seed: allowed
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: vpn-shoot
+          garden.sapcloud.io/role: system-component
+          origin: gardener

--- a/charts/shoot-core/components/charts/network-policies/templates/allow-to-dns.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-to-dns.yaml
@@ -1,0 +1,31 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  annotations:
+    gardener.cloud/description: |
+      Allows Egress from pods labeled with 'networking.gardener.cloud/to-dns=allowed'
+      to DNS running in the 'kube-system' namespace.
+  name: gardener.cloud--allow-to-dns
+  namespace: kube-system
+  labels:
+    origin: gardener
+spec:
+  podSelector:
+    matchLabels:
+      networking.gardener.cloud/to-dns: allowed
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - podSelector:
+        matchExpressions:
+        - {key: k8s-app, operator: In, values: [kube-dns,coredns]}
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 8053
+    - protocol: TCP
+      port: 8053

--- a/charts/shoot-core/components/charts/network-policies/templates/allow-to-public-networks.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-to-public-networks.yaml
@@ -1,0 +1,21 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  annotations:
+    gardener.cloud/description: |
+      Allows Egress from pods labeled with 'networking.gardener.cloud/to-public-networks=allowed'
+      to all networks.
+  name: gardener.cloud--allow-to-public-networks
+  namespace: kube-system
+  labels:
+    origin: gardener
+spec:
+  podSelector:
+    matchLabels:
+      networking.gardener.cloud/to-public-networks: allowed
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -233,6 +233,7 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 		nodeExporterConfig        = map[string]interface{}{}
 		blackboxExporterConfig    = map[string]interface{}{}
 		nodeProblemDetectorConfig = map[string]interface{}{}
+		networkPolicyConfig       = map[string]interface{}{}
 	)
 
 	proxyConfig := b.Shoot.Info.Spec.Kubernetes.KubeProxy
@@ -304,6 +305,7 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 			"node-exporter":     nodeExporter,
 			"blackbox-exporter": blackboxExporter,
 		},
+		"network-policies":      networkPolicyConfig,
 		"node-problem-detector": nodeProblemDetector,
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
If users create network policies in the kube-system namespace, it could prevent some gardener components from working. This PR adds network polices for the blackbox exporter running in the kube-system namespace of the shoot.

**Which issue(s) this PR fixes**:
#565 will be partially fixed

**Special notes for your reviewer**:
cc @zanetworker 
Prometheus will still be able to scrape the blackbox exporter and the blackbox exporter can still probe the kubernetes endpoint even if there is another network policy denying all traffic.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Gardener now deploys network policies into the `kube-system` namespace of the shoot to guarantee that the `blackbox-exporter` component can communicate with the control plane.
```
