### PR TITLE
Upgrade kube-state-metrics to 1.9.3

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -88,7 +88,7 @@ images:
 - name: kube-state-metrics
   sourceRepository: github.com/kubernetes/kube-state-metrics
   repository: quay.io/coreos/kube-state-metrics
-  tag: v1.7.2
+  tag: v1.9.3
 - name: node-exporter
   sourceRepository: github.com/prometheus/node_exporter
   repository: quay.io/prometheus/node-exporter


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrades kube-state-metrics to 1.9.3. Includes some new interesting experimental metrics that could be interesting including vpa metrics and network policy metrics.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Upgrades kube-state-metrics to `1.9.3`.
```
