### PR TITLE
Temporarily add Kyma addon

### DIFF
--- a/charts/shoot-addons-kyma/Chart.yaml
+++ b/charts/shoot-addons-kyma/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: An umbrella chart for the temporary Kyma chart
+name: shoot-addons-kyma
+version: 0.1.0

--- a/charts/shoot-addons-kyma/charts/kyma/Chart.yaml
+++ b/charts/shoot-addons-kyma/charts/kyma/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1alpha1
+appVersion: "0.1"
+description: Temporarily experimental support for out-of-the-box installation of Kyma
+name: kyma
+version: 0.1.0

--- a/charts/shoot-addons-kyma/charts/kyma/charts/utils-templates
+++ b/charts/shoot-addons-kyma/charts/kyma/charts/utils-templates
@@ -1,0 +1,1 @@
+../../../../utils-templates

--- a/charts/shoot-addons-kyma/charts/kyma/templates/clusterrolebinding.yaml
+++ b/charts/shoot-addons-kyma/charts/kyma/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: kyma-installer
+  labels:
+    app: kyma-on-gardener
+subjects:
+- kind: ServiceAccount
+  name: kyma-installer
+  namespace: kyma-installer
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/shoot-addons-kyma/charts/kyma/templates/kyma.yaml
+++ b/charts/shoot-addons-kyma/charts/kyma/templates/kyma.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kyma
+  namespace: kyma-installer
+data: {}

--- a/charts/shoot-addons-kyma/charts/kyma/templates/namespace.yaml
+++ b/charts/shoot-addons-kyma/charts/kyma/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kyma-installer

--- a/charts/shoot-addons-kyma/charts/kyma/templates/serviceaccount.yaml
+++ b/charts/shoot-addons-kyma/charts/kyma/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kyma-installer
+  namespace: kyma-installer
+  labels:
+    app: kyma-on-gardener

--- a/charts/shoot-addons-kyma/requirements.yaml
+++ b/charts/shoot-addons-kyma/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- name: kyma
+  repository: http://localhost:10191
+  version: 0.1.0
+  condition: kyma.enabled

--- a/charts/shoot-addons-kyma/values.yaml
+++ b/charts/shoot-addons-kyma/values.yaml
@@ -1,0 +1,2 @@
+kyma:
+  enabled: false

--- a/pkg/apis/garden/validation/validation_shoot.go
+++ b/pkg/apis/garden/validation/validation_shoot.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/garden"
 	"github.com/gardener/gardener/pkg/apis/garden/helper"
+	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
 
@@ -146,6 +147,12 @@ func ValidateShootUpdate(newShoot, oldShoot *garden.Shoot) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newShoot.ObjectMeta, &oldShoot.ObjectMeta, field.NewPath("metadata"))...)
+
+	// TODO: Just a temporary solution. Remove this in a future version once Kyma is moved out again.
+	if metav1.HasAnnotation(oldShoot.ObjectMeta, common.ShootExperimentalAddonKyma) && !metav1.HasAnnotation(newShoot.ObjectMeta, common.ShootExperimentalAddonKyma) {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("metadata", "annotations", common.ShootExperimentalAddonKyma), "experimental kyma addon can not be removed/uninstalled - please delete your cluster if you want to get rid of it"))
+	}
+
 	allErrs = append(allErrs, ValidateShootSpecUpdate(&newShoot.Spec, &oldShoot.Spec, newShoot.DeletionTimestamp != nil, field.NewPath("spec"))...)
 	allErrs = append(allErrs, ValidateShoot(newShoot)...)
 

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -131,6 +131,7 @@ func (b *Botanist) DeployManagedResources(ctx context.Context) error {
 			"shoot-core":                   {false, b.generateCoreAddonsChart},
 			"shoot-core-namespaces":        {true, b.generateCoreNamespacesChart},
 			"addons":                       {false, b.generateOptionalAddonsChart},
+			"addons-kyma":                  {false, b.generateTemporaryKymaAddonsChart},
 		}
 	)
 
@@ -359,5 +360,14 @@ func (b *Botanist) generateOptionalAddonsChart() (*chartrenderer.RenderedChart, 
 	return b.ChartApplierShoot.Render(filepath.Join(common.ChartPath, "shoot-addons"), "addons", metav1.NamespaceSystem, map[string]interface{}{
 		"kubernetes-dashboard": kubernetesDashboard,
 		"nginx-ingress":        nginxIngress,
+	})
+}
+
+// generateTemporaryKymaAddonsChart renders the gardener-resource-manager chart for the kyma addon. After that it
+// creates a ManagedResource CRD that references the rendered manifests and creates it.
+// TODO: Just a temporary solution. Remove this in a future version once Kyma is moved out again.
+func (b *Botanist) generateTemporaryKymaAddonsChart() (*chartrenderer.RenderedChart, error) {
+	return b.ChartApplierShoot.Render(filepath.Join(common.ChartPath, "shoot-addons-kyma"), "kyma", "kyma-installer", map[string]interface{}{
+		"kyma": common.GenerateAddonConfig(nil, metav1.HasAnnotation(b.Shoot.Info.ObjectMeta, common.ShootExperimentalAddonKyma)),
 	})
 }

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -247,6 +247,10 @@ const (
 	// SecretRefChecksumAnnotation is the annotation key for checksum of referred secret in resource spec.
 	SecretRefChecksumAnnotation = "checksum/secret.data"
 
+	// ShootExperimentalAddonKyma is a constant for an annotation on the shoot stating that Kyma shall be installed.
+	// TODO: Just a temporary solution. Remove this in a future version once Kyma is moved out again.
+	ShootExperimentalAddonKyma = "experimental.addons.shoot.gardener.cloud/kyma"
+
 	// ShootExpirationTimestamp is an annotation on a Shoot resource whose value represents the time when the Shoot lifetime
 	// is expired. The lifetime can be extended, but at most by the minimal value of the 'clusterLifetimeDays' property
 	// of referenced quotas.

--- a/pkg/registry/garden/shoot/strategy.go
+++ b/pkg/registry/garden/shoot/strategy.go
@@ -117,6 +117,11 @@ func mustIncreaseGeneration(oldShoot, newShoot *garden.Shoot) bool {
 		return true
 	}
 
+	// TODO: Just a temporary solution. Remove this in a future version once Kyma is moved out again.
+	if oldShoot.ObjectMeta.Annotations[common.ShootExperimentalAddonKyma] != newShoot.ObjectMeta.Annotations[common.ShootExperimentalAddonKyma] {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Temporarily add experimental Kyma addon to ease out-of-the-box installation of Kyma for shoot clusters. This is only temporary and will be removed again in a future version of Gardener. The motivation is to show-case which features it provides. It is by no means a production-ready setup.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Gardener now offers a temporary, experimental Kyma addon that can be installed onto shoot clusters out-of-the-box by annotating the `Shoot` with `experimental.addons.shoot.gardener.cloud/kyma=enabled`. Be aware that we won't provide upgrades or customization, and that this addon is temporary and will be removed in a future version of Gardener again. Its purpose is to ease the Kyma installation and to show-case which features it provides. It is by no means a production-ready setup. Also, please note that, once enabled, the Kyma addon can never be disabled again. The only way to get rid of it is to delete the shoot cluster. You can check the status of the installation by using `kubectl -n kyma-installer logs deploy/kyma-installer -f`.
```
