### PR TITLE
Add fenced flag for test running in a fenced environment

### DIFF
--- a/.test-defs/TestSuiteShootBeta.yaml
+++ b/.test-defs/TestSuiteShootBeta.yaml
@@ -17,6 +17,7 @@ spec:
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME
       -project-namespace=$PROJECT_NAMESPACE
+      -fenced=$FENCED
       -ginkgo.focus="\[BETA\]"
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
 

--- a/.test-defs/TestSuiteShootBetaSerial.yaml
+++ b/.test-defs/TestSuiteShootBetaSerial.yaml
@@ -19,6 +19,7 @@ spec:
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME
       -project-namespace=$PROJECT_NAMESPACE
+      -fenced=$FENCED
       -ginkgo.focus="\[BETA\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 

--- a/.test-defs/TestSuiteShootDefault.yaml
+++ b/.test-defs/TestSuiteShootDefault.yaml
@@ -17,6 +17,7 @@ spec:
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME
       -project-namespace=$PROJECT_NAMESPACE
+      -fenced=$FENCED
       -ginkgo.focus="\[DEFAULT\]"
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
 

--- a/.test-defs/TestSuiteShootDefaultSerial.yaml
+++ b/.test-defs/TestSuiteShootDefaultSerial.yaml
@@ -19,6 +19,7 @@ spec:
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME
       -project-namespace=$PROJECT_NAMESPACE
+      -fenced=$FENCED
       -ginkgo.focus="\[DEFAULT\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 

--- a/.test-defs/TestSuiteShootRelease.yaml
+++ b/.test-defs/TestSuiteShootRelease.yaml
@@ -17,6 +17,7 @@ spec:
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME
       -project-namespace=$PROJECT_NAMESPACE
+      -fenced=$FENCED
       -ginkgo.focus="\[RELEASE\]"
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
 

--- a/.test-defs/TestSuiteShootReleaseSerial.yaml
+++ b/.test-defs/TestSuiteShootReleaseSerial.yaml
@@ -19,6 +19,7 @@ spec:
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME
       -project-namespace=$PROJECT_NAMESPACE
+      -fenced=$FENCED
       -ginkgo.focus="\[RELEASE\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 

--- a/docs/testing/integration_tests.md
+++ b/docs/testing/integration_tests.md
@@ -88,6 +88,7 @@ go test -timeout=0 -mod=vendor ./test/suites/shoot
       -kubecfg=/path/to/gardener/kubeconfig
       -shoot-name=<shoot-name>                             # Name of the shoot to test
       -project-namespace=<gardener project namespace>
+      -fenced=<true|false>                                 # Tested shoot is running in a fenced environment and cannot be reached by gardener
 ```
 or for the gardener suite with:
 ```

--- a/test/framework/shootframework.go
+++ b/test/framework/shootframework.go
@@ -42,6 +42,7 @@ var shootCfg *ShootConfig
 type ShootConfig struct {
 	GardenerConfig *GardenerConfig
 	ShootName      string
+	Fenced         bool
 	SeedScheme     *runtime.Scheme
 
 	CreateTestNamespace         bool
@@ -261,6 +262,8 @@ func RegisterShootFrameworkFlags(flagset *flag.FlagSet) *ShootConfig {
 	newCfg := &ShootConfig{}
 
 	flag.StringVar(&newCfg.ShootName, "shoot-name", "", "name of the shoot")
+	flag.BoolVar(&newCfg.Fenced, "fenced", false,
+		"indicates if the shoot is running in a fenced environment which means that the shoot can only be reached from the gardenlet")
 
 	shootCfg = newCfg
 	return shootCfg

--- a/test/integration/plants/plant.go
+++ b/test/integration/plants/plant.go
@@ -117,6 +117,9 @@ users:
 	)
 
 	framework.CBeforeEach(func(ctx context.Context) {
+		if f.Config.Fenced {
+			ginkgo.Skip("Shoot skipped as it cannot be reached by gardener")
+		}
 		// read a valid kubeconfig form the given shoot
 		kubeconfig, err := framework.GetObjectFromSecret(ctx, f.GardenClient, f.ProjectNamespace, f.ShootKubeconfigSecretName(), framework.KubeconfigSecretKeyName)
 		framework.ExpectNoError(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Added a fenced flag to the testframework to specify if the shoot test is running in a fenced environment and therefore only the gardenlet can reach the shoot.

Also updated the plant test to respect the flag and skip them if the flag is set.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Added the `fenced` parameter to the test framework to specify shoots tests running in a fenced environment
```
