### PR TITLE
Remove deprecated label and annotation

### DIFF
--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -133,13 +133,6 @@ const (
 	// GardenRoleOptionalAddon is the value of the GardenRole key indicating type 'optional-addon'.
 	GardenRoleOptionalAddon = "optional-addon"
 
-	// DeprecatedShootHibernated is a constant for a label on the Shoot namespace in the Seed indicating the Shoot's hibernation status.
-	// +deprecated: Use `Cluster` resource instead.
-	DeprecatedShootHibernated = "shoot.garden.sapcloud.io/hibernated"
-	// DeprecatedShootUID is an annotation key for the shoot namespace in the seed cluster,
-	// which value will be the value of `shoot.status.uid`
-	// +deprecated: Use `Cluster` resource instead.
-	DeprecatedShootUID = "shoot.garden.sapcloud.io/uid"
 	// DeprecatedGardenRoleBackup is the value of GardenRole key indicating type 'backup'.
 	// +deprecated
 	DeprecatedGardenRoleBackup = "backup"
@@ -221,11 +214,6 @@ const (
 	// AnnotationShootOperatedBy is the key for an annotation of a Shoot cluster whose value must be a valid email address and
 	// is used to send alerts to.
 	AnnotationShootOperatedBy = "garden.sapcloud.io/operatedBy"
-	// AnnotationShootCustom is such a prefix so that the shoot namespace in the seed cluster
-	// will be annotated with the annotations of the shoot resource starting with it.
-	// For example, if the shoot is annotated with <AnnotationShootCustom>key=value,
-	// then the namespace in the seed will be annotated with <AnnotationShootCustom>key=value, as well.
-	AnnotationShootCustom = "custom.shoot.sapcloud.io/"
 	// AnnotationShootSkipCleanup is a key for an annotation on a Shoot resource that declares that the clean up steps should be skipped when the
 	// cluster is deleted. Concretely, this will skip everything except the deletion of (load balancer) services and persistent volume resources.
 	AnnotationShootSkipCleanup = "shoot.gardener.cloud/skip-cleanup"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -133,13 +133,6 @@ const (
 	// GardenRoleOptionalAddon is the value of the GardenRole key indicating type 'optional-addon'.
 	GardenRoleOptionalAddon = "optional-addon"
 
-	// DeprecatedShootHibernated is a constant for a label on the Shoot namespace in the Seed indicating the Shoot's hibernation status.
-	// +deprecated: Use `Cluster` resource instead.
-	DeprecatedShootHibernated = "shoot.garden.sapcloud.io/hibernated"
-	// DeprecatedShootUID is an annotation key for the shoot namespace in the seed cluster,
-	// which value will be the value of `shoot.status.uid`
-	// +deprecated: Use `Cluster` resource instead.
-	DeprecatedShootUID = "shoot.garden.sapcloud.io/uid"
 	// DeprecatedGardenRoleBackup is the value of GardenRole key indicating type 'backup'.
 	// +deprecated
 	DeprecatedGardenRoleBackup = "backup"
@@ -221,11 +214,6 @@ const (
 	// AnnotationShootOperatedBy is the key for an annotation of a Shoot cluster whose value must be a valid email address and
 	// is used to send alerts to.
 	AnnotationShootOperatedBy = "garden.sapcloud.io/operatedBy"
-	// AnnotationShootCustom is such a prefix so that the shoot namespace in the seed cluster
-	// will be annotated with the annotations of the shoot resource starting with it.
-	// For example, if the shoot is annotated with <AnnotationShootCustom>key=value,
-	// then the namespace in the seed will be annotated with <AnnotationShootCustom>key=value, as well.
-	AnnotationShootCustom = "custom.shoot.sapcloud.io/"
 	// AnnotationShootSkipCleanup is a key for an annotation on a Shoot resource that declares that the clean up steps should be skipped when the
 	// cluster is deleted. Concretely, this will skip everything except the deletion of (load balancer) services and persistent volume resources.
 	AnnotationShootSkipCleanup = "shoot.gardener.cloud/skip-cleanup"


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove deprecated label `"shoot.garden.sapcloud.io/hibernated"` and annotation `"shoot.garden.sapcloud.io/uid"`. A machinery needs to switch to the Cluster resource.
Remove the logic that duplicates the `"custom.shoot.sapcloud.io/"` prefixed annotations to the namespace in the Seed.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Deprecated annotation `shoot.garden.sapcloud.io/uid` and label `shoot.garden.sapcloud.io/hibernated` are no longer added to the Shoot namespace.
```
```improvement operator
Shoot annotations prefixed with `custom.shoot.sapcloud.io/` are no longer maintained on the Shoot namespace.
```
