### PR TITLE
Fix shoot deletion for incompleted clusters

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -211,18 +211,18 @@ func (b *Botanist) WakeUpControlPlane(ctx context.Context) error {
 		return err
 	}
 
-	if err := kubernetes.ScaleDeployment(ctx, client, kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), 1); err != nil {
-		return err
-	}
-	if err := b.WaitUntilKubeAPIServerReady(ctx); err != nil {
-		return err
-	}
-
 	if err := b.DeployKubeAPIServerService(); err != nil {
 		return err
 	}
 
 	if err := b.WaitUntilKubeAPIServerServiceIsReady(ctx); err != nil {
+		return err
+	}
+
+	if err := kubernetes.ScaleDeployment(ctx, client, kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), 1); err != nil {
+		return err
+	}
+	if err := b.WaitUntilKubeAPIServerReady(ctx); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When a cluster is deleted during it's being woken up it can happen that the deletion fails because the Kube-Apiserver service is not available. This PR improves the wake-up logic in the deletion flow to ensure that the service is created and available.

**Special notes for your reviewer**:
/cc @dguendisch @zanetworker

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
An issue has been fixed which caused the deletion of previously woken-up shoot clusters to fail.
```
