### PR TITLE
Convert times to UTC when comparing

### DIFF
--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -281,7 +281,7 @@ func (b *Botanist) WaitForControllersToBeActive(ctx context.Context) error {
 					return
 				}
 
-				if delta := metav1.Now().Sub(leaderElectionRecord.RenewTime.Time); delta <= pollInterval-time.Second {
+				if delta := metav1.Now().UTC().Sub(leaderElectionRecord.RenewTime.Time.UTC()); delta <= pollInterval-time.Second {
 					out <- &checkOutput{controllerName: controller.name, ready: true}
 					return
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
It is always safer to convert times to UTC when comparing them.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
