### PR TITLE
Add external label "name" to prometheus.

### DIFF
--- a/charts/seed-bootstrap/dashboards/alerts-dashboard.json
+++ b/charts/seed-bootstrap/dashboards/alerts-dashboard.json
@@ -63,6 +63,7 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
+      "options": {},
       "postfix": "Firing Alert(s)",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -147,6 +148,7 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
+      "options": {},
       "postfix": "Cluster(s)",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -232,6 +234,7 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
+      "options": {},
       "postfix": " Pending Alert(s)",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -316,6 +319,7 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
+      "options": {},
       "postfix": " Cluster(s)",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -371,57 +375,58 @@
       "id": 16,
       "links": [],
       "options": {
-        "maxValue": 100,
-        "minValue": 0,
+        "fieldOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "defaults": {
+            "decimals": null,
+            "mappings": [
+              {
+                "from": "",
+                "id": 1,
+                "operator": "",
+                "text": "0",
+                "to": "",
+                "type": 1,
+                "value": "null"
+              },
+              {
+                "from": "",
+                "id": 2,
+                "operator": "",
+                "text": "0",
+                "to": "",
+                "type": 1,
+                "value": "No data"
+              }
+            ],
+            "max": 100,
+            "min": 0,
+            "thresholds": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 40
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ],
+            "unit": "percent"
+          },
+          "override": {},
+          "values": false
+        },
         "orientation": "auto",
         "showThresholdLabels": false,
-        "showThresholdMarkers": false,
-        "thresholds": [
-          {
-            "color": "green",
-            "index": 0,
-            "value": null
-          },
-          {
-            "color": "yellow",
-            "index": 1,
-            "value": 40
-          },
-          {
-            "color": "red",
-            "index": 2,
-            "value": 80
-          }
-        ],
-        "valueMappings": [
-          {
-            "from": "",
-            "id": 1,
-            "operator": "",
-            "text": "0",
-            "to": "",
-            "type": 1,
-            "value": "null"
-          },
-          {
-            "from": "",
-            "id": 2,
-            "operator": "",
-            "text": "0",
-            "to": "",
-            "type": 1,
-            "value": "No data"
-          }
-        ],
-        "valueOptions": {
-          "decimals": null,
-          "prefix": "",
-          "stat": "mean",
-          "suffix": "",
-          "unit": "percent"
-        }
+        "showThresholdMarkers": false
       },
-      "pluginVersion": "6.1.4",
+      "pluginVersion": "6.3.2",
       "targets": [
         {
           "expr": "(count(count(ALERTS) by (cluster)) / count(count(seed:container_cpu_usage_seconds_total:sum_by_pod{namespace=~\"shoot-(.+)\"}) by (namespace))) * 100",
@@ -477,6 +482,7 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
+      "options": {},
       "postfix": "Cluster(s)",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -532,6 +538,7 @@
       },
       "id": 9,
       "links": [],
+      "options": {},
       "pageSize": null,
       "scroll": true,
       "showHeader": true,
@@ -599,6 +606,7 @@
       },
       "id": 7,
       "links": [],
+      "options": {},
       "pageSize": null,
       "scroll": true,
       "showHeader": true,
