### PR TITLE
Let extensions API use v1beta1 version of core API

### DIFF
--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -7157,5 +7157,5 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>857401a84</code>.
+on git commit <code>1d09d6259</code>.
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -1744,7 +1744,7 @@ string
 <code>conditions</code></br>
 <em>
 <a href="../core#core.gardener.cloud/v1alpha1.Condition">
-[]github.com/gardener/gardener/pkg/apis/core/v1alpha1.Condition
+[]github.com/gardener/gardener/pkg/apis/core/v1beta1.Condition
 </a>
 </em>
 </td>
@@ -1758,7 +1758,7 @@ string
 <code>lastError</code></br>
 <em>
 <a href="../core#core.gardener.cloud/v1alpha1.LastError">
-github.com/gardener/gardener/pkg/apis/core/v1alpha1.LastError
+github.com/gardener/gardener/pkg/apis/core/v1beta1.LastError
 </a>
 </em>
 </td>
@@ -1772,7 +1772,7 @@ github.com/gardener/gardener/pkg/apis/core/v1alpha1.LastError
 <code>lastOperation</code></br>
 <em>
 <a href="../core#core.gardener.cloud/v1alpha1.LastOperation">
-github.com/gardener/gardener/pkg/apis/core/v1alpha1.LastOperation
+github.com/gardener/gardener/pkg/apis/core/v1beta1.LastOperation
 </a>
 </em>
 </td>
@@ -3190,5 +3190,5 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>857401a84</code>.
+on git commit <code>1d09d6259</code>.
 </em></p>

--- a/hack/api-reference/garden.md
+++ b/hack/api-reference/garden.md
@@ -8223,5 +8223,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>857401a84</code>.
+on git commit <code>1d09d6259</code>.
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,5 +555,5 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>857401a84</code>.
+on git commit <code>1d09d6259</code>.
 </em></p>

