### PR TITLE
Update nginx-ingress version and allow configurability of `externalTrafficPolicy`

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -97,7 +97,7 @@ images:
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-  tag: "0.22.0"
+  tag: "0.26.1"
 - name: ingress-default-backend
   sourceRepository: github.com/gardener/ingress-default-backend
   repository: eu.gcr.io/gardener-project/gardener/ingress-default-backend

--- a/charts/shoot-addons/charts/nginx-ingress/templates/clusterrole.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/clusterrole.yaml
@@ -47,6 +47,7 @@ rules:
       - watch
   - apiGroups:
       - extensions
+      - "networking.k8s.io" # k8s 1.14+
     resources:
       - ingresses
     verbs:
@@ -62,6 +63,7 @@ rules:
       - patch
   - apiGroups:
       - extensions
+      - "networking.k8s.io" # k8s 1.14+
     resources:
       - ingresses/status
     verbs:

--- a/charts/shoot-addons/charts/nginx-ingress/templates/role.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/role.yaml
@@ -13,12 +13,45 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - configmaps
       - namespaces
-      - pods
-      - secrets
     verbs:
       - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - extensions
+      - "networking.k8s.io" # k8s 1.14+
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+      - "networking.k8s.io" # k8s 1.14+
+    resources:
+      - ingresses/status
+    verbs:
+      - update
   - apiGroups:
       - ""
     resources:
@@ -42,4 +75,11 @@ rules:
       - create
       - get
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
 {{- end -}}

--- a/example/90-deprecated-shoot-alicloud.yaml
+++ b/example/90-deprecated-shoot-alicloud.yaml
@@ -179,6 +179,7 @@ spec:
     nginx-ingress:
       enabled: false
       loadBalancerSourceRanges: []
+    # externalTrafficPolicy: Cluster
     # config:
     #   enable-access-log-for-default-backend: "false"
     kubernetes-dashboard:

--- a/example/90-deprecated-shoot-aws.yaml
+++ b/example/90-deprecated-shoot-aws.yaml
@@ -181,6 +181,7 @@ spec:
     nginx-ingress:
       enabled: false
       loadBalancerSourceRanges: []
+    # externalTrafficPolicy: Cluster
     # config:
     #   enable-access-log-for-default-backend: "false"
     kubernetes-dashboard:

--- a/example/90-deprecated-shoot-azure.yaml
+++ b/example/90-deprecated-shoot-azure.yaml
@@ -181,6 +181,7 @@ spec:
     nginx-ingress:
       enabled: false
       loadBalancerSourceRanges: []
+    # externalTrafficPolicy: Cluster
     # config:
     #   enable-access-log-for-default-backend: "false"
     kubernetes-dashboard:

--- a/example/90-deprecated-shoot-gcp.yaml
+++ b/example/90-deprecated-shoot-gcp.yaml
@@ -179,6 +179,7 @@ spec:
     nginx-ingress:
       enabled: false
       loadBalancerSourceRanges: []
+    # externalTrafficPolicy: Cluster
     # config:
     #   enable-access-log-for-default-backend: "false"
     kubernetes-dashboard:

--- a/example/90-deprecated-shoot-openstack.yaml
+++ b/example/90-deprecated-shoot-openstack.yaml
@@ -178,6 +178,7 @@ spec:
     nginx-ingress:
       enabled: false
       loadBalancerSourceRanges: []
+    # externalTrafficPolicy: Cluster
     # config:
     #   enable-access-log-for-default-backend: "false"
     kubernetes-dashboard:

--- a/example/90-deprecated-shoot-packet.yaml
+++ b/example/90-deprecated-shoot-packet.yaml
@@ -174,6 +174,7 @@ spec:
     nginx-ingress:
       enabled: false
       loadBalancerSourceRanges: []
+    # externalTrafficPolicy: Cluster
     # config:
     #   enable-access-log-for-default-backend: "false"
     kubernetes-dashboard:

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -245,6 +245,7 @@ spec:
     nginx-ingress:
       enabled: false
     # loadBalancerSourceRanges: []
+    # externalTrafficPolicy: Cluster
     # config:
     #   enable-access-log-for-default-backend: "false"
     kubernetes-dashboard:

--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -5258,6 +5258,21 @@ map[string]string
 See <a href="https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options">https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options</a></p>
 </td>
 </tr>
+<tr>
+<td>
+<code>externalTrafficPolicy</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#serviceexternaltrafficpolicytype-v1-core">
+Kubernetes core/v1.ServiceExternalTrafficPolicyType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExternalTrafficPolicy controls the <code>.spec.externalTrafficPolicy</code> value of the load balancer <code>Service</code>
+exposing the nginx-ingress. Defaults to <code>Cluster</code>.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="core.gardener.cloud/v1alpha1.OIDCConfig">OIDCConfig
@@ -7394,5 +7409,5 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>cb6aa45dc</code>.
+on git commit <code>722e44a70</code>.
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -3190,5 +3190,5 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>cb6aa45dc</code>.
+on git commit <code>722e44a70</code>.
 </em></p>

