### PR TITLE
Let gardenlet delete the bootstrap token itself

### DIFF
--- a/cmd/gardenlet/app/bootstrap.go
+++ b/cmd/gardenlet/app/bootstrap.go
@@ -40,29 +40,29 @@ func bootstrapKubeconfig(
 	gardenClientConnection *config.GardenClientConnection,
 	seedClientConnection componentbaseconfig.ClientConnectionConfiguration,
 	seedConfig *config.SeedConfig,
-) ([]byte, error) {
+) ([]byte, string, error) {
 	seedRESTCfg, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&seedClientConnection, nil)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	k8sSeedClient, err := kubernetes.NewWithConfig(kubernetes.WithRESTConfig(seedRESTCfg))
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	kubeconfigSecret := &corev1.Secret{}
 	if err := k8sSeedClient.Client().Get(ctx, kutil.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), kubeconfigSecret); client.IgnoreNotFound(err) != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	if len(kubeconfigSecret.Data[kubernetes.KubeConfig]) > 0 {
 		logger.Info("Found kubeconfig generated from bootstrap process. Using it")
-		return kubeconfigSecret.Data[kubernetes.KubeConfig], nil
+		return kubeconfigSecret.Data[kubernetes.KubeConfig], "", nil
 	}
 
 	// kubeconfig secret not found or empty - trigger bootstrap process
 	if gardenClientConnection.BootstrapKubeconfig == nil {
-		return nil, fmt.Errorf("cannot trigger kubeconfig bootstrap process because `.gardenClientConnection.bootstrapKubeconfig` is not set")
+		return nil, "", fmt.Errorf("cannot trigger kubeconfig bootstrap process because `.gardenClientConnection.bootstrapKubeconfig` is not set")
 	}
 
 	logger.Info("No kubeconfig for garden cluster found, but bootstrap kubeconfig was given.")
@@ -70,24 +70,24 @@ func bootstrapKubeconfig(
 	// check if we got a kubeconfig for bootstrapping
 	bootstrapKubeconfigSecret := &corev1.Secret{}
 	if err := k8sSeedClient.Client().Get(ctx, kutil.Key(gardenClientConnection.BootstrapKubeconfig.Namespace, gardenClientConnection.BootstrapKubeconfig.Name), bootstrapKubeconfigSecret); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if len(bootstrapKubeconfigSecret.Data[kubernetes.KubeConfig]) == 0 {
-		return nil, fmt.Errorf("bootstrap kubeconfig secret does not contain a kubeconfig")
+		return nil, "", fmt.Errorf("bootstrap kubeconfig secret does not contain a kubeconfig")
 	}
 
 	// create certificate client with bootstrap kubeconfig in order to create CSR
 	bootstrapClientConfig, err := clientcmd.NewClientConfigFromBytes(bootstrapKubeconfigSecret.Data[kubernetes.KubeConfig])
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	bootstrapConfig, err := bootstrapClientConfig.ClientConfig()
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	bootstrapClient, err := certificatesv1beta1client.NewForConfig(bootstrapConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create certificates signing request client: %v", err)
+		return nil, "", fmt.Errorf("unable to create certificates signing request client: %v", err)
 	}
 
 	logger.Info("Creating certificate signing request...")
@@ -99,11 +99,11 @@ func bootstrapKubeconfig(
 	}
 	privateKeyData, err := keyutil.MakeEllipticPrivateKeyPEM()
 	if err != nil {
-		return nil, fmt.Errorf("error generating key: %v", err)
+		return nil, "", fmt.Errorf("error generating key: %v", err)
 	}
-	certData, err := bootstrap.RequestSeedCertificate(ctx, bootstrapClient.CertificateSigningRequests(), privateKeyData, seedName)
+	certData, csrName, err := bootstrap.RequestSeedCertificate(ctx, bootstrapClient.CertificateSigningRequests(), privateKeyData, seedName)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	logger.Infof("Certificate signing request got approved! Creating kubeconfig and storing it in secret %s/%s", gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name)
@@ -111,7 +111,7 @@ func bootstrapKubeconfig(
 	// marshal kubeconfig with just derived client certificate
 	kubeconfig, err := bootstrap.MarshalKubeconfigFromBootstrapping(bootstrapConfig, privateKeyData, certData)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	// store kubeconfig in kubeconfig secret in seed cluster and delete bootstrap kubeconfig secret
@@ -123,14 +123,14 @@ func bootstrapKubeconfig(
 		kubeconfigSecret.Data = map[string][]byte{kubernetes.KubeConfig: kubeconfig}
 		return nil
 	}); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	logger.Infof("Deleting secret %s/%s holding bootstrap kubeconfig", gardenClientConnection.BootstrapKubeconfig.Namespace, gardenClientConnection.BootstrapKubeconfig.Name)
 
 	if err := k8sSeedClient.Client().Delete(ctx, bootstrapKubeconfigSecret); client.IgnoreNotFound(err) != nil {
-		return nil, err
+		return nil, "", err
 	}
 
-	return kubeconfig, nil
+	return kubeconfig, csrName, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Let gardenlet delete the bootstrap token itself. After requesting the certificate the gardenlet waits until it's approved and issued. The controller-manager just waited for approval but not for issuing. Hence, there might be a race condition. I've seen cases where GCM deleted the bootstrap token before the gardenlet could fetch the cert after approval, and then got stuck because it could no longer talk to the kube-apiserver (as the bootstrap token was already deleted).
Generally, it's better to let the gardenlet delete its bootstrap token itself as soon as it is ready such that these race conditions cannot happen in the first place. GCM is only responsible for auto-approval now.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
