### PR TITLE
Fix wrong type assertion in guestbook test

### DIFF
--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -112,7 +112,8 @@ func (t *GuestBookTest) WaitUntilGuestbookAppIsAvailable(ctx context.Context, gu
 // DeployGuestBookApp deploys the redis helmchart and the guestbook app application
 func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 	if t.framework.Namespace == "" {
-		framework.ExpectNoError(t.framework.CreateNewNamespace(ctx))
+		_, err := t.framework.CreateNewNamespace(ctx)
+		framework.ExpectNoError(err)
 	}
 	shoot := t.framework.Shoot
 	if !shoot.Spec.Addons.NginxIngress.Enabled {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes wrong type assertion in guestbook test

```
GuestBook
 /src/test/integration/shoots/applications/shoot_app.go:66
   [DEFAULT] [RELEASE] [SHOOT] should deploy guestbook app successfully [It]
   /src/test/framework/gingko_utils.go:26
   Expected an error-type.  Got:
       <string>: gardener-e2e-zsz6l
   /src/test/framework/applications/guestbooktest.go:115
```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
