### PR TITLE
Changed names of etcd-main and etcd-events contants.

### DIFF
--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -97,12 +97,10 @@ const (
 	// StatefulSetNameAlertManager is a constant for the name of a Kubernetes stateful set object that contains
 	// the alertmanager pod.
 	StatefulSetNameAlertManager = "alertmanager"
-	// StatefulSetNameETCDMain is a constant for the name of a Kubernetes stateful set object that contains
-	// the etcd-main pod.
-	StatefulSetNameETCDMain = "etcd-main"
-	// StatefulSetNameETCDEvents is a constant for the name of a Kubernetes stateful set object that contains
-	// the etcd-events pod.
-	StatefulSetNameETCDEvents = "etcd-events"
+	// ETCDMain is a constant for the name of etcd-main Etcd object.
+	ETCDMain = "etcd-main"
+	// ETCDEvents is a constant for the name of etcd-events Etcd object.
+	ETCDEvents = "etcd-events"
 	// StatefulSetNameElasticSearch is a constant for the name of a Kubernetes stateful set object that contains
 	// the elasticsearch-logging pod.
 	StatefulSetNameElasticSearch = "elasticsearch-logging"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -97,12 +97,10 @@ const (
 	// StatefulSetNameAlertManager is a constant for the name of a Kubernetes stateful set object that contains
 	// the alertmanager pod.
 	StatefulSetNameAlertManager = "alertmanager"
-	// StatefulSetNameETCDMain is a constant for the name of a Kubernetes stateful set object that contains
-	// the etcd-main pod.
-	StatefulSetNameETCDMain = "etcd-main"
-	// StatefulSetNameETCDEvents is a constant for the name of a Kubernetes stateful set object that contains
-	// the etcd-events pod.
-	StatefulSetNameETCDEvents = "etcd-events"
+	// ETCDMain is a constant for the name of etcd-main Etcd object.
+	ETCDMain = "etcd-main"
+	// ETCDEvents is a constant for the name of etcd-events Etcd object.
+	ETCDEvents = "etcd-events"
 	// StatefulSetNameElasticSearch is a constant for the name of a Kubernetes stateful set object that contains
 	// the elasticsearch-logging pod.
 	StatefulSetNameElasticSearch = "elasticsearch-logging"

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -215,7 +215,7 @@ func (b *Botanist) DeleteClusterAutoscaler(ctx context.Context) error {
 func (b *Botanist) WakeUpControlPlane(ctx context.Context) error {
 	client := b.K8sSeedClient.Client()
 
-	for _, statefulset := range []string{v1beta1constants.StatefulSetNameETCDEvents, v1beta1constants.StatefulSetNameETCDMain} {
+	for _, statefulset := range []string{v1beta1constants.ETCDEvents, v1beta1constants.ETCDMain} {
 		if err := kubernetes.ScaleStatefulSet(ctx, client, kutil.Key(b.Shoot.SeedNamespace, statefulset), 1); err != nil {
 			return err
 		}
@@ -303,7 +303,7 @@ func (b *Botanist) HibernateControlPlane(ctx context.Context) error {
 		}
 	}
 
-	for _, statefulset := range []string{v1beta1constants.StatefulSetNameETCDEvents, v1beta1constants.StatefulSetNameETCDMain} {
+	for _, statefulset := range []string{v1beta1constants.ETCDEvents, v1beta1constants.ETCDMain} {
 		if err := kubernetes.ScaleStatefulSet(ctx, c, kutil.Key(b.Shoot.SeedNamespace, statefulset), 0); client.IgnoreNotFound(err) != nil {
 			return err
 		}

--- a/pkg/operation/botanist/health_check_test.go
+++ b/pkg/operation/botanist/health_check_test.go
@@ -200,8 +200,8 @@ var _ = Describe("health check", func() {
 		}
 
 		// control plane stateful sets
-		etcdMainStatefulSet   = newStatefulSet(seedNamespace, v1beta1constants.StatefulSetNameETCDMain, v1beta1constants.GardenRoleControlPlane, true)
-		etcdEventsStatefulSet = newStatefulSet(seedNamespace, v1beta1constants.StatefulSetNameETCDEvents, v1beta1constants.GardenRoleControlPlane, true)
+		etcdMainStatefulSet   = newStatefulSet(seedNamespace, v1beta1constants.ETCDMain, v1beta1constants.GardenRoleControlPlane, true)
+		etcdEventsStatefulSet = newStatefulSet(seedNamespace, v1beta1constants.ETCDEvents, v1beta1constants.GardenRoleControlPlane, true)
 
 		requiredControlPlaneStatefulSets = []*appsv1.StatefulSet{
 			etcdMainStatefulSet,

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -1166,10 +1166,10 @@ func dnsNamesForService(name, namespace string) []string {
 
 func dnsNamesForEtcd(namespace string) []string {
 	names := []string{
-		fmt.Sprintf("%s-0", v1beta1constants.StatefulSetNameETCDMain),
-		fmt.Sprintf("%s-0", v1beta1constants.StatefulSetNameETCDEvents),
+		fmt.Sprintf("%s-0", v1beta1constants.ETCDMain),
+		fmt.Sprintf("%s-0", v1beta1constants.ETCDEvents),
 	}
-	names = append(names, dnsNamesForService(fmt.Sprintf("%s-client", v1beta1constants.StatefulSetNameETCDMain), namespace)...)
-	names = append(names, dnsNamesForService(fmt.Sprintf("%s-client", v1beta1constants.StatefulSetNameETCDEvents), namespace)...)
+	names = append(names, dnsNamesForService(fmt.Sprintf("%s-client", v1beta1constants.ETCDMain), namespace)...)
+	names = append(names, dnsNamesForService(fmt.Sprintf("%s-client", v1beta1constants.ETCDEvents), namespace)...)
 	return names
 }

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -494,8 +494,8 @@ var (
 	// RequiredControlPlaneStatefulSets is a set of the required shoot control plane stateful
 	// sets running in the seed.
 	RequiredControlPlaneStatefulSets = sets.NewString(
-		v1beta1constants.StatefulSetNameETCDMain,
-		v1beta1constants.StatefulSetNameETCDEvents,
+		v1beta1constants.ETCDMain,
+		v1beta1constants.ETCDEvents,
 	)
 
 	// RequiredSystemComponentDeployments is a set of the required system components.


### PR DESCRIPTION
**What this PR does / why we need it**:
`etcd-main` and `etcd-events` have the prefix `StatefulsetName` in the name for the constants. As we shall not be deploying Statefulsets directly, it no longer makes sense to keep this prefix.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
