### PR TITLE
Assign initial `requests` for kube-apiserver based on minNodes

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -762,7 +762,12 @@ func (b *Botanist) DeployKubeAPIServer() error {
 			defaultValues["replicas"] = 0
 		}
 
-		cpuRequest, memoryRequest, cpuLimit, memoryLimit := getResourcesForAPIServer(b.Shoot.GetMinNodeCount())
+		var cpuRequest, memoryRequest, cpuLimit, memoryLimit string
+		if hvpaEnabled {
+			cpuRequest, memoryRequest, cpuLimit, memoryLimit = getResourcesForAPIServer(b.Shoot.GetMinNodeCount())
+		} else {
+			cpuRequest, memoryRequest, cpuLimit, memoryLimit = getResourcesForAPIServer(b.Shoot.GetMaxNodeCount())
+		}
 		defaultValues["apiServerResources"] = map[string]interface{}{
 			"limits": map[string]interface{}{
 				"cpu":    cpuLimit,

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -762,7 +762,7 @@ func (b *Botanist) DeployKubeAPIServer() error {
 			defaultValues["replicas"] = 0
 		}
 
-		cpuRequest, memoryRequest, cpuLimit, memoryLimit := getResourcesForAPIServer(b.Shoot.GetNodeCount())
+		cpuRequest, memoryRequest, cpuLimit, memoryLimit := getResourcesForAPIServer(b.Shoot.GetMinNodeCount())
 		defaultValues["apiServerResources"] = map[string]interface{}{
 			"limits": map[string]interface{}{
 				"cpu":    cpuLimit,

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -150,11 +150,11 @@ func (s *Shoot) GetWorkerNames() []string {
 	return workerNames
 }
 
-// GetNodeCount returns the sum of all 'maximum' fields of all worker groups of the Shoot.
-func (s *Shoot) GetNodeCount() int32 {
+// GetMinNodeCount returns the sum of all 'minimum' fields of all worker groups of the Shoot.
+func (s *Shoot) GetMinNodeCount() int32 {
 	var nodeCount int32
 	for _, worker := range s.Info.Spec.Provider.Workers {
-		nodeCount += worker.Maximum
+		nodeCount += worker.Minimum
 	}
 	return nodeCount
 }

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -159,6 +159,15 @@ func (s *Shoot) GetMinNodeCount() int32 {
 	return nodeCount
 }
 
+// GetMaxNodeCount returns the sum of all 'maximum' fields of all worker groups of the Shoot.
+func (s *Shoot) GetMaxNodeCount() int32 {
+	var nodeCount int32
+	for _, worker := range s.Info.Spec.Provider.Workers {
+		nodeCount += worker.Maximum
+	}
+	return nodeCount
+}
+
 // GetNodeNetwork returns the nodes network CIDR for the Shoot cluster. If the infrastructure extension
 // controller has generated a nodes network then this CIDR will take priority. Otherwise, the nodes network
 // CIDR specified in the shoot will be returned (if possible). If no CIDR was specified then nil is returned.


### PR DESCRIPTION
**What this PR does / why we need it**:
Assign initial `requests` for kube-apiserver based on minNodes.
Currently Gardener assigns initial `requests` based on maxNodes. If a cluster is created with minNodes = 1 and maxNodes = 100, then we would end up allocating large values for `kube-apiserver` deployment. This was fine when we did not have vertical autoscaling capabilities for kube-apsierver. However, with HVPA, we can assign lower values initially, and depend on HVPA to scale the deployment whenever required.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Assign initial `requests` for kube-apiserver based on cluster autoscaler minNodes instead of maxNodes
```
