### PR TITLE
Shoot Care Controller - adapt  extension condition status

### DIFF
--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -575,7 +575,7 @@ func (b *HealthChecker) CheckLoggingControlPlane(
 // CheckExtensionCondition checks whether the conditions provided by extensions are healthy.
 func (b *HealthChecker) CheckExtensionCondition(condition gardencorev1alpha1.Condition, extensionsCondition []extensionCondition) *gardencorev1alpha1.Condition {
 	for _, cond := range extensionsCondition {
-		if cond.condition.Status == gardencorev1beta1.ConditionFalse {
+		if cond.condition.Status == gardencorev1beta1.ConditionFalse || cond.condition.Status == gardencorev1beta1.ConditionUnknown {
 			c := b.FailedCondition(condition, fmt.Sprintf("%sUnhealthyReport", cond.extensionType), cond.condition.Message)
 			return &c
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Condition.Status for health check conditions on extension resources can be 
{True, False, Unknown}.

The latter is present when the health check could not be performed e.g client error when listing nodes to check if there are as many nodes as required by the machinedeployment.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
