### PR TITLE
Add gardener-apiserver encryption config in gardener runtime charts

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -26,6 +26,9 @@ spec:
         checksum/secret-gardener-audit-webhook-config: {{ include (print $.Template.BasePath "/apiserver/secret-audit-webhook-config.yaml") . | sha256sum }}
         {{- end }}
         checksum/secret-gardener-apiserver-cert: {{ include (print $.Template.BasePath "/apiserver/secret-cert.yaml") . | sha256sum }}
+        {{- if .Values.global.apiserver.encryption.config }}
+        checksum/secret-gardener-apiserver-encryption-config: {{ include (print $.Template.BasePath "/apiserver/secret-gardener-apiserver-encryption-config.yaml") . | sha256sum }}
+        {{- end }}
         checksum/secret-gardener-apiserver-kubeconfig: {{ include (print $.Template.BasePath "/apiserver/secret-kubeconfig.yaml") . | sha256sum }}
       labels:
         app: gardener
@@ -156,6 +159,9 @@ spec:
         - --audit-webhook-version={{ .Values.global.apiserver.audit.webhook.version }}
         {{- end }}
         - --authorization-always-allow-paths=/healthz
+        {{- if .Values.global.apiserver.encryption.config }}
+        - --encryption-provider-config=/etc/gardener-apiserver/encryption/encryption-config.yaml
+        {{- end }}
         {{- if .Values.global.apiserver.etcd.useSidecar }}
         - --etcd-servers=http://localhost:2379
         {{- else }}
@@ -189,6 +195,10 @@ spec:
 {{ toYaml .Values.global.apiserver.dnsConfig | indent 10 }}
         {{- end }}
         volumeMounts:
+        {{- if .Values.global.apiserver.encryption.config }}
+        - name: gardener-apiserver-encryption-config
+          mountPath: /etc/gardener-apiserver/encryption
+        {{- end }}
         - name: gardener-apiserver-cert
           mountPath: /etc/gardener-apiserver/srv
           readOnly: true
@@ -239,6 +249,11 @@ spec:
           mountPath: /var/etcd/data
       {{- end }}
       volumes:
+      {{- if .Values.global.apiserver.encryption.config }}
+      - name: gardener-apiserver-encryption-config
+        secret:
+          secretName: gardener-apiserver-encryption-config
+      {{- end }}
       {{- if .Values.global.apiserver.etcd.useSidecar }}
       - name: etcd
         emptyDir: {}

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/secret-gardener-apiserver-encryption-config.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/secret-gardener-apiserver-encryption-config.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.global.apiserver.encryption.config }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gardener-apiserver-encryption-config
+  namespace: garden
+data:
+  encryption-config.yaml: {{ .Values.global.apiserver.encryption.config | b64enc }}
+{{- end }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -16,6 +16,16 @@ global:
       limits:
         cpu: 300m
         memory: 256Mi
+    encryption:
+      config: |
+        apiVersion: apiserver.config.k8s.io/v1
+        kind: EncryptionConfiguration
+        resources:
+          - resources:
+            - controllerregistrations.core.gardener.cloud
+            - shootstates.core.gardener.cloud
+            providers:
+            - identity: {}
     etcd:
       useSidecar: false # only meant for development purposes. if this is set to true, other etcd config values are ignored
       servers: https://etcd:2379


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/1707 has enabled the use of EncryptionConfiguration for gardener-apiserver, we can now use this feature to enable our ControllerRegistration.
This PR, on the other hand, enables customization of EncryptionConfiguration of gardener-apiserver in its helm charts. Note that ControllerRegistration will not be encrypted by default, since no provider is provided.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
EncryptionConfiguration of gardener-apiserver is now configurable in the helm chart values.
```
