### PR TITLE
fix ComputeClusterIP calculation

### DIFF
--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -183,11 +183,11 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 		vpnTLSAuthSecret = b.Secrets["vpn-seed-tlsauth"]
 		global           = map[string]interface{}{
 			"kubernetesVersion": b.Shoot.Info.Spec.Kubernetes.Version,
-			"podNetwork":        b.Shoot.GetPodNetwork(),
+			"podNetwork":        b.Shoot.Networks.Pods.String(),
 		}
 		coreDNSConfig = map[string]interface{}{
 			"service": map[string]interface{}{
-				"clusterDNS": common.ComputeClusterIP(b.Shoot.GetServiceNetwork(), 10),
+				"clusterDNS": b.Shoot.Networks.CoreDNS.String(),
 				// TODO: resolve conformance test issue before changing:
 				// https://github.com/kubernetes/kubernetes/blob/master/test/e2e/network/dns.go#L44
 				"domain": map[string]interface{}{
@@ -215,8 +215,8 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 			},
 		}
 		vpnShootConfig = map[string]interface{}{
-			"podNetwork":     b.Shoot.GetPodNetwork(),
-			"serviceNetwork": b.Shoot.GetServiceNetwork(),
+			"podNetwork":     b.Shoot.Networks.Pods.String(),
+			"serviceNetwork": b.Shoot.Networks.Services.String(),
 			"tlsAuth":        vpnTLSAuthSecret.Data["vpn.tlsauth"],
 			"podAnnotations": map[string]interface{}{
 				"checksum/secret-vpn-shoot": b.CheckSums["vpn-shoot"],
@@ -229,8 +229,8 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 			"provider":          b.Shoot.Info.Spec.Provider.Type,
 			"region":            b.Shoot.Info.Spec.Region,
 			"kubernetesVersion": b.Shoot.Info.Spec.Kubernetes.Version,
-			"podNetwork":        b.Shoot.GetPodNetwork(),
-			"serviceNetwork":    b.Shoot.GetServiceNetwork(),
+			"podNetwork":        b.Shoot.Networks.Pods.String(),
+			"serviceNetwork":    b.Shoot.Networks.Services.String(),
 			"maintenanceBegin":  b.Shoot.Info.Spec.Maintenance.TimeWindow.Begin,
 			"maintenanceEnd":    b.Shoot.Info.Spec.Maintenance.TimeWindow.End,
 		}

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -672,8 +672,8 @@ func (b *Botanist) DeployKubeAPIServer() error {
 		maxReplicas int32 = 4
 
 		shootNetworks = map[string]interface{}{
-			"services": b.Shoot.GetServiceNetwork(),
-			"pods":     b.Shoot.GetPodNetwork(),
+			"services": b.Shoot.Networks.Services.String(),
+			"pods":     b.Shoot.Networks.Pods.String(),
 		}
 
 		defaultValues = map[string]interface{}{
@@ -956,8 +956,8 @@ func (b *Botanist) DeployKubeControllerManager() error {
 	defaultValues := map[string]interface{}{
 		"clusterName":       b.Shoot.SeedNamespace,
 		"kubernetesVersion": b.Shoot.Info.Spec.Kubernetes.Version,
-		"podNetwork":        b.Shoot.GetPodNetwork(),
-		"serviceNetwork":    b.Shoot.GetServiceNetwork(),
+		"podNetwork":        b.Shoot.Networks.Pods.String(),
+		"serviceNetwork":    b.Shoot.Networks.Services.String(),
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-ca":                             b.CheckSums[v1beta1constants.SecretNameCACluster],
 			"checksum/secret-kube-controller-manager":        b.CheckSums[v1beta1constants.DeploymentNameKubeControllerManager],

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -95,8 +95,8 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 
 	var (
 		networks = map[string]interface{}{
-			"pods":     b.Shoot.GetPodNetwork(),
-			"services": b.Shoot.GetServiceNetwork(),
+			"pods":     b.Shoot.Networks.Pods.String(),
+			"services": b.Shoot.Networks.Services.String(),
 		}
 
 		prometheusConfig = map[string]interface{}{
@@ -114,7 +114,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 				"checksum/secret-vpn-seed-tlsauth": b.CheckSums["vpn-seed-tlsauth"],
 			},
 			"replicas":           b.Shoot.GetReplicas(1),
-			"apiserverServiceIP": common.ComputeClusterIP(b.Shoot.GetServiceNetwork(), 1),
+			"apiserverServiceIP": b.Shoot.Networks.APIServer.String(),
 			"seed": map[string]interface{}{
 				"apiserver": b.K8sSeedClient.RESTConfig().Host,
 				"region":    b.Seed.Info.Spec.Provider.Region,

--- a/pkg/operation/botanist/network.go
+++ b/pkg/operation/botanist/network.go
@@ -52,8 +52,8 @@ func (b *Botanist) DeployNetwork(ctx context.Context) error {
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
 				Type: string(b.Shoot.Info.Spec.Networking.Type),
 			},
-			PodCIDR:     string(b.Shoot.GetPodNetwork()),
-			ServiceCIDR: string(b.Shoot.GetServiceNetwork()),
+			PodCIDR:     b.Shoot.Networks.Pods.String(),
+			ServiceCIDR: b.Shoot.Networks.Services.String(),
 		}
 
 		if b.Shoot.Info.Spec.Networking.ProviderConfig != nil {

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -128,11 +128,9 @@ func (b *Botanist) generateDownloaderConfig(machineImageName string) map[string]
 
 func (b *Botanist) generateOriginalConfig() (map[string]interface{}, error) {
 	var (
-		serviceNetwork = b.Shoot.GetServiceNetwork()
-
 		originalConfig = map[string]interface{}{
 			"kubernetes": map[string]interface{}{
-				"clusterDNS": common.ComputeClusterIP(serviceNetwork, 10),
+				"clusterDNS": b.Shoot.Networks.CoreDNS.String(),
 				"domain":     gardencorev1beta1.DefaultDomain,
 				"version":    b.Shoot.Info.Spec.Kubernetes.Version,
 			},

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -80,7 +80,7 @@ func (b *Botanist) generateWantedSecrets(basicAuthAPIServer *secrets.BasicAuth, 
 	var (
 		apiServerIPAddresses = []net.IP{
 			net.ParseIP("127.0.0.1"),
-			net.ParseIP(common.ComputeClusterIP(b.Shoot.GetServiceNetwork(), 1)),
+			b.Shoot.Networks.APIServer,
 		}
 		apiServerCertDNSNames = append([]string{
 			"kube-apiserver",

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -17,6 +17,7 @@ package shoot
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -102,7 +103,15 @@ func New(k8sGardenClient kubernetes.Interface, k8sGardenCoreInformers gardencore
 	if err != nil {
 		return nil, err
 	}
+
 	shootObj.WantsClusterAutoscaler = needsAutoscaler
+
+	nwkrs, err := ToNetworks(shoot)
+	if err != nil {
+		return nil, err
+	}
+
+	shootObj.Networks = nwkrs
 
 	return shootObj, nil
 }
@@ -148,24 +157,6 @@ func (s *Shoot) GetNodeCount() int32 {
 		nodeCount += worker.Maximum
 	}
 	return nodeCount
-}
-
-// GetPodNetwork returns the pod network CIDR for the Shoot cluster. If no CIDR was specified then an
-// empty string is returned.
-func (s *Shoot) GetPodNetwork() string {
-	if val := s.Info.Spec.Networking.Pods; val != nil {
-		return *val
-	}
-	return ""
-}
-
-// GetServiceNetwork returns the service network CIDR for the Shoot cluster. If no CIDR was specified then an
-// empty string is returned.
-func (s *Shoot) GetServiceNetwork() string {
-	if val := s.Info.Spec.Networking.Services; val != nil {
-		return *val
-	}
-	return ""
 }
 
 // GetNodeNetwork returns the nodes network CIDR for the Shoot cluster. If the infrastructure extension
@@ -417,4 +408,43 @@ func MergeExtensions(registrations []gardencorev1beta1.ControllerRegistration, e
 	}
 
 	return requiredExtensions, nil
+}
+
+// ToNetworks return a network with computed cidrs and ClusterIPs
+// for a Shoot
+func ToNetworks(s *gardencorev1beta1.Shoot) (*Networks, error) {
+	if s.Spec.Networking.Services == nil {
+		return nil, fmt.Errorf("shoot's service cidr is empty")
+	}
+
+	if s.Spec.Networking.Pods == nil {
+		return nil, fmt.Errorf("shoot's pods cidr is empty")
+	}
+
+	_, svc, err := net.ParseCIDR(*s.Spec.Networking.Services)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse shoot's network cidr %v", err)
+	}
+
+	_, pods, err := net.ParseCIDR(*s.Spec.Networking.Pods)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse shoot's network cidr %v", err)
+	}
+
+	apiserver, err := common.ComputeOffsetIP(svc, 1)
+	if err != nil {
+		return nil, fmt.Errorf("cannot calculate default/kubernetes ClusterIP: %v", err)
+	}
+
+	coreDNS, err := common.ComputeOffsetIP(svc, 10)
+	if err != nil {
+		return nil, fmt.Errorf("cannot calculate CoreDNS ClusterIP: %v", err)
+	}
+
+	return &Networks{
+		CoreDNS:   coreDNS,
+		Pods:      pods,
+		Services:  svc,
+		APIServer: apiserver,
+	}, nil
 }

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -15,6 +15,7 @@
 package shoot
 
 import (
+	"net"
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -43,11 +44,25 @@ type Shoot struct {
 	IgnoreAlerts           bool
 	HibernationEnabled     bool
 
+	Networks *Networks
+
 	OperatingSystemConfigsMap map[string]OperatingSystemConfigs
 	Extensions                map[string]Extension
 	InfrastructureStatus      []byte
 	ControlPlaneStatus        []byte
 	MachineDeployments        []extensionsv1alpha1.MachineDeployment
+}
+
+// Networks contains pre-calculated subnets and IP address for various components.
+type Networks struct {
+	// Pods subnet
+	Pods *net.IPNet
+	// Services subnet
+	Services *net.IPNet
+	// APIServer is the ClusterIP of default/kubernetes Service
+	APIServer net.IP
+	// CoreDNS is the ClusterIP of kube-system/coredns Service
+	CoreDNS net.IP
 }
 
 // OperatingSystemConfigs contains operating system configs for the downloader script as well as for the original cloud config.


### PR DESCRIPTION
**What this PR does / why we need it**:

With the current implementation calling `ComputeClusterIP("192.168.64.16/28", 10)` would return `192.168.64.10` which is outside of the netmask.

```console
sipcalc 192.168.64.16/28

-[ipv4 : 192.168.64.16/28] - 0

[CIDR]
Host address            - 192.168.64.16
Host address (decimal)  - 3232251920
Host address (hex)      - C0A84010
Network address         - 192.168.64.16
Network mask            - 255.255.255.240
Network mask (bits)     - 28
Network mask (hex)      - FFFFFFF0
Broadcast address       - 192.168.64.31
Cisco wildcard          - 0.0.0.15
Addresses in network    - 16
Network range           - 192.168.64.16 - 192.168.64.31
Usable range            - 192.168.64.17 - 192.168.64.30
```

**Which issue(s) this PR fixes**:
Fixes # n/a

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
