### PR TITLE
Fix K8s Dashbord defaulting

### DIFF
--- a/pkg/apis/core/v1alpha1/defaults.go
+++ b/pkg/apis/core/v1alpha1/defaults.go
@@ -120,7 +120,7 @@ func SetDefaults_Shoot(obj *Shoot) {
 	}
 	if obj.Spec.Addons.KubernetesDashboard.AuthenticationMode == nil {
 		var defaultAuthMode string
-		if k8sVersionLessThan116 {
+		if *obj.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication {
 			defaultAuthMode = KubernetesDashboardAuthModeBasic
 		} else {
 			defaultAuthMode = KubernetesDashboardAuthModeToken

--- a/pkg/apis/core/v1beta1/defaults.go
+++ b/pkg/apis/core/v1beta1/defaults.go
@@ -120,7 +120,7 @@ func SetDefaults_Shoot(obj *Shoot) {
 	}
 	if obj.Spec.Addons.KubernetesDashboard.AuthenticationMode == nil {
 		var defaultAuthMode string
-		if k8sVersionLessThan116 {
+		if *obj.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication {
 			defaultAuthMode = KubernetesDashboardAuthModeBasic
 		} else {
 			defaultAuthMode = KubernetesDashboardAuthModeToken

--- a/pkg/apis/garden/v1beta1/defaults.go
+++ b/pkg/apis/garden/v1beta1/defaults.go
@@ -239,7 +239,7 @@ func SetDefaults_Shoot(obj *Shoot) {
 	}
 	if obj.Spec.Addons.KubernetesDashboard.AuthenticationMode == nil {
 		var defaultAuthMode string
-		if k8sVersionLessThan116 {
+		if *obj.Spec.Kubernetes.KubeAPIServer.EnableBasicAuthentication {
 			defaultAuthMode = KubernetesDashboardAuthModeBasic
 		} else {
 			defaultAuthMode = KubernetesDashboardAuthModeToken

--- a/test/framework/commonframework.go
+++ b/test/framework/commonframework.go
@@ -118,6 +118,9 @@ func mergeCommonConfigs(base, overwrite *CommonConfig) *CommonConfig {
 	if StringSet(overwrite.ChartDir) {
 		base.ChartDir = overwrite.ChartDir
 	}
+	if overwrite.DisableStateDump {
+		base.DisableStateDump = overwrite.DisableStateDump
+	}
 	return base
 }
 

--- a/test/framework/resources/templates/default-shoot.yaml
+++ b/test/framework/resources/templates/default-shoot.yaml
@@ -4,6 +4,9 @@ metadata:
   name: abc
   namespace: abc
 spec:
+  kubernetes:
+    kubeAPIServer:
+      enableBasicAuthentication: false
   dns: {}
   networking:
     type: calico
@@ -26,4 +29,5 @@ spec:
       enabled: true
     kubernetesDashboard:
       enabled: true
+      authenticationMode: token
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed defaulting for k8s dashboard based on the kube-apiserver authentication method.

**Which issue(s) this PR fixes**:
Fixes #1845 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed a bug in the defaulting of the kubernetes dashboard authentication method to now default based on the api-server authentication method
```
