### PR TITLE
Revert change to gardener test

### DIFF
--- a/.test-defs/PlantTest.yaml
+++ b/.test-defs/PlantTest.yaml
@@ -6,7 +6,7 @@ spec:
   description: Tests the creation of a plant.
 
   activeDeadlineSeconds: 600
-  labels: ["gardener","default"]
+  labels: ["shoot","default"]
 
   command: [bash, -c]
   args:


### PR DESCRIPTION
revert changing the plant test to be pure gardener test as a shoot is needed that is registered as a plant

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @dguendisch @OlegLoewen 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
