### PR TITLE
Adapt PSP RBAC naming and more constants

### DIFF
--- a/charts/shoot-addons/charts/nginx-ingress/templates/psp/nginx-ingress-rolebinding-privileged.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/psp/nginx-ingress-rolebinding-privileged.yaml
@@ -1,12 +1,12 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding
 metadata:
-  name: garden.sapcloud.io:psp:{{ template "nginx-ingress.fullname" . }}
+  name: gardener.cloud:psp:{{ template "nginx-ingress.fullname" . }}
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: garden.sapcloud.io:psp:privileged
+  name: gardener.cloud:psp:privileged
 subjects:
 - kind: ServiceAccount
   name: {{ template "nginx-ingress.fullname" . }}

--- a/charts/shoot-core/components/charts/kube-proxy/templates/psp/kube-proxy-clusterrole.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/psp/kube-proxy-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: garden.sapcloud.io:psp:kube-system:kube-proxy
+  name: gardener.cloud:psp:kube-system:kube-proxy
 rules:
 - apiGroups:
   - policy

--- a/charts/shoot-core/components/charts/kube-proxy/templates/psp/kube-proxy-rolebinding.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/psp/kube-proxy-rolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding
 metadata:
-  name: garden.sapcloud.io:psp:kube-proxy
+  name: gardener.cloud:psp:kube-proxy
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: garden.sapcloud.io:psp:kube-system:kube-proxy
+  name: gardener.cloud:psp:kube-system:kube-proxy
 subjects:
 - kind: ServiceAccount
   name: kube-proxy

--- a/charts/shoot-core/components/charts/monitoring/charts/kube-state-metrics-shoot/templates/rbac.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/kube-state-metrics-shoot/templates/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: garden.sapcloud.io:monitoring:kube-state-metrics
+  name: gardener.cloud:monitoring:kube-state-metrics
   labels:
     component: kube-state-metrics
 rules:
@@ -42,13 +42,13 @@ rules:
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: garden.sapcloud.io:monitoring:kube-state-metrics
+  name: gardener.cloud:monitoring:kube-state-metrics
   labels:
     component: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: garden.sapcloud.io:monitoring:kube-state-metrics
+  name: gardener.cloud:monitoring:kube-state-metrics
 subjects:
 - kind: User
   name: garden.sapcloud.io:monitoring:kube-state-metrics

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-clusterrole.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: garden.sapcloud.io:psp:kube-system:node-exporter
+  name: gardener.cloud:psp:kube-system:node-exporter
 rules:
 - apiGroups:
   - policy

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-rolebinding.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-rolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding
 metadata:
-  name: garden.sapcloud.io:psp:node-exporter
+  name: gardener.cloud:psp:node-exporter
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: garden.sapcloud.io:psp:kube-system:node-exporter
+  name: gardener.cloud:psp:kube-system:node-exporter
 subjects:
 - kind: ServiceAccount
   name: node-exporter

--- a/charts/shoot-core/components/charts/monitoring/charts/prometheus-shoot/templates/rbac.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/prometheus-shoot/templates/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: garden.sapcloud.io:monitoring:prometheus
+  name: gardener.cloud:monitoring:prometheus
 rules:
 - apiGroups: [""]
   resources:
@@ -27,11 +27,11 @@ rules:
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: garden.sapcloud.io:monitoring:prometheus
+  name: gardener.cloud:monitoring:prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: garden.sapcloud.io:monitoring:prometheus
+  name: gardener.cloud:monitoring:prometheus
 subjects:
 - kind: User
   name: garden.sapcloud.io:monitoring:prometheus

--- a/charts/shoot-core/components/charts/podsecuritypolicies/templates/privileged-clusterrole.yaml
+++ b/charts/shoot-core/components/charts/podsecuritypolicies/templates/privileged-clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: garden.sapcloud.io:psp:privileged
+  name: gardener.cloud:psp:privileged
 rules:
 - apiGroups:
   - policy

--- a/charts/shoot-core/components/charts/podsecuritypolicies/templates/privileged-clusterrolebinding.yaml
+++ b/charts/shoot-core/components/charts/podsecuritypolicies/templates/privileged-clusterrolebinding.yaml
@@ -1,16 +1,16 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: garden.sapcloud.io:psp:privileged
+  name: gardener.cloud:psp:privileged
   annotations:
