### PR TITLE
Improve VPA recommendations

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/templates/recommender-deployment.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/recommender-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - --stderrthreshold=info
         - --pod-recommendation-min-cpu-millicores=5
         - --pod-recommendation-min-memory-mb=10
-        - --history-length=24h
+        - --recommendation-margin-fraction=0.05
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/charts/seed-controlplane/charts/etcd/templates/etcd-hvpa.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-hvpa.yaml
@@ -67,11 +67,11 @@ spec:
           containerPolicies:
             - containerName: etcd
               maxAllowed:
-                memory: 30G
-                cpu: "4"
+                memory: {{ .Values.hvpa.maxAllowed.memory }}
+                cpu:  {{ .Values.hvpa.maxAllowed.cpu }}
               minAllowed:
-                memory: 1000M
-                cpu: 300m
+                memory: {{ .Values.hvpa.minAllowed.memory }}
+                cpu: {{ .Values.hvpa.minAllowed.cpu }}
             - containerName: backup-restore
               mode: "Off"
   weightBasedScalingIntervals:

--- a/charts/seed-controlplane/charts/etcd/values.yaml
+++ b/charts/seed-controlplane/charts/etcd/values.yaml
@@ -55,6 +55,12 @@ etcdResources:
 
 hvpa:
   enabled: false
+  maxAllowed:
+    cpu: "4"
+    memory: 30G
+  minAllowed:
+    cpu: 200m
+    memory: 700M
 
 limitsRequestsGapScaleParams:
   cpu:

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hvpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hvpa.yaml
@@ -75,7 +75,7 @@ spec:
                 cpu: "8"
               minAllowed:
                 memory: 400M
-                cpu: 400m
+                cpu: 300m
             - containerName: vpn-seed
               mode: "Off"
             - containerName: blackbox-exporter

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -1050,9 +1050,6 @@ func (b *Botanist) DeployETCD(ctx context.Context) error {
 			"checksum/secret-etcd-server-tls": b.CheckSums["etcd-server-tls"],
 			"checksum/secret-etcd-client-tls": b.CheckSums["etcd-client-tls"],
 		},
-		"hvpa": map[string]interface{}{
-			"enabled": hvpaEnabled,
-		},
 		"maintenanceWindow": b.Shoot.Info.Spec.Maintenance.TimeWindow,
 		"storageCapacity":   b.Seed.GetValidVolumeSize("10Gi"),
 	}
@@ -1067,6 +1064,23 @@ func (b *Botanist) DeployETCD(ctx context.Context) error {
 		if role == common.EtcdRoleMain {
 			// etcd-main emits extensive (histogram) metrics
 			etcd["metrics"] = "extensive"
+			etcd["hvpa"] = map[string]interface{}{
+				"enabled": hvpaEnabled,
+				"minAllowed": map[string]interface{}{
+					"cpu":    "200m",
+					"memory": "700M",
+				},
+			}
+		}
+
+		if role == common.EtcdRoleEvents {
+			etcd["hvpa"] = map[string]interface{}{
+				"enabled": hvpaEnabled,
+				"minAllowed": map[string]interface{}{
+					"cpu":    "50m",
+					"memory": "200M",
+				},
+			}
 		}
 
 		foundEtcd := true


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets the VPA recommender flag `--recommendation-margin-fraction` to `0.05`. Default value is `0.15`. This flag adds a buffer to the recommendation based on the value that is set. This means that the VPA should now make recommendations that are 10% lower. I tested this out and it lowered the recommendations for some containers, specifically prometheus, elasticsearch-logging and gardener-resource-manager, by about 10% (as expected). Below are the recommendations (CPU millicores) for these containers before and after this flag change.
<img width="887" alt="Screen Shot 2020-02-27 at 13 59 04" src="https://user-images.githubusercontent.com/8710621/75447274-53c3cb00-5969-11ea-8d49-5feea7f65135.png">
The rest of the containers were not affected by this change because they were either already getting the minimum recommendation from VPA or HVPA. [Kube-apiserver](https://github.com/gardener/gardener/blob/master/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hvpa.yaml#L78) and [etcd](https://github.com/gardener/gardener/blob/master/charts/seed-controlplane/charts/etcd/templates/etcd-hvpa.yaml#L74) get specific minimum recommendations set by HVPA. Perhaps we can change this HVPA setting for the kube-apiserver and etcd since they decrease our utilization the most. @ggaurav10 @amshuman-kr 


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
`--history-length=24h` flag has been removed since it does nothing.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Vertical Pod Autoscaler provides 10% lower recommendations to improve resource utilization.
```
```improvement operator
HVPA `minAllowed` values for kube-apiserver and etcd have been lowered to improve resource utilization.
```