### PR TITLE
Bump up hvpa-controller version to v0.2.0

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/hvpa.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/hvpa.yaml
@@ -14,18 +14,21 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: 1
-{{- if .Values.global.apiserver.hvpa.scaleUpStabilization }}
-  scaleUpStabilization:
-{{ toYaml .Values.global.apiserver.hvpa.scaleUpStabilization | indent 4 }}
-{{- end }}
-{{- if .Values.global.apiserver.hvpa.scaleDownStabilization }}
-  scaleDownStabilization:
-{{ toYaml .Values.global.apiserver.hvpa.scaleDownStabilization | indent 4 }}
+{{- if .Values.global.apiserver.hvpa.maintenanceWindow }}
+  maintenanceTimeWindow:
+{{ toYaml .Values.global.apiserver.hvpa.maintenanceWindow | indent 4 }}
 {{- end }}
   hpa:
     selector:
       matchLabels:
         role: gardener-apiserver-hpa
+    deploy: true
+    scaleUp:
+      updatePolicy:
+        updateMode: "Auto"
+    scaleDown:
+      updatePolicy:
+        updateMode: "Auto"
     template:
       metadata:
         labels:
@@ -42,12 +45,27 @@ spec:
             name: cpu
             targetAverageUtilization: {{ .Values.global.apiserver.hvpa.targetAverageUtilizationCpu }}
           type: Resource
-    updatePolicy:
-      updateMode: "Auto"
   vpa:
     selector:
       matchLabels:
         role: gardener-apiserver-vpa
+    deploy: true
+    scaleUp:
+      updatePolicy:
+        updateMode: "Auto"
+{{- if .Values.global.apiserver.hvpa.vpaScaleUpStabilization }}
+{{ toYaml .Values.global.apiserver.hvpa.vpaScaleUpStabilization | indent 6 }}
+{{- end }}
+    scaleDown:
+      updatePolicy:
+        updateMode: "Auto"
+{{- if .Values.global.apiserver.hvpa.vpaScaleDownStabilization }}
+{{ toYaml .Values.global.apiserver.hvpa.vpaScaleDownStabilization | indent 6 }}
+{{- end }}
+{{- if .Values.global.apiserver.hvpa.limitsRequestsGapScaleParams }}
+    limitsRequestsGapScaleParams:
+{{ toYaml .Values.global.apiserver.hvpa.limitsRequestsGapScaleParams | indent 6 }}
+{{- end }}
     template:
       metadata:
         labels:
@@ -62,8 +80,6 @@ spec:
               minAllowed:
                 memory: 400M
                 cpu: 400m
-    updatePolicy:
-      updateMode: "Auto"
   weightBasedScalingIntervals:
 {{- if gt (int .Values.global.apiserver.hvpa.maxReplicas) (int .Values.global.apiserver.hvpa.minReplicas) }}
     - vpaWeight: 0

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -14,8 +14,8 @@ global:
         cpu: 100m
         memory: 100Mi
       limits:
-        cpu: "8"
-        memory: 25G
+        cpu: 300m
+        memory: 256Mi
     encryption:
       config: |
         apiVersion: apiserver.config.k8s.io/v1
@@ -66,21 +66,30 @@ global:
       minReplicas: 1
       targetAverageUtilizationCpu: 80
       targetAverageUtilizationMemory: 80
-      scaleUpStabilization:
-        duration: "3m"
-        minCpuChange:
-          value: 300m
+      vpaScaleUpStabilization:
+        stabilizationDuration: "3m"
+        minChange:
+          cpu:
+            value: 300m
+            percentage: 80
+          memory:
+            value: 200M
+            percentage: 80
+      vpaScaleDownStabilization:
+        stabilizationDuration: "15m"
+        minChange:
+          cpu:
+            value: 600m
+            percentage: 80
+          memory:
+            value: 600M
+            percentage: 80
+      limitsRequestsGapScaleParams:
+        cpu:
+          value: "3"
           percentage: 80
