### PR TITLE
Consolidated reserve excess capacity.

### DIFF
--- a/charts/seed-bootstrap/templates/reserve-excess-capacity/deployment.yaml
+++ b/charts/seed-bootstrap/templates/reserve-excess-capacity/deployment.yaml
@@ -27,10 +27,10 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           requests:
-            cpu: 500m
-            memory: 1200Mi
+            cpu: 2
+            memory: 6Gi
           limits:
-            cpu: 500m
-            memory: 1200Mi
+            cpu: 2
+            memory: 6Gi
       priorityClassName: gardener-reserve-excess-capacity
 {{- end }}

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -290,13 +290,6 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 		return err
 	}
 
-	// Fetching associated shoots for the current seed
-	associatedShoots, err := controllerutils.DetermineShootsAssociatedTo(seed, c.shootLister)
-	if err != nil {
-		seedLogger.Error(err.Error())
-		return err
-	}
-
 	// Check whether the Kubernetes version of the Seed cluster fulfills the minimal requirements.
 	seedKubernetesVersion, err := seedObj.CheckMinimumK8SVersion(ctx, c.k8sGardenClient.Client(), c.config.SeedClientConnection.ClientConnectionConfiguration, c.config.SeedSelector == nil)
 	if err != nil {
@@ -313,7 +306,7 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 	if gardencorev1beta1helper.TaintsHave(seedObj.Info.Spec.Taints, gardencorev1beta1.SeedTaintDisableCapacityReservation) {
 		seedObj.MustReserveExcessCapacity(false)
 	}
-	if err := seedpkg.BootstrapCluster(c.k8sGardenClient, seedObj, c.config, c.secrets, c.imageVector, len(associatedShoots)); err != nil {
+	if err := seedpkg.BootstrapCluster(c.k8sGardenClient, seedObj, c.config, c.secrets, c.imageVector); err != nil {
 		conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "BootstrappingFailed", err.Error())
 		c.updateSeedStatus(seed, seedKubernetesVersion, conditionSeedBootstrapped)
 		seedLogger.Error(err.Error())


### PR DESCRIPTION
**What this PR does / why we need it**:
The current [granualar](https://github.com/gardener/gardener/blob/master/pkg/operation/seed/seed.go#L696) reserve excess capacity may not be useful for newly scaled (by VPA or HVPA) control-plane components.

**Which issue(s) this PR fixes**:
By consolidating the reserve excess capacity, we can support both new control-planes as well as newly (vertically) scaled old control-planes.

**Special notes for your reviewer**:

- I have also removed the [proportionate (3%)](https://github.com/gardener/gardener/blob/master/pkg/operation/seed/seed.go#L698) logic based on associated shoots. The reasoning is that neither the rate of creation of new shoot control-planes nor the rate of vertical scaling of existing shoot control-planes is dependent on the associated number of shoots in a seed. Please let me know if this assumption is wrong.
- I have now consolidated 4 replicas into 1 replica for a single control-plane capacity.
- Increased the reserved memory capacity based on the latest data after VPA/HVPA have been introduced.
- Fixed 2 replicas of such reserve excess capacity.
- I have retained the func `DesiredExcessCapacity`  as well as the parameter `numberOfAssociatedShoots` just in case they are required in the future.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Consolidated the reserve excess capacity to support both new control-planes as well as newly (vertically) scaled old control-planes.
```
