### PR TITLE
Add validation for worker machine image

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -718,6 +718,16 @@ func ValidateWorker(worker core.Worker, fldPath *field.Path) field.ErrorList {
 	if len(worker.Machine.Type) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("machine", "type"), "must specify a machine type"))
 	}
+	if worker.Machine.Image == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("machine", "image"), "must specify a machine image"))
+	} else {
+		if len(worker.Machine.Image.Name) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("machine", "image", "name"), "must specify a machine image name"))
+		}
+		if len(worker.Machine.Image.Version) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("machine", "image", "version"), "must specify a machine image version"))
+		}
+	}
 	if worker.Minimum < 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("minimum"), worker.Minimum, "minimum value must not be negative"))
 	}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -56,6 +56,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Name: "worker-name",
 				Machine: core.Machine{
 					Type: "large",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "1.0.0",
+					},
 				},
 				Minimum:        1,
 				Maximum:        1,
@@ -76,6 +80,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Name: "not_compliant",
 				Machine: core.Machine{
 					Type: "large",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "1.0.0",
+					},
 				},
 				Minimum:        1,
 				Maximum:        1,
@@ -86,6 +94,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Name: "worker-name-is-too-long",
 				Machine: core.Machine{
 					Type: "large",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "1.0.0",
+					},
 				},
 				Minimum:        1,
 				Maximum:        1,
@@ -96,6 +108,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Name: "cpu-worker",
 				Machine: core.Machine{
 					Type: "large",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "1.0.0",
+					},
 				},
 				Minimum:        0,
 				Maximum:        2,
@@ -106,6 +122,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Name: "cpu-worker",
 				Machine: core.Machine{
 					Type: "large",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "1.0.0",
+					},
 				},
 				Minimum:        0,
 				Maximum:        0,
@@ -601,6 +621,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.provider.workers[0].machine.type"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.provider.workers[0].machine.image"),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
@@ -1624,12 +1648,81 @@ var _ = Describe("Shoot Validation Tests", func() {
 	})
 
 	Describe("#ValidateWorker", func() {
+		DescribeTable("validate worker machine",
+			func(machine core.Machine, matcher gomegatypes.GomegaMatcher) {
+				maxSurge := intstr.FromInt(1)
+				maxUnavailable := intstr.FromInt(0)
+				worker := core.Worker{
+					Name:           "worker-name",
+					Machine:        machine,
+					MaxSurge:       &maxSurge,
+					MaxUnavailable: &maxUnavailable,
+				}
+				errList := ValidateWorker(worker, nil)
+
+				Expect(errList).To(matcher)
+			},
+
+			Entry("empty machine type",
+				core.Machine{
+					Type: "",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "1.0.0",
+					},
+				},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("machine.type"),
+				}))),
+			),
+			Entry("missing machine image",
+				core.Machine{
+					Type: "large",
+				},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("machine.image"),
+				}))),
+			),
+			Entry("empty machine image name",
+				core.Machine{
+					Type: "large",
+					Image: &core.ShootMachineImage{
+						Name:    "",
+						Version: "1.0.0",
+					},
+				},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("machine.image.name"),
+				}))),
+			),
+			Entry("empty machine image version",
+				core.Machine{
+					Type: "large",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "",
+					},
+				},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("machine.image.version"),
+				}))),
+			),
+		)
+
 		DescribeTable("reject when maxUnavailable and maxSurge are invalid",
 			func(maxUnavailable, maxSurge intstr.IntOrString, expectType field.ErrorType) {
 				worker := core.Worker{
 					Name: "worker-name",
 					Machine: core.Machine{
 						Type: "large",
+						Image: &core.ShootMachineImage{
+							Name:    "image-name",
+							Version: "1.0.0",
+						},
 					},
 					MaxSurge:       &maxSurge,
 					MaxUnavailable: &maxUnavailable,
@@ -1663,6 +1756,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Name: "worker-name",
 					Machine: core.Machine{
 						Type: "large",
+						Image: &core.ShootMachineImage{
+							Name:    "image-name",
+							Version: "1.0.0",
+						},
 					},
 					MaxSurge:       &maxSurge,
 					MaxUnavailable: &maxUnavailable,
@@ -1694,6 +1791,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Name: "worker-name",
 					Machine: core.Machine{
 						Type: "large",
+						Image: &core.ShootMachineImage{
+							Name:    "image-name",
+							Version: "1.0.0",
+						},
 					},
 					MaxSurge:       &maxSurge,
 					MaxUnavailable: &maxUnavailable,
@@ -1724,6 +1825,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 					Name: "worker-name",
 					Machine: core.Machine{
 						Type: "large",
+						Image: &core.ShootMachineImage{
+							Name:    "image-name",
+							Version: "1.0.0",
+						},
 					},
 					MaxSurge:       &maxSurge,
 					MaxUnavailable: &maxUnavailable,
@@ -1764,6 +1869,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Name: "worker-name",
 				Machine: core.Machine{
 					Type: "large",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "1.0.0",
+					},
 				},
 				MaxSurge:       &maxSurge,
 				MaxUnavailable: &maxUnavailable,
@@ -1787,6 +1896,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Name: "worker-name",
 				Machine: core.Machine{
 					Type: "large",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "1.0.0",
+					},
 				},
 				MaxSurge:       &maxSurge,
 				MaxUnavailable: &maxUnavailable,
@@ -1812,6 +1925,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Name: "worker-name",
 				Machine: core.Machine{
 					Type: "large",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "1.0.0",
+					},
 				},
 				MaxSurge:       &maxSurge,
 				MaxUnavailable: &maxUnavailable,
@@ -1845,6 +1962,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Name: "worker-name",
 				Machine: core.Machine{
 					Type: "large",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "1.0.0",
+					},
 				},
 				MaxSurge:              &maxSurge,
 				MaxUnavailable:        &maxUnavailable,
@@ -1868,6 +1989,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Name: "worker-name",
 				Machine: core.Machine{
 					Type: "large",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "1.0.0",
+					},
 				},
 				MaxSurge:              &maxSurge,
 				MaxUnavailable:        &maxUnavailable,
@@ -1895,6 +2020,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Name: "worker-name",
 				Machine: core.Machine{
 					Type: "large",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "1.0.0",
+					},
 				},
 				MaxSurge:       &maxSurge,
 				MaxUnavailable: &maxUnavailable,


### PR DESCRIPTION
**What this PR does / why we need it**:
Add validation for worker machine image for the following cases:

- Do not allow creation of Shoot with empty `machine.image.name` or `machine.image.version`
```yaml
    workers:
    - machine:
        type: large
        image:
          name: ""
          version: ""
```

Creation of such Shoot would fail with:

```yaml
  lastErrors:
  - description: 'Check required extensions failed (extension controllers missing
      or unready: map[OperatingSystemConfig:map[:{}]])'
```

- Do not allow creation of Shoot with `machine.image=nil` (currently only possible if the gardener-apiserver runs with `--disable-admission-plugins=ShootValidator`, the admission plugin that defaults the `machine.image`).

```yaml
    workers:
    - machine:
        type: large
```

Creation of such Shoot would fail with:

```yaml
  lastErrors:
  - description: 'task "Computing operating system specific configuration for shoot
      workers" failed: retry failed with context deadline exceeded, last error: worker
      "foo" doesn''t have a machine image, cannot continue'
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Gardener API server does no longer allow empty values for worker `machine.image.name` and `machine.image.version`.
```
