### PR TITLE
More metrics for seed workload.

### DIFF
--- a/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
+++ b/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
@@ -33,7 +33,35 @@ groups:
   # Recording rules for container count per container
   - record: seed:kube_pod_container_info:count_by_container
     expr: count(kube_pod_container_info) by (container)
-
+  
+  # Recording rules for container restart count per container
+  - record: seed:kube_pod_container_status_restarts_total:sum_by_container
+    expr: sum(kube_pod_container_status_restarts_total) by (container)
+  
+  # Recording rules for deployment spec replicas per deployment
+  - record: seed:kube_deployment_spec_replicas:sum_by_deployment
+    expr: sum(kube_deployment_spec_replicas) by (deployment)
+  
+  # Recording rules for deployment status replicas per deployment
+  - record: seed:kube_deployment_status_replicas:sum_by_deployment
+    expr: sum(kube_deployment_status_replicas) by (deployment)
+  
+  # Recording rules for deployment status replicas available per deployment
+  - record: seed:kube_deployment_status_replicas_available:sum_by_deployment
+    expr: sum(kube_deployment_status_replicas_available) by (deployment)
+  
+  # Recording rules for statefulset spec replicas per statefulset
+  - record: seed:kube_statefulset_replicas:sum_by_statefulset
+    expr: sum(kube_statefulset_replicas) by (statefulset)
+  
+  # Recording rules for statefulset status replicas per statefulset
+  - record: seed:kube_statefulset_status_replicas:sum_by_statefulset
+    expr: sum(kube_statefulset_status_replicas) by (statefulset)
+  
+  # Recording rules for statefulset status replicas available per statefulset
+  - record: seed:kube_statefulset_status_replicas_ready:sum_by_statefulset
+    expr: sum(kube_statefulset_status_replicas_ready) by (statefulset)
+  
   # Recording rules for the sum of the entire seed usage
   - record: seed:container_cpu_usage_seconds_total:sum
     expr: sum(rate(container_cpu_usage_seconds_total[5m]))
@@ -63,20 +91,64 @@ groups:
 
   # Recording rules for the sum of vpa recommendations for the entire seed
   - record: seed:vpa_status_recommendation_target:sum
-    expr: sum(vpa_status_recommendation{recommendation="target"})
+    expr: sum(vpa_status_recommendation{recommendation="target"})  by (resource)
   
   # Recording rules for the sum of hvpa applied recommendations for the entire seed
   - record: seed:hvpa_status_applied_vpa_recommendation_target:sum
-    expr: sum(hvpa_status_applied_vpa_recommendation{recommendation="target"})
+    expr: sum(hvpa_status_applied_vpa_recommendation{recommendation="target"}) by (resource)
 
   # Recording rules for pod count for the entire seed
   - record: seed:kube_pod_info:count
     expr: count(kube_pod_info)
 
+  # Recording rules for pod count by status for the entire seed
+  - record: seed:kube_pod_status_ready:sum_by_condition
+    expr: sum(kube_pod_status_ready) by (condition)
+
+  # Recording rules for pod count by phase for the entire seed
+  - record: seed:kube_pod_status_phase:sum_by_phase
+    expr: sum(kube_pod_status_phase) by (phase)
+
+  # Recording rules for reserve excess capacity pod count by phase for the entire seed
+  - record: seed:kube_pod_status_phase_reserve_excess_capacity:sum_by_phase
+    expr: sum(kube_pod_status_phase{pod=~"reserve-excess-capacity.*"}) by (phase)
+
   # Recording rules for images running on seed
   - record: seed:images:count
     expr: count(kube_pod_container_info) by (image)
+  
+  # Recording rules for container count for the entire seed
+  - record: seed:kube_pod_container_info:count
+    expr: count(kube_pod_container_info)
 
+  # Recording rules for container restart count for the entire seed
+  - record: seed:kube_pod_container_status_restarts_total:sum
+    expr: sum(kube_pod_container_status_restarts_total)
+  
+  # Recording rules for deployment spec replicas for the entire seed
+  - record: seed:kube_deployment_spec_replicas:sum
+    expr: sum(kube_deployment_spec_replicas)
+  
+  # Recording rules for deployment status replicas for the entire seed
+  - record: seed:kube_deployment_status_replicas:sum
+    expr: sum(kube_deployment_status_replicas)
+  
+  # Recording rules for deployment status replicas available for the entire seed
+  - record: seed:kube_deployment_status_replicas_available:sum
+    expr: sum(kube_deployment_status_replicas_available)
+  
+  # Recording rules for statefulset spec replicas for the entire seed
+  - record: seed:kube_statefulset_replicas:sum
+    expr: sum(kube_statefulset_replicas)
+  
+  # Recording rules for statefulset status replicas for the entire seed
+  - record: seed:kube_statefulset_status_replicas:sum
+    expr: sum(kube_statefulset_status_replicas)
+  
+  # Recording rules for statefulset status replicas available for the entire seed
+  - record: seed:kube_statefulset_status_replicas_ready:sum
+    expr: sum(kube_statefulset_status_replicas_ready)
+  
   # Recording rules for node metrics for the entire seed
   - record: seed:kube_node_info:count
     expr: count(kube_node_info)
