### PR TITLE
Changed dwd probe kubeconfigs to client certs.

### DIFF
--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -250,6 +250,9 @@ const (
 	// DependencyWatchdogInternalProbeSecretName is the name of the kubecfg secret with cluster IP access.
 	DependencyWatchdogInternalProbeSecretName = "dependency-watchdog-internal-probe"
 
+	// DependencyWatchdogUserName is the user name of the dependency-watchdog.
+	DependencyWatchdogUserName = "gardener.cloud:system:dependency-watchdog"
+
 	// DeprecatedKubecfgInternalProbeSecretName is the name of the kubecfg secret with cluster IP access.
 	DeprecatedKubecfgInternalProbeSecretName = "kubecfg-internal"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Earlier the shoot-wise kubeconfigs for dependency-watchdog probes were using [static tokens](https://github.com/gardener/gardener/blob/master/pkg/operation/botanist/secrets.go#L560).
But these secrets were not rotated along with [`kubecfg`](https://github.com/gardener/gardener/blob/master/pkg/operation/botanist/secrets.go#L687).
So, after rotation, the dependency-watchdog probes fail for that shoot.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
1. Now client-certs are used for the probe kubeconfigs. 
1. I have also added the code to delete old probe kubeconfig secrets contain the tokens.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Changed dependency-watchdog probe shoot kubeconfigs to use client certs.
```
