### PR TITLE
Keep old machine image in shoot validator admission plugin

### DIFF
--- a/pkg/apis/garden/helper/helpers.go
+++ b/pkg/apis/garden/helper/helpers.go
@@ -269,3 +269,13 @@ func QuotaScope(scopeRef corev1.ObjectReference) (string, error) {
 	}
 	return "", fmt.Errorf("unknown quota scope")
 }
+
+// FindWorkerByName tries to find the worker with the given name. If it cannot be found it returns nil.
+func FindWorkerByName(workers []garden.Worker, name string) *garden.Worker {
+	for _, w := range workers {
+		if w.Name == name {
+			return &w
+		}
+	}
+	return nil
+}

--- a/pkg/apis/garden/helper/helpers_test.go
+++ b/pkg/apis/garden/helper/helpers_test.go
@@ -319,4 +319,14 @@ var _ = Describe("helper", func() {
 		Entry("dns providers but different type", &garden.DNS{Providers: []garden.DNSProvider{{Type: &differentType}}}, false),
 		Entry("dns providers and unmanaged type", &garden.DNS{Providers: []garden.DNSProvider{{Type: &unmanagedType}}}, true),
 	)
+
+	DescribeTable("#FindWorkerByName",
+		func(workers []garden.Worker, name string, expectedWorker *garden.Worker) {
+			Expect(FindWorkerByName(workers, name)).To(Equal(expectedWorker))
+		},
+
+		Entry("no workers", nil, "", nil),
+		Entry("worker not found", []garden.Worker{{Name: "foo"}}, "bar", nil),
+		Entry("worker found", []garden.Worker{{Name: "foo"}}, "foo", &garden.Worker{Name: "foo"}),
+	)
 })

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -345,12 +345,10 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 		return apierrors.NewBadRequest(err.Error())
 	}
 
-	for idx, worker := range shoot.Spec.Provider.Workers {
-		if shoot.DeletionTimestamp == nil && worker.Machine.Image == nil {
-			shoot.Spec.Provider.Workers[idx].Machine.Image = image
-		}
-	}
-
+	// General approach with machine image defaulting in this code: Try to keep the machine image
+	// from the old shoot object to not accidentally update it to the default machine image.
+	// This should only happen in the maintenance time window of shoots and is performed by the
+	// shoot maintenance controller.
 	switch shoot.Spec.Provider.Type {
 	case "aws":
 		if shoot.Spec.Cloud.AWS.MachineImage == nil {
@@ -359,7 +357,7 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 
 		for idx, worker := range shoot.Spec.Cloud.AWS.Workers {
 			if shoot.DeletionTimestamp == nil && worker.Machine.Image == nil {
-				shoot.Spec.Cloud.AWS.Workers[idx].Machine.Image = shoot.Spec.Cloud.AWS.MachineImage
+				shoot.Spec.Cloud.AWS.Workers[idx].Machine.Image = getOldWorkerMachineImageOrDefault(oldShoot.Spec.Cloud.AWS.Workers, worker.Name, shoot.Spec.Cloud.AWS.MachineImage)
 			}
 		}
 
@@ -390,7 +388,7 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 
 		for idx, worker := range shoot.Spec.Cloud.Azure.Workers {
 			if shoot.DeletionTimestamp == nil && worker.Machine.Image == nil {
-				shoot.Spec.Cloud.Azure.Workers[idx].Machine.Image = shoot.Spec.Cloud.Azure.MachineImage
+				shoot.Spec.Cloud.Azure.Workers[idx].Machine.Image = getOldWorkerMachineImageOrDefault(oldShoot.Spec.Cloud.Azure.Workers, worker.Name, shoot.Spec.Cloud.Azure.MachineImage)
 			}
 		}
 
@@ -421,7 +419,7 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 
 		for idx, worker := range shoot.Spec.Cloud.GCP.Workers {
 			if shoot.DeletionTimestamp == nil && worker.Machine.Image == nil {
-				shoot.Spec.Cloud.GCP.Workers[idx].Machine.Image = shoot.Spec.Cloud.GCP.MachineImage
+				shoot.Spec.Cloud.GCP.Workers[idx].Machine.Image = getOldWorkerMachineImageOrDefault(oldShoot.Spec.Cloud.GCP.Workers, worker.Name, shoot.Spec.Cloud.GCP.MachineImage)
 			}
 		}
 
@@ -452,7 +450,7 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 
 		for idx, worker := range shoot.Spec.Cloud.OpenStack.Workers {
 			if shoot.DeletionTimestamp == nil && worker.Machine.Image == nil {
-				shoot.Spec.Cloud.OpenStack.Workers[idx].Machine.Image = shoot.Spec.Cloud.OpenStack.MachineImage
+				shoot.Spec.Cloud.OpenStack.Workers[idx].Machine.Image = getOldWorkerMachineImageOrDefault(oldShoot.Spec.Cloud.OpenStack.Workers, worker.Name, shoot.Spec.Cloud.OpenStack.MachineImage)
 			}
 		}
 
@@ -483,7 +481,7 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 
 		for idx, worker := range shoot.Spec.Cloud.Packet.Workers {
 			if shoot.DeletionTimestamp == nil && worker.Machine.Image == nil {
-				shoot.Spec.Cloud.Packet.Workers[idx].Machine.Image = shoot.Spec.Cloud.Packet.MachineImage
+				shoot.Spec.Cloud.Packet.Workers[idx].Machine.Image = getOldWorkerMachineImageOrDefault(oldShoot.Spec.Cloud.Packet.Workers, worker.Name, shoot.Spec.Cloud.Packet.MachineImage)
 			}
 		}
 
@@ -514,7 +512,7 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 
 		for idx, worker := range shoot.Spec.Cloud.Alicloud.Workers {
 			if shoot.DeletionTimestamp == nil && worker.Machine.Image == nil {
-				shoot.Spec.Cloud.Alicloud.Workers[idx].Machine.Image = shoot.Spec.Cloud.Alicloud.MachineImage
+				shoot.Spec.Cloud.Alicloud.Workers[idx].Machine.Image = getOldWorkerMachineImageOrDefault(oldShoot.Spec.Cloud.Alicloud.Workers, worker.Name, shoot.Spec.Cloud.Alicloud.MachineImage)
 			}
 		}
 
@@ -548,7 +546,7 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 
 	for idx, worker := range shoot.Spec.Provider.Workers {
 		if shoot.DeletionTimestamp == nil && worker.Machine.Image == nil {
-			shoot.Spec.Provider.Workers[idx].Machine.Image = image
+			shoot.Spec.Provider.Workers[idx].Machine.Image = getOldWorkerMachineImageOrDefault(oldShoot.Spec.Provider.Workers, worker.Name, image)
 		}
 	}
 
@@ -1300,4 +1298,11 @@ func validateMachineImagesConstraints(constraints []garden.CloudProfileMachineIm
 		}
 	}
 	return false, validValues
+}
+
+func getOldWorkerMachineImageOrDefault(workers []garden.Worker, name string, defaultImage *garden.ShootMachineImage) *garden.ShootMachineImage {
+	if oldWorker := helper.FindWorkerByName(workers, name); oldWorker != nil && oldWorker.Machine.Image != nil {
+		return oldWorker.Machine.Image
+	}
+	return defaultImage
 }

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -2961,6 +2961,120 @@ var _ = Describe("validator", func() {
 				Expect(apierrors.IsForbidden(err)).To(BeTrue())
 			})
 
