### PR TITLE
Change prometheus scrape interval to 1m

### DIFF
--- a/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/config.yaml
@@ -7,8 +7,8 @@ data:
   prometheus.yaml: |
 
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 1m
       external_labels:
         seed: {{ .Values.aggregatePrometheus.seed }}
 

--- a/charts/seed-bootstrap/templates/prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/config.yaml
@@ -7,8 +7,8 @@ data:
   prometheus.yaml: |
 
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 1m
     rule_files:
     - /etc/prometheus/rules/*.yaml
 
@@ -174,7 +174,7 @@ data:
         regex: vpa-exporter;metrics;garden
       metric_relabel_configs:
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.vpa | indent 6 }}
-    
+
 {{- if .Values.hvpa.enabled }}
     - job_name: 'hvpa-controller'
       kubernetes_sd_configs:

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -14,8 +14,8 @@ data:
     # take note that there is a limit of 500 samples per target
 
     global:
-      evaluation_interval: 30s
-      scrape_interval: 30s
+      evaluation_interval: 1m
+      scrape_interval: 1m
       external_labels:
         cluster: {{ .Release.Namespace }}
         project: {{ .Values.shoot.project }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Each prometheus's scrape interval is now 1m. This will reduce cross cluster network traffic. To reduce complexity the global scrape interval has been changed instead of configuring this per job.
Partial fix for #1953 

**Special notes for your reviewer**:
/cc @zanetworker 
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
All prometheus scrape intervals have been set to 1m.
```
