### PR TITLE
Ensure value to be string in shoot-info chart

### DIFF
--- a/charts/shoot-core/components/charts/shoot-info/templates/configmap.yaml
+++ b/charts/shoot-core/components/charts/shoot-info/templates/configmap.yaml
@@ -5,8 +5,8 @@ metadata:
   name: shoot-info
   namespace: kube-system
 data:
-  projectName: {{ .Values.projectName }}
-  shootName: {{ .Values.shootName }}
+  projectName: "{{ .Values.projectName }}"
+  shootName: "{{ .Values.shootName }}"
   provider: {{ .Values.provider }}
   region: {{ .Values.region }}
   kubernetesVersion: {{ .Values.kubernetesVersion }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix bug shoot-info configmap can't be created when shoot name is a pure number.
**Which issue(s) this PR fixes**:
Fixes #1818

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
If the shoot name is a pure number, now Gardener can successfully create `shoot-info` configmap in `kube-system` namespace of shoot cluster.
```
