### PR TITLE
Fix allow adding zones

### DIFF
--- a/pkg/apis/core/v1alpha1/conversions.go
+++ b/pkg/apis/core/v1alpha1/conversions.go
@@ -1207,13 +1207,19 @@ func Convert_v1alpha1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conv
 
 		out.Spec.Cloud.Azure.Zones = nil
 		out.Spec.Cloud.Azure.Workers = nil
+		zones := sets.NewString()
 		for _, worker := range in.Spec.Provider.Workers {
 			var o garden.Worker
 			if err := autoConvert_v1alpha1_Worker_To_garden_Worker(&worker, &o, s); err != nil {
 				return err
 			}
 			out.Spec.Cloud.Azure.Workers = append(out.Spec.Cloud.Azure.Workers, o)
-			out.Spec.Cloud.Azure.Zones = o.Zones
+			for _, zone := range o.Zones {
+				if !zones.Has(zone) {
+					out.Spec.Cloud.Azure.Zones = append(out.Spec.Cloud.Azure.Zones, zone)
+					zones.Insert(zone)
+				}
+			}
 		}
 
 	case "gcp":
@@ -1313,9 +1319,13 @@ func Convert_v1alpha1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conv
 				return err
 			}
 			out.Spec.Cloud.GCP.Workers = append(out.Spec.Cloud.GCP.Workers, o)
-			zones.Insert(o.Zones...)
+			for _, zone := range o.Zones {
+				if !zones.Has(zone) {
+					out.Spec.Cloud.GCP.Zones = append(out.Spec.Cloud.GCP.Zones, zone)
+					zones.Insert(zone)
+				}
+			}
 		}
-		out.Spec.Cloud.GCP.Zones = zones.List()
 
 	case "openstack":
 		if out.Spec.Cloud.OpenStack == nil {
@@ -1425,9 +1435,13 @@ func Convert_v1alpha1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conv
 				return err
 			}
 			out.Spec.Cloud.OpenStack.Workers = append(out.Spec.Cloud.OpenStack.Workers, o)
-			zones.Insert(o.Zones...)
+			for _, zone := range o.Zones {
+				if !zones.Has(zone) {
+					out.Spec.Cloud.OpenStack.Zones = append(out.Spec.Cloud.OpenStack.Zones, zone)
+					zones.Insert(zone)
+				}
+			}
 		}
-		out.Spec.Cloud.OpenStack.Zones = zones.List()
 
 	case "alicloud":
 		if out.Spec.Cloud.Alicloud == nil {
@@ -1555,9 +1569,13 @@ func Convert_v1alpha1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conv
 				return err
 			}
 			out.Spec.Cloud.Packet.Workers = append(out.Spec.Cloud.Packet.Workers, o)
-			zones.Insert(o.Zones...)
+			for _, zone := range o.Zones {
+				if !zones.Has(zone) {
+					out.Spec.Cloud.Packet.Zones = append(out.Spec.Cloud.Packet.Zones, zone)
+					zones.Insert(zone)
+				}
+			}
 		}
-		out.Spec.Cloud.Packet.Zones = zones.List()
 
 		var cloudControllerManager *garden.CloudControllerManagerConfig
 		if data, ok := in.Annotations[garden.MigrationShootCloudControllerManager]; ok {

--- a/pkg/apis/core/v1beta1/conversions.go
+++ b/pkg/apis/core/v1beta1/conversions.go
@@ -1134,13 +1134,19 @@ func Convert_v1beta1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conve
 
 		out.Spec.Cloud.Azure.Zones = nil
 		out.Spec.Cloud.Azure.Workers = nil
+		zones := sets.NewString()
 		for _, worker := range in.Spec.Provider.Workers {
 			var o garden.Worker
 			if err := autoConvert_v1beta1_Worker_To_garden_Worker(&worker, &o, s); err != nil {
 				return err
 			}
 			out.Spec.Cloud.Azure.Workers = append(out.Spec.Cloud.Azure.Workers, o)
-			out.Spec.Cloud.Azure.Zones = o.Zones
+			for _, zone := range o.Zones {
+				if !zones.Has(zone) {
+					out.Spec.Cloud.Azure.Zones = append(out.Spec.Cloud.Azure.Zones, zone)
+					zones.Insert(zone)
+				}
+			}
 		}
 
 	case "gcp":
@@ -1240,9 +1246,13 @@ func Convert_v1beta1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conve
 				return err
 			}
 			out.Spec.Cloud.GCP.Workers = append(out.Spec.Cloud.GCP.Workers, o)
