### PR TITLE
Allow sha256 image tags in imagevector

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -61,7 +61,7 @@ spec:
       {{- end }}
       containers:
       - name: gardener-apiserver
-        image: {{ required ".Values.global.apiserver.image.repository is required" .Values.global.apiserver.image.repository }}:{{ required ".Values.global.apiserver.image.tag is required" .Values.global.apiserver.image.tag }}
+        image: {{ include "utils-templates.image" .Values.global.apiserver.image }}
         imagePullPolicy: {{ .Values.global.apiserver.image.pullPolicy }}
         command:
         - /gardener-apiserver

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
@@ -54,7 +54,7 @@ spec:
       {{- end }}
       containers:
       - name: gardener-controller-manager
-        image: {{ required ".Values.global.controller.image.repository is required" .Values.global.controller.image.repository }}:{{ required ".Values.global.controller.image.tag is required" .Values.global.controller.image.tag }}
+        image: {{ include "utils-templates.image" .Values.global.controller.image }}
         imagePullPolicy: {{ .Values.global.controller.image.pullPolicy }}
         command:
         - /gardener-controller-manager

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
@@ -49,7 +49,7 @@ spec:
       {{- end }}
       containers:
       - name: gardener-scheduler
-        image: {{ required ".Values.global.scheduler.image.repository is required" .Values.global.scheduler.image.repository }}:{{ required ".Values.global.scheduler.image.tag is required" .Values.global.scheduler.image.tag }}
+        image: {{ include "utils-templates.image" .Values.global.scheduler.image }}
         imagePullPolicy: {{ .Values.global.scheduler.image.pullPolicy }}
         command:
         - /gardener-scheduler

--- a/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
       {{- end }}
       containers:
       - name: gardenlet
-        image: {{ required ".Values.global.gardenlet.image.repository is required" .Values.global.gardenlet.image.repository }}:{{ required ".Values.global.gardenlet.image.tag is required" .Values.global.gardenlet.image.tag }}
+        image: {{ include "utils-templates.image" .Values.global.gardenlet.image }}
         imagePullPolicy: {{ .Values.global.gardenlet.image.pullPolicy }}
         command:
         - /gardenlet

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/_init-containers.tpl
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/_init-containers.tpl
@@ -25,7 +25,7 @@
       resourceFieldRef:
         resource: limits.cpu
   resources:
-{{- include "util-templates.resource-quantity" .Values.elasticsearch.sgadmin | indent 4 }}
+{{- include "utils-templates.resource-quantity" .Values.elasticsearch.sgadmin | indent 4 }}
   httpHeaders:
     - name: Authorization
       value: Basic {{ .Values.elasticsearch.readinessProbe.httpAuth }}

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/statefulset.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/statefulset.yaml
@@ -64,7 +64,7 @@ spec:
             resourceFieldRef:
               resource: limits.cpu
         resources:
-{{- include "util-templates.resource-quantity" .Values.elasticsearch | indent 10 }}
+{{- include "utils-templates.resource-quantity" .Values.elasticsearch | indent 10 }}
         ports:
         - containerPort: {{ .Values.global.elasticsearchPorts.db }}
           name: http

--- a/charts/utils-templates/templates/_image.tpl
+++ b/charts/utils-templates/templates/_image.tpl
@@ -1,0 +1,7 @@
+{{- define "utils-templates.image" -}}
+{{- if hasPrefix "sha256:" (required "$.tag is required" $.tag) -}}
+{{ required "$.repository is required" $.repository }}@{{ required "$.tag is required" $.tag }}
+{{- else -}}
+{{ required "$.repository is required" $.repository }}:{{ required "$.tag is required" $.tag }}
+{{- end -}}
+{{- end -}}

--- a/charts/utils-templates/templates/_resources.tpl
+++ b/charts/utils-templates/templates/_resources.tpl
@@ -2,7 +2,7 @@
 util-templates.resource-quantity returns resource quantity based on number of objects (such as nodes, pods etc..),
 resource per object, object weight and base resource quantity.
 */}}
