### PR TITLE
Temporarily add experimental Kyma addon

### DIFF
--- a/charts/shoot-addons-kyma/Chart.yaml
+++ b/charts/shoot-addons-kyma/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: An umbrella chart for the temporary Kyma chart
+name: shoot-addons-kyma
+version: 0.1.0

--- a/charts/shoot-addons-kyma/charts/kyma/Chart.yaml
+++ b/charts/shoot-addons-kyma/charts/kyma/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1alpha1
+appVersion: "0.1"
+description: Temporarily experimental support for out-of-the-box installation of Kyma
+name: kyma
+version: 0.1.0

--- a/charts/shoot-addons-kyma/charts/kyma/charts/utils-templates
+++ b/charts/shoot-addons-kyma/charts/kyma/charts/utils-templates
@@ -1,0 +1,1 @@
+../../../../utils-templates

--- a/charts/shoot-addons-kyma/charts/kyma/files/certificate.sh
+++ b/charts/shoot-addons-kyma/charts/kyma/files/certificate.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+echo "---> Get Shoot Domain"
+SHOOT_DOMAIN="$(kubectl -n kube-system get configmap shoot-info -o jsonpath='{.data.domain}')"
+DOMAIN="$SUBDOMAIN.$SHOOT_DOMAIN"
+
+echo "---> Requesting certificate for domain ${DOMAIN}"
+cat <<EOF | kubectl apply -f -
+---
+apiVersion: cert.gardener.cloud/v1alpha1
+kind: Certificate
+metadata:
+  name: kyma-cert
+  namespace: kyma-installer
+spec:
+  commonName: "*.$DOMAIN"
+EOF
+
+while :
+do
+STATUS="$(kubectl get -n kyma-installer certificate.cert.gardener.cloud kyma-cert -o jsonpath='{.status.state}')"
+if [ "$STATUS" = "Ready" ]; then
+    break
+else
+    echo "Waiting for Certicate generation, status is ${STATUS}"
+    sleep $DELAY
+fi
+done
+
+CERT_SECRET_NAME=$(kubectl get -n kyma-installer certificate kyma-cert -o jsonpath="{.spec.secretRef.name}")
+echo "---> Getting certificate from secret"
+TLS_CERT=$(kubectl get -n kyma-installer secret  $CERT_SECRET_NAME -o jsonpath="{.data['tls\.crt']}" | sed 's/ /\\ /g' | tr -d '\n')
+TLS_KEY=$(kubectl get -n kyma-installer secret  $CERT_SECRET_NAME -o jsonpath="{.data['tls\.key']}" | sed 's/ /\\ /g' | tr -d '\n')
+
+echo "---> Configuring Kyma Installer"
+cat <<EOF | kubectl apply -f -
+---
+apiVersion: v1
+data:
+  global.domainName: "${DOMAIN}"
+  global.tlsCrt: "${TLS_CERT}"
+  global.tlsKey: "${TLS_KEY}"
+kind: ConfigMap
+metadata:
+  labels:
+    installer: overrides
+  name: owndomain-overrides
+  namespace: kyma-installer
+EOF

--- a/charts/shoot-addons-kyma/charts/kyma/files/dns.sh
+++ b/charts/shoot-addons-kyma/charts/kyma/files/dns.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+echo "---> Configuring DNS entry"
+SHOOT_DOMAIN="$(kubectl -n kube-system get configmap shoot-info -o jsonpath='{.data.domain}')"
+DOMAIN="$SUBDOMAIN.$SHOOT_DOMAIN"
+
+kubectl -n istio-system annotate service istio-ingressgateway dns.gardener.cloud/class='garden' dns.gardener.cloud/dnsnames='*.'$DOMAIN'' --overwrite
+echo "---> Installation finished, browse to https://console.${DOMAIN}"
+echo "---> The user name is 'admin@kyma.cx', get the password with: kubectl get secret admin-user -n kyma-system -o jsonpath='{.data.password}' | base64 -D"

--- a/charts/shoot-addons-kyma/charts/kyma/files/installation.sh
+++ b/charts/shoot-addons-kyma/charts/kyma/files/installation.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+echo "---> Applying Kyma-Installer for ${KYMA_VERSION}"
+kubectl apply -f https://raw.githubusercontent.com/kyma-project/kyma/$KYMA_VERSION/installation/resources/installer.yaml
+
+echo "---> Apply Kyma installation CR for ${KYMA_VERSION}"
+kubectl -n default apply -f https://raw.githubusercontent.com/kyma-project/kyma/$KYMA_VERSION/installation/resources/installer-cr-cluster.yaml.tpl