-    garden.sapcloud.io/description: |
+    gardener.cloud/description: |
       Allow all authenticated users to use the privileged PSP.
       The subject field is configured via .spec.kubernetes.allowPrivilegedContainers flag on the Shoot resource.
       Do not manually change it as it'll be reconciled back to the original state.
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: garden.sapcloud.io:psp:privileged
+  name: gardener.cloud:psp:privileged
 {{- if .Values.allowPrivilegedContainers }}
 subjects:
 - kind: Group

--- a/charts/shoot-core/components/charts/podsecuritypolicies/templates/privileged-psp.yaml
+++ b/charts/shoot-core/components/charts/podsecuritypolicies/templates/privileged-psp.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gardener.privileged
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
-    garden.sapcloud.io/description: |
+    garden.cloud/description: |
       gardener.privileged allows full unrestricted access to Pod features, as if the PodSecurityPolicy controller was not enabled.
 spec:
   privileged: true

--- a/charts/shoot-core/components/charts/podsecuritypolicies/templates/unprivileged-clusterrole.yaml
+++ b/charts/shoot-core/components/charts/podsecuritypolicies/templates/unprivileged-clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: garden.sapcloud.io:psp:unprivileged
+  name: gardener.cloud:psp:unprivileged
 rules:
 - apiGroups:
   - policy

--- a/charts/shoot-core/components/charts/podsecuritypolicies/templates/unprivileged-clusterrolebinding.yaml
+++ b/charts/shoot-core/components/charts/podsecuritypolicies/templates/unprivileged-clusterrolebinding.yaml
@@ -1,14 +1,14 @@
 apiVersion: {{ include "rbacversion" .}}
 kind: ClusterRoleBinding
 metadata:
-  name: garden.sapcloud.io:psp:unprivileged
+  name: gardener.cloud:psp:unprivileged
   annotations:
-    garden.sapcloud.io/description: |
+    gardener.cloud/description: |
       Allow all authenticated users to use the unprivileged PSP.
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: garden.sapcloud.io:psp:unprivileged
+  name: gardener.cloud:psp:unprivileged
 subjects:
 - kind: Group
   apiGroup: rbac.authorization.k8s.io

--- a/charts/shoot-core/components/charts/podsecuritypolicies/templates/unprivileged-kube-system-rolebinding.yaml
+++ b/charts/shoot-core/components/charts/podsecuritypolicies/templates/unprivileged-kube-system-rolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding
 metadata:
-  name: garden.sapcloud.io:psp:unprivileged
+  name: gardener.cloud:psp:unprivileged
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: garden.sapcloud.io:psp:unprivileged
+  name: gardener.cloud:psp:unprivileged
 subjects:
 - kind: Group
   # All service accounts in the kube-system namespace are allowed to use this.

--- a/charts/shoot-core/components/charts/podsecuritypolicies/templates/unprivileged-psp.yaml
+++ b/charts/shoot-core/components/charts/podsecuritypolicies/templates/unprivileged-psp.yaml
@@ -7,7 +7,7 @@ metadata:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '{{ template "podsecuritypolicies.seccompAllowedProfileNames" . }}'
     # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
     # apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
-    garden.sapcloud.io/description: |
+    gardener.cloud/description: |
       gardener.unprivileged grants the mininimum amount of privileges necessary to run non-privileged Pods.
       This policy cannot be tuned down, but can be used as a template.
 spec:

--- a/charts/shoot-core/components/charts/vpn-shoot/templates/psp/vpn-shoot-clusterrole.yaml
+++ b/charts/shoot-core/components/charts/vpn-shoot/templates/psp/vpn-shoot-clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: garden.sapcloud.io:psp:kube-system:vpn-shoot
+  name: gardener.cloud:psp:kube-system:vpn-shoot
 rules:
 - apiGroups:
   - policy

--- a/charts/shoot-core/components/charts/vpn-shoot/templates/psp/vpn-shoot-rolebinding.yaml
+++ b/charts/shoot-core/components/charts/vpn-shoot/templates/psp/vpn-shoot-rolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding
 metadata:
-  name: garden.sapcloud.io:psp:vpn-shoot
+  name: gardener.cloud:psp:vpn-shoot
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: garden.sapcloud.io:psp:kube-system:vpn-shoot
+  name: gardener.cloud:psp:kube-system:vpn-shoot
 subjects:
 - kind: ServiceAccount
   name: vpn-shoot

