### PR TITLE
Add shoot-info configmap to kube-system namespace

### DIFF
--- a/charts/shoot-core/components/charts/shoot-info/Chart.yaml
+++ b/charts/shoot-core/components/charts/shoot-info/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for a configmap containing shoot information
+name: shoot-info
+version: 0.1.0

--- a/charts/shoot-core/components/charts/shoot-info/templates/configmap.yaml
+++ b/charts/shoot-core/components/charts/shoot-info/templates/configmap.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shoot-info
+  namespace: kube-system
+data:
+  projectName: {{ .Values.projectName }}
+  shootName: {{ .Values.shootName }}
+  provider: {{ .Values.provider }}
+  region: {{ .Values.region }}
+  kubernetesVersion: {{ .Values.kubernetesVersion }}
+  domain: {{ .Values.domain }}
+  podNetwork: {{ .Values.podNetwork }}
+  serviceNetwork: {{ .Values.serviceNetwork }}
+  nodeNetwork: {{ .Values.nodeNetwork }}
+  maintenanceBegin: {{ .Values.maintenanceBegin }}
+  maintenanceEnd: {{ .Values.maintenanceEnd }}
+  extensions: {{ .Values.extensions }}

--- a/charts/shoot-core/components/charts/shoot-info/values.yaml
+++ b/charts/shoot-core/components/charts/shoot-info/values.yaml
@@ -1,0 +1,12 @@
+projectName: core
+shootName: crazy-botany
+provider: aws
+region: eu-west-1
+kubernetesVersion: 1.15.1
+domain: crazy-botany.core.my-custom-domain.com
+podNetwork: 100.96.0.0/11
+serviceNetwork: 100.64.0.0/13
+nodeNetwork: 10.250.0.0/16
+maintenanceBegin: 210000+0000
+maintenanceEnd: 220000+0000
+extensions: shoot-dns-service,foo-bar

--- a/charts/shoot-core/components/values.yaml
+++ b/charts/shoot-core/components/values.yaml
@@ -27,3 +27,16 @@ metrics-server:
     metrics-server: image-repository:image-tag
 podsecuritypolicies:
   allowPrivilegedContainers: false
+shoot-info:
+  projectName: core
+  shootName: crazy-botany
+  provider: aws
+  region: eu-west-1
+  kubernetesVersion: 1.15.1
+  domain: crazy-botany.core.my-custom-domain.com
+  podNetwork: 100.96.0.0/11
+  serviceNetwork: 100.64.0.0/13
+  nodeNetwork: 10.250.0.0/16
+  maintenanceBegin: 210000+0000
+  maintenanceEnd: 220000+0000
+  extensions: shoot-dns-service,foo-bar


### PR DESCRIPTION
**What this PR does / why we need it**:
Every shoot cluster will now feature a `shoot-info` configmap in its `kube-system` namespace. This configmap contains some important information about the shoot cluster itself, e.g., maintenance time window, project name, etc.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Every shoot cluster will now feature a `shoot-info` configmap in its `kube-system` namespace. This configmap contains some important information about the shoot cluster itself, e.g., maintenance time window, project name, etc.
```