--- a/charts/shoot-addons-kyma/charts/kyma/files/tiller.sh
+++ b/charts/shoot-addons-kyma/charts/kyma/files/tiller.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+echo "---> Applying Tiller for ${KYMA_VERSION}"
+kubectl apply -f https://raw.githubusercontent.com/kyma-project/kyma/$KYMA_VERSION/installation/resources/tiller.yaml

--- a/charts/shoot-addons-kyma/charts/kyma/files/wait-for-certificate.sh
+++ b/charts/shoot-addons-kyma/charts/kyma/files/wait-for-certificate.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+until kubectl get cm owndomain-overrides -n kyma-installer
+do
+    echo "---> Certificate is not ready yet"
+    sleep $DELAY
+done

--- a/charts/shoot-addons-kyma/charts/kyma/files/wait-for-installation.sh
+++ b/charts/shoot-addons-kyma/charts/kyma/files/wait-for-installation.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+until [[ $STATUS == "Installed" ]]; do
+    STATUS="$(kubectl -n default get installation/kyma-installation -o jsonpath='{.status.state}')"
+    DESCRIPTION="$(kubectl -n default get installation/kyma-installation -o jsonpath='{.status.description}')"
+    echo "---> Waiting for Kyma-Installer. Status: $STATUS, Description: $DESCRIPTION"
+    sleep $DELAY
+done

--- a/charts/shoot-addons-kyma/charts/kyma/files/wait-for-tiller.sh
+++ b/charts/shoot-addons-kyma/charts/kyma/files/wait-for-tiller.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+until [[ $(kubectl get pod -l name=tiller -n kube-system -o jsonpath='{.items[*].status.containerStatuses[0].ready}') == "true" ]]
+do
+    echo "---> Tiller is not ready yet"
+    sleep $DELAY
+done

--- a/charts/shoot-addons-kyma/charts/kyma/templates/clusterrolebinding.yaml
+++ b/charts/shoot-addons-kyma/charts/kyma/templates/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kyma-initializer
+  labels:
+    app: kyma-initializer
+subjects:
+- kind: ServiceAccount
+  name: kyma-initializer
+  namespace: kyma-installer
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/shoot-addons-kyma/charts/kyma/templates/configmap.yaml
+++ b/charts/shoot-addons-kyma/charts/kyma/templates/configmap.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-overrides
+  namespace: kyma-installer
+  labels:
+    component: istio
+    installer: overrides
+    app: kyma-initializer
+data:
+  global.proxy.includeIPRanges: '*'

--- a/charts/shoot-addons-kyma/charts/kyma/templates/job-certificate.yaml
+++ b/charts/shoot-addons-kyma/charts/kyma/templates/job-certificate.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: kyma-initializer
+  name: kyma-initializer-certificate
+  namespace: kyma-installer
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      name: kyma-initializer-certificate
+      namespace: kyma-installer
+      annotations:
+        sidecar.istio.io/inject: “false”
+      labels:
+        app: kyma-initializer
+    spec:
+      serviceAccountName: kyma-initializer
+      restartPolicy: Never
+      initContainers:
+      - name: requirements
+        image: {{ .Values.jobs.image | quote }}
+        env:
+          - name: K8S_VERSION
+            value: {{ .Values.requires.k8s.version | quote }}
+          - name: GARDENER_EXTENSIONS
+            value: {{ .Values.requires.gardener.extensions | quote }}
+        command:
+          - bash
+          - -c
+          - |
+{{ .Files.Get "files/requirements.sh" | printf "%s" | indent 12 }}
+      containers:
+      - name: certs
+        image: {{ .Values.jobs.image | quote }}
+        env:
+          - name: DELAY
+            value: {{ .Values.jobs.delay | quote }}
+          - name: SUBDOMAIN
+            value: {{ .Values.kyma.subdomain | quote }}
+        command:
+          - bash
+          - -c
+          - |
+{{ .Files.Get "files/certificate.sh" | printf "%s" | indent 12 }}

