### PR TITLE
Fix project-member ClusterRole aggregation

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -114,7 +114,7 @@ rules:
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: gardener.cloud:system:project-member-aggregation
+  name: gardener.cloud:system:project-member
   labels:
     gardener.cloud/role: project-member
     app: gardener
@@ -129,7 +129,7 @@ aggregationRule:
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: gardener.cloud:system:project-member
+  name: gardener.cloud:system:project-member-aggregation
   labels:
     rbac.gardener.cloud/aggregate-to-project-member: "true"
     app: gardener
@@ -198,7 +198,7 @@ rules:
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: gardener.cloud:system:project-viewer-aggregation
+  name: gardener.cloud:system:project-viewer
   labels:
     garden.sapcloud.io/role: project-viewer
     gardener.cloud/role: project-viewer
@@ -214,7 +214,7 @@ aggregationRule:
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: gardener.cloud:system:project-viewer
+  name: gardener.cloud:system:project-viewer-aggregation
   labels:
     rbac.gardener.cloud/aggregate-to-project-viewer: "true"
     app: gardener


### PR DESCRIPTION
**What this PR does / why we need it**:
Since the introduction of #1601 the web terminal feature of the gardener dashboard does not work anymore for endusers, as the project-member ClusterRole aggregation does not work as intended: The `gardener.cloud:system:project-member` rolebinding has a roleRef to ClusterRole `gardener.cloud:system:project-member` instead of a roleRef to the ClusterRole `gardener.cloud:system:project-member-aggregation`. 

The roleRef cannot be changed without recreating the rolebinding (which can't be done easily).

Instead, this PR switches the ClusterRole `gardener.cloud:system:project-member` with `gardener.cloud:system:project-member-aggregation`, so that the `gardener.cloud:system:project-member` now contains the `aggregationRule` part and `gardener.cloud:system:project-member-aggregation` contains the `rules` part.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed `Project` related ClusterRole aggregations. These are required e.g. for the Webterminal feature of the gardener dashboard and fixes the error: terminals.dashboard.gardener.cloud is forbidden: User "user@example.com" cannot list resource "terminals" in API group "dashboard.gardener.cloud" in the namespace "garden-project"
```
