### PR TITLE
Add Gardener managed label constants and helpers

### DIFF
--- a/docs/extensions/controlplane-exposure.md
+++ b/docs/extensions/controlplane-exposure.md
@@ -9,7 +9,10 @@ Now, Gardener commissions an external, provider-specific controller to take over
 As mentioned in the [controlplane](controlplane.md) document Gardener shall not deploy any other provider-specific component.
 Instead, it creates a `ControlPlane` CRD with purpose `exposure` that should be picked up by provider extensions.
 Its purpose is to trigger the deployment of such provider-specific components in the shoot namespace in the seed cluster that are needed to expose the kube-apiserver.
-The shoot cluster's kube-apiserver are exposed via a `Service` of type `LoadBalancer`. This load balancer is part of the seed provider's infrastructure. As the seed provider might differ from the shoot provider (you may run the control plane of an Azure shoot in a GCP seed) it's the seed provider extension controller that should act on the `ControlPlane` resources with purpose `exposure`.
+
+The shoot cluster's kube-apiserver are exposed via a `Service` of type `LoadBalancer` from the shoot provider (you may run the control plane of an Azure shoot in a GCP seed) it's the seed provider extension controller that should act on the `ControlPlane` resources with purpose `exposure`.
+
+If [SNI](https://github.com/gardener/gardener/blob/master/docs/proposals/08-shoot-apiserver-via-sni.md) is enabled, then the `Service` from above is of type `ClusterIP` and  Gardner will not create `ControlPlane` resources with purpose `exposure`.
 
 ## What needs to be implemented to support a new infrastructure provider?
 

--- a/docs/extensions/controlplane-webhooks.md
+++ b/docs/extensions/controlplane-webhooks.md
@@ -52,10 +52,13 @@ The kube-apiserver command line **shall not** contain any provider-specific flag
 
 These flags can be added by webhooks if needed.
 
-The kube-apiserver command line **may** contain a number of additional provider-independent flags. In general, webhooks should ignore these unless they are known to interfere with the desired kube-apiserver behavior for the specific provider. Among the flags to be considered are:
+The `kube-apiserver` command line **may** contain a number of additional provider-independent flags. In general, webhooks should ignore these unless they are known to interfere with the desired kube-apiserver behavior for the specific provider. Among the flags to be considered are:
 
 * `--endpoint-reconciler-type`
+* `--advertise-address`
 * `--feature-gates`
+
+Gardener **may** use [SNI](https://github.com/gardener/gardener/blob/master/docs/proposals/08-shoot-apiserver-via-sni.md) to expose the apiserver (`APIServerSNI` feature gate). In this case, Gardener **shall** label the `kube-apiserver`'s `Deployment` with `core.gardener.cloud/apiserver-exposure: gardener-managed` label and expects that the `--endpoint-reconciler-type` and `--advertise-address` flags are not modified.
 
 The `--enable-admission-plugins` flag **may** contain admission plugins that are not compatible with CSI plugins such as `PersistentVolumeLabel`. Webhooks should therefore ensure that such admission plugins are either explicitly enabled (if CSI plugins are not used) or disabled (otherwise).
 
@@ -63,7 +66,9 @@ The `env` field of the `kube-apiserver` container **shall not** contain any prov
 
 The `volumes` field of the pod template of the `kube-apiserver` deployment, and respectively the `volumeMounts` field of the `kube-apiserver` container **shall not** contain any provider-specific `Secret` or `ConfigMap` resources. If such resources should be mounted as volumes, this should be done by webhooks.
 
-The `kube-apiserver` service **shall** be of type `LoadBalancer` but **shall not** contain any provider-specific annotations that may be needed to actually provision a load balancer resource in the Seed provider's cloud. If any such annotations are needed, they should be added by webhooks (typically `controlplaneexposure` webhooks).
+The `kube-apiserver` `Service` **may** be of type `LoadBalancer`, but **shall not** contain any provider-specific annotations that may be needed to actually provision a load balancer resource in the Seed provider's cloud. If any such annotations are needed, they should be added by webhooks (typically `controlplaneexposure` webhooks).
+
+The `kube-apiserver` `Service` **shall** be of type `ClusterIP`, if Gardener is using [SNI](https://github.com/gardener/gardener/blob/master/docs/proposals/08-shoot-apiserver-via-sni.md) to expose the apiserver (`APIServerSNI` feature gate). In this case, Gardener **shall** label this `Service` with `core.gardener.cloud/apiserver-exposure: gardener-managed` label and expects that no mutations happen.
 
 ### kube-controller-manager
 

--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -204,6 +204,13 @@ const (
 	// LabelScheduler is a constant for a label for the kube-scheduler.
 	LabelScheduler = "scheduler"
 
+	// LabelAPIServerExposure is a constant for label key which gardener can add to various objects related
+	// to kube-apiserver exposure.
+	LabelAPIServerExposure = "core.gardener.cloud/apiserver-exposure"
+	// LabelAPIServerExposureGardenerManaged is a constant for label value which gardener sets on the label key
+	// "core.gardener.cloud/apiserver-exposure" to indicate that it's responsible for apiserver exposure (via SNI).
+	LabelAPIServerExposureGardenerManaged = "gardener-managed"
+
 	// GardenNamespace is the namespace in which the configuration and secrets for
 	// the Gardener controller manager will be stored (e.g., secrets for the Seed clusters).
 	// It is also used by the gardener-apiserver.

--- a/pkg/apis/core/v1alpha1/helper/helper.go
+++ b/pkg/apis/core/v1alpha1/helper/helper.go
@@ -752,3 +752,19 @@ func GetExtensionResourceState(extensionsResourcesStates []gardencorev1alpha1.Ex
 	}
 	return -1, nil
 }
+
+// IsAPIServerExposureManaged returns true, if the Object is managed by Gardener for API server exposure.
+// This indicates to extensions that they should not mutate the object.
+// Gardener marks the kube-apiserver Service and Deployment as managed by it when it uses SNI to expose them.
+func IsAPIServerExposureManaged(obj metav1.Object) bool {
+	if obj == nil {
+		return false
+	}
+
+	if v, found := obj.GetLabels()[v1alpha1constants.LabelAPIServerExposure]; found &&
+		v == v1alpha1constants.LabelAPIServerExposureGardenerManaged {
+		return true
+	}
+
+	return false
+}

--- a/pkg/apis/core/v1alpha1/helper/helpers_test.go
+++ b/pkg/apis/core/v1alpha1/helper/helpers_test.go
@@ -850,4 +850,32 @@ var _ = Describe("helper", func() {
 			false,
 		),
 	)
+
+	DescribeTable("#IsAPIServerExposureManaged",
+		func(obj metav1.Object, expected bool) {
+			Expect(IsAPIServerExposureManaged(obj)).To(Equal(expected))
+		},
+		Entry("object is nil",
+			nil,
+			false,
+		),
+		Entry("label is not present",
+			&metav1.ObjectMeta{Labels: map[string]string{
+				"foo": "bar",
+			}},
+			false,
+		),
+		Entry("label's value is not the same",
+			&metav1.ObjectMeta{Labels: map[string]string{
+				"core.gardener.cloud/apiserver-exposure": "some-dummy-value",
+			}},
+			false,
+		),
+		Entry("label's value is gardener-managed",
+			&metav1.ObjectMeta{Labels: map[string]string{
+				"core.gardener.cloud/apiserver-exposure": "gardener-managed",
+			}},
+			true,
+		),
+	)
 })

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -204,6 +204,13 @@ const (
 	// LabelScheduler is a constant for a label for the kube-scheduler.
 	LabelScheduler = "scheduler"
 
+	// LabelAPIServerExposure is a constant for label key which gardener can add to various objects related
+	// to kube-apiserver exposure.
+	LabelAPIServerExposure = "core.gardener.cloud/apiserver-exposure"
+	// LabelAPIServerExposureGardenerManaged is a constant for label value which gardener sets on the label key
+	// "core.gardener.cloud/apiserver-exposure" to indicate that it's responsible for apiserver exposure (via SNI).
+	LabelAPIServerExposureGardenerManaged = "gardener-managed"
+
 	// GardenNamespace is the namespace in which the configuration and secrets for
 	// the Gardener controller manager will be stored (e.g., secrets for the Seed clusters).
 	// It is also used by the gardener-apiserver.

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -742,3 +742,19 @@ func WrapWithLastError(err error, lastError *gardencorev1beta1.LastError) error 
 	}
 	return errors.Wrapf(err, "last error: %s", lastError.Description)
 }
