### PR TITLE
Fix computation of component descriptor

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -2,22 +2,20 @@
 
 set -e
 
-descriptor_file="${COMPONENT_DESCRIPTOR_PATH}"
 images_file="$(dirname "$0")/../charts/images.yaml"
 images="$(yaml2json < $images_file)"
 
 echo "enriching creating component descriptor from ${BASE_DEFINITION_PATH}"
 
 eval "$(jq -r ".images |
-  map(if (.name != \"gardenlet\") then
-    (if (.name == \"hyperkube\") then
+  map(select(.name != \"gardenlet\") |
+    if (.name == \"hyperkube\") then
       \"--generic-dependencies '{\\\"name\\\": \\\"\" + .name + \"\\\", \\\"version\\\": \\\"\" + .tag + \"\\\"}'\"
     elif (.repository | startswith(\"eu.gcr.io/gardener-project/gardener\")) then
       \"--component-dependencies '{\\\"name\\\": \\\"\" + .sourceRepository + \"\\\", \\\"version\\\": \\\"\" + .tag + \"\\\"}'\"
     else
       \"--container-image-dependencies '{\\\"name\\\": \\\"\" + .name + \"\\\", \\\"image_reference\\\": \\\"\" + .repository + \":\" + .tag + \"\\\", \\\"version\\\": \\\"\" + .tag + \"\\\"}'\"
-    end)
-  end) |
+    end) |
   \"${ADD_DEPENDENCIES_CMD} \\\\\n\" +
   join(\" \\\\\n\")" <<< "$images")"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Without this fix:

```
enriching creating component descriptor from /tmp/build/60e5e9b3/component_descriptor_dir/base_component_descriptor
jq: error: syntax error, unexpected end (Unix shell quoting issues?) at <top-level>, line 10:
  end) |  
jq: error: Possibly unterminated 'if' statement at <top-level>, line 2:
  map(if (.name != "gardenlet") then      
jq: 2 compile errors
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
