### PR TITLE
Prevent potential nil pointer in shoot validator admission plugin

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -161,6 +161,10 @@ func (v *ValidateShoot) Admit(a admission.Attributes, o admission.ObjectInterfac
 		if reflect.DeepEqual(newShoot.Spec, oldShoot.Spec) && reflect.DeepEqual(newShoot.ObjectMeta, oldShoot.ObjectMeta) {
 			return nil
 		}
+
+		if newShoot.Spec.Provider.Type != oldShoot.Spec.Provider.Type {
+			return apierrors.NewBadRequest("shoot provider type was changed which is not allowed")
+		}
 	}
 
 	shoot, ok := a.GetObject().(*garden.Shoot)


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent potential nil pointer in shoot validator admission plugin:

Steps to reproduce the nil pointer exception in gardener-apiserver:
1. have a shoot on aws
1. edit the shoot: `kubectl edit shoot -n <namespace> <name>`
1. delete the section about `aws`, replace it with a valid `gcp` section
1. replace `profile: aws` by `profile: gcp`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
