### PR TITLE
Remove hard-coded calico fluentd config

### DIFF
--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
@@ -129,16 +129,9 @@ data:
 
     [FILTER]
         Name                parser
-        Match               kubernetes.calico-node*calico-node*
-        Key_Name            log
-        Parser              caliconodeParser
-        Reserve_Data        True
-
-    [FILTER]
-        Name                parser
         Match               kubernetes.alertmanager*alertmanager*
         Key_Name            log
-        Parser              alermanagerParser
+        Parser              alertmanagerParser
         Reserve_Data        True
 
     [FILTER]
@@ -209,7 +202,7 @@ data:
         Name                parser
         Match               kubernetes.prometheus*prometheus*
         Key_Name            log
-        Parser              alermanagerParser
+        Parser              alertmanagerParser
         Reserve_Data        True
 
     [FILTER]
@@ -305,14 +298,7 @@ data:
         Time_Format %Y-%m-%d %H:%M:%S.%L
 
     [PARSER]
-        Name        caliconodeParser
-        Format      regex
-        Regex       ^(?<time>\d{4}-\d{2}-\d{2}\s+[^ ]*)\s+\[(?<severity>\w*)\]\[(?<pid>\d+)\]\s+(?<source>[^:]*):\s+(?<log>.*)
-        Time_Key    time
-        Time_Format %Y-%m-%d %H:%M:%S.%L
-
-    [PARSER]
-        Name        alermanagerParser
+        Name        alertmanagerParser
         Format      regex
         Regex       ^level=(?<severity>\w+)\s+ts=(?<time>\d{4}-\d{2}-\d{2}[Tt].*[zZ])\s+caller=(?<source>[^\s]*+)\s+(?<log>.*)
         Time_Key    time


### PR DESCRIPTION
**What this PR does / why we need it**:
The calico extension has been created months back, but the fluentd logging config was still hard-coded in g/g. With this PR it's now cleaned up.

**Special notes for your reviewer**:
See corresponding PR on g/gext: https://github.com/gardener/gardener-extensions/pull/550 - the networking-calico extension now implements the extension logging contract and defines the fluentd config on via its Helm chart.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The hard-coded calico logging configuration has been removed from the fluentd configuration. Please ensure that your `networking-calico` extension version (if you use it) is at least <TODO>.
```
