### PR TITLE
Fix panic during Shoot creation

### DIFF
--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -167,14 +167,14 @@ func ComputeOperationType(meta metav1.ObjectMeta, lastOperation *gardencorev1bet
 	switch {
 	case meta.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationMigrate:
 		return gardencorev1beta1.LastOperationTypeMigrate
-	case (lastOperation.Type == gardencorev1beta1.LastOperationTypeMigrate && lastOperation.State != gardencorev1beta1.LastOperationStateSucceeded):
-		return gardencorev1beta1.LastOperationTypeMigrate
 	case meta.DeletionTimestamp != nil:
 		return gardencorev1beta1.LastOperationTypeDelete
 	case lastOperation == nil:
 		return gardencorev1beta1.LastOperationTypeCreate
 	case (lastOperation.Type == gardencorev1beta1.LastOperationTypeCreate && lastOperation.State != gardencorev1beta1.LastOperationStateSucceeded):
 		return gardencorev1beta1.LastOperationTypeCreate
+	case (lastOperation.Type == gardencorev1beta1.LastOperationTypeMigrate && lastOperation.State != gardencorev1beta1.LastOperationStateSucceeded):
+		return gardencorev1beta1.LastOperationTypeMigrate
 	}
 	return gardencorev1beta1.LastOperationTypeReconcile
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix panic during Shoot creation.

Steps to reproduce:
1. Apply Shoot.
2. Ensure it has no `.status.lastOperation`
3. `make start-gardenlet` and ensure it panics with

```
panic(0x2453e20, 0x36d4e80)
	/usr/local/opt/go/libexec/src/runtime/panic.go:679 +0x1b2
github.com/gardener/gardener/pkg/apis/core/v1beta1/helper.ComputeOperationType(...)
	/Users/i331370/go/src/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/helper.go:170
github.com/gardener/gardener/pkg/gardenlet/controller/shoot.(*Controller).reconcileShoot(0xc000280140, 0xc00087a000, 0xc0002ee930, 0x0, 0x0, 0x0, 0x203000)
	/Users/i331370/go/src/github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot_control.go:276 +0x1d5d
github.com/gardener/gardener/pkg/gardenlet/controller/shoot.(*Controller).reconcileShootRequest(0xc000280140, 0xc000045100, 0xf, 0xc000045110, 0xa, 0x23cb8e0, 0xc0009d2650, 0xc000036c90, 0x20758a9)
	/Users/i331370/go/src/github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot_control.go:135 +0x2a8
sigs.k8s.io/controller-runtime/pkg/reconcile.Func.Reconcile(0xc000e08f10, 0xc000045100, 0xf, 0xc000045110, 0xa, 0xa, 0x0, 0x0, 0x53395763306f4162)
	/Users/i331370/go/src/github.com/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/reconcile/reconcile.go:93 +0x4e
github.com/gardener/gardener/pkg/controllerutils.worker.func1.1(0x2985e60, 0xc000662b80, 0x291d700, 0xc000e08f10, 0x2694165, 0x5, 0x0)
	/Users/i331370/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:99 +0x132
github.com/gardener/gardener/pkg/controllerutils.worker.func1()
	/Users/i331370/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:116 +0x7e
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc0005a0cc0)
	/Users/i331370/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x5e
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0005a0cc0, 0x3b9aca00, 0x0, 0x1, 0xc000132000)
	/Users/i331370/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/Users/i331370/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
github.com/gardener/gardener/pkg/controllerutils.CreateWorker.func1(0x2985e60, 0xc000662b80, 0x2694165, 0x5, 0x291d700, 0xc000e08f10, 0x2962920, 0xc0000f1dc0, 0xc0009bcfc0, 0xc0004b0694)
	/Users/i331370/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:57 +0xb4
created by github.com/gardener/gardener/pkg/controllerutils.CreateWorker
	/Users/i331370/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:56 +0xec
exit status 2
make: *** [start-gardenlet] Error 1
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