-{{- define "util-templates.resource-quantity" -}}
+{{- define "utils-templates.resource-quantity" -}}
 {{- range $resourceKey, $resourceValue := (required "$.resource is required" $.resources) }}
 {{ $resourceKey }}:
 {{- range $unit, $r := $resourceValue }}

--- a/pkg/gardenlet/controller/shoot/seed_registration_control.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control.go
@@ -589,12 +589,21 @@ func deployGardenlet(ctx context.Context, k8sGardenClient kubernetes.Interface, 
 		imageVectorOverwrite = string(data)
 	}
 
+	var (
+		repository = gardenletImage.String()
+		tag        = version.Get().GitVersion
+	)
+	if gardenletImage.Tag != nil {
+		repository = gardenletImage.Repository
+		tag = *gardenletImage.Tag
+	}
+
 	values := map[string]interface{}{
 		"global": map[string]interface{}{
 			"gardenlet": map[string]interface{}{
 				"image": map[string]interface{}{
-					"repository": gardenletImage.String(),
-					"tag":        version.Get().GitVersion,
+					"repository": repository,
+					"tag":        tag,
 				},
 				"revisionHistoryLimit": 0,
 				"vpa":                  true,

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -374,23 +374,19 @@ func (o *Operation) ShootVersion() string {
 	return o.Shoot.Info.Spec.Kubernetes.Version
 }
 
-func (o *Operation) injectImages(values map[string]interface{}, names []string, opts ...imagevector.FindOptionFunc) (map[string]interface{}, error) {
-	return chart.InjectImages(values, o.ImageVector, names, opts...)
-}
-
 // InjectSeedSeedImages injects images that shall run on the Seed and target the Seed's Kubernetes version.
 func (o *Operation) InjectSeedSeedImages(values map[string]interface{}, names ...string) (map[string]interface{}, error) {
-	return o.injectImages(values, names, imagevector.RuntimeVersion(o.SeedVersion()), imagevector.TargetVersion(o.SeedVersion()))
+	return chart.InjectImages(values, o.ImageVector, names, imagevector.RuntimeVersion(o.SeedVersion()), imagevector.TargetVersion(o.SeedVersion()))
 }
 
 // InjectSeedShootImages injects images that shall run on the Seed but target the Shoot's Kubernetes version.
 func (o *Operation) InjectSeedShootImages(values map[string]interface{}, names ...string) (map[string]interface{}, error) {
-	return o.injectImages(values, names, imagevector.RuntimeVersion(o.SeedVersion()), imagevector.TargetVersion(o.ShootVersion()))
+	return chart.InjectImages(values, o.ImageVector, names, imagevector.RuntimeVersion(o.SeedVersion()), imagevector.TargetVersion(o.ShootVersion()))
 }
 
 // InjectShootShootImages injects images that shall run on the Shoot and target the Shoot's Kubernetes version.
 func (o *Operation) InjectShootShootImages(values map[string]interface{}, names ...string) (map[string]interface{}, error) {
-	return o.injectImages(values, names, imagevector.RuntimeVersion(o.ShootVersion()), imagevector.TargetVersion(o.ShootVersion()))
+	return chart.InjectImages(values, o.ImageVector, names, imagevector.RuntimeVersion(o.ShootVersion()), imagevector.TargetVersion(o.ShootVersion()))
 }
 
 // SyncClusterResourceToSeed creates or updates the `Cluster` extension resource for the shoot in the seed cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
The image vector now supports sha256 image tags. Along the way, I fixed a bug in the scoring and improved it so that equal matches lead to a higher score than `>=` or `<=` matches.

**Special notes for your reviewer**:
/cc @timuthy @ccwienk @AndreasBurger @RaphaelVogel @vlerenc 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The imagevector does now support `sha256` image tags.
```
