### PR TITLE
Add seed taint for disabling excess capacity reservation.

### DIFF
--- a/example/50-seed.yaml
+++ b/example/50-seed.yaml
@@ -32,9 +32,10 @@ spec:
     blockCIDRs:
     - 169.254.169.254/32
 # taints:
-# - key: seed.gardener.cloud/disable-dns # all shoots on this seed won't use any DNS, just the plain IPs/hostnames
-# - key: seed.gardener.cloud/protected   # only shoots in the `garden` namespace can use this seed
-# - key: seed.gardener.cloud/invisible   # the gardener-scheduler won't consider this seed for shoots
+# - key: seed.gardener.cloud/disable-dns                  # all shoots on this seed won't use any DNS, just the plain IPs/hostnames
+# - key: seed.gardener.cloud/protected                    # only shoots in the `garden` namespace can use this seed
+# - key: seed.gardener.cloud/invisible                    # the gardener-scheduler won't consider this seed for shoots
+# - key: seed.gardener.cloud/disable-capacity-reservation # this seed will not deploy excess-capacity-reservation pods
 # volume:
 #  minimumSize: 20Gi
 #  providers:

--- a/pkg/apis/core/v1alpha1/helper/helper.go
+++ b/pkg/apis/core/v1alpha1/helper/helper.go
@@ -187,17 +187,18 @@ func TaintsHave(taints []gardencorev1alpha1.SeedTaint, key string) bool {
 }
 
 type ShootedSeed struct {
-	DisableDNS        *bool
-	Protected         *bool
-	Visible           *bool
-	MinimumVolumeSize *string
-	APIServer         *ShootedSeedAPIServer
-	BlockCIDRs        []string
-	ShootDefaults     *gardencorev1alpha1.ShootNetworks
-	Backup            *gardencorev1alpha1.SeedBackup
-	NoGardenlet       bool
-	UseServiceAccountBootstrapping  bool
-	WithSecretRef     bool
+	DisableDNS                     *bool
+	DisableCapacityReservation     *bool
+	Protected                      *bool
+	Visible                        *bool
+	MinimumVolumeSize              *string
+	APIServer                      *ShootedSeedAPIServer
+	BlockCIDRs                     []string
+	ShootDefaults                  *gardencorev1alpha1.ShootNetworks
+	Backup                         *gardencorev1alpha1.SeedBackup
+	NoGardenlet                    bool
+	UseServiceAccountBootstrapping bool
+	WithSecretRef                  bool
 }
 
 type ShootedSeedAPIServer struct {
@@ -273,6 +274,9 @@ func parseShootedSeed(annotation string) (*ShootedSeed, error) {
 
 	if _, ok := flags["disable-dns"]; ok {
 		shootedSeed.DisableDNS = &trueVar
+	}
+	if _, ok := flags["disable-capacity-reservation"]; ok {
+		shootedSeed.DisableCapacityReservation = &trueVar
 	}
 	if _, ok := flags["no-gardenlet"]; ok {
 		shootedSeed.NoGardenlet = true

--- a/pkg/apis/core/v1alpha1/types_seed.go
+++ b/pkg/apis/core/v1alpha1/types_seed.go
@@ -168,6 +168,10 @@ const (
 	// SeedTaintInvisible is a constant for a taint key on a seed that marks it as invisible. Invisible seeds
 	// are not considered by the gardener-scheduler.
 	SeedTaintInvisible = "seed.gardener.cloud/invisible"
+	// SeedTaintDisableCapacityReservation is a constant for a taint key on a seed that marks it for disabling
+	// excess capacity reservation. This can be useful for seed clusters which only host shooted seeds to reduce
+	// costs.
+	SeedTaintDisableCapacityReservation = "seed.gardener.cloud/disable-capacity-reservation"
 )
 
 // SeedVolume contains settings for persistentvolumes created in the seed cluster.

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -187,6 +187,7 @@ func TaintsHave(taints []gardencorev1beta1.SeedTaint, key string) bool {
 
 type ShootedSeed struct {
 	DisableDNS                     *bool
+	DisableCapacityReservation     *bool
 	Protected                      *bool
 	Visible                        *bool
 	MinimumVolumeSize              *string
@@ -272,6 +273,9 @@ func parseShootedSeed(annotation string) (*ShootedSeed, error) {
 
 	if _, ok := flags["disable-dns"]; ok {
 		shootedSeed.DisableDNS = &trueVar
+	}
+	if _, ok := flags["disable-capacity-reservation"]; ok {
+		shootedSeed.DisableCapacityReservation = &trueVar
 	}
 	if _, ok := flags["no-gardenlet"]; ok {
 		shootedSeed.NoGardenlet = true

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -168,6 +168,10 @@ const (
 	// SeedTaintInvisible is a constant for a taint key on a seed that marks it as invisible. Invisible seeds
 	// are not considered by the gardener-scheduler.
 	SeedTaintInvisible = "seed.gardener.cloud/invisible"
+	// SeedTaintDisableCapacityReservation is a constant for a taint key on a seed that marks it for disabling
+	// excess capacity reservation. This can be useful for seed clusters which only host shooted seeds to reduce
+	// costs.
+	SeedTaintDisableCapacityReservation = "seed.gardener.cloud/disable-capacity-reservation"
 )
 
 // SeedVolume contains settings for persistentvolumes created in the seed cluster.

--- a/pkg/apis/garden/types.go
+++ b/pkg/apis/garden/types.go
@@ -674,6 +674,10 @@ const (
 	// SeedTaintInvisible is a constant for a taint key on a seed that marks it as invisible. Invisible seeds
 	// are not considered by the gardener-scheduler.
 	SeedTaintInvisible = "seed.gardener.cloud/invisible"
+	// SeedTaintDisableCapacityReservation is a constant for a taint key on a seed that marks it for disabling
+	// excess capacity reservation. This can be useful for seed clusters which only host shooted seeds to reduce
+	// costs.
+	SeedTaintDisableCapacityReservation = "seed.gardener.cloud/disable-capacity-reservation"
 )
 
 ////////////////////////////////////////////////////

--- a/pkg/apis/garden/validation/validation_seed.go
+++ b/pkg/apis/garden/validation/validation_seed.go
@@ -128,7 +128,7 @@ func ValidateSeedSpec(seedSpec *garden.SeedSpec, fldPath *field.Path) field.Erro
 	}
 
 	var (
-		supportedTaintKeys = sets.NewString(garden.SeedTaintDisableDNS, garden.SeedTaintProtected, garden.SeedTaintInvisible)
+		supportedTaintKeys = sets.NewString(garden.SeedTaintDisableDNS, garden.SeedTaintProtected, garden.SeedTaintInvisible, garden.SeedTaintDisableCapacityReservation)
 		foundTaintKeys     = sets.NewString()
 	)
 

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -310,6 +310,9 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 	if c.config.Controllers.Seed.ReserveExcessCapacity != nil {
 		seedObj.MustReserveExcessCapacity(*c.config.Controllers.Seed.ReserveExcessCapacity)
 	}
+	if gardencorev1beta1helper.TaintsHave(seedObj.Info.Spec.Taints, gardencorev1beta1.SeedTaintDisableCapacityReservation) {
+		seedObj.MustReserveExcessCapacity(false)
+	}
 	if err := seedpkg.BootstrapCluster(c.k8sGardenClient, seedObj, c.config, c.secrets, c.imageVector, len(associatedShoots)); err != nil {
 		conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "BootstrappingFailed", err.Error())
 		c.updateSeedStatus(seed, seedKubernetesVersion, conditionSeedBootstrapped)

--- a/pkg/gardenlet/controller/shoot/seed_registration_control.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control.go
@@ -291,6 +291,9 @@ func prepareSeedConfig(ctx context.Context, k8sGardenClient kubernetes.Interface
 	if shootedSeedConfig.DisableDNS != nil && *shootedSeedConfig.DisableDNS {
 		taints = append(taints, gardencorev1beta1.SeedTaint{Key: gardencorev1beta1.SeedTaintDisableDNS})
 	}
+	if shootedSeedConfig.DisableCapacityReservation != nil && *shootedSeedConfig.DisableCapacityReservation {
+		taints = append(taints, gardencorev1beta1.SeedTaint{Key: gardencorev1beta1.SeedTaintDisableCapacityReservation})
+	}
 	if shootedSeedConfig.Protected != nil && *shootedSeedConfig.Protected {
 		taints = append(taints, gardencorev1beta1.SeedTaint{Key: gardencorev1beta1.SeedTaintProtected})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Generally, excess-capacity-reservation in a Gardener Seed has the positive effect of providing enough computational resources for Gardener Shoots before new shoots are created. The end-user benefits from this feature as it makes the time for provisioning shoots more constant.

However, computational resources at cloud providers are expensive and the amount of resources that the excess-capacity-reservation is allocating is computed statically by the Gardener, an administrator cannot influence the amount of resources that this mechanism requests. 

Gardener has the ability to deploy shooted seeds and thus there can be scenarios where a seed cluster will not contain any end-user shoot clusters but only a pretty stable amount of shooted seeds. For these cases it would actually be acceptable if shoot provisioning takes a little longer than usual and the cloud provider scales up during the provisioning of the new control plane. This would be more cost-efficient and there will be no end-user effected.

Therefore, this PR adds a new seed taint to disable the deployment of the excess capacity resources individually per seed.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement
Adds a new seed taint "seed.gardener.cloud/disable-capacity-reservation" to disable the deployment of excess-capacity-reservation resources. The taint can also be set using the shooted seed annotation "disable-capacity-reservation".
```
