### PR TITLE
Allow gardenlet to in-cluster kubeconfig for shoots

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -42,6 +42,12 @@ const (
 	// controllers in order to communicate with the shoot's API server. The client certificate has administrator
 	// privileges.
 	SecretNameGardener = "gardener"
+	// SecretNameGardenerInternal is a constant for the name of a Kubernetes secret object that contains the client
+	// certificate and a kubeconfig for a shoot cluster. It is used by Gardener and can be used by extension
+	// controllers in order to communicate with the shoot's API server. The client certificate has administrator
+	// privileges. The difference to the "gardener" secret is that is contains the in-cluster endpoint as address to
+	// for the shoot API server instead the DNS name or load balancer address.
+	SecretNameGardenerInternal = "gardener-internal"
 
 	// DeploymentNameClusterAutoscaler is a constant for the name of a Kubernetes deployment object that contains
 	// the cluster-autoscaler pod.

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -122,7 +122,7 @@ func (b *Botanist) generateDownloaderConfig(machineImageName string) map[string]
 	return map[string]interface{}{
 		"type":    machineImageName,
 		"purpose": extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
-		"server":  fmt.Sprintf("https://%s", b.Shoot.ComputeAPIServerURL(false, true, b.APIServerAddress)),
+		"server":  fmt.Sprintf("https://%s", b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true)),
 	}
 }
 

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -174,7 +174,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 			},
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false, b.APIServerAddress),
+				APIServerURL: b.Shoot.ComputeInClusterAPIServerAddress(true),
 			},
 		},
 
@@ -209,7 +209,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false, b.APIServerAddress),
+				APIServerURL: b.Shoot.ComputeInClusterAPIServerAddress(true),
 			},
 		},
 
@@ -244,7 +244,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false, b.APIServerAddress),
+				APIServerURL: b.Shoot.ComputeInClusterAPIServerAddress(true),
 			},
 		},
 
@@ -264,7 +264,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false, b.APIServerAddress),
+				APIServerURL: b.Shoot.ComputeInClusterAPIServerAddress(true),
 			},
 		},
 
@@ -284,7 +284,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(false, true, b.APIServerAddress),
+				APIServerURL: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
 			},
 		},
 
@@ -304,7 +304,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false, b.APIServerAddress),
+				APIServerURL: b.Shoot.ComputeInClusterAPIServerAddress(true),
 			},
 		},
 
@@ -324,7 +324,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(true, false, b.APIServerAddress),
+				APIServerURL: b.Shoot.ComputeInClusterAPIServerAddress(true),
 			},
 		},
 
@@ -359,7 +359,25 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(false, true, b.APIServerAddress),
+				APIServerURL: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
+			},
+		},
+		&secrets.ControlPlaneSecretConfig{
+			CertificateSecretConfig: &secrets.CertificateSecretConfig{
+				Name: v1beta1constants.SecretNameGardenerInternal,
+
+				CommonName:   gardencorev1beta1.GardenerName,
+				Organization: []string{user.SystemPrivilegedGroup},
+				DNSNames:     nil,
+				IPAddresses:  nil,
+
+				CertType:  secrets.ClientCert,
+				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
+			},
+
+			KubeConfigRequest: &secrets.KubeConfigRequest{
+				ClusterName:  b.Shoot.SeedNamespace,
+				APIServerURL: b.Shoot.ComputeInClusterAPIServerAddress(false),
 			},
 		},
 
@@ -379,7 +397,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 			KubeConfigRequest: &secrets.KubeConfigRequest{
 				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeAPIServerURL(false, true, b.APIServerAddress),
+				APIServerURL: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
 			},
 		},
 
@@ -544,7 +562,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 
 		KubeConfigRequest: &secrets.KubeConfigRequest{
 			ClusterName:  b.Shoot.SeedNamespace,
-			APIServerURL: b.Shoot.ComputeAPIServerURL(false, false, b.APIServerAddress),
+			APIServerURL: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, false),
 		},
 	})
 
@@ -563,7 +581,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 		},
 		KubeConfigRequest: &secrets.KubeConfigRequest{
 			ClusterName:  b.Shoot.SeedNamespace,
-			APIServerURL: fmt.Sprintf("%s.%s.svc", v1beta1constants.DeploymentNameKubeAPIServer, b.Shoot.SeedNamespace),
+			APIServerURL: b.Shoot.ComputeInClusterAPIServerAddress(false),
 		},
 	})
 
