### PR TITLE
Set shoot conditions to unknown if gardenlet stops sending heartbeats

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/configmap-componentconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/configmap-componentconfig.yaml
@@ -57,6 +57,9 @@ data:
         {{- if .Values.global.controller.config.controllers.seed.monitorPeriod }}
         monitorPeriod: {{ .Values.global.controller.config.controllers.seed.monitorPeriod }}
         {{- end }}
+        {{- if .Values.global.controller.config.controllers.seed.shootMonitorPeriod }}
+        shootMonitorPeriod: {{ .Values.global.controller.config.controllers.seed.shootMonitorPeriod }}
+        {{- end }}
       {{- end }}
       shootMaintenance:
         concurrentSyncs: {{ required ".Values.global.controller.config.controllers.shootMaintenance.concurrentSyncs is required" .Values.global.controller.config.controllers.shootMaintenance.concurrentSyncs }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -192,6 +192,7 @@ global:
           concurrentSyncs: 5
           syncPeriod: 1m
           monitorPeriod: 40s
+          shootMonitorPeriod: 300s
         shootMaintenance:
           concurrentSyncs: 5
         shootQuota:

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -14,6 +14,7 @@ controllers:
     concurrentSyncs: 5
     syncPeriod: 30s
   # monitorPeriod: 40s
+  # shootMonitorPeriod: 300s
   shootMaintenance:
     concurrentSyncs: 5
   shootHibernation:

--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -7274,5 +7274,9 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
+<<<<<<< HEAD
 on git commit <code>753d7857c</code>.
+=======
+on git commit <code>13d359fa9</code>.
+>>>>>>> Set shoot conditions to unknown if gardenlet stops sending heartbeats
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -3102,5 +3102,9 @@ the cluster-autoscaler properly.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
+<<<<<<< HEAD
 on git commit <code>753d7857c</code>.
+=======
+on git commit <code>13d359fa9</code>.
+>>>>>>> Set shoot conditions to unknown if gardenlet stops sending heartbeats
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,5 +555,9 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
+<<<<<<< HEAD
 on git commit <code>753d7857c</code>.
+=======
+on git commit <code>13d359fa9</code>.
+>>>>>>> Set shoot conditions to unknown if gardenlet stops sending heartbeats
 </em></p>

--- a/pkg/controllermanager/apis/config/types.go
+++ b/pkg/controllermanager/apis/config/types.go
@@ -130,6 +130,10 @@ type SeedControllerConfiguration struct {
 	// condition in `Seed` resources as `Unknown` in case the gardenlet did not send heartbeats.
 	// +optional
 	MonitorPeriod *metav1.Duration
+	// ShootMonitorPeriod is the duration after the seed controller will mark Gardener's conditions
+	// in `Shoot` resources as `Unknown` in case the gardenlet of the responsible seed cluster did
+	// not send heartbeats.
+	ShootMonitorPeriod *metav1.Duration
 	// SyncPeriod is the duration how often the existing resources are reconciled.
 	SyncPeriod metav1.Duration
 }

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -115,6 +115,10 @@ func SetDefaults_ControllerManagerConfiguration(obj *ControllerManagerConfigurat
 		v := metav1.Duration{Duration: 40 * time.Second}
 		obj.Controllers.Seed.MonitorPeriod = &v
 	}
+	if obj.Controllers.Seed.ShootMonitorPeriod == nil {
+		v := metav1.Duration{Duration: 5 * obj.Controllers.Seed.MonitorPeriod.Duration}
+		obj.Controllers.Seed.ShootMonitorPeriod = &v
+	}
 
 	if obj.Discovery.TTL == nil {
 		obj.Discovery.TTL = &metav1.Duration{Duration: DefaultDiscoveryTTL}

--- a/pkg/controllermanager/apis/config/v1alpha1/types.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/types.go
@@ -140,6 +140,11 @@ type SeedControllerConfiguration struct {
 	// condition in `Seed` resources as `Unknown` in case the gardenlet did not send heartbeats.
 	// +optional
 	MonitorPeriod *metav1.Duration `json:"monitorPeriod,omitempty"`
+	// ShootMonitorPeriod is the duration after the seed controller will mark Gardener's conditions
+	// in `Shoot` resources as `Unknown` in case the gardenlet of the responsible seed cluster did
+	// not send heartbeats.
+	// +optional
+	ShootMonitorPeriod *metav1.Duration `json:"shootMonitorPeriod,omitempty"`
 	// SyncPeriod is the duration how often the existing resources are reconciled.
 	SyncPeriod metav1.Duration `json:"syncPeriod"`
 }

--- a/pkg/controllermanager/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/zz_generated.conversion.go
@@ -532,6 +532,7 @@ func Convert_config_SecretBindingControllerConfiguration_To_v1alpha1_SecretBindi
 func autoConvert_v1alpha1_SeedControllerConfiguration_To_config_SeedControllerConfiguration(in *SeedControllerConfiguration, out *config.SeedControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = in.ConcurrentSyncs
 	out.MonitorPeriod = (*v1.Duration)(unsafe.Pointer(in.MonitorPeriod))
+	out.ShootMonitorPeriod = (*v1.Duration)(unsafe.Pointer(in.ShootMonitorPeriod))
 	out.SyncPeriod = in.SyncPeriod
 	return nil
 }
@@ -544,6 +545,7 @@ func Convert_v1alpha1_SeedControllerConfiguration_To_config_SeedControllerConfig
 func autoConvert_config_SeedControllerConfiguration_To_v1alpha1_SeedControllerConfiguration(in *config.SeedControllerConfiguration, out *SeedControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = in.ConcurrentSyncs
 	out.MonitorPeriod = (*v1.Duration)(unsafe.Pointer(in.MonitorPeriod))
+	out.ShootMonitorPeriod = (*v1.Duration)(unsafe.Pointer(in.ShootMonitorPeriod))
 	out.SyncPeriod = in.SyncPeriod
 	return nil
 }

--- a/pkg/controllermanager/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -287,6 +287,11 @@ func (in *SeedControllerConfiguration) DeepCopyInto(out *SeedControllerConfigura
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.ShootMonitorPeriod != nil {
+		in, out := &in.ShootMonitorPeriod, &out.ShootMonitorPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	out.SyncPeriod = in.SyncPeriod
 	return
 }

--- a/pkg/controllermanager/apis/config/zz_generated.deepcopy.go
+++ b/pkg/controllermanager/apis/config/zz_generated.deepcopy.go
@@ -287,6 +287,11 @@ func (in *SeedControllerConfiguration) DeepCopyInto(out *SeedControllerConfigura
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.ShootMonitorPeriod != nil {
+		in, out := &in.ShootMonitorPeriod, &out.ShootMonitorPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	out.SyncPeriod = in.SyncPeriod
 	return
 }

--- a/pkg/controllermanager/controller/seed/seed_lifecycle_control.go
+++ b/pkg/controllermanager/controller/seed/seed_lifecycle_control.go
@@ -15,17 +15,20 @@
 package seed
 
 import (
+	"context"
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions/core/v1beta1"
+	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/utils/flow"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 )
@@ -55,62 +58,153 @@ func (c *Controller) reconcileSeedKey(key string) error {
 		return err
 	}
 
-	if err := c.control.Reconcile(seed, key); err != nil {
+	fastRequeue, err := c.control.Reconcile(seed, key)
+	if err != nil {
 		return err
 	}
 
-	c.seedQueue.AddAfter(key, 10*time.Second)
+	if fastRequeue {
+		c.seedQueue.AddAfter(key, 10*time.Second)
+	} else {
+		c.seedQueue.AddAfter(key, time.Minute)
+	}
+
 	return nil
 }
 
 // ControlInterface implements the control logic for managing the lifecycle for Seeds. It is implemented as an interface to allow
 // for extensions that provide different semantics. Currently, there is only one implementation.
 type ControlInterface interface {
-	Reconcile(seed *gardencorev1beta1.Seed, key string) error
+	Reconcile(seed *gardencorev1beta1.Seed, key string) (bool, error)
 }
 
 // NewDefaultControl returns a new instance of the default implementation ControlInterface that
 // implements the documented semantics for checking the lifecycle for Seeds. You should use an instance returned from NewDefaultControl()
 // for any scenario other than testing.
-func NewDefaultControl(k8sGardenClient kubernetes.Interface, k8sGardenCoreInformers gardencoreinformers.Interface, config *config.ControllerManagerConfiguration) ControlInterface {
-	return &defaultControl{k8sGardenClient, k8sGardenCoreInformers, config}
+func NewDefaultControl(k8sGardenClient kubernetes.Interface, shootLister gardencorelisters.ShootLister, config *config.ControllerManagerConfiguration) ControlInterface {
+	return &defaultControl{k8sGardenClient, shootLister, config}
 }
 
 type defaultControl struct {
-	k8sGardenClient        kubernetes.Interface
-	k8sGardenCoreInformers gardencoreinformers.Interface
-	config                 *config.ControllerManagerConfiguration
+	k8sGardenClient kubernetes.Interface
+	shootLister     gardencorelisters.ShootLister
+	config          *config.ControllerManagerConfiguration
 }
 
-func (c *defaultControl) Reconcile(seedObj *gardencorev1beta1.Seed, key string) error {
+func (c *defaultControl) Reconcile(seedObj *gardencorev1beta1.Seed, key string) (fastRequeue bool, err error) {
 	var (
+		ctx        = context.TODO()
 		seed       = seedObj.DeepCopy()
 		seedLogger = logger.NewFieldLogger(logger.Logger, "seed", seed.Name)
 	)
 
-	// New seeds don't have conditions, i.e., gardenlet never reported anything yet. Let's wait until it sends a heart beat.
+	// New seeds don't have conditions, i.e., gardenlet never reported anything yet. Let's wait until it sends the first heart beat.
 	if len(seed.Status.Conditions) == 0 {
-		return nil
+		return true, nil
 	}
 
 	for _, condition := range seed.Status.Conditions {
-		if condition.Type == gardencorev1beta1.SeedGardenletReady && (condition.Status == gardencorev1beta1.ConditionUnknown || !condition.LastUpdateTime.UTC().Before(time.Now().UTC().Add(-c.config.Controllers.Seed.MonitorPeriod.Duration))) {
-			return nil
+		// If the `GardenletReady` condition is not yet `Unknown` then check when it most recently sent a heartbeat and wait for the
+		// configured `monitorPeriod` before proceeding with any action.
+		if condition.Type == gardencorev1beta1.SeedGardenletReady && condition.Status != gardencorev1beta1.ConditionUnknown && !condition.LastUpdateTime.UTC().Before(time.Now().UTC().Add(-c.config.Controllers.Seed.MonitorPeriod.Duration)) {
+			return true, nil
 		}
 	}
 
-	seedLogger.Infof("Setting status for seed %q to 'unknown' as gardenlet stopped reporting seed status.", seed.Name)
+	seedLogger.Debugf("Setting status for seed %q to 'Unknown' as gardenlet stopped reporting seed status.", seed.Name)
 
 	conditionGardenletReady := gardencorev1beta1helper.GetOrInitCondition(seed.Status.Conditions, gardencorev1beta1.SeedGardenletReady)
 	conditionGardenletReady = gardencorev1beta1helper.UpdatedCondition(conditionGardenletReady, gardencorev1beta1.ConditionUnknown, "SeedStatusUnknown", "Gardenlet stopped posting seed status.")
 
 	// Update Seed status
-	// We don't handle the error here as we don't want to run into the exponential backoff for the hearbeat.
-	_, err := kutil.TryUpdateSeedConditions(c.k8sGardenClient.GardenCore(), retry.DefaultBackoff, seed.ObjectMeta,
+	if _, err := kutil.TryUpdateSeedConditions(c.k8sGardenClient.GardenCore(), retry.DefaultBackoff, seed.ObjectMeta,
 		func(seed *gardencorev1beta1.Seed) (*gardencorev1beta1.Seed, error) {
 			seed.Status.Conditions = gardencorev1beta1helper.MergeConditions(seed.Status.Conditions, conditionGardenletReady)
 			return seed, nil
 		},
+	); err != nil {
+		return false, err
+	}
+
+	// If the `GardenletReady` condition is `Unknown` for at least the configured `shootMonitorPeriod` then we will mark the conditions
+	// and constraints for all the shoots that belong to this seed as `Unknown`. The reason is that the gardenlet didn't send a heartbeat
+	// anymore, hence, it most likely didn't check the shoot status. This means that the current shoot status might not reflect the truth
+	// anymore. We are indicating this by marking it as `Unknown`.
+	if !conditionGardenletReady.LastTransitionTime.UTC().Before(time.Now().UTC().Add(-c.config.Controllers.Seed.ShootMonitorPeriod.Duration)) {
+		return true, nil
+	}
+
+	seedLogger.Debugf("Gardenlet didn't send a heartbeat for at least %s - setting the shoot conditions/constraints to 'unknown' for all shoots on this seed", c.config.Controllers.Seed.ShootMonitorPeriod.Duration)
+
+	shootList, err := c.shootLister.List(labels.Everything())
+	if err != nil {
+		return false, err
+	}
+
+	var fns []flow.TaskFn
+
+	for _, shoot := range shootList {
+		if shoot.Spec.SeedName == nil || *shoot.Spec.SeedName != seed.Name {
+			continue
+		}
+
+		fns = append(fns, func(ctx context.Context) error {
+			return c.setStatusToUnknown(shoot)
+		})
+	}
+
+	if err := flow.Parallel(fns...)(ctx); err != nil {
+		return false, err
+	}
+
+	return false, nil
+}
+
+func (c *defaultControl) setStatusToUnknown(shoot *gardencorev1beta1.Shoot) error {
+	var (
+		reason = "StatusUnknown"
+		msg    = "Gardenlet stopped sending heartbeats."
+
+		conditions = map[gardencorev1beta1.ConditionType]gardencorev1beta1.Condition{
+			gardencorev1beta1.ShootAPIServerAvailable:      {},
+			gardencorev1beta1.ShootControlPlaneHealthy:     {},
+			gardencorev1beta1.ShootEveryNodeReady:          {},
+			gardencorev1beta1.ShootSystemComponentsHealthy: {},
+		}
+
+		constraints = map[gardencorev1beta1.ConditionType]gardencorev1beta1.Condition{
+			gardencorev1beta1.ShootHibernationPossible: {},
+		}
+	)
+
+	for conditionType := range conditions {
+		c := gardencorev1beta1helper.GetOrInitCondition(shoot.Status.Conditions, conditionType)
+		c = gardencorev1beta1helper.UpdatedCondition(c, gardencorev1beta1.ConditionUnknown, reason, msg)
+		conditions[conditionType] = c
+	}
+
+	for conditionType := range constraints {
+		c := gardencorev1beta1helper.GetOrInitCondition(shoot.Status.Constraints, conditionType)
+		c = gardencorev1beta1helper.UpdatedCondition(c, gardencorev1beta1.ConditionUnknown, reason, msg)
+		constraints[conditionType] = c
+	}
+
+	_, err := kutil.TryUpdateShootStatus(c.k8sGardenClient.GardenCore(), retry.DefaultBackoff, shoot.ObjectMeta,
+		func(shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
+			shoot.Status.Conditions = gardencorev1beta1helper.MergeConditions(shoot.Status.Conditions, conditionMapToConditions(conditions)...)
+			shoot.Status.Constraints = gardencorev1beta1helper.MergeConditions(shoot.Status.Constraints, conditionMapToConditions(constraints)...)
+			return shoot, nil
+		},
 	)
 	return err
+}
+
+func conditionMapToConditions(m map[gardencorev1beta1.ConditionType]gardencorev1beta1.Condition) []gardencorev1beta1.Condition {
+	output := make([]gardencorev1beta1.Condition, 0, len(m))
+
+	for _, condition := range m {
+		output = append(output, condition)
+	}
+
+	return output
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The gardener-controller-manager now sets all shoot conditions and constraints to `Unknown` in case the responsible gardenlet is not sending heartbeats anymore.
Concretely, if the `GardenletReady` condition is `Unknown` for at least the configured `shootMonitorPeriod` then we will mark the conditions and constraints for all the shoots that belong to this seed as `Unknown`. The reason is that the gardenlet didn't send a heartbeat anymore, hence, it most likely didn't check the shoot status. This means that the current shoot status might not reflect the truth anymore. We are indicating this by marking it as `Unknown`.

**Which issue(s) this PR fixes**:
Fixes #1877

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The gardener-controller-manager configuration now supports a new `.controllers.seed.shootMonitorPeriod` field. This field controls the time after which the controller-manager will set the status to `Unknown` for all the shoot conditions and constraints in case the responsible gardenlet does not send heartbeats anymore.
```