--- a/hack/api-reference/garden.md
+++ b/hack/api-reference/garden.md
@@ -5790,6 +5790,21 @@ map[string]string
 See <a href="https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options">https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options</a></p>
 </td>
 </tr>
+<tr>
+<td>
+<code>externalTrafficPolicy</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#serviceexternaltrafficpolicytype-v1-core">
+Kubernetes core/v1.ServiceExternalTrafficPolicyType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExternalTrafficPolicy controls the <code>.spec.externalTrafficPolicy</code> value of the load balancer <code>Service</code>
+exposing the nginx-ingress. Defaults to <code>Cluster</code>.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="garden.sapcloud.io/v1beta1.OIDCConfig">OIDCConfig
@@ -8191,5 +8206,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>cb6aa45dc</code>.
+on git commit <code>722e44a70</code>.
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,5 +555,5 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>cb6aa45dc</code>.
+on git commit <code>722e44a70</code>.
 </em></p>

--- a/hack/templates/resources/90-deprecated-shoot.yaml.tpl
+++ b/hack/templates/resources/90-deprecated-shoot.yaml.tpl
@@ -666,6 +666,7 @@ spec:
     nginx-ingress:
       enabled: ${value("spec.addons.nginx-ingress.enabled", "false")}
       loadBalancerSourceRanges: ${value("spec.addons.nginx-ingress.loadBalancerSourceRanges", [])}
+    # externalTrafficPolicy: Cluster
     # config:
     #   enable-access-log-for-default-backend: "false"
     kubernetes-dashboard:

--- a/pkg/apis/core/v1alpha1/defaults.go
+++ b/pkg/apis/core/v1alpha1/defaults.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/utils"
 
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -155,6 +156,14 @@ func SetDefaults_Worker(obj *Worker) {
 	}
 	if obj.MaxUnavailable == nil {
 		obj.MaxUnavailable = &DefaultWorkerMaxUnavailable
+	}
+}
+
+// SetDefaults_NginxIngress sets default values for NginxIngress objects.
+func SetDefaults_NginxIngress(obj *NginxIngress) {
+	if obj.ExternalTrafficPolicy == nil {
+		v := corev1.ServiceExternalTrafficPolicyTypeCluster
+		obj.ExternalTrafficPolicy = &v
 	}
 }
 

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -182,6 +182,10 @@ type NginxIngress struct {
 	// See https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options
 	// +optional
 	Config map[string]string `json:"config,omitempty"`
+	// ExternalTrafficPolicy controls the `.spec.externalTrafficPolicy` value of the load balancer `Service`
+	// exposing the nginx-ingress. Defaults to `Cluster`.
+	// +optional
+	ExternalTrafficPolicy *corev1.ServiceExternalTrafficPolicyType `json:"externalTrafficPolicy,omitempty"`
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/pkg/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.conversion.go
@@ -3145,6 +3145,7 @@ func autoConvert_v1alpha1_NginxIngress_To_garden_NginxIngress(in *NginxIngress, 
 	}
 	out.LoadBalancerSourceRanges = *(*[]string)(unsafe.Pointer(&in.LoadBalancerSourceRanges))
 	out.Config = *(*map[string]string)(unsafe.Pointer(&in.Config))
+	out.ExternalTrafficPolicy = (*v1.ServiceExternalTrafficPolicyType)(unsafe.Pointer(in.ExternalTrafficPolicy))
 	return nil
 }
 
@@ -3159,6 +3160,7 @@ func autoConvert_garden_NginxIngress_To_v1alpha1_NginxIngress(in *garden.NginxIn
 	}
 	out.LoadBalancerSourceRanges = *(*[]string)(unsafe.Pointer(&in.LoadBalancerSourceRanges))
 	out.Config = *(*map[string]string)(unsafe.Pointer(&in.Config))
+	out.ExternalTrafficPolicy = (*v1.ServiceExternalTrafficPolicyType)(unsafe.Pointer(in.ExternalTrafficPolicy))
 	return nil
 }
 

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1923,6 +1923,11 @@ func (in *NginxIngress) DeepCopyInto(out *NginxIngress) {
 			(*out)[key] = val
 		}
 	}
