### PR TITLE
More seed metrics for costing and scaling.

### DIFF
--- a/charts/seed-bootstrap/charts/kube-state-metrics/Chart.yaml
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Kube-state-metrics for Kubernetes
+name: kube-state-metrics
+version: 0.1.0

--- a/charts/seed-bootstrap/charts/kube-state-metrics/charts/utils-templates
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/charts/utils-templates
@@ -1,0 +1,1 @@
+../../../../utils-templates

--- a/charts/seed-bootstrap/charts/kube-state-metrics/templates/kube-state-metrics.yaml
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/templates/kube-state-metrics.yaml
@@ -1,0 +1,117 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: kube-state-metrics
+    type: seed
+
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: gardener.cloud:monitoring:kube-state-metrics
+  labels:
+    component: kube-state-metrics
+    type: seed
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: {{ .Release.Namespace }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: kube-state-metrics
+    type: seed
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: metrics
+  selector:
+    component: kube-state-metrics
+    type: seed
+---
+apiVersion: "autoscaling.k8s.io/v1beta2"
+kind: VerticalPodAutoscaler
+metadata:
+  name: kube-state-metrics-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRef:
+    apiVersion: {{ include "deploymentversion" . }}
+    kind: Deployment
+    name: kube-state-metrics
+  updatePolicy:
+    updateMode: "Auto"
+---
+apiVersion: {{ include "deploymentversion" . }}
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    garden.sapcloud.io/role: monitoring
+    component: kube-state-metrics
+    type: seed
+spec:
+  revisionHistoryLimit: 0
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      component: kube-state-metrics
+      type: seed
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        garden.sapcloud.io/role: monitoring
+        component: kube-state-metrics
+        type: seed
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-seed-apiserver: allowed
+        networking.gardener.cloud/from-prometheus: allowed
+    spec:
+      serviceAccountName: kube-state-metrics
+      containers:
+      - name: kube-state-metrics
+        image: {{ index .Values.global.images "kube-state-metrics" }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /kube-state-metrics
+        - --port=8080
+        - --telemetry-port=8081
+        - --collectors=deployments,pods,statefulsets,nodes
+        ports:
+        - name: metrics
+          containerPort: 8080
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi

--- a/charts/seed-bootstrap/charts/kube-state-metrics/values.yaml
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/values.yaml
@@ -1,0 +1,4 @@
+global:
+  images:
+    kube-state-metrics: image-repository:image-tag
+replicas: 1

--- a/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
+++ b/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
@@ -1,45 +1,157 @@
 groups:
 - name: recording-rules.rules
   rules:
-  # Recording rules for pod usage
-  - record: seed:container_cpu_usage_seconds_total:sum_by_pod
-    expr: sum(rate(container_cpu_usage_seconds_total[5m])) by (pod, namespace)
+  # Recording rules for the sum of the usage per container
+  - record: seed:container_cpu_usage_seconds_total:sum_by_container
+    expr: sum(rate(container_cpu_usage_seconds_total[5m])) by (container)
 
-  - record: seed:container_memory_working_set_bytes:sum_by_pod
-    expr: sum(container_memory_working_set_bytes) by (pod, namespace)
+  - record: seed:container_memory_working_set_bytes:sum_by_container
+    expr: sum(container_memory_working_set_bytes) by (container)
 
-  - record: seed:container_network_receive_bytes_total:sum_by_pod
-    expr: sum(rate(container_network_receive_bytes_total[5m])) by (pod, namespace)
+  # Recording rules for the sum of the requests per container
+  - record: seed:kube_pod_container_resource_requests_cpu_cores:sum_by_container
+    expr: sum(kube_pod_container_resource_requests_cpu_cores) by (container) 
 
-  - record: seed:container_network_transmit_bytes_total:sum_by_pod
-    expr: sum(rate(container_network_transmit_bytes_total[5m])) by (pod, namespace)
+  - record: seed:kube_pod_container_resource_requests_memory_bytes:sum_by_container
+    expr: sum(kube_pod_container_resource_requests_memory_bytes) by (container) 
+
+  # Recording rules for the sum of the limits per container
+  - record: seed:kube_pod_container_resource_limits_cpu_cores:sum_by_container
+    expr: sum(kube_pod_container_resource_limits_cpu_cores) by (container) 
+
+  - record: seed:kube_pod_container_resource_limits_memory_bytes:sum_by_container
+    expr: sum(kube_pod_container_resource_limits_memory_bytes) by (container) 
+
+  # Recording rules for the sum of vpa recommendations per container
+  - record: seed:vpa_status_recommendation_target:sum_by_container
+    expr: sum(vpa_status_recommendation{recommendation="target"}) by (container, resource)
+  
+  # Recording rules for the sum of hvpa applied recommendations per container
+  - record: seed:hvpa_status_applied_vpa_recommendation_target:sum_by_container
+    expr: sum(hvpa_status_applied_vpa_recommendation{recommendation="target"}) by (container, resource)
+
+  # Recording rules for container count per container
+  - record: seed:kube_pod_container_info:count_by_container
+    expr: count(kube_pod_container_info) by (container)
 
   # Recording rules for the sum of the entire seed usage
   - record: seed:container_cpu_usage_seconds_total:sum
-    expr: sum(seed:container_cpu_usage_seconds_total:sum_by_pod)
+    expr: sum(rate(container_cpu_usage_seconds_total[5m]))
 
   - record: seed:container_memory_working_set_bytes:sum
-    expr: sum(seed:container_memory_working_set_bytes:sum_by_pod)
+    expr: sum(container_memory_working_set_bytes)
 
   - record: seed:container_network_receive_bytes_total:sum
-    expr: sum(seed:container_network_receive_bytes_total:sum_by_pod)
+    expr: sum(rate(container_network_receive_bytes_total[5m]))
 
   - record: seed:container_network_transmit_bytes_total:sum
-    expr: sum(seed:container_network_transmit_bytes_total:sum_by_pod)
+    expr: sum(rate(container_network_transmit_bytes_total[5m]))
 
-  # Recording rules for the sum of all control plane usage
-  - record: seed:container_cpu_usage_seconds_total:sum_cp
-    expr: sum(seed:container_cpu_usage_seconds_total:sum_by_pod{namespace=~"((shoot-|shoot--)(\\w.+))"})
+  # Recording rules for the sum of the requests in the entire seed
+  - record: seed:kube_pod_container_resource_requests_cpu_cores:sum
+    expr: sum(kube_pod_container_resource_requests_cpu_cores)
 
-  - record: seed:container_memory_working_set_bytes:sum_cp
-    expr: sum(seed:container_memory_working_set_bytes:sum_by_pod{namespace=~"((shoot-|shoot--)(\\w.+))"})
+  - record: seed:kube_pod_container_resource_requests_memory_bytes:sum
+    expr: sum(kube_pod_container_resource_requests_memory_bytes)
 
-  - record: seed:container_network_receive_bytes_total:sum_cp
-    expr: sum(seed:container_network_receive_bytes_total:sum_by_pod{namespace=~"((shoot-|shoot--)(\\w.+))"})
+  # Recording rules for the sum of the limits in the entire seed
+  - record: seed:kube_pod_container_resource_limits_cpu_cores:sum
+    expr: sum(kube_pod_container_resource_limits_cpu_cores)
 
-  - record: seed:container_network_transmit_bytes_total:sum_cp
-    expr: sum(seed:container_network_transmit_bytes_total:sum_by_pod{namespace=~"((shoot-|shoot--)(\\w.+))"})
+  - record: seed:kube_pod_container_resource_limits_memory_bytes:sum
+    expr: sum(kube_pod_container_resource_limits_memory_bytes)
+
+  # Recording rules for the sum of vpa recommendations for the entire seed
+  - record: seed:vpa_status_recommendation_target:sum
+    expr: sum(vpa_status_recommendation{recommendation="target"})
+  
+  # Recording rules for the sum of hvpa applied recommendations for the entire seed
+  - record: seed:hvpa_status_applied_vpa_recommendation_target:sum
+    expr: sum(hvpa_status_applied_vpa_recommendation{recommendation="target"})
+
+  # Recording rules for pod count for the entire seed
+  - record: seed:kube_pod_info:count
+    expr: count(kube_pod_info)
 
   # Recording rules for images running on seed
   - record: seed:images:count
-    expr: count(container_cpu_cfs_periods_total{type="seed"}) by (image)
+    expr: count(kube_pod_container_info) by (image)
+
+  # Recording rules for node metrics for the entire seed
+  - record: seed:kube_node_info:count
+    expr: count(kube_node_info)
+
+  - record: seed:kube_node_status_condition:sum_by_condition
+    expr: sum(kube_node_status_condition) by (condition, status)
+
+  - record: seed:node_cpu_seconds_total:sum
+    expr: sum(rate(node_cpu_seconds_total{mode!="idle"}[5m]))
+
+  - record: seed:node_memory_Active_bytes:sum
+    expr: sum(node_memory_Active_bytes)
+
+  - record: seed:kube_node_status_allocatable_cpu_cores:max
+    expr: max(kube_node_status_allocatable_cpu_cores)
+  
+  - record: seed:kube_node_status_allocatable_cpu_cores:sum
+    expr: sum(kube_node_status_allocatable_cpu_cores)
+
+  - record: seed:kube_node_status_allocatable_memory_bytes:max
+    expr: max(kube_node_status_allocatable_memory_bytes)
+
+  - record: seed:kube_node_status_allocatable_memory_bytes:sum
+    expr: sum(kube_node_status_allocatable_memory_bytes)
+  
+  - record: seed:kube_node_status_allocatable_pods:max
+    expr: max(kube_node_status_allocatable_pods)
+
+  - record: seed:kube_node_status_allocatable_pods:sum
+    expr: sum(kube_node_status_allocatable_pods)
+
+  # Recording rules for the active shoots in the entire seed
+  - record: seed:active_shoots_total:sum
+    expr: count(kube_pod_info{pod="etcd-main-0"})
+
+  # Recording rules for all the shoots in the entire seed
+  - record: seed:all_shoots_total:sum
+    expr: count(kube_statefulset_replicas{statefulset="etcd-main"})
+
+  # Recording rules for the sum of all control plane usage
+  - record: seed:container_cpu_usage_seconds_total:sum_cp
+    expr: sum(rate(container_cpu_usage_seconds_total{namespace=~"((shoot-|shoot--)(\\w.+))"}[5m]))
+
+  - record: seed:container_memory_working_set_bytes:sum_cp
+    expr: sum(container_memory_working_set_bytes{namespace=~"((shoot-|shoot--)(\\w.+))"})
+
+  - record: seed:container_network_receive_bytes_total:sum_cp
+    expr: sum(rate(container_network_receive_bytes_total{namespace=~"((shoot-|shoot--)(\\w.+))"}[5m]))
+
+  - record: seed:container_network_transmit_bytes_total:sum_cp
+    expr: sum(rate(container_network_transmit_bytes_total{namespace=~"((shoot-|shoot--)(\\w.+))"}[5m]))
+
+  # Recording rules for the sum of the requests for all the control planes
+  - record: seed:kube_pod_container_resource_requests_cpu_cores:sum_cp
+    expr: sum(kube_pod_container_resource_requests_cpu_cores{namespace=~"((shoot-|shoot--)(\\w.+))"})
+
+  - record: seed:kube_pod_container_resource_requests_memory_bytes:sum_cp
+    expr: sum(kube_pod_container_resource_requests_memory_bytes{namespace=~"((shoot-|shoot--)(\\w.+))"})
+
+  # Recording rules for the sum of the limits for all the control planes
+  - record: seed:kube_pod_container_resource_limits_cpu_cores:sum_cp
+    expr: sum(kube_pod_container_resource_limits_cpu_cores{namespace=~"((shoot-|shoot--)(\\w.+))"})
+
+  - record: seed:kube_pod_container_resource_limits_memory_bytes:sum_cp
+    expr: sum(kube_pod_container_resource_limits_memory_bytes{namespace=~"((shoot-|shoot--)(\\w.+))"})
+
+  # Recording rules for the sum of vpa recommendations for all the control-planes
+  - record: seed:vpa_status_recommendation_target:sum
+    expr: sum(vpa_status_recommendation{recommendation="target", namespace=~"((shoot-|shoot--)(\\w.+))"})
+  
+  # Recording rules for the sum of hvpa applied recommendations for all the control-planes
+  - record: seed:hvpa_status_applied_vpa_recommendation_target:sum
+    expr: sum(hvpa_status_applied_vpa_recommendation{recommendation="target", namespace=~"((shoot-|shoot--)(\\w.+))"})
+
+  # Recording rules for pod count for all the control-planes
+  - record: seed:kube_pod_info:count_cp
+    expr: count(kube_pod_info{namespace=~"((shoot-|shoot--)(\\w.+))"})
+

--- a/charts/seed-bootstrap/templates/prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/config.yaml
@@ -112,3 +112,84 @@ data:
       metric_relabel_configs:
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.kubelet | indent 6 }}
 