-			zones.Insert(o.Zones...)
+			for _, zone := range o.Zones {
+				if !zones.Has(zone) {
+					out.Spec.Cloud.GCP.Zones = append(out.Spec.Cloud.GCP.Zones, zone)
+					zones.Insert(zone)
+				}
+			}
 		}
-		out.Spec.Cloud.GCP.Zones = zones.List()
 
 	case "openstack":
 		if out.Spec.Cloud.OpenStack == nil {
@@ -1352,9 +1362,13 @@ func Convert_v1beta1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conve
 				return err
 			}
 			out.Spec.Cloud.OpenStack.Workers = append(out.Spec.Cloud.OpenStack.Workers, o)
-			zones.Insert(o.Zones...)
+			for _, zone := range o.Zones {
+				if !zones.Has(zone) {
+					out.Spec.Cloud.OpenStack.Zones = append(out.Spec.Cloud.OpenStack.Zones, zone)
+					zones.Insert(zone)
+				}
+			}
 		}
-		out.Spec.Cloud.OpenStack.Zones = zones.List()
 
 	case "alicloud":
 		if out.Spec.Cloud.Alicloud == nil {
@@ -1482,9 +1496,13 @@ func Convert_v1beta1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conve
 				return err
 			}
 			out.Spec.Cloud.Packet.Workers = append(out.Spec.Cloud.Packet.Workers, o)
-			zones.Insert(o.Zones...)
+			for _, zone := range o.Zones {
+				if !zones.Has(zone) {
+					out.Spec.Cloud.Packet.Zones = append(out.Spec.Cloud.Packet.Zones, zone)
+					zones.Insert(zone)
+				}
+			}
 		}
-		out.Spec.Cloud.Packet.Zones = zones.List()
 
 		var cloudControllerManager *garden.CloudControllerManagerConfig
 		if data, ok := in.Annotations[garden.MigrationShootCloudControllerManager]; ok {

--- a/pkg/apis/garden/v1beta1/conversions.go
+++ b/pkg/apis/garden/v1beta1/conversions.go
@@ -40,6 +40,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
 )
 
@@ -1482,8 +1483,11 @@ func Convert_v1beta1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conve
 				w.Zones = data.Zones
 			}
 
-			if w.Zones == nil {
-				w.Zones = in.Spec.Cloud.AWS.Zones
+			usedZones := sets.NewString(w.Zones...)
+			for _, zone := range in.Spec.Cloud.AWS.Zones {
+				if !usedZones.Has(zone) {
+					w.Zones = append(w.Zones, zone)
+				}
 			}
 
 			out.Spec.Provider.Workers = append(out.Spec.Provider.Workers, w)
@@ -1623,8 +1627,12 @@ func Convert_v1beta1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conve
 				w.ProviderConfig = data.ProviderConfig
 				w.Zones = data.Zones
 			}
-			if w.Zones == nil && zoned {
-				w.Zones = in.Spec.Cloud.Azure.Zones
+
+			usedZones := sets.NewString(w.Zones...)
+			for _, zone := range in.Spec.Cloud.Azure.Zones {
+				if !usedZones.Has(zone) {
+					w.Zones = append(w.Zones, zone)
+				}
 			}
 
 			out.Spec.Provider.Workers = append(out.Spec.Provider.Workers, w)
@@ -1760,8 +1768,11 @@ func Convert_v1beta1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conve
 				w.Zones = data.Zones
 			}
 
-			if w.Zones == nil {
-				w.Zones = in.Spec.Cloud.GCP.Zones
+			usedZones := sets.NewString(w.Zones...)
+			for _, zone := range in.Spec.Cloud.GCP.Zones {
+				if !usedZones.Has(zone) {
+					w.Zones = append(w.Zones, zone)
+				}
 			}
 
 			out.Spec.Provider.Workers = append(out.Spec.Provider.Workers, w)
@@ -1897,8 +1908,11 @@ func Convert_v1beta1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conve
 				w.Volume = data.Volume
 			}
 
