### PR TITLE
[release-v1.0] Make volume type optional for Worker resources

### DIFF
--- a/charts/seed-bootstrap/templates/extensions/crd-worker.yaml
+++ b/charts/seed-bootstrap/templates/extensions/crd-worker.yaml
@@ -124,7 +124,6 @@ spec:
                         description: Type is the type of the volume.
                         type: string
                     required:
-                    - type
                     - size
                     type: object
                   zones:


### PR DESCRIPTION
**What this PR does / why we need it**:
Certain extension controllers might not need the type information of a volume. Therefore, this field should be optional for `Worker` resources.

**Special notes for your reviewer**:
Backport of https://github.com/gardener/gardener/pull/1930

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
A bug has been fixed which caused a reconciliation failure for shoot clusters which specify `spec.provider.workers[].volume.size` without `spec.provider.workers[].volume.type`.
```

