### PR TITLE
Support multiple DNS providers

### DIFF
--- a/charts/seed-dns/provider/templates/dnsprovider.yaml
+++ b/charts/seed-dns/provider/templates/dnsprovider.yaml
@@ -17,6 +17,10 @@ metadata:
   annotations:
     dns.gardener.cloud/realms: "{{ .Release.Namespace }},"
 {{- end }}
+{{- if .Values.providerLabels }}
+  labels:
+{{ toYaml .Values.providerLabels | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.provider }}
   secretRef:

--- a/charts/seed-dns/provider/values.yaml
+++ b/charts/seed-dns/provider/values.yaml
@@ -1,6 +1,7 @@
 name: internal
 purpose: internal
 provider: ""
+# providerLabels: # YAML formated labels used for provider
 secretData: {}
 domains:
   include: []

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -193,6 +193,7 @@ spec:
   # providers:
   # - type: aws-route53
   #   secretName: my-custom-domain-secret
+  #   primary: true # `true` indicates that this provider is also used to manage the shoot domain `.spec.dns.domain`
   #   domains:
   #     include:
   #     - my-custom-domain.com

--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -2920,6 +2920,18 @@ DNSIncludeExclude
 </tr>
 <tr>
 <td>
+<code>primary</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Primary indicates that this DNSProvider is used for shoot related domains.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>secretName</code></br>
 <em>
 string
