### PR TITLE
Remove merge artifacts from api-reference

### DIFF
--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -7274,9 +7274,5 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-<<<<<<< HEAD
-on git commit <code>753d7857c</code>.
-=======
-on git commit <code>13d359fa9</code>.
->>>>>>> Set shoot conditions to unknown if gardenlet stops sending heartbeats
+on git commit <code>37f4ded7c</code>.
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -3102,9 +3102,5 @@ the cluster-autoscaler properly.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-<<<<<<< HEAD
-on git commit <code>753d7857c</code>.
-=======
-on git commit <code>13d359fa9</code>.
->>>>>>> Set shoot conditions to unknown if gardenlet stops sending heartbeats
+on git commit <code>37f4ded7c</code>.
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,9 +555,5 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-<<<<<<< HEAD
-on git commit <code>753d7857c</code>.
-=======
-on git commit <code>13d359fa9</code>.
->>>>>>> Set shoot conditions to unknown if gardenlet stops sending heartbeats
+on git commit <code>37f4ded7c</code>.
 </em></p>


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove merge artifacts from api-reference introduced in #1911

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
