### PR TITLE
Deploy gardenlet with highest possible priority

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
@@ -36,6 +36,7 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+      priorityClassName: gardenlet
       {{- if not .Values.global.gardenlet.config.seedClientConnection.kubeconfig }}
       serviceAccountName: {{ required ".Values.global.gardenlet.serviceAccountName is required" .Values.global.gardenlet.serviceAccountName }}
       {{- else }}

--- a/charts/gardener/gardenlet/charts/runtime/templates/priorityclass.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/priorityclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: {{ include "priorityclassversion" . }}
+kind: PriorityClass
+metadata:
+  name: gardenlet
+value: 1000000000
+globalDefault: false
+description: "This class is used to ensure that the gardenlet has a high priority and is not preempted in favor of other pods."


### PR DESCRIPTION
**What this PR does / why we need it**:
We should ensure that the gardenlet always runs and is never preempted in favor of other pods. This PR creates a `PriorityClass` for the gardenlet and deploys it with the highest possible prio (1 billion).

**Which issue(s) this PR fixes**:
Fixes #1726

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The gardenlet Helm chart now come with a `PriorityClass` for the gardenlet `Deployment` to ensure it always runs and is never preempted in favor of other pods.
```
