### PR TITLE
Fix panic when creating a shoot

### DIFF
--- a/test/framework/gardenerframework.go
+++ b/test/framework/gardenerframework.go
@@ -152,6 +152,9 @@ func RegisterGardenerFrameworkFlags(flagset *flag.FlagSet) *GardenerConfig {
 func (f *GardenerFramework) NewShootFramework(shoot *gardencorev1beta1.Shoot) (*ShootFramework, error) {
 	shootFramework := &ShootFramework{
 		GardenerFramework: f,
+		Config: &ShootConfig{
+			GardenerConfig: f.GardenerFrameworkConfig,
+		},
 	}
 	if err := shootFramework.AddShoot(context.TODO(), shoot.GetName(), shoot.GetNamespace()); err != nil {
 		return nil, err

--- a/test/system/shoot_creation/create_test.go
+++ b/test/system/shoot_creation/create_test.go
@@ -31,9 +31,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/gardener/gardener/test/framework"
-	"path"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -240,11 +238,4 @@ func printShoot(shoot *gardencorev1beta1.Shoot) error {
 	}
 	fmt.Print(string(d))
 	return nil
-}
-
-// getProjectRootPath gets the root path of the project relative to the integration test folder
-func getProjectRootPath() string {
-	_, filename, _, _ := runtime.Caller(0)
-	dir := path.Join(path.Dir(filename), "../../../")
-	return dir
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a panic when the shoot framework is initialized from the gardener framework.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
