### PR TITLE
Enable VPA for alertmanager

### DIFF
--- a/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
@@ -163,4 +163,4 @@ spec:
     kind: StatefulSet
     name: alertmanager
   updatePolicy:
-    updateMode: "Off"
+    updateMode: "Auto"


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we enable the VPA for `alertmanager`.
/cc @ialidzhikov @vlvasilev @wyb1 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `alertmanager` `StatefulSet` is now automatically scaled vertically by the VPA.
```
