### PR TITLE
Add another case for returning a Migrate operation

### DIFF
--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -7224,5 +7224,5 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>5b69a02f5</code>.
+on git commit <code>62e1b589a</code>.
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -3052,5 +3052,5 @@ the cluster-autoscaler properly.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>5b69a02f5</code>.
+on git commit <code>62e1b589a</code>.
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,5 +555,5 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>5b69a02f5</code>.
+on git commit <code>62e1b589a</code>.
 </em></p>

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -167,6 +167,8 @@ func ComputeOperationType(meta metav1.ObjectMeta, lastOperation *gardencorev1bet
 	switch {
 	case meta.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationMigrate:
 		return gardencorev1beta1.LastOperationTypeMigrate
+	case (lastOperation.Type == gardencorev1beta1.LastOperationTypeMigrate && lastOperation.State != gardencorev1beta1.LastOperationStateSucceeded):
+		return gardencorev1beta1.LastOperationTypeMigrate
 	case meta.DeletionTimestamp != nil:
 		return gardencorev1beta1.LastOperationTypeDelete
 	case lastOperation == nil:


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we can compute current Operation as Migrate when the Migrate annotation is removed and the lastOperation type Migrate was unsuccessful.

**Which issue(s) this PR fixes**:
Part of [ #1631](https://github.com/gardener/gardener/issues/1631)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
NONE
```
