### PR TITLE
Make hvpa CRD v1.11 compatible

### DIFF
--- a/charts/seed-bootstrap/charts/hvpa/templates/hvpa-crd.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/templates/hvpa-crd.yaml
@@ -959,7 +959,9 @@ spec:
               format: int32
               type: integer
           type: object
+      {{- if semverCompare ">= 1.12" .Capabilities.KubeVersion.GitVersion }}
       type: object
+      {{- end }}
   versions:
   - name: v1alpha1
     served: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Make hvpa CRD v1.11 compatible.

The relevant error was: `must only have "properties", "required" or "description" at the root if the status subresource is enabled`
`type` is not allowed under `.spec.validation.openAPIV3Schema` in Kubernetes v1.11. Ref jetstack/cert-manager#2200.


**Which issue(s) this PR fixes**:
Fixes #1776 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue preventing HVPA to be properly bootstrapped on v1.11.x Seed is now fixed.
```
