### PR TITLE
Renounce hard-coded Kind user

### DIFF
--- a/hack/common
+++ b/hack/common
@@ -54,7 +54,6 @@ k8s_env() {
 k8s_username() {
     case $(k8s_env) in
         $KIND)
-            echo "kubernetes-admin"
             ;;
         $DOCKER_FOR_DESKTOP)
             echo "$(k8s_nodename)"

--- a/hack/start-apiserver
+++ b/hack/start-apiserver
@@ -39,8 +39,8 @@ case $(k8s_env) in
           -ldflags "$ld_flags" \
           cmd/gardener-apiserver/main.go \
           --etcd-servers http://localhost:32379 \
-          --tls-cert-file <(kubectl config view -o go-template="{{range .users}}{{if eq .name \""$(k8s_username)"\"}}{{index .user \"client-certificate-data\"}}{{end}}{{end}}" --raw | base64 -d) \
-          --tls-private-key-file <(kubectl config view -o go-template="{{range .users}}{{if eq .name \""$(k8s_username)"\"}}{{index .user \"client-key-data\"}}{{end}}{{end}}" --raw | base64 -d) \
+          --tls-cert-file <(kind get kubeconfig | sed -n -e 's/^.*client-certificate-data: //p' | base64 -d) \
+          --tls-private-key-file <(kind get kubeconfig | sed -n -e 's/^.*client-key-data: //p' | base64 -d) \
           $apiserver_flags
         ;;
     $DOCKER_FOR_DESKTOP)


### PR DESCRIPTION
**What this PR does / why we need it**:
The default `Kind` username was changed some time ago which broke Gardener's local dev setup. With this PR, we get rid of the hard-coded user name.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The local development setup scripts have been updated to be compatible with the latest `Kind` version (v0.6.1).
```
