### PR TITLE
Add LastOperationTypeMigrate to pkg/apis/core

### DIFF
--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -7196,5 +7196,5 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>ab4ddfc16</code>.
+on git commit <code>9e15bb19e</code>.
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -3204,5 +3204,5 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>ab4ddfc16</code>.
+on git commit <code>9e15bb19e</code>.
 </em></p>

--- a/hack/api-reference/garden.md
+++ b/hack/api-reference/garden.md
@@ -8261,5 +8261,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>ab4ddfc16</code>.
+on git commit <code>9e15bb19e</code>.
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,5 +555,5 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>ab4ddfc16</code>.
+on git commit <code>9e15bb19e</code>.
 </em></p>

--- a/pkg/apis/core/v1alpha1/helper/helper.go
+++ b/pkg/apis/core/v1alpha1/helper/helper.go
@@ -166,6 +166,8 @@ func IsControllerInstallationSuccessful(controllerInstallation gardencorev1alpha
 // ComputeOperationType checksthe <lastOperation> and determines whether is it is Create operation or reconcile operation
 func ComputeOperationType(meta metav1.ObjectMeta, lastOperation *gardencorev1alpha1.LastOperation) gardencorev1alpha1.LastOperationType {
 	switch {
+	case meta.Annotations[v1alpha1constants.GardenerOperation] == v1alpha1constants.GardenerOperationMigrate:
+		return gardencorev1alpha1.LastOperationTypeMigrate
 	case meta.DeletionTimestamp != nil:
 		return gardencorev1alpha1.LastOperationTypeDelete
 	case lastOperation == nil:

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -75,6 +75,8 @@ const (
 	LastOperationTypeReconcile LastOperationType = "Reconcile"
 	// LastOperationTypeDelete indicates a 'delete' operation.
 	LastOperationTypeDelete LastOperationType = "Delete"
+	// LastOperationTypeMigrate indicates a 'migrate' operation.
+	LastOperationTypeMigrate LastOperationType = "Migrate"
 )
 
 // LastOperationState is a string alias.

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -165,6 +165,8 @@ func IsControllerInstallationSuccessful(controllerInstallation gardencorev1beta1
 // ComputeOperationType checksthe <lastOperation> and determines whether is it is Create operation or reconcile operation
 func ComputeOperationType(meta metav1.ObjectMeta, lastOperation *gardencorev1beta1.LastOperation) gardencorev1beta1.LastOperationType {
 	switch {
+	case meta.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationMigrate:
+		return gardencorev1beta1.LastOperationTypeMigrate
 	case meta.DeletionTimestamp != nil:
 		return gardencorev1beta1.LastOperationTypeDelete
 	case lastOperation == nil:

--- a/pkg/apis/core/v1beta1/types_common.go
+++ b/pkg/apis/core/v1beta1/types_common.go
@@ -75,6 +75,8 @@ const (
 	LastOperationTypeReconcile LastOperationType = "Reconcile"
 	// LastOperationTypeDelete indicates a 'delete' operation.
 	LastOperationTypeDelete LastOperationType = "Delete"
+	// LastOperationTypeMigrate indicates a 'migrate' operation.
+	LastOperationTypeMigrate LastOperationType = "Migrate"
 )
 
 // LastOperationState is a string alias.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add LastOperationTypeMigrate constant.
The plan is to use this constant to provide more clear information during cleanup of extension resources in the source seed(the lastOperationTypeMigrate  will be specified in the extension resource status). Otherwise when there is an annotation "gardener.cloud/operation=migrate" and the lastOperationType will be Reconcile. 
**Which issue(s) this PR fixes**:
Part of [#1631](https://github.com/gardener/gardener/issues/1631)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Add LastOperationTypeMigrate constant in pkg/apis/core
```