+	if in.ExternalTrafficPolicy != nil {
+		in, out := &in.ExternalTrafficPolicy, &out.ExternalTrafficPolicy
+		*out = new(v1.ServiceExternalTrafficPolicyType)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/core/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.defaults.go
@@ -65,6 +65,11 @@ func SetObjectDefaults_SecretBindingList(in *SecretBindingList) {
 
 func SetObjectDefaults_Shoot(in *Shoot) {
 	SetDefaults_Shoot(in)
+	if in.Spec.Addons != nil {
+		if in.Spec.Addons.NginxIngress != nil {
+			SetDefaults_NginxIngress(in.Spec.Addons.NginxIngress)
+		}
+	}
 	if in.Spec.Maintenance != nil {
 		SetDefaults_Maintenance(in.Spec.Maintenance)
 	}

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -1197,6 +1197,9 @@ type NginxIngress struct {
 	// Config contains custom configuration for the nginx-ingress-controller configuration.
 	// See https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options
 	Config map[string]string
+	// ExternalTrafficPolicy controls the `.spec.externalTrafficPolicy` value of the load balancer `Service`
+	// exposing the nginx-ingress. Defaults to `Cluster`.
+	ExternalTrafficPolicy *corev1.ServiceExternalTrafficPolicyType
 }
 
 // Monocular describes configuration values for the monocular addon.

--- a/pkg/apis/garden/v1beta1/defaults.go
+++ b/pkg/apis/garden/v1beta1/defaults.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 
 	rbacv1 "k8s.io/api/rbac/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -241,6 +242,14 @@ func SetDefaults_Shoot(obj *Shoot) {
 			defaultAuthMode = KubernetesDashboardAuthModeToken
 		}
 		obj.Spec.Addons.KubernetesDashboard.AuthenticationMode = &defaultAuthMode
+	}
+}
+
+// SetDefaults_NginxIngress sets default values for NginxIngress objects.
+func SetDefaults_NginxIngress(obj *NginxIngress) {
+	if obj.ExternalTrafficPolicy == nil {
+		v := corev1.ServiceExternalTrafficPolicyTypeCluster
+		obj.ExternalTrafficPolicy = &v
 	}
 }
 

--- a/pkg/apis/garden/v1beta1/types.go
+++ b/pkg/apis/garden/v1beta1/types.go
@@ -1329,6 +1329,10 @@ type NginxIngress struct {
 	// See https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options
 	// +optional
 	Config map[string]string `json:"config,omitempty"`
+	// ExternalTrafficPolicy controls the `.spec.externalTrafficPolicy` value of the load balancer `Service`
+	// exposing the nginx-ingress. Defaults to `Cluster`.
+	// +optional
+	ExternalTrafficPolicy *corev1.ServiceExternalTrafficPolicyType `json:"externalTrafficPolicy,omitempty"`
 }
 
 // Monocular describes configuration values for the monocular addon.

--- a/pkg/apis/garden/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.conversion.go
@@ -3684,6 +3684,7 @@ func autoConvert_v1beta1_NginxIngress_To_garden_NginxIngress(in *NginxIngress, o
 	}
 	out.LoadBalancerSourceRanges = *(*[]string)(unsafe.Pointer(&in.LoadBalancerSourceRanges))
 	out.Config = *(*map[string]string)(unsafe.Pointer(&in.Config))
+	out.ExternalTrafficPolicy = (*v1.ServiceExternalTrafficPolicyType)(unsafe.Pointer(in.ExternalTrafficPolicy))
 	return nil
 }
 
@@ -3698,6 +3699,7 @@ func autoConvert_garden_NginxIngress_To_v1beta1_NginxIngress(in *garden.NginxIng
 	}
 	out.LoadBalancerSourceRanges = *(*[]string)(unsafe.Pointer(&in.LoadBalancerSourceRanges))
 	out.Config = *(*map[string]string)(unsafe.Pointer(&in.Config))
+	out.ExternalTrafficPolicy = (*v1.ServiceExternalTrafficPolicyType)(unsafe.Pointer(in.ExternalTrafficPolicy))
 	return nil
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.deepcopy.go
@@ -2257,6 +2257,11 @@ func (in *NginxIngress) DeepCopyInto(out *NginxIngress) {
 			(*out)[key] = val
 		}
 	}
