### PR TITLE
Make nodeless setup even easier and add some docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ local-garden-up:
 	@./hack/local-garden/apply-rbac-garden-ns
 
 	# Now you can start using the cluster at with `export KUBECONFIG=hack/local-garden/kubeconfigs/default-admin.conf`
-	# Then you need to run ./hack/dev-setup-register-gardener to register gardener.
+	# Then you need to run `make dev-setup` to setup config and certificates files for gardener's components and to register the gardener-apiserver.
 	# Finally, run `make start-apiserver,start-controller-manager,start-scheduler,start-gardenlet` to start the gardener components as usual.
 
 .PHONY: local-garden-down

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -135,12 +135,45 @@ cd gardener
 1. You have understood the [principles of Kubernetes](https://kubernetes.io/docs/concepts/), and its [components](https://kubernetes.io/docs/concepts/overview/components/), what their purpose is and how they interact with each other.
 1. You have understood the [architecture of Gardener](https://github.com/gardener/documentation/wiki/Architecture), and what the various clusters are used for.
 
-The development of the Gardener could happen by targeting any cluster.
-You basically need a Garden cluster (e.g., a [Minikube](https://github.com/kubernetes/minikube) cluster) and one Seed cluster per cloud provider.
+#### Start a local kubernetes cluster
 
-The commands below will configure your `minikube` with the absolute minimum resources to launch Gardener API Server and Gardener Controller Manager on your local machine.
+For the development of Gardener you need some kind of Kubernetes cluster, which can be used as a "garden" cluster.
+I.e. you need a Kubernetes API server on which you can register a `APIService` Gardener's own Extension API Server.  
+For this you can use a standard tool from the community to setup a local cluster like minikube, kind or the Kubernetes Cluster feature in Docker for Desktop.
 
-#### Start minikube
+However, if you develop and run Gardener's components locally, you don't actually a fully fledged Kubernetes Cluster,
+i.e. you don't actually need to run Pods on it. If you want to use a more lightweight approach for development purposes,
+you can use the "nodeless Garden cluster setup" residing in `hack/local-garden`. This is the easiest way to get your
+Gardener development setup up and running.
+
+**Using the nodeless cluster setup**
+
+Setting up a local nodeless Garden cluster is quite simple. The only prerequisite is a running docker daemon.
+Just use the provided Makefile rules to start your local Garden:
+```bash
+make local-garden-up
+[...]
+Starting gardener-dev kube-etcd cluster..!
+Starting gardener-dev kube-apiserver..!
+Starting gardener-dev kube-controller-manager..!
+Starting gardener-dev gardener-etcd cluster..!
+namespace/garden created
+clusterrole.rbac.authorization.k8s.io/gardener.cloud:admin created
+clusterrolebinding.rbac.authorization.k8s.io/front-proxy-client created
+[...]
+```
+
+This will start all minimally required components of a Kubernetes cluster (`etcd`, `kube-apiserver`, `kube-controller-manager`)
+and an `etcd` Instance for the `gardener-apiserver` as Docker containers.
+
+To tear down the local Garden cluster and remove the Docker containers, simply run:
+```bash
+make local-garden-down
+```
+
+**Using minikube**
+
+Alternatively, spin up a cluster with minikube with this command:
 
 ```bash
 minikube start --embed-certs #  `--embed-certs` can be omitted if minikube has already been set to create self-contained kubeconfig files.
@@ -151,6 +184,9 @@ minikube start --embed-certs #  `--embed-certs` can be omitted if minikube has a
 ```
 
 #### Prepare the Gardener
+
+Now, that you have started your local cluster, we can go ahead and register the Gardener API Server.
+Just point your `KUBECONFIG` environment variable to the local cluster you created in the previous step and run:
 
 ```bash
 make dev-setup

--- a/hack/dev-setup
+++ b/hack/dev-setup
@@ -24,6 +24,9 @@ kubernetes_env="$(k8s_env)"
 
 # test if we are running against a Minikube, Docker or kind Kubernetes local setup
 case "${kubernetes_env}" in
+    $NODELESS)
+        echo "Found Nodeless Kubernetes ..."
+        ;;
     $KIND)
         echo "Found kind ..."
         LOCAL_K8S_HOST_IP=localhost
@@ -55,7 +58,8 @@ cp ${EXAMPLE_DIR}/20-componentconfig-gardenlet.yaml ${DEV_DIR}/
 kubectl apply -f ${EXAMPLE_DIR}/00-namespace-garden.yaml
 kubectl apply -f ${EXAMPLE_DIR}/00-namespace-garden-dev.yaml
 
-cat <<EOF | kubectl apply -f -
+if [ "${kubernetes_env}" != $NODELESS ] ; then
+  cat <<EOF | kubectl apply -f -
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -100,6 +104,7 @@ spec:
     run: etcd
   type: NodePort
 EOF
+fi
 
 mkdir -p ${DEV_DIR}/tls
 

--- a/hack/local-garden/README.md
+++ b/hack/local-garden/README.md
@@ -1,6 +1,7 @@
 # Local-Garden
 
-This is a small guide on how to operate the local-garden directory is structured. 
+This is a small guide on how the local-garden directory is structured.  
+To learn how you can use the nodeless setup in this directory, please see [this document](../../docs/development/local_setup.md).
 
 ## Components 
 Local-Garden consists of the following main directories:

--- a/hack/start-apiserver
+++ b/hack/start-apiserver
@@ -64,7 +64,7 @@ case $(k8s_env) in
           --tls-private-key-file ~/.minikube/apiserver.key \
           $apiserver_flags
         ;;
-      $NODELESS)
+    $NODELESS)
         echo "Found Nodeless Kubernetes ..."
         GO111MODULE=on go run \
           -mod=vendor \


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the nodeless local setup to make it even easier to get started with it.
Now you can just run `make local-garden-up` and `make dev-setup` and your good to go.
I also added some documentation for how to get started with in `docs/development/local_setup.md`.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
It is now even easier to get started developing on Gardener by leveraging the nodeless local setup. Please refer to the [documentation](https://github.com/gardener/gardener/blob/master/docs/development/local_setup.md) to see how to use it.
```
