### PR TITLE
Rework seed extension control

### DIFF
--- a/pkg/apis/core/v1alpha1/helper/condition_builder.go
+++ b/pkg/apis/core/v1alpha1/helper/condition_builder.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper
+
+import (
+	"fmt"
+
+	api "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ConditionBuilder build a Condition.
+type ConditionBuilder interface {
+	WithOldCondition(old api.Condition) ConditionBuilder
+	WithStatus(status api.ConditionStatus) ConditionBuilder
+	WithReason(reason string) ConditionBuilder
+	WithMessage(message string) ConditionBuilder
+	WithNowFunc(now func() metav1.Time) ConditionBuilder
+	Build() (new api.Condition, updated bool)
+}
+
+// defaultConditionBuilder build a Condition.
+type defaultConditionBuilder struct {
+	old           api.Condition
+	status        api.ConditionStatus
+	conditionType api.ConditionType
+	reason        string
+	message       string
+	nowFunc       func() metav1.Time
+}
+
+// NewConditionBuilder returns a ConditionBuilder for a specific condition.
+func NewConditionBuilder(conditionType api.ConditionType) (ConditionBuilder, error) {
+	if conditionType == "" {
+		return nil, fmt.Errorf("conditionType cannot be empty")
+	}
+
+	return &defaultConditionBuilder{
+		conditionType: conditionType,
+		nowFunc:       metav1.Now,
+	}, nil
+}
+
+// WithOldCondition sets the old condition. It can be used to prodive default values.
+// The old's condition type is overridden to the one specified in the builder.
+func (b *defaultConditionBuilder) WithOldCondition(old api.Condition) ConditionBuilder {
+	old.Type = b.conditionType
+	b.old = old
+
+	return b
+}
+
+// WithStatus sets the status of the condition.
+func (b *defaultConditionBuilder) WithStatus(status api.ConditionStatus) ConditionBuilder {
+	b.status = status
+	return b
+}
+
+// WithReason sets the reason of the condition.
+func (b *defaultConditionBuilder) WithReason(reason string) ConditionBuilder {
+	b.reason = reason
+	return b
+}
+
+// WithMessage sets the message of the condition.
+func (b *defaultConditionBuilder) WithMessage(message string) ConditionBuilder {
+	b.message = message
+	return b
+}
+
+// WithNowFunc sets the function used for getting the current time.
+// Should only be used for tests.
+func (b *defaultConditionBuilder) WithNowFunc(now func() metav1.Time) ConditionBuilder {
+	b.nowFunc = now
+	return b
+}
+
+// Build creates the condition and returns if there are modifications with the OldCondition.
+// If OldCondition is provided:
+// - Any changes to status set the `LastTransitionTime`
+// - Any updates to the message or the reason cause set `LastUpdateTime` to the current time.
+func (b *defaultConditionBuilder) Build() (new api.Condition, updated bool) {
+	var (
+		now       = b.nowFunc()
+		emptyTime = metav1.Time{}
+	)
+
+	new = *b.old.DeepCopy()
+
+	if new.LastTransitionTime == emptyTime {
+		new.LastTransitionTime = now
+	}
+
+	if new.LastUpdateTime == emptyTime {
+		new.LastUpdateTime = now
+	}
+
+	new.Type = b.conditionType
+
+	if b.status != "" {
+		new.Status = b.status
+	} else if b.status == "" && b.old.Status == "" {
+		new.Status = api.ConditionUnknown
+	}
+
+	if b.reason != "" {
+		new.Reason = b.reason
+	} else if b.reason == "" && b.old.Reason == "" {
+		new.Reason = "ConditionInitialized"
+	}
+
+	if b.message != "" {
+		new.Message = b.message
+	} else if b.message == "" && b.old.Message == "" {
+		new.Message = "The condition has been initialized but its semantic check has not been performed yet."
+	}
+
+	if new.Status != b.old.Status {
+		new.LastTransitionTime = now
+	}
+
+	if new.Reason != b.old.Reason || new.Message != b.old.Message {
+		new.LastUpdateTime = now
+	}
+
+	return new, !apiequality.Semantic.DeepEqual(new, b.old)
+}

--- a/pkg/apis/core/v1alpha1/helper/condition_builder_test.go
+++ b/pkg/apis/core/v1alpha1/helper/condition_builder_test.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper_test
+
+import (
+	"time"
+
+	api "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	. "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Builder", func() {
+
+	const (
+		conditionType = api.ConditionType("Test")
+		// re-decalared so the underlying constant is not changed
+		unknowStatus       = api.ConditionStatus("Unknown")
+		fooStatus          = api.ConditionStatus("Foo")
+		bazReason          = "Baz"
+		fubarMessage       = "FuBar"
+		unitializedMessage = `The condition has been initialized but its semantic check has not been performed yet.`
+		initializedReason  = "ConditionInitialized"
+	)
+
+	var (
+		defaultTime     metav1.Time
+		defaultTimeFunc func() metav1.Time
+	)
+
+	BeforeEach(func() {
+		defaultTime = metav1.NewTime(time.Unix(2, 2))
+		defaultTimeFunc = func() metav1.Time {
+			return defaultTime
+		}
+	})
+
+	Describe("#NewConditionBuilder", func() {
+
+		It("should return error if condition type is empty", func() {
+			bldr, err := NewConditionBuilder("")
+
+			Expect(bldr).To(BeNil())
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return not empty builder on success", func() {
+			bldr, err := NewConditionBuilder("Foo")
+
+			Expect(bldr).ToNot(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("#Build", func() {
+
+		var (
+			result  api.Condition
+			updated bool
+			bldr    ConditionBuilder
+		)
+
+		JustBeforeEach(func() {
+			bldr, _ = NewConditionBuilder(conditionType)
+		})
+
+		Context("empty condition", func() {
+
+			JustBeforeEach(func() {
+				result, updated = bldr.WithNowFunc(defaultTimeFunc).Build()
+			})
+
+			It("should mark the result as updated", func() {
+				Expect(updated).To(BeTrue())
+			})
+
+			It("should return correct result", func() {
+				Expect(result).To(Equal(api.Condition{
+					Type:               conditionType,
+					Status:             unknowStatus,
+					LastTransitionTime: defaultTime,
+					LastUpdateTime:     defaultTime,
+					Reason:             initializedReason,
+					Message:            unitializedMessage,
+				}))
+			})
+		})
+
+		Context("#WithStatus", func() {
+			JustBeforeEach(func() {
+				result, updated = bldr.
+					WithNowFunc(defaultTimeFunc).
+					WithStatus(fooStatus).
+					Build()
+			})
+
+			It("should mark the result as updated", func() {
+				Expect(updated).To(BeTrue())
+			})
+
+			It("should return correct result", func() {
+				Expect(result).To(Equal(api.Condition{
+					Type:               conditionType,
+					Status:             fooStatus,
+					LastTransitionTime: defaultTime,
+					LastUpdateTime:     defaultTime,
+					Reason:             initializedReason,
+					Message:            unitializedMessage,
+				}))
+			})
+		})
+
+		Context("#WithReason", func() {
+			JustBeforeEach(func() {
+				result, updated = bldr.
+					WithNowFunc(defaultTimeFunc).
+					WithReason(bazReason).
+					Build()
+			})
+
+			It("should mark the result as updated", func() {
+				Expect(updated).To(BeTrue())
+			})
+
+			It("should return correct result", func() {
+				Expect(result).To(Equal(api.Condition{
+					Type:               conditionType,
+					Status:             unknowStatus,
+					LastTransitionTime: defaultTime,
+					LastUpdateTime:     defaultTime,
+					Reason:             bazReason,
+					Message:            unitializedMessage,
+				}))
+			})
+		})
+
+		Context("#WithMessage", func() {
+			JustBeforeEach(func() {
+				result, updated = bldr.
+					WithNowFunc(defaultTimeFunc).
+					WithMessage(fubarMessage).
+					Build()
+			})
+
+			It("should mark the result as updated", func() {
+				Expect(updated).To(BeTrue())
+			})
+
+			It("should return correct result", func() {
+				Expect(result).To(Equal(api.Condition{
+					Type:               conditionType,
+					Status:             unknowStatus,
+					LastTransitionTime: defaultTime,
+					LastUpdateTime:     defaultTime,
+					Reason:             initializedReason,
+					Message:            fubarMessage,
+				}))
+			})
+		})
+
+		Context("#WithOldCondition", func() {
+			JustBeforeEach(func() {
+				result, updated = bldr.
+					WithNowFunc(defaultTimeFunc).
+					WithOldCondition(api.Condition{
+						Type:               conditionType,
+						Status:             fooStatus,
+						LastTransitionTime: metav1.NewTime(time.Unix(10, 0)),
+						LastUpdateTime:     metav1.NewTime(time.Unix(11, 0)),
+						Reason:             bazReason,
+						Message:            fubarMessage,
+					}).
+					Build()
+			})
+
+			It("should mark the result as not updated", func() {
+				Expect(updated).To(BeFalse())
+			})
+
+			It("should return correct result", func() {
+				Expect(result).To(Equal(api.Condition{
+					Type:               conditionType,
+					Status:             fooStatus,
+					LastTransitionTime: metav1.NewTime(time.Unix(10, 0)),
+					LastUpdateTime:     metav1.NewTime(time.Unix(11, 0)),
+					Reason:             bazReason,
+					Message:            fubarMessage,
+				}))
+			})
+		})
+
+		Context("Full override", func() {
+			JustBeforeEach(func() {
+				result, updated = bldr.
+					WithNowFunc(defaultTimeFunc).
+					WithStatus("SomeNewStatus").
+					WithMessage("Some message").
+					WithReason("SomeNewReason").
+					WithOldCondition(api.Condition{
+						Type:               conditionType,
+						Status:             fooStatus,
+						LastTransitionTime: metav1.NewTime(time.Unix(10, 0)),
+						LastUpdateTime:     metav1.NewTime(time.Unix(11, 0)),
+						Reason:             bazReason,
+						Message:            fubarMessage,
+					}).
+					Build()
+			})
+
+			It("should mark the result as updated", func() {
+				Expect(updated).To(BeTrue())
+			})
+
+			It("should return correct result", func() {
+				Expect(result).To(Equal(api.Condition{
+					Type:               conditionType,
+					Status:             api.ConditionStatus("SomeNewStatus"),
+					LastTransitionTime: defaultTime,
+					LastUpdateTime:     defaultTime,
+					Reason:             "SomeNewReason",
+					Message:            "Some message",
+				}))
+			})
+		})
+	})
+})

--- a/pkg/apis/core/v1beta1/helper/condition_builder.go
+++ b/pkg/apis/core/v1beta1/helper/condition_builder.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper
+
+import (
+	"fmt"
+
+	api "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ConditionBuilder build a Condition.
+type ConditionBuilder interface {
+	WithOldCondition(old api.Condition) ConditionBuilder
+	WithStatus(status api.ConditionStatus) ConditionBuilder
+	WithReason(reason string) ConditionBuilder
+	WithMessage(message string) ConditionBuilder
+	WithNowFunc(now func() metav1.Time) ConditionBuilder
+	Build() (new api.Condition, updated bool)
+}
+
+// defaultConditionBuilder build a Condition.
+type defaultConditionBuilder struct {
+	old           api.Condition
+	status        api.ConditionStatus
+	conditionType api.ConditionType
+	reason        string
+	message       string
+	nowFunc       func() metav1.Time
+}
+
+// NewConditionBuilder returns a ConditionBuilder for a specific condition.
+func NewConditionBuilder(conditionType api.ConditionType) (ConditionBuilder, error) {
+	if conditionType == "" {
+		return nil, fmt.Errorf("conditionType cannot be empty")
+	}
+
+	return &defaultConditionBuilder{
+		conditionType: conditionType,
+		nowFunc:       metav1.Now,
+	}, nil
+}
+
+// WithOldCondition sets the old condition. It can be used to prodive default values.
+// The old's condition type is overridden to the one specified in the builder.
+func (b *defaultConditionBuilder) WithOldCondition(old api.Condition) ConditionBuilder {
+	old.Type = b.conditionType
+	b.old = old
+
+	return b
+}
+
+// WithStatus sets the status of the condition.
+func (b *defaultConditionBuilder) WithStatus(status api.ConditionStatus) ConditionBuilder {
+	b.status = status
+	return b
+}
+
+// WithReason sets the reason of the condition.
+func (b *defaultConditionBuilder) WithReason(reason string) ConditionBuilder {
+	b.reason = reason
+	return b
+}
+
+// WithMessage sets the message of the condition.
+func (b *defaultConditionBuilder) WithMessage(message string) ConditionBuilder {
+	b.message = message
+	return b
+}
+
+// WithNowFunc sets the function used for getting the current time.
+// Should only be used for tests.
+func (b *defaultConditionBuilder) WithNowFunc(now func() metav1.Time) ConditionBuilder {
+	b.nowFunc = now
+	return b
+}
+
+// Build creates the condition and returns if there are modifications with the OldCondition.
+// If OldCondition is provided:
+// - Any changes to status set the `LastTransitionTime`
+// - Any updates to the message or the reason cause set `LastUpdateTime` to the current time.
+func (b *defaultConditionBuilder) Build() (new api.Condition, updated bool) {
+	var (
+		now       = b.nowFunc()
+		emptyTime = metav1.Time{}
+	)
+
+	new = *b.old.DeepCopy()
+
+	if new.LastTransitionTime == emptyTime {
+		new.LastTransitionTime = now
+	}
+
+	if new.LastUpdateTime == emptyTime {
+		new.LastUpdateTime = now
+	}
+
+	new.Type = b.conditionType
+
+	if b.status != "" {
+		new.Status = b.status
+	} else if b.status == "" && b.old.Status == "" {
+		new.Status = api.ConditionUnknown
+	}
+
+	if b.reason != "" {
+		new.Reason = b.reason
+	} else if b.reason == "" && b.old.Reason == "" {
+		new.Reason = "ConditionInitialized"
+	}
+
+	if b.message != "" {
+		new.Message = b.message
+	} else if b.message == "" && b.old.Message == "" {
+		new.Message = "The condition has been initialized but its semantic check has not been performed yet."
+	}
+
+	if new.Status != b.old.Status {
+		new.LastTransitionTime = now
+	}
+
+	if new.Reason != b.old.Reason || new.Message != b.old.Message {
+		new.LastUpdateTime = now
+	}
+
+	return new, !apiequality.Semantic.DeepEqual(new, b.old)
+}

--- a/pkg/apis/core/v1beta1/helper/condition_builder_test.go
+++ b/pkg/apis/core/v1beta1/helper/condition_builder_test.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper_test
+
+import (
+	"time"
+
+	api "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Builder", func() {
+
+	const (
+		conditionType = api.ConditionType("Test")
+		// re-decalared so the underlying constant is not changed
+		unknowStatus       = api.ConditionStatus("Unknown")
+		fooStatus          = api.ConditionStatus("Foo")
+		bazReason          = "Baz"
+		fubarMessage       = "FuBar"
+		unitializedMessage = `The condition has been initialized but its semantic check has not been performed yet.`
+		initializedReason  = "ConditionInitialized"
+	)
+
+	var (
+		defaultTime     metav1.Time
+		defaultTimeFunc func() metav1.Time
+	)
+
+	BeforeEach(func() {
+		defaultTime = metav1.NewTime(time.Unix(2, 2))
+		defaultTimeFunc = func() metav1.Time {
+			return defaultTime
+		}
+	})
+
+	Describe("#NewConditionBuilder", func() {
+
+		It("should return error if condition type is empty", func() {
+			bldr, err := NewConditionBuilder("")
+
+			Expect(bldr).To(BeNil())
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return not empty builder on success", func() {
+			bldr, err := NewConditionBuilder("Foo")
+
+			Expect(bldr).ToNot(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("#Build", func() {
+
+		var (
+			result  api.Condition
+			updated bool
+			bldr    ConditionBuilder
+		)
+
+		JustBeforeEach(func() {
+			bldr, _ = NewConditionBuilder(conditionType)
+		})
+
+		Context("empty condition", func() {
+
+			JustBeforeEach(func() {
+				result, updated = bldr.WithNowFunc(defaultTimeFunc).Build()
+			})
+
+			It("should mark the result as updated", func() {
+				Expect(updated).To(BeTrue())
+			})
+
+			It("should return correct result", func() {
+				Expect(result).To(Equal(api.Condition{
+					Type:               conditionType,
+					Status:             unknowStatus,
+					LastTransitionTime: defaultTime,
+					LastUpdateTime:     defaultTime,
+					Reason:             initializedReason,
+					Message:            unitializedMessage,
+				}))
+			})
+		})
+
+		Context("#WithStatus", func() {
+			JustBeforeEach(func() {
+				result, updated = bldr.
+					WithNowFunc(defaultTimeFunc).
+					WithStatus(fooStatus).
+					Build()
+			})
+
+			It("should mark the result as updated", func() {
+				Expect(updated).To(BeTrue())
+			})
+
+			It("should return correct result", func() {
+				Expect(result).To(Equal(api.Condition{
+					Type:               conditionType,
+					Status:             fooStatus,
+					LastTransitionTime: defaultTime,
+					LastUpdateTime:     defaultTime,
+					Reason:             initializedReason,
+					Message:            unitializedMessage,
+				}))
+			})
+		})
+
+		Context("#WithReason", func() {
+			JustBeforeEach(func() {
+				result, updated = bldr.
+					WithNowFunc(defaultTimeFunc).
+					WithReason(bazReason).
+					Build()
+			})
+
+			It("should mark the result as updated", func() {
+				Expect(updated).To(BeTrue())
+			})
+
+			It("should return correct result", func() {
+				Expect(result).To(Equal(api.Condition{
+					Type:               conditionType,
+					Status:             unknowStatus,
+					LastTransitionTime: defaultTime,
+					LastUpdateTime:     defaultTime,
+					Reason:             bazReason,
+					Message:            unitializedMessage,
+				}))
+			})
+		})
+
+		Context("#WithMessage", func() {
+			JustBeforeEach(func() {
+				result, updated = bldr.
+					WithNowFunc(defaultTimeFunc).
+					WithMessage(fubarMessage).
+					Build()
+			})
+
+			It("should mark the result as updated", func() {
+				Expect(updated).To(BeTrue())
+			})
+
+			It("should return correct result", func() {
+				Expect(result).To(Equal(api.Condition{
+					Type:               conditionType,
+					Status:             unknowStatus,
+					LastTransitionTime: defaultTime,
+					LastUpdateTime:     defaultTime,
+					Reason:             initializedReason,
+					Message:            fubarMessage,
+				}))
+			})
+		})
+
+		Context("#WithOldCondition", func() {
+			JustBeforeEach(func() {
+				result, updated = bldr.
+					WithNowFunc(defaultTimeFunc).
+					WithOldCondition(api.Condition{
+						Type:               conditionType,
+						Status:             fooStatus,
+						LastTransitionTime: metav1.NewTime(time.Unix(10, 0)),
+						LastUpdateTime:     metav1.NewTime(time.Unix(11, 0)),
+						Reason:             bazReason,
+						Message:            fubarMessage,
+					}).
+					Build()
+			})
+
+			It("should mark the result as not updated", func() {
+				Expect(updated).To(BeFalse())
+			})
+
+			It("should return correct result", func() {
+				Expect(result).To(Equal(api.Condition{
+					Type:               conditionType,
+					Status:             fooStatus,
+					LastTransitionTime: metav1.NewTime(time.Unix(10, 0)),
+					LastUpdateTime:     metav1.NewTime(time.Unix(11, 0)),
+					Reason:             bazReason,
+					Message:            fubarMessage,
+				}))
+			})
+		})
+
+		Context("Full override", func() {
+			JustBeforeEach(func() {
+				result, updated = bldr.
+					WithNowFunc(defaultTimeFunc).
+					WithStatus("SomeNewStatus").
+					WithMessage("Some message").
+					WithReason("SomeNewReason").
+					WithOldCondition(api.Condition{
+						Type:               conditionType,
+						Status:             fooStatus,
+						LastTransitionTime: metav1.NewTime(time.Unix(10, 0)),
+						LastUpdateTime:     metav1.NewTime(time.Unix(11, 0)),
+						Reason:             bazReason,
+						Message:            fubarMessage,
+					}).
+					Build()
+			})
+
+			It("should mark the result as updated", func() {
+				Expect(updated).To(BeTrue())
+			})
+
+			It("should return correct result", func() {
+				Expect(result).To(Equal(api.Condition{
+					Type:               conditionType,
+					Status:             api.ConditionStatus("SomeNewStatus"),
+					LastTransitionTime: defaultTime,
+					LastUpdateTime:     defaultTime,
+					Reason:             "SomeNewReason",
+					Message:            "Some message",
+				}))
+			})
+		})
+	})
+})

--- a/pkg/gardenlet/controller/seed/seed.go
+++ b/pkg/gardenlet/controller/seed/seed.go
@@ -102,7 +102,7 @@ func NewSeedController(
 		k8sGardenCoreInformers:  gardenCoreInformerFactory,
 		control:                 NewDefaultControl(k8sGardenClient, gardenCoreInformerFactory, secrets, imageVector, identity, recorder, config, secretLister, shootLister),
 		heartbeatControl:        NewDefaultHeartbeatControl(k8sGardenClient, gardenCoreV1beta1Informer, identity, config),
-		extensionCheckControl:   NewDefaultExtensionCheckControl(k8sGardenClient, controllerInstallationLister, recorder),
+		extensionCheckControl:   NewDefaultExtensionCheckControl(k8sGardenClient.GardenCore(), controllerInstallationLister, metav1.Now),
 		config:                  config,
 		recorder:                recorder,
 		seedLister:              seedLister,

--- a/pkg/gardenlet/controller/seed/seed_extension_control.go
+++ b/pkg/gardenlet/controller/seed/seed_extension_control.go
@@ -18,17 +18,15 @@ import (
 	"fmt"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/logger"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/retry"
 )
 
 func (c *Controller) controllerInstallationOfSeedAdd(obj interface{}) {
@@ -80,35 +78,34 @@ type ExtensionCheckControlInterface interface {
 // implements the documented semantics for Seeds. You should use an instance returned from NewDefaultExtensionCheckControl() for any
 // scenario other than testing.
 func NewDefaultExtensionCheckControl(
-	k8sGardenClient kubernetes.Interface,
+	gardenCoreClient gardencoreclientset.Interface,
 	controllerInstallationLister gardencorelisters.ControllerInstallationLister,
-	recorder record.EventRecorder,
+	nowFunc func() metav1.Time,
 ) ExtensionCheckControlInterface {
 	return &defaultExtensionCheckControl{
-		k8sGardenClient,
+		gardenCoreClient,
 		controllerInstallationLister,
-		recorder,
+		nowFunc,
 	}
 }
 
 type defaultExtensionCheckControl struct {
-	k8sGardenClient              kubernetes.Interface
+	gardenCoreClient             gardencoreclientset.Interface
 	controllerInstallationLister gardencorelisters.ControllerInstallationLister
-	recorder                     record.EventRecorder
+	nowFunc                      func() metav1.Time
 }
 
 func (c *defaultExtensionCheckControl) ReconcileExtensionCheckFor(obj *gardencorev1beta1.Seed) error {
-	var (
-		seed                         = obj.DeepCopy()
-		conditionSeedExtensionsReady = gardencorev1beta1helper.GetOrInitCondition(seed.Status.Conditions, gardencorev1beta1.SeedExtensionsReady)
-	)
-
-	conditionSeedExtensionsReady = gardencorev1beta1helper.UpdatedCondition(conditionSeedExtensionsReady, gardencorev1beta1.ConditionTrue, "AllExtensionsReady", "All extensions installed into the seed cluster are ready and healthy.")
-
 	controllerInstallationList, err := c.controllerInstallationLister.List(labels.Everything())
 	if err != nil {
 		return err
 	}
+
+	var (
+		seed         = obj.DeepCopy()
+		notInstalled = sets.NewString()
+		notReady     = sets.NewString()
+	)
 
 	for _, controllerInstallation := range controllerInstallationList {
 		if controllerInstallation.Spec.SeedRef.Name != seed.Name {
@@ -116,13 +113,13 @@ func (c *defaultExtensionCheckControl) ReconcileExtensionCheckFor(obj *gardencor
 		}
 
 		if len(controllerInstallation.Status.Conditions) == 0 {
-			conditionSeedExtensionsReady = gardencorev1beta1helper.UpdatedCondition(conditionSeedExtensionsReady, gardencorev1beta1.ConditionFalse, "NotAllExtensionsInstalled", fmt.Sprintf("Extension %q has not yet been installed", controllerInstallation.Name))
-			break
+			notInstalled.Insert(controllerInstallation.Name)
+			continue
 		}
 
 		var (
-			allRequiredConditionsHealthy = true
-			requiredConditions           = map[gardencorev1beta1.ConditionType]struct{}{
+			conditionsReady    = 0
+			requiredConditions = map[gardencorev1beta1.ConditionType]struct{}{
 				gardencorev1beta1.ControllerInstallationValid:     {},
 				gardencorev1beta1.ControllerInstallationInstalled: {},
 				gardencorev1beta1.ControllerInstallationHealthy:   {},
@@ -135,22 +132,51 @@ func (c *defaultExtensionCheckControl) ReconcileExtensionCheckFor(obj *gardencor
 			}
 
 			if condition.Status != gardencorev1beta1.ConditionTrue {
-				conditionSeedExtensionsReady = gardencorev1beta1helper.UpdatedCondition(conditionSeedExtensionsReady, gardencorev1beta1.ConditionFalse, "NotAllExtensionsReady", fmt.Sprintf("Condition %q for extension %q is %s: %s", condition.Type, condition.Status, controllerInstallation.Name, condition.Message))
-				allRequiredConditionsHealthy = false
 				break
 			}
+
+			conditionsReady++
 		}
 
-		if !allRequiredConditionsHealthy {
-			break
+		if conditionsReady != len(requiredConditions) {
+			notReady.Insert(controllerInstallation.Name)
 		}
 	}
 
-	_, err = kutil.TryUpdateSeedConditions(c.k8sGardenClient.GardenCore(), retry.DefaultBackoff, seed.ObjectMeta,
-		func(seed *gardencorev1beta1.Seed) (*gardencorev1beta1.Seed, error) {
-			seed.Status.Conditions = gardencorev1beta1helper.MergeConditions(seed.Status.Conditions, conditionSeedExtensionsReady)
-			return seed, nil
-		},
-	)
+	bldr, err := helper.NewConditionBuilder(gardencorev1beta1.SeedExtensionsReady)
+	if err != nil {
+		return err
+	}
+
+	if c := helper.GetCondition(seed.Status.Conditions, gardencorev1beta1.SeedExtensionsReady); c != nil {
+		bldr.WithOldCondition(*c)
+	}
+
+	switch {
+	case notInstalled.Len() != 0:
+		bldr.
+			WithStatus(gardencorev1beta1.ConditionFalse).
+			WithReason("NotAllExtensionsInstalled").
+			WithMessage(fmt.Sprintf("Extensions %q are not installed", notInstalled.List()))
+	case notReady.Len() != 0:
+		bldr.
+			WithStatus(gardencorev1beta1.ConditionFalse).
+			WithReason("NotAllExtensionsReady").
+			WithMessage(fmt.Sprintf("Extensions %q are not ready", notReady.List()))
+	default:
+		bldr.
+			WithStatus(gardencorev1beta1.ConditionTrue).
+			WithReason("AllExtensionsReady").
+			WithMessage("All extensions installed into the seed cluster are ready and healthy.")
+	}
+
+	newCondition, update := bldr.WithNowFunc(c.nowFunc).Build()
+	if !update {
+		return nil
+	}
+
+	seed.Status.Conditions = helper.MergeConditions(seed.Status.Conditions, newCondition)
+
+	_, err = c.gardenCoreClient.CoreV1beta1().Seeds().UpdateStatus(seed)
 	return err
 }

--- a/pkg/gardenlet/controller/seed/seed_extension_control_test.go
+++ b/pkg/gardenlet/controller/seed/seed_extension_control_test.go
@@ -1,0 +1,390 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seed_test
+
+import (
+	"fmt"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/core/clientset/versioned/fake"
+	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
+	seedctrl "github.com/gardener/gardener/pkg/gardenlet/controller/seed"
+	"github.com/gardener/gardener/pkg/logger"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ = Describe("ExtensionControlReconcile", func() {
+	var (
+		fakeClient         *fake.Clientset
+		indexer            cache.Indexer
+		seed               *gardencorev1beta1.Seed
+		lister             gardencorelisters.ControllerInstallationLister
+		defaultTime        metav1.Time
+		defaultTimeFunc    func() metav1.Time
+		controller         seedctrl.ExtensionCheckControlInterface
+		updatedSeed        *gardencorev1beta1.Seed
+		expectedUpdateCall bool
+	)
+
+	BeforeEach(func() {
+		// This should not be here!!! Hidden dependency!!!
+		logger.Logger = logger.NewNopLogger()
+
+		seed = &gardencorev1beta1.Seed{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		}
+
+		indexer = cache.NewIndexer(
+			cache.MetaNamespaceKeyFunc,
+			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+
+		lister = gardencorelisters.NewControllerInstallationLister(indexer)
+
+		defaultTime = metav1.NewTime(time.Unix(2, 2))
+		defaultTimeFunc = func() metav1.Time {
+			return defaultTime
+		}
+
+		updatedSeed = nil
+		fakeClient = fake.NewSimpleClientset()
+		fakeClient.PrependReactor("update", "seeds", func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+			if action.GetSubresource() != "status" {
+				return true, nil, fmt.Errorf("expected a update on the seeds/status, got %v instead", action)
+			}
+
+			updatedSeed = action.(testing.UpdateAction).GetObject().(*gardencorev1beta1.Seed)
+
+			return true, updatedSeed, nil
+		})
+	})
+
+	JustBeforeEach(func() {
+		controller = seedctrl.NewDefaultExtensionCheckControl(fakeClient, lister, defaultTimeFunc)
+	})
+
+	AfterEach(func() {
+		if expectedUpdateCall {
+			Expect(fakeClient.Actions()).To(HaveLen(1), "one status update should be executed")
+		} else {
+			Expect(fakeClient.Actions()).To(BeEmpty(), "no status update should be executed")
+		}
+	})
+
+	Context("listing of controller installations fails", func() {
+		BeforeEach(func() {
+			lister = &failingControllerInstalltionLister{}
+		})
+
+		It("should return error", func() {
+			Expect(controller.ReconcileExtensionCheckFor(seed)).To(HaveOccurred())
+		})
+
+	})
+
+	Context("update needed", func() {
+		var (
+			current, expected gardencorev1beta1.Condition
+			assertConditions  = func() {
+				DescribeTable("condition exist",
+					// seed and expected conditions are wrrapped in functions, so they are not evaluated
+					// at compile time.
+					func(mutateFunc func()) {
+						mutateFunc()
+						seed.Status.Conditions = []gardencorev1beta1.Condition{current}
+
+						result := controller.ReconcileExtensionCheckFor(seed)
+
+						Expect(result).ToNot(HaveOccurred(), "update should succeed")
+						Expect(updatedSeed.Status.Conditions).To(ConsistOf(expected))
+					},
+
+					Entry("message is different", func() {
+						current.Message = "Some message"
+						expected.LastUpdateTime = defaultTime
+					}),
+					Entry("reason is different", func() {
+						current.Reason = "Some reason"
+						expected.LastUpdateTime = defaultTime
+					}),
+					Entry("message and reason is different", func() {
+						current.Message = "Some message"
+						current.Reason = "Some reason"
+						expected.LastUpdateTime = defaultTime
+					}),
+					Entry("status is different", func() {
+						current.Status = gardencorev1beta1.ConditionProgressing
+						expected.LastTransitionTime = defaultTime
+					}),
+				)
+				It("condition does not exists", func() {
+					expected.LastTransitionTime = defaultTime
+					expected.LastUpdateTime = defaultTime
+					result := controller.ReconcileExtensionCheckFor(seed)
+
+					Expect(result).ToNot(HaveOccurred(), "update should succeed")
+					Expect(updatedSeed.Status.Conditions).To(ConsistOf(expected))
+				})
+			}
+		)
+
+		BeforeEach(func() {
+			expectedUpdateCall = true
+		})
+
+		Context("AllExtensionsReady", func() {
+			BeforeEach(func() {
+				current = gardencorev1beta1.Condition{
+					Type:               "ExtensionsReady",
+					Status:             gardencorev1beta1.ConditionTrue,
+					Reason:             "AllExtensionsReady",
+					Message:            "All extensions installed into the seed cluster are ready and healthy.",
+					LastTransitionTime: metav1.NewTime(time.Unix(1, 1)),
+					LastUpdateTime:     metav1.NewTime(time.Unix(1, 1)),
+				}
+				expected = *current.DeepCopy()
+			})
+
+			assertConditions()
+		})
+
+		Context("NotAllExtensionsInstalled", func() {
+			BeforeEach(func() {
+				current = gardencorev1beta1.Condition{
+					Type:               "ExtensionsReady",
+					Status:             gardencorev1beta1.ConditionFalse,
+					Reason:             "NotAllExtensionsInstalled",
+					Message:            `Extensions ["foo-1" "foo-3"] are not installed`,
+					LastTransitionTime: metav1.NewTime(time.Unix(1, 1)),
+					LastUpdateTime:     metav1.NewTime(time.Unix(1, 1)),
+				}
+				expected = *current.DeepCopy()
+
+				c1 := &gardencorev1beta1.ControllerInstallation{}
+				c1.SetName("foo-1")
+				c1.Spec.SeedRef.Name = "test"
+
+				c2 := c1.DeepCopy()
+				c2.SetName("foo-2")
+				c2.Spec.SeedRef.Name = "not-seed-2"
+
+				c3 := c1.DeepCopy()
+				c3.SetName("foo-3")
+
+				Expect(indexer.Add(c1)).NotTo(HaveOccurred(), "adding to the index should succeed")
+				Expect(indexer.Add(c2)).NotTo(HaveOccurred(), "adding to the index should succeed")
+				Expect(indexer.Add(c3)).NotTo(HaveOccurred(), "adding to the index should succeed")
+
+			})
+
+			assertConditions()
+		})
+
+		Context("NotAllExtensionsReady", func() {
+			BeforeEach(func() {
+				current = gardencorev1beta1.Condition{
+					Type:               "ExtensionsReady",
+					Status:             gardencorev1beta1.ConditionFalse,
+					Reason:             "NotAllExtensionsReady",
+					Message:            `Extensions ["foo-2"] are not ready`,
+					LastTransitionTime: metav1.NewTime(time.Unix(1, 1)),
+					LastUpdateTime:     metav1.NewTime(time.Unix(1, 1)),
+				}
+				expected = *current.DeepCopy()
+
+				c1 := &gardencorev1beta1.ControllerInstallation{}
+				c1.SetName("foo-1")
+				c1.Spec.SeedRef.Name = "test"
+				c1.Status.Conditions = []gardencorev1beta1.Condition{
+					// string literal to ensure that the tests fails if the constant is changed
+					{
+						Type:   "Valid",
+						Status: gardencorev1beta1.ConditionTrue,
+					},
+					{
+						Type:   "Installed",
+						Status: gardencorev1beta1.ConditionTrue,
+					},
+					{
+						Type:   "Healthy",
+						Status: gardencorev1beta1.ConditionTrue,
+					},
+					{
+						Type:   "RandomType",
+						Status: gardencorev1beta1.ConditionTrue,
+					},
+					{
+						Type:   "AnotherRandomType",
+						Status: gardencorev1beta1.ConditionFalse,
+					},
+				}
+
+				c2 := c1.DeepCopy()
+				c2.SetName("foo-2")
+				c2.Status.Conditions[1].Status = gardencorev1beta1.ConditionFalse
+
+				Expect(indexer.Add(c1)).NotTo(HaveOccurred(), "adding to the index should succeed")
+				Expect(indexer.Add(c2)).NotTo(HaveOccurred(), "adding to the index should succeed")
+
+			})
+
+			assertConditions()
+		})
+	})
+
+	Context("update not needed", func() {
+		var (
+			current gardencorev1beta1.Condition
+		)
+
+		BeforeEach(func() {
+			expectedUpdateCall = false
+		})
+
+		Context("AllExtensionsReady", func() {
+			BeforeEach(func() {
+				current = gardencorev1beta1.Condition{
+					Type:               "ExtensionsReady",
+					Status:             gardencorev1beta1.ConditionTrue,
+					Reason:             "AllExtensionsReady",
+					Message:            "All extensions installed into the seed cluster are ready and healthy.",
+					LastTransitionTime: metav1.NewTime(time.Unix(1, 1)),
+					LastUpdateTime:     metav1.NewTime(time.Unix(1, 1)),
+				}
+			})
+
+			// assertConditions()
+
+			It("should do nothing", func() {
+				seed.Status.Conditions = []gardencorev1beta1.Condition{current}
+
+				result := controller.ReconcileExtensionCheckFor(seed)
+
+				Expect(result).To(BeNil(), "no error should be returned")
+			})
+		})
+
+		Context("NotAllExtensionsInstalled", func() {
+			BeforeEach(func() {
+				current = gardencorev1beta1.Condition{
+					Type:               "ExtensionsReady",
+					Status:             gardencorev1beta1.ConditionFalse,
+					Reason:             "NotAllExtensionsInstalled",
+					Message:            `Extensions ["foo-1" "foo-3"] are not installed`,
+					LastTransitionTime: metav1.NewTime(time.Unix(1, 1)),
+					LastUpdateTime:     metav1.NewTime(time.Unix(1, 1)),
+				}
+
+				c1 := &gardencorev1beta1.ControllerInstallation{}
+				c1.SetName("foo-1")
+				c1.Spec.SeedRef.Name = "test"
+
+				c2 := c1.DeepCopy()
+				c2.SetName("foo-2")
+				c2.Spec.SeedRef.Name = "not-seed-2"
+
+				c3 := c1.DeepCopy()
+				c3.SetName("foo-3")
+
+				Expect(indexer.Add(c1)).NotTo(HaveOccurred(), "adding to the index should succeed")
+				Expect(indexer.Add(c2)).NotTo(HaveOccurred(), "adding to the index should succeed")
+				Expect(indexer.Add(c3)).NotTo(HaveOccurred(), "adding to the index should succeed")
+			})
+
+			// assertConditions()
+
+			It("should do nothing", func() {
+				seed.Status.Conditions = []gardencorev1beta1.Condition{current}
+
+				result := controller.ReconcileExtensionCheckFor(seed)
+
+				Expect(result).To(BeNil(), "no error should be returned")
+			})
+		})
+
+		Context("NotAllExtensionsReady", func() {
+			BeforeEach(func() {
+				current = gardencorev1beta1.Condition{
+					Type:               "ExtensionsReady",
+					Status:             gardencorev1beta1.ConditionFalse,
+					Reason:             "NotAllExtensionsReady",
+					Message:            `Extensions ["foo-2"] are not ready`,
+					LastTransitionTime: metav1.NewTime(time.Unix(1, 1)),
+					LastUpdateTime:     metav1.NewTime(time.Unix(1, 1)),
+				}
+
+				c1 := &gardencorev1beta1.ControllerInstallation{}
+				c1.SetName("foo-1")
+				c1.Spec.SeedRef.Name = "test"
+				c1.Status.Conditions = []gardencorev1beta1.Condition{
+					// string literal to ensure that the tests fails if the constant is changed
+					{
+						Type:   "Valid",
+						Status: gardencorev1beta1.ConditionTrue,
+					},
+					{
+						Type:   "Installed",
+						Status: gardencorev1beta1.ConditionTrue,
+					},
+					{
+						Type:   "Healthy",
+						Status: gardencorev1beta1.ConditionTrue,
+					},
+					{
+						Type:   "RandomType",
+						Status: gardencorev1beta1.ConditionTrue,
+					},
+					{
+						Type:   "AnotherRandomType",
+						Status: gardencorev1beta1.ConditionFalse,
+					},
+				}
+
+				c2 := c1.DeepCopy()
+				c2.SetName("foo-2")
+				c2.Status.Conditions[1].Status = gardencorev1beta1.ConditionFalse
+
+				Expect(indexer.Add(c1)).NotTo(HaveOccurred(), "adding to the index should succeed")
+				Expect(indexer.Add(c2)).NotTo(HaveOccurred(), "adding to the index should succeed")
+
+			})
+
+			It("should do nothing", func() {
+				seed.Status.Conditions = []gardencorev1beta1.Condition{current}
+
+				result := controller.ReconcileExtensionCheckFor(seed)
+
+				Expect(result).To(BeNil(), "no error should be returned")
+			})
+		})
+	})
+})
+
+type failingControllerInstalltionLister struct{}
+
+func (f *failingControllerInstalltionLister) List(selector labels.Selector) (ret []*gardencorev1beta1.ControllerInstallation, err error) {
+	return nil, fmt.Errorf("dummy error")
+}
+
+func (f *failingControllerInstalltionLister) Get(name string) (*gardencorev1beta1.ControllerInstallation, error) {
+	return nil, fmt.Errorf("dummy error")
+}

--- a/pkg/gardenlet/controller/seed/seed_suite_test.go
+++ b/pkg/gardenlet/controller/seed/seed_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seed_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSeed(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Seed Controller Suite")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

It now updates the status only when there is an actual change in it. Health checks on the controller installations (changes in their `.status`) no longer cause the condition `ExtensionsReady` to have it's `LastUpdateTime` constantly modified when there are no actual changes in `Reason` and `Message` fields.

This PR also adds additional helper `ConditionBuilder` in  `pkg/apis/core/v1{alpha1|beta1}/helper`. This allows for fluent update of the condition and checks to ensure that correct `LastUpdateTime` and `LastTransitionTime` are set only when the condition has been modified.

It also moves the `metav1.Now` function provided inside of the struct making it easier for tests and without any global state modifications.

**Which issue(s) this PR fixes**:

Fixes #1781

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
