### PR TITLE
Change API version priority

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/apiservice-v1alpha1-core-gardener-cloud.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/apiservice-v1alpha1-core-gardener-cloud.yaml
@@ -16,8 +16,8 @@ spec:
   {{- end }}
   group: core.gardener.cloud
   version: v1alpha1
-  groupPriorityMinimum: 10
-  versionPriority: 10
+  groupPriorityMinimum: 11
+  versionPriority: 11
   service:
     name: gardener-apiserver
     namespace: garden

--- a/charts/gardener/controlplane/charts/application/templates/apiservice-v1beta1-core-gardener-cloud.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/apiservice-v1beta1-core-gardener-cloud.yaml
@@ -16,8 +16,8 @@ spec:
   {{- end }}
   group: core.gardener.cloud
   version: v1beta1
-  groupPriorityMinimum: 11
-  versionPriority: 11
+  groupPriorityMinimum: {{ required ".Values.global.apiserver.groupPriorityMinimum is required" .Values.global.apiserver.groupPriorityMinimum }}
+  versionPriority: {{ required ".Values.global.apiserver.versionPriority is required" .Values.global.apiserver.versionPriority }}
   service:
     name: gardener-apiserver
     namespace: garden

--- a/charts/gardener/controlplane/charts/application/templates/apiservice-v1beta1-garden-sapcloud-io.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/apiservice-v1beta1-garden-sapcloud-io.yaml
@@ -16,8 +16,8 @@ spec:
   {{- end }}
   group: garden.sapcloud.io
   version: v1beta1
-  groupPriorityMinimum: {{ required ".Values.global.apiserver.groupPriorityMinimum is required" .Values.global.apiserver.groupPriorityMinimum }}
-  versionPriority: {{ required ".Values.global.apiserver.versionPriority is required" .Values.global.apiserver.versionPriority }}
+  groupPriorityMinimum: 10
+  versionPriority: 10
   service:
     name: gardener-apiserver
     namespace: garden

--- a/hack/dev-setup-register-gardener
+++ b/hack/dev-setup-register-gardener
@@ -123,8 +123,8 @@ spec:
   insecureSkipTLSVerify: true
   group: garden.sapcloud.io
   version: v1beta1
-  groupPriorityMinimum: 10000
-  versionPriority: 20
+  groupPriorityMinimum: 10
+  versionPriority: 10
   service:
     name: gardener-apiserver
     namespace: garden
@@ -137,8 +137,8 @@ spec:
   insecureSkipTLSVerify: true
   group: core.gardener.cloud
   version: v1alpha1
-  groupPriorityMinimum: 10
-  versionPriority: 10
+  groupPriorityMinimum: 9999
+  versionPriority: 19
   service:
     name: gardener-apiserver
     namespace: garden
@@ -151,8 +151,8 @@ spec:
   insecureSkipTLSVerify: true
   group: core.gardener.cloud
   version: v1beta1
-  groupPriorityMinimum: 11
-  versionPriority: 11
+  groupPriorityMinimum: 10000
+  versionPriority: 20
   service:
     name: gardener-apiserver
     namespace: garden


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR the API priority of `garden.sapcloud.io/v1beta1` will be lowered in favor of the new `core.gardener.cloud/v1beta1`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
The new `core.gardener.cloud/v1beta1` API version now has the highest priority. This means that e.g. `kubectl get shoot` will no longer return the `Shoot` in `garden.sapcloud.io/v1beta1` but in `core.gardener.cloud/v1beta1`. If the `garden.sapcloud.io/v1beta1` is desired then `kubectl get shoot.garden.sapcloud.io` should be used. In some cases the `.kube` caches should be cleaned by `rm -rf ~/.kube/cache; rm -rf ~/.kube/http-cache`. Please note that this is the last step before the `garden.sapcloud.io/v1beta1` will finally be removed.
```
```action developer
Developers might want to re-run `./hack/dev-setup-register-gardener` in order to refresh the API version priority. In some cases the `.kube` caches should be cleaned by `rm -rf ~/.kube/cache; rm -rf ~/.kube/http-cache`.
```