@@ -7296,5 +7308,5 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>2bdda9f61</code>.
+on git commit <code>8f4d7313c</code>.
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -3102,5 +3102,5 @@ the cluster-autoscaler properly.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>2bdda9f61</code>.
+on git commit <code>8f4d7313c</code>.
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,5 +555,5 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>2bdda9f61</code>.
+on git commit <code>8f4d7313c</code>.
 </em></p>

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -176,6 +176,8 @@ type DNS struct {
 type DNSProvider struct {
 	// Domains contains information about which domains shall be included/excluded for this provider.
 	Domains *DNSIncludeExclude
+	// Primary indicates that this DNSProvider is used for shoot related domains.
+	Primary *bool
 	// SecretName is a name of a secret containing credentials for the stated domain and the
 	// provider. When not specified, the Gardener will use the cloud provider credentials referenced
 	// by the Shoot and try to find respective credentials there. Specifying this field may override

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -213,6 +213,9 @@ type DNSProvider struct {
 	// Domains contains information about which domains shall be included/excluded for this provider.
 	// +optional
 	Domains *DNSIncludeExclude `json:"domains,omitempty"`
+	// Primary indicates that this DNSProvider is used for shoot related domains.
+	// +optional
+	Primary *bool `json:"primary,omitempty"`
 	// SecretName is a name of a secret containing credentials for the stated domain and the
 	// provider. When not specified, the Gardener will use the cloud provider credentials referenced
 	// by the Shoot and try to find respective credentials there. Specifying this field may override

--- a/pkg/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2118,6 +2118,7 @@ func Convert_core_DNSIncludeExclude_To_v1alpha1_DNSIncludeExclude(in *core.DNSIn
 
 func autoConvert_v1alpha1_DNSProvider_To_core_DNSProvider(in *DNSProvider, out *core.DNSProvider, s conversion.Scope) error {
 	out.Domains = (*core.DNSIncludeExclude)(unsafe.Pointer(in.Domains))
+	out.Primary = (*bool)(unsafe.Pointer(in.Primary))
 	out.SecretName = (*string)(unsafe.Pointer(in.SecretName))
 	out.Type = (*string)(unsafe.Pointer(in.Type))
 	out.Zones = (*core.DNSIncludeExclude)(unsafe.Pointer(in.Zones))
@@ -2131,6 +2132,7 @@ func Convert_v1alpha1_DNSProvider_To_core_DNSProvider(in *DNSProvider, out *core
 
 func autoConvert_core_DNSProvider_To_v1alpha1_DNSProvider(in *core.DNSProvider, out *DNSProvider, s conversion.Scope) error {
 	out.Domains = (*DNSIncludeExclude)(unsafe.Pointer(in.Domains))
+	out.Primary = (*bool)(unsafe.Pointer(in.Primary))
 	out.SecretName = (*string)(unsafe.Pointer(in.SecretName))
 	out.Type = (*string)(unsafe.Pointer(in.Type))
 	out.Zones = (*DNSIncludeExclude)(unsafe.Pointer(in.Zones))

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -951,6 +951,11 @@ func (in *DNSProvider) DeepCopyInto(out *DNSProvider) {
 		*out = new(DNSIncludeExclude)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Primary != nil {
+		in, out := &in.Primary, &out.Primary
+		*out = new(bool)
+		**out = **in
+	}
 	if in.SecretName != nil {
 		in, out := &in.SecretName, &out.SecretName
 		*out = new(string)

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -758,3 +758,19 @@ func IsAPIServerExposureManaged(obj metav1.Object) bool {
 
 	return false
 }
+
+// FindPrimaryDNSProvider finds the primary provider among the given `providers`.
+// It returns the first provider in case no primary provider is available or the first one if multiple candidates are found.
+func FindPrimaryDNSProvider(providers []gardencorev1beta1.DNSProvider) *gardencorev1beta1.DNSProvider {
+	for _, provider := range providers {
+		if provider.Primary != nil && *provider.Primary {
+			primaryProvider := provider
+			return &primaryProvider
+		}
+	}
+	// TODO: timuthy - Only required for migration and can be removed in a future version.
+	if len(providers) > 0 {
+		return &providers[0]
+	}
+	return nil
+}

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -210,6 +210,9 @@ type DNSProvider struct {
 	// Domains contains information about which domains shall be included/excluded for this provider.
 	// +optional
 	Domains *DNSIncludeExclude `json:"domains,omitempty"`
+	// Primary indicates that this DNSProvider is used for shoot related domains.
+	// +optional
+	Primary *bool `json:"primary,omitempty"`
 	// SecretName is a name of a secret containing credentials for the stated domain and the
 	// provider. When not specified, the Gardener will use the cloud provider credentials referenced
 	// by the Shoot and try to find respective credentials there. Specifying this field may override

--- a/pkg/apis/core/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1beta1/zz_generated.conversion.go
@@ -1988,6 +1988,7 @@ func Convert_core_DNSIncludeExclude_To_v1beta1_DNSIncludeExclude(in *core.DNSInc
 
 func autoConvert_v1beta1_DNSProvider_To_core_DNSProvider(in *DNSProvider, out *core.DNSProvider, s conversion.Scope) error {
 	out.Domains = (*core.DNSIncludeExclude)(unsafe.Pointer(in.Domains))
+	out.Primary = (*bool)(unsafe.Pointer(in.Primary))
 	out.SecretName = (*string)(unsafe.Pointer(in.SecretName))
 	out.Type = (*string)(unsafe.Pointer(in.Type))
 	out.Zones = (*core.DNSIncludeExclude)(unsafe.Pointer(in.Zones))
@@ -2001,6 +2002,7 @@ func Convert_v1beta1_DNSProvider_To_core_DNSProvider(in *DNSProvider, out *core.
 
 func autoConvert_core_DNSProvider_To_v1beta1_DNSProvider(in *core.DNSProvider, out *DNSProvider, s conversion.Scope) error {
 	out.Domains = (*DNSIncludeExclude)(unsafe.Pointer(in.Domains))
+	out.Primary = (*bool)(unsafe.Pointer(in.Primary))
 	out.SecretName = (*string)(unsafe.Pointer(in.SecretName))
 	out.Type = (*string)(unsafe.Pointer(in.Type))
 	out.Zones = (*DNSIncludeExclude)(unsafe.Pointer(in.Zones))

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -951,6 +951,11 @@ func (in *DNSProvider) DeepCopyInto(out *DNSProvider) {
 		*out = new(DNSIncludeExclude)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Primary != nil {
+		in, out := &in.Primary, &out.Primary
+		*out = new(bool)
+		**out = **in
+	}
 	if in.SecretName != nil {
 		in, out := &in.SecretName, &out.SecretName
 		*out = new(string)

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -951,6 +951,11 @@ func (in *DNSProvider) DeepCopyInto(out *DNSProvider) {
 		*out = new(DNSIncludeExclude)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Primary != nil {
+		in, out := &in.Primary, &out.Primary
+		*out = new(bool)
+		**out = **in
+	}
 	if in.SecretName != nil {
 		in, out := &in.SecretName, &out.SecretName
 		*out = new(string)

--- a/pkg/client/core/openapi/zz_generated.openapi.go
+++ b/pkg/client/core/openapi/zz_generated.openapi.go
@@ -1706,6 +1706,13 @@ func schema_pkg_apis_core_v1alpha1_DNSProvider(ref common.ReferenceCallback) com
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.DNSIncludeExclude"),
 						},
 					},
+					"primary": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Primary indicates that this DNSProvider is used for shoot related domains.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"secretName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "SecretName is a name of a secret containing credentials for the stated domain and the provider. When not specified, the Gardener will use the cloud provider credentials referenced by the Shoot and try to find respective credentials there. Specifying this field may override this behavior, i.e. forcing the Gardener to only look into the given secret.",
@@ -6738,6 +6745,13 @@ func schema_pkg_apis_core_v1beta1_DNSProvider(ref common.ReferenceCallback) comm
 						SchemaProps: spec.SchemaProps{
 							Description: "Domains contains information about which domains shall be included/excluded for this provider.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.DNSIncludeExclude"),
+						},
+					},
+					"primary": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Primary indicates that this DNSProvider is used for shoot related domains.",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 					"secretName": {

--- a/pkg/client/kubernetes/apply.go
+++ b/pkg/client/kubernetes/apply.go
@@ -208,7 +208,7 @@ func (c *Applier) ApplyManifest(ctx context.Context, r UnstructuredReader, optio
 		}
 
 		if err := c.applyObject(ctx, obj, options); err != nil {
-			allErrs = multierror.Append(allErrs, fmt.Errorf("could not apply object of kind \"%s\" \"%s/%s\": %+v", obj.GetKind(), obj.GetNamespace(), obj.GetName(), err))
+			allErrs = multierror.Append(allErrs, fmt.Errorf("could not apply object of kind %q \"%s/%s\": %+v", obj.GetKind(), obj.GetNamespace(), obj.GetName(), err))
 			continue
 		}
 	}
@@ -238,7 +238,7 @@ func (c *Applier) DeleteManifest(ctx context.Context, r UnstructuredReader) erro
 		}
 
 		if err := c.deleteObject(ctx, obj); err != nil {
-			allErrs = multierror.Append(allErrs, fmt.Errorf("could not delete object of kind \"%s\" \"%s/%s\": %+v", obj.GetKind(), obj.GetNamespace(), obj.GetName(), err))
+			allErrs = multierror.Append(allErrs, fmt.Errorf("could not delete object of kind %q \"%s/%s\": %+v", obj.GetKind(), obj.GetNamespace(), obj.GetName(), err))
 			continue
 		}
 	}

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -441,10 +441,15 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation, errorContext *er
 			Fn:           flow.TaskFn(botanist.DestroyInternalDomainDNSRecord).DoIf(dnsEnabled),
 			Dependencies: flow.NewTaskIDs(syncPoint),
 		})
+		deleteDNSProviders = g.Add(flow.Task{
+			Name:         "Deleting DNS providers",
+			Fn:           flow.TaskFn(botanist.DeleteDNSProviders).DoIf(dnsEnabled),
+			Dependencies: flow.NewTaskIDs(destroyInternalDomainDNSRecord),
+		})
 		deleteNamespace = g.Add(flow.Task{
 			Name:         "Deleting shoot namespace in Seed",
 			Fn:           flow.TaskFn(botanist.DeleteNamespace).Retry(defaultInterval),
-			Dependencies: flow.NewTaskIDs(syncPoint, destroyInternalDomainDNSRecord, deleteKubeAPIServer),
+			Dependencies: flow.NewTaskIDs(syncPoint, deleteDNSProviders, deleteKubeAPIServer),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until shoot namespace in Seed has been deleted",

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1934,6 +1934,13 @@ func schema_pkg_apis_core_v1alpha1_DNSProvider(ref common.ReferenceCallback) com
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.DNSIncludeExclude"),
 						},
 					},
+					"primary": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Primary indicates that this DNSProvider is used for shoot related domains.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"secretName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "SecretName is a name of a secret containing credentials for the stated domain and the provider. When not specified, the Gardener will use the cloud provider credentials referenced by the Shoot and try to find respective credentials there. Specifying this field may override this behavior, i.e. forcing the Gardener to only look into the given secret.",
@@ -6966,6 +6973,13 @@ func schema_pkg_apis_core_v1beta1_DNSProvider(ref common.ReferenceCallback) comm
 						SchemaProps: spec.SchemaProps{
 							Description: "Domains contains information about which domains shall be included/excluded for this provider.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.DNSIncludeExclude"),
+						},
+					},
+					"primary": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Primary indicates that this DNSProvider is used for shoot related domains.",
+							Type:        []string{"boolean"},
+							Format:      "",
 						},
 					},
 					"secretName": {

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -34,8 +34,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// DNSPurposeIngress is a constant for a DNS record used for the ingress domain name.
-const DNSPurposeIngress = "ingress"
+// DNSIngressName is a constant for a DNS resources used for the ingress domain name.
+const DNSIngressName = "ingress"
 
 // EnsureIngressDNSRecord creates the respective wildcard DNS record for the nginx-ingress-controller.
 func (b *Botanist) EnsureIngressDNSRecord(ctx context.Context) error {
@@ -48,16 +48,16 @@ func (b *Botanist) EnsureIngressDNSRecord(ctx context.Context) error {
 		return err
 	}
 
-	if err := b.waitUntilDNSProviderReady(ctx, DNSPurposeExternal); err != nil {
+	if err := b.waitUntilDNSProviderReady(ctx, DNSIngressName); err != nil {
 		return err
 	}
 
-	return b.deployDNSEntry(ctx, DNSPurposeIngress, b.Shoot.GetIngressFQDN("*"), loadBalancerIngress)
+	return b.deployDNSEntry(ctx, DNSIngressName, b.Shoot.GetIngressFQDN("*"), loadBalancerIngress)
 }
 
 // DestroyIngressDNSRecord destroys the nginx-ingress resources created by Terraform.
 func (b *Botanist) DestroyIngressDNSRecord(ctx context.Context) error {
-	return b.deleteDNSEntry(ctx, DNSPurposeIngress)
+	return b.deleteDNSEntry(ctx, DNSIngressName)
 }
 
 // GenerateKubernetesDashboardConfig generates the values which are required to render the chart of

--- a/pkg/operation/botanist/constraints_check.go
+++ b/pkg/operation/botanist/constraints_check.go
@@ -17,6 +17,7 @@ package botanist
 import (
 	"context"
 	"fmt"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 
@@ -73,7 +74,7 @@ func (b *Botanist) CheckHibernationPossible(ctx context.Context, constraint gard
 				}
 
 				c := gardencorev1beta1helper.UpdatedCondition(constraint, gardencorev1beta1.ConditionFalse, "ProblematicWebhooks",
-					fmt.Sprintf("Shoot cannot be hibernated because of ValidatingWebhookConfiguration \"%s\": webhook \"%s\" with failurePolicy \"%s\" will probably prevent the Shoot from being woken up again",
+					fmt.Sprintf("Shoot cannot be hibernated because of ValidatingWebhookConfiguration %q: webhook %q with failurePolicy %q will probably prevent the Shoot from being woken up again",
 						webhookConfig.Name, w.Name, failurePolicy))
 				return &c, nil
 			}
@@ -96,7 +97,7 @@ func (b *Botanist) CheckHibernationPossible(ctx context.Context, constraint gard
 				}
 
 				c := gardencorev1beta1helper.UpdatedCondition(constraint, gardencorev1beta1.ConditionFalse, "ProblematicWebhooks",
-					fmt.Sprintf("Shoot cannot be hibernated because of MutatingWebhookConfiguration \"%s\": webhook \"%s\" with failurePolicy \"%s\" will probably prevent the Shoot from being woken up again",
+					fmt.Sprintf("Shoot cannot be hibernated because of MutatingWebhookConfiguration %q: webhook %q with failurePolicy %q will probably prevent the Shoot from being woken up again",
 						webhookConfig.Name, w.Name, failurePolicy))
 				return &c, nil
 			}

--- a/pkg/operation/shoot/shoot_test.go
+++ b/pkg/operation/shoot/shoot_test.go
@@ -224,6 +224,7 @@ var _ = Describe("shoot", func() {
 									{
 										Type:       &provider,
 										SecretName: &dnsSecretName,
+										Primary:    pointer.BoolPtr(true),
 									},
 								},
 							},
@@ -286,7 +287,8 @@ var _ = Describe("shoot", func() {
 								Domain: &domain,
 								Providers: []gardencorev1beta1.DNSProvider{
 									{
-										Type: &provider,
+										Type:    &provider,
+										Primary: pointer.BoolPtr(true),
 									},
 								},
 							},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements the support for multiple DNS providers.

A new (optional) field was added to the `DNSProvider` struct which identifies a given provider as the one managing the shoot domain. This handling is a best effort implementation to avoid removing such a provider by the end user.

```
dns:
  providers:    
  - secretName: custom-dns
    type: google-clouddns
    primary: true
```

**Which issue(s) this PR fixes**:
Fixes #1572 

**Special notes for your reviewer**:
Some migration logic is necessary to fill out the newly introduced field. I'll remove this again in on of the upcoming versions.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Gardener now supports the configuration of multiple DNS providers in the shoot.
```
```noteworthy operator
Gardener now supports the configuration of multiple DNS providers in the shoot. These providers can especially be used in combination with the `shoot-dns-service` (https://github.com/gardener/gardener-extension-shoot-dns-service) in your Garden environment.
```