+
+// IsAPIServerExposureManaged returns true, if the Object is managed by Gardener for API server exposure.
+// This indicates to extensions that they should not mutate the object.
+// Gardener marks the kube-apiserver Service and Deployment as managed by it when it uses SNI to expose them.
+func IsAPIServerExposureManaged(obj metav1.Object) bool {
+	if obj == nil {
+		return false
+	}
+
+	if v, found := obj.GetLabels()[v1beta1constants.LabelAPIServerExposure]; found &&
+		v == v1beta1constants.LabelAPIServerExposureGardenerManaged {
+		return true
+	}
+
+	return false
+}

--- a/pkg/apis/core/v1beta1/helper/helpers_test.go
+++ b/pkg/apis/core/v1beta1/helper/helpers_test.go
@@ -850,4 +850,32 @@ var _ = Describe("helper", func() {
 			false,
 		),
 	)
+
+	DescribeTable("#IsAPIServerExposureManaged",
+		func(obj metav1.Object, expected bool) {
+			Expect(IsAPIServerExposureManaged(obj)).To(Equal(expected))
+		},
+		Entry("object is nil",
+			nil,
+			false,
+		),
+		Entry("label is not present",
+			&metav1.ObjectMeta{Labels: map[string]string{
+				"foo": "bar",
+			}},
+			false,
+		),
+		Entry("label's value is not the same",
+			&metav1.ObjectMeta{Labels: map[string]string{
+				"core.gardener.cloud/apiserver-exposure": "some-dummy-value",
+			}},
+			false,
+		),
+		Entry("label's value is gardener-managed",
+			&metav1.ObjectMeta{Labels: map[string]string{
+				"core.gardener.cloud/apiserver-exposure": "gardener-managed",
+			}},
+			true,
+		),
+	)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

