### PR TITLE
Remove duplicated defaulting code in test framework

### DIFF
--- a/test/system/shoot_creation/create_test.go
+++ b/test/system/shoot_creation/create_test.go
@@ -208,18 +208,6 @@ func prepareShoot(ctx context.Context, f *framework.GardenerFramework) *gardenco
 	cloudprofile, err := f.GetCloudProfile(ctx, shootObject.Spec.CloudProfileName)
 	Expect(err).ToNot(HaveOccurred())
 
-	nginxIngress := &gardencorev1beta1.NginxIngress{Addon: gardencorev1beta1.Addon{Enabled: true}}
-	kubernetesDashboard := &gardencorev1beta1.KubernetesDashboard{Addon: gardencorev1beta1.Addon{Enabled: true}}
-	if shootObject.Spec.Addons != nil {
-		shootObject.Spec.Addons.NginxIngress = nginxIngress
-		shootObject.Spec.Addons.KubernetesDashboard = kubernetesDashboard
-	} else {
-		shootObject.Spec.Addons = &gardencorev1beta1.Addons{
-			NginxIngress:        nginxIngress,
-			KubernetesDashboard: kubernetesDashboard,
-		}
-	}
-
 	if networkingPods != nil && len(*networkingPods) > 0 {
 		shootObject.Spec.Networking.Pods = networkingPods
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove duplicated defaulting code in the test framework and rely on the default shoot yaml

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
