### PR TITLE
Improve DNS validation

### DIFF
--- a/pkg/apis/garden/validation/validation_shoot.go
+++ b/pkg/apis/garden/validation/validation_shoot.go
@@ -857,7 +857,9 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *garden.ShootSpec, deletionTimesta
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Cloud.Packet.Zones, oldSpec.Cloud.Packet.Zones, packetPath.Child("zones"))...)
 	}
 
-	allErrs = append(allErrs, validateDNSUpdate(newSpec.DNS, oldSpec.DNS, fldPath.Child("dns"))...)
+	seedGotAssigned := oldSpec.SeedName == nil && newSpec.SeedName != nil
+
+	allErrs = append(allErrs, validateDNSUpdate(newSpec.DNS, oldSpec.DNS, seedGotAssigned, fldPath.Child("dns"))...)
 	allErrs = append(allErrs, validateKubernetesVersionUpdate(newSpec.Kubernetes.Version, oldSpec.Kubernetes.Version, fldPath.Child("kubernetes", "version"))...)
 	allErrs = append(allErrs, validateKubeProxyModeUpdate(newSpec.Kubernetes.KubeProxy, oldSpec.Kubernetes.KubeProxy, newSpec.Kubernetes.Version, fldPath.Child("kubernetes", "kubeProxy"))...)
 	allErrs = append(allErrs, validateKubeControllerManagerConfiguration(newSpec.Kubernetes.KubeControllerManager, oldSpec.Kubernetes.KubeControllerManager, fldPath.Child("kubernetes", "kubeControllerManager"))...)
@@ -921,7 +923,7 @@ func validateKubeProxyModeUpdate(newConfig, oldConfig *garden.KubeProxyConfig, v
 	return allErrs
 }
 
-func validateDNSUpdate(new, old *garden.DNS, fldPath *field.Path) field.ErrorList {
+func validateDNSUpdate(new, old *garden.DNS, seedGotAssigned bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if old != nil && new == nil {
@@ -933,24 +935,28 @@ func validateDNSUpdate(new, old *garden.DNS, fldPath *field.Path) field.ErrorLis
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Domain, old.Domain, fldPath.Child("domain"))...)
 		}
 
-		providersNew := 0
-		if new != nil {
-			providersNew = len(new.Providers)
-		}
+		// allow to finalize DNS configuration during seed assignment. this is required because
+		// some decisions about the DNS setup can only be taken once the target seed is clarified.
+		if !seedGotAssigned {
+			providersNew := 0
+			if new != nil {
+				providersNew = len(new.Providers)
+			}
 
-		providersOld := 0
-		if old != nil {
-			providersOld = len(old.Providers)
-		}
+			providersOld := 0
+			if old != nil {
+				providersOld = len(old.Providers)
+			}
 
-		if providersNew != providersOld {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("providers"), "adding or removing providers is not yet allowed"))
-			return allErrs
-		}
+			if providersNew != providersOld {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("providers"), "adding or removing providers is not yet allowed"))
+				return allErrs
+			}
 
-		for i, provider := range new.Providers {
-			if provider.Type != old.Providers[i].Type {
-				allErrs = append(allErrs, apivalidation.ValidateImmutableField(provider.Type, old.Providers[i].Type, fldPath.Child("providers").Index(i).Child("type"))...)
+			for i, provider := range new.Providers {
+				if provider.Type != old.Providers[i].Type {
+					allErrs = append(allErrs, apivalidation.ValidateImmutableField(provider.Type, old.Providers[i].Type, fldPath.Child("providers").Index(i).Child("type"))...)
+				}
 			}
 		}
 	}

--- a/pkg/apis/garden/validation/validation_shoot.go
+++ b/pkg/apis/garden/validation/validation_shoot.go
@@ -924,25 +924,30 @@ func validateKubeProxyModeUpdate(newConfig, oldConfig *garden.KubeProxyConfig, v
 func validateDNSUpdate(new, old *garden.DNS, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if new != nil && old != nil && old.Domain != nil && new.Domain != old.Domain {
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Domain, old.Domain, fldPath.Child("domain"))...)
+	if old != nil && new == nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(new, old, fldPath)...)
 	}
 
-	providersNew := 0
-	if new != nil {
-		providersNew = len(new.Providers)
-	}
+	if new != nil && old != nil {
+		if old.Domain != nil && new.Domain != old.Domain {
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Domain, old.Domain, fldPath.Child("domain"))...)
+		}
 
