### PR TITLE
Disable memory metric for horizontal scaling of shoots' kube-apiserver in HVPA

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hpa.yaml
@@ -17,10 +17,10 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: {{ .Values.targetAverageUtilizationCpu }}
+      targetAverageUtilization: {{ .Values.hpa.targetAverageUtilizationCpu }}
   - type: Resource
     resource:
       name: memory
-      targetAverageUtilization: {{ .Values.targetAverageUtilizationMemory }}
+      targetAverageUtilization: {{ .Values.hpa.targetAverageUtilizationMemory }}
 {{- end }}
 {{ end }}

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hvpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hvpa.yaml
@@ -31,13 +31,15 @@ spec:
         maxReplicas: {{ .Values.maxReplicas }}
         minReplicas: {{ .Values.minReplicas }}
         metrics:
+{{- if .Values.hpa.memoryMetricForHpaEnabled }}
         - resource:
             name: memory
-            targetAverageUtilization: {{ .Values.targetAverageUtilizationMemory }}
+            targetAverageUtilization: {{ .Values.hpa.targetAverageUtilizationMemory }}
           type: Resource
+{{- end }}
         - resource:
             name: cpu
-            targetAverageUtilization: {{ .Values.targetAverageUtilizationCpu }}
+            targetAverageUtilization: {{ .Values.hpa.targetAverageUtilizationCpu }}
           type: Resource
   vpa:
     selector:

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -87,8 +87,11 @@ apiServerResources:
 
 maxReplicas: 1
 minReplicas: 1
-targetAverageUtilizationCpu: 80
-targetAverageUtilizationMemory: 80
+
+hpa:
+  targetAverageUtilizationCpu: 80
+  memoryMetricForHpaEnabled: false
+  targetAverageUtilizationMemory: 80
 
 auditConfig:
   auditPolicy: ""

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -661,10 +661,12 @@ func (b *Botanist) DeployKubeAPIServerService() error {
 // DeployKubeAPIServer deploys kube-apiserver deployment.
 func (b *Botanist) DeployKubeAPIServer() error {
 	hvpaEnabled := gardenletfeatures.FeatureGate.Enabled(features.HVPA)
+	memoryMetricForHpaEnabled := false
 
 	if b.ShootedSeed != nil {
 		// Override for shooted seeds
 		hvpaEnabled = gardenletfeatures.FeatureGate.Enabled(features.HVPAForShootedSeed)
+		memoryMetricForHpaEnabled = true
 	}
 
 	var (
@@ -697,6 +699,9 @@ func (b *Botanist) DeployKubeAPIServer() error {
 			},
 			"hvpa": map[string]interface{}{
 				"enabled": hvpaEnabled,
+			},
+			"hpa": map[string]interface{}{
+				"memoryMetricForHpaEnabled": memoryMetricForHpaEnabled,
 			},
 		}
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enabled memory metric for horizontal scaling only for seeds, and disables it for the shoot kube-apiservers.
Since kube-apiserver caches objects in the memory, this cache gets duplicated among its replicas. This throws off HPA's estimations of memory requirement for the kube-apiserver because of which we see multiple replicas of kube-apiserver even in shoots with no activity. These replicas have very low (baseline) CPU usage, however, high memory usage.
Currently the memory metric is disabled only for shoots. Depending on our observation of its efficacy and stability, we plan to make the same changes for shooted seeds also.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Disable memory metric for horizontal scaling of shoots' kube-apiserver in HVPA. This would help in scaling down kube-apiserver horizontally when the load is low since the affect of memory caching is eliminated. This helps in decreasing the cost of seeds.
```
