### PR TITLE
Enable scale down also for kube-apiserver via HVPA

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hvpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hvpa.yaml
@@ -61,7 +61,7 @@ spec:
             - containerName: blackbox-exporter
               mode: "Off"
     updatePolicy:
-      updateMode: "ScaleUp"
+      updateMode: "Auto"
   weightBasedScalingIntervals:
     - vpaWeight: 0
       startReplicaCount: {{ .Values.minReplicas }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable vertical scale down also for kube-apiserver via HVPA

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Enabled vertical scale down also for kube-apiserver via HVPA
```