-        minMemChange:
-          value: 200M
-          percentage: 80
-      scaleDownStabilization:
-        duration: "15m"
-        minCpuChange:
-          value: 600m
-          percentage: 80
-        minMemChange:
-          value: 600M
+        memory:
+          value: "5G"
           percentage: 80
 
     audit:

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -220,4 +220,4 @@ images:
 - name: hvpa-controller
   sourceRepository: github.com/gardener/hvpa-controller
   repository: eu.gcr.io/gardener-project/gardener/hvpa-controller
-  tag: "0.1.0"
+  tag: "v0.2.0

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -220,4 +220,4 @@ images:
 - name: hvpa-controller
   sourceRepository: github.com/gardener/hvpa-controller
   repository: eu.gcr.io/gardener-project/gardener/hvpa-controller
-  tag: "v0.2.0
+  tag: "v0.2.0"

--- a/charts/seed-bootstrap/charts/hvpa/templates/hvpa-crd.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/templates/hvpa-crd.yaml
@@ -38,6 +38,131 @@ spec:
             hpa:
               description: Hpa defines the spec of HPA
               properties:
+                deploy:
+                  description: Deploy defines whether the HPA is deployed or not
+                  type: boolean
+                scaleDown:
+                  description: ScaleDown defines the parameters for scale down
+                  properties:
+                    minChange:
+                      description: MinChange is the minimum change in the resource
+                        on which HVPA acts HVPA uses minimum of the Value and Percentage
+                        value
+                      properties:
+                        cpu:
+                          description: Scale parameters for CPU
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                        memory:
+                          description: Scale parameters for memory
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                        replicas:
+                          description: Scale patameters for replicas
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                      type: object
+                    stabilizationDuration:
+                      description: StabilizationDuration defines the minimum delay
+                        in minutes between 2 consecutive scale operations Valid time
+                        units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                      type: string
+                    updatePolicy:
+                      description: Describes the rules on when changes are applied.
+                        If not specified, all fields in the `UpdatePolicy` are set
+                        to their default values.
+                      properties:
+                        updateMode:
+                          description: Controls when autoscaler applies changes to
+                            the resources. The default is 'Auto'.
+                          type: string
+                      type: object
+                  type: object
+                scaleUp:
+                  description: ScaleUp defines the parameters for scale up
+                  properties:
+                    minChange:
+                      description: MinChange is the minimum change in the resource
+                        on which HVPA acts HVPA uses minimum of the Value and Percentage
+                        value
+                      properties:
+                        cpu:
+                          description: Scale parameters for CPU
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                        memory:
+                          description: Scale parameters for memory
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                        replicas:
+                          description: Scale patameters for replicas
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                      type: object
+                    stabilizationDuration:
+                      description: StabilizationDuration defines the minimum delay
+                        in minutes between 2 consecutive scale operations Valid time
+                        units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                      type: string
+                    updatePolicy:
+                      description: Describes the rules on when changes are applied.
+                        If not specified, all fields in the `UpdatePolicy` are set
+                        to their default values.
+                      properties:
+                        updateMode:
+                          description: Controls when autoscaler applies changes to
+                            the resources. The default is 'Auto'.
+                          type: string
+                      type: object
+                  type: object
                 selector:
                   description: 'Selector is a label query that should match HPA. Must
                     match in order to be controlled. If empty, defaulted to labels
@@ -413,93 +538,27 @@ spec:
                       - maxReplicas
                       type: object
                   type: object
-                updatePolicy:
-                  description: Describes the rules on how changes are applied. If
-                    not specified, all fields in the `UpdatePolicy` are set to their
-                    default values.
-                  properties:
-                    updateMode:
-                      description: Controls when autoscaler applies changes to the
-                        resources. The default is 'On'.
-                      type: string
-                  type: object
+              type: object
+            maintenanceTimeWindow:
+              description: MaintenanceTimeWindow contains information about the time
+                window for maintenance operations.
+              properties:
+                begin:
+                  description: Begin is the beginning of the time window in the format
+                    HHMMSS+ZONE, e.g. "220000+0100".
+                  type: string
+                end:
+                  description: End is the end of the time window in the format HHMMSS+ZONE,
+                    e.g. "220000+0100".
+                  type: string
+              required:
+              - begin
+              - end
               type: object
             replicas:
               description: Replicas is the number of replicas of target resource
               format: int32
               type: integer
