### PR TITLE
Allow Gardenlet bootstrapping with service account

### DIFF
--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -278,11 +278,12 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 	var (
 		kubeconfigFromBootstrap []byte
 		csrName                 string
+		seedName                string
 		err                     error
 	)
 
 	if cfg.GardenClientConnection.KubeconfigSecret != nil {
-		kubeconfigFromBootstrap, csrName, err = bootstrapKubeconfig(ctx, logger, cfg.GardenClientConnection, cfg.SeedClientConnection.ClientConnectionConfiguration, cfg.SeedConfig)
+		kubeconfigFromBootstrap, csrName, seedName, err = bootstrapKubeconfig(ctx, logger, cfg.GardenClientConnection, cfg.SeedClientConnection.ClientConnectionConfiguration, cfg.SeedConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -314,10 +315,10 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 		return nil, err
 	}
 
-	// Delete bootstrap token if certificate was freshly acquired
+	// Delete bootstrap auth data if certificate was freshly acquired
 	if len(csrName) > 0 {
-		logger.Infof("Deleting bootstrap token secret used to request a certificate")
-		if err := bootstrap.DeleteBootstrapToken(ctx, k8sGardenClient.Client(), csrName); err != nil {
+		logger.Infof("Deleting bootstrap authentication data used to request a certificate")
+		if err := bootstrap.DeleteBootstrapAuth(ctx, k8sGardenClient.Client(), csrName, seedName); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/apis/core/v1alpha1/helper/helper.go
+++ b/pkg/apis/core/v1alpha1/helper/helper.go
@@ -196,6 +196,7 @@ type ShootedSeed struct {
 	ShootDefaults     *gardencorev1alpha1.ShootNetworks
 	Backup            *gardencorev1alpha1.SeedBackup
 	NoGardenlet       bool
+	UseServiceAccountBootstrapping  bool
 	WithSecretRef     bool
 }
 
@@ -275,6 +276,9 @@ func parseShootedSeed(annotation string) (*ShootedSeed, error) {
 	}
 	if _, ok := flags["no-gardenlet"]; ok {
 		shootedSeed.NoGardenlet = true
+	}
+	if _, ok := flags["use-serviceaccount-bootstrapping"]; ok {
+		shootedSeed.UseServiceAccountBootstrapping = true
 	}
 	if _, ok := flags["with-secret-ref"]; ok {
 		shootedSeed.WithSecretRef = true

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -186,16 +186,17 @@ func TaintsHave(taints []gardencorev1beta1.SeedTaint, key string) bool {
 }
 
 type ShootedSeed struct {
-	DisableDNS        *bool
-	Protected         *bool
-	Visible           *bool
-	MinimumVolumeSize *string
-	APIServer         *ShootedSeedAPIServer
-	BlockCIDRs        []string
-	ShootDefaults     *gardencorev1beta1.ShootNetworks
-	Backup            *gardencorev1beta1.SeedBackup
-	NoGardenlet       bool
-	WithSecretRef     bool
+	DisableDNS                     *bool
+	Protected                      *bool
+	Visible                        *bool
+	MinimumVolumeSize              *string
+	APIServer                      *ShootedSeedAPIServer
+	BlockCIDRs                     []string
+	ShootDefaults                  *gardencorev1beta1.ShootNetworks
+	Backup                         *gardencorev1beta1.SeedBackup
+	NoGardenlet                    bool
+	UseServiceAccountBootstrapping bool
+	WithSecretRef                  bool
 }
 
 type ShootedSeedAPIServer struct {
@@ -274,6 +275,9 @@ func parseShootedSeed(annotation string) (*ShootedSeed, error) {
 	}
 	if _, ok := flags["no-gardenlet"]; ok {
 		shootedSeed.NoGardenlet = true
+	}
+	if _, ok := flags["use-serviceaccount-bootstrapping"]; ok {
+		shootedSeed.UseServiceAccountBootstrapping = true
 	}
 	if _, ok := flags["with-secret-ref"]; ok {
 		shootedSeed.WithSecretRef = true

--- a/pkg/gardenlet/bootstrap/bootstrap_suite_test.go
+++ b/pkg/gardenlet/bootstrap/bootstrap_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBootstrap(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gardenlet Bootstrap Suite")
+}

--- a/pkg/gardenlet/bootstrap/bootstrap_test.go
+++ b/pkg/gardenlet/bootstrap/bootstrap_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap_test
+
+import (
+	"context"
+	"fmt"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	. "github.com/gardener/gardener/pkg/gardenlet/bootstrap"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
+	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Bootstrap", func() {
+	Describe("BuildBootstrapperName", func() {
+		It("should return the correct name", func() {
+			name := "foo"
+			result := BuildBootstrapperName(name)
+			Expect(result).To(Equal(fmt.Sprintf("%s:%s", GardenerSeedBootstrapper, name)))
+		})
+	})
+
+	Describe("#DeleteBootstrapAuth", func() {
+		var (
+			ctrl *gomock.Controller
+			c    *mockclient.MockClient
+
+			ctx     = context.TODO()
+			csrName = "csr-name"
+			csrKey  = kutil.Key(csrName)
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			c = mockclient.NewMockClient(ctrl)
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("should return an error because the CSR was not found", func() {
+			c.EXPECT().
+				Get(ctx, csrKey, gomock.AssignableToTypeOf(&certificatesv1beta1.CertificateSigningRequest{})).
+				Return(apierrors.NewNotFound(schema.GroupResource{Resource: "CertificateSigningRequests"}, csrName))
+
+			Expect(DeleteBootstrapAuth(ctx, c, csrName, "")).NotTo(Succeed())
+		})
+
+		It("should delete nothing because the username in the CSR does not match a known pattern", func() {
+			c.EXPECT().
+				Get(ctx, csrKey, gomock.AssignableToTypeOf(&certificatesv1beta1.CertificateSigningRequest{})).
+				Return(nil)
+
+			Expect(DeleteBootstrapAuth(ctx, c, csrName, "")).To(Succeed())
+		})
+
+		It("should delete the bootstrap token secret", func() {
+			var (
+				bootstrapTokenID         = "12345"
+				bootstrapTokenSecretName = "bootstrap-token-" + bootstrapTokenID
+				bootstrapTokenUserName   = bootstraptokenapi.BootstrapUserPrefix + bootstrapTokenID
+				bootstrapTokenSecret     = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: bootstrapTokenSecretName}}
+			)
+
+			gomock.InOrder(
+				c.EXPECT().
+					Get(ctx, csrKey, gomock.AssignableToTypeOf(&certificatesv1beta1.CertificateSigningRequest{})).
+					DoAndReturn(func(_ context.Context, _ client.ObjectKey, csr *certificatesv1beta1.CertificateSigningRequest) error {
+						csr.Spec.Username = bootstrapTokenUserName
+						return nil
+					}),
+
+				c.EXPECT().
+					Delete(ctx, bootstrapTokenSecret),
+			)
+
+			Expect(DeleteBootstrapAuth(ctx, c, csrName, "")).To(Succeed())
+		})
+
+		It("should delete the service account and cluster role binding", func() {
+			var (
+				seedName                = "foo"
+				serviceAccountName      = "foo"
+				serviceAccountNamespace = v1beta1constants.GardenNamespace
+				serviceAccountUserName  = serviceaccount.MakeUsername(serviceAccountNamespace, serviceAccountName)
+				serviceAccount          = &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: serviceAccountNamespace, Name: serviceAccountName}}
+
+				clusterRoleBinding = &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: BuildBootstrapperName(seedName)}}
+			)
+
+			gomock.InOrder(
+				c.EXPECT().
+					Get(ctx, csrKey, gomock.AssignableToTypeOf(&certificatesv1beta1.CertificateSigningRequest{})).
+					DoAndReturn(func(_ context.Context, _ client.ObjectKey, csr *certificatesv1beta1.CertificateSigningRequest) error {
+						csr.Spec.Username = serviceAccountUserName
+						return nil
+					}),
+
+				c.EXPECT().
+					Delete(ctx, serviceAccount),
+
+				c.EXPECT().
+					Delete(ctx, clusterRoleBinding),
+			)
+
+			Expect(DeleteBootstrapAuth(ctx, c, csrName, seedName)).To(Succeed())
+		})
+	})
+})

