### PR TITLE
Use ResourcesApplied condition of ManagedResource to check ControllerInstallation Installed condition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/frankban/quicktest v1.5.0 // indirect
 	github.com/gardener/controller-manager-library v0.1.1-0.20191212112146-917449ad760c // indirect
 	github.com/gardener/external-dns-management v0.7.3
-	github.com/gardener/gardener-resource-manager v0.9.1-0.20200124091350-6ea41bbae81f
+	github.com/gardener/gardener-resource-manager v0.10.0
 	github.com/gardener/hvpa-controller v0.0.0-20191014062307-fad3bdf06a25
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/spec v0.19.2

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/gardener/controller-manager-library v0.1.1-0.20191212112146-917449ad7
 github.com/gardener/controller-manager-library v0.1.1-0.20191212112146-917449ad760c/go.mod h1:v6cbldxmpL2fYBEB2lSnq3LSEPwIHus9En6iIhwNE1k=
 github.com/gardener/external-dns-management v0.7.3 h1:SAW9ur2mjZ+x89xbmcplJgqNUmFGYIZLI2E+PaBhhG0=
 github.com/gardener/external-dns-management v0.7.3/go.mod h1:Y3om11E865x4aQ7cmcHjknb8RMgCO153huRb/SvP+9o=
-github.com/gardener/gardener-resource-manager v0.9.1-0.20200124091350-6ea41bbae81f h1:kaJJ2j6/uHTt6tDQiDO25HOq6Uit6Hu31hu47HfY/Lw=
-github.com/gardener/gardener-resource-manager v0.9.1-0.20200124091350-6ea41bbae81f/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
+github.com/gardener/gardener-resource-manager v0.10.0 h1:6OUKoWI3oha42F0oJN8OEo3UR+D3onOCel4Th+zgotU=
+github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/hvpa-controller v0.0.0-20191014062307-fad3bdf06a25 h1:nOFITmV7vt4fcYPEXgj66Qs83FdDEMvL/LQcR0diRRE=
 github.com/gardener/hvpa-controller v0.0.0-20191014062307-fad3bdf06a25/go.mod h1:yj7YJ6ijo4adcpXQKutPFZfQuKLdM5UMZZUlpbM3vig=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/pkg/registry/core/controllerinstallation/storage/tableconvertor.go
+++ b/pkg/registry/core/controllerinstallation/storage/tableconvertor.go
@@ -42,6 +42,7 @@ func newTableConvertor() rest.TableConvertor {
 			{Name: "Seed", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["seed"]},
 			{Name: "Valid", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["Valid"]},
 			{Name: "Installed", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["installed"]},
+			{Name: "Healthy", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["healthy"]},
 			{Name: "Age", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"]},
 		},
 	}
@@ -82,6 +83,11 @@ func (c *convertor) ConvertToTable(ctx context.Context, o runtime.Object, tableO
 			cells = append(cells, "<unknown>")
 		}
 		if cond := helper.GetCondition(obj.Status.Conditions, core.ControllerInstallationInstalled); cond != nil {
+			cells = append(cells, cond.Status)
+		} else {
+			cells = append(cells, "<unknown>")
+		}
+		if cond := helper.GetCondition(obj.Status.Conditions, core.ControllerInstallationHealthy); cond != nil {
 			cells = append(cells, cond.Status)
 		} else {
 			cells = append(cells, "<unknown>")

--- a/vendor/github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1/helper/helper.go
+++ b/vendor/github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1/helper/helper.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper
+
+import (
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Now determines the current metav1.Time.
+var Now = metav1.Now
+
+// InitCondition initializes a new Condition with an Unknown status.
+func InitCondition(conditionType resourcesv1alpha1.ConditionType) resourcesv1alpha1.ManagedResourceCondition {
+	return resourcesv1alpha1.ManagedResourceCondition{
+		Type:               conditionType,
+		Status:             resourcesv1alpha1.ConditionUnknown,
+		Reason:             "ConditionInitialized",
+		Message:            "The condition has been initialized but its semantic check has not been performed yet.",
+		LastTransitionTime: Now(),
+	}
+}
+
+// GetCondition returns the condition with the given <conditionType> out of the list of <conditions>.
+// In case the required type could not be found, it returns nil.
+func GetCondition(conditions []resourcesv1alpha1.ManagedResourceCondition, conditionType resourcesv1alpha1.ConditionType) *resourcesv1alpha1.ManagedResourceCondition {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return &condition
+		}
+	}
+
+	return nil
+}
+
+// GetOrInitCondition tries to retrieve the condition with the given condition type from the given conditions.
+// If the condition could not be found, it returns an initialized condition of the given type.
+func GetOrInitCondition(conditions []resourcesv1alpha1.ManagedResourceCondition, conditionType resourcesv1alpha1.ConditionType) resourcesv1alpha1.ManagedResourceCondition {
+	if condition := GetCondition(conditions, conditionType); condition != nil {
+		return *condition
+	}
+
+	return InitCondition(conditionType)
+}
+
+// UpdatedCondition updates the properties of one specific condition.
+func UpdatedCondition(condition resourcesv1alpha1.ManagedResourceCondition, status resourcesv1alpha1.ConditionStatus, reason, message string) resourcesv1alpha1.ManagedResourceCondition {
+	newCondition := resourcesv1alpha1.ManagedResourceCondition{
+		Type:               condition.Type,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: condition.LastTransitionTime,
+		LastUpdateTime:     Now(),
+	}
+
+	if condition.Status != status {
+		newCondition.LastTransitionTime = Now()
+	}
+
+	return newCondition
+}
+
+// MergeConditions merges the given <oldConditions> with the <newConditions>. Existing conditions are superseded by
+// the <newConditions> (depending on the condition type).
+func MergeConditions(oldConditions []resourcesv1alpha1.ManagedResourceCondition, newConditions ...resourcesv1alpha1.ManagedResourceCondition) []resourcesv1alpha1.ManagedResourceCondition {
+	var (
+		out         = make([]resourcesv1alpha1.ManagedResourceCondition, 0, len(oldConditions))
+		typeToIndex = make(map[resourcesv1alpha1.ConditionType]int, len(oldConditions))
+	)
+
+	for i, condition := range oldConditions {
+		out = append(out, condition)
+		typeToIndex[condition.Type] = i
+	}
+
+	for _, condition := range newConditions {
+		if index, ok := typeToIndex[condition.Type]; ok {
+			out[index] = condition
+			continue
+		}
+		out = append(out, condition)
+	}
+
+	return out
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -121,9 +121,10 @@ github.com/gardener/controller-manager-library/pkg/utils
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
 github.com/gardener/external-dns-management/pkg/client/dns/clientset/versioned/scheme
-# github.com/gardener/gardener-resource-manager v0.9.1-0.20200124091350-6ea41bbae81f
+# github.com/gardener/gardener-resource-manager v0.10.0
 github.com/gardener/gardener-resource-manager/pkg/apis/resources
 github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1
+github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1/helper
 github.com/gardener/gardener-resource-manager/pkg/health
 github.com/gardener/gardener-resource-manager/pkg/manager
 # github.com/gardener/hvpa-controller v0.0.0-20191014062307-fad3bdf06a25


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR the gardenlet uses the `ResourcesApplied` condition of the ManagedResource to determine the `Installed` condition for a given ControllerInstallation.
Also a column `HEALTHY` is added to the ControllerInstallation table converter.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Depends on [gardener-resource-manager#32](https://github.com/gardener/gardener-resource-manager/pull/32)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The gardenlet now uses the `ResourcesApplied` condition of the ManagedResource to determine the `Installed` condition for a given ControllerInstallation.
```