+			It("should use latest machine image as old shoot does not specify one", func() {
+				imageName := "some-image"
+				version1 := "1.1.1"
+				version2 := "2.2.2"
+
+				cloudProfile.Spec.MachineImages = []garden.CloudProfileMachineImage{
+					{
+						Name: imageName,
+						Versions: []garden.ExpirableVersion{
+							{
+								Version: version2,
+							},
+							{
+								Version:        version1,
+								ExpirationDate: &metav1.Time{Time: metav1.Now().Add(time.Second * -1000)},
+							},
+						},
+					},
+				}
+
+				shoot.Spec.Provider.Workers[0].Machine.Image = nil
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, nil, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(&garden.ShootMachineImage{
+					Name:    imageName,
+					Version: version2,
+				}))
+			})
+
+			It("should not touch the machine image of the old shoot", func() {
+				imageName := "some-image"
+				version1 := "1.1.1"
+				version2 := "2.2.2"
+
+				cloudProfile.Spec.MachineImages = append(cloudProfile.Spec.MachineImages, garden.CloudProfileMachineImage{
+					Name: imageName,
+					Versions: []garden.ExpirableVersion{
+						{
+							Version: version2,
+						},
+						{
+							Version:        version1,
+							ExpirationDate: &metav1.Time{Time: metav1.Now().Add(time.Second * -1000)},
+						},
+					},
+				})
+
+				shoot.Spec.Provider.Workers[0].Machine.Image = &garden.ShootMachineImage{
+					Name:    imageName,
+					Version: version1,
+				}
+				newShoot := shoot.DeepCopy()
+				newShoot.Spec.Provider.Workers[0].Machine.Image = nil
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(newShoot, &shoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(*newShoot).To(Equal(shoot))
+			})
+
+			It("should respect the desired machine image of the new shoot", func() {
+				imageName := "some-image"
+				version1 := "1.1.1"
+				version2 := "2.2.2"
+
+				cloudProfile.Spec.MachineImages = append(cloudProfile.Spec.MachineImages, garden.CloudProfileMachineImage{
+					Name: imageName,
+					Versions: []garden.ExpirableVersion{
+						{
+							Version: version2,
+						},
+						{
+							Version:        version1,
+							ExpirationDate: &metav1.Time{Time: metav1.Now().Add(time.Second * -1000)},
+						},
+					},
+				})
+
+				shoot.Spec.Provider.Workers[0].Machine.Image = &garden.ShootMachineImage{
+					Name:    imageName,
+					Version: version1,
+				}
+				newShoot := shoot.DeepCopy()
+				newShoot.Spec.Provider.Workers[0].Machine.Image = &garden.ShootMachineImage{
+					Name:    imageName,
+					Version: version2,
+				}
+
+				gardenInformerFactory.Garden().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				gardenInformerFactory.Garden().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+				gardenInformerFactory.Garden().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(newShoot, &shoot, garden.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(newShoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(&garden.ShootMachineImage{
+					Name:    imageName,
+					Version: version2,
+				}))
+			})
+
 			It("should not reject due to an usable machine type", func() {
 				shoot.Spec.Provider.Workers = []garden.Worker{
 					{


### PR DESCRIPTION
**What this PR does / why we need it**:
Keep old machine image in shoot validator admission plugin during update requests if possible. If old does not specify an image then set the default image.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
An issue that unintentionally updated the machine image to the latest one during shoot updates when no image was provided has been fixed.
```