--- a/charts/shoot-addons-kyma/charts/kyma/templates/job-installation.yaml
+++ b/charts/shoot-addons-kyma/charts/kyma/templates/job-installation.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kyma-initializer-installation
+  namespace: kyma-installer
+  labels:
+    app: kyma-initializer
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      name: kyma-initializer-installation
+      namespace: kyma-installer
+      annotations:
+        sidecar.istio.io/inject: “false”
+      labels:
+        app: kyma-initializer
+    spec:
+      serviceAccountName: kyma-initializer
+      restartPolicy: Never
+      initContainers:
+      - name: requirements
+        image: {{ .Values.jobs.image | quote }}
+        env:
+          - name: K8S_VERSION
+            value: {{ .Values.requires.k8s.version | quote }}
+          - name: GARDENER_EXTENSIONS
+            value: {{ .Values.requires.gardener.extensions | quote }}
+        command:
+          - bash
+          - -c
+          - |
+{{ .Files.Get "files/requirements.sh" | printf "%s" | indent 12 }}
+      - name: wait-for-tiller
+        image: {{ .Values.jobs.image | quote }}
+        env:
+          - name: DELAY
+            value: {{ .Values.jobs.delay | quote}}
+        command:
+          - bash
+          - -c
+          - |
+{{ .Files.Get "files/wait-for-tiller.sh" | printf "%s" | indent 12 }}
+      - name: wait-for-certificate
+        image: {{ .Values.jobs.image | quote }}
+        env:
+          - name: DELAY
+            value: {{ .Values.jobs.delay | quote }}
+        command:
+          - bash
+          - -c
+          - |
+{{ .Files.Get "files/wait-for-certificate.sh" | printf "%s" | indent 12 }}
+      containers:
+      - name: installation
+        image: {{ .Values.jobs.image | quote }}
+        env:
+          - name: KYMA_VERSION
+            value: {{ .Values.kyma.version | quote }}
+        command:
+          - bash
+          - -c
+          - |
+{{ .Files.Get "files/installation.sh" | printf "%s" | indent 12 }}

--- a/charts/shoot-addons-kyma/charts/kyma/templates/job-tiller.yaml
+++ b/charts/shoot-addons-kyma/charts/kyma/templates/job-tiller.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kyma-initializer-tiller
+  namespace: kyma-installer
+  labels:
+    app: kyma-initializer
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      name: kyma-initializer-tiller
+      namespace: kyma-installer
+      annotations:
+        sidecar.istio.io/inject: “false”
+      labels:
+        app: kyma-initializer
+    spec:
+      serviceAccountName: kyma-initializer
+      restartPolicy: Never
+      initContainers:
+      - name: requirements
+        image: {{ .Values.jobs.image | quote }}
+        env:
+          - name: K8S_VERSION
+            value: {{ .Values.requires.k8s.version | quote }}
+          - name: GARDENER_EXTENSIONS
+            value: {{ .Values.requires.gardener.extensions | quote }}
+        command:
+          - bash
+          - -c
+          - |
+{{ .Files.Get "files/requirements.sh" | printf "%s" | indent 12 }}
+      containers:
+      - name: tiller
+        image: {{ .Values.jobs.image | quote }}
+        env:
+          - name: KYMA_VERSION
+            value: {{ .Values.kyma.version | quote }}
+        command:
+          - bash
+          - -c
+          - |
+{{ .Files.Get "files/tiller.sh" | printf "%s" | indent 12 }}

--- a/charts/shoot-addons-kyma/charts/kyma/templates/namespace.yaml
+++ b/charts/shoot-addons-kyma/charts/kyma/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kyma-installer

--- a/charts/shoot-addons-kyma/charts/kyma/templates/serviceaccount.yaml
+++ b/charts/shoot-addons-kyma/charts/kyma/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kyma-initializer
+  namespace: kyma-installer
+  labels:
+    app: kyma-initializer

--- a/charts/shoot-addons-kyma/charts/kyma/values.yaml
+++ b/charts/shoot-addons-kyma/charts/kyma/values.yaml
@@ -1,0 +1,12 @@
+---
+jobs:
+  image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20190325-ff66a3a
+  delay: 30
+kyma:
+  version: "1.8.0"
+  subdomain: "kyma"
+requires:
+  k8s:
+    version: "1.15"
+  gardener:
+    extensions: "shoot-cert-service,shoot-dns-service"

--- a/charts/shoot-addons-kyma/requirements.yaml
+++ b/charts/shoot-addons-kyma/requirements.yaml
@@ -1,0 +1,5 @@
+dependencies:
+- name: kyma
+  repository: http://localhost:10191
+  version: 0.1.0
+  condition: kyma.enabled

