### PR TITLE
Make validation func public

### DIFF
--- a/pkg/apis/garden/validation/validation_shoot.go
+++ b/pkg/apis/garden/validation/validation_shoot.go
@@ -767,16 +767,16 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *garden.ShootSpec, deletionTimesta
 		allErrs = append(allErrs, validateK8SNetworksImmutability(oldSpec.Cloud.AWS.Networks.K8SNetworks, newSpec.Cloud.AWS.Networks.K8SNetworks, awsPath.Child("networks"))...)
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.AWS.Networks.VPC, oldSpec.Cloud.AWS.Networks.VPC, awsPath.Child("networks", "vpc"))...)
 
-		if shouldEnforceImmutability(newSpec.Cloud.AWS.Networks.Internal, oldSpec.Cloud.AWS.Networks.Internal) {
+		if ShouldEnforceImmutability(newSpec.Cloud.AWS.Networks.Internal, oldSpec.Cloud.AWS.Networks.Internal) {
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.AWS.Networks.Internal, oldSpec.Cloud.AWS.Networks.Internal, awsPath.Child("networks", "internal"))...)
 		}
-		if shouldEnforceImmutability(newSpec.Cloud.AWS.Networks.Public, oldSpec.Cloud.AWS.Networks.Public) {
+		if ShouldEnforceImmutability(newSpec.Cloud.AWS.Networks.Public, oldSpec.Cloud.AWS.Networks.Public) {
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.AWS.Networks.Public, oldSpec.Cloud.AWS.Networks.Public, awsPath.Child("networks", "public"))...)
 		}
-		if shouldEnforceImmutability(newSpec.Cloud.AWS.Networks.Workers, oldSpec.Cloud.AWS.Networks.Workers) {
+		if ShouldEnforceImmutability(newSpec.Cloud.AWS.Networks.Workers, oldSpec.Cloud.AWS.Networks.Workers) {
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.AWS.Networks.Workers, oldSpec.Cloud.AWS.Networks.Workers, awsPath.Child("networks", "workers"))...)
 		}
-		if shouldEnforceImmutability(newSpec.Cloud.AWS.Zones, oldSpec.Cloud.AWS.Zones) {
+		if ShouldEnforceImmutability(newSpec.Cloud.AWS.Zones, oldSpec.Cloud.AWS.Zones) {
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.AWS.Zones, oldSpec.Cloud.AWS.Zones, awsPath.Child("zones"))...)
 		}
 	}
@@ -797,7 +797,7 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *garden.ShootSpec, deletionTimesta
 		} else if len(oldSpec.Cloud.Azure.Zones) == 0 && len(newSpec.Cloud.Azure.Zones) > 0 {
 			allErrs = append(allErrs, field.ErrorList{field.Invalid(azurePath.Child("zones"), newSpec.Cloud.Azure.Zones, "Can't move from non zoned cluster to zoned cluster")}...)
 		} else {
-			if shouldEnforceImmutability(newSpec.Cloud.Azure.Zones, oldSpec.Cloud.Azure.Zones) {
+			if ShouldEnforceImmutability(newSpec.Cloud.Azure.Zones, oldSpec.Cloud.Azure.Zones) {
 				allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.Azure.Zones, oldSpec.Cloud.Azure.Zones, azurePath.Child("zones"))...)
 			}
 		}
@@ -813,7 +813,7 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *garden.ShootSpec, deletionTimesta
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.GCP.Networks.Internal, oldSpec.Cloud.GCP.Networks.Internal, gcpPath.Child("networks", "internal"))...)
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.GCP.Networks.Workers, oldSpec.Cloud.GCP.Networks.Workers, gcpPath.Child("networks", "workers"))...)
 
-		if shouldEnforceImmutability(newSpec.Cloud.GCP.Zones, oldSpec.Cloud.GCP.Zones) {
+		if ShouldEnforceImmutability(newSpec.Cloud.GCP.Zones, oldSpec.Cloud.GCP.Zones) {
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.GCP.Zones, oldSpec.Cloud.GCP.Zones, gcpPath.Child("zones"))...)
 		}
 	}
@@ -827,7 +827,7 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *garden.ShootSpec, deletionTimesta
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.OpenStack.Networks.Router, oldSpec.Cloud.OpenStack.Networks.Router, openStackPath.Child("networks", "router"))...)
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.OpenStack.Networks.Workers, oldSpec.Cloud.OpenStack.Networks.Workers, openStackPath.Child("networks", "workers"))...)
 
-		if shouldEnforceImmutability(newSpec.Cloud.OpenStack.Zones, oldSpec.Cloud.OpenStack.Zones) {
+		if ShouldEnforceImmutability(newSpec.Cloud.OpenStack.Zones, oldSpec.Cloud.OpenStack.Zones) {
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.OpenStack.Zones, oldSpec.Cloud.OpenStack.Zones, openStackPath.Child("zones"))...)
 		}
 	}
@@ -840,10 +840,10 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *garden.ShootSpec, deletionTimesta
 		allErrs = append(allErrs, validateK8SNetworksImmutability(oldSpec.Cloud.Alicloud.Networks.K8SNetworks, newSpec.Cloud.Alicloud.Networks.K8SNetworks, alicloudPath.Child("networks"))...)
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.Alicloud.Networks.VPC, oldSpec.Cloud.Alicloud.Networks.VPC, alicloudPath.Child("networks", "vpc"))...)
 
-		if shouldEnforceImmutability(newSpec.Cloud.Alicloud.Networks.Workers, oldSpec.Cloud.Alicloud.Networks.Workers) {
+		if ShouldEnforceImmutability(newSpec.Cloud.Alicloud.Networks.Workers, oldSpec.Cloud.Alicloud.Networks.Workers) {
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.Alicloud.Networks.Workers, oldSpec.Cloud.Alicloud.Networks.Workers, alicloudPath.Child("networks", "workers"))...)
 		}
-		if shouldEnforceImmutability(newSpec.Cloud.Alicloud.Zones, oldSpec.Cloud.Alicloud.Zones) {
+		if ShouldEnforceImmutability(newSpec.Cloud.Alicloud.Zones, oldSpec.Cloud.Alicloud.Zones) {
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.Alicloud.Zones, oldSpec.Cloud.Alicloud.Zones, alicloudPath.Child("zones"))...)
 		}
 	}

--- a/pkg/apis/garden/validation/validation_utils.go
+++ b/pkg/apis/garden/validation/validation_utils.go
@@ -15,10 +15,11 @@
 package validation
 
 import (
+	"strconv"
+
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"strconv"
 )
 
 // ValidateName is a helper function for validating that a name is a DNS sub domain.
@@ -45,14 +46,17 @@ func getPercentValue(intOrStringValue intstr.IntOrString) (int, bool) {
 	return value, true
 }
 
-func shouldEnforceImmutability(new, old []string) bool {
+// ShouldEnforceImmutability compares the given slices and returns if a immutability should be enforced.
+// It mainly checks if the order of the same elements in `new` and `old` is the same, i.e. only an addition
+// of elements to `new` is allowed.
+func ShouldEnforceImmutability(new, old []string) bool {
 	sizeDelta := len(new) - len(old)
 	if sizeDelta > 0 {
 		newA := new[:len(new)-sizeDelta]
 		if equal(newA, old) {
 			return false
 		}
-		return shouldEnforceImmutability(newA, old)
+		return ShouldEnforceImmutability(newA, old)
 	}
 	return sizeDelta < 0 || sizeDelta == 0
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This change is required to let other modules reuse the `ShouldEnforceImmutability` validation function.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
