### PR TITLE
Revert nginx-ingress version to 0.22.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -102,7 +102,7 @@ images:
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-  tag: "0.26.1"
+  tag: "0.22.0"
 - name: ingress-default-backend
   sourceRepository: github.com/gardener/ingress-default-backend
   repository: eu.gcr.io/gardener-project/gardener/ingress-default-backend


### PR DESCRIPTION
**What this PR does / why we need it**:
Revert the deprecated nginx-ingress addon version to 0.22.0 as it breaks certain end-users. Generally, we advice to deploy nginx-ingress on your own and leverage the DNS service extension for shoot clusters in order to get full control over version and customization suitable to your workload's needs.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The version of the nginx-ingress addon has been reverted from `v0.26.1` to `v0.22.0`. Generally, we advice to deploy nginx-ingress on your own and leverage the DNS service extension for shoot clusters in order to get full control over version and customization suitable to your workload's needs.
```