### PR TITLE
Adds shootstate admission plugin

### DIFF
--- a/pkg/apiserver/admission/initializer/initializer.go
+++ b/pkg/apiserver/admission/initializer/initializer.go
@@ -16,6 +16,7 @@ package initializer
 
 import (
 	coreclientset "github.com/gardener/gardener/pkg/client/core/clientset/internalversion"
+	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	settingsinformer "github.com/gardener/gardener/pkg/client/settings/informers/externalversions"
 
@@ -29,6 +30,7 @@ import (
 func New(
 	coreInformers coreinformers.SharedInformerFactory,
 	coreClient coreclientset.Interface,
+	externalCoreInformers externalcoreinformers.SharedInformerFactory,
 	settingsInformers settingsinformer.SharedInformerFactory,
 	kubeInformers kubeinformers.SharedInformerFactory,
 	kubeClient kubernetes.Interface,
@@ -37,6 +39,8 @@ func New(
 	return pluginInitializer{
 		coreInformers: coreInformers,
 		coreClient:    coreClient,
+
+		externalCoreInformers: externalCoreInformers,
 
 		settingsInformers: settingsInformers,
 
@@ -55,6 +59,10 @@ func (i pluginInitializer) Initialize(plugin admission.Interface) {
 	}
 	if wants, ok := plugin.(WantsInternalCoreClientset); ok {
 		wants.SetInternalCoreClientset(i.coreClient)
+	}
+
+	if wants, ok := plugin.(WantsExternalCoreInformerFactory); ok {
+		wants.SetExternalCoreInformerFactory(i.externalCoreInformers)
 	}
 
 	if wants, ok := plugin.(WantsSettingsInformerFactory); ok {

--- a/pkg/apiserver/admission/initializer/types.go
+++ b/pkg/apiserver/admission/initializer/types.go
@@ -16,6 +16,7 @@ package initializer
 
 import (
 	coreclientset "github.com/gardener/gardener/pkg/client/core/clientset/internalversion"
+	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	settingsinformer "github.com/gardener/gardener/pkg/client/settings/informers/externalversions"
 
@@ -34,6 +35,12 @@ type WantsInternalCoreInformerFactory interface {
 // WantsInternalCoreClientset defines a function which sets Core Clientset for admission plugins that need it.
 type WantsInternalCoreClientset interface {
 	SetInternalCoreClientset(coreclientset.Interface)
+	admission.InitializationValidator
+}
+
+// WantsExternalCoreInformerFactory defines a function which sets external Core InformerFactory for admission plugins that need it.
+type WantsExternalCoreInformerFactory interface {
+	SetExternalCoreInformerFactory(externalcoreinformers.SharedInformerFactory)
 	admission.InitializationValidator
 }
 
@@ -64,6 +71,8 @@ type WantsAuthorizer interface {
 type pluginInitializer struct {
 	coreInformers coreinformers.SharedInformerFactory
 	coreClient    coreclientset.Interface
+
+	externalCoreInformers externalcoreinformers.SharedInformerFactory
 
 	settingsInformers settingsinformer.SharedInformerFactory
 

--- a/plugin/pkg/shootstate/validator/admission.go
+++ b/plugin/pkg/shootstate/validator/admission.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shootstate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	coreclientset "github.com/gardener/gardener/pkg/client/core/clientset/internalversion"
+	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	corev1alpha1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1alpha1"
+
+	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const (
+	// PluginName is the name of this admission plugin.
+	PluginName = "ShootStateDeletionValidator"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, NewFactory)
+}
+
+// NewFactory creates a new PluginFactory.
+func NewFactory(config io.Reader) (admission.Interface, error) {
+	return New()
+}
+
+// ValidateShootStateDeletion contains listers and admission handler.
+type ValidateShootStateDeletion struct {
+	*admission.Handler
+	shootStateLister corev1alpha1listers.ShootStateLister
+	coreClient       coreclientset.Interface
+	readyFunc        admission.ReadyFunc
+}
+
+var (
+	_ = admissioninitializer.WantsExternalCoreInformerFactory(&ValidateShootStateDeletion{})
+	_ = admissioninitializer.WantsInternalCoreClientset(&ValidateShootStateDeletion{})
+
+	readyFuncs = []admission.ReadyFunc{}
+)
+
+// New creates a new ShootStateDeletion admission plugin.
+func New() (*ValidateShootStateDeletion, error) {
+	return &ValidateShootStateDeletion{
+		Handler: admission.NewHandler(admission.Delete),
+	}, nil
+}
+
+// AssignReadyFunc assigns the ready function to the admission handler.
+func (d *ValidateShootStateDeletion) AssignReadyFunc(f admission.ReadyFunc) {
+	d.readyFunc = f
+	d.SetReadyFunc(f)
+}
+
+// SetExternalCoreInformerFactory sets the external garden core informer factory.
+func (d *ValidateShootStateDeletion) SetExternalCoreInformerFactory(f externalcoreinformers.SharedInformerFactory) {
+	shootStateInformer := f.Core().V1alpha1().ShootStates()
+	d.shootStateLister = shootStateInformer.Lister()
+
+	readyFuncs = append(readyFuncs, shootStateInformer.Informer().HasSynced)
+}
+
+// SetInternalCoreClientset sets the garden core clientset.
+func (d *ValidateShootStateDeletion) SetInternalCoreClientset(c coreclientset.Interface) {
+	d.coreClient = c
+}
+
+func (d *ValidateShootStateDeletion) waitUntilReady(attrs admission.Attributes) error {
+	// Wait until the caches have been synced
+	if d.readyFunc == nil {
+		d.AssignReadyFunc(func() bool {
+			for _, readyFunc := range readyFuncs {
+				if !readyFunc() {
+					return false
+				}
+			}
+			return true
+		})
+	}
+
+	if !d.WaitForReady() {
+		return admission.NewForbidden(attrs, errors.New("not yet ready to handle request"))
+	}
+
+	return nil
+}
+
+// ValidateInitialization checks whether the plugin was correctly initialized.
+func (d *ValidateShootStateDeletion) ValidateInitialization() error {
+	if d.shootStateLister == nil {
+		return errors.New("missing ShootState lister")
+	}
+
+	if d.coreClient == nil {
+		return errors.New("missing garden core client")
+	}
+
+	return nil
+}
+
+var _ admission.ValidationInterface = &ValidateShootStateDeletion{}
+
+// Validate makes admissions decisions based on deletion confirmation annotation.
+func (d *ValidateShootStateDeletion) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	if a.GetKind().GroupKind() != core.Kind("ShootState") {
+		return nil
+	}
+
+	if err := d.waitUntilReady(a); err != nil {
+		return fmt.Errorf("err while waiting for ready %v", err)
+	}
+
+	if a.GetName() == "" {
+		return d.validateDeleteCollection(ctx, a)
+	}
+
+	return d.validateDelete(ctx, a)
+}
+
+func (d *ValidateShootStateDeletion) validateDeleteCollection(ctx context.Context, attrs admission.Attributes) error {
+	shootStateList, err := d.shootStateLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	for _, shootState := range shootStateList {
+		if err := d.validateDelete(ctx, d.createAttributesWithName(shootState.Name, attrs)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *ValidateShootStateDeletion) validateDelete(ctx context.Context, attrs admission.Attributes) error {
+	if _, err := d.coreClient.Core().Shoots(attrs.GetNamespace()).Get(attrs.GetName(), metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("error retrieving Shoot %s in namespace %s: %v", attrs.GetName(), attrs.GetNamespace(), err)
+	}
+	return admission.NewForbidden(attrs, fmt.Errorf("Shoot %s in namespace %s still exists", attrs.GetName(), attrs.GetNamespace()))
+}
+
+func (d *ValidateShootStateDeletion) createAttributesWithName(objName string, a admission.Attributes) admission.Attributes {
+	return admission.NewAttributesRecord(a.GetObject(),
+		a.GetOldObject(),
+		a.GetKind(),
+		a.GetNamespace(),
+		objName,
+		a.GetResource(),
+		a.GetSubresource(),
+		a.GetOperation(),
+		a.GetOperationOptions(),
+		a.IsDryRun(),
+		a.GetUserInfo())
+}

--- a/plugin/pkg/shootstate/validator/admission_test.go
+++ b/plugin/pkg/shootstate/validator/admission_test.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shootstate
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	corev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/core/clientset/internalversion/fake"
+	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/client-go/testing"
+)
+
+var _ = Describe("Validate ShootState deletion", func() {
+	var (
+		shoot                             core.Shoot
+		shootState                        corev1alpha1.ShootState
+		gardenExternalCoreInformerFactory externalcoreinformers.SharedInformerFactory
+		gardenClient                      *fake.Clientset
+		admissionHandler                  *ValidateShootStateDeletion
+	)
+
+	BeforeEach(func() {
+		shootState = corev1alpha1.ShootState{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "garden-foo",
+			},
+		}
+
+		shoot = core.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "garden-foo",
+			},
+		}
+
+		admissionHandler, _ = New()
+		admissionHandler.AssignReadyFunc(func() bool { return true })
+
+		gardenExternalCoreInformerFactory = externalcoreinformers.NewSharedInformerFactory(nil, 0)
+		admissionHandler.SetExternalCoreInformerFactory(gardenExternalCoreInformerFactory)
+
+		gardenClient = &fake.Clientset{}
+		admissionHandler.SetInternalCoreClientset(gardenClient)
+	})
+
+	It("should do nothing because the resource is not ShootState", func() {
+		attrs := admission.NewAttributesRecord(nil, nil, core.Kind("Foo").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("foos").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+		err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should forbid ShootState deletion because shoot object exists ", func() {
+		attrs := admission.NewAttributesRecord(&shootState, nil, corev1alpha1.Kind("ShootState").WithVersion("v1alpha1"), shootState.Namespace, shootState.Name, corev1alpha1.Resource("shootstates").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+		gardenClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+			return true, &shoot, nil
+		})
+
+		err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsForbidden(err)).To(BeTrue())
+	})
+
+	It("should return an error which is not Forbidden if retrieving the shoot fails with an error different from NotFound", func() {
+		attrs := admission.NewAttributesRecord(&shootState, nil, corev1alpha1.Kind("ShootState").WithVersion("v1alpha1"), shootState.Namespace, shootState.Name, corev1alpha1.Resource("shootstates").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+		gardenClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewInternalError(errors.New("Internal Server Error"))
+		})
+
+		err := admissionHandler.Validate(context.TODO(), attrs, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsForbidden(err)).To(BeFalse())
+	})
+
+	It("should allow ShootState deletion because shoot object does not exist", func() {
+		attrs := admission.NewAttributesRecord(&shootState, nil, corev1alpha1.Kind("ShootState").WithVersion("v1alpha1"), shootState.Namespace, shootState.Name, corev1alpha1.Resource("shootstates").WithVersion("v1alpha1"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+		gardenClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewNotFound(core.Resource("shoot"), "foo")
+		})
+
+		err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("Delete collection", func() {
+		It("should allow deletion because no corresponding Shoot objects exists for the ShootStates", func() {
+			secondShootState := shootState.DeepCopy()
+			secondShootState.Name = "bar"
+
+			Expect(gardenExternalCoreInformerFactory.Core().V1alpha1().ShootStates().Informer().GetStore().Add(&shootState)).NotTo(HaveOccurred())
+			Expect(gardenExternalCoreInformerFactory.Core().V1alpha1().ShootStates().Informer().GetStore().Add(secondShootState)).NotTo(HaveOccurred())
+
+			attrs := admission.NewAttributesRecord(nil, nil, corev1alpha1.Kind("ShootState").WithVersion("v1alpha1"), shootState.Namespace, "", corev1alpha1.Resource("shootstates").WithVersion("valpha1"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+			gardenClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewNotFound(core.Resource("shoot"), "")
+			})
+
+			err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should forbid ShootState deletion", func() {
+			secondShootState := shootState.DeepCopy()
+			secondShootState.Name = "bar"
+
+			Expect(gardenExternalCoreInformerFactory.Core().V1alpha1().ShootStates().Informer().GetStore().Add(&shootState)).NotTo(HaveOccurred())
+			Expect(gardenExternalCoreInformerFactory.Core().V1alpha1().ShootStates().Informer().GetStore().Add(secondShootState)).NotTo(HaveOccurred())
+
+			attrs := admission.NewAttributesRecord(nil, nil, corev1alpha1.Kind("ShootState").WithVersion("v1alpha1"), shootState.Namespace, "", corev1alpha1.Resource("shootstates").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+			gardenClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+				return true, &shoot, nil
+			})
+
+			err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsForbidden(err)).To(BeTrue())
+		})
+	})
+
+	Describe("#Register", func() {
+		It("should register the plugin", func() {
+			plugins := admission.NewPlugins()
+			Register(plugins)
+
+			registered := plugins.Registered()
+			Expect(registered).To(HaveLen(1))
+			Expect(registered).To(ContainElement(PluginName))
+		})
+	})
+
+	Describe("#NewFactory", func() {
+		It("should create a new PluginFactory", func() {
+			f, err := NewFactory(nil)
+
+			Expect(f).NotTo(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("#New", func() {
+		It("should only handle DELETE operations", func() {
+			dr, err := New()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dr.Handles(admission.Create)).NotTo(BeTrue())
+			Expect(dr.Handles(admission.Update)).NotTo(BeTrue())
+			Expect(dr.Handles(admission.Connect)).NotTo(BeTrue())
+			Expect(dr.Handles(admission.Delete)).To(BeTrue())
+		})
+	})
+
+	Describe("#ValidateInitialization", func() {
+		It("should return error if no ShootStateLister is set", func() {
+			dr, _ := New()
+
+			err := dr.ValidateInitialization()
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should not return error if ShootStateLister and core client is set", func() {
+			dr, _ := New()
+			dr.SetExternalCoreInformerFactory(externalcoreinformers.NewSharedInformerFactory(nil, 0))
+			dr.SetInternalCoreClientset(&fake.Clientset{})
+			err := dr.ValidateInitialization()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/plugin/pkg/shootstate/validator/shootstate_suite_test.go
+++ b/plugin/pkg/shootstate/validator/shootstate_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shootstate
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestValidator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Admission ShootStateDeletion Suite")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an admission plugin for ShootState resources which will forbid deletion of the ShootState object if its corresponding Shoot object still exists

**Which issue(s) this PR fixes**:
Part of #1631 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Adds admission plugin which forbids ShootState deletion if the corresponding Shoot still exist.
```