-            scaleDownStabilization:
-              description: ScaleDownStabilization defines stabilization parameters
-                after last scaling
-              properties:
-                duration:
-                  description: Duration defines the minimum delay in minutes between
-                    2 consecutive scale operations Valid time units are "ns", "us"
-                    (or "µs"), "ms", "s", "m", "h"
-                  type: string
-                minCpuChange:
-                  description: MinCpuChange is the minimum change in CPU on which
-                    HVPA acts HVPA uses minimum of the Value and Percentage value
-                  properties:
-                    percentage:
-                      description: Percentage is the percentage of currently allocated
-                        value to be used as threshold
-                      format: int32
-                      type: integer
-                    value:
-                      description: Value is the absolute value of the threshold
-                      type: string
-                  type: object
-                minMemChange:
-                  description: MinMemChange is the minimum change in memory on which
-                    HVPA acts HVPA uses minimum of the Value and Percentage value
-                  properties:
-                    percentage:
-                      description: Percentage is the percentage of currently allocated
-                        value to be used as threshold
-                      format: int32
-                      type: integer
-                    value:
-                      description: Value is the absolute value of the threshold
-                      type: string
-                  type: object
-              type: object
-            scaleUpStabilization:
-              description: ScaleUpStabilization defines stabilization parameters after
-                last scaling
-              properties:
-                duration:
-                  description: Duration defines the minimum delay in minutes between
-                    2 consecutive scale operations Valid time units are "ns", "us"
-                    (or "µs"), "ms", "s", "m", "h"
-                  type: string
-                minCpuChange:
-                  description: MinCpuChange is the minimum change in CPU on which
-                    HVPA acts HVPA uses minimum of the Value and Percentage value
-                  properties:
-                    percentage:
-                      description: Percentage is the percentage of currently allocated
-                        value to be used as threshold
-                      format: int32
-                      type: integer
-                    value:
-                      description: Value is the absolute value of the threshold
-                      type: string
-                  type: object
-                minMemChange:
-                  description: MinMemChange is the minimum change in memory on which
-                    HVPA acts HVPA uses minimum of the Value and Percentage value
-                  properties:
-                    percentage:
-                      description: Percentage is the percentage of currently allocated
-                        value to be used as threshold
-                      format: int32
-                      type: integer
-                    value:
-                      description: Value is the absolute value of the threshold
-                      type: string
-                  type: object
-              type: object
             targetRef:
               description: TargetRef points to the controller managing the set of
                 pods for the autoscaler to control
@@ -520,6 +579,172 @@ spec:
             vpa:
               description: Vpa defines the spec of VPA
               properties:
