### PR TITLE
[WIP] Allow project memebers to update Role and RoleBindings

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -190,6 +190,20 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 
 # Cluster role setting the permissions for a project viewer. It gets bound by a RoleBinding
 # in a respective project namespace.
@@ -248,6 +262,15 @@ rules:
   - settings.gardener.cloud
   resources:
   - openidconnectpresets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
   verbs:
   - get
   - list


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows project members to define their own `Role` and `RoleBindings`. 

Privilege escalation is prevented by the [RBAC API](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping).

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Project members are now allowed to define their own `Roles` and `RoleBindings` to further customize the access to the resources in their Project namespace. 
```

```noteworthy user
Project viewrs are now allowed to view `Roles` and `RoleBindings` in their Project namespace. 
```