### PR TITLE
Increase default CPU limit for Gardenlet chart

### DIFF
--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -14,7 +14,7 @@ global:
         cpu: 100m
         memory: 100Mi
       limits:
-        cpu: 750m
+        cpu: 2000m
         memory: 512Mi
     additionalVolumes: []
     additionalVolumeMounts: []


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR increases the default CPU limit in the Gardenlet chart. This is to accommodate CPU spikes when multiple shoots are created in parallel and the Gardenlet requires a lot of CPU power to generate the secrets and certificates. We have observed that the VPA does not scale up (fast enough?), and that the Gardenlet runs into a crash loop as it can't renew its leader lease due to the CPU throttling. @vlerenc motivated to increase the default CPU limit as CPU is compressable and it doesn't harm too much. Ideally, the VPA should behave correctly and scale the Gardenlet up in this case, though, we have not yet fully understood the situation and are investigating. Consider this PR as a stop-gap solution.
/cc @amshuman-kr @ggaurav10 @wyb1 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