@@ -646,7 +654,7 @@
       ],
       "targets": [
         {
-          "expr": "count(ALERTS{cluster=~\"$Cluster\", severity=~\"$Severity\", alertstate=~\"$AlertState\"}) by (alertname, cluster, severity, alertstate)",
+          "expr": "count(ALERTS{project=~\"$Project\",name=~\"$Shoot\", severity=~\"$Severity\", alertstate=~\"$AlertState\"}) by (alertname, project, name, severity, alertstate)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -681,6 +689,7 @@
       "decimals": 0,
       "description": "Shows the number of ($Severity) alerts in Alert State ($AlertState) for the selected clusters.",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 24,
@@ -688,6 +697,7 @@
         "y": 24
       },
       "id": 4,
+      "interval": "",
       "legend": {
         "alignAsTable": true,
         "avg": false,
@@ -703,6 +713,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -713,10 +726,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count(ALERTS{alertname=~\"$Alertname\", severity=~\"$Severity\", alertstate=~\"$AlertState\", cluster=~\"$Cluster\"}) by (cluster)",
+          "expr": "count(ALERTS{alertname=~\"$Alertname\", severity=~\"$Severity\", alertstate=~\"$AlertState\", project=~\"$Project\", name=~\"$Shoot\"}) by (name,project)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
+          "legendFormat": "{{ project }}/{{ name }}",
           "refId": "A"
         }
       ],
@@ -771,6 +784,7 @@
       "decimals": 0,
       "description": "Shows alerts that are/were active with the selected severity and alert state from the selected clusters. Includes the alertnames of the alerts.",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 24,
@@ -793,6 +807,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -803,10 +820,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count(ALERTS{alertname=~\"$Alertname\", severity=~\"$Severity\", alertstate=~\"$AlertState\", cluster=~\"$Cluster\"}) by (alertname,cluster)",
+          "expr": "count(ALERTS{alertname=~\"$Alertname\", severity=~\"$Severity\", alertstate=~\"$AlertState\", project=~\"$Project\", name=~\"$Shoot\"}) by (alertname,project,name)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ alertname }}/{{ cluster }}",
+          "legendFormat": "{{ alertname }}/{{ project }}/{{ name }}",
           "refId": "A"
         }
       ],
@@ -854,7 +871,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 18,
+  "schemaVersion": 19,
   "style": "dark",
   "tags": [
     "monitoring",
@@ -865,19 +882,50 @@
       {
         "allValue": null,
         "current": {
-          "text": "All",
-          "value": "$__all"
+          "text": "d064864",
+          "value": "d064864"
         },
         "datasource": "prometheus",
-        "definition": "label_values(cluster)",
+        "definition": "label_values(ALERTS, project)",
         "hide": 0,
-        "includeAll": true,
+        "includeAll": false,
         "label": null,
         "multi": true,
-        "name": "Cluster",
+        "name": "Project",
         "options": [],
-        "query": "label_values(cluster)",
-        "refresh": 1,
+        "query": "label_values(ALERTS, project)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "shootwb",
+          "value": "shootwb"
+        },
+        "datasource": "prometheus",
+        "definition": "label_values(ALERTS{project=~\"$Project\"}, name)",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": true,
+        "name": "Shoot",
+        "options": [
+          {
+            "selected": true,
+            "text": "shootwb",
+            "value": "shootwb"
+          }
+        ],
+        "query": "label_values(ALERTS{project=~\"$Project\"}, name)",
+        "refresh": 0,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,

--- a/charts/seed-bootstrap/dashboards/cluster-overview.json
+++ b/charts/seed-bootstrap/dashboards/cluster-overview.json
@@ -1,7 +1,6 @@
 {
   "annotations": {
-    "list": [
-    ]
+    "list": []
   },
   "description": "",
   "editable": true,
@@ -18,6 +17,7 @@
       "decimals": 0,
       "description": "Shows how many API Servers are running for the selected shoot.",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
@@ -38,6 +38,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -48,7 +51,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "shoot:kube_apiserver:sum_by_pod{cluster=~\"$shoot\"}",
+          "expr": "sum(shoot:kube_apiserver:sum_by_pod{project=~\"$Project\", name=~\"$Shoot\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "API Server Replicas",
@@ -105,6 +108,7 @@
       "decimals": 0,
       "description": "Shows the number of nodes that the selected cluster has.",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
@@ -125,6 +129,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -135,10 +142,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "shoot:kube_node_info:count{cluster=~\"$shoot\"}",
+          "expr": "sum(shoot:kube_node_info:count{project=~\"$Project\", name=~\"$Shoot\"}) by (name, project)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ cluster }}",
+          "legendFormat": "{{ project }}/{{ name }}",
           "refId": "A"
         }
       ],
@@ -192,6 +199,7 @@
       "decimals": 0,
       "description": "Shows the total number of pods in the shoot's control plane at any given time.",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 8,
@@ -212,6 +220,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -222,7 +233,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count(seed:container_cpu_usage_seconds_total:sum_by_pod{namespace=~\"$shoot\"})\n",
+          "expr": "count(seed:container_cpu_usage_seconds_total:sum_by_pod{namespace=~\"shoot(-|--)$Project(-|--)$Shoot\"})\n",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "pods",
@@ -278,6 +289,7 @@
       "dashes": false,
       "description": "Shows the CPU usage of the control plane for the selected shoot.",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
@@ -298,6 +310,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -308,10 +323,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(seed:container_cpu_usage_seconds_total:sum_by_pod{namespace=~\"$shoot\"})",
+          "expr": "sum(seed:container_cpu_usage_seconds_total:sum_by_pod{namespace=~\"shoot(-|--)$Project(-|--)$Shoot\"})",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "$shoot",
+          "legendFormat": "$Project/$Shoot",
           "refId": "A"
         }
       ],
@@ -363,6 +378,7 @@
       "dashes": false,
       "description": "Shows the memory usage of the selected control plane.",
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 9,
         "w": 12,
@@ -383,6 +399,9 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 2,
       "points": false,
@@ -393,10 +412,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(seed:container_memory_working_set_bytes:sum_by_pod{namespace=~\"$shoot\"})",
+          "expr": "sum(seed:container_memory_working_set_bytes:sum_by_pod{namespace=~\"shoot(-|--)$Project(-|--)$Shoot\"})",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "$shoot",
+          "legendFormat": "$Project/$Shoot",
           "refId": "A"
         }
       ],
@@ -443,7 +462,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 18,
+  "schemaVersion": 19,
   "style": "dark",
   "tags": [
     "Control Planes",
@@ -454,16 +473,37 @@
       {
         "allValue": null,
         "datasource": "prometheus",
-        "definition": "label_values(namespace)",
+        "definition": "label_values(shoot:availability,project)",
         "hide": 0,
         "includeAll": false,
-        "label": "Shoot",
+        "label": null,
         "multi": false,
-        "name": "shoot",
+        "name": "Project",
         "options": [],
-        "query": "label_values(namespace)",
+        "query": "label_values(shoot:availability,project)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "datasource": "prometheus",
+        "definition": "label_values(shoot:availability{project=~\"$Project\"},name)",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "Shoot",
+        "options": [],
+        "query": "label_values(shoot:availability{project=~\"$Project\"},name)",
         "refresh": 1,
-        "regex": "((shoot-|shoot--)(\\w.+))",
+        "regex": "",
         "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
@@ -475,7 +515,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -20,6 +20,7 @@ data:
         cluster: {{ .Release.Namespace }}
         project: {{ .Values.shoot.project }}
         shoot_name: {{ .Values.shoot.name }}
+        name: {{ .Values.shoot.name }}
         seed_api: {{ .Values.seed.apiserver }}
         seed_region: {{ .Values.seed.region }}
         seed_provider: {{ .Values.seed.provider }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This will deprecate the old label "shoot_name" so we use the same labels that the gardener-metrics-exporter uses.

The dashboards have also been adjusted to use the new label.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
