### PR TITLE
Disable node anti affinity for single replica

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -40,6 +40,7 @@ spec:
       {{- if not .Values.global.apiserver.kubeconfig }}
       serviceAccountName: {{ required ".Values.global.apiserver.serviceAccountName is required" .Values.global.apiserver.serviceAccountName }}
       {{- end }}
+      {{- if gt (int .Values.global.apiserver.replicaCount) 1 }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -54,6 +55,7 @@ spec:
                 values:
                 - apiserver
             topologyKey: kubernetes.io/hostname
+      {{- end }}
       containers:
       - name: gardener-apiserver
         image: {{ required ".Values.global.apiserver.image.repository is required" .Values.global.apiserver.image.repository }}:{{ required ".Values.global.apiserver.image.tag is required" .Values.global.apiserver.image.tag }}

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
@@ -36,6 +36,7 @@ spec:
       {{- if not .Values.global.controller.kubeconfig }}
       serviceAccountName: {{ required ".Values.global.controller.serviceAccountName is required" .Values.global.controller.serviceAccountName }}
       {{- end }}
+      {{- if gt (int .Values.global.controller.replicaCountreplicaCount) 1 }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -50,6 +51,7 @@ spec:
                 values:
                 - controller-manager
             topologyKey: kubernetes.io/hostname
+      {{- end }}
       containers:
       - name: gardener-controller-manager
         image: {{ required ".Values.global.controller.image.repository is required" .Values.global.controller.image.repository }}:{{ required ".Values.global.controller.image.tag is required" .Values.global.controller.image.tag }}

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
@@ -31,6 +31,7 @@ spec:
       {{- if not .Values.global.scheduler.kubeconfig }}
       serviceAccountName: {{ required ".Values.global.scheduler.serviceAccountName is required" .Values.global.scheduler.serviceAccountName }}
       {{- end }}
+      {{- if gt (int .Values.global.scheduler.replicaCount) 1 }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -45,6 +46,7 @@ spec:
                 values:
                 - scheduler
             topologyKey: kubernetes.io/hostname
+      {{- end }}
       containers:
       - name: gardener-scheduler
         image: {{ required ".Values.global.scheduler.image.repository is required" .Values.global.scheduler.image.repository }}:{{ required ".Values.global.scheduler.image.tag is required" .Values.global.scheduler.image.tag }}

--- a/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
@@ -38,6 +38,7 @@ spec:
       {{- if not .Values.global.gardenlet.kubeconfig }}
       serviceAccountName: {{ required ".Values.global.gardenlet.serviceAccountName is required" .Values.global.gardenlet.serviceAccountName }}
       {{- end }}
+      {{- if gt (int .Values.global.gardenlet.replicaCount) 1 }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -52,6 +53,7 @@ spec:
                 values:
                 - gardenlet
             topologyKey: kubernetes.io/hostname
+      {{- end }}
       containers:
       - name: gardenlet
         image: {{ required ".Values.global.gardenlet.image.repository is required" .Values.global.gardenlet.image.repository }}:{{ required ".Values.global.gardenlet.image.tag is required" .Values.global.gardenlet.image.tag }}

--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-statefulset.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-statefulset.yaml
@@ -26,6 +26,7 @@ spec:
         networking.gardener.cloud/from-aggregate-prometheus: allowed
         networking.gardener.cloud/to-dns: allowed
     spec:
+      {{- if gt (int .Values.fluentd.replicaCount ) 1 }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -40,6 +41,7 @@ spec:
                 values:
                 - logging
             topologyKey: "kubernetes.io/hostname"
+      {{- end }}
       containers:
       - name: fluentd-es
         image: {{ index .Values.global.images "fluentd-es" }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable node anti affinity when a single replica is used.

This will improve rolling updates when the container image was not changed, because the scheduler will prefer nodes where the image is already cached.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