--- a/pkg/apis/core/types_common.go
+++ b/pkg/apis/core/types_common.go
@@ -102,9 +102,4 @@ const (
 	// GardenerName is the value in a Garden resource's `.metadata.finalizers[]` array on which the Gardener will react
 	// when performing a delete request on a resource.
 	GardenerName = "gardener"
-
-	// ExternalGardenerName is the value in a Kubernetes core resources `.metadata.finalizers[]` array on which the
-	// Gardener will react when performing a delete request on a resource.
-	// TODO: migrate this to gardener.cloud
-	ExternalGardenerName = "garden.sapcloud.io/gardener"
 )

--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -89,8 +89,6 @@ const (
 	// the prometheus pod.
 	StatefulSetNamePrometheus = "prometheus"
 
-	// GardenPurpose is a constant for the key in a label describing the purpose of the respective object.
-	GardenPurpose = "garden.sapcloud.io/purpose"
 	// GardenerPurpose is a constant for the key in a label describing the purpose of the respective object.
 	GardenerPurpose = "gardener.cloud/purpose"
 
@@ -107,7 +105,8 @@ const (
 	GardenerOperationRestore = "restore"
 
 	// DeprecatedGardenRole is the key for an annotation on a Kubernetes object indicating what it is used for.
-	// +deprecated
+	//
+	// Deprecated: Use `GardenRole` instead.
 	DeprecatedGardenRole = "garden.sapcloud.io/role"
 	// GardenRole is a constant for a label that describes a role.
 	GardenRole = "gardener.cloud/role"
@@ -134,9 +133,6 @@ const (
 	// which value will be the value of `shoot.status.uid`
 	// +deprecated: Use `Cluster` resource instead.
 	DeprecatedShootUID = "shoot.garden.sapcloud.io/uid"
-	// DeprecatedGardenRoleBackup is the value of GardenRole key indicating type 'backup'.
-	// +deprecated
-	DeprecatedGardenRoleBackup = "backup"
 
 	// SeedResourceManagerClass is the resource-class managed by the Gardener-Resource-Manager
 	// instance in the garden namespace on the seeds.
@@ -215,13 +211,20 @@ const (
 
 	// AnnotationShootUseAsSeed is a constant for an annotation on a Shoot resource indicating that the Shoot shall be registered as Seed in the
 	// Garden cluster once successfully created.
-	AnnotationShootUseAsSeed = "shoot.garden.sapcloud.io/use-as-seed"
+	AnnotationShootUseAsSeed = "shoot.gardener.cloud/use-as-seed"
+	// AnnotationShootUseAsSeedDeprecated is a constant for an annotation on a Shoot resource indicating that the Shoot shall be registered as Seed in the
+	// Garden cluster once successfully created.
+	//
+	// Deprecated: Use `AnnotationShootUseAsSeed` instead.
+	AnnotationShootUseAsSeedDeprecated = "shoot.garden.sapcloud.io/use-as-seed"
 	// AnnotationShootIgnoreAlerts is the key for an annotation of a Shoot cluster whose value indicates
 	// if alerts for this cluster should be ignored
-	AnnotationShootIgnoreAlerts = "shoot.garden.sapcloud.io/ignore-alerts"
-	// AnnotationShootOperatedBy is the key for an annotation of a Shoot cluster whose value must be a valid email address and
-	// is used to send alerts to.
-	AnnotationShootOperatedBy = "garden.sapcloud.io/operatedBy"
+	AnnotationShootIgnoreAlerts = "shoot.gardener.cloud/ignore-alerts"
+	// AnnotationShootIgnoreAlertsDeprecated is the key for an annotation of a Shoot cluster whose value indicates
+	// if alerts for this cluster should be ignored
+	//
+	// Deprecated: Use `AnnotationShootIgnoreAlerts` instead.
+	AnnotationShootIgnoreAlertsDeprecated = "shoot.garden.sapcloud.io/ignore-alerts"
 	// AnnotationShootSkipCleanup is a key for an annotation on a Shoot resource that declares that the clean up steps should be skipped when the
 	// cluster is deleted. Concretely, this will skip everything except the deletion of (load balancer) services and persistent volume resources.
 	AnnotationShootSkipCleanup = "shoot.gardener.cloud/skip-cleanup"

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -153,7 +153,12 @@ const (
 	GardenerName = "gardener"
 	// ExternalGardenerName is the value in a Kubernetes core resources `.metadata.finalizers[]` array on which the
 	// Gardener will react when performing a delete request on a resource.
-	ExternalGardenerName = "garden.sapcloud.io/gardener"
+	ExternalGardenerName = "gardener.cloud/gardener"
+	// ExternalGardenerNameDeprecated is the value in a Kubernetes core resources `.metadata.finalizers[]` array on which the
+	// Gardener will react when performing a delete request on a resource.
+	//
+	// Deprecated: Use `ExternalGardenerName` instead.
+	ExternalGardenerNameDeprecated = "garden.sapcloud.io/gardener"
 )
 
 const (

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -95,8 +95,6 @@ const (
 	// the prometheus pod.
 	StatefulSetNamePrometheus = "prometheus"
 
-	// GardenPurpose is a constant for the key in a label describing the purpose of the respective object.
-	GardenPurpose = "garden.sapcloud.io/purpose"
 	// GardenerPurpose is a constant for the key in a label describing the purpose of the respective object.
 	GardenerPurpose = "gardener.cloud/purpose"
 
@@ -113,7 +111,8 @@ const (
 	GardenerOperationRestore = "restore"
 
 	// DeprecatedGardenRole is the key for an annotation on a Kubernetes object indicating what it is used for.
-	// +deprecated
+	//
+	// Deprecated: Use `GardenRole` instead.
 	DeprecatedGardenRole = "garden.sapcloud.io/role"
 	// GardenRole is a constant for a label that describes a role.
 	GardenRole = "gardener.cloud/role"
@@ -140,9 +139,6 @@ const (
 	// which value will be the value of `shoot.status.uid`
 	// +deprecated: Use `Cluster` resource instead.
 	DeprecatedShootUID = "shoot.garden.sapcloud.io/uid"
-	// DeprecatedGardenRoleBackup is the value of GardenRole key indicating type 'backup'.
-	// +deprecated
-	DeprecatedGardenRoleBackup = "backup"
 
 	// SeedResourceManagerClass is the resource-class managed by the Gardener-Resource-Manager
 	// instance in the garden namespace on the seeds.
@@ -221,13 +217,20 @@ const (
 
 	// AnnotationShootUseAsSeed is a constant for an annotation on a Shoot resource indicating that the Shoot shall be registered as Seed in the
 	// Garden cluster once successfully created.
-	AnnotationShootUseAsSeed = "shoot.garden.sapcloud.io/use-as-seed"
+	AnnotationShootUseAsSeed = "shoot.gardener.cloud/use-as-seed"
+	// AnnotationShootUseAsSeedDeprecated is a constant for an annotation on a Shoot resource indicating that the Shoot shall be registered as Seed in the
+	// Garden cluster once successfully created.
+	//
+	// Deprecated: Use `AnnotationShootUseAsSeed` instead.
+	AnnotationShootUseAsSeedDeprecated = "shoot.garden.sapcloud.io/use-as-seed"
 	// AnnotationShootIgnoreAlerts is the key for an annotation of a Shoot cluster whose value indicates
 	// if alerts for this cluster should be ignored
-	AnnotationShootIgnoreAlerts = "shoot.garden.sapcloud.io/ignore-alerts"
-	// AnnotationShootOperatedBy is the key for an annotation of a Shoot cluster whose value must be a valid email address and
-	// is used to send alerts to.
-	AnnotationShootOperatedBy = "garden.sapcloud.io/operatedBy"
+	AnnotationShootIgnoreAlerts = "shoot.gardener.cloud/ignore-alerts"
+	// AnnotationShootIgnoreAlertsDeprecated is the key for an annotation of a Shoot cluster whose value indicates
+	// if alerts for this cluster should be ignored
+	//
+	// Deprecated: Use `AnnotationShootIgnoreAlerts` instead.
+	AnnotationShootIgnoreAlertsDeprecated = "shoot.garden.sapcloud.io/ignore-alerts"
 	// AnnotationShootSkipCleanup is a key for an annotation on a Shoot resource that declares that the clean up steps should be skipped when the
 	// cluster is deleted. Concretely, this will skip everything except the deletion of (load balancer) services and persistent volume resources.
 	AnnotationShootSkipCleanup = "shoot.gardener.cloud/skip-cleanup"

--- a/pkg/apis/core/v1beta1/constants/utils.go
+++ b/pkg/apis/core/v1beta1/constants/utils.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+// GetShootUseAsSeedAnnotation fetches the value for AnnotationShootUseAsSeed annotation.
+// If not present, it fallbacks to AnnotationShootUseAsSeedDeprecated.
+func GetShootUseAsSeedAnnotation(annotations map[string]string) (string, bool) {
+	return getDeprecatedAnnotation(annotations, AnnotationShootUseAsSeed, AnnotationShootUseAsSeedDeprecated)
+}
+
+// GetShootIgnoreAlertsAnnotation fetches the value for AnnotationShootIgnoreAlerts annotation.
+// If not present, it fallbacks to AnnotationShootIgnoreAlertsDeprecated.
+func GetShootIgnoreAlertsAnnotation(annotations map[string]string) (string, bool) {
+	return getDeprecatedAnnotation(annotations, AnnotationShootIgnoreAlerts, AnnotationShootIgnoreAlertsDeprecated)
+}
+
+func getDeprecatedAnnotation(annotations map[string]string, annotationKey, deprecatedAnnotationKey string) (string, bool) {
+	val, ok := annotations[annotationKey]
+	if !ok {
+		val, ok = annotations[deprecatedAnnotationKey]
+	}
+
+	return val, ok
+}

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -504,7 +504,7 @@ func ReadShootedSeed(shoot *gardencorev1beta1.Shoot) (*ShootedSeed, error) {
 		return nil, nil
 	}
 
-	val, ok := shoot.Annotations[v1beta1constants.AnnotationShootUseAsSeed]
+	val, ok := v1beta1constants.GetShootUseAsSeedAnnotation(shoot.Annotations)
 	if !ok {
 		return nil, nil
 	}
@@ -547,7 +547,7 @@ func ShootWantsClusterAutoscaler(shoot *gardencorev1beta1.Shoot) (bool, error) {
 // ShootIgnoresAlerts checks if the alerts for the annotated shoot cluster should be ignored.
 func ShootIgnoresAlerts(shoot *gardencorev1beta1.Shoot) bool {
 	ignore := false
-	if value, ok := shoot.Annotations[v1beta1constants.AnnotationShootIgnoreAlerts]; ok {
+	if value, ok := v1beta1constants.GetShootIgnoreAlertsAnnotation(shoot.Annotations); ok {
 		ignore, _ = strconv.ParseBool(value)
 	}
 	return ignore

--- a/pkg/apis/core/v1beta1/types_common.go
+++ b/pkg/apis/core/v1beta1/types_common.go
@@ -153,7 +153,12 @@ const (
 	GardenerName = "gardener"
 	// ExternalGardenerName is the value in a Kubernetes core resources `.metadata.finalizers[]` array on which the
 	// Gardener will react when performing a delete request on a resource.
-	ExternalGardenerName = "garden.sapcloud.io/gardener"
+	ExternalGardenerName = "gardener.cloud/gardener"
+	// ExternalGardenerNameDeprecated is the value in a Kubernetes core resources `.metadata.finalizers[]` array on which the
+	// Gardener will react when performing a delete request on a resource.
+	//
+	// Deprecated: Use `ExternalGardenerName` instead.
+	ExternalGardenerNameDeprecated = "garden.sapcloud.io/gardener"
 )
 
 const (

--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -15,12 +15,9 @@
 package validation
 
 import (
-	"fmt"
 	"net"
-	"regexp"
 
 	"github.com/gardener/gardener/pkg/apis/core"
-	"github.com/gardener/gardener/pkg/operation/common"
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
 
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
@@ -34,7 +31,6 @@ func ValidateSeed(seed *core.Seed) field.ErrorList {
 
 	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&seed.ObjectMeta, false, ValidateName, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, ValidateSeedSpec(&seed.Spec, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateSeedAnnotation(seed.ObjectMeta.Annotations, field.NewPath("metadata", "annotations"))...)
 
 	return allErrs
 }
@@ -47,20 +43,6 @@ func ValidateSeedUpdate(newSeed, oldSeed *core.Seed) field.ErrorList {
 	allErrs = append(allErrs, ValidateSeedSpecUpdate(&newSeed.Spec, &oldSeed.Spec, field.NewPath("spec"))...)
 	allErrs = append(allErrs, ValidateSeed(newSeed)...)
 
-	return allErrs
-}
-
-//ValidateSeedAnnotation validates the annotations of seed
-func ValidateSeedAnnotation(annotations map[string]string, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-	if annotations != nil {
-		if v, ok := annotations[common.AnnotatePersistentVolumeMinimumSize]; ok {
-			volumeSizeRegex, _ := regexp.Compile(`^(\d)+Gi$`)
-			if !volumeSizeRegex.MatchString(v) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Key(common.AnnotatePersistentVolumeMinimumSize), v, fmt.Sprintf("volume size must match the regex %s", volumeSizeRegex)))
-			}
-		}
-	}
 	return allErrs
 }
 

--- a/pkg/apis/core/validation/seed_test.go
+++ b/pkg/apis/core/validation/seed_test.go
@@ -17,7 +17,6 @@ package validation_test
 import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	. "github.com/gardener/gardener/pkg/apis/core/validation"
-	"github.com/gardener/gardener/pkg/operation/common"
 	. "github.com/gardener/gardener/pkg/utils/validation/gomega"
 
 	. "github.com/onsi/ginkgo"
@@ -44,9 +43,6 @@ var _ = Describe("Seed Validation Tests", func() {
 			seed = &core.Seed{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "seed-1",
-					Annotations: map[string]string{
-						common.AnnotatePersistentVolumeMinimumSize: "10Gi",
-					},
 				},
 				Spec: core.SeedSpec{
 					Provider: core.SeedProvider{
@@ -100,14 +96,6 @@ var _ = Describe("Seed Validation Tests", func() {
 				"Type":  Equal(field.ErrorTypeRequired),
 				"Field": Equal("metadata.name"),
 			}))
-		})
-
-		It("should forbid invalid annotations", func() {
-			seed.ObjectMeta.Annotations = map[string]string{
-				common.AnnotatePersistentVolumeMinimumSize: "10Gix",
-			}
-			errorList := ValidateSeed(seed)
-			Expect(errorList).To(HaveLen(1))
 		})
 
 		It("should forbid Seed specification with empty or invalid keys", func() {

--- a/pkg/controllerutils/finalizers.go
+++ b/pkg/controllerutils/finalizers.go
@@ -23,6 +23,7 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
@@ -70,9 +71,14 @@ func RemoveFinalizer(ctx context.Context, c client.Client, obj kutil.Object, fin
 		if err != nil {
 			return false, err
 		}
-		if !sets.NewString(obj.GetFinalizers()...).Has(finalizer) {
+		if !HasFinalizer(obj, finalizer) {
 			return true, nil
 		}
 		return false, nil
 	}, pollerCtx.Done())
+}
+
+// HasFinalizer checks whether the given obj has the given finalizer.
+func HasFinalizer(obj metav1.Object, finalizer string) bool {
+	return sets.NewString(obj.GetFinalizers()...).Has(finalizer)
 }

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
@@ -109,6 +109,14 @@ func (r *reconciler) reconcileBackupBucket(backupBucket *gardencorev1beta1.Backu
 		return reconcile.Result{}, err
 	}
 
+	// TODO: This code can be removed in a future version.
+	if controllerutils.HasFinalizer(secret, gardencorev1beta1.ExternalGardenerNameDeprecated) {
+		if err := controllerutils.RemoveFinalizer(r.ctx, r.client, secret.DeepCopy(), gardencorev1beta1.ExternalGardenerNameDeprecated); err != nil {
+			backupBucketLogger.Errorf("Failed to remove deprecated external gardener finalizer on referenced secret: %+v", err.Error())
+			return reconcile.Result{}, err
+		}
+	}
+
 	seedClient, err := seedpkg.GetSeedClient(r.ctx, r.client, r.config.SeedClientConnection.ClientConnectionConfiguration, r.config.SeedSelector == nil, *backupBucket.Spec.SeedName)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -211,6 +219,14 @@ func (r *reconciler) deleteBackupBucket(backupBucket *gardencorev1beta1.BackupBu
 	if err := controllerutils.RemoveFinalizer(r.ctx, r.client, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
 		backupBucketLogger.Errorf("Failed to remove external gardener finalizer on referred secret: %+v", err)
 		return reconcile.Result{}, err
+	}
+
+	// TODO: This code can be removed in a future version.
+	if controllerutils.HasFinalizer(secret, gardencorev1beta1.ExternalGardenerNameDeprecated) {
+		if err := controllerutils.RemoveFinalizer(r.ctx, r.client, secret, gardencorev1beta1.ExternalGardenerNameDeprecated); err != nil {
+			backupBucketLogger.Errorf("Failed to remove deprecated external gardener finalizer on referenced secret: %+v", err)
+			return reconcile.Result{}, err
+		}
 	}
 
 	return reconcile.Result{}, controllerutils.RemoveGardenerFinalizer(r.ctx, r.client, backupBucket)

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -217,6 +217,14 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 					seedLogger.Error(err.Error())
 					return err
 				}
+
+				// TODO: This code can be removed in a future version.
+				if controllerutils.HasFinalizer(secret, gardencorev1beta1.ExternalGardenerNameDeprecated) {
+					if err := controllerutils.RemoveFinalizer(ctx, c.k8sGardenClient.Client(), secret, gardencorev1beta1.ExternalGardenerNameDeprecated); err != nil {
+						seedLogger.Error(err.Error())
+						return err
+					}
+				}
 			}
 
 			// Remove finalizer from Seed
@@ -275,6 +283,14 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 		if err := controllerutils.EnsureFinalizer(ctx, c.k8sGardenClient.Client(), secret, gardencorev1beta1.ExternalGardenerName); err != nil {
 			seedLogger.Error(err.Error())
 			return err
+		}
+
+		// TODO: This code can be removed in a future version.
+		if controllerutils.HasFinalizer(secret, gardencorev1beta1.ExternalGardenerNameDeprecated) {
+			if err := controllerutils.RemoveFinalizer(ctx, c.k8sGardenClient.Client(), secret, gardencorev1beta1.ExternalGardenerNameDeprecated); err != nil {
+				seedLogger.Error(err.Error())
+				return err
+			}
 		}
 	}
 

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -374,16 +374,6 @@ const (
 	// Deprecated: Use `ShootIgnore` instead.
 	ShootIgnoreDeprecated = "shoot.garden.sapcloud.io/ignore"
 
-	// AnnotatePersistentVolumeMinimumSize is used to specify the minimum size of persistent volume in the cluster
-	//
-	// Deprecated: Use `corev1beta1.Seed` instead.
-	AnnotatePersistentVolumeMinimumSize = "persistentvolume.garden.sapcloud.io/minimumSize"
-
-	// AnnotatePersistentVolumeProvider is used to tell volume provider in the k8s cluster
-	//
-	// Deprecated: Use `corev1beta1.Seed` instead.
-	AnnotatePersistentVolumeProvider = "persistentvolume.garden.sapcloud.io/provider"
-
 	// BackupNamespacePrefix is a constant for backup namespace created for shoot's backup infrastructure related resources.
 	BackupNamespacePrefix = "backup"
 

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -95,10 +95,6 @@ func updateKubeletConfig(kubeletConfig *core.KubeletConfig) {
 }
 
 func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
-	var (
-		oldPurpose, newPurpose string
-	)
-
 	// The Shoot specification changes.
 	if !apiequality.Semantic.DeepEqual(oldShoot.Spec, newShoot.Spec) {
 		return true
@@ -137,12 +133,6 @@ func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
 			delete(newShoot.Annotations, common.ShootOperationDeprecated)
 			return true
 		}
-	}
-
-	oldPurpose = oldShoot.ObjectMeta.Annotations[v1beta1constants.GardenPurpose]
-	newPurpose = newShoot.ObjectMeta.Annotations[v1beta1constants.GardenPurpose]
-	if oldPurpose != newPurpose {
-		return true
 	}
 
 	// TODO: Just a temporary solution. Remove this in a future version once Kyma is moved out again.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adapt PSP RBAC naming and more constants to the new API group.

**Which issue(s) this PR fixes**:
Ref gardener/gardener#1649

**Special notes for your reviewer**:
I think I will need 1 more PR for deprecated labels/annotations handling in the charts.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Two more annotations from to the old API group have now equivalents in the new API group as follows:

`shoot.garden.sapcloud.io/use-as-seed` -> `shoot.gardener.cloud/use-as-seed`
`shoot.garden.sapcloud.io/ignore-alerts` -> `shoot.gardener.cloud/ignore-alerts`
```