### PR TITLE
RFC: simplify k8s go module definition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,15 +66,15 @@ require (
 
 replace (
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.2
-	k8s.io/api => k8s.io/api v0.16.6
-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.16.6
-	k8s.io/apimachinery => k8s.io/apimachinery v0.16.6
-	k8s.io/apiserver => k8s.io/apiserver v0.16.6
-	k8s.io/client-go => k8s.io/client-go v0.16.6
-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.16.6
-	k8s.io/code-generator => k8s.io/code-generator v0.16.6
-	k8s.io/component-base => k8s.io/component-base v0.16.6
+	k8s.io/api => k8s.io/api v0.16.0
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.16.0
+	k8s.io/apimachinery => k8s.io/apimachinery v0.16.0
+	k8s.io/apiserver => k8s.io/apiserver v0.16.0
+	k8s.io/client-go => k8s.io/client-go v0.16.0
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.16.0
+	k8s.io/code-generator => k8s.io/code-generator v0.16.0
+	k8s.io/component-base => k8s.io/component-base v0.16.0
 	k8s.io/helm => k8s.io/helm v2.13.1+incompatible
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.16.6
-	k8s.io/kube-openapi => k8s.io/kube-openapi v0.16.6
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.16.0
+	k8s.io/kube-openapi => k8s.io/kube-openapi v0.16.0
 )

--- a/go.mod
+++ b/go.mod
@@ -46,35 +46,35 @@ require (
 	golang.org/x/lint v0.0.0-20190409202823-959b441ac422
 	google.golang.org/grpc v1.23.0
 	gopkg.in/yaml.v2 v2.2.4
-	k8s.io/api v0.0.0-20191004102349-159aefb8556b
-	k8s.io/apiextensions-apiserver v0.0.0-20190918161926-8f644eb6e783
-	k8s.io/apimachinery v0.0.0-20191004074956-c5d2f014d689
-	k8s.io/apiserver v0.0.0-20191010014313-3893be10d307
-	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
-	k8s.io/cluster-bootstrap v0.0.0-20190918163108-da9fdfce26bb
-	k8s.io/code-generator v0.0.0-20190912054826-cd179ad6a269
-	k8s.io/component-base v0.0.0-20190918160511-547f6c5d7090
+	k8s.io/api v0.0.0
+	k8s.io/apiextensions-apiserver v0.0.0
+	k8s.io/apimachinery v0.0.0
+	k8s.io/apiserver v0.0.0
+	k8s.io/client-go v0.0.0
+	k8s.io/cluster-bootstrap v0.0.0
+	k8s.io/code-generator v0.0.0
+	k8s.io/component-base v0.0.0
 	k8s.io/helm v2.14.2+incompatible
-	k8s.io/klog v0.4.0
-	k8s.io/kube-aggregator v0.0.0-20191004104030-d9d5f0cc7532
-	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
-	k8s.io/metrics v0.0.0-20191004105854-2e8cf7d0888c
-	k8s.io/utils v0.0.0-20190801114015-581e00157fb1
+	k8s.io/klog v1.0.0
+	k8s.io/kube-aggregator v0.0.0
+	k8s.io/kube-openapi v0.0.0
+	k8s.io/metrics v0.0.0
+	k8s.io/utils v0.0.0
 	sigs.k8s.io/controller-runtime v0.4.0
 	sigs.k8s.io/yaml v1.1.0
 )
 
 replace (
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.2
-	k8s.io/api => k8s.io/api v0.0.0-20190918155943-95b840bb6a1f // kubernetes-1.16.0
-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190918161926-8f644eb6e783 // kubernetes-1.16.0
-	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655 // kubernetes-1.16.0
-	k8s.io/apiserver => k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad // kubernetes-1.16.0
-	k8s.io/client-go => k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90 // kubernetes-1.16.0
-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.0.0-20190918163108-da9fdfce26bb // kubernetes-1.16.0
-	k8s.io/code-generator => k8s.io/code-generator v0.0.0-20190912054826-cd179ad6a269 // kubernetes-1.16.0
-	k8s.io/component-base => k8s.io/component-base v0.0.0-20190918160511-547f6c5d7090 // kubernetes-1.16.0
+	k8s.io/api => k8s.io/api v0.16.6
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.16.6
+	k8s.io/apimachinery => k8s.io/apimachinery v0.16.6
+	k8s.io/apiserver => k8s.io/apiserver v0.16.6
+	k8s.io/client-go => k8s.io/client-go v0.16.6
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.16.6
+	k8s.io/code-generator => k8s.io/code-generator v0.16.6
+	k8s.io/component-base => k8s.io/component-base v0.16.6
 	k8s.io/helm => k8s.io/helm v2.13.1+incompatible
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.0.0-20190918161219-8c8f079fddc3 // kubernetes-1.16.0
-	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.16.6
+	k8s.io/kube-openapi => k8s.io/kube-openapi v0.16.6
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
As discussed today i want you to show how the go.mod dependencies to all kubernetes artefacts can be made more readable.

```
