### PR TITLE
Remove machineclass constant from Gardener APIs

### DIFF
--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -114,8 +114,6 @@ const (
 	GardenPurpose = "garden.sapcloud.io/purpose"
 	// GardenerPurpose is a constant for the key in a label describing the purpose of the respective object.
 	GardenerPurpose = "gardener.cloud/purpose"
-	// GardenPurposeMachineClass is a constant for the 'machineclass' value in a label.
-	GardenPurposeMachineClass = "machineclass"
 
 	// GardenerOperation is a constant for an annotation on a resource that describes a desired operation.
 	GardenerOperation = "gardener.cloud/operation"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -114,8 +114,6 @@ const (
 	GardenPurpose = "garden.sapcloud.io/purpose"
 	// GardenerPurpose is a constant for the key in a label describing the purpose of the respective object.
 	GardenerPurpose = "gardener.cloud/purpose"
-	// GardenPurposeMachineClass is a constant for the 'machineclass' value in a label.
-	GardenPurposeMachineClass = "machineclass"
 
 	// GardenerOperation is a constant for an annotation on a resource that describes a desired operation.
 	GardenerOperation = "gardener.cloud/operation"


### PR DESCRIPTION
**What this PR does / why we need it**:
Gardener does nothing with these `machineclass` constants anymore, hence, the better place to live is the gardener/gardener-extensions repo. Will open a follow-up PR there.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
