### PR TITLE
Store resources in etcd in `core.gardener.cloud/v1beta1` version

### DIFF
--- a/pkg/apis/core/install/install.go
+++ b/pkg/apis/core/install/install.go
@@ -29,5 +29,5 @@ func Install(scheme *runtime.Scheme) {
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 	utilruntime.Must(v1beta1.AddToScheme(scheme))
 
-	utilruntime.Must(scheme.SetVersionPriority(v1alpha1.SchemeGroupVersion, v1beta1.SchemeGroupVersion))
+	utilruntime.Must(scheme.SetVersionPriority(v1beta1.SchemeGroupVersion, v1alpha1.SchemeGroupVersion))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Store resources in etcd in `core.gardener.cloud/v1beta1` version
With #1707 the storage version was accidentally changed back to `garden.sapcloud.io/v1beta1` again. With this change we now use the cohabitating resource concept and change the version priority to `v1beta1` instead of `v1alpha1` for the `core.gardener.cloud` API group. 
Please note that the `ShootState` resource is handled specially as it was not yet promoted to `v1beta1`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
All resources are now stored in etcd in the `core.gardener.cloud/v1beta1` version (except `ShootState` resources as they were not yet promoted to `v1beta1`).
```
