### PR TITLE
Allow 1.17 Kubernetes clients to be instantiated

### DIFF
--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -228,6 +228,7 @@ var supportedKubernetesVersions = []string{
 	"1.14",
 	"1.15",
 	"1.16",
+	"1.17",
 }
 
 func checkIfSupportedKubernetesVersion(gitVersion string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow 1.17 Kubernetes clients to be instantiated. The extensions revendor the g/g repo and cannot instantiate a client without this change.

**Which issue(s) this PR fixes**:
Part of #1709

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
