### PR TITLE
Clean up .spec.purpose defaulting from annotation

### DIFF
--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -46,9 +46,6 @@ const (
 	// DeploymentNameClusterAutoscaler is a constant for the name of a Kubernetes deployment object that contains
 	// the cluster-autoscaler pod.
 	DeploymentNameClusterAutoscaler = "cluster-autoscaler"
-	// DeploymentNameDependencyWatchdog is a constant for the name of a Kubernetes deployment object that contains
-	// the dependency-watchdog pod.
-	DeploymentNameDependencyWatchdog = "dependency-watchdog"
 	// DeploymentNameKubeAPIServer is a constant for the name of a Kubernetes deployment object that contains
 	// the kube-apiserver pod.
 	DeploymentNameKubeAPIServer = "kube-apiserver"

--- a/pkg/apis/core/v1alpha1/defaults.go
+++ b/pkg/apis/core/v1alpha1/defaults.go
@@ -17,7 +17,6 @@ package v1alpha1
 import (
 	"math"
 
-	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	"github.com/gardener/gardener/pkg/utils"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
@@ -130,15 +129,6 @@ func SetDefaults_Shoot(obj *Shoot) {
 
 	if obj.Spec.Purpose == nil {
 		p := ShootPurposeEvaluation
-
-		// backwards compatibility - take purpose from annotation if given. If not, default.
-		// TODO: This code can be removed in a future version
-		if v, ok := obj.Annotations[v1alpha1constants.GardenerPurpose]; ok && (v == string(ShootPurposeEvaluation) || v == string(ShootPurposeTesting) || v == string(ShootPurposeDevelopment) || v == string(ShootPurposeProduction) || (v == string(ShootPurposeInfrastructure) && obj.Namespace == v1alpha1constants.GardenNamespace)) {
-			p = ShootPurpose(v)
-		} else if v, ok := obj.Annotations[v1alpha1constants.GardenPurpose]; ok && (v == string(ShootPurposeEvaluation) || v == string(ShootPurposeTesting) || v == string(ShootPurposeDevelopment) || v == string(ShootPurposeProduction) || (v == string(ShootPurposeInfrastructure) && obj.Namespace == v1alpha1constants.GardenNamespace)) {
-			p = ShootPurpose(v)
-		}
-
 		obj.Spec.Purpose = &p
 	}
 }

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -52,9 +52,6 @@ const (
 	// DeploymentNameClusterAutoscaler is a constant for the name of a Kubernetes deployment object that contains
 	// the cluster-autoscaler pod.
 	DeploymentNameClusterAutoscaler = "cluster-autoscaler"
-	// DeploymentNameDependencyWatchdog is a constant for the name of a Kubernetes deployment object that contains
-	// the dependency-watchdog pod.
-	DeploymentNameDependencyWatchdog = "dependency-watchdog"
 	// DeploymentNameKubeAPIServer is a constant for the name of a Kubernetes deployment object that contains
 	// the kube-apiserver pod.
 	DeploymentNameKubeAPIServer = "kube-apiserver"

--- a/pkg/apis/core/v1beta1/defaults.go
+++ b/pkg/apis/core/v1beta1/defaults.go
@@ -17,7 +17,6 @@ package v1beta1
 import (
 	"math"
 
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
@@ -130,15 +129,6 @@ func SetDefaults_Shoot(obj *Shoot) {
 
 	if obj.Spec.Purpose == nil {
 		p := ShootPurposeEvaluation
-
-		// backwards compatibility - take purpose from annotation if given. If not, default.
-		// TODO: This code can be removed in a future version
-		if v, ok := obj.Annotations[v1beta1constants.GardenerPurpose]; ok && (v == string(ShootPurposeEvaluation) || v == string(ShootPurposeTesting) || v == string(ShootPurposeDevelopment) || v == string(ShootPurposeProduction) || (v == string(ShootPurposeInfrastructure) && obj.Namespace == v1beta1constants.GardenNamespace)) {
-			p = ShootPurpose(v)
-		} else if v, ok := obj.Annotations[v1beta1constants.GardenPurpose]; ok && (v == string(ShootPurposeEvaluation) || v == string(ShootPurposeTesting) || v == string(ShootPurposeDevelopment) || v == string(ShootPurposeProduction) || (v == string(ShootPurposeInfrastructure) && obj.Namespace == v1beta1constants.GardenNamespace)) {
-			p = ShootPurpose(v)
-		}
-
 		obj.Spec.Purpose = &p
 	}
 }

--- a/pkg/gardenlet/controller/shoot/shoot_utils.go
+++ b/pkg/gardenlet/controller/shoot/shoot_utils.go
@@ -44,10 +44,6 @@ var (
 	}
 )
 
-func statusToBool(status Status) bool {
-	return status == StatusHealthy
-}
-
 func statusValue(s Status) int {
 	value, ok := shootStatusValues[s]
 	if !ok {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Clean up `.spec.purpose` defaulting from annotation
- Clean up deletion of legacy `gardener-external-admission-controller` resources during seed bootstrap.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
`gardener-apiserver` does no longer use the value of `garden.sapcloud.io/purpose` or `gardener.cloud/purpose` when `.spec.purpose` is not specified.
```
