### PR TITLE
Add networkpolicies for grafana in garden namespace

### DIFF
--- a/charts/global-network-policies/templates/allow-to-aggregate-prometheus.yaml
+++ b/charts/global-network-policies/templates/allow-to-aggregate-prometheus.yaml
@@ -1,0 +1,25 @@
+apiVersion: {{ include "networkpolicyversion" . }}
+kind: NetworkPolicy
+metadata:
+  annotations:
+    gardener.cloud/description: |
+      Allows Egress from pods labeled with 'networking.gardener.cloud/to-aggregate-prometheus=allowed'
+      to the aggregate-prometheus.
+  name: allow-to-aggregate-prometheus
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      networking.gardener.cloud/to-aggregate-prometheus: allowed
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          role: garden
+      podSelector:
+        matchLabels:
+          app: aggregate-prometheus
+          role: monitoring
+  policyTypes:
+  - Egress
+  ingress: []

--- a/charts/seed-bootstrap/templates/grafana/grafana-deployment.yaml
+++ b/charts/seed-bootstrap/templates/grafana/grafana-deployment.yaml
@@ -21,6 +21,8 @@ spec:
         checksum/configmap-dashboard-providers: {{ include (print $.Template.BasePath "/grafana/grafana-dashboard-providers-configmap.yaml") . | sha256sum }}
       labels:
         garden.sapcloud.io/role: monitoring
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-aggregate-prometheus: allowed
         component: grafana
     spec:
       containers:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds some networkpolicies for the grafana in the garden namespace.

Partial fix for #1953 

**Special notes for your reviewer**:
/cc @zanetworker 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Grafana is no longer able to access the internet.
```
