### PR TITLE
Fix check in SecretBinding controller for secret release

### DIFF
--- a/pkg/controllermanager/controller/secretbinding/secretbinding_control_test.go
+++ b/pkg/controllermanager/controller/secretbinding/secretbinding_control_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -33,8 +34,12 @@ var _ = Describe("SecretBindingControl", func() {
 			gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory
 			c                         *defaultControl
 
-			secretNamespace = "foo"
-			secretName      = "bar"
+			secretBinding1Namespace = "foo"
+			secretBinding1Name      = "bar"
+			secretBinding2Namespace = "baz"
+			secretBinding2Name      = "bax"
+			secretNamespace         = "foo"
+			secretName              = "bar"
 		)
 
 		BeforeEach(func() {
@@ -46,15 +51,19 @@ var _ = Describe("SecretBindingControl", func() {
 			c = &defaultControl{secretBindingLister: secretBindingLister}
 		})
 
-		It("should return true as no other secretbinding references the secret", func() {
-			allowed, err := c.mayReleaseSecret(secretNamespace, secretName)
+		It("should return true as no other secretbinding exists", func() {
+			allowed, err := c.mayReleaseSecret(secretBinding1Namespace, secretBinding1Name, secretNamespace, secretName)
 
 			Expect(allowed).To(BeTrue())
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should return false as another secretbinding references the secret", func() {
+		It("should return true as no other secretbinding references the secret", func() {
 			secretBinding := &gardencorev1beta1.SecretBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretBinding1Name,
+					Namespace: secretBinding1Namespace,
+				},
 				SecretRef: corev1.SecretReference{
 					Namespace: secretNamespace,
 					Name:      secretName,
@@ -63,7 +72,27 @@ var _ = Describe("SecretBindingControl", func() {
 
 			Expect(gardenCoreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(secretBinding)).To(Succeed())
 
-			allowed, err := c.mayReleaseSecret(secretNamespace, secretName)
+			allowed, err := c.mayReleaseSecret(secretBinding1Namespace, secretBinding1Name, secretNamespace, secretName)
+
+			Expect(allowed).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return false as another secretbinding references the secret", func() {
+			secretBinding := &gardencorev1beta1.SecretBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretBinding2Name,
+					Namespace: secretBinding2Namespace,
+				},
+				SecretRef: corev1.SecretReference{
+					Namespace: secretNamespace,
+					Name:      secretName,
+				},
+			}
+
+			Expect(gardenCoreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(secretBinding)).To(Succeed())
+
+			allowed, err := c.mayReleaseSecret(secretBinding1Namespace, secretBinding1Name, secretNamespace, secretName)
 
 			Expect(allowed).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
@@ -74,7 +103,7 @@ var _ = Describe("SecretBindingControl", func() {
 				SecretBindingLister: c.secretBindingLister,
 			}
 
-			allowed, err := c.mayReleaseSecret(secretNamespace, secretName)
+			allowed, err := c.mayReleaseSecret(secretBinding1Namespace, secretBinding1Name, secretNamespace, secretName)
 
 			Expect(allowed).To(BeFalse())
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:
The `mayReleaseSecret` function is called when a `SecretBinding` has a deletion timestamp. It lists all `SecretBinding`s in all namespaces, however, it was not excluding the `SecretBinding` it was called for. Hence, finalizer release for secrets could never succeed.

**Special notes for your reviewer**:
Thanks @Diaphteiros and @timuthy for reporting!

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The controller-manager does now correctly release the finalizer in`Secret`s if no referencing `SecretBinding`s exist anymore.
```
