### PR TITLE
updated supported k8s version for kyma addon

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -133,12 +133,12 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *fi
 
 	// TODO: Just a temporary solution. Remove this in a future version once Kyma is moved out again.
 	if metav1.HasAnnotation(meta, common.ShootExperimentalAddonKyma) {
-		kubernetesGeq114Less116, err := versionutils.CheckVersionMeetsConstraint(spec.Kubernetes.Version, ">= 1.14, < 1.16")
+		kubernetesGeq114Less117, err := versionutils.CheckVersionMeetsConstraint(spec.Kubernetes.Version, ">= 1.14, < 1.17")
 		if err != nil {
-			kubernetesGeq114Less116 = false
+			kubernetesGeq114Less117 = false
 		}
-		if !kubernetesGeq114Less116 {
-			allErrs = append(allErrs, field.Forbidden(field.NewPath("kubernetes", "version"), "experimental kyma addon needs Kubernetes >= 1.14 and < 1.16"))
+		if !kubernetesGeq114Less117 {
+			allErrs = append(allErrs, field.Forbidden(field.NewPath("kubernetes", "version"), "experimental kyma addon needs Kubernetes >= 1.14 and < 1.17"))
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The kyma addon is based on a Kyma 1.10 which supports K8S 1.16. So the validation rule for the shoot spec should be adjusted to allow a 1.16 version for the kyma addon

**Which issue(s) this PR fixes**:
Follow-up on https://github.com/gardener/gardener/pull/1935

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