@@ -582,7 +600,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 		},
 		KubeConfigRequest: &secrets.KubeConfigRequest{
 			ClusterName:  b.Shoot.SeedNamespace,
-			APIServerURL: b.Shoot.ComputeAPIServerURL(false, true, b.APIServerAddress),
+			APIServerURL: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
 		},
 	})
 

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"net"
 	"strings"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -189,12 +190,32 @@ func (o *Operation) InitializeShootClients() error {
 		}
 	}
 
-	k8sShootClient, err := kubernetes.NewClientFromSecret(o.K8sSeedClient, o.Shoot.SeedNamespace, gardencorev1beta1.GardenerName,
+	secretName := v1beta1constants.SecretNameGardener
+	// If the gardenlet runs in the same cluster like the API server of the shoot then use the internal kubeconfig
+	// and communicate internally. Otherwise, fall back to the "external" kubeconfig and communicate via the
+	// load balancer of the shoot API server.
+	addr, err := net.LookupHost(o.Shoot.ComputeInClusterAPIServerAddress(false))
+	if err != nil {
+		o.Logger.Warnf("service DNS name lookup of kube-apiserver failed (%+v), falling back to external kubeconfig", err)
+	} else if len(addr) > 0 {
+		secretName = v1beta1constants.SecretNameGardenerInternal
+	}
+
+	k8sShootClient, err := kubernetes.NewClientFromSecret(o.K8sSeedClient, o.Shoot.SeedNamespace, secretName,
 		kubernetes.WithClientConnectionOptions(o.Config.ShootClientConnection.ClientConnectionConfiguration),
 		kubernetes.WithClientOptions(client.Options{
 			Scheme: kubernetes.ShootScheme,
 		}),
 	)
+	// TODO: This if-condition can be removed in a future version when all shoots were reconciled with Gardener v1.1 version.
+	if secretName == v1beta1constants.SecretNameGardenerInternal && err != nil && apierrors.IsNotFound(err) {
+		k8sShootClient, err = kubernetes.NewClientFromSecret(o.K8sSeedClient, o.Shoot.SeedNamespace, v1beta1constants.SecretNameGardener,
+			kubernetes.WithClientConnectionOptions(o.Config.ShootClientConnection.ClientConnectionConfiguration),
+			kubernetes.WithClientOptions(client.Options{
+				Scheme: kubernetes.ShootScheme,
+			}),
+		)
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -203,14 +203,19 @@ func (s *Shoot) GetReplicas(wokenUp int) int {
 	return wokenUp
 }
 
-// ComputeAPIServerURL takes a boolean value identifying whether the component connecting to the API server
-// runs in the Seed cluster <runsInSeed>, and a boolean value <useInternalClusterDomain> which determines whether the
-// internal or the external cluster domain should be used.
-func (s *Shoot) ComputeAPIServerURL(runsInSeed, useInternalClusterDomain bool, apiServerAddress string) string {
-	if runsInSeed {
-		return v1beta1constants.DeploymentNameKubeAPIServer
+// ComputeInClusterAPIServerAddress returns the internal address for the shoot API server depending on whether
+// the caller runs in the shoot namespace or not.
+func (s *Shoot) ComputeInClusterAPIServerAddress(runsInShootNamespace bool) string {
+	url := v1beta1constants.DeploymentNameKubeAPIServer
+	if !runsInShootNamespace {
+		url = fmt.Sprintf("%s.%s.svc", url, s.SeedNamespace)
 	}
+	return url
+}
 
+// ComputeOutOfClusterAPIServerAddress returns the external address for the shoot API server depending on whether
+// the caller wants to use the internal cluster domain and whether DNS is disabled on this seed.
+func (s *Shoot) ComputeOutOfClusterAPIServerAddress(apiServerAddress string, useInternalClusterDomain bool) string {
 	if s.DisableDNS {
 		return apiServerAddress
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The gardenlet does now create a new `gardener-internal` secret in every shoot namespace that can be used to communicate with the shoot API server via its Kubernetes service (in-cluster). If it does not run in the same seed cluster then it falls back to the `gardener` secret which contains a kubeconfig with the public address to the shoot's API server.

**Special notes for your reviewer**:
/cc @vlerenc 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The gardenlet does now create a new `gardener-internal` secret in every shoot namespace that can be used to communicate with the shoot API server via its Kubernetes service (in-cluster). If it does not run in the same seed cluster then it falls back to the `gardener` secret which contains a kubeconfig with the public address to the shoot's API server.
```
