### PR TITLE
Fix bug preventing Kubernetes version updates for kubelets

### DIFF
--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.service
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.service
@@ -15,6 +15,11 @@
     RestartSec=5
     EnvironmentFile=/etc/environment
     EnvironmentFile=-/var/lib/kubelet/extra_args
+    {{- if semverCompare "< 1.17" .Values.kubernetes.version }}
+    ExecStartPre=/bin/docker run --rm -v /opt/bin:/opt/bin:rw {{ required "images.hyperkube is required" .Values.images.hyperkube }} /bin/sh -c "cp /usr/local/bin/kubelet /opt/bin"
+    {{- else }}
+    ExecStartPre=/bin/docker run --rm -v /opt/bin:/opt/bin:rw --entrypoint /bin/sh {{ required "images.hyperkube is required" .Values.images.hyperkube }} -c "cp /usr/local/bin/kubelet /opt/bin"
+    {{- end }}
     ExecStart=/opt/bin/kubelet \
 {{ include "kubelet-flags" . | trim | replace "\n" " \\\n" | indent 8 }}
 {{- end -}}

--- a/charts/seed-operatingsystemconfig/original/values.yaml
+++ b/charts/seed-operatingsystemconfig/original/values.yaml
@@ -9,6 +9,7 @@ osc:
 #   root certificates
 images:
   pause-container: image-repository
+  hyperkube: image-repository
 kubernetes:
   clusterDNS: 100.64.0.10
   domain: cluster.local

--- a/charts/shoot-cloud-config/templates/scripts/_cloud-config-script.sh
+++ b/charts/shoot-cloud-config/templates/scripts/_cloud-config-script.sh
@@ -29,9 +29,9 @@ docker-preload "{{ $name }}" "{{ $image }}"
 {{ end }}
 
 {{- if semverCompare "< 1.17" .kubernetesVersion }}
-docker run --rm -v /opt/bin:/opt/bin:rw {{ required "images.hyperkube is required" .images.hyperkube }} /bin/sh -c "cp /usr/local/bin/kubectl /opt/bin && cp /usr/local/bin/kubelet /opt/bin"
+docker run --rm -v /opt/bin:/opt/bin:rw {{ required "images.hyperkube is required" .images.hyperkube }} /bin/sh -c "cp /usr/local/bin/kubectl /opt/bin"
 {{- else }}
-docker run --rm -v /opt/bin:/opt/bin:rw --entrypoint /bin/sh {{ required "images.hyperkube is required" .images.hyperkube }} -c "cp /usr/local/bin/kubectl /opt/bin && cp /usr/local/bin/kubelet /opt/bin"
+docker run --rm -v /opt/bin:/opt/bin:rw --entrypoint /bin/sh {{ required "images.hyperkube is required" .images.hyperkube }} -c "cp /usr/local/bin/kubectl /opt/bin"
 {{- end }}
 
 cat << 'EOF' | base64 -d > "$PATH_CLOUDCONFIG"

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -147,7 +147,7 @@ func (b *Botanist) generateOriginalConfig() (map[string]interface{}, error) {
 	}
 	originalConfig["caBundle"] = caBundle
 
-	return b.InjectShootShootImages(originalConfig, common.PauseContainerImageName)
+	return b.InjectShootShootImages(originalConfig, common.PauseContainerImageName, common.HyperkubeImageName)
 }
 
 func (b *Botanist) deployOperatingSystemConfigsForWorker(machineTypes []gardencorev1beta1.MachineType, machineImage *gardencorev1beta1.ShootMachineImage, downloaderConfig, originalConfig map[string]interface{}, worker gardencorev1beta1.Worker) (*shoot.OperatingSystemConfigs, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug that prevented Kubernetes version upgrades for the kubelets.
Before:
`Jan 22 15:40:11 ip-10-250-31-53.eu-west-1.compute.internal download-cloud-config.sh[25231]: cp: cannot create regular file '/opt/bin/kubelet': Text file busy`

Now, the `kubelet.service` copies its binary via the `ExecPreStart` directive instead of the cloud-config-downloader trying to periodically do it.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
A bug has been fixed that prevented the update of Kubernetes versions for kubelets.
```