--- a/pkg/gardenlet/controller/shoot/seed_registration_control.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control.go
@@ -43,6 +43,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -417,43 +418,14 @@ func deployGardenlet(ctx context.Context, k8sGardenClient kubernetes.Interface, 
 		return err
 	}
 
-	// create bootstrap token and bootstrap kubeconfig in case there is no existing gardenlet kubeconfig yet
+	// create bootstrap kubeconfig in case there is no existing gardenlet kubeconfig yet
 	var bootstrapKubeconfigValues map[string]interface{}
 	if err := k8sSeedClient.Client().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace, gardenletKubeconfigSecretName), &corev1.Secret{}); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
 
-		var (
-			tokenID               = utils.ComputeSHA256Hex([]byte(shoot.Name))[:6]
-			validity              = 24 * time.Hour
-			refreshBootstrapToken = true
-			bootstrapTokenSecret  *corev1.Secret
-		)
-
-		secret := &corev1.Secret{}
-		if err := k8sGardenClient.Client().Get(ctx, kutil.Key(metav1.NamespaceSystem, bootstraptokenutil.BootstrapTokenSecretName(tokenID)), secret); client.IgnoreNotFound(err) != nil {
-			return err
-		}
-
-		if expirationTime, ok := secret.Data[bootstraptokenapi.BootstrapTokenExpirationKey]; ok {
-			t, err := time.Parse(time.RFC3339, string(expirationTime))
-			if err != nil {
-				return err
-			}
-
-			if !t.Before(metav1.Now().UTC()) {
-				bootstrapTokenSecret = secret
-				refreshBootstrapToken = false
-			}
-		}
-
-		if refreshBootstrapToken {
-			bootstrapTokenSecret, err = kutil.ComputeBootstrapToken(ctx, k8sGardenClient.Client(), tokenID, fmt.Sprintf("A bootstrap token for the Gardenlet for shooted seed %q.", shoot.Name), validity)
-			if err != nil {
-				return err
-			}
-		}
+		var bootstrapKubeconfig []byte
 
 		restConfig := *k8sGardenClient.RESTConfig()
 		if addr := cfg.GardenClientConnection.GardenClusterAddress; addr != nil {
@@ -465,9 +437,92 @@ func deployGardenlet(ctx context.Context, k8sGardenClient kubernetes.Interface, 
 			}
 		}
 
