### PR TITLE
Fixes shoot care controller panic

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_care_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_care_control.go
@@ -177,7 +177,7 @@ func (c *defaultCareControl) Care(shootObj *gardencorev1alpha1.Shoot, key string
 		)
 
 		// Update Shoot status
-		shoot, err = c.updateShootConditions(shoot, conditionAPIServerAvailable, conditionControlPlaneHealthy, conditionEveryNodeReady, conditionSystemComponentsHealthy)
+		updatedShoot, err := c.updateShootConditions(shoot, conditionAPIServerAvailable, conditionControlPlaneHealthy, conditionEveryNodeReady, conditionSystemComponentsHealthy)
 		if err != nil {
 			botanist.Logger.Errorf("Could not update Shoot conditions: %+v", err)
 			return nil // We do not want to run in the exponential backoff for the condition checks.
@@ -186,12 +186,12 @@ func (c *defaultCareControl) Care(shootObj *gardencorev1alpha1.Shoot, key string
 		// Mark Shoot as healthy/unhealthy
 		_, _ = kutil.TryUpdateShootLabels(
 			c.k8sGardenClient.GardenCore(),
-			retry.DefaultBackoff, shoot.ObjectMeta,
+			retry.DefaultBackoff, updatedShoot.ObjectMeta,
 			StatusLabelTransform(
 				ComputeStatus(
-					shoot.Status.LastOperation,
-					shoot.Status.LastErrors,
-					shoot.Status.LastError,
+					updatedShoot.Status.LastOperation,
+					updatedShoot.Status.LastErrors,
+					updatedShoot.Status.LastError,
 					conditionAPIServerAvailable,
 					conditionControlPlaneHealthy,
 					conditionEveryNodeReady,
@@ -206,7 +206,7 @@ func (c *defaultCareControl) Care(shootObj *gardencorev1alpha1.Shoot, key string
 		constraintHibernationPossible = botanist.ConstraintsChecks(ctx, initializeShootClients, constraintHibernationPossible)
 
 		// Update Shoot status
-		shoot, err = c.updateShootConstraints(shoot, constraintHibernationPossible)
+		_, err = c.updateShootConstraints(shoot, constraintHibernationPossible)
 		if err != nil {
 			botanist.Logger.Errorf("Could not update Shoot constraints: %+v", err)
 			return nil


### PR DESCRIPTION
Co-authored-by: Zanetworker <adel.zaalouk@sap.com>

**What this PR does / why we need it**:
This PR fixes a panic in the shoot care controller which especially happened if the controller ran into retry conflicts.

```
goroutine 4070634 [running]:
github.com/gardener/gardener/pkg/controllermanager/controller/shoot.(*defaultCareControl).updateShootConditions(0xc0028e6780, 0x0, 0xc015f741c0, 0x4, 0x4, 0xc02dfbf2a0, 0xb, 0x0)
    /go/src/github.com/gardener/gardener/pkg/controllermanager/controller/shoot/shoot_care_control.go:222 +0xaf
github.com/gardener/gardener/pkg/controllermanager/controller/shoot.(*defaultCareControl).Care.func1(0x1c41380, 0xc000044030, 0x0, 0xc0486c1a40)
    /go/src/github.com/gardener/gardener/pkg/controllermanager/controller/shoot/shoot_care_control.go:180 +0x4a0
github.com/gardener/gardener/pkg/utils/flow.Parallel.func1.1(0xc0680f9890, 0xc0032d3500, 0xc04e714910, 0x1c41380, 0xc000044030)
    /go/src/github.com/gardener/gardener/pkg/utils/flow/taskfn.go:153 +0x77
created by github.com/gardener/gardener/pkg/utils/flow.Parallel.func1
    /go/src/github.com/gardener/gardener/pkg/utils/flow/taskfn.go:151 +0x104
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue in the shoot care controller has been fixed which caused the Gardener-Controller-Manager to crash.
```
