### PR TITLE
Fix warning messages appearing during coredns import

### DIFF
--- a/charts/shoot-core/components/charts/coredns/templates/coredns-custom-configmap.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-custom-configmap.yaml
@@ -5,3 +5,8 @@ metadata:
   namespace:  kube-system
   annotations:
     resources.gardener.cloud/ignore: "true"
+data:
+  changeme.server: |
+    # checkout the docs on how to use: https://github.com/gardener/gardener/blob/master/docs/usage/custom-dns.md
+  changeme.override: |
+    # checkout the docs on how to use: https://github.com/gardener/gardener/blob/master/docs/usage/custom-dns.md

--- a/docs/usage/custom-dns.md
+++ b/docs/usage/custom-dns.md
@@ -28,7 +28,7 @@ data:
             cache 30
             forward . 1.2.3.4
         }
-   Corefile.override: |
+  corefile.override: |
          # <some-plugin> <some-plugin-config>
          debug
          whoami
@@ -40,7 +40,7 @@ if you want to customize the current server configuration (it is optional settin
 Once this `ConfigMap` is applied, you can roll-out your CoreDNS deployment using:
 
 ```bash
-kubectl -n kube-system rollout restart deploy CoreDNS
+kubectl -n kube-system rollout restart deploy coredns
 ```
 
 This will reload the config into CoreDNS.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure that benign warning messages (e.g., `[WARNING] No files matching import glob pattern: custom/*.override`)  are not printed out for the users. This is to avoid confusion. 

**Which issue(s) this PR fixes**:
Fixes #1788 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Warning messages for CoreDNS imports are now removed for new shoot clusters. If you want to remove them for your existing shoot clusters then add [this `data` section](https://github.com/gardener/gardener/pull/1815/files#diff-c96baf38fb1d7553db613f6cd3c891ccR8-R12) to the `coredns-custom` configmap in your `kube-system` namespace.
```