@@ -145,13 +217,53 @@ groups:
 
   # Recording rules for the sum of vpa recommendations for all the control-planes
   - record: seed:vpa_status_recommendation_target:sum
-    expr: sum(vpa_status_recommendation{recommendation="target", namespace=~"((shoot-|shoot--)(\\w.+))"})
+    expr: sum(vpa_status_recommendation{recommendation="target", namespace=~"((shoot-|shoot--)(\\w.+))"}) by (resource)
   
   # Recording rules for the sum of hvpa applied recommendations for all the control-planes
   - record: seed:hvpa_status_applied_vpa_recommendation_target:sum
-    expr: sum(hvpa_status_applied_vpa_recommendation{recommendation="target", namespace=~"((shoot-|shoot--)(\\w.+))"})
+    expr: sum(hvpa_status_applied_vpa_recommendation{recommendation="target", namespace=~"((shoot-|shoot--)(\\w.+))"}) by (resource)
 
   # Recording rules for pod count for all the control-planes
   - record: seed:kube_pod_info:count_cp
     expr: count(kube_pod_info{namespace=~"((shoot-|shoot--)(\\w.+))"})
+  
+  # Recording rules for pod count by status for all the control-planes
+  - record: seed:kube_pod_status_ready:sum_cp_by_condition
+    expr: sum(kube_pod_status_ready{namespace=~"((shoot-|shoot--)(\\w.+))"}) by (condition)
 
+  # Recording rules for pod count by phase for all the control-planes
+  - record: seed:kube_pod_status_phase:sum_cp_by_phase
+    expr: sum(kube_pod_status_phase{namespace=~"((shoot-|shoot--)(\\w.+))"}) by (phase)
+
+  # Recording rules for container count for all the control-planes
+  - record: seed:kube_pod_container_info:count_cp
+    expr: count(kube_pod_container_info{namespace=~"((shoot-|shoot--)(\\w.+))"})
+  
+  # Recording rules for container restart count for all the control-planes
+  - record: seed:kube_pod_container_status_restarts_total:sum_cp
+    expr: sum(kube_pod_container_status_restarts_total{namespace=~"((shoot-|shoot--)(\\w.+))"})
+  
+  # Recording rules for deployment spec replicas for all the control-planes
+  - record: seed:kube_deployment_spec_replicas:sum_cp
+    expr: sum(kube_deployment_spec_replicas{namespace=~"((shoot-|shoot--)(\\w.+))"})
+  
+  # Recording rules for deployment status replicas for all the control-planes
+  - record: seed:kube_deployment_status_replicas:sum_cp
+    expr: sum(kube_deployment_status_replicas{namespace=~"((shoot-|shoot--)(\\w.+))"})
+  
+  # Recording rules for deployment status replicas available for all the control-planes
+  - record: seed:kube_deployment_status_replicas_available:sum_cp
+    expr: sum(kube_deployment_status_replicas_available{namespace=~"((shoot-|shoot--)(\\w.+))"})
+  
+  # Recording rules for statefulset spec replicas for all the control-planes
+  - record: seed:kube_statefulset_replicas:sum_cp
+    expr: sum(kube_statefulset_replicas{namespace=~"((shoot-|shoot--)(\\w.+))"})
+  
+  # Recording rules for statefulset status replicas for all the control-planes
+  - record: seed:kube_statefulset_status_replicas:sum_cp
+    expr: sum(kube_statefulset_status_replicas{namespace=~"((shoot-|shoot--)(\\w.+))"})
+  
+  # Recording rules for statefulset status replicas available for all the control-planes
+  - record: seed:kube_statefulset_status_replicas_ready:sum_cp
+    expr: sum(kube_statefulset_status_replicas_ready{namespace=~"((shoot-|shoot--)(\\w.+))"})
+  


### PR DESCRIPTION
**What this PR does / why we need it**:
Some more aggregate metrics to monitor the seed workload with more focus on the health of the seed workload. Includes container restart counts, ready replicas for deployment/statefulsets, pod counts by phase and state etc.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow up to #1863.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Some more aggregate metrics to monitor the seed workload with more focus on the health of the seed workload. Includes container restart counts, ready replicas for deployment/statefulsets, pod counts by phase and state etc.
```
