### PR TITLE
Use internal DNS for dependency-watchdog external probe.

### DIFF
--- a/charts/seed-bootstrap/charts/dependency-watchdog/templates/probe-configmap.yaml
+++ b/charts/seed-bootstrap/charts/dependency-watchdog/templates/probe-configmap.yaml
@@ -12,9 +12,9 @@ data:
     - name: shoot-kube-apiserver
       probe:
         external:
-          kubeconfigSecretName: kubecfg
+          kubeconfigSecretName: dependency-watchdog-external-probe
         internal:
-          kubeconfigSecretName: kubecfg-internal
+          kubeconfigSecretName: dependency-watchdog-internal-probe
       dependantScales:
       - scaleRef:
           apiVersion: {{ include "deploymentversion" . }}

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -548,10 +548,10 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 		},
 	})
 
-	// Secret definition for kubecfg-internal
+	// Secret definition for dependency-watchdog-internal-probe
 	secretList = append(secretList, &secrets.ControlPlaneSecretConfig{
 		CertificateSecretConfig: &secrets.CertificateSecretConfig{
-			Name:      common.KubecfgInternalSecretName,
+			Name:      common.DependencyWatchdogInternalProbeSecretName,
 			SigningCA: certificateAuthorities[v1alpha1constants.SecretNameCACluster],
 		},
 
@@ -561,6 +561,22 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 		KubeConfigRequest: &secrets.KubeConfigRequest{
 			ClusterName:  b.Shoot.SeedNamespace,
 			APIServerURL: fmt.Sprintf("%s.%s.svc", v1alpha1constants.DeploymentNameKubeAPIServer, b.Shoot.SeedNamespace),
+		},
+	})
+
+	// Secret definition for dependency-watchdog-external-probe
+	secretList = append(secretList, &secrets.ControlPlaneSecretConfig{
+		CertificateSecretConfig: &secrets.CertificateSecretConfig{
+			Name:      common.DependencyWatchdogExternalProbeSecretName,
+			SigningCA: certificateAuthorities[v1alpha1constants.SecretNameCACluster],
+		},
+
+		BasicAuth: basicAuthAPIServer,
+		Token:     kubecfgToken,
+
+		KubeConfigRequest: &secrets.KubeConfigRequest{
+			ClusterName:  b.Shoot.SeedNamespace,
+			APIServerURL: b.Shoot.ComputeAPIServerURL(false, true, b.APIServerAddress),
 		},
 	})
 

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -219,8 +219,14 @@ const (
 	// KubecfgSecretName is the name of the kubecfg secret.
 	KubecfgSecretName = "kubecfg"
 
-	// KubecfgInternalSecretName is the name of the kubecfg secret with cluster IP access.
-	KubecfgInternalSecretName = "kubecfg-internal"
+	// DependencyWatchdogExternalProbeSecretName is the name of the kubecfg secret with internal DNS for external access.
+	DependencyWatchdogExternalProbeSecretName = "dependency-watchdog-external-probe"
+
+	// DependencyWatchdogInternalProbeSecretName is the name of the kubecfg secret with cluster IP access.
+	DependencyWatchdogInternalProbeSecretName = "dependency-watchdog-internal-probe"
+
+	// DeprecatedKubecfgInternalProbeSecretName is the name of the kubecfg secret with cluster IP access.
+	DeprecatedKubecfgInternalProbeSecretName = "kubecfg-internal"
 
 	// KubeAPIServerHealthCheck is a key for the kube-apiserver-health-check user.
 	KubeAPIServerHealthCheck = "kube-apiserver-health-check"

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -760,6 +760,7 @@ func deleteDependencyWatchdogFromNS(crClient client.Client, ns string) error {
 		{"", "v1", "ConfigMap", v1alpha1constants.ConfigMapNameDependencyWatchdog},
 		{"rbac.authorization.k8s.io", "v1", "RoleBinding", v1alpha1constants.RoleBindingNameDependencyWatchdog},
 		{"", "v1", "ServiceAccount", v1alpha1constants.ServiceAccountNameDependencyWatchdog},
+		{"", "v1", "Secret", common.DeprecatedKubecfgInternalProbeSecretName},
 	} {
 		u := &unstructured.Unstructured{}
 		u.SetName(obj.name)


### PR DESCRIPTION
**What this PR does / why we need it**:
The external probe of dependency-watchdog now uses the internal DNS to the shoot apiserver to avoid clash with shoot deletion workflow.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The external probe of dependency-watchdog now uses the internal DNS to the shoot apiserver to avoid clash with shoot deletion workflow.
```