+                deploy:
+                  description: Deploy defines whether the VPA is deployed or not
+                  type: boolean
+                limitsRequestsGapScaleParams:
+                  description: LimitsRequestsGapScaleParams is the scaling thresholds
+                    for limits
+                  properties:
+                    cpu:
+                      description: Scale parameters for CPU
+                      properties:
+                        percentage:
+                          description: Percentage is the percentage of currently allocated
+                            value to be used for scaling
+                          format: int32
+                          type: integer
+                        value:
+                          description: Value is the absolute value of the scaling
+                          type: string
+                      type: object
+                    memory:
+                      description: Scale parameters for memory
+                      properties:
+                        percentage:
+                          description: Percentage is the percentage of currently allocated
+                            value to be used for scaling
+                          format: int32
+                          type: integer
+                        value:
+                          description: Value is the absolute value of the scaling
+                          type: string
+                      type: object
+                    replicas:
+                      description: Scale patameters for replicas
+                      properties:
+                        percentage:
+                          description: Percentage is the percentage of currently allocated
+                            value to be used for scaling
+                          format: int32
+                          type: integer
+                        value:
+                          description: Value is the absolute value of the scaling
+                          type: string
+                      type: object
+                  type: object
+                scaleDown:
+                  description: ScaleDown defines the parameters for scale down
+                  properties:
+                    minChange:
+                      description: MinChange is the minimum change in the resource
+                        on which HVPA acts HVPA uses minimum of the Value and Percentage
+                        value
+                      properties:
+                        cpu:
+                          description: Scale parameters for CPU
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                        memory:
+                          description: Scale parameters for memory
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                        replicas:
+                          description: Scale patameters for replicas
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                      type: object
+                    stabilizationDuration:
+                      description: StabilizationDuration defines the minimum delay
+                        in minutes between 2 consecutive scale operations Valid time
+                        units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                      type: string
+                    updatePolicy:
+                      description: Describes the rules on when changes are applied.
+                        If not specified, all fields in the `UpdatePolicy` are set
+                        to their default values.
+                      properties:
+                        updateMode:
+                          description: Controls when autoscaler applies changes to
+                            the resources. The default is 'Auto'.
+                          type: string
+                      type: object
+                  type: object
+                scaleUp:
+                  description: ScaleUp defines the parameters for scale up
+                  properties:
+                    minChange:
+                      description: MinChange is the minimum change in the resource
+                        on which HVPA acts HVPA uses minimum of the Value and Percentage
+                        value
+                      properties:
+                        cpu:
+                          description: Scale parameters for CPU
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                        memory:
+                          description: Scale parameters for memory
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                        replicas:
+                          description: Scale patameters for replicas
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                      type: object
+                    stabilizationDuration:
+                      description: StabilizationDuration defines the minimum delay
+                        in minutes between 2 consecutive scale operations Valid time
+                        units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                      type: string
+                    updatePolicy:
+                      description: Describes the rules on when changes are applied.
+                        If not specified, all fields in the `UpdatePolicy` are set
+                        to their default values.
+                      properties:
+                        updateMode:
+                          description: Controls when autoscaler applies changes to
+                            the resources. The default is 'Auto'.
+                          type: string
+                      type: object
+                  type: object
                 selector:
                   description: 'Selector is a label query that should match VPA. Must
                     match in order to be controlled. If empty, defaulted to labels
@@ -618,16 +843,6 @@ spec:
                           type: object
                       type: object
                   type: object
-                updatePolicy:
-                  description: Describes the rules on how changes are applied. If
-                    not specified, all fields in the `UpdatePolicy` are set to their
-                    default values.
-                  properties:
-                    updateMode:
-                      description: Controls when autoscaler applies changes to the
-                        resources. The default is 'On'.
-                      type: string
-                  type: object
               type: object
             weightBasedScalingIntervals:
               description: WeightBasedScalingIntervals defines the intervals of replica
@@ -664,12 +879,20 @@ spec:
         status:
           description: HvpaStatus defines the observed state of Hvpa
           properties:
-            hpaUpdatePolicy:
+            hpaScaleDownUpdatePolicy:
               description: Current HPA UpdatePolicy set in the spec
               properties:
                 updateMode:
                   description: Controls when autoscaler applies changes to the resources.
-                    The default is 'On'.
+                    The default is 'Auto'.
+                  type: string
+              type: object
+            hpaScaleUpUpdatePolicy:
+              description: Current HPA UpdatePolicy set in the spec
+              properties:
+                updateMode:
+                  description: Controls when autoscaler applies changes to the resources.
+                    The default is 'Auto'.
                   type: string
               type: object
             hpaWeight:
@@ -946,12 +1169,20 @@ spec:
               description: TargetSelector is the string form of the label selector
                 of HPA. This is required for HPA to work with scale subresource.
               type: string
-            vpaUpdatePolicy:
+            vpaScaleDownUpdatePolicy:
               description: Current VPA UpdatePolicy set in the spec
               properties:
                 updateMode:
                   description: Controls when autoscaler applies changes to the resources.
