### PR TITLE
Cleanup Project admission for "garden.sapcloud.io/createdBy"

### DIFF
--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -277,16 +277,6 @@ func (r *ReferenceManager) Admit(ctx context.Context, a admission.Attributes, o 
 				project.Spec.Owner = project.Spec.CreatedBy
 			}
 		}
-		if a.GetOperation() == admission.Update {
-			if createdBy, ok := project.Annotations[common.GardenCreatedBy]; ok {
-				project.Spec.CreatedBy = &rbacv1.Subject{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     rbacv1.UserKind,
-					Name:     createdBy,
-				}
-				delete(project.Annotations, common.GardenCreatedBy)
-			}
-		}
 
 		if project.Spec.Owner != nil {
 			ownerPartOfMember := false


### PR DESCRIPTION
**What this PR does / why we need it**:
I guess this UPDATE handling was introduced in #480 to migrate existing Projects from `garden.sapcloud.io/createdBy` annotation to `.spec.createdBy`. And I guess we can now remove it as `.spec.createdBy` is set during creation and it is immutable.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
