### PR TITLE
Fix merge apply functions for Service

### DIFF
--- a/pkg/client/kubernetes/apply_test.go
+++ b/pkg/client/kubernetes/apply_test.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -30,6 +31,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/discovery"
 	memcache "k8s.io/client-go/discovery/cached/memory"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -237,6 +239,444 @@ spec:
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(resultingService.Secrets)).To(Equal(1))
 				Expect(resultingService.Secrets[0].Name).To(Equal("test-secret"))
+			})
+
+			Context("DefaultApplierOptions", func() {
+				var (
+					old      *corev1.Service
+					new      *corev1.Service
+					expected *corev1.Service
+				)
+
+				BeforeEach(func() {
+					old = &corev1.Service{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "Service",
+							APIVersion: "v1",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-service",
+							Namespace: "test-ns",
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP: "1.2.3.4",
+							Type:      corev1.ServiceTypeClusterIP,
+							Selector:  map[string]string{"foo": "bar"},
+							Ports: []corev1.ServicePort{
+								{
+									Name:       "foo",
+									Protocol:   corev1.ProtocolTCP,
+									Port:       123,
+									TargetPort: intstr.FromInt(456),
+								},
+							},
+						},
+					}
+
+					new = old.DeepCopy()
+					new.Spec.ClusterIP = ""
+					expected = old.DeepCopy()
+					expected.ResourceVersion = "2"
+				})
+
+				DescribeTable("Existing ClusterIP service",
+					func(mutator func()) {
+						mutator()
+						Expect(c.Create(context.TODO(), old)).ToNot(HaveOccurred())
+
+						manifest := mkManifest(new)
+						manifestReader := kubernetes.NewManifestReader(manifest)
+
+						err := applier.ApplyManifest(context.TODO(), manifestReader, kubernetes.DefaultApplierOptions)
+						Expect(err).NotTo(HaveOccurred())
+
+						result := &corev1.Service{}
+						err = c.Get(context.TODO(), client.ObjectKey{Name: "test-service", Namespace: "test-ns"}, result)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(result).To(Equal(expected))
+					},
+
+					Entry(
+						"ClusterIP with changed ports", func() {
+							new.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							new.Spec.Ports[0].Port = 999
+							new.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+
+							expected.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							expected.Spec.Ports[0].Port = 999
+							expected.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+						}),
+					Entry(
+						"ClusterIP with changed ClusterIP, should not update it", func() {
+							new.Spec.ClusterIP = "5.6.7.8"
+						}),
+					Entry(
+						"Headless ClusterIP", func() {
+							new.Spec.ClusterIP = "None"
+
+							expected.Spec.ClusterIP = "None"
+						}),
+					Entry(
+						"ClusterIP without passing any type, should update it", func() {
+							new.Spec.ClusterIP = "5.6.7.8"
+							new.Spec.Type = ""
+							new.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							new.Spec.Ports[0].Port = 999
+							new.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+
+							expected.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							expected.Spec.Ports[0].Port = 999
+							expected.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+						}),
+					Entry(
+						"NodePort with changed ports", func() {
+							new.Spec.Type = corev1.ServiceTypeNodePort
+							new.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							new.Spec.Ports[0].Port = 999
+							new.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							new.Spec.Ports[0].NodePort = 444
+
+							expected.Spec.Type = corev1.ServiceTypeNodePort
+							expected.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							expected.Spec.Ports[0].Port = 999
+							expected.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							expected.Spec.Ports[0].NodePort = 444
+						}),
+					Entry(
+						"ExternalName removes ClusterIP", func() {
+							new.Spec.Type = corev1.ServiceTypeExternalName
+							new.Spec.Selector = nil
+							new.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							new.Spec.Ports[0].Port = 999
+							new.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							new.Spec.Ports[0].NodePort = 0
+							new.Spec.ClusterIP = ""
+							new.Spec.ExternalName = "foo.com"
+							new.Spec.HealthCheckNodePort = 0
+
+							expected.Spec.Type = corev1.ServiceTypeExternalName
+							expected.Spec.Selector = nil
+							expected.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							expected.Spec.Ports[0].Port = 999
+							expected.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							expected.Spec.Ports[0].NodePort = 0
+							expected.Spec.ClusterIP = ""
+							expected.Spec.ExternalName = "foo.com"
+							expected.Spec.HealthCheckNodePort = 0
+						}),
+				)
+
+				DescribeTable("Existing NodePort service",
+					func(mutator func()) {
+						old.Spec.Ports[0].NodePort = 3333
+						old.Spec.Type = corev1.ServiceTypeNodePort
+
+						new.Spec.Ports[0].NodePort = 3333
+						new.Spec.Type = corev1.ServiceTypeNodePort
+
+						expected.Spec.Ports[0].NodePort = 3333
+						expected.Spec.Type = corev1.ServiceTypeNodePort
+
+						mutator()
+						Expect(c.Create(context.TODO(), old)).ToNot(HaveOccurred())
+
+						manifest := mkManifest(new)
+						manifestReader := kubernetes.NewManifestReader(manifest)
+
+						err := applier.ApplyManifest(context.TODO(), manifestReader, kubernetes.DefaultApplierOptions)
+						Expect(err).NotTo(HaveOccurred())
+
+						result := &corev1.Service{}
+						err = c.Get(context.TODO(), client.ObjectKey{Name: "test-service", Namespace: "test-ns"}, result)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(result).To(Equal(expected))
+					},
+
+					Entry(
+						"ClusterIP with changed ports", func() {
+							new.Spec.Type = corev1.ServiceTypeClusterIP
+							new.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							new.Spec.Ports[0].Port = 999
+							new.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							new.Spec.Ports[0].NodePort = 0
+
+							expected.Spec.Type = corev1.ServiceTypeClusterIP
+							expected.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							expected.Spec.Ports[0].Port = 999
+							expected.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							expected.Spec.Ports[0].NodePort = 0
+						}),
+					Entry(
+						"ClusterIP changed, should not update it", func() {
+							new.Spec.ClusterIP = "5.6.7.8"
+						}),
+					Entry(
+						"Headless ClusterIP type service", func() {
+							new.Spec.Type = corev1.ServiceTypeClusterIP
+							new.Spec.ClusterIP = "None"
+
+							expected.Spec.ClusterIP = "None"
+							expected.Spec.Type = corev1.ServiceTypeClusterIP
+						}),
+					Entry(
+						"NodePort with changed ports", func() {
+							new.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							new.Spec.Ports[0].Port = 999
+							new.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							new.Spec.Ports[0].NodePort = 444
+
+							expected.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							expected.Spec.Ports[0].Port = 999
+							expected.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							expected.Spec.Ports[0].NodePort = 444
+						}),
+					Entry(
+						"NodePort with changed ports and without nodePort", func() {
+							new.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							new.Spec.Ports[0].Port = 999
+							new.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							new.Spec.Ports[0].NodePort = 0
+
+							expected.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							expected.Spec.Ports[0].Port = 999
+							expected.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+						}),
+					Entry(
+						"ExternalName removes ClusterIP", func() {
+							new.Spec.Type = corev1.ServiceTypeExternalName
+							new.Spec.Selector = nil
+							new.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							new.Spec.Ports[0].Port = 999
+							new.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							new.Spec.Ports[0].NodePort = 0
+							new.Spec.ClusterIP = ""
+							new.Spec.ExternalName = "foo.com"
+							new.Spec.HealthCheckNodePort = 0
+
+							expected.Spec.Type = corev1.ServiceTypeExternalName
+							expected.Spec.Selector = nil
+							expected.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							expected.Spec.Ports[0].Port = 999
+							expected.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							expected.Spec.Ports[0].NodePort = 0
+							expected.Spec.ClusterIP = ""
+							expected.Spec.ExternalName = "foo.com"
+							expected.Spec.HealthCheckNodePort = 0
+						}),
+				)
+
+				DescribeTable("Existing LoadBalancer service change to service of type",
+					func(mutator func()) {
+						old.Spec.Ports[0].NodePort = 3333
+						old.Spec.Type = corev1.ServiceTypeLoadBalancer
+
+						new.Spec.Ports[0].NodePort = 3333
+						new.Spec.Type = corev1.ServiceTypeLoadBalancer
+
+						expected.Spec.Ports[0].NodePort = 3333
+						expected.Spec.Type = corev1.ServiceTypeLoadBalancer
+
+						mutator()
+						Expect(c.Create(context.TODO(), old)).ToNot(HaveOccurred())
+
+						manifest := mkManifest(new)
+						manifestReader := kubernetes.NewManifestReader(manifest)
+
+						err := applier.ApplyManifest(context.TODO(), manifestReader, kubernetes.DefaultApplierOptions)
+						Expect(err).NotTo(HaveOccurred())
+
+						result := &corev1.Service{}
+						err = c.Get(context.TODO(), client.ObjectKey{Name: "test-service", Namespace: "test-ns"}, result)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(result).To(Equal(expected))
+					},
+
+					Entry(
+						"ClusterIP with changed ports", func() {
+							new.Spec.Type = corev1.ServiceTypeClusterIP
+							new.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							new.Spec.Ports[0].Port = 999
+							new.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							new.Spec.Ports[0].NodePort = 0
+
+							expected.Spec.Type = corev1.ServiceTypeClusterIP
+							expected.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							expected.Spec.Ports[0].Port = 999
+							expected.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							expected.Spec.Ports[0].NodePort = 0
+						}),
+					Entry(
+						"Cluster with ClusterIP changed, should not update it", func() {
+							new.Spec.ClusterIP = "5.6.7.8"
+						}),
+					Entry(
+						"Headless ClusterIP type service", func() {
+							new.Spec.Type = corev1.ServiceTypeClusterIP
+							new.Spec.ClusterIP = "None"
+
+							expected.Spec.ClusterIP = "None"
+							expected.Spec.Type = corev1.ServiceTypeClusterIP
+						}),
+					Entry(
+						"NodePort with changed ports", func() {
+							new.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							new.Spec.Ports[0].Port = 999
+							new.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							new.Spec.Ports[0].NodePort = 444
+
+							expected.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							expected.Spec.Ports[0].Port = 999
+							expected.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							expected.Spec.Ports[0].NodePort = 444
+						}),
+					Entry(
+						"NodePort with changed ports and without nodePort", func() {
+							new.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							new.Spec.Ports[0].Port = 999
+							new.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							new.Spec.Ports[0].NodePort = 0
+
+							expected.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							expected.Spec.Ports[0].Port = 999
+							expected.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+						}),
+					Entry(
+						"ExternalName removes ClusterIP", func() {
+							new.Spec.Type = corev1.ServiceTypeExternalName
+							new.Spec.Selector = nil
+							new.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							new.Spec.Ports[0].Port = 999
+							new.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							new.Spec.Ports[0].NodePort = 0
+							new.Spec.ClusterIP = ""
+							new.Spec.ExternalName = "foo.com"
+							new.Spec.HealthCheckNodePort = 0
+
+							expected.Spec.Type = corev1.ServiceTypeExternalName
+							expected.Spec.Selector = nil
+							expected.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							expected.Spec.Ports[0].Port = 999
+							expected.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							expected.Spec.Ports[0].NodePort = 0
+							expected.Spec.ClusterIP = ""
+							expected.Spec.ExternalName = "foo.com"
+							expected.Spec.HealthCheckNodePort = 0
+						}),
+					Entry(
+						"LoadBalancer with ExternalTrafficPolicy=Local and HealthCheckNodePort", func() {
+							new.Spec.HealthCheckNodePort = 123
+							new.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+
+							expected.Spec.HealthCheckNodePort = 123
+							expected.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+						}),
+					Entry(
+						"LoadBalancer with ExternalTrafficPolicy=Local and no HealthCheckNodePort", func() {
+							old.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+							old.Spec.HealthCheckNodePort = 3333
+
+							new.Spec.HealthCheckNodePort = 0
+							new.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+
+							expected.Spec.HealthCheckNodePort = 3333
+							expected.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+						}),
+				)
+
+				DescribeTable("Existing ExternalName service change to service of type",
+					func(mutator func()) {
+						old.Spec.Ports[0].NodePort = 0
+						old.Spec.Type = corev1.ServiceTypeExternalName
+						old.Spec.HealthCheckNodePort = 0
+						old.Spec.ClusterIP = ""
+						old.Spec.ExternalName = "baz.bar"
+						old.Spec.Selector = nil
+
+						new.Spec.Ports[0].NodePort = 0
+						new.Spec.Type = corev1.ServiceTypeExternalName
+						new.Spec.HealthCheckNodePort = 0
+						new.Spec.ClusterIP = ""
+						new.Spec.ExternalName = "baz.bar"
+						new.Spec.Selector = nil
+
+						expected.Spec.Ports[0].NodePort = 0
+						expected.Spec.Type = corev1.ServiceTypeExternalName
+						expected.Spec.HealthCheckNodePort = 0
+						expected.Spec.ClusterIP = ""
+						expected.Spec.ExternalName = "baz.bar"
+						expected.Spec.Selector = nil
+
+						mutator()
+						Expect(c.Create(context.TODO(), old)).ToNot(HaveOccurred())
+
+						manifest := mkManifest(new)
+						manifestReader := kubernetes.NewManifestReader(manifest)
+
+						err := applier.ApplyManifest(context.TODO(), manifestReader, kubernetes.DefaultApplierOptions)
+						Expect(err).NotTo(HaveOccurred())
+
+						result := &corev1.Service{}
+						err = c.Get(context.TODO(), client.ObjectKey{Name: "test-service", Namespace: "test-ns"}, result)
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(result).To(Equal(expected))
+					},
+
+					Entry(
+						"ClusterIP with changed ports", func() {
+							new.Spec.Type = corev1.ServiceTypeClusterIP
+							new.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							new.Spec.Ports[0].Port = 999
+							new.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							new.Spec.Ports[0].NodePort = 0
+							new.Spec.ExternalName = ""
+							new.Spec.ClusterIP = "3.4.5.6"
+
+							expected.Spec.Type = corev1.ServiceTypeClusterIP
+							expected.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							expected.Spec.Ports[0].Port = 999
+							expected.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							expected.Spec.Ports[0].NodePort = 0
+							expected.Spec.ExternalName = ""
+							expected.Spec.ClusterIP = "3.4.5.6"
+						}),
+					Entry(
+						"NodePort with changed ports", func() {
+							new.Spec.Type = corev1.ServiceTypeNodePort
+							new.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							new.Spec.Ports[0].Port = 999
+							new.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							new.Spec.Ports[0].NodePort = 444
+							new.Spec.ExternalName = ""
+							new.Spec.ClusterIP = "3.4.5.6"
+
+							expected.Spec.Type = corev1.ServiceTypeNodePort
+							expected.Spec.Ports[0].Protocol = corev1.ProtocolUDP
+							expected.Spec.Ports[0].Port = 999
+							expected.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+							expected.Spec.Ports[0].NodePort = 444
+							expected.Spec.ExternalName = ""
+							expected.Spec.ClusterIP = "3.4.5.6"
+						}),
+					Entry(
+						"LoadBalancer with ExternalTrafficPolicy=Local and HealthCheckNodePort", func() {
+							new.Spec.Type = corev1.ServiceTypeLoadBalancer
+							new.Spec.HealthCheckNodePort = 123
+							new.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+							new.Spec.ExternalName = ""
+							new.Spec.ClusterIP = "3.4.5.6"
+
+							expected.Spec.Type = corev1.ServiceTypeLoadBalancer
+							expected.Spec.HealthCheckNodePort = 123
+							expected.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+							expected.Spec.ExternalName = ""
+							expected.Spec.ClusterIP = "3.4.5.6"
+						}),
+				)
+
 			})
 
 			It("should create objects with namespace", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

The `Service` applier was not handling all use-cases around services:

- Headless `ClusterIP` services  (`.spec.clusterIP=1.2.3.4` ->  `.spec.clusterIP=None`)
- `ClusterIP`/`NodePort`/`LoadBalancer` <=> `ExternalName` type
- `LoadBalancer`/`NodePort` -> `ClusterIP`
- `.spec.healthCheckNodePort` should only be defaulted to the previous value if both the new and old `Service` are of type `LoadBalancer` with  `.spec.externalTrafficPolicy: Local` and the current value of the new service's `.spec.healthCheckNodePort` is `0`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