-		bootstrapKubeconfig, err := bootstrap.MarshalKubeconfigFromBootstrapToken(&restConfig, kutil.BootstrapTokenFrom(bootstrapTokenSecret.Data))
-		if err != nil {
-			return err
+		if shootedSeedConfig.UseServiceAccountBootstrapping {
+			// create temporary service account with bootstrap kubeconfig in order to create CSR
+			saName := "gardenlet-bootstrap-" + shoot.Name
+			sa := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      saName,
+					Namespace: v1beta1constants.GardenNamespace,
+				},
+			}
+			if _, err := controllerutil.CreateOrUpdate(ctx, k8sGardenClient.Client(), sa, func() error { return nil }); err != nil {
+				return err
+			}
+
+			if len(sa.Secrets) == 0 {
+				return fmt.Errorf("service account token controller has not yet created a secret for the service account")
+			}
+
+			saSecret := &corev1.Secret{}
+			if err := k8sGardenClient.Client().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace, sa.Secrets[0].Name), saSecret); err != nil {
+				return err
+			}
+
+			clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: bootstrap.BuildBootstrapperName(shoot.Name),
+				},
+			}
+			if _, err := controllerutil.CreateOrUpdate(ctx, k8sGardenClient.Client(), clusterRoleBinding, func() error {
+				clusterRoleBinding.RoleRef = rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "ClusterRole",
+					Name:     bootstrap.GardenerSeedBootstrapper,
+				}
+				clusterRoleBinding.Subjects = []rbacv1.Subject{
+					{
+						Kind:      "ServiceAccount",
+						Name:      saName,
+						Namespace: v1beta1constants.GardenNamespace,
+					},
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+
+			bootstrapKubeconfig, err = bootstrap.MarshalKubeconfigWithToken(&restConfig, string(saSecret.Data[corev1.ServiceAccountTokenKey]))
+			if err != nil {
+				return err
+			}
+		} else {
+			// create bootstrap token with bootstrap kubeconfig in order to create CSR
+			var (
+				tokenID               = utils.ComputeSHA256Hex([]byte(shoot.Name))[:6]
+				validity              = 24 * time.Hour
+				refreshBootstrapToken = true
+				bootstrapTokenSecret  *corev1.Secret
+			)
+
+			secret := &corev1.Secret{}
+			if err := k8sGardenClient.Client().Get(ctx, kutil.Key(metav1.NamespaceSystem, bootstraptokenutil.BootstrapTokenSecretName(tokenID)), secret); client.IgnoreNotFound(err) != nil {
+				return err
+			}
+
+			if expirationTime, ok := secret.Data[bootstraptokenapi.BootstrapTokenExpirationKey]; ok {
+				t, err := time.Parse(time.RFC3339, string(expirationTime))
+				if err != nil {
+					return err
+				}
+
+				if !t.Before(metav1.Now().UTC()) {
+					bootstrapTokenSecret = secret
+					refreshBootstrapToken = false
+				}
+			}
+
+			if refreshBootstrapToken {
+				bootstrapTokenSecret, err = kutil.ComputeBootstrapToken(ctx, k8sGardenClient.Client(), tokenID, fmt.Sprintf("A bootstrap token for the Gardenlet for shooted seed %q.", shoot.Name), validity)
+				if err != nil {
+					return err
+				}
+			}
+
+			bootstrapKubeconfig, err = bootstrap.MarshalKubeconfigWithToken(&restConfig, kutil.BootstrapTokenFrom(bootstrapTokenSecret.Data))
+			if err != nil {
+				return err
+			}
 		}
 
 		bootstrapKubeconfigValues = map[string]interface{}{


### PR DESCRIPTION
**What this PR does / why we need it**:
The `shoot.garden.sapcloud.io/use-as-seed` annotation now supports as `use-serviceaccount-bootstrapping` configuration option. If set, the Gardenlet will not create a bootstrap token but a service account when it deploys itself into a shooted seed cluster. This is useful in case the Garden cluster does not support bootstrap tokens.

**Which issue(s) this PR fixes**:
Fixes #1809

**Special notes for your reviewer**:
Do not merge yet - waiting for @majst01 and @Gerrit91 to test it.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `shoot.garden.sapcloud.io/use-as-seed` annotation now supports as `use-serviceaccount-bootstrapping` configuration option. If set, the Gardenlet will not create a bootstrap token but a service account when it deploys itself into a shooted seed cluster. This is useful in case the Garden cluster does not support bootstrap tokens.
```
