### PR TITLE
Fixed RBAC rules for monitoring

### DIFF
--- a/charts/seed-bootstrap/templates/clusterrole-kube-state-metrics.yaml
+++ b/charts/seed-bootstrap/templates/clusterrole-kube-state-metrics.yaml
@@ -27,6 +27,7 @@ rules:
 - apiGroups: ["apps"]
   resources:
   - statefulsets
+  - deployments
   verbs: ["list", "watch"]
 - apiGroups: ["batch"]
   resources:

--- a/charts/shoot-core/components/charts/monitoring/charts/kube-state-metrics-shoot/templates/rbac.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/kube-state-metrics-shoot/templates/rbac.yaml
@@ -52,3 +52,5 @@ roleRef:
 subjects:
 - kind: User
   name: garden.sapcloud.io:monitoring:kube-state-metrics
+- kind: User
+  name: gardener.cloud:monitoring:kube-state-metrics

--- a/charts/shoot-core/components/charts/monitoring/charts/prometheus-shoot/templates/rbac.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/prometheus-shoot/templates/rbac.yaml
@@ -35,3 +35,5 @@ roleRef:
 subjects:
 - kind: User
   name: garden.sapcloud.io:monitoring:prometheus
+- kind: User
+  name: gardener.cloud:monitoring:prometheus

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -21,7 +21,6 @@ import (
 	"net"
 	"os/exec"
 
-	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
@@ -294,8 +293,8 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{
 				Name: "kube-state-metrics",
 
-				CommonName:   fmt.Sprintf("%s:monitoring:kube-state-metrics", core.GroupName),
-				Organization: []string{fmt.Sprintf("%s:monitoring", core.GroupName)},
+				CommonName:   "gardener.cloud:monitoring:kube-state-metrics",
+				Organization: []string{"gardener.cloud:monitoring"},
 				DNSNames:     nil,
 				IPAddresses:  nil,
 
@@ -314,8 +313,8 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{
 				Name: "prometheus",
 
-				CommonName:   fmt.Sprintf("%s:monitoring:prometheus", core.GroupName),
-				Organization: []string{fmt.Sprintf("%s:monitoring", core.GroupName)},
+				CommonName:   "gardener.cloud:monitoring:prometheus",
+				Organization: []string{"gardener.cloud:monitoring"},
 				DNSNames:     nil,
 				IPAddresses:  nil,
 
@@ -334,8 +333,8 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{
 				Name: "prometheus-kubelet",
 
-				CommonName:   fmt.Sprintf("%s:monitoring:prometheus", core.GroupName),
-				Organization: []string{fmt.Sprintf("%s:monitoring", core.GroupName)},
+				CommonName:   "gardener.cloud:monitoring:prometheus",
+				Organization: []string{"gardener.cloud:monitoring"},
 				DNSNames:     nil,
 				IPAddresses:  nil,
 
@@ -490,7 +489,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 			Name: common.AlertManagerTLS,
 
 			CommonName:   "alertmanager",
-			Organization: []string{fmt.Sprintf("%s:monitoring:ingress", core.GroupName)},
+			Organization: []string{"gardener.cloud:monitoring:ingress"},
 			DNSNames:     b.ComputeAlertManagerHosts(),
 			IPAddresses:  nil,
 
@@ -504,7 +503,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 			Name: common.GrafanaTLS,
 
 			CommonName:   "grafana",
-			Organization: []string{fmt.Sprintf("%s:monitoring:ingress", core.GroupName)},
+			Organization: []string{"gardener.cloud:monitoring:ingress"},
 			DNSNames:     b.ComputeGrafanaHosts(),
 			IPAddresses:  nil,
 
@@ -518,7 +517,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 			Name: common.PrometheusTLS,
 
 			CommonName:   "prometheus",
-			Organization: []string{fmt.Sprintf("%s:monitoring:ingress", core.GroupName)},
+			Organization: []string{"gardener.cloud:monitoring:ingress"},
 			DNSNames:     b.ComputePrometheusHosts(),
 			IPAddresses:  nil,
 
@@ -592,7 +591,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 				Name: common.KibanaTLS,
 
 				CommonName:   "kibana",
-				Organization: []string{fmt.Sprintf("%s:logging:ingress", core.GroupName)},
+				Organization: []string{"gardener.cloud:logging:ingress"},
 				DNSNames:     b.ComputeKibanaHosts(),
 				IPAddresses:  nil,
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes RBAC rules for the new `core.gardener.cloud:monitoring:*` Users (introduced in #1832).
It also adds missing permissions for `kube-state-metrics-seed` to `deployments.apps` which are needed in version `v1.9.3` (ref https://github.com/gardener/gardener/pull/1859).
It also changes CNs/Os of certificates for monitoring components from `core.gardener.cloud:monitoring:*` to `gardener.cloud:monitoring:*` (accidentally introduced in #1832)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
