### PR TITLE
Validate minimum value for kubelet pod pids limit

### DIFF
--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1768,6 +1768,47 @@ var _ = Describe("Shoot Validation Tests", func() {
 				})))),
 		)
 
+		Describe("pod pids limits", func() {
+			It("should ensure pod pids limits are non-negative", func() {
+				var podPIDsLimit int64 = -1
+				kubeletConfig := core.KubeletConfig{
+					PodPIDsLimit: &podPIDsLimit,
+				}
+
+				errList := ValidateKubeletConfig(kubeletConfig, nil)
+
+				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("podPIDsLimit"),
+				}))))
+			})
+
+			It("should ensure pod pids limits are at least 100", func() {
+				var podPIDsLimit int64 = 99
+				kubeletConfig := core.KubeletConfig{
+					PodPIDsLimit: &podPIDsLimit,
+				}
+
+				errList := ValidateKubeletConfig(kubeletConfig, nil)
+
+				Expect(errList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("podPIDsLimit"),
+				}))))
+			})
+
+			It("should allow pod pids limits of at least 100", func() {
+				var podPIDsLimit int64 = 100
+				kubeletConfig := core.KubeletConfig{
+					PodPIDsLimit: &podPIDsLimit,
+				}
+
+				errList := ValidateKubeletConfig(kubeletConfig, nil)
+
+				Expect(errList).To(BeEmpty())
+			})
+		})
+
 		validResourceQuantity := resource.MustParse(validResourceQuantityValueMi)
 		DescribeTable("validate the kubelet configuration - EvictionMinimumReclaim",
 			func(memoryAvailable, imagefsAvailable, imagefsInodesFree, nodefsAvailable, nodefsInodesFree resource.Quantity, matcher gomegatypes.GomegaMatcher) {

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -15,7 +15,10 @@
 package shoot_test
 
 import (
+	"context"
+
 	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/validation"
 	shootregistry "github.com/gardener/gardener/pkg/registry/core/shoot"
 
 	. "github.com/onsi/ginkgo"
@@ -24,6 +27,73 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 )
+
+var _ = Describe("Strategy", func() {
+	Context("PrepareForUpdate", func() {
+		Context("pod pids limit", func() {
+			It("should enforce the minimum limit value", func() {
+				var tooSmallValue int64 = 10
+
+				shoot := newShoot("foo")
+				shoot.Spec.Kubernetes.Kubelet = &core.KubeletConfig{
+					PodPIDsLimit: &tooSmallValue,
+				}
+				shoot.Spec.Provider.Workers = []core.Worker{
+					{
+						Kubernetes: &core.WorkerKubernetes{
+							Kubelet: &core.KubeletConfig{
+								PodPIDsLimit: &tooSmallValue,
+							},
+						},
+					},
+				}
+
+				oldShoot := newShoot("foo")
+				oldShoot.Spec.Kubernetes.Kubelet = shoot.Spec.Kubernetes.Kubelet.DeepCopy()
+				oldShoot.Spec.Provider.Workers = []core.Worker{*shoot.Spec.Provider.Workers[0].DeepCopy()}
+
+				shootregistry.Strategy.PrepareForUpdate(context.TODO(), shoot, oldShoot)
+
+				Expect(*shoot.Spec.Kubernetes.Kubelet.PodPIDsLimit).To(Equal(validation.PodPIDsLimitMinimum))
+				Expect(*oldShoot.Spec.Kubernetes.Kubelet.PodPIDsLimit).To(Equal(validation.PodPIDsLimitMinimum))
+				Expect(*shoot.Spec.Provider.Workers[0].Kubernetes.Kubelet.PodPIDsLimit).To(Equal(validation.PodPIDsLimitMinimum))
+				Expect(*oldShoot.Spec.Provider.Workers[0].Kubernetes.Kubelet.PodPIDsLimit).To(Equal(validation.PodPIDsLimitMinimum))
+			})
+
+			It("should not touch values that are above the minimum", func() {
+				var (
+					tooSmallValue   int64 = 10
+					highEnoughValue int64 = 105
+				)
+
+				shoot := newShoot("foo")
+				shoot.Spec.Kubernetes.Kubelet = &core.KubeletConfig{
+					PodPIDsLimit: &tooSmallValue,
+				}
+				shoot.Spec.Provider.Workers = []core.Worker{
+					{
+						Kubernetes: &core.WorkerKubernetes{
+							Kubelet: &core.KubeletConfig{
+								PodPIDsLimit: &highEnoughValue,
+							},
+						},
+					},
+				}
+
+				oldShoot := newShoot("foo")
+				oldShoot.Spec.Kubernetes.Kubelet = shoot.Spec.Kubernetes.Kubelet.DeepCopy()
+				oldShoot.Spec.Provider.Workers = []core.Worker{*shoot.Spec.Provider.Workers[0].DeepCopy()}
+
+				shootregistry.Strategy.PrepareForUpdate(context.TODO(), shoot, oldShoot)
+
+				Expect(*shoot.Spec.Kubernetes.Kubelet.PodPIDsLimit).To(Equal(validation.PodPIDsLimitMinimum))
+				Expect(*oldShoot.Spec.Kubernetes.Kubelet.PodPIDsLimit).To(Equal(validation.PodPIDsLimitMinimum))
+				Expect(*shoot.Spec.Provider.Workers[0].Kubernetes.Kubelet.PodPIDsLimit).To(Equal(highEnoughValue))
+				Expect(*oldShoot.Spec.Provider.Workers[0].Kubernetes.Kubelet.PodPIDsLimit).To(Equal(highEnoughValue))
+			})
+		})
+	})
+})
 
 var _ = Describe("ToSelectableFields", func() {
 	It("should return correct fields", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Validate minimum value for the pod pids limit field in the kubelet config to ensure at least the system processes can run smoothly. /cc @schrodit 

**Which issue(s) this PR fixes**:
Fixes #1536

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
The minimum value for the `podPidsLimit` field in the kubelet configuration for `Shoot` resources is now `100`. If you have specified a value less then `100` the gardener-apiserver will automatically migrate it for you, however, you should switch to the new minimum value as this auto-migration logic will be removed again with one of the next releases.
```
