### PR TITLE
Fix potential bug in secret releasing for binding deletion

### DIFF
--- a/pkg/controllermanager/controller/secretbinding/secretbinding.go
+++ b/pkg/controllermanager/controller/secretbinding/secretbinding.go
@@ -68,7 +68,7 @@ func NewSecretBindingController(k8sGardenClient kubernetes.Interface, gardenInfo
 	secretBindingController := &Controller{
 		k8sGardenClient:        k8sGardenClient,
 		k8sGardenCoreInformers: gardenInformerFactory,
-		control:                NewDefaultControl(k8sGardenClient, gardenInformerFactory, recorder, secretLister, shootLister),
+		control:                NewDefaultControl(k8sGardenClient, gardenInformerFactory, recorder, secretBindingLister, secretLister, shootLister),
 		recorder:               recorder,
 		secretBindingLister:    secretBindingLister,
 		secretBindingQueue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "SecretBinding"),

--- a/pkg/controllermanager/controller/secretbinding/secretbinding_control_test.go
+++ b/pkg/controllermanager/controller/secretbinding/secretbinding_control_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2018 2020 SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secretbinding
+
+import (
+	"fmt"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var _ = Describe("SecretBindingControl", func() {
+	Describe("#mayReleaseSecret", func() {
+		var (
+			gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory
+			c                         *defaultControl
+
+			secretNamespace = "foo"
+			secretName      = "bar"
+		)
+
+		BeforeEach(func() {
+			gardenCoreInformerFactory = gardencoreinformers.NewSharedInformerFactory(nil, 0)
+
+			secretBindingInformer := gardenCoreInformerFactory.Core().V1beta1().SecretBindings()
+			secretBindingLister := secretBindingInformer.Lister()
+
+			c = &defaultControl{secretBindingLister: secretBindingLister}
+		})
+
+		It("should return true as no other secretbinding references the secret", func() {
+			allowed, err := c.mayReleaseSecret(secretNamespace, secretName)
+
+			Expect(allowed).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return false as another secretbinding references the secret", func() {
+			secretBinding := &gardencorev1beta1.SecretBinding{
+				SecretRef: corev1.SecretReference{
+					Namespace: secretNamespace,
+					Name:      secretName,
+				},
+			}
+
+			Expect(gardenCoreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(secretBinding)).To(Succeed())
+
+			allowed, err := c.mayReleaseSecret(secretNamespace, secretName)
+
+			Expect(allowed).To(BeFalse())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return an error as the list failed", func() {
+			c.secretBindingLister = &fakeLister{
+				SecretBindingLister: c.secretBindingLister,
+			}
+
+			allowed, err := c.mayReleaseSecret(secretNamespace, secretName)
+
+			Expect(allowed).To(BeFalse())
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+type fakeLister struct {
+	gardencorelisters.SecretBindingLister
+}
+
+func (c *fakeLister) List(labels.Selector) ([]*gardencorev1beta1.SecretBinding, error) {
+	return nil, fmt.Errorf("fake error")
+}

--- a/pkg/controllermanager/controller/secretbinding/secretbinding_suite_test.go
+++ b/pkg/controllermanager/controller/secretbinding/secretbinding_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2018 2020 SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secretbinding_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSecretBinding(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ControllerManager SecretBinding Controller Suite")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, the `SecretBinding` controller was releasing the finalizer from the referenced `Secret` if the `SecretBinding` was not used by `Shoot`s in this namespace.
However, generally, there might be another `SecretBinding` in a different namespace that references the same `Secret`. Consequently, the finalizer may be only be removed from the `Secret` if there is no other `SecretBinding` references it.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug that may accidentally release the finalizer from `Secret`s when a referencing `SecretBinding` resource is deleted has been fixed.
```
