### PR TITLE
[WIP] Refactor secret deployment to use ShootState

### DIFF
--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -30,6 +30,8 @@ import (
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	"github.com/gardener/gardener/pkg/apiserver/storage"
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/internalversion"
+	gardenexternalcoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
+	gardenexternalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	gardenclientset "github.com/gardener/gardener/pkg/client/garden/clientset/internalversion"
 	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/internalversion"
@@ -46,6 +48,7 @@ import (
 	openidconnectpreset "github.com/gardener/gardener/plugin/pkg/shoot/oidc/openidconnectpreset"
 	shootquotavalidator "github.com/gardener/gardener/plugin/pkg/shoot/quotavalidator"
 	shootvalidator "github.com/gardener/gardener/plugin/pkg/shoot/validator"
+	shootstatevalidator "github.com/gardener/gardener/plugin/pkg/shootstate"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -98,13 +101,14 @@ These so-called control plane components are hosted in Kubernetes clusters thems
 
 // Options has all the context and parameters needed to run a Gardener API server.
 type Options struct {
-	Recommended             *genericoptions.RecommendedOptions
-	CoreInformerFactory     gardencoreinformers.SharedInformerFactory
-	GardenInformerFactory   gardeninformers.SharedInformerFactory
-	KubeInformerFactory     kubeinformers.SharedInformerFactory
-	SettingsInformerFactory settingsinformer.SharedInformerFactory
-	StdOut                  io.Writer
-	StdErr                  io.Writer
+	Recommended                 *genericoptions.RecommendedOptions
+	CoreInformerFactory         gardencoreinformers.SharedInformerFactory
+	GardenInformerFactory       gardeninformers.SharedInformerFactory
+	KubeInformerFactory         kubeinformers.SharedInformerFactory
+	SettingsInformerFactory     settingsinformer.SharedInformerFactory
+	CoreExternalInformerFactory gardenexternalcoreinformers.SharedInformerFactory
+	StdOut                      io.Writer
+	StdErr                      io.Writer
 }
 
 // NewOptions returns a new Options object.
@@ -155,6 +159,7 @@ func (o *Options) complete() error {
 	plantvalidator.Register(o.Recommended.Admission.Plugins)
 	openidconnectpreset.Register(o.Recommended.Admission.Plugins)
 	clusteropenidconnectpreset.Register(o.Recommended.Admission.Plugins)
+	shootstatevalidator.Register(o.Recommended.Admission.Plugins)
 
 	allOrderedPlugins := []string{
 		resourcereferencemanager.PluginName,
@@ -166,6 +171,7 @@ func (o *Options) complete() error {
 		deletionconfirmation.PluginName,
 		openidconnectpreset.PluginName,
 		clusteropenidconnectpreset.PluginName,
+		shootstatevalidator.PluginName,
 	}
 
 	o.Recommended.Admission.RecommendedPluginOrder = append(o.Recommended.Admission.RecommendedPluginOrder, allOrderedPlugins...)
@@ -203,6 +209,13 @@ func (o *Options) config() (*apiserver.Config, error) {
 		coreInformerFactory := gardencoreinformers.NewSharedInformerFactory(coreClient, gardenerAPIServerConfig.LoopbackClientConfig.Timeout)
 		o.CoreInformerFactory = coreInformerFactory
 
+		coreExternalClient, err := gardenexternalcoreclientset.NewForConfig(gardenerAPIServerConfig.LoopbackClientConfig)
+		if err != nil {
+			return nil, err
+		}
+		coreExternalInformerFactory := gardenexternalcoreinformers.NewSharedInformerFactory(coreExternalClient, gardenerAPIServerConfig.LoopbackClientConfig.Timeout)
+		o.CoreExternalInformerFactory = coreExternalInformerFactory
+
 		// garden client
 		gardenClient, err := gardenclientset.NewForConfig(gardenerAPIServerConfig.LoopbackClientConfig)
 		if err != nil {
@@ -223,6 +236,8 @@ func (o *Options) config() (*apiserver.Config, error) {
 			admissioninitializer.New(
 				coreInformerFactory,
 				coreClient,
+				coreExternalInformerFactory,
+				coreExternalClient,
 				gardenInformerFactory,
 				gardenClient,
 				o.SettingsInformerFactory,
@@ -260,6 +275,7 @@ func (o Options) run(stopCh <-chan struct{}) error {
 		o.GardenInformerFactory.Start(context.StopCh)
 		o.KubeInformerFactory.Start(context.StopCh)
 		o.SettingsInformerFactory.Start(context.StopCh)
+		o.CoreExternalInformerFactory.Start(context.StopCh)
 		return nil
 	}); err != nil {
 		return err

--- a/pkg/apis/core/types_shootstate.go
+++ b/pkg/apis/core/types_shootstate.go
@@ -54,7 +54,7 @@ type GardenerResourceData struct {
 	// Name of the object required to generate resources
 	Name string
 	// Data contains the payload required to generate resources
-	Data map[string]string
+	Data map[string][]byte
 }
 
 // ExtensionResourceState contains the kind of the extension custom resource and its last observed state in the Shoot's

--- a/pkg/apis/core/v1alpha1/helper/helper.go
+++ b/pkg/apis/core/v1alpha1/helper/helper.go
@@ -750,3 +750,61 @@ func GetExtensionResourceState(extensionsResourcesStates []gardencorev1alpha1.Ex
 	}
 	return -1, nil
 }
+
+// RemoveGardenerResourceData removes the resourceData with the given name from the provided GardenerResourceData list
+func RemoveGardenerResourceData(gardenerResourceDataList []gardencorev1alpha1.GardenerResourceData, name string) []gardencorev1alpha1.GardenerResourceData {
+	index, _ := GetGardenerResourceData(gardenerResourceDataList, name)
+	if index < 0 {
+		return gardenerResourceDataList
+	}
+
+	newGardnerResourceDataList := make([]gardencorev1alpha1.GardenerResourceData, 0, len(gardenerResourceDataList)-1)
+	for _, resourceData := range gardenerResourceDataList {
+		if resourceData.Name != name {
+			newGardnerResourceDataList = append(newGardnerResourceDataList, resourceData)
+		}
+	}
+
+	return newGardnerResourceDataList
+}
+
+// GetGardenerResourceData returns a pointer to the GardenerResourceData with the specified name.
+func GetGardenerResourceData(gardenerResourceDataList []gardencorev1alpha1.GardenerResourceData, name string) (int, *gardencorev1alpha1.GardenerResourceData) {
+	for i, resourceData := range gardenerResourceDataList {
+		if resourceData.Name == name {
+			return i, &gardenerResourceDataList[i]
+		}
+	}
+	return -1, nil
+}
+
+// CreateGardenerResourceDataMap creates a new GardenerResourceDataSet from the given GardenerResourceData list
+func CreateGardenerResourceDataMap(resourceDataList []gardencorev1alpha1.GardenerResourceData) (map[string]gardencorev1alpha1.GardenerResourceData, error) {
+	gardenerResourceDataMap := make(map[string]gardencorev1alpha1.GardenerResourceData, len(resourceDataList))
+
+	for _, item := range resourceDataList {
+		if _, ok := gardenerResourceDataMap[item.Name]; ok {
+			return nil, fmt.Errorf("duplicate entry found in gardener resource data in ShootState: %s", item.Name)
+		}
+		gardenerResourceDataMap[item.Name] = item
+	}
+
+	return gardenerResourceDataMap, nil
+}
+
+// AddGardenerResourceDataFromMap takes a list and a map of GardenerResourceData objects. If an object with the same name exists in the list and in the map its data in the list is overwritten.
+// All objects which exist in the map but not in the list are appended to the list. In the end the modified list is returned
+func AddGardenerResourceDataFromMap(resourceDataList []gardencorev1alpha1.GardenerResourceData, resourceDataMap map[string]gardencorev1alpha1.GardenerResourceData) []gardencorev1alpha1.GardenerResourceData {
+	for i, dataFromList := range resourceDataList {
+		if dataFromMap, ok := resourceDataMap[dataFromList.Name]; ok {
+			resourceDataList[i].Data = dataFromMap.Data
+			delete(resourceDataMap, dataFromList.Name)
+		}
+	}
+
+	for _, item := range resourceDataMap {
+		resourceDataList = append(resourceDataList, item)
+	}
+
+	return resourceDataList
+}

--- a/pkg/apis/core/v1alpha1/types_shootstate.go
+++ b/pkg/apis/core/v1alpha1/types_shootstate.go
@@ -61,7 +61,7 @@ type GardenerResourceData struct {
 	// Name of the object required to generate resources
 	Name string `json:"name"`
 	// Data contains the payload required to generate resources
-	Data map[string]string `json:"data"`
+	Data map[string][]byte `json:"data"`
 }
 
 // ExtensionResourceState contains the kind of the extension custom resource and its last observed state in the Shoot's

--- a/pkg/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2344,7 +2344,7 @@ func Convert_garden_Gardener_To_v1alpha1_Gardener(in *garden.Gardener, out *Gard
 
 func autoConvert_v1alpha1_GardenerResourceData_To_core_GardenerResourceData(in *GardenerResourceData, out *core.GardenerResourceData, s conversion.Scope) error {
 	out.Name = in.Name
-	out.Data = *(*map[string]string)(unsafe.Pointer(&in.Data))
+	out.Data = *(*map[string][]byte)(unsafe.Pointer(&in.Data))
 	return nil
 }
 
@@ -2355,7 +2355,7 @@ func Convert_v1alpha1_GardenerResourceData_To_core_GardenerResourceData(in *Gard
 
 func autoConvert_core_GardenerResourceData_To_v1alpha1_GardenerResourceData(in *core.GardenerResourceData, out *GardenerResourceData, s conversion.Scope) error {
 	out.Name = in.Name
-	out.Data = *(*map[string]string)(unsafe.Pointer(&in.Data))
+	out.Data = *(*map[string][]byte)(unsafe.Pointer(&in.Data))
 	return nil
 }
 

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1090,9 +1090,17 @@ func (in *GardenerResourceData) DeepCopyInto(out *GardenerResourceData) {
 	*out = *in
 	if in.Data != nil {
 		in, out := &in.Data, &out.Data
-		*out = make(map[string]string, len(*in))
+		*out = make(map[string][]byte, len(*in))
 		for key, val := range *in {
-			(*out)[key] = val
+			var outVal []byte
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make([]byte, len(*in))
+				copy(*out, *in)
+			}
+			(*out)[key] = outVal
 		}
 	}
 	return

--- a/pkg/apis/core/validation/shootstate_test.go
+++ b/pkg/apis/core/validation/shootstate_test.go
@@ -44,9 +44,9 @@ var _ = Describe("validation", func() {
 		It("should forbid shootState containing data required for gardener resource generation with empty name", func() {
 			shootState.Spec.Gardener = []core.GardenerResourceData{
 				{
-					Data: map[string]string{
-						"ca.key": "ca-key",
-						"ca.crt": "ca-crt",
+					Data: map[string][]byte{
+						"ca.key": []byte("ca-key"),
+						"ca.crt": []byte("ca-crt"),
 					},
 				},
 			}

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -607,9 +607,17 @@ func (in *GardenerResourceData) DeepCopyInto(out *GardenerResourceData) {
 	*out = *in
 	if in.Data != nil {
 		in, out := &in.Data, &out.Data
-		*out = make(map[string]string, len(*in))
+		*out = make(map[string][]byte, len(*in))
 		for key, val := range *in {
-			(*out)[key] = val
+			var outVal []byte
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make([]byte, len(*in))
+				copy(*out, *in)
+			}
+			(*out)[key] = outVal
 		}
 	}
 	return

--- a/pkg/apiserver/admission/initializer/initializer.go
+++ b/pkg/apiserver/admission/initializer/initializer.go
@@ -16,6 +16,8 @@ package initializer
 
 import (
 	coreclientset "github.com/gardener/gardener/pkg/client/core/clientset/internalversion"
+	externalcoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
+	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	gardenclientset "github.com/gardener/gardener/pkg/client/garden/clientset/internalversion"
 	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/internalversion"
@@ -30,6 +32,8 @@ import (
 // New constructs new instance of PluginInitializer
 func New(coreInformers coreinformers.SharedInformerFactory,
 	coreClient coreclientset.Interface,
+	coreExternalInformers externalcoreinformers.SharedInformerFactory,
+	externalCoreClient externalcoreclientset.Interface,
 	gardenInformers gardeninformers.SharedInformerFactory,
 	gardenClient gardenclientset.Interface,
 	settingsInformers settingsinformer.SharedInformerFactory,
@@ -39,6 +43,9 @@ func New(coreInformers coreinformers.SharedInformerFactory,
 	return pluginInitializer{
 		coreInformers: coreInformers,
 		coreClient:    coreClient,
+
+		externalCoreInformers: coreExternalInformers,
+		externalCoreClient:    externalCoreClient,
 
 		gardenInformers: gardenInformers,
 		gardenClient:    gardenClient,
@@ -71,6 +78,14 @@ func (i pluginInitializer) Initialize(plugin admission.Interface) {
 
 	if wants, ok := plugin.(WantsSettingsInformerFactory); ok {
 		wants.SetSettingsInformerFactory(i.settingsInformers)
+	}
+
+	if wants, ok := plugin.(WantsExternalCoreInformerFactory); ok {
+		wants.SetExternalCoreInformerFactory(i.externalCoreInformers)
+	}
+
+	if wants, ok := plugin.(WantsExternalCoreClientset); ok {
+		wants.SetExternalCoreClientset(i.externalCoreClient)
 	}
 
 	if wants, ok := plugin.(WantsKubeInformerFactory); ok {

--- a/pkg/apiserver/admission/initializer/types.go
+++ b/pkg/apiserver/admission/initializer/types.go
@@ -16,6 +16,8 @@ package initializer
 
 import (
 	coreclientset "github.com/gardener/gardener/pkg/client/core/clientset/internalversion"
+	externalcoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
+	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	gardenclientset "github.com/gardener/gardener/pkg/client/garden/clientset/internalversion"
 	gardeninformers "github.com/gardener/gardener/pkg/client/garden/informers/internalversion"
@@ -27,15 +29,27 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// WantsInternalCoreInformerFactory defines a function which sets InformerFactory for admission plugins that need it.
+// WantsInternalCoreInformerFactory defines a function which sets Core InformerFactory for admission plugins that need it.
 type WantsInternalCoreInformerFactory interface {
 	SetInternalCoreInformerFactory(coreinformers.SharedInformerFactory)
+	admission.InitializationValidator
+}
+
+// WantsExternalCoreInformerFactory defines a function which sets external Core InformerFactory for admission plugins that need
+type WantsExternalCoreInformerFactory interface {
+	SetExternalCoreInformerFactory(externalcoreinformers.SharedInformerFactory)
 	admission.InitializationValidator
 }
 
 // WantsInternalCoreClientset defines a function which sets Core Clientset for admission plugins that need it.
 type WantsInternalCoreClientset interface {
 	SetInternalCoreClientset(coreclientset.Interface)
+	admission.InitializationValidator
+}
+
+// WantsExternalCoreClientset defines a function which sets external Core Clientset for admission plugins that need it.
+type WantsExternalCoreClientset interface {
+	SetExternalCoreClientset(externalcoreclientset.Interface)
 	admission.InitializationValidator
 }
 
@@ -78,6 +92,9 @@ type WantsAuthorizer interface {
 type pluginInitializer struct {
 	coreInformers coreinformers.SharedInformerFactory
 	coreClient    coreclientset.Interface
+
+	externalCoreInformers externalcoreinformers.SharedInformerFactory
+	externalCoreClient    externalcoreclientset.Interface
 
 	gardenInformers gardeninformers.SharedInformerFactory
 	gardenClient    gardenclientset.Interface

--- a/pkg/client/core/openapi/zz_generated.openapi.go
+++ b/pkg/client/core/openapi/zz_generated.openapi.go
@@ -1930,7 +1930,7 @@ func schema_pkg_apis_core_v1alpha1_GardenerResourceData(ref common.ReferenceCall
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Type:   []string{"string"},
-										Format: "",
+										Format: "byte",
 									},
 								},
 							},

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2281,7 +2281,7 @@ func schema_pkg_apis_core_v1alpha1_GardenerResourceData(ref common.ReferenceCall
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Type:   []string{"string"},
-										Format: "",
+										Format: "byte",
 									},
 								},
 							},

--- a/pkg/utils/secrets/control_plane.go
+++ b/pkg/utils/secrets/control_plane.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/gardener/gardener/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -60,6 +61,11 @@ func (s *ControlPlaneSecretConfig) GetName() string {
 // Generate implements ConfigInterface.
 func (s *ControlPlaneSecretConfig) Generate() (Interface, error) {
 	return s.GenerateControlPlane()
+}
+
+// Type implements Typer.
+func (s *ControlPlaneSecretConfig) Type() corev1.SecretType {
+	return corev1.SecretTypeOpaque
 }
 
 // GenerateControlPlane computes a secret for a control plane component of the clusters managed by Gardener.

--- a/pkg/utils/secrets/types.go
+++ b/pkg/utils/secrets/types.go
@@ -14,10 +14,17 @@
 
 package secrets
 
+import corev1 "k8s.io/api/core/v1"
+
 // ConfigInterface define functions needed for generating a specific secret.
 type ConfigInterface interface {
 	GetName() string
 	Generate() (Interface, error)
+}
+
+// Typer retrieves the type of the secret which should be created
+type Typer interface {
+	Type() corev1.SecretType
 }
 
 // Interface defines functions needed for defining the data map of a Kubernetes secret.

--- a/plugin/pkg/shootstate/admission.go
+++ b/plugin/pkg/shootstate/admission.go
@@ -1,0 +1,158 @@
+package shootstate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
+	externalinformer "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	v1alpha1 "github.com/gardener/gardener/pkg/client/core/listers/core/v1alpha1"
+	gardenclientset "github.com/gardener/gardener/pkg/client/garden/clientset/internalversion"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const (
+	// PluginName is the name of this admission plugin.
+	PluginName = "ShootStateDeletion"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, NewFactory)
+}
+
+// NewFactory creates a new PluginFactory.
+func NewFactory(config io.Reader) (admission.Interface, error) {
+	return New()
+}
+
+// ValidateShootStateDeletion contains listers and admission handler.
+type ValidateShootStateDeletion struct {
+	*admission.Handler
+	shootStateLister v1alpha1.ShootStateLister
+	gardenClient     gardenclientset.Interface
+	readyFunc        admission.ReadyFunc
+}
+
+var (
+	_ = admissioninitializer.WantsExternalCoreInformerFactory(&ValidateShootStateDeletion{})
+	_ = admissioninitializer.WantsInternalGardenClientset(&ValidateShootStateDeletion{})
+
+	readyFuncs = []admission.ReadyFunc{}
+)
+
+// New creates a new ShootStateDeletion admission plugin.
+func New() (*ValidateShootStateDeletion, error) {
+	return &ValidateShootStateDeletion{
+		Handler: admission.NewHandler(admission.Delete),
+	}, nil
+}
+
+// AssignReadyFunc assigns the ready function to the admission handler.
+func (d *ValidateShootStateDeletion) AssignReadyFunc(f admission.ReadyFunc) {
+	d.readyFunc = f
+	d.SetReadyFunc(f)
+}
+
+// SetExternalCoreInformerFactory gets the garden core informer factory and adds it.
+func (d *ValidateShootStateDeletion) SetExternalCoreInformerFactory(f externalinformer.SharedInformerFactory) {
+	shootStateInformer := f.Core().V1alpha1().ShootStates()
+	d.shootStateLister = shootStateInformer.Lister()
+
+	readyFuncs = append(readyFuncs, shootStateInformer.Informer().HasSynced)
+}
+
+// SetInternalGardenClientset gets the garden clientset and adds it
+func (d *ValidateShootStateDeletion) SetInternalGardenClientset(c gardenclientset.Interface) {
+	d.gardenClient = c
+}
+
+func (d *ValidateShootStateDeletion) waitUntilReady(attrs admission.Attributes) error {
+	// Wait until the caches have been synced
+	if d.readyFunc == nil {
+		d.AssignReadyFunc(func() bool {
+			for _, readyFunc := range readyFuncs {
+				if !readyFunc() {
+					return false
+				}
+			}
+			return true
+		})
+	}
+
+	if !d.WaitForReady() {
+		return admission.NewForbidden(attrs, errors.New("not yet ready to handle request"))
+	}
+
+	return nil
+}
+
+// ValidateInitialization checks whether the plugin was correctly initialized.
+func (d *ValidateShootStateDeletion) ValidateInitialization() error {
+	if d.shootStateLister == nil {
+		return errors.New("missing ShootState lister")
+	}
+
+	return nil
+}
+
+var _ admission.ValidationInterface = &ValidateShootStateDeletion{}
+
+// Validate makes admissions decisions based on deletion confirmation annotation.
+func (d *ValidateShootStateDeletion) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	if a.GetKind().GroupKind() != core.Kind("ShootState") {
+		return nil
+	}
+
+	if err := d.waitUntilReady(a); err != nil {
+		return fmt.Errorf("Err while waiting for ready %v", err)
+	}
+
+	if a.GetName() == "" {
+		return d.validateDeleteCollection(ctx, a)
+	}
+
+	return d.validateDelete(ctx, a)
+}
+
+func (d *ValidateShootStateDeletion) validateDeleteCollection(ctx context.Context, attrs admission.Attributes) error {
+	shootStateList, err := d.shootStateLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for _, shootState := range shootStateList {
+		if err := d.validateDelete(ctx, d.createAdmissionAttributes(shootState, attrs)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *ValidateShootStateDeletion) validateDelete(ctx context.Context, attrs admission.Attributes) error {
+	_, err := d.gardenClient.Garden().Shoots(attrs.GetNamespace()).Get(attrs.GetName(), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return admission.NewForbidden(attrs, fmt.Errorf("Shoot %s in namespace %s still exists", attrs.GetName(), attrs.GetNamespace()))
+}
+
+func (d *ValidateShootStateDeletion) createAdmissionAttributes(obj metav1.Object, a admission.Attributes) admission.Attributes {
+	return admission.NewAttributesRecord(a.GetObject(),
+		a.GetOldObject(),
+		a.GetKind(),
+		a.GetNamespace(),
+		obj.GetName(),
+		a.GetResource(),
+		a.GetSubresource(),
+		a.GetOperation(),
+		a.GetOperationOptions(),
+		a.IsDryRun(),
+		a.GetUserInfo())
+}

--- a/plugin/pkg/shootstate/admission_test.go
+++ b/plugin/pkg/shootstate/admission_test.go
@@ -1,0 +1,175 @@
+package shootstate
+
+import (
+	"context"
+
+	corev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	"github.com/gardener/gardener/pkg/apis/garden"
+	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	"github.com/gardener/gardener/pkg/client/garden/clientset/internalversion/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/client-go/testing"
+)
+
+var _ = Describe("Validate ShootState deletion", func() {
+	var (
+		shoot                             garden.Shoot
+		shootState                        corev1alpha1.ShootState
+		gardenExternalCoreInformerFactory externalcoreinformers.SharedInformerFactory
+		gardenClient                      *fake.Clientset
+		admissionHandler                  *ValidateShootStateDeletion
+	)
+
+	BeforeEach(func() {
+		shootState = corev1alpha1.ShootState{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "garden-foo",
+			},
+		}
+
+		shoot = garden.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "garden-foo",
+			},
+		}
+
+		admissionHandler, _ = New()
+		admissionHandler.AssignReadyFunc(func() bool { return true })
+
+		gardenExternalCoreInformerFactory = externalcoreinformers.NewSharedInformerFactory(nil, 0)
+		admissionHandler.SetExternalCoreInformerFactory(gardenExternalCoreInformerFactory)
+
+		gardenClient = &fake.Clientset{}
+		admissionHandler.SetInternalGardenClientset(gardenClient)
+	})
+
+	It("should do nothing because the resource is not ShootState", func() {
+		attrs := admission.NewAttributesRecord(nil, nil, garden.Kind("Foo").WithVersion("version"), shoot.Namespace, shoot.Name, garden.Resource("foos").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+		err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should forbid ShootState deletion because shoot object exist ", func() {
+		attrs := admission.NewAttributesRecord(&shootState, nil, corev1alpha1.Kind("ShootState").WithVersion("v1alpha1"), shootState.Namespace, shootState.Name, corev1alpha1.Resource("shootstates").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+		gardenClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+			return true, &shoot, nil
+		})
+
+		err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsForbidden(err)).To(BeTrue())
+	})
+
+	It("should allow ShootState deletion because shoot object does not exist", func() {
+		attrs := admission.NewAttributesRecord(&shootState, nil, corev1alpha1.Kind("ShootState").WithVersion("v1alpha1"), shootState.Namespace, shootState.Name, corev1alpha1.Resource("shootstates").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+		gardenClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewNotFound(garden.Resource("shoot"), "foo")
+		})
+
+		err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("Delete collection", func() {
+		It("should allow deletion because no corresponding Shoot objects exist for the ShootStates", func() {
+			secondShootState := shootState.DeepCopy()
+			secondShootState.Name = "bar"
+
+			Expect(gardenExternalCoreInformerFactory.Core().V1alpha1().ShootStates().Informer().GetStore().Add(&shootState)).NotTo(HaveOccurred())
+			Expect(gardenExternalCoreInformerFactory.Core().V1alpha1().ShootStates().Informer().GetStore().Add(secondShootState)).NotTo(HaveOccurred())
+
+			attrs := admission.NewAttributesRecord(nil, nil, corev1alpha1.Kind("ShootState").WithVersion("v1alpha1"), shootState.Namespace, "", corev1alpha1.Resource("shootstates").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+			gardenClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewNotFound(garden.Resource("shoot"), "")
+			})
+
+			err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should forbit ShootState deletion", func() {
+			secondShootState := shootState.DeepCopy()
+			secondShootState.Name = "bar"
+
+			Expect(gardenExternalCoreInformerFactory.Core().V1alpha1().ShootStates().Informer().GetStore().Add(&shootState)).NotTo(HaveOccurred())
+			Expect(gardenExternalCoreInformerFactory.Core().V1alpha1().ShootStates().Informer().GetStore().Add(secondShootState)).NotTo(HaveOccurred())
+
+			attrs := admission.NewAttributesRecord(nil, nil, corev1alpha1.Kind("ShootState").WithVersion("v1alpha1"), shootState.Namespace, "", corev1alpha1.Resource("shootstates").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+			gardenClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+				return true, &shoot, nil
+			})
+
+			err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsForbidden(err)).To(BeTrue())
+		})
+	})
+
+	Describe("#Register", func() {
+		It("should register the plugin", func() {
+			plugins := admission.NewPlugins()
+			Register(plugins)
+
+			registered := plugins.Registered()
+			Expect(registered).To(HaveLen(1))
+			Expect(registered).To(ContainElement(PluginName))
+		})
+	})
+
+	Describe("#NewFactory", func() {
+		It("should create a new PluginFactory", func() {
+			f, err := NewFactory(nil)
+
+			Expect(f).NotTo(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("#New", func() {
+		It("should only handle DELETE operations", func() {
+			dr, err := New()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dr.Handles(admission.Create)).NotTo(BeTrue())
+			Expect(dr.Handles(admission.Update)).NotTo(BeTrue())
+			Expect(dr.Handles(admission.Connect)).NotTo(BeTrue())
+			Expect(dr.Handles(admission.Delete)).To(BeTrue())
+		})
+	})
+
+	Describe("#ValidateInitialization", func() {
+		It("should return error if no ShootStateLister is set", func() {
+			dr, _ := New()
+
+			err := dr.ValidateInitialization()
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should not return error if ShootStateLister is set", func() {
+			dr, _ := New()
+			dr.SetExternalCoreInformerFactory(externalcoreinformers.NewSharedInformerFactory(nil, 0))
+
+			err := dr.ValidateInitialization()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/plugin/pkg/shootstate/shootstate_suite_test.go
+++ b/plugin/pkg/shootstate/shootstate_suite_test.go
@@ -1,0 +1,13 @@
+package shootstate
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestValidator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Admission ShootStateDeletion Suite")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is part of the Control Plane Migration
Refactors the deploy secrets step and splits it into 2 parts. 
- The first one will generate secrets which have to be saved in the ShootState resource so that they can be used for migration at a later point.
- The second part uses the saved secret data in the ShootState resource to generate secret objects and deploy them in the Shoot's control plane
- An additional temporary step is used to first load already existing secrets in the Shoot's control plane to the ShootState so that they do not get regenerated.

**Which issue(s) this PR fixes**:
Part of #1631 

**Special notes for your reviewer**:
The ETCD encryption secret will be done in a separate PR.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Refactored Shoot control plane secret generation and deployment logic so that secrets which are required to be persisted for control plane migration are saved in the ShootState resource.
```
