### PR TITLE
Fixed labels in etcd resources to help in grouping

### DIFF
--- a/charts/seed-controlplane/charts/etcd/templates/allow-from-apiserver-network-policy.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/allow-from-apiserver-network-policy.yaml
@@ -6,6 +6,8 @@ metadata:
       Allows Ingress to etcd pods from the Shoot's Kubernetes API Server.
   name: allow-etcd
   namespace: {{ .Release.Namespace }}
+  labels:
+    garden.sapcloud.io/role: controlplane
 spec:
   podSelector:
     matchLabels:

--- a/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/configmap-etcd-bootstrap.yaml
@@ -5,7 +5,9 @@ metadata:
   name: etcd-bootstrap-{{ .Values.role }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: etcd
+    garden.sapcloud.io/role: controlplane
+    app: etcd-statefulset
+    role: {{ .Values.role }}
 data:
   bootstrap.sh: |-
     #!/bin/sh

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-client-service.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-client-service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: etcd-{{ .Values.role }}-client
   namespace: {{ .Release.Namespace }}
   labels:
+    garden.sapcloud.io/role: controlplane
     app: etcd-statefulset
     role: {{ .Values.role }}
 spec:

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-hvpa.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-hvpa.yaml
@@ -6,6 +6,10 @@ kind: Hvpa
 metadata:
   name: etcd-{{ .Values.role }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    garden.sapcloud.io/role: controlplane
+    app: etcd-statefulset
+    role: {{ .Values.role }}
 spec:
   replicas: 1
 {{- if .Values.scaleUpStabilization }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the labels in etcd resources deployed to make grouping of resources pertaining to a role possible. This is needed to help etcd-druid adopt existing etcd resource.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