-                    The default is 'On'.
+                    The default is 'Auto'.
+                  type: string
+              type: object
+            vpaScaleUpUpdatePolicy:
+              description: Current VPA UpdatePolicy set in the spec
+              properties:
+                updateMode:
+                  description: Controls when autoscaler applies changes to the resources.
+                    The default is 'Auto'.
                   type: string
               type: object
             vpaWeight:

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-hvpa.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-hvpa.yaml
@@ -54,13 +54,10 @@ spec:
 {{- if .Values.scaleDownStabilization }}
 {{ toYaml .Values.scaleDownStabilization | indent 6 }}
 {{- end }}
+{{- if .Values.limitsRequestsGapScaleParams }}
     limitsRequestsGapScaleParams:
-      cpu:
-        value: "3"
-        percentage: 80
-      memory:
-        value: "5G"
-        percentage: 80
+{{ toYaml .Values.limitsRequestsGapScaleParams | indent 6 }}
+{{- end }}
     template:
       metadata:
         labels:

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-hvpa.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-hvpa.yaml
@@ -12,18 +12,15 @@ metadata:
     role: {{ .Values.role }}
 spec:
   replicas: 1
-{{- if .Values.scaleUpStabilization }}
-  scaleUpStabilization:
-{{ toYaml .Values.scaleUpStabilization | indent 4 }}
-{{- end }}
-{{- if .Values.scaleDownStabilization }}
-  scaleDownStabilization:
-{{ toYaml .Values.scaleDownStabilization | indent 4 }}
+{{- if .Values.maintenanceWindow }}
+  maintenanceTimeWindow:
+{{ toYaml .Values.maintenanceWindow | indent 4 }}
 {{- end }}
   hpa:
     selector:
       matchLabels:
         role: etcd-hpa-{{ .Values.role }}
+    deploy: false
     template:
       metadata:
         labels:
@@ -34,18 +31,36 @@ spec:
         metrics:
         - resource:
             name: memory
-            targetAverageUtilization: {{ .Values.targetAverageUtilization }}
+            targetAverageUtilization: {{ .Values.targetAverageUtilizationMemory }}
           type: Resource
         - resource:
             name: cpu
-            targetAverageUtilization: {{ .Values.targetAverageUtilization }}
+            targetAverageUtilization: {{ .Values.targetAverageUtilizationCpu }}
           type: Resource
-    updatePolicy:
-      updateMode: "Auto"
   vpa:
     selector:
       matchLabels:
         role: etcd-vpa-{{ .Values.role }}
+    deploy: true
+    scaleUp:
+      updatePolicy:
+        updateMode: "Auto"
+{{- if .Values.scaleUpStabilization }}
+{{ toYaml .Values.scaleUpStabilization | indent 6 }}
+{{- end }}
+    scaleDown:
+      updatePolicy:
+        updateMode: "MaintenanceWindow"
+{{- if .Values.scaleDownStabilization }}
+{{ toYaml .Values.scaleDownStabilization | indent 6 }}
+{{- end }}
+    limitsRequestsGapScaleParams:
+      cpu:
+        value: "3"
+        percentage: 80
+      memory:
+        value: "5G"
+        percentage: 80
     template:
       metadata:
         labels:
@@ -62,8 +77,6 @@ spec:
                 cpu: 300m
             - containerName: backup-restore
               mode: "Off"
-    updatePolicy:
-      updateMode: "ScaleUp"
   weightBasedScalingIntervals:
     - vpaWeight: 100
       startReplicaCount: {{ .Values.replicas }}

--- a/charts/seed-controlplane/charts/etcd/values.yaml
+++ b/charts/seed-controlplane/charts/etcd/values.yaml
@@ -40,6 +40,10 @@ targetAverageUtilizationCpu: 80
 targetAverageUtilizationMemory: 80
 
 maintenanceWindow: {}
+# maintenanceWindow example:
+#maintenanceWindow:
+  #begin: 230000+0000
+  #end: 000000+0000
 
 etcdResources:
   requests:
