### PR TITLE
Support Custom Pod Labels for Gardener runtime

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         checksum/secret-gardener-apiserver-encryption-config: {{ include (print $.Template.BasePath "/apiserver/secret-gardener-apiserver-encryption-config.yaml") . | sha256sum }}
         {{- end }}
         checksum/secret-gardener-apiserver-kubeconfig: {{ include (print $.Template.BasePath "/apiserver/secret-kubeconfig.yaml") . | sha256sum }}
+        {{- if .Values.global.apiserver.podAnnotations }}
+{{ toYaml .Values.global.apiserver.podAnnotations | indent 8 }}
+        {{- end }}
       labels:
         app: gardener
         role: apiserver
@@ -38,6 +41,9 @@ spec:
         heritage: "{{ .Release.Service }}"
         {{- if .Values.global.apiserver.etcd.useSidecar }}
         sidecar: etcd
+        {{- end }}
+        {{- if .Values.global.apiserver.podLabels }}
+{{ toYaml .Values.global.apiserver.podLabels | indent 8 }}
         {{- end }}
     spec:
       {{- if not .Values.global.apiserver.kubeconfig }}

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
@@ -26,12 +26,18 @@ spec:
         checksum/secret-internal-domain: {{ include "gardener.secret-internal-domain" . | sha256sum }}
         checksum/secret-alerting: {{ include "gardener.secret-alerting" . | sha256sum }}
         checksum/secret-openvpn-diffie-hellman: {{ include "gardener.secret-openvpn-diffie-hellman" . | sha256sum }}
+        {{- if .Values.global.controller.podAnnotations }}
+{{ toYaml .Values.global.controller.podAnnotations | indent 8 }}
+        {{- end }}
       labels:
         app: gardener
         role: controller-manager
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+        {{- if .Values.global.controller.podLabels }}
+{{ toYaml .Values.global.controller.podLabels | indent 8 }}
+        {{- end }}
     spec:
       {{- if not .Values.global.controller.kubeconfig }}
       serviceAccountName: {{ required ".Values.global.controller.serviceAccountName is required" .Values.global.controller.serviceAccountName }}

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
@@ -21,12 +21,18 @@ spec:
       annotations:
         checksum/configmap-gardener-scheduler-config: {{ include (print $.Template.BasePath "/scheduler/configmap-componentconfig.yaml") . | sha256sum }}
         checksum/secret-gardener-scheduler-kubeconfig: {{ include (print $.Template.BasePath "/scheduler/secret-kubeconfig.yaml") . | sha256sum }}
+        {{- if .Values.global.scheduler.podAnnotations }}
+{{ toYaml .Values.global.scheduler.podAnnotations | indent 8 }}
+        {{- end }}
       labels:
         app: gardener
         role: scheduler
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+        {{- if .Values.global.scheduler.podLabels }}
+{{ toYaml .Values.global.scheduler.podLabels | indent 8 }}
+        {{- end }}
     spec:
       {{- if not .Values.global.scheduler.kubeconfig }}
       serviceAccountName: {{ required ".Values.global.scheduler.serviceAccountName is required" .Values.global.scheduler.serviceAccountName }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -16,6 +16,8 @@ global:
       limits:
         cpu: 300m
         memory: 256Mi
+  # podAnnotations: # YAML formated annotations used for pod template
+  # podLabels: # YAML formated labels used for pod template
     encryption:
       config: |
         apiVersion: apiserver.config.k8s.io/v1
@@ -183,6 +185,8 @@ global:
       limits:
         cpu: 750m
         memory: 512Mi
+  # podAnnotations: # YAML formated annotations used for pod template
+  # podLabels: # YAML formated labels used for pod template
     additionalVolumes: []
     additionalVolumeMounts: []
     env: []
@@ -259,6 +263,8 @@ global:
       limits:
         cpu: 300m
         memory: 256Mi
+  # podAnnotations: # YAML formated annotations used for pod template
+  # podLabels: # YAML formated labels used for pod template
     vpa: false
     config:
       clientConnection:

--- a/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
@@ -29,12 +29,18 @@ spec:
         {{- end }}
         checksum/secret-gardenlet-kubeconfig-garden: {{ include (print $.Template.BasePath "/secret-kubeconfig-garden.yaml") . | sha256sum }}
         checksum/secret-gardenlet-kubeconfig-seed: {{ include (print $.Template.BasePath "/secret-kubeconfig-seed.yaml") . | sha256sum }}
+        {{- if .Values.global.gardenlet.podAnnotations }}
+{{ toYaml .Values.global.gardenlet.podAnnotations | indent 8 }}
+        {{- end }}
       labels:
         app: gardener
         role: gardenlet
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+        {{- if .Values.global.gardenlet.podLabels }}
+{{ toYaml .Values.global.gardenlet.podLabels | indent 8 }}
+        {{- end }}
     spec:
       priorityClassName: gardenlet
       {{- if not .Values.global.gardenlet.config.seedClientConnection.kubeconfig }}

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -16,6 +16,8 @@ global:
       limits:
         cpu: 2000m
         memory: 512Mi
+  # podAnnotations: # YAML formated annotations used for pod template
+  # podLabels: # YAML formated labels used for pod template
     additionalVolumes: []
     additionalVolumeMounts: []
     env: []


### PR DESCRIPTION
**What this PR does / why we need it**:
Support Custom Pod Annotations and Labels for Gardener runtime components.

A valid use case is to enable seamless integration with network policies in the hosting cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The pods for the gardener components `apiserver`, `controller manager`, `scheduler` and `gardenlet` can be extended with custom annotations and labels via the gardener helm [chart](https://github.com/gardener/gardener/tree/master/charts/gardener). 
```