### PR TITLE
Add recording rule for count of images running in the seed

### DIFF
--- a/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
+++ b/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
@@ -39,3 +39,7 @@ groups:
 
   - record: seed:container_network_transmit_bytes_total:sum_cp
     expr: sum(seed:container_network_transmit_bytes_total:sum_by_pod{namespace=~"((shoot-|shoot--)(\\w.+))"})
+
+  # Recording rules for images running on seed
+  - record: seed:images:count
+    expr: count(container_cpu_cfs_periods_total{type="seed"}) by (image)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a recording rule that will keep track of how many of each image we have running in all seeds.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
New metric `seed:images:count` exposes a count of the images running in the seeds.
```
