### PR TITLE
add merge patch strategy to apis

### DIFF
--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -7394,5 +7394,5 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>b8e714c8a</code>.
+on git commit <code>cb6aa45dc</code>.
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -3190,5 +3190,5 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>b8e714c8a</code>.
+on git commit <code>cb6aa45dc</code>.
 </em></p>

--- a/hack/api-reference/garden.md
+++ b/hack/api-reference/garden.md
@@ -8191,5 +8191,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>b8e714c8a</code>.
+on git commit <code>cb6aa45dc</code>.
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,5 +555,5 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>b8e714c8a</code>.
+on git commit <code>cb6aa45dc</code>.
 </em></p>

--- a/pkg/apis/core/v1alpha1/types_cloudprofile.go
+++ b/pkg/apis/core/v1alpha1/types_cloudprofile.go
@@ -55,14 +55,20 @@ type CloudProfileSpec struct {
 	// Kubernetes contains constraints regarding allowed values of the 'kubernetes' block in the Shoot specification.
 	Kubernetes KubernetesSettings `json:"kubernetes"`
 	// MachineImages contains constraints regarding allowed values for machine images in the Shoot specification.
-	MachineImages []MachineImage `json:"machineImages"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	MachineImages []MachineImage `json:"machineImages" patchStrategy:"merge" patchMergeKey:"name"`
 	// MachineTypes contains constraints regarding allowed values for machine types in the 'workers' block in the Shoot specification.
-	MachineTypes []MachineType `json:"machineTypes"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	MachineTypes []MachineType `json:"machineTypes" patchStrategy:"merge" patchMergeKey:"name"`
 	// ProviderConfig contains provider-specific configuration for the profile.
 	// +optional
 	ProviderConfig *ProviderConfig `json:"providerConfig,omitempty"`
 	// Regions contains constraints regarding allowed values for regions and zones.
-	Regions []Region `json:"regions"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	Regions []Region `json:"regions" patchStrategy:"merge" patchMergeKey:"name"`
 	// SeedSelector contains an optional list of labels on `Seed` resources that marks those seeds whose shoots may use this provider profile.
 	// An empty list means that all seeds of the same provider type are supported.
 	// This is useful for environments that are of the same type (like openstack) but may have different "instances"/landscapes.
@@ -71,15 +77,19 @@ type CloudProfileSpec struct {
 	// Type is the name of the provider.
 	Type string `json:"type"`
 	// VolumeTypes contains constraints regarding allowed values for volume types in the 'workers' block in the Shoot specification.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	// +optional
-	VolumeTypes []VolumeType `json:"volumeTypes,omitempty"`
+	VolumeTypes []VolumeType `json:"volumeTypes,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // KubernetesSettings contains constraints regarding allowed values of the 'kubernetes' block in the Shoot specification.
 type KubernetesSettings struct {
 	// Versions is the list of allowed Kubernetes versions with optional expiration dates for Shoot clusters.
+	// +patchMergeKey=version
+	// +patchStrategy=merge
 	// +optional
-	Versions []ExpirableVersion `json:"versions,omitempty"`
+	Versions []ExpirableVersion `json:"versions,omitempty" patchStrategy:"merge" patchMergeKey:"version"`
 }
 
 // MachineImage defines the name and multiple versions of the machine image in any environment.
@@ -87,7 +97,9 @@ type MachineImage struct {
 	// Name is the name of the image.
 	Name string `json:"name"`
 	// Versions contains versions and expiration dates of the machine image
-	Versions []ExpirableVersion `json:"versions"`
+	// +patchMergeKey=version
+	// +patchStrategy=merge
+	Versions []ExpirableVersion `json:"versions" patchStrategy:"merge" patchMergeKey:"version"`
 }
 
 // ExpirableVersion contains a version and an expiration date.
@@ -132,8 +144,10 @@ type Region struct {
 	// Name is a region name.
 	Name string `json:"name"`
 	// Zones is a list of availability zones in this region.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	// +optional
-	Zones []AvailabilityZone `json:"zones,omitempty"`
+	Zones []AvailabilityZone `json:"zones,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // AvailabilityZone is an availability zone.

--- a/pkg/apis/core/v1alpha1/types_controllerinstallation.go
+++ b/pkg/apis/core/v1alpha1/types_controllerinstallation.go
@@ -57,8 +57,10 @@ type ControllerInstallationSpec struct {
 // ControllerInstallationStatus is the status of a ControllerInstallation.
 type ControllerInstallationStatus struct {
 	// Conditions represents the latest available observations of a ControllerInstallations's current state.
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	// +optional
-	Conditions []Condition `json:"conditions,omitempty"`
+	Conditions []Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	// ProviderStatus contains type-specific status.
 	// +optional
 	ProviderStatus *ProviderConfig `json:"providerStatus,omitempty"`

--- a/pkg/apis/core/v1alpha1/types_plant.go
+++ b/pkg/apis/core/v1alpha1/types_plant.go
@@ -58,15 +58,19 @@ type PlantSpec struct {
 	// clusters to be added to Gardener.
 	SecretRef corev1.LocalObjectReference `json:"secretRef"`
 	// Endpoints is the configuration plant endpoints
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	// +optional
-	Endpoints []Endpoint `json:"endpoints,omitempty"`
+	Endpoints []Endpoint `json:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // PlantStatus is the status of a Plant.
 type PlantStatus struct {
 	// Conditions represents the latest available observations of a Plant's current state.
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	// +optional
-	Conditions []Condition `json:"conditions,omitempty"`
+	Conditions []Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	// ObservedGeneration is the most recent generation observed for this Plant. It corresponds to the
 	// Plant's generation, which is updated on mutation by the API Server.
 	// +optional

--- a/pkg/apis/core/v1alpha1/types_seed.go
+++ b/pkg/apis/core/v1alpha1/types_seed.go
@@ -82,8 +82,10 @@ type SeedStatus struct {
 	// +optional
 	Gardener Gardener `json:"gardener,omitempty"`
 	// Conditions represents the latest available observations of a Seed's current state.
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	// +optional
-	Conditions []Condition `json:"conditions,omitempty"`
+	Conditions []Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	// ObservedGeneration is the most recent generation observed for this Seed. It corresponds to the
 	// Seed's generation, which is updated on mutation by the API Server.
 	// +optional
@@ -164,8 +166,10 @@ type SeedVolume struct {
 	// +optional
 	MinimumSize *resource.Quantity `json:"minimumSize,omitempty"`
 	// Providers is a list of storage class provisioner types for the seed.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	// +optional
-	Providers []SeedVolumeProvider `json:"providers,omitempty"`
+	Providers []SeedVolumeProvider `json:"providers,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // SeedVolumeProvider is a storage class provisioner type.

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -96,10 +96,14 @@ type ShootSpec struct {
 type ShootStatus struct {
 	// Conditions represents the latest available observations of a Shoots's current state.
 	// +optional
-	Conditions []Condition `json:"conditions,omitempty"`
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	Conditions []Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	// Constraints represents conditions of a Shoot's current state that constraint some operations on it.
 	// +optional
-	Constraints []Condition `json:"constraints,omitempty"`
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	Constraints []Condition `json:"constraints,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	// Gardener holds information about the Gardener which last acted on the Shoot.
 	Gardener Gardener `json:"gardener"`
 	// IsHibernated indicates whether the Shoot is currently hibernated.
@@ -192,8 +196,10 @@ type DNS struct {
 	Domain *string `json:"domain,omitempty"`
 	// Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
 	// not a default domain is used.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	// +optional
-	Providers []DNSProvider `json:"providers,omitempty"`
+	Providers []DNSProvider `json:"providers,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // DNSProvider contains information about a DNS provider.
@@ -335,8 +341,10 @@ type KubeAPIServerConfig struct {
 	KubernetesConfig `json:",inline"`
 	// AdmissionPlugins contains the list of user-defined admission plugins (additional to those managed by Gardener), and, if desired, the corresponding
 	// configuration.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	// +optional
-	AdmissionPlugins []AdmissionPlugin `json:"admissionPlugins,omitempty"`
+	AdmissionPlugins []AdmissionPlugin `json:"admissionPlugins,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// APIAudiences are the identifiers of the API. The service account token authenticator will
 	// validate that tokens used against the API are bound to at least one of these audiences.
 	// If `serviceAccountConfig.issuer` is configured and this is not, this defaults to a single
@@ -775,7 +783,9 @@ type Provider struct {
 	// +optional
 	InfrastructureConfig *ProviderConfig `json:"infrastructureConfig,omitempty"`
 	// Workers is a list of worker groups.
-	Workers []Worker `json:"workers"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	Workers []Worker `json:"workers" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // Worker is the base definition of a worker group.

--- a/pkg/apis/core/v1alpha1/types_shootstate.go
+++ b/pkg/apis/core/v1alpha1/types_shootstate.go
@@ -47,8 +47,10 @@ type ShootStateList struct {
 // ShootStateSpec is the specification of the ShootState.
 type ShootStateSpec struct {
 	// Gardener holds the data required to generate resources deployed by the gardenlet
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	// +optional
-	Gardener []GardenerResourceData `json:"gardener,omitempty"`
+	Gardener []GardenerResourceData `json:"gardener,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// Extensions holds the state of custom resources reconciled by extension controllers in the seed
 	// +optional
 	Extensions []ExtensionResourceState `json:"extensions,omitempty"`

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -79,10 +79,12 @@ type OperatingSystemConfigSpec struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// +optional
-	Units []Unit `json:"units,omitempty"`
+	Units []Unit `json:"units,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// Files is a list of files that should get written to the host's file system.
+	// +patchMergeKey=path
+	// +patchStrategy=merge
 	// +optional
-	Files []File `json:"files,omitempty"`
+	Files []File `json:"files,omitempty" patchStrategy:"merge" patchMergeKey:"path"`
 	// ProviderConfig is the configuration passed to extension resource.
 	// +optional
 	ProviderConfig *runtime.RawExtension `json:"providerConfig,omitempty"`
@@ -105,7 +107,7 @@ type Unit struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// +optional
-	DropIns []DropIn `json:"dropIns,omitempty"`
+	DropIns []DropIn `json:"dropIns,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // DropIn is a drop-in configuration for a systemd unit.

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -78,7 +78,9 @@ type WorkerSpec struct {
 	// +optional
 	SSHPublicKey []byte `json:"sshPublicKey,omitempty"`
 	// Pools is a list of worker pools.
-	Pools []WorkerPool `json:"pools"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	Pools []WorkerPool `json:"pools" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // WorkerPool is the definition of a specific worker pool.
@@ -148,7 +150,9 @@ type WorkerStatus struct {
 
 	// MachineDeployments is a list of created machine deployments. It will be used to e.g. configure
 	// the cluster-autoscaler properly.
-	MachineDeployments []MachineDeployment `json:"machineDeployments,omitempty"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	MachineDeployments []MachineDeployment `json:"machineDeployments,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// ProviderStatus contains provider-specific output for this worker.
 	// +optional
 	ProviderStatus *runtime.RawExtension `json:"providerStatus,omitempty"`

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -94,18 +94,28 @@ type AWSProfile struct {
 // AWSConstraints is an object containing constraints for certain values in the Shoot specification.
 type AWSConstraints struct {
 	// DNSProviders contains constraints regarding allowed values of the 'dns.provider' block in the Shoot specification.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	// +optional
-	DNSProviders []DNSProviderConstraint `json:"dnsProviders,omitempty"`
+	DNSProviders []DNSProviderConstraint `json:"dnsProviders,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// Kubernetes contains constraints regarding allowed values of the 'kubernetes' block in the Shoot specification.
 	Kubernetes KubernetesConstraints `json:"kubernetes"`
 	// MachineImages contains constraints regarding allowed values for machine images in the Shoot specification.
-	MachineImages []MachineImage `json:"machineImages"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	MachineImages []MachineImage `json:"machineImages" patchStrategy:"merge" patchMergeKey:"name"`
 	// MachineTypes contains constraints regarding allowed values for machine types in the 'workers' block in the Shoot specification.
-	MachineTypes []MachineType `json:"machineTypes"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	MachineTypes []MachineType `json:"machineTypes" patchStrategy:"merge" patchMergeKey:"name"`
 	// VolumeTypes contains constraints regarding allowed values for volume types in the 'workers' block in the Shoot specification.
-	VolumeTypes []VolumeType `json:"volumeTypes"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	VolumeTypes []VolumeType `json:"volumeTypes" patchStrategy:"merge" patchMergeKey:"name"`
 	// Zones contains constraints regarding allowed values for 'zones' block in the Shoot specification.
-	Zones []Zone `json:"zones"`
+	// +patchMergeKey=region
+	// +patchStrategy=merge
+	Zones []Zone `json:"zones" patchStrategy:"merge" patchMergeKey:"region"`
 }
 
 // MachineImage defines the name and multiple versions of the machine image in any environment.
@@ -116,8 +126,10 @@ type MachineImage struct {
 	// +optional
 	Version string `json:"version,omitempty"`
 	// Versions contains versions and expiration dates of the machine image
+	// +patchMergeKey=version
+	// +patchStrategy=merge
 	// +optional
-	Versions []MachineImageVersion `json:"versions,omitempty"`
+	Versions []MachineImageVersion `json:"versions,omitempty" patchStrategy:"merge" patchMergeKey:"version"`
 }
 
 // MachineImageVersion contains a version and an expiration date of a machine image
@@ -136,27 +148,41 @@ type AzureProfile struct {
 	// Constraints is an object containing constraints for certain values in the Shoot specification.
 	Constraints AzureConstraints `json:"constraints"`
 	// CountUpdateDomains is list of Azure update domain counts for each region.
-	CountUpdateDomains []AzureDomainCount `json:"countUpdateDomains"`
+	// +patchMergeKey=region
+	// +patchStrategy=merge
+	CountUpdateDomains []AzureDomainCount `json:"countUpdateDomains" patchStrategy:"merge" patchMergeKey:"region"`
 	// CountFaultDomains is list of Azure fault domain counts for each region.
-	CountFaultDomains []AzureDomainCount `json:"countFaultDomains"`
+	// +patchMergeKey=region
+	// +patchStrategy=merge
+	CountFaultDomains []AzureDomainCount `json:"countFaultDomains" patchStrategy:"merge" patchMergeKey:"region"`
 }
 
 // AzureConstraints is an object containing constraints for certain values in the Shoot specification.
 type AzureConstraints struct {
 	// DNSProviders contains constraints regarding allowed values of the 'dns.provider' block in the Shoot specification.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	// +optional
-	DNSProviders []DNSProviderConstraint `json:"dnsProviders,omitempty"`
+	DNSProviders []DNSProviderConstraint `json:"dnsProviders,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// Kubernetes contains constraints regarding allowed values of the 'kubernetes' block in the Shoot specification.
 	Kubernetes KubernetesConstraints `json:"kubernetes"`
 	// MachineImages contains constraints regarding allowed values for machine images in the Shoot specification.
-	MachineImages []MachineImage `json:"machineImages"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	MachineImages []MachineImage `json:"machineImages" patchStrategy:"merge" patchMergeKey:"name"`
 	// MachineTypes contains constraints regarding allowed values for machine types in the 'workers' block in the Shoot specification.
-	MachineTypes []MachineType `json:"machineTypes"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	MachineTypes []MachineType `json:"machineTypes" patchStrategy:"merge" patchMergeKey:"name"`
 	// VolumeTypes contains constraints regarding allowed values for volume types in the 'workers' block in the Shoot specification.
-	VolumeTypes []VolumeType `json:"volumeTypes"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	VolumeTypes []VolumeType `json:"volumeTypes" patchStrategy:"merge" patchMergeKey:"name"`
 	// Zones contains constraints regarding allowed values for 'zones' block in the Shoot specification.
+	// +patchMergeKey=region
+	// +patchStrategy=merge
 	// +optional
-	Zones []Zone `json:"zones,omitempty"`
+	Zones []Zone `json:"zones" patchStrategy:"merge" patchMergeKey:"region"`
 }
 
 // AzureDomainCount defines the region and the count for this domain count value.
@@ -176,18 +202,28 @@ type GCPProfile struct {
 // GCPConstraints is an object containing constraints for certain values in the Shoot specification.
 type GCPConstraints struct {
 	// DNSProviders contains constraints regarding allowed values of the 'dns.provider' block in the Shoot specification.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	// +optional
-	DNSProviders []DNSProviderConstraint `json:"dnsProviders,omitempty"`
+	DNSProviders []DNSProviderConstraint `json:"dnsProviders,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// Kubernetes contains constraints regarding allowed values of the 'kubernetes' block in the Shoot specification.
 	Kubernetes KubernetesConstraints `json:"kubernetes"`
 	// MachineImages contains constraints regarding allowed values for machine images in the Shoot specification.
-	MachineImages []MachineImage `json:"machineImages"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	MachineImages []MachineImage `json:"machineImages" patchStrategy:"merge" patchMergeKey:"name"`
 	// MachineTypes contains constraints regarding allowed values for machine types in the 'workers' block in the Shoot specification.
-	MachineTypes []MachineType `json:"machineTypes"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	MachineTypes []MachineType `json:"machineTypes" patchStrategy:"merge" patchMergeKey:"name"`
 	// VolumeTypes contains constraints regarding allowed values for volume types in the 'workers' block in the Shoot specification.
-	VolumeTypes []VolumeType `json:"volumeTypes"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	VolumeTypes []VolumeType `json:"volumeTypes" patchStrategy:"merge" patchMergeKey:"name"`
 	// Zones contains constraints regarding allowed values for 'zones' block in the Shoot specification.
-	Zones []Zone `json:"zones"`
+	// +patchMergeKey=region
+	// +patchStrategy=merge
+	Zones []Zone `json:"zones" patchStrategy:"merge" patchMergeKey:"region"`
 }
 
 // OpenStackProfile defines certain constraints and definitions for the OpenStack cloud.
@@ -211,20 +247,32 @@ type OpenStackProfile struct {
 // OpenStackConstraints is an object containing constraints for certain values in the Shoot specification.
 type OpenStackConstraints struct {
 	// DNSProviders contains constraints regarding allowed values of the 'dns.provider' block in the Shoot specification.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	// +optional
-	DNSProviders []DNSProviderConstraint `json:"dnsProviders,omitempty"`
+	DNSProviders []DNSProviderConstraint `json:"dnsProviders,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// FloatingPools contains constraints regarding allowed values of the 'floatingPoolName' block in the Shoot specification.
-	FloatingPools []OpenStackFloatingPool `json:"floatingPools"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	FloatingPools []OpenStackFloatingPool `json:"floatingPools" patchStrategy:"merge" patchMergeKey:"name"`
 	// Kubernetes contains constraints regarding allowed values of the 'kubernetes' block in the Shoot specification.
 	Kubernetes KubernetesConstraints `json:"kubernetes"`
 	// LoadBalancerProviders contains constraints regarding allowed values of the 'loadBalancerProvider' block in the Shoot specification.
-	LoadBalancerProviders []OpenStackLoadBalancerProvider `json:"loadBalancerProviders"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	LoadBalancerProviders []OpenStackLoadBalancerProvider `json:"loadBalancerProviders" patchStrategy:"merge" patchMergeKey:"name"`
 	// MachineImages contains constraints regarding allowed values for machine images in the Shoot specification.
-	MachineImages []MachineImage `json:"machineImages"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	MachineImages []MachineImage `json:"machineImages" patchStrategy:"merge" patchMergeKey:"name"`
 	// MachineTypes contains constraints regarding allowed values for machine types in the 'workers' block in the Shoot specification.
-	MachineTypes []OpenStackMachineType `json:"machineTypes"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	MachineTypes []OpenStackMachineType `json:"machineTypes" patchStrategy:"merge" patchMergeKey:"name"`
 	// Zones contains constraints regarding allowed values for 'zones' block in the Shoot specification.
-	Zones []Zone `json:"zones"`
+	// +patchMergeKey=region
+	// +patchStrategy=merge
+	Zones []Zone `json:"zones" patchStrategy:"merge" patchMergeKey:"region"`
 }
 
 // OpenStackFloatingPool contains constraints regarding allowed values of the 'floatingPoolName' block in the Shoot specification.
@@ -232,8 +280,10 @@ type OpenStackFloatingPool struct {
 	// Name is the name of the floating pool.
 	Name string `json:"name"`
 	// LoadBalancerClasses contains a list of supported labeled load balancer network settings.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	// +optional
-	LoadBalancerClasses []OpenStackLoadBalancerClass `json:"loadBalancerClasses,omitempty"`
+	LoadBalancerClasses []OpenStackLoadBalancerClass `json:"loadBalancerClasses,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // OpenStackLoadBalancerProvider contains constraints regarding allowed values of the 'loadBalancerProvider' block in the Shoot specification.
@@ -251,18 +301,28 @@ type AlicloudProfile struct {
 // AlicloudConstraints is an object containing constraints for certain values in the Shoot specification
 type AlicloudConstraints struct {
 	// DNSProviders contains constraints regarding allowed values of the 'dns.provider' block in the Shoot specification.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	// +optional
-	DNSProviders []DNSProviderConstraint `json:"dnsProviders,omitempty"`
+	DNSProviders []DNSProviderConstraint `json:"dnsProviders,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// Kubernetes contains constraints regarding allowed values of the 'kubernetes' block in the Shoot specification.
 	Kubernetes KubernetesConstraints `json:"kubernetes"`
 	// MachineImages contains constraints regarding allowed values for machine images in the Shoot specification.
-	MachineImages []MachineImage `json:"machineImages"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	MachineImages []MachineImage `json:"machineImages" patchStrategy:"merge" patchMergeKey:"name"`
 	// MachineTypes contains constraints regarding allowed values for machine types in the 'workers' block in the Shoot specification.
-	MachineTypes []AlicloudMachineType `json:"machineTypes"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	MachineTypes []AlicloudMachineType `json:"machineTypes" patchStrategy:"merge" patchMergeKey:"name"`
 	// VolumeTypes contains constraints regarding allowed values for volume types in the 'workers' block in the Shoot specification.
-	VolumeTypes []AlicloudVolumeType `json:"volumeTypes"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	VolumeTypes []AlicloudVolumeType `json:"volumeTypes" patchStrategy:"merge" patchMergeKey:"name"`
 	// Zones contains constraints regarding allowed values for 'zones' block in the Shoot specification.
-	Zones []Zone `json:"zones"`
+	// +patchMergeKey=region
+	// +patchStrategy=merge
+	Zones []Zone `json:"zones" patchStrategy:"merge" patchMergeKey:"region"`
 }
 
 // AlicloudMachineType defines certain machine types and zone constraints.
@@ -291,13 +351,21 @@ type PacketConstraints struct {
 	// Kubernetes contains constraints regarding allowed values of the 'kubernetes' block in the Shoot specification.
 	Kubernetes KubernetesConstraints `json:"kubernetes"`
 	// MachineImages contains constraints regarding allowed values for machine images in the Shoot specification.
-	MachineImages []MachineImage `json:"machineImages"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	MachineImages []MachineImage `json:"machineImages" patchStrategy:"merge" patchMergeKey:"name"`
 	// MachineTypes contains constraints regarding allowed values for machine types in the 'workers' block in the Shoot specification.
-	MachineTypes []MachineType `json:"machineTypes"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	MachineTypes []MachineType `json:"machineTypes" patchStrategy:"merge" patchMergeKey:"name"`
 	// VolumeTypes contains constraints regarding allowed values for volume types in the 'workers' block in the Shoot specification.
-	VolumeTypes []VolumeType `json:"volumeTypes"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	VolumeTypes []VolumeType `json:"volumeTypes" patchStrategy:"merge" patchMergeKey:"name"`
 	// Zones contains constraints regarding allowed values for 'zones' block in the Shoot specification.
-	Zones []Zone `json:"zones"`
+	// +patchMergeKey=region
+	// +patchStrategy=merge
+	Zones []Zone `json:"zones" patchStrategy:"merge" patchMergeKey:"region"`
 }
 
 // DNSProviderConstraint contains constraints regarding allowed values of the 'dns.provider' block in the Shoot specification.
@@ -312,8 +380,10 @@ type KubernetesConstraints struct {
 	// +optional
 	Versions []string `json:"versions,omitempty"`
 	// OfferedVersions is the list of allowed Kubernetes versions with optional expiration dates for Shoot clusters.
+	// +patchMergeKey=version
+	// +patchStrategy=merge
 	// +optional
-	OfferedVersions []KubernetesVersion `json:"offeredVersions,omitempty"`
+	OfferedVersions []KubernetesVersion `json:"offeredVersions,omitempty" patchStrategy:"merge" patchMergeKey:"version"`
 }
 
 // KubernetesVersion contains the version code and optional expiration date for a kubernetes version
@@ -555,8 +625,10 @@ type SeedStatus struct {
 	// +optional
 	Gardener Gardener `json:"gardener,omitempty"`
 	// Conditions represents the latest available observations of a Seed's current state.
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	// +optional
-	Conditions []gardencorev1alpha1.Condition `json:"conditions,omitempty"`
+	Conditions []gardencorev1alpha1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	// ObservedGeneration is the most recent generation observed for this Seed. It corresponds to the
 	// Seed's generation, which is updated on mutation by the API Server.
 	// +optional
@@ -739,11 +811,15 @@ type ShootSpec struct {
 // ShootStatus holds the most recently observed status of the Shoot cluster.
 type ShootStatus struct {
 	// Conditions represents the latest available observations of a Shoots's current state.
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	// +optional
-	Conditions []gardencorev1alpha1.Condition `json:"conditions,omitempty"`
+	Conditions []gardencorev1alpha1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	// Constraints represents conditions of a Shoot's current state that constraint some operations on it.
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	// +optional
-	Constraints []gardencorev1alpha1.Condition `json:"constraints,omitempty"`
+	Constraints []gardencorev1alpha1.Condition `json:"constraints,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	// Gardener holds information about the Gardener which last acted on the Shoot.
 	Gardener Gardener `json:"gardener"`
 	// LastOperation holds information about the last operation on the Shoot.
@@ -836,7 +912,9 @@ type AWSCloud struct {
 	// Networks holds information about the Kubernetes and infrastructure networks.
 	Networks AWSNetworks `json:"networks"`
 	// Workers is a list of worker groups.
-	Workers []AWSWorker `json:"workers"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	Workers []AWSWorker `json:"workers" patchStrategy:"merge" patchMergeKey:"name"`
 	// Zones is a list of availability zones to deploy the Shoot cluster to.
 	Zones []string `json:"zones"`
 }
@@ -883,7 +961,9 @@ type Alicloud struct {
 	// Networks holds information about the Kubernetes and infrastructure networks.
 	Networks AlicloudNetworks `json:"networks"`
 	// Workers is a list of worker groups.
-	Workers []AlicloudWorker `json:"workers"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	Workers []AlicloudWorker `json:"workers" patchStrategy:"merge" patchMergeKey:"name"`
 	// Zones is a list of availability zones to deploy the Shoot cluster to, currently, only one is supported.
 	Zones []string `json:"zones"`
 }
@@ -926,7 +1006,9 @@ type PacketCloud struct {
 	// Networks holds information about the Kubernetes and infrastructure networks.
 	Networks PacketNetworks `json:"networks"`
 	// Workers is a list of worker groups.
-	Workers []PacketWorker `json:"workers"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	Workers []PacketWorker `json:"workers" patchStrategy:"merge" patchMergeKey:"name"`
 	// Zones is a list of availability zones to deploy the Shoot cluster to, currently, only one is supported.
 	Zones []string `json:"zones"`
 }
@@ -958,7 +1040,9 @@ type AzureCloud struct {
 	// +optional
 	ResourceGroup *AzureResourceGroup `json:"resourceGroup,omitempty"`
 	// Workers is a list of worker groups.
-	Workers []AzureWorker `json:"workers"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	Workers []AzureWorker `json:"workers" patchStrategy:"merge" patchMergeKey:"name"`
 	// Zones is a list of availability zones to deploy the Shoot cluster to.
 	// +optional
 	Zones []string `json:"zones,omitempty"`
@@ -1014,7 +1098,9 @@ type GCPCloud struct {
 	// Networks holds information about the Kubernetes and infrastructure networks.
 	Networks GCPNetworks `json:"networks"`
 	// Workers is a list of worker groups.
-	Workers []GCPWorker `json:"workers"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	Workers []GCPWorker `json:"workers" patchStrategy:"merge" patchMergeKey:"name"`
 	// Zones is a list of availability zones to deploy the Shoot cluster to.
 	Zones []string `json:"zones"`
 }
@@ -1054,8 +1140,10 @@ type OpenStackCloud struct {
 	// LoadBalancerProvider is the name of the load balancer provider in the OpenStack environment.
 	LoadBalancerProvider string `json:"loadBalancerProvider"`
 	// LoadBalancerClasses available for a dedicated Shoot.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	// +optional
-	LoadBalancerClasses []OpenStackLoadBalancerClass `json:"loadBalancerClasses,omitempty"`
+	LoadBalancerClasses []OpenStackLoadBalancerClass `json:"loadBalancerClasses,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// ShootMachineImage holds information about the machine image to use for all workers.
 	// It will default to the latest version of the first image stated in the referenced CloudProfile if no
 	// value has been provided.
@@ -1064,7 +1152,9 @@ type OpenStackCloud struct {
 	// Networks holds information about the Kubernetes and infrastructure networks.
 	Networks OpenStackNetworks `json:"networks"`
 	// Workers is a list of worker groups.
-	Workers []OpenStackWorker `json:"workers"`
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	Workers []OpenStackWorker `json:"workers" patchStrategy:"merge" patchMergeKey:"name"`
 	// Zones is a list of availability zones to deploy the Shoot cluster to.
 	Zones []string `json:"zones"`
 }
@@ -1258,8 +1348,10 @@ type KubeLego struct {
 type Kube2IAM struct {
 	Addon `json:",inline"`
 	// Roles is list of AWS IAM roles which should be created by the Gardener.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	// +optional
-	Roles []Kube2IAMRole `json:"roles,omitempty"`
+	Roles []Kube2IAMRole `json:"roles,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // Kube2IAMRole allows passing AWS IAM policies which will result in IAM roles.
@@ -1414,8 +1506,10 @@ type KubeAPIServerConfig struct {
 	KubernetesConfig `json:",inline"`
 	// AdmissionPlugins contains the list of user-defined admission plugins (additional to those managed by Gardener), and, if desired, the corresponding
 	// configuration.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	// +optional
-	AdmissionPlugins []AdmissionPlugin `json:"admissionPlugins,omitempty"`
+	AdmissionPlugins []AdmissionPlugin `json:"admissionPlugins,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// APIAudiences are the identifiers of the API. The service account token authenticator will
 	// validate that tokens used against the API are bound to at least one of these audiences.
 	// If `serviceAccountConfig.issuer` is configured and this is not, this defaults to a single

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1231,6 +1231,12 @@ func schema_pkg_apis_core_v1alpha1_CloudProfileSpec(ref common.ReferenceCallback
 						},
 					},
 					"machineImages": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "MachineImages contains constraints regarding allowed values for machine images in the Shoot specification.",
 							Type:        []string{"array"},
@@ -1244,6 +1250,12 @@ func schema_pkg_apis_core_v1alpha1_CloudProfileSpec(ref common.ReferenceCallback
 						},
 					},
 					"machineTypes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "MachineTypes contains constraints regarding allowed values for machine types in the 'workers' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -1263,6 +1275,12 @@ func schema_pkg_apis_core_v1alpha1_CloudProfileSpec(ref common.ReferenceCallback
 						},
 					},
 					"regions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Regions contains constraints regarding allowed values for regions and zones.",
 							Type:        []string{"array"},
@@ -1289,6 +1307,12 @@ func schema_pkg_apis_core_v1alpha1_CloudProfileSpec(ref common.ReferenceCallback
 						},
 					},
 					"volumeTypes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "VolumeTypes contains constraints regarding allowed values for volume types in the 'workers' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -1607,6 +1631,12 @@ func schema_pkg_apis_core_v1alpha1_ControllerInstallationStatus(ref common.Refer
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "type",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Conditions represents the latest available observations of a ControllerInstallations's current state.",
 							Type:        []string{"array"},
@@ -1816,6 +1846,12 @@ func schema_pkg_apis_core_v1alpha1_DNS(ref common.ReferenceCallback) common.Open
 						},
 					},
 					"providers": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if not a default domain is used.",
 							Type:        []string{"array"},
@@ -2279,6 +2315,12 @@ func schema_pkg_apis_core_v1alpha1_KubeAPIServerConfig(ref common.ReferenceCallb
 						},
 					},
 					"admissionPlugins": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "AdmissionPlugins contains the list of user-defined admission plugins (additional to those managed by Gardener), and, if desired, the corresponding configuration.",
 							Type:        []string{"array"},
@@ -2843,6 +2885,12 @@ func schema_pkg_apis_core_v1alpha1_KubernetesSettings(ref common.ReferenceCallba
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"versions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "version",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Versions is the list of allowed Kubernetes versions with optional expiration dates for Shoot clusters.",
 							Type:        []string{"array"},
@@ -3007,6 +3055,12 @@ func schema_pkg_apis_core_v1alpha1_MachineImage(ref common.ReferenceCallback) co
 						},
 					},
 					"versions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "version",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Versions contains versions and expiration dates of the machine image",
 							Type:        []string{"array"},
@@ -3565,6 +3619,12 @@ func schema_pkg_apis_core_v1alpha1_PlantSpec(ref common.ReferenceCallback) commo
 						},
 					},
 					"endpoints": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Endpoints is the configuration plant endpoints",
 							Type:        []string{"array"},
@@ -3594,6 +3654,12 @@ func schema_pkg_apis_core_v1alpha1_PlantStatus(ref common.ReferenceCallback) com
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "type",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Conditions represents the latest available observations of a Plant's current state.",
 							Type:        []string{"array"},
@@ -3887,6 +3953,12 @@ func schema_pkg_apis_core_v1alpha1_Provider(ref common.ReferenceCallback) common
 						},
 					},
 					"workers": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Workers is a list of worker groups.",
 							Type:        []string{"array"},
@@ -4067,6 +4139,12 @@ func schema_pkg_apis_core_v1alpha1_Region(ref common.ReferenceCallback) common.O
 						},
 					},
 					"zones": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Zones is a list of availability zones in this region.",
 							Type:        []string{"array"},
@@ -4508,6 +4586,12 @@ func schema_pkg_apis_core_v1alpha1_SeedStatus(ref common.ReferenceCallback) comm
 						},
 					},
 					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "type",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Conditions represents the latest available observations of a Seed's current state.",
 							Type:        []string{"array"},
@@ -4577,6 +4661,12 @@ func schema_pkg_apis_core_v1alpha1_SeedVolume(ref common.ReferenceCallback) comm
 						},
 					},
 					"providers": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Providers is a list of storage class provisioner types for the seed.",
 							Type:        []string{"array"},
@@ -5014,6 +5104,12 @@ func schema_pkg_apis_core_v1alpha1_ShootStateSpec(ref common.ReferenceCallback) 
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"gardener": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Gardener holds the data required to generate resources deployed by the gardenlet",
 							Type:        []string{"array"},
@@ -5055,6 +5151,12 @@ func schema_pkg_apis_core_v1alpha1_ShootStatus(ref common.ReferenceCallback) com
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "type",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Conditions represents the latest available observations of a Shoots's current state.",
 							Type:        []string{"array"},
@@ -5068,6 +5170,12 @@ func schema_pkg_apis_core_v1alpha1_ShootStatus(ref common.ReferenceCallback) com
 						},
 					},
 					"constraints": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "type",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Constraints represents conditions of a Shoot's current state that constraint some operations on it.",
 							Type:        []string{"array"},
@@ -5402,6 +5510,12 @@ func schema_pkg_apis_garden_v1beta1_AWSCloud(ref common.ReferenceCallback) commo
 						},
 					},
 					"workers": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Workers is a list of worker groups.",
 							Type:        []string{"array"},
@@ -5445,6 +5559,12 @@ func schema_pkg_apis_garden_v1beta1_AWSConstraints(ref common.ReferenceCallback)
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"dnsProviders": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "DNSProviders contains constraints regarding allowed values of the 'dns.provider' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -5464,6 +5584,12 @@ func schema_pkg_apis_garden_v1beta1_AWSConstraints(ref common.ReferenceCallback)
 						},
 					},
 					"machineImages": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "MachineImages contains constraints regarding allowed values for machine images in the Shoot specification.",
 							Type:        []string{"array"},
@@ -5477,6 +5603,12 @@ func schema_pkg_apis_garden_v1beta1_AWSConstraints(ref common.ReferenceCallback)
 						},
 					},
 					"machineTypes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "MachineTypes contains constraints regarding allowed values for machine types in the 'workers' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -5490,6 +5622,12 @@ func schema_pkg_apis_garden_v1beta1_AWSConstraints(ref common.ReferenceCallback)
 						},
 					},
 					"volumeTypes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "VolumeTypes contains constraints regarding allowed values for volume types in the 'workers' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -5503,6 +5641,12 @@ func schema_pkg_apis_garden_v1beta1_AWSConstraints(ref common.ReferenceCallback)
 						},
 					},
 					"zones": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "region",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Zones contains constraints regarding allowed values for 'zones' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -5965,6 +6109,12 @@ func schema_pkg_apis_garden_v1beta1_Alicloud(ref common.ReferenceCallback) commo
 						},
 					},
 					"workers": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Workers is a list of worker groups.",
 							Type:        []string{"array"},
@@ -6008,6 +6158,12 @@ func schema_pkg_apis_garden_v1beta1_AlicloudConstraints(ref common.ReferenceCall
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"dnsProviders": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "DNSProviders contains constraints regarding allowed values of the 'dns.provider' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -6027,6 +6183,12 @@ func schema_pkg_apis_garden_v1beta1_AlicloudConstraints(ref common.ReferenceCall
 						},
 					},
 					"machineImages": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "MachineImages contains constraints regarding allowed values for machine images in the Shoot specification.",
 							Type:        []string{"array"},
@@ -6040,6 +6202,12 @@ func schema_pkg_apis_garden_v1beta1_AlicloudConstraints(ref common.ReferenceCall
 						},
 					},
 					"machineTypes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "MachineTypes contains constraints regarding allowed values for machine types in the 'workers' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -6053,6 +6221,12 @@ func schema_pkg_apis_garden_v1beta1_AlicloudConstraints(ref common.ReferenceCall
 						},
 					},
 					"volumeTypes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "VolumeTypes contains constraints regarding allowed values for volume types in the 'workers' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -6066,6 +6240,12 @@ func schema_pkg_apis_garden_v1beta1_AlicloudConstraints(ref common.ReferenceCall
 						},
 					},
 					"zones": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "region",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Zones contains constraints regarding allowed values for 'zones' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -6508,6 +6688,12 @@ func schema_pkg_apis_garden_v1beta1_AzureCloud(ref common.ReferenceCallback) com
 						},
 					},
 					"workers": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Workers is a list of worker groups.",
 							Type:        []string{"array"},
@@ -6551,6 +6737,12 @@ func schema_pkg_apis_garden_v1beta1_AzureConstraints(ref common.ReferenceCallbac
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"dnsProviders": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "DNSProviders contains constraints regarding allowed values of the 'dns.provider' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -6570,6 +6762,12 @@ func schema_pkg_apis_garden_v1beta1_AzureConstraints(ref common.ReferenceCallbac
 						},
 					},
 					"machineImages": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "MachineImages contains constraints regarding allowed values for machine images in the Shoot specification.",
 							Type:        []string{"array"},
@@ -6583,6 +6781,12 @@ func schema_pkg_apis_garden_v1beta1_AzureConstraints(ref common.ReferenceCallbac
 						},
 					},
 					"machineTypes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "MachineTypes contains constraints regarding allowed values for machine types in the 'workers' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -6596,6 +6800,12 @@ func schema_pkg_apis_garden_v1beta1_AzureConstraints(ref common.ReferenceCallbac
 						},
 					},
 					"volumeTypes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "VolumeTypes contains constraints regarding allowed values for volume types in the 'workers' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -6609,6 +6819,12 @@ func schema_pkg_apis_garden_v1beta1_AzureConstraints(ref common.ReferenceCallbac
 						},
 					},
 					"zones": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "region",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Zones contains constraints regarding allowed values for 'zones' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -6736,6 +6952,12 @@ func schema_pkg_apis_garden_v1beta1_AzureProfile(ref common.ReferenceCallback) c
 						},
 					},
 					"countUpdateDomains": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "region",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "CountUpdateDomains is list of Azure update domain counts for each region.",
 							Type:        []string{"array"},
@@ -6749,6 +6971,12 @@ func schema_pkg_apis_garden_v1beta1_AzureProfile(ref common.ReferenceCallback) c
 						},
 					},
 					"countFaultDomains": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "region",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "CountFaultDomains is list of Azure fault domain counts for each region.",
 							Type:        []string{"array"},
@@ -7460,6 +7688,12 @@ func schema_pkg_apis_garden_v1beta1_GCPCloud(ref common.ReferenceCallback) commo
 						},
 					},
 					"workers": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Workers is a list of worker groups.",
 							Type:        []string{"array"},
@@ -7503,6 +7737,12 @@ func schema_pkg_apis_garden_v1beta1_GCPConstraints(ref common.ReferenceCallback)
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"dnsProviders": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "DNSProviders contains constraints regarding allowed values of the 'dns.provider' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -7522,6 +7762,12 @@ func schema_pkg_apis_garden_v1beta1_GCPConstraints(ref common.ReferenceCallback)
 						},
 					},
 					"machineImages": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "MachineImages contains constraints regarding allowed values for machine images in the Shoot specification.",
 							Type:        []string{"array"},
@@ -7535,6 +7781,12 @@ func schema_pkg_apis_garden_v1beta1_GCPConstraints(ref common.ReferenceCallback)
 						},
 					},
 					"machineTypes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "MachineTypes contains constraints regarding allowed values for machine types in the 'workers' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -7548,6 +7800,12 @@ func schema_pkg_apis_garden_v1beta1_GCPConstraints(ref common.ReferenceCallback)
 						},
 					},
 					"volumeTypes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "VolumeTypes contains constraints regarding allowed values for volume types in the 'workers' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -7561,6 +7819,12 @@ func schema_pkg_apis_garden_v1beta1_GCPConstraints(ref common.ReferenceCallback)
 						},
 					},
 					"zones": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "region",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Zones contains constraints regarding allowed values for 'zones' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -8086,6 +8350,12 @@ func schema_pkg_apis_garden_v1beta1_Kube2IAM(ref common.ReferenceCallback) commo
 						},
 					},
 					"roles": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Roles is list of AWS IAM roles which should be created by the Gardener.",
 							Type:        []string{"array"},
@@ -8165,6 +8435,12 @@ func schema_pkg_apis_garden_v1beta1_KubeAPIServerConfig(ref common.ReferenceCall
 						},
 					},
 					"admissionPlugins": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "AdmissionPlugins contains the list of user-defined admission plugins (additional to those managed by Gardener), and, if desired, the corresponding configuration.",
 							Type:        []string{"array"},
@@ -8728,6 +9004,12 @@ func schema_pkg_apis_garden_v1beta1_KubernetesConstraints(ref common.ReferenceCa
 						},
 					},
 					"offeredVersions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "version",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "OfferedVersions is the list of allowed Kubernetes versions with optional expiration dates for Shoot clusters.",
 							Type:        []string{"array"},
@@ -8827,6 +9109,12 @@ func schema_pkg_apis_garden_v1beta1_MachineImage(ref common.ReferenceCallback) c
 						},
 					},
 					"versions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "version",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Versions contains versions and expiration dates of the machine image",
 							Type:        []string{"array"},
@@ -9348,6 +9636,12 @@ func schema_pkg_apis_garden_v1beta1_OpenStackCloud(ref common.ReferenceCallback)
 						},
 					},
 					"loadBalancerClasses": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "LoadBalancerClasses available for a dedicated Shoot.",
 							Type:        []string{"array"},
@@ -9373,6 +9667,12 @@ func schema_pkg_apis_garden_v1beta1_OpenStackCloud(ref common.ReferenceCallback)
 						},
 					},
 					"workers": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Workers is a list of worker groups.",
 							Type:        []string{"array"},
@@ -9416,6 +9716,12 @@ func schema_pkg_apis_garden_v1beta1_OpenStackConstraints(ref common.ReferenceCal
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"dnsProviders": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "DNSProviders contains constraints regarding allowed values of the 'dns.provider' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -9429,6 +9735,12 @@ func schema_pkg_apis_garden_v1beta1_OpenStackConstraints(ref common.ReferenceCal
 						},
 					},
 					"floatingPools": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "FloatingPools contains constraints regarding allowed values of the 'floatingPoolName' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -9448,6 +9760,12 @@ func schema_pkg_apis_garden_v1beta1_OpenStackConstraints(ref common.ReferenceCal
 						},
 					},
 					"loadBalancerProviders": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "LoadBalancerProviders contains constraints regarding allowed values of the 'loadBalancerProvider' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -9461,6 +9779,12 @@ func schema_pkg_apis_garden_v1beta1_OpenStackConstraints(ref common.ReferenceCal
 						},
 					},
 					"machineImages": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "MachineImages contains constraints regarding allowed values for machine images in the Shoot specification.",
 							Type:        []string{"array"},
@@ -9474,6 +9798,12 @@ func schema_pkg_apis_garden_v1beta1_OpenStackConstraints(ref common.ReferenceCal
 						},
 					},
 					"machineTypes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "MachineTypes contains constraints regarding allowed values for machine types in the 'workers' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -9487,6 +9817,12 @@ func schema_pkg_apis_garden_v1beta1_OpenStackConstraints(ref common.ReferenceCal
 						},
 					},
 					"zones": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "region",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Zones contains constraints regarding allowed values for 'zones' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -9523,6 +9859,12 @@ func schema_pkg_apis_garden_v1beta1_OpenStackFloatingPool(ref common.ReferenceCa
 						},
 					},
 					"loadBalancerClasses": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "LoadBalancerClasses contains a list of supported labeled load balancer network settings.",
 							Type:        []string{"array"},
@@ -9947,6 +10289,12 @@ func schema_pkg_apis_garden_v1beta1_PacketCloud(ref common.ReferenceCallback) co
 						},
 					},
 					"workers": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Workers is a list of worker groups.",
 							Type:        []string{"array"},
@@ -10009,6 +10357,12 @@ func schema_pkg_apis_garden_v1beta1_PacketConstraints(ref common.ReferenceCallba
 						},
 					},
 					"machineImages": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "MachineImages contains constraints regarding allowed values for machine images in the Shoot specification.",
 							Type:        []string{"array"},
@@ -10022,6 +10376,12 @@ func schema_pkg_apis_garden_v1beta1_PacketConstraints(ref common.ReferenceCallba
 						},
 					},
 					"machineTypes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "MachineTypes contains constraints regarding allowed values for machine types in the 'workers' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -10035,6 +10395,12 @@ func schema_pkg_apis_garden_v1beta1_PacketConstraints(ref common.ReferenceCallba
 						},
 					},
 					"volumeTypes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "name",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "VolumeTypes contains constraints regarding allowed values for volume types in the 'workers' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -10048,6 +10414,12 @@ func schema_pkg_apis_garden_v1beta1_PacketConstraints(ref common.ReferenceCallba
 						},
 					},
 					"zones": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "region",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Zones contains constraints regarding allowed values for 'zones' block in the Shoot specification.",
 							Type:        []string{"array"},
@@ -10951,6 +11323,12 @@ func schema_pkg_apis_garden_v1beta1_SeedStatus(ref common.ReferenceCallback) com
 						},
 					},
 					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "type",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Conditions represents the latest available observations of a Seed's current state.",
 							Type:        []string{"array"},
@@ -11254,6 +11632,12 @@ func schema_pkg_apis_garden_v1beta1_ShootStatus(ref common.ReferenceCallback) co
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "type",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Conditions represents the latest available observations of a Shoots's current state.",
 							Type:        []string{"array"},
@@ -11267,6 +11651,12 @@ func schema_pkg_apis_garden_v1beta1_ShootStatus(ref common.ReferenceCallback) co
 						},
 					},
 					"constraints": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-patch-merge-key": "type",
+								"x-kubernetes-patch-strategy":  "merge",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Constraints represents conditions of a Shoot's current state that constraint some operations on it.",
 							Type:        []string{"array"},


### PR DESCRIPTION
**What this PR does / why we need it**:

Add merge patch strategy for various list items in different fields.
This allow for adding items to slices and strategically modifying fields in lists.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Patch strategy and patch merge keys are added to the public APIs. This allows for effective usage of [kubectl patch](https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/) command.
```
