### PR TITLE
Increase sync period for central gardener-resource-manager

### DIFF
--- a/charts/seed-bootstrap/templates/gardener-resource-manager/deployment.yaml
+++ b/charts/seed-bootstrap/templates/gardener-resource-manager/deployment.yaml
@@ -33,6 +33,7 @@ spec:
         - --max-concurrent-workers={{ .Values.gardenerResourceManager.concurrentSyncs }}
         - --resource-class={{ .Values.gardenerResourceManager.resourceClass }}
         - --sync-period={{ .Values.gardenerResourceManager.syncPeriod }}
+        - --health-sync-period={{ .Values.gardenerResourceManager.healthSyncPeriod }}
         {{- if .Values.gardenerResourceManager.resources }}
         resources:
 {{ toYaml .Values.gardenerResourceManager.resources | indent 10 }}

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -123,6 +123,7 @@ gardenerResourceManager:
       memory: 512Mi
   replicas: 1
   resourceClass: seed
-  syncPeriod: 1m0s
+  syncPeriod: 1h0m0s
+  healthSyncPeriod: 1m0s
   concurrentSyncs: 20
   podAnnotations: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR increases the sync period for the central seed grm to `1h` as it is not required to do it more often (only operators have access to the seed). For the per-shoot grm we don't change the sync period, however, we would like to get https://github.com/gardener/gardener-resource-manager/pull/33 in (with a separate PR once a release of g/grm is built) which drastically decreases the cache resync period. The motivation for both is to reduce unnecessary egress traffic.

**Special notes for your reviewer**:
* /cc @vlerenc
* Also related: https://github.com/gardener/gardener-resource-manager/pull/33 and a new g/grm release.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
NONE
```
