### PR TITLE
Requeue shoots after 30s instead of immediately when seed is synced

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -335,7 +335,14 @@ func (c *Controller) reconcileShoot(shoot *gardencorev1beta1.Shoot, logger *logr
 			return reconcile.Result{}, err
 		}
 
-		return reconcile.Result{}, utilerrors.WithSuppressed(err, c.updateShootStatusProcessing(shoot, message))
+		if err := c.updateShootStatusProcessing(shoot, message); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{
+			Requeue:      true,
+			RequeueAfter: 30 * time.Second,
+		}, nil
 	}
 
 	if failedOrIgnored {


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent unneeded load of the Gardenlet when the seed is sync (e.g., after a new version is rolled out or it restarts). Now, shoots are requeued after `30s` instead of immediately when their seed is synced.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