@@ -51,3 +55,11 @@ etcdResources:
 
 hvpa:
   enabled: false
+
+limitsRequestsGapScaleParams:
+  cpu:
+    value: "3"
+    percentage: 80
+  memory:
+    value: "5G"
+    percentage: 80

--- a/charts/seed-controlplane/charts/etcd/values.yaml
+++ b/charts/seed-controlplane/charts/etcd/values.yaml
@@ -17,32 +17,37 @@ servicePorts:
 metrics: basic
 
 scaleUpStabilization:
-  duration: "5m"
-  minCpuChange:
-    value: "1"
-    percentage: 80
-  minMemChange:
-    value: 2G
-    percentage: 80
+  stabilizationDuration: "5m"
+  minChange:
+    cpu:
+      value: "1"
+      percentage: 80
+    memory:
+      value: 2G
+      percentage: 80
 
 scaleDownStabilization:
-  duration: "15m"
-  minCpuChange:
-    value: "1"
-    percentage: 80
-  minMemChange:
-    value: 2G
-    percentage: 80
+  stabilizationDuration: "15m"
+  minChange:
+    cpu:
+      value: "1"
+      percentage: 80
+    memory:
+      value: 2G
+      percentage: 80
 
-targetAverageUtilization: 80
+targetAverageUtilizationCpu: 80
+targetAverageUtilizationMemory: 80
+
+maintenanceWindow: {}
 
 etcdResources:
   requests:
     cpu: 300m
-    memory: 1000M
+    memory: 1G
   limits:
-    cpu: "4"
-    memory: 30G
+    cpu: 900m
+    memory: 3G
 
 hvpa:
   enabled: false

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hvpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hvpa.yaml
@@ -56,13 +56,10 @@ spec:
 {{- if .Values.scaleDownStabilization }}
 {{ toYaml .Values.scaleDownStabilization | indent 6 }}
 {{- end }}
+{{- if .Values.limitsRequestsGapScaleParams }}
     limitsRequestsGapScaleParams:
-      cpu:
-        value: "3"
-        percentage: 80
-      memory:
-        value: "5G"
-        percentage: 80
+{{ toYaml .Values.limitsRequestsGapScaleParams | indent 6 }}
+{{- end }}
     template:
       metadata:
         labels:

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hvpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hvpa.yaml
@@ -8,18 +8,21 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
-{{- if .Values.scaleUpStabilization }}
-  scaleUpStabilization:
-{{ toYaml .Values.scaleUpStabilization | indent 4 }}
-{{- end }}
-{{- if .Values.scaleDownStabilization }}
-  scaleDownStabilization:
-{{ toYaml .Values.scaleDownStabilization | indent 4 }}
+{{- if .Values.maintenanceWindow }}
+  maintenanceTimeWindow:
+{{ toYaml .Values.maintenanceWindow | indent 4 }}
 {{- end }}
   hpa:
     selector:
       matchLabels:
         role: apiserver-hpa
+    deploy: true
+    scaleUp:
+      updatePolicy:
+        updateMode: "Auto"
+    scaleDown:
+      updatePolicy:
+        updateMode: "Auto"
     template:
       metadata:
         labels:
@@ -30,18 +33,36 @@ spec:
         metrics:
         - resource:
             name: memory
-            targetAverageUtilization: {{ .Values.targetAverageUtilization }}
+            targetAverageUtilization: {{ .Values.targetAverageUtilizationMemory }}
           type: Resource
         - resource:
             name: cpu
-            targetAverageUtilization: {{ .Values.targetAverageUtilization }}
+            targetAverageUtilization: {{ .Values.targetAverageUtilizationCpu }}
           type: Resource
-    updatePolicy:
-      updateMode: "Auto"
   vpa:
     selector:
       matchLabels:
         role: apiserver-vpa
