### PR TITLE
Ensure workers not deployed before network ready

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -259,7 +259,7 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation, operationType
 		deployWorker = g.Add(flow.Task{
 			Name:         "Configuring shoot worker pools",
 			Fn:           flow.TaskFn(botanist.DeployWorker).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(deployCloudProviderSecret, waitUntilInfrastructureReady, initializeShootClients, computeShootOSConfig),
+			Dependencies: flow.NewTaskIDs(deployCloudProviderSecret, waitUntilInfrastructureReady, initializeShootClients, computeShootOSConfig, waitUntilNetworkIsReady),
 		})
 		waitUntilWorkerReady = g.Add(flow.Task{
 			Name:         "Waiting until shoot worker nodes have been reconciled",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to prevent machines from deploying before network plugin is installed.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Network and worker deployments are serialized.
```
