### PR TITLE
Improve shoot care controller status updates

### DIFF
--- a/pkg/utils/kubernetes/shoot.go
+++ b/pkg/utils/kubernetes/shoot.go
@@ -115,30 +115,6 @@ func TryUpdateShootLabels(g gardencore.Interface, backoff wait.Backoff, meta met
 	})
 }
 
-// TryUpdateShootConditions tries to update the status of the shoot matching the given <meta>.
-// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
-// The transformation function is applied to the current state of the Shoot object. If the transformation
-// yields a semantically equal Shoot (regarding conditions), no update is done and the operation returns normally.
-func TryUpdateShootConditions(g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1alpha1.Shoot) (*gardencorev1alpha1.Shoot, error)) (*gardencorev1alpha1.Shoot, error) {
-	return tryUpdateShoot(g, backoff, meta, transform, func(g gardencore.Interface, shoot *gardencorev1alpha1.Shoot) (*gardencorev1alpha1.Shoot, error) {
-		return g.CoreV1alpha1().Shoots(shoot.Namespace).UpdateStatus(shoot)
-	}, func(cur, updated *gardencorev1alpha1.Shoot) bool {
-		return equality.Semantic.DeepEqual(cur.Status.Conditions, updated.Status.Conditions)
-	})
-}
-
-// TryUpdateShootConstraints tries to update the status of the shoot matching the given <meta>.
-// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
-// The transformation function is applied to the current state of the Shoot object. If the transformation
-// yields a semantically equal Shoot (regarding conditions), no update is done and the operation returns normally.
-func TryUpdateShootConstraints(g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1alpha1.Shoot) (*gardencorev1alpha1.Shoot, error)) (*gardencorev1alpha1.Shoot, error) {
-	return tryUpdateShoot(g, backoff, meta, transform, func(g gardencore.Interface, shoot *gardencorev1alpha1.Shoot) (*gardencorev1alpha1.Shoot, error) {
-		return g.CoreV1alpha1().Shoots(shoot.Namespace).UpdateStatus(shoot)
-	}, func(cur, updated *gardencorev1alpha1.Shoot) bool {
-		return equality.Semantic.DeepEqual(cur.Status.Constraints, updated.Status.Constraints)
-	})
-}
-
 // TryUpdateShootAnnotations tries to update the annotations of the shoot matching the given <meta>.
 // It retries with the given <backoff> characteristics as long as it gets Conflict errors.
 // The transformation function is applied to the current state of the Shoot object. If the transformation


### PR DESCRIPTION
**What this PR does / why we need it**:
The shoot conditions and constraints are now fetched in parallel, but the status of the `Shoot` is only updated once at the end.

**Which issue(s) this PR fixes**:
Fixes #1697

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
