### PR TITLE
Readd the shoot.garden.sapcloud.io/uid annotation to the Shoot namespace

### DIFF
--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -133,6 +133,10 @@ const (
 	// GardenRoleOptionalAddon is the value of the GardenRole key indicating type 'optional-addon'.
 	GardenRoleOptionalAddon = "optional-addon"
 
+	// DeprecatedShootUID is an annotation key for the shoot namespace in the seed cluster,
+	// which value will be the value of `shoot.status.uid`
+	// +deprecated: Use `Cluster` resource instead.
+	DeprecatedShootUID = "shoot.garden.sapcloud.io/uid"
 	// DeprecatedGardenRoleBackup is the value of GardenRole key indicating type 'backup'.
 	// +deprecated
 	DeprecatedGardenRoleBackup = "backup"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -133,6 +133,10 @@ const (
 	// GardenRoleOptionalAddon is the value of the GardenRole key indicating type 'optional-addon'.
 	GardenRoleOptionalAddon = "optional-addon"
 
+	// DeprecatedShootUID is an annotation key for the shoot namespace in the seed cluster,
+	// which value will be the value of `shoot.status.uid`
+	// +deprecated: Use `Cluster` resource instead.
+	DeprecatedShootUID = "shoot.garden.sapcloud.io/uid"
 	// DeprecatedGardenRoleBackup is the value of GardenRole key indicating type 'backup'.
 	// +deprecated
 	DeprecatedGardenRoleBackup = "backup"

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -66,6 +66,9 @@ func (b *Botanist) DeployNamespace(ctx context.Context) error {
 	}
 
 	if err := kutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), namespace, func() error {
+		namespace.Annotations = map[string]string{
+			v1beta1constants.DeprecatedShootUID: string(b.Shoot.Info.Status.UID),
+		}
 		namespace.Labels = map[string]string{
 			v1beta1constants.DeprecatedGardenRole:    v1beta1constants.GardenRoleShoot,
 			v1beta1constants.GardenRole:              v1beta1constants.GardenRoleShoot,


### PR DESCRIPTION
**What this PR does / why we need it**:
This annotation was removed with #1885. The backupentry controller still watches on namespaces and uses this annotation. See https://github.com/gardener/gardener-extensions/blob/a83364393e2f8c15c1f846e422aedd24856bbe80/pkg/controller/backupentry/mapper.go#L92

According to @swapnilgm , there might be a data race currently.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Readd the `shoot.garden.sapcloud.io/uid` annotation to the Shoot namespace as there is still machinery that relies on it.
```
