### PR TITLE
Fix early exit in chart applier

### DIFF
--- a/pkg/client/kubernetes/apply.go
+++ b/pkg/client/kubernetes/apply.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io"
 
+	utilerrors "github.com/gardener/gardener/pkg/utils/errors"
+	"github.com/hashicorp/go-multierror"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -188,44 +190,60 @@ func (c *Applier) mergeObjects(newObj, oldObj *unstructured.Unstructured, mergeF
 // all concatenated in a byte slice, and sends them one after the other to the API server. If a resource
 // already exists at the API server, it will update it. It returns an error as soon as the first error occurs.
 func (c *Applier) ApplyManifest(ctx context.Context, r UnstructuredReader, options ApplierOptions) error {
+	allErrs := &multierror.Error{
+		ErrorFormat: utilerrors.NewErrorFormatFuncWithPrefix("failed to apply manifests"),
+	}
+
 	for {
 		obj, err := r.Read()
 		if err == io.EOF {
-			return nil
+			break
 		}
 		if err != nil {
-			return err
+			allErrs = multierror.Append(allErrs, fmt.Errorf("could not read object: %+v", err))
+			continue
 		}
 		if obj == nil {
 			continue
 		}
 
 		if err := c.applyObject(ctx, obj, options); err != nil {
-			return err
+			allErrs = multierror.Append(allErrs, fmt.Errorf("could not apply object of kind \"%s\" \"%s/%s\": %+v", obj.GetKind(), obj.GetNamespace(), obj.GetName(), err))
+			continue
 		}
 	}
+
+	return allErrs.ErrorOrNil()
 }
 
 // DeleteManifest is a function which does the same like `kubectl delete -f <file>`. It takes a bunch of manifests <m>,
 // all concatenated in a byte slice, and sends them one after the other to the API server for deletion.
 // It returns an error as soon as the first error occurs.
 func (c *Applier) DeleteManifest(ctx context.Context, r UnstructuredReader) error {
+	allErrs := &multierror.Error{
+		ErrorFormat: utilerrors.NewErrorFormatFuncWithPrefix("failed to delete manifests"),
+	}
+
 	for {
 		obj, err := r.Read()
 		if err == io.EOF {
-			return nil
+			break
 		}
 		if err != nil {
-			return err
+			allErrs = multierror.Append(allErrs, fmt.Errorf("could not read object: %+v", err))
+			continue
 		}
 		if obj == nil {
 			continue
 		}
 
 		if err := c.deleteObject(ctx, obj); err != nil {
-			return err
+			allErrs = multierror.Append(allErrs, fmt.Errorf("could not delete object of kind \"%s\" \"%s/%s\": %+v", obj.GetKind(), obj.GetNamespace(), obj.GetName(), err))
+			continue
 		}
 	}
+
+	return allErrs.ErrorOrNil()
 }
 
 // UnstructuredReader an interface that all manifest readers should implement

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -325,7 +325,7 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 	if err := seedpkg.BootstrapCluster(c.k8sGardenClient, seedObj, c.config, c.secrets, c.imageVector); err != nil {
 		conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "BootstrappingFailed", err.Error())
 		c.updateSeedStatus(seed, seedKubernetesVersion, conditionSeedBootstrapped)
-		seedLogger.Error(err.Error())
+		seedLogger.Errorf("Seed bootstrapping failed: %+v", err)
 		return err
 	}
 

--- a/pkg/utils/errors/errors_test.go
+++ b/pkg/utils/errors/errors_test.go
@@ -21,6 +21,7 @@ import (
 	errorsmock "github.com/gardener/gardener/pkg/mock/gardener/utils/errors"
 	utilerrors "github.com/gardener/gardener/pkg/utils/errors"
 	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 
 	. "github.com/onsi/ginkgo"
@@ -229,6 +230,35 @@ var _ = Describe("Errors", func() {
 			)
 
 			Expect(err).To(Succeed())
+		})
+	})
+})
+
+var _ = Describe("Multierrors", func() {
+	var (
+		allErrs    *multierror.Error
+		err1, err2 error
+	)
+
+	BeforeEach(func() {
+		err1 = fmt.Errorf("error 1")
+		err2 = fmt.Errorf("error 2")
+	})
+
+	Describe("#NewErrorFormatFuncWithPrefix", func() {
+		BeforeEach(func() {
+			allErrs = &multierror.Error{
+				ErrorFormat: utilerrors.NewErrorFormatFuncWithPrefix("prefix"),
+			}
+		})
+
+		It("should format a multierror correctly if it contains 1 error", func() {
+			allErrs.Errors = []error{err1}
+			Expect(allErrs.Error()).To(Equal("prefix: 1 error occurred: error 1"))
+		})
+		It("should format a multierror correctly if it contains multiple errors", func() {
+			allErrs.Errors = []error{err1, err2}
+			Expect(allErrs.Error()).To(Equal("prefix: 2 errors occurred: [error 1, error 2]"))
 		})
 	})
 })

--- a/pkg/utils/errors/multierror.go
+++ b/pkg/utils/errors/multierror.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"fmt"
+	"github.com/hashicorp/go-multierror"
+)
+
+// NewErrorFormatFuncWithPrefix creates a new multierror.ErrorFormatFunc which can be used as an ErrorFormat on
+// multierror.Error instances. The error string is prefixed with <prefix>, all errors are concatenated at the end.
+// This is similar to multierror.ListFormatFunc but does not use any escape sequences, which will look weird in
+// the status of Kubernetes objects or controller logs.
+func NewErrorFormatFuncWithPrefix(prefix string) multierror.ErrorFormatFunc {
+	return func(es []error) string {
+		if len(es) == 1 {
+			return fmt.Sprintf("%s: 1 error occurred: %s", prefix, es[0])
+		}
+
+		combinedMsg := ""
+		for i, err := range es {
+			if i > 0 {
+				combinedMsg += ", "
+			}
+			combinedMsg += err.Error()
+		}
+
+		return fmt.Sprintf("%s: %d errors occurred: [%s]", prefix, len(es), combinedMsg)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, the chart applier did an early exit on error if one of the manifests could not be applied (for example because of a `KindMismatch`). Consequently all following manifests would not be applied, even if they were correct.
With this PR, the chart applier instead tries to apply all given manifests and returns a combined error for all failed manifests if there are any.

**Which issue(s) this PR fixes**:
Fixes #1939

**Special notes for your reviewer**:
For example, when a new Seed is bootstrapped and one manifest cannot be applied (as described in #1939), the Seed condition will look similar to this:
```yaml
status:
  conditions:
  - lastTransitionTime: "2020-02-18T11:13:18Z"
    lastUpdateTime: "2020-02-18T11:13:18Z"
    message: 'failed to apply manifests: 1 error occurred: could not apply object
      of kind "VerticalPodAutoscaler" "garden/kube-state-metrics-vpa": no matches
      for kind "VerticalPodAutoscaler" in version "autoscaling.k8s.io/v1beta2"'
    reason: BootstrappingFailed
    status: "False"
    type: Bootstrapped
```
Though, the rest of the chart is still applied and the bootstrapping will succeed on the second try.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The Chart Applier now returns a combined error in case a rendered Manifest cannot be applied instead of doing an early exit on error.
```
