### PR TITLE
Remove health check for calico typha

### DIFF
--- a/pkg/operation/botanist/botanist_suite_test.go
+++ b/pkg/operation/botanist/botanist_suite_test.go
@@ -230,14 +230,12 @@ var _ = Describe("health check", func() {
 
 		// system component deployments
 		calicoKubeControllersDeployment = newDeployment(shootNamespace, common.CalicoKubeControllersDeploymentName, v1alpha1constants.GardenRoleSystemComponent, true)
-		calicoTyphaDeployment           = newDeployment(shootNamespace, common.CalicoTyphaDeploymentName, v1alpha1constants.GardenRoleSystemComponent, true)
 		coreDNSDeployment               = newDeployment(shootNamespace, common.CoreDNSDeploymentName, v1alpha1constants.GardenRoleSystemComponent, true)
 		vpnShootDeployment              = newDeployment(shootNamespace, common.VPNShootDeploymentName, v1alpha1constants.GardenRoleSystemComponent, true)
 		metricsServerDeployment         = newDeployment(shootNamespace, common.MetricsServerDeploymentName, v1alpha1constants.GardenRoleSystemComponent, true)
 
 		requiredSystemComponentDeployments = []*appsv1.Deployment{
 			calicoKubeControllersDeployment,
-			calicoTyphaDeployment,
 			coreDNSDeployment,
 			vpnShootDeployment,
 			metricsServerDeployment,
@@ -422,7 +420,6 @@ var _ = Describe("health check", func() {
 			"0.100.200",
 			[]*appsv1.Deployment{
 				calicoKubeControllersDeployment,
-				calicoTyphaDeployment,
 				coreDNSDeployment,
 				vpnShootDeployment,
 			},
@@ -439,8 +436,7 @@ var _ = Describe("health check", func() {
 			"0.100.200",
 			[]*appsv1.Deployment{
 				calicoKubeControllersDeployment,
-				newDeployment(calicoTyphaDeployment.Namespace, calicoTyphaDeployment.Name, roleOf(calicoTyphaDeployment), false),
-				coreDNSDeployment,
+				newDeployment(coreDNSDeployment.Namespace, coreDNSDeployment.Name, roleOf(coreDNSDeployment), false),
 				vpnShootDeployment,
 				metricsServerDeployment,
 			},

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -189,9 +189,6 @@ const (
 	// CalicoKubeControllersDeploymentName is the name of calico-kube-controllers deployment.
 	CalicoKubeControllersDeploymentName = "calico-kube-controllers"
 
-	// CalicoTyphaDeploymentName is the name of the calico-typha deployment.
-	CalicoTyphaDeploymentName = "calico-typha-deploy"
-
 	// CoreDNSDeploymentName is the name of the coredns deployment.
 	CoreDNSDeploymentName = "coredns"
 
@@ -462,7 +459,6 @@ var (
 	// RequiredSystemComponentDeployments is a set of the required system components.
 	RequiredSystemComponentDeployments = sets.NewString(
 		CalicoKubeControllersDeploymentName,
-		CalicoTyphaDeploymentName,
 		CoreDNSDeploymentName,
 		VPNShootDeploymentName,
 		MetricsServerDeploymentName,


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove health check for calico typha

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
With https://github.com/gardener/gardener-extensions/pull/432 typha can be disabled and this check is failing now for clusters with disabled typha. 

On the other hand, with the extensibility Gardener should not take care for provider specific components like calico, so these health checks have to be implemented by the extensions themselves. See https://github.com/gardener/gardener-extensions/pull/472 for reference.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The system-component health check for calico-typha has been removed.
```

```noteworthy developer
The exported variable `pkg/operation/common.CalicoTyphaDeploymentName` has been removed
```