### PR TITLE
Expose kube-scheduler and cluster-autoscaler logs to end users

### DIFF
--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
@@ -252,7 +252,17 @@ data:
 
     [FILTER]
         Name record_modifier
+        Match *kube-scheduler*
+        Record type user
+
+    [FILTER]
+        Name record_modifier
         Match *cloud-controller-manager*
+        Record type user
+
+    [FILTER]
+        Name record_modifier
+        Match *cluster-autoscaler*
         Record type user
 
     [FILTER]


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR the end users will be able to see the logs from `kube-scheduler` and `cluster-autoscaler` in the Kibana dashboard, just like they are already doing for kube-apiserver, kube-controller-manager and cloud-controller-manager.


**Which issue(s) this PR fixes**:
Fixes #logging

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The Gardener users now have access to the logs from the `kube-scheduler` and `cluster-autoscaler` of their shoot clusters.
```