+	if in.ExternalTrafficPolicy != nil {
+		in, out := &in.ExternalTrafficPolicy, &out.ExternalTrafficPolicy
+		*out = new(v1.ServiceExternalTrafficPolicyType)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/garden/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/garden/v1beta1/zz_generated.defaults.go
@@ -126,6 +126,11 @@ func SetObjectDefaults_SeedList(in *SeedList) {
 
 func SetObjectDefaults_Shoot(in *Shoot) {
 	SetDefaults_Shoot(in)
+	if in.Spec.Addons != nil {
+		if in.Spec.Addons.NginxIngress != nil {
+			SetDefaults_NginxIngress(in.Spec.Addons.NginxIngress)
+		}
+	}
 	if in.Spec.Cloud.AWS != nil {
 		for i := range in.Spec.Cloud.AWS.Workers {
 			a := &in.Spec.Cloud.AWS.Workers[i]

--- a/pkg/apis/garden/validation/validation_shoot_test.go
+++ b/pkg/apis/garden/validation/validation_shoot_test.go
@@ -404,6 +404,32 @@ var _ = Describe("Shoot Validation Tests", func() {
 			))
 		})
 
+		It("should allow external traffic policies 'Cluster' for nginx-ingress", func() {
+			v := corev1.ServiceExternalTrafficPolicyTypeCluster
+			shoot.Spec.Addons.NginxIngress.ExternalTrafficPolicy = &v
+			errorList := ValidateShoot(shoot)
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should allow external traffic policies 'Local' for nginx-ingress", func() {
+			v := corev1.ServiceExternalTrafficPolicyTypeLocal
+			shoot.Spec.Addons.NginxIngress.ExternalTrafficPolicy = &v
+			errorList := ValidateShoot(shoot)
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should forbid unsupported external traffic policies for nginx-ingress", func() {
+			v := corev1.ServiceExternalTrafficPolicyType("something-else")
+			shoot.Spec.Addons.NginxIngress.ExternalTrafficPolicy = &v
+
+			errorList := ValidateShoot(shoot)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeNotSupported),
+				"Field": Equal("spec.addons.nginx-ingress.externalTrafficPolicy"),
+			}))))
+		})
+
 		It("should forbid using basic auth mode for kubernetes dashboard when it's disabled in kube-apiserver config", func() {
 			shoot.Spec.Addons.KubernetesDashboard.AuthenticationMode = makeStringPointer(garden.KubernetesDashboardAuthModeBasic)
 			shoot.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication = makeBoolPointer(false)

--- a/pkg/apis/garden/zz_generated.deepcopy.go
+++ b/pkg/apis/garden/zz_generated.deepcopy.go
@@ -2410,6 +2410,11 @@ func (in *NginxIngress) DeepCopyInto(out *NginxIngress) {
 			(*out)[key] = val
 		}
 	}
+	if in.ExternalTrafficPolicy != nil {
+		in, out := &in.ExternalTrafficPolicy, &out.ExternalTrafficPolicy
+		*out = new(v1.ServiceExternalTrafficPolicyType)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3369,6 +3369,13 @@ func schema_pkg_apis_core_v1alpha1_NginxIngress(ref common.ReferenceCallback) co
 							},
 						},
 					},
+					"externalTrafficPolicy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ExternalTrafficPolicy controls the `.spec.externalTrafficPolicy` value of the load balancer `Service` exposing the nginx-ingress. Defaults to `Cluster`.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"enabled"},
 			},
@@ -9471,6 +9478,13 @@ func schema_pkg_apis_garden_v1beta1_NginxIngress(ref common.ReferenceCallback) c
 									},
 								},
 							},
+						},
+					},
+					"externalTrafficPolicy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ExternalTrafficPolicy controls the `.spec.externalTrafficPolicy` value of the load balancer `Service` exposing the nginx-ingress. Defaults to `Cluster`.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -90,6 +90,7 @@ func (b *Botanist) GenerateNginxIngressConfig() (map[string]interface{}, error) 
 				"customConfig": b.Shoot.Info.Spec.Addons.NginxIngress.Config,
 				"service": map[string]interface{}{
 					"loadBalancerSourceRanges": b.Shoot.Info.Spec.Addons.NginxIngress.LoadBalancerSourceRanges,
+					"externalTrafficPolicy":    *b.Shoot.Info.Spec.Addons.NginxIngress.ExternalTrafficPolicy,
 				},
 			},
 		}

--- a/test/integration/framework/applications/guestbooktest.go
+++ b/test/integration/framework/applications/guestbooktest.go
@@ -233,7 +233,6 @@ func (t *GuestBookTest) Cleanup(ctx context.Context, shootTestOperations *framew
 					Name:      RedisMaster,
 				},
 			}
-
 		)
 
 		err := deleteResource(ctx, redisMasterServiceToDelete)


### PR DESCRIPTION
**What this PR does / why we need it**:
* Update of nginx-ingress version from `v0.22.0` to `v0.26.1`.
* Allow configurability of `externalTrafficPolicy` attribute exposing the nginx-ingress load balancer service. Some end-users might want to set it to `Local`. The default is, as earlier, `Cluster`.

**Which issue(s) this PR fixes**:
Fixes #1254

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
It is now possible to configure the external traffic policy for the load balancer service exposing the nginx-ingress addon by setting `.spec.addons.nginx-ingress.externalTrafficPolicy`. It defaults to `Cluster` and valid values are `{Cluster,Local}`.
```
```improvement user
The version of the nginx-ingress addon has been bumped from `v0.22.0` to `v0.26.1`.
```