-			if w.Zones == nil {
-				w.Zones = in.Spec.Cloud.OpenStack.Zones
+			usedZones := sets.NewString(w.Zones...)
+			for _, zone := range in.Spec.Cloud.OpenStack.Zones {
+				if !usedZones.Has(zone) {
+					w.Zones = append(w.Zones, zone)
+				}
 			}
 
 			out.Spec.Provider.Workers = append(out.Spec.Provider.Workers, w)
@@ -2037,8 +2051,11 @@ func Convert_v1beta1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conve
 				w.Zones = data.Zones
 			}
 
-			if w.Zones == nil {
-				w.Zones = in.Spec.Cloud.Alicloud.Zones
+			usedZones := sets.NewString(w.Zones...)
+			for _, zone := range in.Spec.Cloud.Alicloud.Zones {
+				if !usedZones.Has(zone) {
+					w.Zones = append(w.Zones, zone)
+				}
 			}
 
 			out.Spec.Provider.Workers = append(out.Spec.Provider.Workers, w)
@@ -2139,8 +2156,11 @@ func Convert_v1beta1_Shoot_To_garden_Shoot(in *Shoot, out *garden.Shoot, s conve
 				w.Zones = data.Zones
 			}
 
-			if w.Zones == nil {
-				w.Zones = in.Spec.Cloud.Packet.Zones
+			usedZones := sets.NewString(w.Zones...)
+			for _, zone := range in.Spec.Cloud.Packet.Zones {
+				if !usedZones.Has(zone) {
+					w.Zones = append(w.Zones, zone)
+				}
 			}
 
 			out.Spec.Provider.Workers = append(out.Spec.Provider.Workers, w)
@@ -2247,7 +2267,6 @@ func Convert_garden_Shoot_To_v1beta1_Shoot(in *garden.Shoot, out *Shoot, s conve
 		}
 		metav1.SetMetaDataAnnotation(&out.ObjectMeta, garden.MigrationShootProvider, string(data))
 	}
-
 	return nil
 }
 

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -1185,7 +1185,10 @@ top:
 }
 
 func validateZones(constraints []garden.Region, region, oldRegion, zone string) (bool, []string) {
-	validValues := []string{}
+	var (
+		validValues = []string{}
+		regionFound = false
+	)
 
 	for _, r := range constraints {
 		if r.Name == region {
@@ -1195,10 +1198,12 @@ func validateZones(constraints []garden.Region, region, oldRegion, zone string) 
 					return true, nil
 				}
 			}
+			regionFound = true
+			break
 		}
 	}
 
-	if region == oldRegion {
+	if !regionFound && region == oldRegion {
 		return true, nil
 	}
 

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1142,6 +1142,37 @@ var _ = Describe("validator", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(apierrors.IsForbidden(err)).To(BeTrue())
 			})