+    - job_name: node-exporter
+      honor_labels: false
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [ kube-system ]
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+        action: keep
+        regex: node-exporter;metrics
+      # common metrics
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
+      - source_labels: [ __meta_kubernetes_pod_node_name ]
+        target_label: node
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.nodeExporter | indent 6 }}
+
+    - job_name: kube-state-metrics
+      honor_labels: false
+      # Service is used, because we only care about metric from one kube-state-metrics instance
+      # and not multiple in HA setup
+      kubernetes_sd_configs:
+      - role: service
+        namespaces:
+          names: [{{ .Release.Namespace }}]
+      relabel_configs:
+      - source_labels: [ __meta_kubernetes_service_label_component ]
+        action: keep
+        regex: kube-state-metrics
+      - source_labels: [ __meta_kubernetes_service_port_name ]
+        action: keep
+      - source_labels: [ __meta_kubernetes_service_label_type ]
+        regex: (.+)
+        target_label: type
+        replacement: ${1}
+      - target_label: instance
+        replacement: kube-state-metrics
+      metric_relabel_configs:
+      - source_labels: [ pod ]
+        regex: ^.+\.tf-pod.+$
+        action: drop
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.kubeStateMetrics | indent 6 }}
+
+    - job_name: 'vpa-exporter'
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [ garden ]
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+        - __meta_kubernetes_namespace
+        action: keep
+        regex: vpa-exporter;metrics;garden
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.vpa | indent 6 }}
+    
+{{- if .Values.hvpa.enabled }}
+    - job_name: 'hvpa-controller'
+      kubernetes_sd_configs:
+      - role: endpoints
+        namespaces:
+          names: [ garden ]
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+        - __meta_kubernetes_namespace
+        action: keep
+        regex: hvpa-controller;metrics;garden
+      metric_relabel_configs:
+{{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.hvpa | indent 6 }}
+{{- end }}
+
+

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -35,6 +35,62 @@ allowedMetrics:
   - kubelet_volume_stats_available_bytes
   - kubelet_volume_stats_capacity_bytes
 
