### PR TITLE
Remove provider-specific class types from autoscaler RBAC

### DIFF
--- a/charts/seed-bootstrap/templates/clusterrole-cluster-autoscaler.yaml
+++ b/charts/seed-bootstrap/templates/clusterrole-cluster-autoscaler.yaml
@@ -6,15 +6,7 @@ rules:
 - apiGroups:
   - machine.sapcloud.io
   resources:
-  - alicloudmachineclasses
-  - awsmachineclasses
-  - azuremachineclasses
-  - gcpmachineclasses
-  - packetmachineclasses
-  - openstackmachineclasses
-  - machinedeployments
-  - machines
-  - machinesets
+  - "*"
   verbs:
   - create
   - delete


### PR DESCRIPTION
**What this PR does / why we need it**:
Let's remove the explicit resource listing in the autoscaler role to prevent the necessity to touch the gardener/gardener code base when a new provider extension is added.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
