### PR TITLE
Use shoot framework for update and reconcile tests

### DIFF
--- a/test/system/complete_reconcile/gardener_reconcile_test.go
+++ b/test/system/complete_reconcile/gardener_reconcile_test.go
@@ -47,7 +47,7 @@ func validateFlags() {
 }
 
 func init() {
-	framework.RegisterGardenerFrameworkFlags(nil)
+	framework.RegisterShootFrameworkFlags(nil)
 }
 
 var _ = Describe("Shoot reconciliation testing", func() {

--- a/test/system/shoot_update/shoot_update_test.go
+++ b/test/system/shoot_update/shoot_update_test.go
@@ -46,7 +46,7 @@ var kubernetesVersion = flag.String("version", "", "the version to update the sh
 const UpdateKubernetesVersionTimeout = 45 * time.Minute
 
 func init() {
-	framework.RegisterGardenerFrameworkFlags(nil)
+	framework.RegisterShootFrameworkFlags(nil)
 }
 
 var _ = Describe("Shoot update testing", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
The kubernetes update test and the full reconcile test are now using the shoot framework flags.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