+  nodeExporter:
+  - node_cpu_seconds_total
+  - node_filesystem_avail_bytes
+  - node_filesystem_free_bytes
+  - node_filesystem_size_bytes
+  - node_load1
+  - node_load5
+  - node_load15
+  - node_memory_Active_bytes
+  - node_nf_conntrack_entries
+  - node_nf_conntrack_entries_limit
+  - process_max_fds
+  - process_open_fds
+
+  kubeStateMetrics:
+  - kube_daemonset_metadata_generation
+  - kube_daemonset_status_current_number_scheduled
+  - kube_daemonset_status_desired_number_scheduled
+  - kube_daemonset_status_number_available
+  - kube_daemonset_status_number_unavailable
+  - kube_daemonset_updated_number_scheduled
+  - kube_deployment_metadata_generation
+  - kube_deployment_spec_replicas
+  - kube_deployment_status_observed_generation
+  - kube_deployment_status_replicas
+  - kube_deployment_status_replicas_available
+  - kube_deployment_status_replicas_unavailable
+  - kube_deployment_status_replicas_updated
+  - kube_node_info
+  - kube_node_labels
+  - kube_node_spec_unschedulable
+  - kube_node_status_allocatable_cpu_cores
+  - kube_node_status_allocatable_memory_bytes
+  - kube_node_status_allocatable_pods
+  - kube_node_status_capacity_cpu_cores
+  - kube_node_status_capacity_memory_bytes
+  - kube_node_status_capacity_pods
+  - kube_node_status_condition
+  - kube_pod_container_info
+  - kube_pod_container_resource_limits_cpu_cores
+  - kube_pod_container_resource_limits_memory_bytes
+  - kube_pod_container_resource_requests_cpu_cores
+  - kube_pod_container_resource_requests_memory_bytes
+  - kube_pod_container_status_restarts_total
+  - kube_pod_info
+  - kube_pod_labels
+  - kube_pod_status_phase
+  - kube_pod_status_ready
+  - kube_statefulset_metadata_generation
+  - kube_statefulset_replicas
+  - kube_statefulset_status_observed_generation
+  - kube_statefulset_status_replicas
+  - kube_statefulset_status_replicas_current
+  - kube_statefulset_status_replicas_ready
+  - kube_statefulset_status_replicas_updated
+
   fluentd: []
   fluentbit: []
 
