### PR TITLE
Fix bug in project legacy resource deletion

### DIFF
--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -148,16 +148,10 @@ func (c *defaultControl) reconcile(project *gardencorev1beta1.Project, projectLo
 	}
 
 	// Delete legacy resources
-	// TODO: This can be removed in a future version of Gardener.
+	// TODO: This can be removed in a future version of Gardener (post v1.0 release).
 	for _, obj := range []runtime.Object{
-		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("garden.sapcloud.io:system:project:%s", project.Name)}},
-		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("garden.sapcloud.io:system:project-member:%s", project.Name)}},
-		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("garden.sapcloud.io:system:project-viewer:%s", project.Name)}},
-		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("garden.sapcloud.io:system:project:%s", project.Name)}},
-		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("garden.sapcloud.io:system:project-member:%s", project.Name)}},
-		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("garden.sapcloud.io:system:project-viewer:%s", project.Name)}},
-		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "garden.sapcloud.io:system:project-member", Namespace: project.Name}},
-		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "garden.sapcloud.io:system:project-viewer", Namespace: project.Name}},
+		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "garden.sapcloud.io:system:project-member", Namespace: namespace.Name}},
+		&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "garden.sapcloud.io:system:project-viewer", Namespace: namespace.Name}},
 	} {
 		if err := c.k8sGardenClient.Client().Delete(ctx, obj); client.IgnoreNotFound(err) != nil {
 			c.reportEvent(project, true, gardencorev1beta1.ProjectEventNamespaceReconcileFailed, "Error while cleaning up legacy RBAC rules for namespace %q: %+v", namespace.Name, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug where the project controller did not delete the legacy `garden.sapcloud.io:system` `RoleBinding`s in project namespaces. The global resources have been properly cleaned up, so this code was removed.

/cc @petersutter 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The legacy `garden.sapcloud.io:system` `RoleBinding`s in project namespaces are now properly cleaned up.
```