--- a/charts/shoot-addons-kyma/values.yaml
+++ b/charts/shoot-addons-kyma/values.yaml
@@ -1,0 +1,13 @@
+kyma:
+  enabled: false
+  jobs:
+    image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20190325-ff66a3a
+    delay: 30
+  kyma:
+    version: "1.8.0"
+    subdomain: "kyma"
+  requires:
+    k8s:
+      version: "1.15"
+    gardener:
+      extensions: "shoot-cert-service,shoot-dns-service"

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -131,6 +131,8 @@ func (b *Botanist) DeployManagedResources(ctx context.Context) error {
 			"shoot-core":                   {false, b.generateCoreAddonsChart},
 			"shoot-core-namespaces":        {true, b.generateCoreNamespacesChart},
 			"addons":                       {false, b.generateOptionalAddonsChart},
+			// TODO: Just a temporary solution. Remove this in a future version once Kyma is moved out again.
+			"addons-kyma": {false, b.generateTemporaryKymaAddonsChart},
 		}
 	)
 
@@ -359,5 +361,14 @@ func (b *Botanist) generateOptionalAddonsChart() (*chartrenderer.RenderedChart, 
 	return b.ChartApplierShoot.Render(filepath.Join(common.ChartPath, "shoot-addons"), "addons", metav1.NamespaceSystem, map[string]interface{}{
 		"kubernetes-dashboard": kubernetesDashboard,
 		"nginx-ingress":        nginxIngress,
+	})
+}
+
+// generateTemporaryKymaAddonsChart renders the gardener-resource-manager chart for the kyma addon. After that it
+// creates a ManagedResource CRD that references the rendered manifests and creates it.
+// TODO: Just a temporary solution. Remove this in a future version once Kyma is moved out again.
+func (b *Botanist) generateTemporaryKymaAddonsChart() (*chartrenderer.RenderedChart, error) {
+	return b.ChartApplierShoot.Render(filepath.Join(common.ChartPath, "shoot-addons-kyma"), "kyma", "kyma-installer", map[string]interface{}{
+		"kyma": common.GenerateAddonConfig(nil, metav1.HasAnnotation(b.Shoot.Info.ObjectMeta, common.ShootExperimentalAddonKyma)),
 	})
 }

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -253,6 +253,10 @@ const (
 	// SecretRefChecksumAnnotation is the annotation key for checksum of referred secret in resource spec.
 	SecretRefChecksumAnnotation = "checksum/secret.data"
 
+	// ShootExperimentalAddonKyma is a constant for an annotation on the shoot stating that Kyma shall be installed.
+	// TODO: Just a temporary solution. Remove this in a future version once Kyma is moved out again.
+	ShootExperimentalAddonKyma = "experimental.addons.shoot.gardener.cloud/kyma"
+
 	// ShootExpirationTimestamp is an annotation on a Shoot resource whose value represents the time when the Shoot lifetime
 	// is expired. The lifetime can be extended, but at most by the minimal value of the 'clusterLifetimeDays' property
 	// of referenced quotas.

--- a/pkg/registry/garden/shoot/strategy.go
+++ b/pkg/registry/garden/shoot/strategy.go
@@ -117,6 +117,11 @@ func mustIncreaseGeneration(oldShoot, newShoot *garden.Shoot) bool {
 		return true
 	}
 
+	// TODO: Just a temporary solution. Remove this in a future version once Kyma is moved out again.
+	if oldShoot.ObjectMeta.Annotations[common.ShootExperimentalAddonKyma] != newShoot.ObjectMeta.Annotations[common.ShootExperimentalAddonKyma] {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Temporarily add experimental Kyma addon to ease out-of-the-box installation of Kyma for shoot clusters. This is only temporary and will be removed again in a future version of Gardener. The motivation is to show-case which features it provides. It is by no means a production-ready setup.

**Special notes for your reviewer(s):**
Follow-up of #1711

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Gardener now offers a temporary, experimental Kyma addon that can be installed onto shoot clusters out-of-the-box by annotating the `Shoot` with `experimental.addons.shoot.gardener.cloud/kyma=enabled`. Be aware that we won't provide upgrades or customization, and that this addon is temporary and will be removed in a future version of Gardener again. Its purpose is to ease the Kyma installation and to show-case which features it provides. It is by no means a production-ready setup. Also, please note that, once enabled, the Kyma addon can never be disabled again. The only way to get rid of it is to delete the shoot cluster. You can check the status of the installation by using `kubectl -n kyma-installer logs deploy/kyma-installer -f`.
```
