### PR TITLE
Unify RBAC for seed kube-state-metrics

### DIFF
--- a/charts/seed-bootstrap/charts/kube-state-metrics/templates/clusterrole.yaml
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/templates/clusterrole.yaml
@@ -1,0 +1,35 @@
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  labels:
+    component: kube-state-metrics
+    type: seed
+  name: gardener.cloud:monitoring:kube-state-metrics-seed
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - pods
+      - services
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - namespaces
+    verbs: ["list", "watch"]
+  - apiGroups: ["extensions"]
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+    verbs: ["list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - statefulsets
+      - deployments
+    verbs: ["list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - cronjobs
+      - jobs
+    verbs: ["list", "watch"]

--- a/charts/seed-bootstrap/charts/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -1,14 +1,14 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: gardener.cloud:monitoring:kube-state-metrics
+  name: gardener.cloud:monitoring:kube-state-metrics-seed
   labels:
     component: kube-state-metrics
     type: seed
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kube-state-metrics
+  name: gardener.cloud:monitoring:kube-state-metrics-seed
 subjects:
 - kind: ServiceAccount
   name: kube-state-metrics


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR mainly fixes a naming clash of the `ClusterRoleBinding: gardener.cloud:monitoring:kube-state-metrics` which happens for shooted seed clusters.

```
time="2020-02-28T10:05:23Z" level=error msg="Seed bootstrapping failed: failed to apply manifests: 1 error occurred: could not apply object of kind \"ClusterRoleBinding\" \"default/gardener.cloud:monitoring:kube-state-metrics\": ClusterRoleBinding.rbac.authorization.k8s.io \"gardener.cloud:monitoring:kube-state-metrics\" is invalid: roleRef: Invalid value: rbac.RoleRef{APIGroup:\"rbac.authorization.k8s.io\", Kind:\"ClusterRole\", Name:\"kube-state-metrics\"}: cannot change roleRef"
```

Additionally, it adds an explicit `ClusterRole` for the Kube-State-Metrics component which is deployed to the `garden` namespace in the seed instead of reusing the one from the `kube-state-metrics-seed` components.

Thanks for reporting @majst01

**Special notes for your reviewer**:
/cc @amshuman-kr @wyb1

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
