### PR TITLE
Allow authenticated users to read `Seed` resources

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -44,12 +44,12 @@ aggregationRule:
       gardener.cloud/role: project-member
 rules: []
 
-# Cluster role with cluster role binding allowing all authenticated users to read the cloudprofiles
+# Cluster role with cluster role binding allowing all authenticated users to read some global resources
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: gardener.cloud:system:cloudprofiles
+  name: gardener.cloud:system:read-global-resources
   labels:
     app: gardener
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -60,6 +60,7 @@ rules:
   - core.gardener.cloud
   resources:
   - cloudprofiles
+  - seeds
   verbs:
   - get
   - list
@@ -68,7 +69,7 @@ rules:
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: gardener.cloud:system:cloudprofiles
+  name: gardener.cloud:system:read-global-resources
   labels:
     app: gardener
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -77,7 +78,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gardener.cloud:system:cloudprofiles
+  name: gardener.cloud:system:read-global-resources
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group


### PR DESCRIPTION
**What this PR does / why we need it**:
We should expose in which regions and with which configuration (networking, etc.) we have seed clusters to our end-users so that they can better define their shoot resources (e.g., disjunct networks).

/cc @vlerenc 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The `gardener.cloud:system:cloudprofiles` `ClusterRole` and `ClusterRoleBinding` resources have been renamed to `gardener.cloud:system:read-global-resources`. They are now allowing all authenticated users to read `CloudProfile` and `Seed` resources.
```
```noteworthy user
Authenticated users can now read/list/watch `Seed` resources.
```
