### PR TITLE
Prevent panic in scheduler when checking networks

### DIFF
--- a/pkg/scheduler/controller/shoot/scheduler_control.go
+++ b/pkg/scheduler/controller/shoot/scheduler_control.go
@@ -358,11 +358,13 @@ func networksAreDisjointed(seed *gardencorev1beta1.Seed, shoot *gardencorev1beta
 		errorMessages []string
 	)
 
-	if shootPodsNetwork == nil {
-		shootPodsNetwork = seed.Spec.Networks.ShootDefaults.Pods
-	}
-	if shootServicesNetwork == nil {
-		shootServicesNetwork = seed.Spec.Networks.ShootDefaults.Services
+	if seed.Spec.Networks.ShootDefaults != nil {
+		if shootPodsNetwork == nil {
+			shootPodsNetwork = seed.Spec.Networks.ShootDefaults.Pods
+		}
+		if shootServicesNetwork == nil {
+			shootServicesNetwork = seed.Spec.Networks.ShootDefaults.Services
+		}
 	}
 
 	for _, e := range cidrvalidation.ValidateNetworkDisjointedness(

--- a/pkg/scheduler/controller/shoot/scheduler_test.go
+++ b/pkg/scheduler/controller/shoot/scheduler_test.go
@@ -398,6 +398,19 @@ var _ = Describe("Scheduler_Control", func() {
 			Expect(bestSeed).To(BeNil())
 		})
 
+		It("should fail because it cannot find a seed cluster due to no shoot networks specified and no defaults", func() {
+			gardenCoreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
+			gardenCoreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)
+
+			seed.Spec.Networks.ShootDefaults = nil
+			shoot.Spec.Networking = gardencorev1beta1.Networking{}
+
+			bestSeed, err := determineSeed(&shoot, gardenCoreInformerFactory.Core().V1beta1().Seeds().Lister(), gardenCoreInformerFactory.Core().V1beta1().Shoots().Lister(), gardenCoreInformerFactory.Core().V1beta1().CloudProfiles().Lister(), schedulerConfiguration.Schedulers.Shoot.Strategy)
+
+			Expect(err).To(HaveOccurred())
+			Expect(bestSeed).To(BeNil())
+		})
+
 		It("should fail because it cannot find a seed cluster due to region that no seed supports", func() {
 			gardenCoreInformerFactory.Core().V1beta1().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
 			gardenCoreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(&seed)


### PR DESCRIPTION
**What this PR does / why we need it**:
If the `Seed` object does not specify shoot default networks and a shoot is created without networks then the scheduler panics. This PR fixes the problem.

```
E0221 09:04:15.762660    8466 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 160 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x21ad380, 0x319bb20)
	/Users/rfranzke/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/Users/rfranzke/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x82
panic(0x21ad380, 0x319bb20)
	/usr/local/Cellar/go/1.13.1/libexec/src/runtime/panic.go:679 +0x1b2
github.com/gardener/gardener/pkg/scheduler/controller/shoot.networksAreDisjointed(0xc00027c800, 0xc000426a80, 0x235f3c0, 0x31ba640, 0xc00003fa90)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/scheduler/controller/shoot/scheduler_control.go:362 +0x304
github.com/gardener/gardener/pkg/scheduler/controller/shoot.filterCandidates(0xc000426a80, 0xc00082e078, 0x1, 0x1, 0x2397ce8, 0xa, 0xc00082e078, 0x1, 0x1)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/scheduler/controller/shoot/scheduler_control.go:245 +0xf5
github.com/gardener/gardener/pkg/scheduler/controller/shoot.determineSeed(0xc000426a80, 0x25957e0, 0xc0004bc9e0, 0x2595820, 0xc0004bc9c0, 0x2595620, 0xc0004bca00, 0x2397ce8, 0xa, 0x243a500, ...)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/scheduler/controller/shoot/scheduler_control.go:188 +0x23e
github.com/gardener/gardener/pkg/scheduler/controller/shoot.(*defaultControl).ScheduleShoot(0xc0005c6690, 0x25c60e0, 0xc00010ef00, 0xc000426380, 0xc000195440, 0x15, 0x0, 0x0)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/scheduler/controller/shoot/scheduler_control.go:130 +0x2c7
github.com/gardener/gardener/pkg/scheduler/controller/shoot.(*SchedulerController).reconcileShootKey(0xc0001ce4d0, 0x25c60e0, 0xc00010ef00, 0xc000195440, 0x15, 0x1, 0xc0008221f0)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/scheduler/controller/shoot/scheduler_control.go:92 +0x284
github.com/gardener/gardener/pkg/scheduler/controller/shoot.(*SchedulerController).Run.func2(0xc000195440, 0x15, 0xc000195440, 0x15)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/scheduler/controller/shoot/scheduler.go:122 +0x50
github.com/gardener/gardener/pkg/controllerutils.DeprecatedCreateWorker.func1(0xc000195420, 0xa, 0xc00019542b, 0xa, 0x0, 0x0, 0xc0008221d0, 0x0)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:46 +0x20a
sigs.k8s.io/controller-runtime/pkg/reconcile.Func.Reconcile(0xc000580b80, 0xc000195420, 0xa, 0xc00019542b, 0xa, 0xa, 0x0, 0x0, 0x0)
	/Users/rfranzke/go/src/github.com/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/reconcile/reconcile.go:93 +0x4e
github.com/gardener/gardener/pkg/controllerutils.worker.func1.1(0x25e6120, 0xc0001929a0, 0x258c620, 0xc000580b80, 0x239fcdc, 0x12, 0x0)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:99 +0x132
github.com/gardener/gardener/pkg/controllerutils.worker.func1()
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:116 +0x7e
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000815d00)
	/Users/rfranzke/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x5e
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000815d00, 0x3b9aca00, 0x0, 0x1, 0xc0001bc660)
	/Users/rfranzke/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/Users/rfranzke/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
github.com/gardener/gardener/pkg/controllerutils.CreateWorker.func1(0x25e6120, 0xc0001929a0, 0x239fcdc, 0x12, 0x258c620, 0xc000580b80, 0x25c60e0, 0xc00010ef00, 0xc0002f4060, 0xc0001700c0)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:57 +0xb4
created by github.com/gardener/gardener/pkg/controllerutils.CreateWorker
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:56 +0xec
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2019314]

goroutine 160 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/Users/rfranzke/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:55 +0x105
panic(0x21ad380, 0x319bb20)
	/usr/local/Cellar/go/1.13.1/libexec/src/runtime/panic.go:679 +0x1b2
github.com/gardener/gardener/pkg/scheduler/controller/shoot.networksAreDisjointed(0xc00027c800, 0xc000426a80, 0x235f3c0, 0x31ba640, 0xc00003fa90)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/scheduler/controller/shoot/scheduler_control.go:362 +0x304
github.com/gardener/gardener/pkg/scheduler/controller/shoot.filterCandidates(0xc000426a80, 0xc00082e078, 0x1, 0x1, 0x2397ce8, 0xa, 0xc00082e078, 0x1, 0x1)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/scheduler/controller/shoot/scheduler_control.go:245 +0xf5
github.com/gardener/gardener/pkg/scheduler/controller/shoot.determineSeed(0xc000426a80, 0x25957e0, 0xc0004bc9e0, 0x2595820, 0xc0004bc9c0, 0x2595620, 0xc0004bca00, 0x2397ce8, 0xa, 0x243a500, ...)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/scheduler/controller/shoot/scheduler_control.go:188 +0x23e
github.com/gardener/gardener/pkg/scheduler/controller/shoot.(*defaultControl).ScheduleShoot(0xc0005c6690, 0x25c60e0, 0xc00010ef00, 0xc000426380, 0xc000195440, 0x15, 0x0, 0x0)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/scheduler/controller/shoot/scheduler_control.go:130 +0x2c7
github.com/gardener/gardener/pkg/scheduler/controller/shoot.(*SchedulerController).reconcileShootKey(0xc0001ce4d0, 0x25c60e0, 0xc00010ef00, 0xc000195440, 0x15, 0x1, 0xc0008221f0)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/scheduler/controller/shoot/scheduler_control.go:92 +0x284
github.com/gardener/gardener/pkg/scheduler/controller/shoot.(*SchedulerController).Run.func2(0xc000195440, 0x15, 0xc000195440, 0x15)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/scheduler/controller/shoot/scheduler.go:122 +0x50
github.com/gardener/gardener/pkg/controllerutils.DeprecatedCreateWorker.func1(0xc000195420, 0xa, 0xc00019542b, 0xa, 0x0, 0x0, 0xc0008221d0, 0x0)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:46 +0x20a
sigs.k8s.io/controller-runtime/pkg/reconcile.Func.Reconcile(0xc000580b80, 0xc000195420, 0xa, 0xc00019542b, 0xa, 0xa, 0x0, 0x0, 0x0)
	/Users/rfranzke/go/src/github.com/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/reconcile/reconcile.go:93 +0x4e
github.com/gardener/gardener/pkg/controllerutils.worker.func1.1(0x25e6120, 0xc0001929a0, 0x258c620, 0xc000580b80, 0x239fcdc, 0x12, 0x0)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:99 +0x132
github.com/gardener/gardener/pkg/controllerutils.worker.func1()
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:116 +0x7e
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000815d00)
	/Users/rfranzke/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x5e
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000815d00, 0x3b9aca00, 0x0, 0x1, 0xc0001bc660)
	/Users/rfranzke/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/Users/rfranzke/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
github.com/gardener/gardener/pkg/controllerutils.CreateWorker.func1(0x25e6120, 0xc0001929a0, 0x239fcdc, 0x12, 0x258c620, 0xc000580b80, 0x25c60e0, 0xc00010ef00, 0xc0002f4060, 0xc0001700c0)
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:57 +0xb4
created by github.com/gardener/gardener/pkg/controllerutils.CreateWorker
	/Users/rfranzke/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:56 +0xec
exit status 2
make: *** [start-scheduler] Error 1
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug that caused a scheduler panic when a `Shoot` with `.spec.networking.pods = .spec.networking.services = nil` is created and there is at least one `Seed` with `.spec.networking.shootDefaults = nil` has been fixed.
```