--- a/pkg/api/extensions/accessor.go
+++ b/pkg/api/extensions/accessor.go
@@ -17,7 +17,7 @@ package extensions
 import (
 	"fmt"
 
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -128,13 +128,13 @@ func (u unstructuredLastOperationAccessor) GetProgress() int {
 }
 
 // GetState implements LastOperation.
-func (u unstructuredLastOperationAccessor) GetState() gardencorev1alpha1.LastOperationState {
-	return gardencorev1alpha1.LastOperationState(nestedString(u.UnstructuredContent(), "status", "lastOperation", "state"))
+func (u unstructuredLastOperationAccessor) GetState() gardencorev1beta1.LastOperationState {
+	return gardencorev1beta1.LastOperationState(nestedString(u.UnstructuredContent(), "status", "lastOperation", "state"))
 }
 
 // GetType implements LastOperation.
-func (u unstructuredLastOperationAccessor) GetType() gardencorev1alpha1.LastOperationType {
-	return gardencorev1alpha1.LastOperationType(nestedString(u.UnstructuredContent(), "status", "lastOperation", "type"))
+func (u unstructuredLastOperationAccessor) GetType() gardencorev1beta1.LastOperationType {
+	return gardencorev1beta1.LastOperationType(nestedString(u.UnstructuredContent(), "status", "lastOperation", "type"))
 }
 
 // GetExtensionType implements Spec.
@@ -143,16 +143,16 @@ func (u unstructuredSpecAccessor) GetExtensionType() string {
 }
 
 // GetConditions implements Status.
-func (u unstructuredStatusAccessor) GetConditions() []gardencorev1alpha1.Condition {
+func (u unstructuredStatusAccessor) GetConditions() []gardencorev1beta1.Condition {
 	val, ok, err := unstructured.NestedFieldNoCopy(u.UnstructuredContent(), "status", "conditions")
 	if err != nil || !ok {
 		return nil
 	}
-	var conditions []gardencorev1alpha1.Condition
+	var conditions []gardencorev1beta1.Condition
 	interfaceConditionSlice := val.([]interface{})
 	for _, interfaceCondition := range interfaceConditionSlice {
 		new := interfaceCondition.(map[string]interface{})
-		condition := &gardencorev1alpha1.Condition{}
+		condition := &gardencorev1beta1.Condition{}
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(new, condition)
 		if err != nil {
 			return nil
@@ -163,7 +163,7 @@ func (u unstructuredStatusAccessor) GetConditions() []gardencorev1alpha1.Conditi
 }
 
 // SetConditions implements Status.
-func (u unstructuredStatusAccessor) SetConditions(conditions []gardencorev1alpha1.Condition) {
+func (u unstructuredStatusAccessor) SetConditions(conditions []gardencorev1beta1.Condition) {
 	var interfaceSlice = make([]interface{}, len(conditions))
 	for i, d := range conditions {
 		unstrc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&d)
@@ -207,11 +207,11 @@ func (u unstructuredLastErrorAccessor) GetTaskID() *string {
 }
 
 // GetCodes implements LastError.
-func (u unstructuredLastErrorAccessor) GetCodes() []gardencorev1alpha1.ErrorCode {
+func (u unstructuredLastErrorAccessor) GetCodes() []gardencorev1beta1.ErrorCode {
 	codeStrings := nestedStringSlice(u.Object, "status", "lastError", "codes")
-	var codes []gardencorev1alpha1.ErrorCode
+	var codes []gardencorev1beta1.ErrorCode
 	for _, codeString := range codeStrings {
-		codes = append(codes, gardencorev1alpha1.ErrorCode(codeString))
+		codes = append(codes, gardencorev1beta1.ErrorCode(codeString))
 	}
 	return codes
 }

--- a/pkg/api/extensions/accessor_test.go
+++ b/pkg/api/extensions/accessor_test.go
@@ -17,9 +17,10 @@ package extensions
 import (
 	"time"
 
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsinstall "github.com/gardener/gardener/pkg/apis/extensions/install"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -51,7 +52,7 @@ func mkUnstructuredAccessorWithStatus(status extensionsv1alpha1.DefaultStatus) e
 	return mkUnstructuredAccessor(&extensionsv1alpha1.Infrastructure{Status: extensionsv1alpha1.InfrastructureStatus{DefaultStatus: status}}).GetExtensionStatus()
 }
 
-func mkUnstructuredAccessorWithLastOperation(lastOperation *gardencorev1alpha1.LastOperation) extensionsv1alpha1.LastOperation {
+func mkUnstructuredAccessorWithLastOperation(lastOperation *gardencorev1beta1.LastOperation) extensionsv1alpha1.LastOperation {
 	return mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{LastOperation: lastOperation}).GetLastOperation()
 }
 
@@ -65,7 +66,7 @@ var _ = Describe("Accessor", func() {
 			Expect(acc).To(BeIdenticalTo(extension))
 		})
 
-		It("should create an unstructured accessor for unstructures", func() {
+		It("should create an unstructured accessor for unstructured", func() {
 			u := &unstructured.Unstructured{}
 			acc, err := Accessor(u)
 
@@ -100,7 +101,7 @@ var _ = Describe("Accessor", func() {
 					It("should get the description", func() {
 						var (
 							desc = "desc"
-							acc  = mkUnstructuredAccessorWithLastOperation(&gardencorev1alpha1.LastOperation{Description: desc})
+							acc  = mkUnstructuredAccessorWithLastOperation(&gardencorev1beta1.LastOperation{Description: desc})
 						)
 
 						Expect(acc.GetDescription()).To(Equal(desc))
@@ -111,7 +112,7 @@ var _ = Describe("Accessor", func() {
 					It("should get the last update time", func() {
 						var (
 							t   = metav1.NewTime(time.Unix(50, 0))
-							acc = mkUnstructuredAccessorWithLastOperation(&gardencorev1alpha1.LastOperation{LastUpdateTime: t})
+							acc = mkUnstructuredAccessorWithLastOperation(&gardencorev1beta1.LastOperation{LastUpdateTime: t})
 						)
 
 						Expect(acc.GetLastUpdateTime()).To(Equal(t))
@@ -122,7 +123,7 @@ var _ = Describe("Accessor", func() {
 					It("should get the progress", func() {
 						var (
 							progress = 10
-							acc      = mkUnstructuredAccessorWithLastOperation(&gardencorev1alpha1.LastOperation{Progress: progress})
+							acc      = mkUnstructuredAccessorWithLastOperation(&gardencorev1beta1.LastOperation{Progress: progress})
 						)
 
 						Expect(acc.GetProgress()).To(Equal(progress))
@@ -132,8 +133,8 @@ var _ = Describe("Accessor", func() {
 				Describe("#GetState", func() {
 					It("should get the state", func() {
 						var (
-							state = gardencorev1alpha1.LastOperationStateSucceeded
-							acc   = mkUnstructuredAccessorWithLastOperation(&gardencorev1alpha1.LastOperation{State: state})
+							state = gardencorev1beta1.LastOperationStateSucceeded
+							acc   = mkUnstructuredAccessorWithLastOperation(&gardencorev1beta1.LastOperation{State: state})
 						)
 
 						Expect(acc.GetState()).To(Equal(state))
@@ -143,8 +144,8 @@ var _ = Describe("Accessor", func() {
 				Describe("#GetType", func() {
 					It("should get the type", func() {
 						var (
-							t   = gardencorev1alpha1.LastOperationTypeReconcile
-							acc = mkUnstructuredAccessorWithLastOperation(&gardencorev1alpha1.LastOperation{Type: t})
+							t   = gardencorev1beta1.LastOperationTypeReconcile
+							acc = mkUnstructuredAccessorWithLastOperation(&gardencorev1beta1.LastOperation{Type: t})
 						)
 
 						Expect(acc.GetType()).To(Equal(t))
@@ -153,10 +154,10 @@ var _ = Describe("Accessor", func() {
 				Describe("#Get Conditions", func() {
 					It("should get the conditions", func() {
 						var (
-							conditions = []gardencorev1alpha1.Condition{
+							conditions = []gardencorev1beta1.Condition{
 								{
 									Type:           "ABC",
-									Status:         gardencorev1alpha1.ConditionTrue,
+									Status:         gardencorev1beta1.ConditionTrue,
 									Reason:         "reason",
 									Message:        "message",
 									LastUpdateTime: metav1.NewTime(metav1.Now().Round(time.Second)),
@@ -173,10 +174,10 @@ var _ = Describe("Accessor", func() {
 					It("should set the conditions", func() {
 						var (
 							acc        = mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{})
-							conditions = []gardencorev1alpha1.Condition{
+							conditions = []gardencorev1beta1.Condition{
 								{
 									Type:           "ABC",
-									Status:         gardencorev1alpha1.ConditionTrue,
+									Status:         gardencorev1beta1.ConditionTrue,
 									Reason:         "reason",
 									Message:        "message",
 									LastUpdateTime: metav1.NewTime(metav1.Now().Round(time.Second)),

--- a/pkg/apis/core/v1alpha1/helper/helper.go
+++ b/pkg/apis/core/v1alpha1/helper/helper.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 
 	"github.com/Masterminds/semver"
+	errors "github.com/pkg/errors"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -726,4 +727,12 @@ func GetDefaultMachineImageFromCloudProfile(profile gardencorev1alpha1.CloudProf
 		return nil
 	}
 	return &profile.Spec.MachineImages[0]
+}
+
+// WrapWithLastError is wrapper function for gardencorev1alpha1.LastError
+func WrapWithLastError(err error, lastError *gardencorev1alpha1.LastError) error {
+	if err == nil || lastError == nil {
+		return err
+	}
+	return errors.Wrapf(err, "last error: %s", lastError.Description)
 }

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 
 	"github.com/Masterminds/semver"
+	errors "github.com/pkg/errors"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -696,4 +697,12 @@ func GetDefaultMachineImageFromCloudProfile(profile gardencorev1beta1.CloudProfi
 		return nil
 	}
 	return &profile.Spec.MachineImages[0]
+}
+
+// WrapWithLastError is wrapper function for gardencorev1beta1.LastError
+func WrapWithLastError(err error, lastError *gardencorev1beta1.LastError) error {
+	if err == nil || lastError == nil {
+		return err
+	}
+	return errors.Wrapf(err, "last error: %s", lastError.Description)
 }

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -15,7 +15,7 @@
 package v1alpha1
 
 import (
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -23,9 +23,9 @@ import (
 type Status interface {
 	// GetConditions retrieves the Conditions of a status.
 	// Conditions may be nil.
-	GetConditions() []gardencorev1alpha1.Condition
+	GetConditions() []gardencorev1beta1.Condition
 	// SetConditions sets the Conditions of a status.
-	SetConditions([]gardencorev1alpha1.Condition)
+	SetConditions([]gardencorev1beta1.Condition)
 	// GetLastOperation retrieves the LastOperation of a status.
 	// LastOperation may be nil.
 	GetLastOperation() LastOperation
@@ -45,9 +45,9 @@ type LastOperation interface {
 	// GetProgress returns progress of the last operation.
 	GetProgress() int
 	// GetState returns the LastOperationState of the last operation.
-	GetState() gardencorev1alpha1.LastOperationState
+	GetState() gardencorev1beta1.LastOperationState
 	// GetType returns the LastOperationType of the last operation.
-	GetType() gardencorev1alpha1.LastOperationType
+	GetType() gardencorev1beta1.LastOperationType
 }
 
 // LastError is the last error on an object.
@@ -57,7 +57,7 @@ type LastError interface {
 	// GetTaskID gets the task ID of the last error.
 	GetTaskID() *string
 	// GetCodes gets the error codes of the last error.
-	GetCodes() []gardencorev1alpha1.ErrorCode
+	GetCodes() []gardencorev1beta1.ErrorCode
 	// GetLastUpdateTime retrieves the last time the error was updated.
 	GetLastUpdateTime() *metav1.Time
 }

--- a/pkg/apis/extensions/v1alpha1/types_defaults.go
+++ b/pkg/apis/extensions/v1alpha1/types_defaults.go
@@ -15,7 +15,7 @@
 package v1alpha1
 
 import (
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -34,13 +34,13 @@ func (d *DefaultSpec) GetExtensionType() string {
 type DefaultStatus struct {
 	// Conditions represents the latest available observations of a Seed's current state.
 	// +optional
-	Conditions []gardencorev1alpha1.Condition `json:"conditions,omitempty"`
+	Conditions []gardencorev1beta1.Condition `json:"conditions,omitempty"`
 	// LastError holds information about the last occurred error during an operation.
 	// +optional
-	LastError *gardencorev1alpha1.LastError `json:"lastError,omitempty"`
+	LastError *gardencorev1beta1.LastError `json:"lastError,omitempty"`
 	// LastOperation holds information about the last operation on the resource.
 	// +optional
-	LastOperation *gardencorev1alpha1.LastOperation `json:"lastOperation,omitempty"`
+	LastOperation *gardencorev1beta1.LastOperation `json:"lastOperation,omitempty"`
 	// ObservedGeneration is the most recent generation observed for this resource.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// State can be filled by the operating controller with what ever data it needs.
@@ -49,12 +49,12 @@ type DefaultStatus struct {
 }
 
 // GetConditions implements Status.
-func (d *DefaultStatus) GetConditions() []gardencorev1alpha1.Condition {
+func (d *DefaultStatus) GetConditions() []gardencorev1beta1.Condition {
 	return d.Conditions
 }
 
 // SetConditions implements Status.
-func (d *DefaultStatus) SetConditions(c []gardencorev1alpha1.Condition) {
+func (d *DefaultStatus) SetConditions(c []gardencorev1beta1.Condition) {
 	d.Conditions = c
 }
 

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	corev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -456,19 +456,19 @@ func (in *DefaultStatus) DeepCopyInto(out *DefaultStatus) {
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]corev1alpha1.Condition, len(*in))
+		*out = make([]v1beta1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.LastError != nil {
 		in, out := &in.LastError, &out.LastError
-		*out = new(corev1alpha1.LastError)
+		*out = new(v1beta1.LastError)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.LastOperation != nil {
 		in, out := &in.LastOperation, &out.LastOperation
-		*out = new(corev1alpha1.LastOperation)
+		*out = new(v1beta1.LastOperation)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.State != nil {

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_control.go
@@ -318,7 +318,7 @@ func waitUntilBackupBucketDeleted(ctx context.Context, gardenClient client.Clien
 		}
 
 		logger.Infof("Waiting for backupBucket to be deleted...")
-		return utilsretry.MinorError(common.WrapWithLastError(fmt.Errorf("BackupBucket is still present"), lastError))
+		return utilsretry.MinorError(gardencorev1alpha1helper.WrapWithLastError(fmt.Errorf("BackupBucket is still present"), lastError))
 	}); err != nil {
 		message := fmt.Sprintf("Error while waiting for backupBucket object to be deleted")
 		if lastError != nil {

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
@@ -23,6 +23,8 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/common"
@@ -259,7 +261,7 @@ func (a *actuator) deleteBackupBucketExtension(ctx context.Context) error {
 
 // waitUntilBackupBucketExtensionDeleted waits until backup bucket extension resource is deleted in seed cluster.
 func (a *actuator) waitUntilBackupBucketExtensionDeleted(ctx context.Context) error {
-	var lastError *gardencorev1alpha1.LastError
+	var lastError *gardencorev1beta1.LastError
 
 	if err := retry.UntilTimeout(ctx, defaultInterval, defaultTimeout, func(ctx context.Context) (bool, error) {
 		bb := &extensionsv1alpha1.BackupBucket{}
@@ -276,7 +278,7 @@ func (a *actuator) waitUntilBackupBucketExtensionDeleted(ctx context.Context) er
 		}
 
 		a.logger.Infof("Waiting for backupBucket to be deleted...")
-		return retry.MinorError(common.WrapWithLastError(fmt.Errorf("BackupBucket is still present"), lastError))
+		return retry.MinorError(gardencorev1beta1helper.WrapWithLastError(fmt.Errorf("BackupBucket is still present"), lastError))
 	}); err != nil {
 		message := fmt.Sprintf("Error while waiting for backupBucket object to be deleted")
 		if lastError != nil {

--- a/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
@@ -23,6 +23,8 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -249,7 +251,7 @@ func (a *actuator) deleteBackupEntryExtension(ctx context.Context) error {
 
 // waitUntilBackupEntryExtensionDeleted waits until backup entry extension resource is deleted in seed cluster.
 func (a *actuator) waitUntilBackupEntryExtensionDeleted(ctx context.Context) error {
-	var lastError *gardencorev1alpha1.LastError
+	var lastError *gardencorev1beta1.LastError
 
 	if err := retry.UntilTimeout(ctx, defaultInterval, defaultTimeout, func(ctx context.Context) (bool, error) {
 		be := &extensionsv1alpha1.BackupEntry{}
@@ -266,7 +268,7 @@ func (a *actuator) waitUntilBackupEntryExtensionDeleted(ctx context.Context) err
 		}
 
 		a.logger.Infof("Waiting for backupEntry to be deleted...")
-		return retry.MinorError(common.WrapWithLastError(fmt.Errorf("backupEntry is still present"), lastError))
+		return retry.MinorError(gardencorev1beta1helper.WrapWithLastError(fmt.Errorf("backupEntry is still present"), lastError))
 	}); err != nil {
 		message := fmt.Sprintf("Error while waiting for backupEntry object to be deleted")
 		if lastError != nil {

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -25,6 +25,8 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/features"
@@ -438,7 +440,7 @@ func (b *Botanist) WaitUntilControlPlaneDeleted(ctx context.Context) error {
 
 // waitUntilControlPlaneDeleted waits until the control plane resource with the following name has been deleted.
 func (b *Botanist) waitUntilControlPlaneDeleted(ctx context.Context, name string) error {
-	var lastError *gardencorev1alpha1.LastError
+	var lastError *gardencorev1beta1.LastError
 
 	if err := retry.UntilTimeout(ctx, DefaultInterval, ControlPlaneDefaultTimeout, func(ctx context.Context) (bool, error) {
 		cp := &extensionsv1alpha1.ControlPlane{}
@@ -455,7 +457,7 @@ func (b *Botanist) waitUntilControlPlaneDeleted(ctx context.Context, name string
 		}
 
 		b.Logger.Infof("Waiting for control plane to be deleted...")
-		return retry.MinorError(common.WrapWithLastError(fmt.Errorf("control plane is not yet deleted"), lastError))
+		return retry.MinorError(gardencorev1beta1helper.WrapWithLastError(fmt.Errorf("control plane is not yet deleted"), lastError))
 	}); err != nil {
 		message := fmt.Sprintf("Failed to delete control plane")
 		if lastError != nil {

--- a/pkg/operation/botanist/extension.go
+++ b/pkg/operation/botanist/extension.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"fmt"
 
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -138,7 +138,7 @@ func (b *Botanist) DeleteExtensionResources(ctx context.Context) error {
 // WaitUntilExtensionResourcesDeleted waits until all extension resources are gone or the context is cancelled.
 func (b *Botanist) WaitUntilExtensionResourcesDeleted(ctx context.Context) error {
 	var (
-		lastError  *gardencorev1alpha1.LastError
+		lastError  *gardencorev1beta1.LastError
 		extensions = &extensionsv1alpha1.ExtensionList{}
 	)
 
@@ -172,7 +172,7 @@ func (b *Botanist) WaitUntilExtensionResourcesDeleted(ctx context.Context) error
 					lastError = lastErr
 				}
 
-				return retry.MinorError(common.WrapWithLastError(fmt.Errorf("extension %s is still present", name), lastError))
+				return retry.MinorError(gardencorev1beta1helper.WrapWithLastError(fmt.Errorf("extension %s is still present", name), lastError))
 			}); err != nil {
 				message := fmt.Sprintf("Failed waiting for extension delete")
 				if lastError != nil {

--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -25,6 +25,7 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
@@ -574,7 +575,7 @@ func (b *HealthChecker) CheckLoggingControlPlane(
 // CheckExtensionCondition checks whether the conditions provided by extensions are healthy.
 func (b *HealthChecker) CheckExtensionCondition(condition gardencorev1alpha1.Condition, extensionsCondition []extensionCondition) *gardencorev1alpha1.Condition {
 	for _, cond := range extensionsCondition {
-		if cond.condition.Status == gardencorev1alpha1.ConditionFalse {
+		if cond.condition.Status == gardencorev1beta1.ConditionFalse {
 			c := b.FailedCondition(condition, fmt.Sprintf("%sUnhealthyReport", cond.extensionType), cond.condition.Message)
 			return &c
 		}
@@ -929,7 +930,7 @@ func (b *Botanist) MonitoringHealthChecks(checker *HealthChecker, inactiveAlerts
 }
 
 type extensionCondition struct {
-	condition     gardencorev1alpha1.Condition
+	condition     gardencorev1beta1.Condition
 	extensionType string
 	extensionName string
 }
@@ -966,11 +967,11 @@ func (b *Botanist) getAllExtensionConditions(ctx context.Context) ([]extensionCo
 
 			for _, condition := range acc.GetExtensionStatus().GetConditions() {
 				switch condition.Type {
-				case gardencorev1alpha1.ShootControlPlaneHealthy:
+				case gardencorev1beta1.ShootControlPlaneHealthy:
 					conditionsControlPlaneHealthy = append(conditionsControlPlaneHealthy, extensionCondition{condition, kind, name})
-				case gardencorev1alpha1.ShootEveryNodeReady:
+				case gardencorev1beta1.ShootEveryNodeReady:
 					conditionsEveryNodeReady = append(conditionsEveryNodeReady, extensionCondition{condition, kind, name})
-				case gardencorev1alpha1.ShootSystemComponentsHealthy:
+				case gardencorev1beta1.ShootSystemComponentsHealthy:
 					conditionsSystemComponentsHealthy = append(conditionsSystemComponentsHealthy, extensionCondition{condition, kind, name})
 				}
 			}

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -22,6 +22,8 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/common"
@@ -119,7 +121,7 @@ func (b *Botanist) WaitUntilInfrastructureReady(ctx context.Context) error {
 
 // WaitUntilInfrastructureDeleted waits until the infrastructure resource has been deleted.
 func (b *Botanist) WaitUntilInfrastructureDeleted(ctx context.Context) error {
-	var lastError *gardencorev1alpha1.LastError
+	var lastError *gardencorev1beta1.LastError
 
 	if err := retry.UntilTimeout(ctx, DefaultInterval, InfrastructureDefaultTimeout, func(ctx context.Context) (bool, error) {
 		infrastructure := &extensionsv1alpha1.Infrastructure{}
@@ -136,7 +138,7 @@ func (b *Botanist) WaitUntilInfrastructureDeleted(ctx context.Context) error {
 		}
 
 		b.Logger.Infof("Waiting for infrastructure to be deleted...")
-		return retry.MinorError(common.WrapWithLastError(fmt.Errorf("infrastructure is still present"), lastError))
+		return retry.MinorError(gardencorev1beta1helper.WrapWithLastError(fmt.Errorf("infrastructure is still present"), lastError))
 	}); err != nil {
 		message := fmt.Sprintf("Failed to delete infrastructure")
 		if lastError != nil {

--- a/pkg/operation/botanist/network.go
+++ b/pkg/operation/botanist/network.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"time"
 
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/operation/common"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -91,7 +91,7 @@ func (b *Botanist) WaitUntilNetworkIsReady(ctx context.Context) error {
 
 // WaitUntilNetworkIsDeleted waits until the Network resource has been deleted.
 func (b *Botanist) WaitUntilNetworkIsDeleted(ctx context.Context) error {
-	var lastError *gardencorev1alpha1.LastError
+	var lastError *gardencorev1beta1.LastError
 
 	if err := retry.UntilTimeout(ctx, DefaultInterval, NetworkDefaultTimeout, func(ctx context.Context) (bool, error) {
 		network := &extensionsv1alpha1.Network{}
@@ -108,7 +108,7 @@ func (b *Botanist) WaitUntilNetworkIsDeleted(ctx context.Context) error {
 		}
 
 		b.Logger.Infof("Waiting for Network to be deleted...")
-		return retry.MinorError(common.WrapWithLastError(fmt.Errorf("network is still present"), lastError))
+		return retry.MinorError(gardencorev1beta1helper.WrapWithLastError(fmt.Errorf("network is still present"), lastError))
 	}); err != nil {
 		message := fmt.Sprintf("Failed to delete Network")
 		if lastError != nil {

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"time"
 
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/operation/common"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -149,7 +149,7 @@ func (b *Botanist) WaitUntilWorkerReady(ctx context.Context) error {
 
 // WaitUntilWorkerDeleted waits until the worker extension resource has been deleted.
 func (b *Botanist) WaitUntilWorkerDeleted(ctx context.Context) error {
-	var lastError *gardencorev1alpha1.LastError
+	var lastError *gardencorev1beta1.LastError
 
 	if err := retry.UntilTimeout(ctx, DefaultInterval, WorkerDefaultTimeout, func(ctx context.Context) (bool, error) {
 		worker := &extensionsv1alpha1.Worker{}
@@ -166,7 +166,7 @@ func (b *Botanist) WaitUntilWorkerDeleted(ctx context.Context) error {
 		}
 
 		b.Logger.Infof("Waiting for worker to be deleted...")
-		return retry.MinorError(common.WrapWithLastError(fmt.Errorf("worker is still present"), lastError))
+		return retry.MinorError(gardencorev1beta1helper.WrapWithLastError(fmt.Errorf("worker is still present"), lastError))
 	}); err != nil {
 		message := fmt.Sprintf("Error while waiting for worker object to be deleted")
 		if lastError != nil {

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -34,7 +34,6 @@ import (
 	"github.com/gardener/gardener/pkg/version"
 
 	jsoniter "github.com/json-iterator/go"
-	errors2 "github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -601,12 +600,4 @@ func GetSecretFromSecretRef(ctx context.Context, c client.Client, secretRef *cor
 		return nil, err
 	}
 	return secret, nil
-}
-
-// WrapWithLastError is wrapper function for gardencorev1alpha1.LastError
-func WrapWithLastError(err error, lastError *gardencorev1alpha1.LastError) error {
-	if err == nil || lastError == nil {
-		return err
-	}
-	return errors2.Wrapf(err, "last error: %s", lastError.Description)
 }

--- a/pkg/utils/kubernetes/health/health.go
+++ b/pkg/utils/kubernetes/health/health.go
@@ -22,6 +22,8 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
@@ -327,7 +329,7 @@ func CheckExtensionObject(obj extensionsv1alpha1.Object) error {
 		return fmt.Errorf("observed generation outdated (%d/%d)", status.GetObservedGeneration(), obj.GetGeneration())
 	}
 
-	op, ok := obj.GetAnnotations()[v1alpha1constants.GardenerOperation]
+	op, ok := obj.GetAnnotations()[v1beta1constants.GardenerOperation]
 	if ok {
 		return fmt.Errorf("gardener operation %q is not yet picked up by extension controller", op)
 	}
@@ -341,7 +343,7 @@ func CheckExtensionObject(obj extensionsv1alpha1.Object) error {
 		return fmt.Errorf("extension did not record a last operation yet")
 	}
 
-	if lastOp.GetState() != gardencorev1alpha1.LastOperationStateSucceeded {
+	if lastOp.GetState() != gardencorev1beta1.LastOperationStateSucceeded {
 		return fmt.Errorf("extension state is not succeeded but %v", lastOp.GetState())
 	}
 	return nil

--- a/pkg/utils/kubernetes/health/health_test.go
+++ b/pkg/utils/kubernetes/health/health_test.go
@@ -19,10 +19,11 @@ import (
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 
-	gardenv1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -170,76 +171,76 @@ var _ = Describe("health", func() {
 
 	Context("CheckMachineDeployment", func() {
 		DescribeTable("machine deployments",
-			func(machineDeployment *gardenv1alpha1.MachineDeployment, matcher types.GomegaMatcher) {
+			func(machineDeployment *machinev1alpha1.MachineDeployment, matcher types.GomegaMatcher) {
 				err := health.CheckMachineDeployment(machineDeployment)
 				Expect(err).To(matcher)
 			},
-			Entry("healthy", &gardenv1alpha1.MachineDeployment{
-				Status: gardenv1alpha1.MachineDeploymentStatus{Conditions: []gardenv1alpha1.MachineDeploymentCondition{
+			Entry("healthy", &machinev1alpha1.MachineDeployment{
+				Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
 					{
-						Type:   gardenv1alpha1.MachineDeploymentAvailable,
-						Status: gardenv1alpha1.ConditionTrue,
+						Type:   machinev1alpha1.MachineDeploymentAvailable,
+						Status: machinev1alpha1.ConditionTrue,
 					},
 					{
-						Type:   gardenv1alpha1.MachineDeploymentProgressing,
-						Status: gardenv1alpha1.ConditionTrue,
-					},
-				}},
-			}, BeNil()),
-			Entry("healthy without progressing", &gardenv1alpha1.MachineDeployment{
-				Status: gardenv1alpha1.MachineDeploymentStatus{Conditions: []gardenv1alpha1.MachineDeploymentCondition{
-					{
-						Type:   gardenv1alpha1.MachineDeploymentAvailable,
-						Status: gardenv1alpha1.ConditionTrue,
+						Type:   machinev1alpha1.MachineDeploymentProgressing,
+						Status: machinev1alpha1.ConditionTrue,
 					},
 				}},
 			}, BeNil()),
-			Entry("unhealthy without available", &gardenv1alpha1.MachineDeployment{}, HaveOccurred()),
-			Entry("unhealthy with false available", &gardenv1alpha1.MachineDeployment{
-				Status: gardenv1alpha1.MachineDeploymentStatus{Conditions: []gardenv1alpha1.MachineDeploymentCondition{
+			Entry("healthy without progressing", &machinev1alpha1.MachineDeployment{
+				Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
 					{
-						Type:   gardenv1alpha1.MachineDeploymentAvailable,
-						Status: gardenv1alpha1.ConditionFalse,
+						Type:   machinev1alpha1.MachineDeploymentAvailable,
+						Status: machinev1alpha1.ConditionTrue,
+					},
+				}},
+			}, BeNil()),
+			Entry("unhealthy without available", &machinev1alpha1.MachineDeployment{}, HaveOccurred()),
+			Entry("unhealthy with false available", &machinev1alpha1.MachineDeployment{
+				Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
+					{
+						Type:   machinev1alpha1.MachineDeploymentAvailable,
+						Status: machinev1alpha1.ConditionFalse,
 					},
 					{
-						Type:   gardenv1alpha1.MachineDeploymentProgressing,
-						Status: gardenv1alpha1.ConditionTrue,
+						Type:   machinev1alpha1.MachineDeploymentProgressing,
+						Status: machinev1alpha1.ConditionTrue,
 					},
 				}},
 			}, HaveOccurred()),
-			Entry("unhealthy with false progressing", &gardenv1alpha1.MachineDeployment{
-				Status: gardenv1alpha1.MachineDeploymentStatus{Conditions: []gardenv1alpha1.MachineDeploymentCondition{
+			Entry("unhealthy with false progressing", &machinev1alpha1.MachineDeployment{
+				Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
 					{
-						Type:   gardenv1alpha1.MachineDeploymentAvailable,
-						Status: gardenv1alpha1.ConditionTrue,
+						Type:   machinev1alpha1.MachineDeploymentAvailable,
+						Status: machinev1alpha1.ConditionTrue,
 					},
 					{
-						Type:   gardenv1alpha1.MachineDeploymentProgressing,
-						Status: gardenv1alpha1.ConditionFalse,
-					},
-				}},
-			}, HaveOccurred()),
-			Entry("unhealthy with bad condition", &gardenv1alpha1.MachineDeployment{
-				Status: gardenv1alpha1.MachineDeploymentStatus{Conditions: []gardenv1alpha1.MachineDeploymentCondition{
-					{
-						Type:   gardenv1alpha1.MachineDeploymentAvailable,
-						Status: gardenv1alpha1.ConditionTrue,
-					},
-					{
-						Type:   gardenv1alpha1.MachineDeploymentProgressing,
-						Status: gardenv1alpha1.ConditionFalse,
-					},
-					{
-						Type:   gardenv1alpha1.MachineDeploymentReplicaFailure,
-						Status: gardenv1alpha1.ConditionTrue,
+						Type:   machinev1alpha1.MachineDeploymentProgressing,
+						Status: machinev1alpha1.ConditionFalse,
 					},
 				}},
 			}, HaveOccurred()),
-			Entry("not observed at latest version", &gardenv1alpha1.MachineDeployment{
+			Entry("unhealthy with bad condition", &machinev1alpha1.MachineDeployment{
+				Status: machinev1alpha1.MachineDeploymentStatus{Conditions: []machinev1alpha1.MachineDeploymentCondition{
+					{
+						Type:   machinev1alpha1.MachineDeploymentAvailable,
+						Status: machinev1alpha1.ConditionTrue,
+					},
+					{
+						Type:   machinev1alpha1.MachineDeploymentProgressing,
+						Status: machinev1alpha1.ConditionFalse,
+					},
+					{
+						Type:   machinev1alpha1.MachineDeploymentReplicaFailure,
+						Status: machinev1alpha1.ConditionTrue,
+					},
+				}},
+			}, HaveOccurred()),
+			Entry("not observed at latest version", &machinev1alpha1.MachineDeployment{
 				ObjectMeta: metav1.ObjectMeta{Generation: 1},
 			}, HaveOccurred()),
-			Entry("not enough updated replicas", &gardenv1alpha1.MachineDeployment{
-				Spec: gardenv1alpha1.MachineDeploymentSpec{Replicas: 1},
+			Entry("not enough updated replicas", &machinev1alpha1.MachineDeployment{
+				Spec: machinev1alpha1.MachineDeploymentSpec{Replicas: 1},
 			}, HaveOccurred()),
 		)
 	})
@@ -316,8 +317,8 @@ var _ = Describe("health", func() {
 				&extensionsv1alpha1.Infrastructure{
 					Status: extensionsv1alpha1.InfrastructureStatus{
 						DefaultStatus: extensionsv1alpha1.DefaultStatus{
-							LastOperation: &gardencorev1alpha1.LastOperation{
-								State: gardencorev1alpha1.LastOperationStateSucceeded,
+							LastOperation: &gardencorev1beta1.LastOperation{
+								State: gardencorev1beta1.LastOperationStateSucceeded,
 							},
 						},
 					},
@@ -330,8 +331,8 @@ var _ = Describe("health", func() {
 					},
 					Status: extensionsv1alpha1.InfrastructureStatus{
 						DefaultStatus: extensionsv1alpha1.DefaultStatus{
-							LastOperation: &gardencorev1alpha1.LastOperation{
-								State: gardencorev1alpha1.LastOperationStateSucceeded,
+							LastOperation: &gardencorev1beta1.LastOperation{
+								State: gardencorev1beta1.LastOperationStateSucceeded,
 							},
 						},
 					},
@@ -346,8 +347,8 @@ var _ = Describe("health", func() {
 					},
 					Status: extensionsv1alpha1.InfrastructureStatus{
 						DefaultStatus: extensionsv1alpha1.DefaultStatus{
-							LastOperation: &gardencorev1alpha1.LastOperation{
-								State: gardencorev1alpha1.LastOperationStateSucceeded,
+							LastOperation: &gardencorev1beta1.LastOperation{
+								State: gardencorev1beta1.LastOperationStateSucceeded,
 							},
 						},
 					},
@@ -357,11 +358,11 @@ var _ = Describe("health", func() {
 				&extensionsv1alpha1.Infrastructure{
 					Status: extensionsv1alpha1.InfrastructureStatus{
 						DefaultStatus: extensionsv1alpha1.DefaultStatus{
-							LastError: &gardencorev1alpha1.LastError{
+							LastError: &gardencorev1beta1.LastError{
 								Description: "something happened",
 							},
-							LastOperation: &gardencorev1alpha1.LastOperation{
-								State: gardencorev1alpha1.LastOperationStateSucceeded,
+							LastOperation: &gardencorev1beta1.LastOperation{
+								State: gardencorev1beta1.LastOperationStateSucceeded,
 							},
 						},
 					},
@@ -374,8 +375,8 @@ var _ = Describe("health", func() {
 				&extensionsv1alpha1.Infrastructure{
 					Status: extensionsv1alpha1.InfrastructureStatus{
 						DefaultStatus: extensionsv1alpha1.DefaultStatus{
-							LastOperation: &gardencorev1alpha1.LastOperation{
-								State: gardencorev1alpha1.LastOperationStateError,
+							LastOperation: &gardencorev1beta1.LastOperation{
+								State: gardencorev1beta1.LastOperationStateError,
 							},
 						},
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:
Let extensions API use `v1beta1` version of core API. In the next step we can adapt GCM/gardenlet/scheduler to use the `v1beta1` version.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
The `extensions.gardener.cloud/v1alpha1` API now uses types from the `core.gardener.cloud/v1beta1` (instead of the `core.gardener.cloud/v1alpha1` API).
```