+
+			It("should reject due to an invalid zone update", func() {
+				oldShoot := shoot.DeepCopy()
+				shoot.Spec.Cloud.AWS.Zones = append(shoot.Spec.Cloud.AWS.Zones, oldShoot.Spec.Cloud.AWS.Zones...)
+				shoot.Spec.Cloud.AWS.Zones = append(shoot.Spec.Cloud.AWS.Zones, "invalid-zone")
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
+			It("should allow update when zone has removed from CloudProfile", func() {
+				oldShoot := shoot.DeepCopy()
+				shoot.Spec.Cloud.AWS.Zones = []string{}
+				cloudProfile.Spec.Regions = cloudProfile.Spec.Regions[1:]
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
 		Context("tests for Azure cloud", func() {
@@ -1690,6 +1721,37 @@ var _ = Describe("validator", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(apierrors.IsForbidden(err)).To(BeTrue())
 			})
+
+			It("should reject due to an invalid zone update", func() {
+				oldShoot := shoot.DeepCopy()
+				shoot.Spec.Cloud.GCP.Zones = append(shoot.Spec.Cloud.GCP.Zones, oldShoot.Spec.Cloud.GCP.Zones...)
+				shoot.Spec.Cloud.GCP.Zones = append(shoot.Spec.Cloud.GCP.Zones, "invalid-zone")
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
+			It("should allow update when zone has removed from CloudProfile", func() {
+				oldShoot := shoot.DeepCopy()
+				shoot.Spec.Cloud.GCP.Zones = []string{}
+				cloudProfile.Spec.Regions = cloudProfile.Spec.Regions[1:]
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
 		Context("tests for Packet cloud", func() {
@@ -1933,6 +1995,37 @@ var _ = Describe("validator", func() {
 
 				Expect(err).To(HaveOccurred())
 				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
+			It("should reject due to an invalid zone update", func() {
+				oldShoot := shoot.DeepCopy()
+				shoot.Spec.Cloud.Packet.Zones = append(shoot.Spec.Cloud.Packet.Zones, oldShoot.Spec.Cloud.Packet.Zones...)
+				shoot.Spec.Cloud.Packet.Zones = append(shoot.Spec.Cloud.Packet.Zones, "invalid-zone")
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
+			It("should allow update when zone has removed from CloudProfile", func() {
+				oldShoot := shoot.DeepCopy()
+				shoot.Spec.Cloud.Packet.Zones = []string{}
+				cloudProfile.Spec.Regions = cloudProfile.Spec.Regions[1:]
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
@@ -2217,6 +2310,37 @@ var _ = Describe("validator", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(apierrors.IsForbidden(err)).To(BeTrue())
 			})
+
+			It("should reject due to an invalid zone update", func() {
+				oldShoot := shoot.DeepCopy()
+				shoot.Spec.Cloud.OpenStack.Zones = append(shoot.Spec.Cloud.OpenStack.Zones, oldShoot.Spec.Cloud.OpenStack.Zones...)
+				shoot.Spec.Cloud.OpenStack.Zones = append(shoot.Spec.Cloud.OpenStack.Zones, "invalid-zone")
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
+			It("should allow update when zone has removed from CloudProfile", func() {
+				oldShoot := shoot.DeepCopy()
+				shoot.Spec.Cloud.OpenStack.Zones = []string{}
+				cloudProfile.Spec.Regions = cloudProfile.Spec.Regions[1:]
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
 		Context("tests for Alicloud", func() {
@@ -2474,6 +2598,51 @@ var _ = Describe("validator", func() {
 
 				Expect(err).To(HaveOccurred())
 				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
+			It("should reject due to an invalid zone", func() {
+				shoot.Spec.Provider.Workers[0].Zones = []string{"invalid-zone"}
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
+			It("should reject due to an invalid zone update", func() {
+				oldShoot := shoot.DeepCopy()
+				shoot.Spec.Cloud.Alicloud.Zones = append(shoot.Spec.Cloud.Alicloud.Zones, oldShoot.Spec.Cloud.Alicloud.Zones...)
+				shoot.Spec.Cloud.Alicloud.Zones = append(shoot.Spec.Cloud.Alicloud.Zones, "invalid-zone")
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
+			It("should allow update when zone has removed from CloudProfile", func() {
+				oldShoot := shoot.DeepCopy()
+				shoot.Spec.Cloud.Alicloud.Zones = []string{}
+				cloudProfile.Spec.Regions = cloudProfile.Spec.Regions[1:]
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("should reject due to an machine type is not available in shoot zones", func() {
@@ -2887,6 +3056,37 @@ var _ = Describe("validator", func() {
 
 				Expect(err).To(HaveOccurred())
 				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
+			It("should reject due to an invalid zone update", func() {
+				oldShoot := shoot.DeepCopy()
+				shoot.Spec.Provider.Workers[0].Zones = append(shoot.Spec.Provider.Workers[0].Zones, oldShoot.Spec.Provider.Workers[0].Zones...)
+				shoot.Spec.Provider.Workers[0].Zones = append(shoot.Spec.Provider.Workers[0].Zones, "invalid-zone")
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			})
+
+			It("should allow update when zone has removed from CloudProfile", func() {
+				oldShoot := shoot.DeepCopy()
+				shoot.Spec.Provider.Workers[0].Zones = []string{}
+				cloudProfile.Spec.Regions = cloudProfile.Spec.Regions[1:]
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes several issues that arise when zones are added to shoot resources:

- Zones can now be added on shoot updates which was previously not possible due to conversion issues between `garden.sapcloud.io` and `core.gardener.cloud`.
- The order of listed zones in `garden.sapcloud.io` is now fixed. Due to conversion, the zones were sorted alphabetically but we should list them after the order they have been added.
- Zones that have been added afterwards are now validated against the the `CloudProfile`. (unintentionally removed by e1a33853094b486cb253ed4eb5eead67532823e1)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
An issue has been fixed which prevented availability zones from being added to existing shoot clusters.
```
```improvement user
Availability zone updates to shoot clusters are now validated against the corresponding `CloudProfile`.
```