-	providersOld := 0
-	if old != nil {
-		providersOld = len(old.Providers)
-	}
-	if providersNew != providersOld {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("providers"), "adding or removing providers is not yet allowed"))
-		return allErrs
-	}
+		providersNew := 0
+		if new != nil {
+			providersNew = len(new.Providers)
+		}
 
-	if new != nil {
+		providersOld := 0
+		if old != nil {
+			providersOld = len(old.Providers)
+		}
+
+		if providersNew != providersOld {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("providers"), "adding or removing providers is not yet allowed"))
+			return allErrs
+		}
+
 		for i, provider := range new.Providers {
 			if provider.Type != old.Providers[i].Type {
 				allErrs = append(allErrs, apivalidation.ValidateImmutableField(provider.Type, old.Providers[i].Type, fldPath.Child("providers").Index(i).Child("type"))...)

--- a/pkg/apis/garden/validation/validation_shoot_test.go
+++ b/pkg/apis/garden/validation/validation_shoot_test.go
@@ -3718,6 +3718,20 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}))))
 			})
 
+			It("should allow updating the dns providers if seed is assigned", func() {
+				oldShoot := shoot.DeepCopy()
+				oldShoot.Spec.SeedName = nil
+				oldShoot.Spec.DNS.Providers[0].Type = makeStringPointer("some-dns-provider")
+
+				newShoot := prepareShootForUpdate(oldShoot)
+				newShoot.Spec.SeedName = makeStringPointer("seed")
+				newShoot.Spec.DNS.Providers = nil
+
+				errorList := ValidateShootUpdate(newShoot, oldShoot)
+
+				Expect(errorList).To(BeEmpty())
+			})
+
 			It("should forbid updating the dns provider", func() {
 				newShoot := prepareShootForUpdate(shoot)
 				shoot.Spec.DNS.Providers[0].Type = makeStringPointer("some-other-provider")

--- a/pkg/apis/garden/validation/validation_shoot_test.go
+++ b/pkg/apis/garden/validation/validation_shoot_test.go
@@ -3694,6 +3694,18 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(BeEmpty())
 			})
 
+			It("should forbid removing the dns section", func() {
+				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.DNS = nil
+
+				errorList := ValidateShootUpdate(newShoot, shoot)
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.dns"),
+				}))))
+			})
+
 			It("should forbid updating the dns domain", func() {
 				newShoot := prepareShootForUpdate(shoot)
 				newShoot.Spec.DNS.Domain = makeStringPointer("another-domain.com")

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -168,6 +168,9 @@ func (d *DNS) Admit(ctx context.Context, a admission.Attributes, o admission.Obj
 		return apierrors.NewBadRequest(fmt.Sprintf("could not get referenced seed: %+v", err.Error()))
 	}
 	if dnsDisabled {
+		if shoot.Spec.DNS != nil {
+			return apierrors.NewBadRequest("shoot's .spec.dns section must be nil if seed with disabled DNS is chosen")
+		}
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains three validation changes:
1. It is now forbidden to remove the `.spec.dns` section during shoot updates. Earlier it was (unintentionally) possible to remove the complete section when updating a shoot.
1. It is now forbidden to choose a seed that disables DNS if the shoot itself specifies a DNS section. Previously, users could bypass the scheduler (by specifying the `.spec.seedName` themselves) without respecting the DNS constraints.
1. It is now allowed to change the `.spec.dns.providers` section when a seed is assigned. We have seen users that still were creating shoots with `.spec.dns.domain=<default-domain>` and `.spec.dns.provider=<some-provider>` (with old `garden.sapcloud.io/v1beta1` API). In `v0.33`, the DNS admission plugin tries to remove `.spec.dns.providers` when it assigns a default domain, and this failed because our validation prevented it. See [this](https://github.com/gardener/gardener/blob/master/plugin/pkg/shoot/dns/admission.go#L248) and [this](https://github.com/gardener/gardener/blob/master/plugin/pkg/shoot/dns/admission.go#L265).

**Special notes for your reviewer**:
Once merged to `master` we should cherry-pick this to `release-v0.33`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
It is now forbidden again to remove the `.spec.dns` section during shoot updates. Earlier it was (unintentionally) possible to remove the complete section when updating a shoot.
```
```improvement user
It is now forbidden to choose a seed that disables DNS if the shoot itself specifies a DNS section.
```
```improvement user
It is now allowed to change the `.spec.dns.providers` section when a seed is assigned as final DNS decisions can only be taken when the seed is clarified.
```