The new label `core.gardener.cloud/apiserver-exposure: gardener-managed` will be used by Gardener to indicate to extensions that it's responsible for managing the said resource. All extensions should check this label (using the helper `IsAPIServerExposureManaged` function) and not modify the resource when they are handling API server exposure. 

In practice all extension controllers modify either the kube-apiserver's `Service` and/or `Deployment` (mainly `--advertise-address`) flags.

- [aws](https://github.com/gardener/gardener-extension-provider-aws/blob/97eb622f329df8405206a05f9847bacf990aa0bb/pkg/webhook/controlplaneexposure/ensurer.go#L45-L67)
- [gcp](https://github.com/gardener/gardener-extension-provider-gcp/blob/72e88bfcba90b142bb260859c51b319b78e1fbc4/pkg/webhook/controlplaneexposure/ensurer.go#L56-L77)
- [azure](https://github.com/gardener/gardener-extension-provider-azure/blob/51c11924610d4b5e9c7db72732f7b1558bbdf05e/pkg/webhook/controlplaneexposure/ensurer.go#L56-L88)
- [openstack](https://github.com/gardener/gardener-extension-provider-openstack/blob/7db5ba187403a4edde126f81b390dd8986de1f05/pkg/webhook/controlplaneexposure/ensurer.go#L56-L78)
- [alicloud](https://github.com/gardener/gardener-extension-provider-alicloud/blob/719048d7ef92e4798fb7977ed88c7cc0e8f7317a/pkg/webhook/controlplaneexposure/ensurer.go#L58-L80)
- [vsphere](https://github.com/gardener/gardener-extension-provider-vsphere/blob/89626fab2dd4438ee239082e455140fc70980c82/pkg/webhook/controlplaneexposure/ensurer.go#L56-L78)


which would break SNI setup.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This a prerequisite for #1135

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action developer
The new label `core.gardener.cloud/apiserver-exposure: gardener-managed` will be used by Gardener to indicate to extensions that Gardener is responsible for managing the said resource. All extensions should check this label (using the helper `IsAPIServerExposureManaged` function) and not modify the resource when they are handling API server exposure. 
```
