### PR TITLE
Add RegEx for new infra dependency

### DIFF
--- a/pkg/apis/core/v1alpha1/helper/errors.go
+++ b/pkg/apis/core/v1alpha1/helper/errors.go
@@ -50,7 +50,7 @@ var (
 	unauthorizedRegexp           = regexp.MustCompile(`(?i)(Unauthorized|InvalidClientTokenId|SignatureDoesNotMatch|Authentication failed|AuthFailure|AuthorizationFailed|invalid character|invalid_grant|invalid_client|Authorization Profile was not found|cannot fetch token|no active subscriptions|InvalidAccessKeyId|InvalidSecretAccessKey)`)
 	quotaExceededRegexp          = regexp.MustCompile(`(?i)(LimitExceeded|Quota)`)
 	insufficientPrivilegesRegexp = regexp.MustCompile(`(?i)(AccessDenied|Forbidden|deny|denied)`)
-	dependenciesRegexp           = regexp.MustCompile(`(?i)(PendingVerification|Access Not Configured|accessNotConfigured|DependencyViolation|OptInRequired|DeleteConflict|Conflict|inactive billing state|ReadOnlyDisabledSubscription|is already being used)`)
+	dependenciesRegexp           = regexp.MustCompile(`(?i)(PendingVerification|Access Not Configured|accessNotConfigured|DependencyViolation|OptInRequired|DeleteConflict|Conflict|inactive billing state|ReadOnlyDisabledSubscription|is already being used|not available in the current hardware cluster)`)
 )
 
 // DetermineError determines the Garden error code for the given error message.

--- a/pkg/apis/core/v1alpha1/helper/errors_test.go
+++ b/pkg/apis/core/v1alpha1/helper/errors_test.go
@@ -38,6 +38,7 @@ var _ = Describe("helper", func() {
 				Entry("quota exceeded", "limitexceeded", NewErrorWithCode(gardencorev1alpha1.ErrorInfraQuotaExceeded, "limitexceeded")),
 				Entry("insufficient privileges", "accessdenied", NewErrorWithCode(gardencorev1alpha1.ErrorInfraInsufficientPrivileges, "accessdenied")),
 				Entry("infrastructure dependencies", "pendingverification", NewErrorWithCode(gardencorev1alpha1.ErrorInfraDependencies, "pendingverification")),
+				Entry("infrastructure dependencies", "not available in the current hardware cluster", NewErrorWithCode(gardencorev1alpha1.ErrorInfraDependencies, "not available in the current hardware cluster")),
 			)
 		})
 	})

--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -50,7 +50,7 @@ var (
 	unauthorizedRegexp           = regexp.MustCompile(`(?i)(Unauthorized|InvalidClientTokenId|SignatureDoesNotMatch|Authentication failed|AuthFailure|AuthorizationFailed|invalid character|invalid_grant|invalid_client|Authorization Profile was not found|cannot fetch token|no active subscriptions|InvalidAccessKeyId|InvalidSecretAccessKey)`)
 	quotaExceededRegexp          = regexp.MustCompile(`(?i)(LimitExceeded|Quota)`)
 	insufficientPrivilegesRegexp = regexp.MustCompile(`(?i)(AccessDenied|Forbidden|deny|denied)`)
-	dependenciesRegexp           = regexp.MustCompile(`(?i)(PendingVerification|Access Not Configured|accessNotConfigured|DependencyViolation|OptInRequired|DeleteConflict|Conflict|inactive billing state|ReadOnlyDisabledSubscription|is already being used)`)
+	dependenciesRegexp           = regexp.MustCompile(`(?i)(PendingVerification|Access Not Configured|accessNotConfigured|DependencyViolation|OptInRequired|DeleteConflict|Conflict|inactive billing state|ReadOnlyDisabledSubscription|is already being used|not available in the current hardware cluster)`)
 )
 
 // DetermineError determines the Garden error code for the given error message.

--- a/pkg/apis/core/v1beta1/helper/errors_test.go
+++ b/pkg/apis/core/v1beta1/helper/errors_test.go
@@ -38,6 +38,7 @@ var _ = Describe("helper", func() {
 				Entry("quota exceeded", "limitexceeded", NewErrorWithCode(gardencorev1beta1.ErrorInfraQuotaExceeded, "limitexceeded")),
 				Entry("insufficient privileges", "accessdenied", NewErrorWithCode(gardencorev1beta1.ErrorInfraInsufficientPrivileges, "accessdenied")),
 				Entry("infrastructure dependencies", "pendingverification", NewErrorWithCode(gardencorev1beta1.ErrorInfraDependencies, "pendingverification")),
+				Entry("infrastructure dependencies", "not available in the current hardware cluster", NewErrorWithCode(gardencorev1beta1.ErrorInfraDependencies, "not available in the current hardware cluster")),
 			)
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
Some cloud providers respond with `not available in the current hardware cluster` when they do not have sufficient machines in this region

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Classify as infrastructure dependency error if a cloud provider does not have sufficient machine types in a region
```
