### PR TITLE
Remove check for worker pool zones

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -169,11 +169,6 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, deletionTimestamp
 	allErrs = append(allErrs, validateKubeControllerManagerConfiguration(newSpec.Kubernetes.KubeControllerManager, oldSpec.Kubernetes.KubeControllerManager, fldPath.Child("kubernetes", "kubeControllerManager"))...)
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Provider.Type, oldSpec.Provider.Type, fldPath.Child("provider", "type"))...)
-	for i, worker := range newSpec.Provider.Workers {
-		if ShouldEnforceImmutability(worker.Zones, oldSpec.Provider.Workers[i].Zones) {
-			allErrs = append(allErrs, apivalidation.ValidateImmutableField(worker.Zones, oldSpec.Provider.Workers[i].Zones, fldPath.Child("provider", "workers").Index(i).Child("zones"))...)
-		}
-	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Networking.Type, oldSpec.Networking.Type, fldPath.Child("networking", "type"))...)
 	if oldSpec.Networking.Pods != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Gardener cannot make assumptions about the `zones` of worker pools, so it shouldn't validate anything here. Instead, the provider extension is responsible.

PS: I anyways added tests for adding, removing, and swapping worker pools to g/g validation.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
A bug has been fixed that prevented worker pools from being added to existing shoot clusters.
```
