### PR TITLE
Let end users read events

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -153,6 +153,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - garden.sapcloud.io
   - core.gardener.cloud
   resources:
@@ -217,6 +225,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
   - configmaps
   - serviceaccounts
   verbs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow end users of Gardener API to read `Events` resources.
This will allow them to see the events attached to their `Shoots`.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Project members are now allowed to read events in their project namespaces. This is improving the `kubectl describe shoot <shoot-name>` experience. 
```