@@ -56,6 +112,18 @@ allowedMetrics:
   - vpa_status_recommendation
   - vpa_spec_container_resource_policy_allowed
   - vpa_metadata_generation
+
+  hvpa:
+  - hvpa_aggregate_applied_scaling_total
+  - hvpa_aggregate_blocked_scalings_total
+  - hvpa_spec_replicas
+  - hvpa_status_replicas
+  - hvpa_status_applied_hpa_current_replicas
+  - hvpa_status_applied_hpa_desired_replicas
+  - hvpa_status_applied_vpa_recommendation
+  - hvpa_status_blocked_hpa_current_replicas
+  - hvpa_status_blocked_hpa_desired_replicas
+  - hvpa_status_blocked_vpa_recommendation
 
 
 ingress:

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -371,6 +371,7 @@ func BootstrapCluster(k8sGardenClient kubernetes.Interface, seed *Seed, config *
 			common.VpaUpdaterImageName,
 			common.HvpaControllerImageName,
 			common.DependencyWatchdogImageName,
+			common.KubeStateMetricsImageName,
 		},
 		imagevector.RuntimeVersion(k8sSeedClient.Version()),
 		imagevector.TargetVersion(k8sSeedClient.Version()),


### PR DESCRIPTION
**What this PR does / why we need it**:
We lack the pod requests, VPA/HVPA recommendations, node utilisation and active shoots metrics in the [aggregate prometheus rules](https://github.com/gardener/gardener/blob/master/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml). This makes it hard to evaluate and tune VPA, HVPA and reserve excess capacity optimally.

**Which issue(s) this PR fixes**:
Recording metrics about pod requests, VPA/HVPA recommendations, node utilisation and active shoots in a seed can help to evolve the tuning of auto-scaling of control-planes as well as reserve excess capacity.

**Special notes for your reviewer**:
- I have removed pod-wise aggregate metrics (even the existing ones) to reduce the load on the aggregate prometheus.
- I have introduced a new `kube-state-metrics` in the `garden` namespace to cover all namespaces in the seed cluster.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Enhanced monitoring for all seed workloads (shoot control-planes, bootstrap components and extensions) by introducing a new kube-state-metrics in the garden namespace to scrape metrics for all the workloads.
The prometheus in the garden namespace now additionally scrapes the new kube-state-metrics, seed node-exporters, vpa-exporter and hvpa-controller.
New recording rules for the prometheus in the garden namespace to aggregate metrics about usage, request, limits, VPA recommendation, HVPA applied recommendations, node usage, allocatable resources, conditions and counts of pods, nodes and shoots hosted on the seed cluster.
These aggregate metrics are automatically scraped by the aggregate-prometheus.
Some of the pod-wise aggregate metrics have been removed to reduce the load on the aggregate-prometheus.
```