+    deploy: true
+    scaleUp:
+      updatePolicy:
+        updateMode: "Auto"
+{{- if .Values.scaleUpStabilization }}
+{{ toYaml .Values.scaleUpStabilization | indent 6 }}
+{{- end }}
+    scaleDown:
+      updatePolicy:
+        updateMode: "Auto"
+{{- if .Values.scaleDownStabilization }}
+{{ toYaml .Values.scaleDownStabilization | indent 6 }}
+{{- end }}
+    limitsRequestsGapScaleParams:
+      cpu:
+        value: "3"
+        percentage: 80
+      memory:
+        value: "5G"
+        percentage: 80
     template:
       metadata:
         labels:
@@ -60,12 +81,12 @@ spec:
               mode: "Off"
             - containerName: blackbox-exporter
               mode: "Off"
-    updatePolicy:
-      updateMode: "Auto"
   weightBasedScalingIntervals:
+{{- if gt (int .Values.maxReplicas) (int .Values.minReplicas) }}
     - vpaWeight: 0
       startReplicaCount: {{ .Values.minReplicas }}
-      lastReplicaCount: {{ .Values.lastReplicaCountForHpa }}
+      lastReplicaCount: {{ sub (int .Values.maxReplicas) 1 }}
+{{- end }}
     - vpaWeight: 100
       startReplicaCount: {{ .Values.maxReplicas }}
       lastReplicaCount: {{ .Values.maxReplicas }}

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -134,3 +134,11 @@ scaleDownStabilization:
     memory:
       value: 200M
       percentage: 80
+
+limitsRequestsGapScaleParams:
+  cpu:
+    value: "3"
+    percentage: 80
+  memory:
+    value: "5G"
+    percentage: 80

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -82,12 +82,13 @@ apiServerResources:
     cpu: 400m
     memory: 400M
   limits:
-    cpu: "8"
-    memory: 25G
+    cpu: 800m
+    memory: 900M
 
 maxReplicas: 1
 minReplicas: 1
-targetAverageUtilization: 80
+targetAverageUtilizationCpu: 80
+targetAverageUtilizationMemory: 80
 
 auditConfig:
   auditPolicy: ""
@@ -115,21 +116,21 @@ hvpa:
   enabled: false
 
 scaleUpStabilization:
-  duration: "3m"
-  minCpuChange:
-    value: 300m
-    percentage: 80
-  minMemChange:
-    value: 200M
-    percentage: 80
+  stabilizationDuration: "3m"
+  minChange:
+    cpu:
+      value: 300m
+      percentage: 80
+    memory:
+      value: 200M
+      percentage: 80
 
 scaleDownStabilization:
-  duration: "15m"
-  minCpuChange:
-    value: 300m
-    percentage: 80
-  minMemChange:
-    value: 200M
-    percentage: 80
-
-lastReplicaCountForHpa: 1
+  stabilizationDuration: "15m"
+  minChange:
+    cpu:
+      value: 300m
+      percentage: 80
+    memory:
+      value: 200M
+      percentage: 80

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -544,7 +544,7 @@ func init() {
 }
 
 // getResourcesForAPIServer returns the cpu and memory requirements for API server based on nodeCount
