### PR TITLE
Set error in ShootStatus if operation cannot be initialized

### DIFF
--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -280,7 +280,7 @@ func ConstructExternalDomain(ctx context.Context, client client.Client, shoot *g
 	case len(shoot.Spec.DNS.Providers) > 0 && shoot.Spec.DNS.Providers[0].SecretName != nil:
 		secret := &corev1.Secret{}
 		if err := client.Get(ctx, kutil.Key(shoot.Namespace, *shoot.Spec.DNS.Providers[0].SecretName), secret); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("could not get dns provider secret \"%s\": %+v", *shoot.Spec.DNS.Providers[0].SecretName, err)
 		}
 		externalDomain.SecretData = secret.Data
 		externalDomain.Provider = *shoot.Spec.DNS.Providers[0].Type


### PR DESCRIPTION
**What this PR does / why we need it**:
Set an error in the Shoot's status if the operation object cannot be initialized.

**Which issue(s) this PR fixes**:
Fixes #1476

If the dns provider secret is missing, the status will look similar to this:
```yaml
status:
  lastOperation:
    description: 'Could not initialize a new operation for Shoot reconciliation: could
      not get dns provider secret "foo": secrets "foo" not found'
    lastUpdateTime: "2019-12-10T07:56:50Z"
    progress: 0
    state: Error
    type: Reconcile
```


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
An issue has been resolved which caused Shoots to be displayed as reconciled successfully instead of showing an error, in case the specified DNS provider secret is missing and the Shoot could not be reconciled or deleted.
```
