### PR TITLE
Add install section to downloader osc

### DIFF
--- a/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
+++ b/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
@@ -28,6 +28,8 @@ spec:
       RestartSec=30
       EnvironmentFile=/etc/environment
       ExecStart=/var/lib/cloud-config-downloader/download-cloud-config.sh
+      [Install]
+      WantedBy=multi-user.target
   files:
   - path: /var/lib/cloud-config-downloader/credentials/server
     permissions: 0644


### PR DESCRIPTION
**What this PR does / why we need it**:
Without the install section, at least ubuntu does not automatically start this service even if enabled, coreos on the other side also specifies this section in all of their services, see https://coreos.com/os/docs/latest/using-systemd-drop-in-units.html

This is a cherry-pick of 9c5fa19eb63c2a48c8fc684afaf3e5f4ac5a7543.

**Special notes for your reviewer**:
Please only merge after Gardener-Extensions v1.1.0 has been released. It includes a change which prevents that all worker nodes will be rolled (https://github.com/gardener/gardener-extensions/pull/474).

/cc @majst01 @Gerrit91 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The bootstrap procedure for node workers has been improved. In some Gardener setups, Ubuntu machines were not able to join the cluster because the `cloud-config-downloader` service didn't start automatically. Please note that all nodes will be rolled out in case your `Worker` extension controllers are not using [`v1.1.0`](https://github.com/gardener/gardener-extensions/releases/tag/v1.1.0) (see https://github.com/gardener/gardener-extensions/pull/474 for more information). [Contributed by @majst01]
```