-func getResourcesForAPIServer(nodeCount int32, hvpaEnabled bool) (string, string, string, string) {
+func getResourcesForAPIServer(nodeCount int32) (string, string, string, string) {
 	var (
 		cpuRequest    string
 		memoryRequest string
@@ -583,12 +583,6 @@ func getResourcesForAPIServer(nodeCount int32, hvpaEnabled bool) (string, string
 
 		cpuLimit = "4000m"
 		memoryLimit = "7800Mi"
-	}
-
-	if hvpaEnabled {
-		// Since we are deploying HVPA for apiserver, we can keep the limits high
-		cpuLimit = "8"
-		memoryLimit = "25G"
 	}
 
 	return cpuRequest, memoryRequest, cpuLimit, memoryLimit
@@ -761,7 +755,7 @@ func (b *Botanist) DeployKubeAPIServer() error {
 			defaultValues["replicas"] = 0
 		}
 
-		cpuRequest, memoryRequest, cpuLimit, memoryLimit := getResourcesForAPIServer(b.Shoot.GetNodeCount(), hvpaEnabled)
+		cpuRequest, memoryRequest, cpuLimit, memoryLimit := getResourcesForAPIServer(b.Shoot.GetNodeCount())
 		defaultValues["apiServerResources"] = map[string]interface{}{
 			"limits": map[string]interface{}{
 				"cpu":    cpuLimit,
@@ -776,25 +770,14 @@ func (b *Botanist) DeployKubeAPIServer() error {
 
 	if foundDeployment && hvpaEnabled {
 		// Deployment is already created AND is controlled by HVPA
-		// Keep the "requests" as it is.
+		// Keep the "resources" as it is.
 		for k := range deployment.Spec.Template.Spec.Containers {
 			v := &deployment.Spec.Template.Spec.Containers[k]
 			if v.Name == "kube-apiserver" {
-				defaultValues["apiServerResources"].(map[string]interface{})["requests"] = map[string]interface{}{
-					"cpu":    v.Resources.Requests.Cpu(),
-					"memory": v.Resources.Requests.Memory(),
-				}
+				defaultValues["apiserverResources"] = v.Resources.DeepCopy()
 				break
 			}
 		}
-	}
-
-	// APIserver will be horizontally scaled until last but one replicas,
-	// after which there will be vertical scaling
-	if maxReplicas > minReplicas {
-		defaultValues["lastReplicaCountForHpa"] = maxReplicas - 1
-	} else {
-		defaultValues["lastReplicaCountForHpa"] = minReplicas
 	}
 
 	defaultValues["minReplicas"] = minReplicas
@@ -1063,7 +1046,8 @@ func (b *Botanist) DeployETCD(ctx context.Context) error {
 		"hvpa": map[string]interface{}{
 			"enabled": hvpaEnabled,
 		},
-		"storageCapacity": b.Seed.GetValidVolumeSize("10Gi"),
+		"maintenanceWindow": b.Shoot.Info.Spec.Maintenance.TimeWindow,
+		"storageCapacity":   b.Seed.GetValidVolumeSize("10Gi"),
 	}
 
 	etcd, err := b.InjectSeedShootImages(etcdConfig, common.ETCDImageName)


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump up hvpa-controller version to v0.2.0:
- Introduces new scale mode: "MaintenanceWindow"
- Scales `limits` along with `requests`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Will remove the WIP label once new release of HVPA is created

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The shoot etcds are now scaled down only during maintenance time window.
```

```noteworthy operator
The resource limits for etcds and the kube-apiservers of shoots are now scaled along with the resource requests.
```

``` improvement operator github.com/gardener/hvpa-controller #53 @ggaurav10
Handled case when maintenance time window is missing
```

``` improvement operator github.com/gardener/hvpa-controller #51 @ggaurav10
Enhanced hvpa controller logs to include details about the reconciling object.
```

``` improvement operator github.com/gardener/hvpa-controller #50 @ggaurav10
HVPA now supports setting scale mode to `MaintenanceWindow`. When this mode is set, scaling happens only during user-defined maintenance time window.
Currently, this mode is supported only for vertical scaling. Support for horizontal scaling is dependent on implementation of `scale` subresource in HVPA
```

``` improvement operator github.com/gardener/hvpa-controller #49 @ggaurav10
Added support of limits scaling
```

``` improvement operator github.com/gardener/hvpa-controller #48 @ggaurav10
Override vpaWeight if HPA is not maxed out and oomkill still happens
```

``` improvement operator github.com/gardener/hvpa-controller #47 @ialidzhikov
The release tags from now are prefixed with `v`.
```

``` improvement operator github.com/gardener/hvpa-controller #46 @amshuman-kr
Aggregated metrics are always initialised. Detailed metrics are initialised as soon as the corresponding resource is reconciled.
```

``` improvement operator github.com/gardener/hvpa-controller #42 @ggaurav10
Change default port to `9569`
```
