### PR TITLE
Remove MCM artifacts after removal in g/g

### DIFF
--- a/charts/seed-bootstrap/templates/extensions/crd-operatingsystemconfig.yaml
+++ b/charts/seed-bootstrap/templates/extensions/crd-operatingsystemconfig.yaml
@@ -106,7 +106,7 @@ spec:
               type: array
             purpose:
               description: Purpose describes how the result of this OperatingSystemConfig
-                is used by Gardener. Either it gets sent to the machine-controller-manager
+                is used by Gardener. Either it gets sent to the Worker extension controller
                 to bootstrap a VM, or it is downloaded by the cloud-config-downloader
                 script already running on a bootstrapped VM.
               type: string

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/vpa-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/vpa-dashboard.json
@@ -526,11 +526,6 @@
             "selected": false,
             "text": "kube-scheduler",
             "value": "kube-scheduler"
-          },
-          {
-            "selected": false,
-            "text": "machine-controller-manager",
-            "value": "machine-controller-manager"
           }
         ],
         "query": "label_values(vpa_status_recommendation{targetKind=~\"$targetKind\"}, targetName)",

--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -7159,5 +7159,5 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>f13d679ab</code>.
+on git commit <code>864ace2ad</code>.
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -987,7 +987,7 @@ OperatingSystemConfigPurpose
 </td>
 <td>
 <p>Purpose describes how the result of this OperatingSystemConfig is used by Gardener. Either it
-gets sent to the machine-controller-manager to bootstrap a VM, or it is downloaded by the
+gets sent to the <code>Worker</code> extension controller to bootstrap a VM, or it is downloaded by the
 cloud-config-downloader script already running on a bootstrapped VM.</p>
 </td>
 </tr>
@@ -2564,7 +2564,7 @@ OperatingSystemConfigPurpose
 </td>
 <td>
 <p>Purpose describes how the result of this OperatingSystemConfig is used by Gardener. Either it
-gets sent to the machine-controller-manager to bootstrap a VM, or it is downloaded by the
+gets sent to the <code>Worker</code> extension controller to bootstrap a VM, or it is downloaded by the
 cloud-config-downloader script already running on a bootstrapped VM.</p>
 </td>
 </tr>
@@ -3204,5 +3204,5 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>f13d679ab</code>.
+on git commit <code>864ace2ad</code>.
 </em></p>

--- a/hack/api-reference/garden.md
+++ b/hack/api-reference/garden.md
@@ -8224,5 +8224,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>f13d679ab</code>.
+on git commit <code>864ace2ad</code>.
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,5 +555,5 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>f13d679ab</code>.
+on git commit <code>864ace2ad</code>.
 </em></p>

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -72,7 +72,7 @@ type OperatingSystemConfigSpec struct {
 	DefaultSpec `json:",inline"`
 
 	// Purpose describes how the result of this OperatingSystemConfig is used by Gardener. Either it
-	// gets sent to the machine-controller-manager to bootstrap a VM, or it is downloaded by the
+	// gets sent to the `Worker` extension controller to bootstrap a VM, or it is downloaded by the
 	// cloud-config-downloader script already running on a bootstrapped VM.
 	Purpose OperatingSystemConfigPurpose `json:"purpose"`
 	// ReloadConfigFilePath is the path to the generated operating system configuration. If set, controllers


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleanup machine-controller-manager left-overs after it got removed entirely from g/g.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
