### PR TITLE
Only deploy required extensions

### DIFF
--- a/docs/extensions/controllerregistration.md
+++ b/docs/extensions/controllerregistration.md
@@ -39,7 +39,8 @@ spec:
 
 This resource expresses that Gardener requires the `os-coreos` extension controller to run on the `aws-eu1` seed cluster.
 
-PS: Currently, for the sake of implementation simplicity, Gardener demands every extension controller for every seed cluster (although, an AWS controller might not make much sense to run on a GCP seed cluster). We plan to change this in the future, i.e., to make Gardener more intelligent so that it can automatically determine which extension is required on which seed cluster.
+The Gardener Controller Manager does automatically determine which extension is required on which seed cluster and will only create `ControllerInstallation` objects for those.
+Also, it will automatically delete `ControllerInstallation`s referencing extension controllers that are no longer required on a seed (e.g., because all shoots on it have been deleted).
 
 ## How do extension controllers get deployed to seeds?
 

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,7 @@ github.com/gardener/etcd-druid v0.1.3 h1:uiPKUHubieRziHR7lr7I0WzIglf2aNVWf94Gm5N
 github.com/gardener/etcd-druid v0.1.3/go.mod h1:/A8kSp7DSo7oOhsOhD9Se/xF6BOD9TQJMawf6k7AOsU=
 github.com/gardener/external-dns-management v0.7.3 h1:SAW9ur2mjZ+x89xbmcplJgqNUmFGYIZLI2E+PaBhhG0=
 github.com/gardener/external-dns-management v0.7.3/go.mod h1:Y3om11E865x4aQ7cmcHjknb8RMgCO153huRb/SvP+9o=
+github.com/gardener/external-dns-management v0.7.6 h1:K5yKXcZIguRP5SNS75EEc2uKZrF9fK3o7JzFldXNg2w=
 github.com/gardener/gardener-resource-manager v0.10.0 h1:6OUKoWI3oha42F0oJN8OEo3UR+D3onOCel4Th+zgotU=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/hvpa-controller v0.0.0-20191014062307-fad3bdf06a25 h1:nOFITmV7vt4fcYPEXgj66Qs83FdDEMvL/LQcR0diRRE=

--- a/pkg/apis/core/field_constants.go
+++ b/pkg/apis/core/field_constants.go
@@ -17,11 +17,17 @@ package core
 // Field path constants that are specific to the internal API
 // representation.
 const (
-	// ShootSeedName is the field selector path for finding
-	// the Seed cluster of a core.gardener.cloud/{v1alpha1,v1beta1} Shoot.
-	ShootSeedName = "spec.seedName"
+	// BackupBucketSeedName is the field selector path for finding
+	// the Seed cluster of a core.gardener.cloud/v1beta1 BackupBucket.
+	BackupBucketSeedName = "spec.seedName"
+	// BackupEntrySeedName is the field selector path for finding
+	// the Seed cluster of a core.gardener.cloud/v1beta1 BackupEntry.
+	BackupEntrySeedName = "spec.seedName"
 
 	// ShootCloudProfileName is the field selector path for finding
 	// the CloudProfile name of a core.gardener.cloud/{v1alpha1,v1beta1} Shoot.
 	ShootCloudProfileName = "spec.cloudProfileName"
+	// ShootSeedName is the field selector path for finding
+	// the Seed cluster of a core.gardener.cloud/{v1alpha1,v1beta1} Shoot.
+	ShootSeedName = "spec.seedName"
 )

--- a/pkg/apis/core/v1alpha1/helper/helper.go
+++ b/pkg/apis/core/v1alpha1/helper/helper.go
@@ -154,13 +154,21 @@ func IsResourceSupported(resources []gardencorev1alpha1.ControllerResource, reso
 // IsControllerInstallationSuccessful returns true if a ControllerInstallation has been marked as "successfully"
 // installed.
 func IsControllerInstallationSuccessful(controllerInstallation gardencorev1alpha1.ControllerInstallation) bool {
+	var (
+		installed bool
+		healthy bool
+	)
+
 	for _, condition := range controllerInstallation.Status.Conditions {
 		if condition.Type == gardencorev1alpha1.ControllerInstallationInstalled && condition.Status == gardencorev1alpha1.ConditionTrue {
-			return true
+			installed = true
+		}
+		if condition.Type == gardencorev1alpha1.ControllerInstallationHealthy && condition.Status == gardencorev1alpha1.ConditionTrue {
+			healthy = true
 		}
 	}
 
-	return false
+	return installed && healthy
 }
 
 // ComputeOperationType checksthe <lastOperation> and determines whether is it is Create operation or reconcile operation

--- a/pkg/apis/core/v1alpha1/helper/helpers_test.go
+++ b/pkg/apis/core/v1alpha1/helper/helpers_test.go
@@ -221,6 +221,10 @@ var _ = Describe("helper", func() {
 						Type:   gardencorev1alpha1.ControllerInstallationInstalled,
 						Status: gardencorev1alpha1.ConditionTrue,
 					},
+					{
+						Type:   gardencorev1alpha1.ControllerInstallationHealthy,
+						Status: gardencorev1alpha1.ConditionTrue,
+					},
 				},
 				true,
 			),
@@ -229,6 +233,41 @@ var _ = Describe("helper", func() {
 					{
 						Type:   gardencorev1alpha1.ControllerInstallationInstalled,
 						Status: gardencorev1alpha1.ConditionFalse,
+					},
+				},
+				false,
+			),
+			Entry("expect false",
+				[]gardencorev1alpha1.Condition{
+					{
+						Type:   gardencorev1alpha1.ControllerInstallationHealthy,
+						Status: gardencorev1alpha1.ConditionFalse,
+					},
+				},
+				false,
+			),
+			Entry("expect false",
+				[]gardencorev1alpha1.Condition{
+					{
+						Type:   gardencorev1alpha1.ControllerInstallationInstalled,
+						Status: gardencorev1alpha1.ConditionTrue,
+					},
+					{
+						Type:   gardencorev1alpha1.ControllerInstallationHealthy,
+						Status: gardencorev1alpha1.ConditionFalse,
+					},
+				},
+				false,
+			),
+			Entry("expect false",
+				[]gardencorev1alpha1.Condition{
+					{
+						Type:   gardencorev1alpha1.ControllerInstallationInstalled,
+						Status: gardencorev1alpha1.ConditionFalse,
+					},
+					{
+						Type:   gardencorev1alpha1.ControllerInstallationHealthy,
+						Status: gardencorev1alpha1.ConditionTrue,
 					},
 				},
 				false,

--- a/pkg/apis/core/v1beta1/conversions.go
+++ b/pkg/apis/core/v1beta1/conversions.go
@@ -24,7 +24,36 @@ import (
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
-	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Shoot"),
+	if err := scheme.AddFieldLabelConversionFunc(
+		SchemeGroupVersion.WithKind("BackupBucket"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name", "metadata.namespace", core.BackupBucketSeedName:
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		},
+	); err != nil {
+		return err
+	}
+
+	if err := scheme.AddFieldLabelConversionFunc(
+		SchemeGroupVersion.WithKind("BackupEntry"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name", "metadata.namespace", core.BackupEntrySeedName:
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		},
+	); err != nil {
+		return err
+	}
+
+	if err := scheme.AddFieldLabelConversionFunc(
+		SchemeGroupVersion.WithKind("Shoot"),
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "metadata.name", "metadata.namespace", core.ShootSeedName, core.ShootCloudProfileName:

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -153,13 +153,21 @@ func IsResourceSupported(resources []gardencorev1beta1.ControllerResource, resou
 // IsControllerInstallationSuccessful returns true if a ControllerInstallation has been marked as "successfully"
 // installed.
 func IsControllerInstallationSuccessful(controllerInstallation gardencorev1beta1.ControllerInstallation) bool {
+	var (
+		installed bool
+		healthy bool
+	)
+
 	for _, condition := range controllerInstallation.Status.Conditions {
 		if condition.Type == gardencorev1beta1.ControllerInstallationInstalled && condition.Status == gardencorev1beta1.ConditionTrue {
-			return true
+			installed = true
+		}
+		if condition.Type == gardencorev1beta1.ControllerInstallationHealthy && condition.Status == gardencorev1beta1.ConditionTrue {
+			healthy = true
 		}
 	}
 
-	return false
+	return installed && healthy
 }
 
 // ComputeOperationType checksthe <lastOperation> and determines whether is it is Create operation or reconcile operation

--- a/pkg/apis/core/v1beta1/helper/helpers_test.go
+++ b/pkg/apis/core/v1beta1/helper/helpers_test.go
@@ -222,6 +222,10 @@ var _ = Describe("helper", func() {
 						Type:   gardencorev1beta1.ControllerInstallationInstalled,
 						Status: gardencorev1beta1.ConditionTrue,
 					},
+					{
+						Type:   gardencorev1beta1.ControllerInstallationHealthy,
+						Status: gardencorev1beta1.ConditionTrue,
+					},
 				},
 				true,
 			),
@@ -230,6 +234,41 @@ var _ = Describe("helper", func() {
 					{
 						Type:   gardencorev1beta1.ControllerInstallationInstalled,
 						Status: gardencorev1beta1.ConditionFalse,
+					},
+				},
+				false,
+			),
+			Entry("expect false",
+				[]gardencorev1beta1.Condition{
+					{
+						Type:   gardencorev1beta1.ControllerInstallationHealthy,
+						Status: gardencorev1beta1.ConditionFalse,
+					},
+				},
+				false,
+			),
+			Entry("expect false",
+				[]gardencorev1beta1.Condition{
+					{
+						Type:   gardencorev1beta1.ControllerInstallationInstalled,
+						Status: gardencorev1beta1.ConditionTrue,
+					},
+					{
+						Type:   gardencorev1beta1.ControllerInstallationHealthy,
+						Status: gardencorev1beta1.ConditionFalse,
+					},
+				},
+				false,
+			),
+			Entry("expect false",
+				[]gardencorev1beta1.Condition{
+					{
+						Type:   gardencorev1beta1.ControllerInstallationInstalled,
+						Status: gardencorev1beta1.ConditionFalse,
+					},
+					{
+						Type:   gardencorev1beta1.ControllerInstallationHealthy,
+						Status: gardencorev1beta1.ConditionTrue,
 					},
 				},
 				false,

--- a/pkg/controllermanager/controller/controllerregistration/backupbucket_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/backupbucket_control.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerregistration
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+)
+
+func (c *Controller) backupBucketAdd(obj interface{}) {
+	backupBucket, ok := obj.(*gardencorev1beta1.BackupBucket)
+	if !ok {
+		return
+	}
+
+	if backupBucket.Spec.SeedName == nil {
+		return
+	}
+
+	c.controllerRegistrationSeedQueue.Add(*backupBucket.Spec.SeedName)
+}
+
+func (c *Controller) backupBucketUpdate(oldObj, newObj interface{}) {
+	oldObject, ok := oldObj.(*gardencorev1beta1.BackupBucket)
+	if !ok {
+		return
+	}
+
+	newObject, ok := newObj.(*gardencorev1beta1.BackupBucket)
+	if !ok {
+		return
+	}
+
+	if apiequality.Semantic.DeepEqual(oldObject.Spec.SeedName, newObject.Spec.SeedName) &&
+		oldObject.Spec.Provider.Type == newObject.Spec.Provider.Type {
+		return
+	}
+
+	c.backupBucketAdd(newObj)
+}
+
+func (c *Controller) backupBucketDelete(obj interface{}) {
+	c.backupBucketAdd(obj)
+}

--- a/pkg/controllermanager/controller/controllerregistration/backupbucket_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/backupbucket_control_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerregistration
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Controller", func() {
+	var (
+		queue *fakeQueue
+		c     *Controller
+
+		seedName = "seed"
+	)
+
+	BeforeEach(func() {
+		queue = &fakeQueue{}
+		c = &Controller{
+			controllerRegistrationSeedQueue: queue,
+		}
+	})
+
+	Describe("#backupBucketAdd", func() {
+		It("should do nothing because object is not a BackupBucket", func() {
+			obj := &gardencorev1beta1.CloudProfile{}
+
+			c.backupBucketAdd(obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should do nothing because the seedName is nil", func() {
+			obj := &gardencorev1beta1.BackupBucket{}
+
+			c.backupBucketAdd(obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should add the object to the queue", func() {
+			obj := &gardencorev1beta1.BackupBucket{
+				Spec: gardencorev1beta1.BackupBucketSpec{
+					SeedName: &seedName,
+				},
+			}
+
+			c.backupBucketAdd(obj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+	})
+
+	Describe("#backupBucketUpdate", func() {
+		It("should do nothing because old object is not a BackupBucket", func() {
+			oldObj := &gardencorev1beta1.CloudProfile{}
+			newObj := &gardencorev1beta1.BackupBucket{}
+
+			c.backupBucketUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should do nothing because new object is not a BackupBucket", func() {
+			oldObj := &gardencorev1beta1.BackupBucket{}
+			newObj := &gardencorev1beta1.CloudProfile{}
+
+			c.backupBucketUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should do nothing because nothing changed", func() {
+			oldObj := &gardencorev1beta1.BackupBucket{}
+			newObj := &gardencorev1beta1.BackupBucket{}
+
+			c.backupBucketUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should add the new obj to the queue because seed name changed", func() {
+			oldObj := &gardencorev1beta1.BackupBucket{}
+			newObj := &gardencorev1beta1.BackupBucket{
+				Spec: gardencorev1beta1.BackupBucketSpec{
+					SeedName: &seedName,
+				},
+			}
+
+			c.backupBucketUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+
+		It("should add the new obj to the queue because provider type changed", func() {
+			oldObj := &gardencorev1beta1.BackupBucket{
+				Spec: gardencorev1beta1.BackupBucketSpec{
+					SeedName: &seedName,
+				},
+			}
+			newObj := oldObj.DeepCopy()
+			newObj.Spec.Provider = gardencorev1beta1.BackupBucketProvider{
+				Type: "type",
+			}
+
+			c.backupBucketUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+	})
+
+	Describe("#backupBucketDelete", func() {
+		It("should do nothing because object is not a BackupBucket", func() {
+			obj := &gardencorev1beta1.CloudProfile{}
+
+			c.backupBucketDelete(obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should do nothing because the seedName is nil", func() {
+			obj := &gardencorev1beta1.BackupBucket{}
+
+			c.backupBucketDelete(obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should add the object to the queue", func() {
+			obj := &gardencorev1beta1.BackupBucket{
+				Spec: gardencorev1beta1.BackupBucketSpec{
+					SeedName: &seedName,
+				},
+			}
+
+			c.backupBucketDelete(obj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+	})
+})

--- a/pkg/controllermanager/controller/controllerregistration/backupentry_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/backupentry_control.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerregistration
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+)
+
+func (c *Controller) backupEntryAdd(obj interface{}) {
+	backupEntry, ok := obj.(*gardencorev1beta1.BackupEntry)
+	if !ok {
+		return
+	}
+
+	if backupEntry.Spec.SeedName == nil {
+		return
+	}
+
+	c.controllerRegistrationSeedQueue.Add(*backupEntry.Spec.SeedName)
+}
+
+func (c *Controller) backupEntryUpdate(oldObj, newObj interface{}) {
+	oldObject, ok := oldObj.(*gardencorev1beta1.BackupEntry)
+	if !ok {
+		return
+	}
+
+	newObject, ok := newObj.(*gardencorev1beta1.BackupEntry)
+	if !ok {
+		return
+	}
+
+	if apiequality.Semantic.DeepEqual(oldObject.Spec.SeedName, newObject.Spec.SeedName) &&
+		oldObject.Spec.BucketName == newObject.Spec.BucketName {
+		return
+	}
+
+	c.backupEntryAdd(newObj)
+}
+
+func (c *Controller) backupEntryDelete(obj interface{}) {
+	c.backupEntryAdd(obj)
+}

--- a/pkg/controllermanager/controller/controllerregistration/backupentry_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/backupentry_control_test.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerregistration
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Controller", func() {
+	var (
+		queue *fakeQueue
+		c     *Controller
+
+		seedName = "seed"
+	)
+
+	BeforeEach(func() {
+		queue = &fakeQueue{}
+		c = &Controller{
+			controllerRegistrationSeedQueue: queue,
+		}
+	})
+
+	Describe("#backupEntryAdd", func() {
+		It("should do nothing because object is not a BackupEntry", func() {
+			obj := &gardencorev1beta1.CloudProfile{}
+
+			c.backupEntryAdd(obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should do nothing because the seedName is nil", func() {
+			obj := &gardencorev1beta1.BackupEntry{}
+
+			c.backupEntryAdd(obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should add the object to the queue", func() {
+			obj := &gardencorev1beta1.BackupEntry{
+				Spec: gardencorev1beta1.BackupEntrySpec{
+					SeedName: &seedName,
+				},
+			}
+
+			c.backupEntryAdd(obj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+	})
+
+	Describe("#backupEntryUpdate", func() {
+		It("should do nothing because old object is not a BackupEntry", func() {
+			oldObj := &gardencorev1beta1.CloudProfile{}
+			newObj := &gardencorev1beta1.BackupEntry{}
+
+			c.backupEntryUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should do nothing because new object is not a BackupEntry", func() {
+			oldObj := &gardencorev1beta1.BackupEntry{}
+			newObj := &gardencorev1beta1.CloudProfile{}
+
+			c.backupEntryUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should do nothing because nothing changed", func() {
+			oldObj := &gardencorev1beta1.BackupEntry{}
+			newObj := &gardencorev1beta1.BackupEntry{}
+
+			c.backupEntryUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should add the new obj to the queue because seed name changed", func() {
+			oldObj := &gardencorev1beta1.BackupEntry{}
+			newObj := &gardencorev1beta1.BackupEntry{
+				Spec: gardencorev1beta1.BackupEntrySpec{
+					SeedName: &seedName,
+				},
+			}
+
+			c.backupEntryUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+
+		It("should add the new obj to the queue because bucket name changed", func() {
+			oldObj := &gardencorev1beta1.BackupEntry{
+				Spec: gardencorev1beta1.BackupEntrySpec{
+					SeedName: &seedName,
+				},
+			}
+			newObj := oldObj.DeepCopy()
+			newObj.Spec.BucketName = "bucket"
+
+			c.backupEntryUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+	})
+
+	Describe("#backupEntryDelete", func() {
+		It("should do nothing because object is not a BackupEntry", func() {
+			obj := &gardencorev1beta1.CloudProfile{}
+
+			c.backupEntryDelete(obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should do nothing because the seedName is nil", func() {
+			obj := &gardencorev1beta1.BackupEntry{}
+
+			c.backupEntryDelete(obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should add the object to the queue", func() {
+			obj := &gardencorev1beta1.BackupEntry{
+				Spec: gardencorev1beta1.BackupEntrySpec{
+					SeedName: &seedName,
+				},
+			}
+
+			c.backupEntryDelete(obj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+	})
+})

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_control.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,33 +16,17 @@ package controllerregistration
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/logger"
-	"github.com/gardener/gardener/pkg/operation/common"
-	"github.com/gardener/gardener/pkg/utils"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	retryutils "github.com/gardener/gardener/pkg/utils/retry"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	multierror "github.com/hashicorp/go-multierror"
-	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/retry"
 )
 
 func (c *Controller) controllerRegistrationAdd(obj interface{}) {
@@ -52,6 +36,16 @@ func (c *Controller) controllerRegistrationAdd(obj interface{}) {
 		return
 	}
 	c.controllerRegistrationQueue.Add(key)
+
+	seedList, err := c.seedLister.List(labels.Everything())
+	if err != nil {
+		logger.Logger.Errorf("error listing seeds: %+v", err)
+		return
+	}
+
+	for _, seed := range seedList {
+		c.controllerRegistrationSeedQueue.Add(seed.Name)
+	}
 }
 
 func (c *Controller) controllerRegistrationUpdate(oldObj, newObj interface{}) {
@@ -93,253 +87,41 @@ type ControlInterface interface {
 }
 
 // NewDefaultControllerRegistrationControl returns a new instance of the default implementation ControlInterface that
-// implements the documented semantics for ControllerRegistrations. You should use an instance returned from
-// NewDefaultControllerRegistrationControl() for any scenario other than testing.
-func NewDefaultControllerRegistrationControl(k8sGardenClient kubernetes.Interface, k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory, recorder record.EventRecorder, config *config.ControllerManagerConfiguration, seedLister gardencorelisters.SeedLister, controllerRegistrationLister gardencorelisters.ControllerRegistrationLister, controllerInstallationLister gardencorelisters.ControllerInstallationLister) ControlInterface {
-	return &defaultControllerRegistrationControl{k8sGardenClient, k8sGardenCoreInformers, recorder, config, seedLister, controllerRegistrationLister, controllerInstallationLister}
+// implements the documented semantics for ControllerRegistrations. You should use an instance returned from NewDefaultControllerRegistrationControl()
+// for any scenario other than testing.
+func NewDefaultControllerRegistrationControl(k8sGardenClient kubernetes.Interface, controllerInstallationLister gardencorelisters.ControllerInstallationLister) ControlInterface {
+	return &defaultControllerRegistrationControl{k8sGardenClient, controllerInstallationLister}
 }
 
 type defaultControllerRegistrationControl struct {
 	k8sGardenClient              kubernetes.Interface
-	k8sGardenCoreInformers       gardencoreinformers.SharedInformerFactory
-	recorder                     record.EventRecorder
-	config                       *config.ControllerManagerConfiguration
-	seedLister                   gardencorelisters.SeedLister
-	controllerRegistrationLister gardencorelisters.ControllerRegistrationLister
 	controllerInstallationLister gardencorelisters.ControllerInstallationLister
 }
 
 func (c *defaultControllerRegistrationControl) Reconcile(obj *gardencorev1beta1.ControllerRegistration) error {
 	var (
+		ctx                    = context.TODO()
 		controllerRegistration = obj.DeepCopy()
-		logger                 = logger.NewFieldLogger(logger.Logger, "controllerregistration", controllerRegistration.Name)
 	)
 
 	if controllerRegistration.DeletionTimestamp != nil {
-		return c.delete(controllerRegistration, logger)
-	}
-	return c.reconcile(controllerRegistration, logger)
-}
-
-func (c *defaultControllerRegistrationControl) reconcile(controllerRegistration *gardencorev1beta1.ControllerRegistration, logger logrus.FieldLogger) error {
-	var (
-		err              error
-		result           error
-		installationsMap = map[string]string{}
-
-		mustWriteFinalizer = false
-	)
-
-	seedList, err := c.seedLister.List(labels.Everything())
-	if err != nil {
-		return err
-	}
-
-	for _, seed := range seedList {
-		if seed.DeletionTimestamp == nil {
-			mustWriteFinalizer = true
+		if !controllerutils.HasFinalizer(controllerRegistration, FinalizerName) {
+			return nil
 		}
-	}
 
-	if mustWriteFinalizer {
-		controllerRegistration, err = kutil.TryUpdateControllerRegistrationWithEqualFunc(c.k8sGardenClient.GardenCore(), retry.DefaultBackoff, controllerRegistration.ObjectMeta, func(c *gardencorev1beta1.ControllerRegistration) (*gardencorev1beta1.ControllerRegistration, error) {
-			if finalizers := sets.NewString(c.Finalizers...); !finalizers.Has(FinalizerName) {
-				finalizers.Insert(FinalizerName)
-				c.Finalizers = finalizers.UnsortedList()
-			}
-			return c, nil
-		}, func(cur, updated *gardencorev1beta1.ControllerRegistration) bool {
-			return sets.NewString(cur.Finalizers...).Has(FinalizerName)
-		})
+		controllerInstallationList, err := c.controllerInstallationLister.List(labels.Everything())
 		if err != nil {
 			return err
 		}
-	}
 
-	// Live lookup to prevent working on a stale cache and trying to create multiple installations for the same
-	// registration/seed combination.
-	controllerInstallationList, err := c.k8sGardenClient.GardenCore().CoreV1beta1().ControllerInstallations().List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-
-	for _, controllerInstallation := range controllerInstallationList.Items {
-		if controllerInstallation.Spec.RegistrationRef.Name == controllerRegistration.Name {
-			installationsMap[controllerInstallation.Spec.SeedRef.Name] = controllerInstallation.Name
-		}
-	}
-
-	for _, seed := range seedList {
-		if err := c.reconcileSeedInstallations(controllerRegistration, seed, installationsMap); err != nil {
-			result = multierror.Append(result, err)
-		}
-	}
-
-	return result
-}
-
-func (c *defaultControllerRegistrationControl) reconcileSeedInstallations(controllerRegistration *gardencorev1beta1.ControllerRegistration, seed *gardencorev1beta1.Seed, installationsMap map[string]string) error {
-	if seed.DeletionTimestamp != nil {
-		if installation, ok := installationsMap[seed.Name]; ok {
-			if seed.Spec.Backup != nil {
-				logger := logger.NewFieldLogger(logger.Logger, "controllerregistration-seed", seed.Name)
-				if err := waitUntilBackupBucketDeleted(context.TODO(), c.k8sGardenClient.Client(), seed, logger); err != nil {
-					return err
-				}
-			}
-
-			if err := c.k8sGardenClient.GardenCore().CoreV1beta1().ControllerInstallations().Delete(installation, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-				return err
+		for _, controllerInstallation := range controllerInstallationList {
+			if controllerInstallation.Spec.RegistrationRef.Name == controllerRegistration.Name {
+				return fmt.Errorf("cannot remove finalizer of ControllerRegistration %q because still found at least one ControllerInstallation", controllerRegistration.Name)
 			}
 		}
-		return nil
+
+		return controllerutils.RemoveFinalizer(ctx, c.k8sGardenClient.Client(), controllerRegistration, FinalizerName)
 	}
 
-	seed, err := kutil.TryUpdateSeedWithEqualFunc(c.k8sGardenClient.GardenCore(), retry.DefaultBackoff, seed.ObjectMeta, func(s *gardencorev1beta1.Seed) (*gardencorev1beta1.Seed, error) {
-		if finalizers := sets.NewString(s.Finalizers...); !finalizers.Has(FinalizerName) {
-			finalizers.Insert(FinalizerName)
-			s.Finalizers = finalizers.UnsortedList()
-		}
-		return s, nil
-	}, func(cur, updated *gardencorev1beta1.Seed) bool {
-		return sets.NewString(cur.Finalizers...).Has(FinalizerName)
-	})
-	if err != nil {
-		return err
-	}
-
-	installationSpec := gardencorev1beta1.ControllerInstallationSpec{
-		SeedRef: corev1.ObjectReference{
-			Name:            seed.Name,
-			ResourceVersion: seed.ResourceVersion,
-		},
-		RegistrationRef: corev1.ObjectReference{
-			Name:            controllerRegistration.Name,
-			ResourceVersion: controllerRegistration.ResourceVersion,
-		},
-	}
-
-	seedSpecMap, err := convertObjToMap(seed.Spec)
-	if err != nil {
-		return err
-	}
-	registrationSpecMap, err := convertObjToMap(controllerRegistration.Spec)
-	if err != nil {
-		return err
-	}
-
-	var (
-		seedSpecHash         = utils.HashForMap(seedSpecMap)[:16]
-		registrationSpecHash = utils.HashForMap(registrationSpecMap)[:16]
-	)
-
-	if name, ok := installationsMap[seed.Name]; ok {
-		_, err := kutil.CreateOrPatchControllerInstallation(c.k8sGardenClient.GardenCore(), metav1.ObjectMeta{Name: name}, func(controllerInstallation *gardencorev1beta1.ControllerInstallation) *gardencorev1beta1.ControllerInstallation {
-			kutil.SetMetaDataLabel(&controllerInstallation.ObjectMeta, common.SeedSpecHash, seedSpecHash)
-			kutil.SetMetaDataLabel(&controllerInstallation.ObjectMeta, common.RegistrationSpecHash, registrationSpecHash)
-			controllerInstallation.Spec = installationSpec
-			return controllerInstallation
-		})
-		return err
-	}
-
-	controllerInstallation := &gardencorev1beta1.ControllerInstallation{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-", controllerRegistration.Name),
-			Labels: map[string]string{
-				common.SeedSpecHash:         seedSpecHash,
-				common.RegistrationSpecHash: registrationSpecHash,
-			},
-		},
-		Spec: installationSpec,
-	}
-
-	_, err = c.k8sGardenClient.GardenCore().CoreV1beta1().ControllerInstallations().Create(controllerInstallation)
-	return err
-}
-
-func (c *defaultControllerRegistrationControl) delete(controllerRegistration *gardencorev1beta1.ControllerRegistration, logger logrus.FieldLogger) error {
-	var (
-		result error
-		count  int
-	)
-
-	controllerInstallationList, err := c.controllerInstallationLister.List(labels.Everything())
-	if err != nil {
-		return err
-	}
-
-	for _, controllerInstallation := range controllerInstallationList {
-		if controllerInstallation.Spec.RegistrationRef.Name == controllerRegistration.Name {
-			count++
-
-			if err := c.k8sGardenClient.GardenCore().CoreV1beta1().ControllerInstallations().Delete(controllerInstallation.Name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-				result = multierror.Append(result, err)
-			}
-		}
-	}
-
-	if result != nil {
-		return result
-	}
-	if count > 0 {
-		return fmt.Errorf("deletion of installations is still pending")
-	}
-
-	_, err = kutil.TryUpdateControllerRegistrationWithEqualFunc(c.k8sGardenClient.GardenCore(), retry.DefaultBackoff, controllerRegistration.ObjectMeta, func(c *gardencorev1beta1.ControllerRegistration) (*gardencorev1beta1.ControllerRegistration, error) {
-		finalizers := sets.NewString(c.Finalizers...)
-		finalizers.Delete(FinalizerName)
-		c.Finalizers = finalizers.UnsortedList()
-		return c, nil
-	}, func(cur, updated *gardencorev1beta1.ControllerRegistration) bool {
-		return !sets.NewString(cur.Finalizers...).Has(FinalizerName)
-	})
-	return err
-}
-
-// waitUntilBackupBucketDeleted waits until backup bucket extension resource is deleted in gardener cluster.
-func waitUntilBackupBucketDeleted(ctx context.Context, gardenClient client.Client, seed *gardencorev1beta1.Seed, logger *logrus.Entry) error {
-	var lastError *gardencorev1beta1.LastError
-
-	if err := retryutils.UntilTimeout(ctx, 5*time.Second, 30*time.Second, func(ctx context.Context) (bool, error) {
-		backupBucketName := string(seed.UID)
-		bb := &gardencorev1beta1.BackupBucket{}
-
-		if err := gardenClient.Get(ctx, kutil.Key(backupBucketName), bb); err != nil {
-			if apierrors.IsNotFound(err) {
-				return retryutils.Ok()
-			}
-			return retryutils.SevereError(err)
-		}
-
-		if lastErr := bb.Status.LastError; lastErr != nil {
-			logger.Errorf("BackupBucket did not get deleted yet, lastError is: %s", lastErr.Description)
-			lastError = lastErr
-		}
-
-		logger.Infof("Waiting for backupBucket to be deleted...")
-		return retryutils.MinorError(gardencorev1beta1helper.WrapWithLastError(fmt.Errorf("BackupBucket is still present"), lastError))
-	}); err != nil {
-		message := fmt.Sprintf("Error while waiting for backupBucket object to be deleted")
-		if lastError != nil {
-			return gardencorev1beta1helper.DetermineError(fmt.Sprintf("%s: %s", message, lastError.Description))
-		}
-		return gardencorev1beta1helper.DetermineError(fmt.Sprintf("%s: %s", message, err.Error()))
-	}
-
-	return nil
-}
-
-func convertObjToMap(in interface{}) (map[string]interface{}, error) {
-	var out map[string]interface{}
-
-	data, err := json.Marshal(in)
-	if err != nil {
-		return nil, err
-	}
-	if err := json.Unmarshal(data, &out); err != nil {
-		return nil, err
-	}
-
-	return out, nil
+	return controllerutils.EnsureFinalizer(ctx, c.k8sGardenClient.Client(), controllerRegistration, FinalizerName)
 }

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_control_test.go
@@ -1,0 +1,384 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerregistration
+
+import (
+	"context"
+	"errors"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
+	"github.com/gardener/gardener/pkg/logger"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	mock "github.com/gardener/gardener/pkg/mock/gardener/kubernetes"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ = Describe("Controller", func() {
+	logger.Logger = logger.NewNopLogger()
+
+	var (
+		gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory
+
+		queue                           *fakeQueue
+		controllerRegistrationSeedQueue *fakeQueue
+		c                               *Controller
+
+		controllerRegistrationName = "controllerRegistration"
+	)
+
+	BeforeEach(func() {
+		gardenCoreInformerFactory = gardencoreinformers.NewSharedInformerFactory(nil, 0)
+		controllerRegistrationInformer := gardenCoreInformerFactory.Core().V1beta1().ControllerRegistrations()
+		controllerRegistrationLister := controllerRegistrationInformer.Lister()
+		seedInformer := gardenCoreInformerFactory.Core().V1beta1().Seeds()
+		seedLister := seedInformer.Lister()
+
+		queue = &fakeQueue{}
+		controllerRegistrationSeedQueue = &fakeQueue{}
+
+		c = &Controller{
+			controllerRegistrationQueue:     queue,
+			controllerRegistrationLister:    controllerRegistrationLister,
+			controllerRegistrationSeedQueue: controllerRegistrationSeedQueue,
+			seedLister:                      seedLister,
+		}
+	})
+
+	Describe("#controllerRegistrationAdd", func() {
+		It("should do nothing because the object key computation fails", func() {
+			obj := "foo"
+
+			c.controllerRegistrationAdd(obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should add the object to the queue", func() {
+			obj := &gardencorev1beta1.ControllerRegistration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: controllerRegistrationName,
+				},
+			}
+
+			c.controllerRegistrationAdd(obj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(controllerRegistrationName))
+		})
+
+		It("should add the object to the queue and not enqueue any seeds due to list error", func() {
+			obj := &gardencorev1beta1.ControllerRegistration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: controllerRegistrationName,
+				},
+			}
+			c.seedLister = newFakeSeedLister(c.seedLister, nil, nil, errors.New("err"))
+
+			c.controllerRegistrationAdd(obj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(controllerRegistrationName))
+		})
+
+		It("should add the object to the queue and enqueue all seeds", func() {
+			obj := &gardencorev1beta1.ControllerRegistration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: controllerRegistrationName,
+				},
+			}
+
+			var (
+				seed1 = "seed1"
+				seed2 = "seed2"
+			)
+			seedList := []*gardencorev1beta1.Seed{
+				{ObjectMeta: metav1.ObjectMeta{Name: seed1}},
+				{ObjectMeta: metav1.ObjectMeta{Name: seed2}},
+			}
+			c.seedLister = newFakeSeedLister(c.seedLister, nil, seedList, nil)
+
+			c.controllerRegistrationAdd(obj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(controllerRegistrationName))
+			Expect(controllerRegistrationSeedQueue.Len()).To(Equal(len(seedList)))
+			Expect(controllerRegistrationSeedQueue.items[0]).To(Equal(seed1))
+			Expect(controllerRegistrationSeedQueue.items[1]).To(Equal(seed2))
+		})
+	})
+
+	Describe("#controllerRegistrationUpdate", func() {
+		It("should do nothing because the object key computation fails", func() {
+			obj := "foo"
+
+			c.controllerRegistrationUpdate(nil, obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should add the object to the queue", func() {
+			obj := &gardencorev1beta1.ControllerRegistration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: controllerRegistrationName,
+				},
+			}
+
+			c.controllerRegistrationUpdate(nil, obj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(controllerRegistrationName))
+		})
+	})
+
+	Describe("#controllerRegistrationDelete", func() {
+		It("should do nothing because the object key computation fails", func() {
+			obj := "foo"
+
+			c.controllerRegistrationDelete(obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should add the object to the queue (tomb stone)", func() {
+			obj := cache.DeletedFinalStateUnknown{
+				Key: controllerRegistrationName,
+			}
+
+			c.controllerRegistrationDelete(obj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(controllerRegistrationName))
+		})
+
+		It("should add the object to the queue", func() {
+			obj := &gardencorev1beta1.ControllerRegistration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: controllerRegistrationName,
+				},
+			}
+
+			c.controllerRegistrationDelete(obj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(controllerRegistrationName))
+		})
+	})
+
+	Describe("#reconcileControllerRegistrationKey", func() {
+		It("should return an error because the key cannot be split", func() {
+			Expect(c.reconcileControllerRegistrationKey("a/b/c")).To(HaveOccurred())
+		})
+
+		It("should return nil because object not found", func() {
+			c.controllerRegistrationLister = newFakeControllerRegistrationLister(c.controllerRegistrationLister, nil, apierrors.NewNotFound(schema.GroupResource{}, controllerRegistrationName))
+
+			Expect(c.reconcileControllerRegistrationKey(controllerRegistrationName)).NotTo(HaveOccurred())
+		})
+
+		It("should return err because object not found", func() {
+			err := errors.New("error")
+
+			c.controllerRegistrationLister = newFakeControllerRegistrationLister(c.controllerRegistrationLister, nil, err)
+
+			Expect(c.reconcileControllerRegistrationKey(controllerRegistrationName)).To(Equal(err))
+		})
+
+		It("should return the result of the reconciliation (nil)", func() {
+			obj := &gardencorev1beta1.ControllerRegistration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: controllerRegistrationName,
+				},
+			}
+
+			c.controllerRegistrationControl = &fakeControllerRegistrationControl{}
+			c.controllerRegistrationLister = newFakeControllerRegistrationLister(c.controllerRegistrationLister, obj, nil)
+
+			Expect(c.reconcileControllerRegistrationKey(controllerRegistrationName)).To(BeNil())
+		})
+
+		It("should return the result of the reconciliation (error)", func() {
+			obj := &gardencorev1beta1.ControllerRegistration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: controllerRegistrationName,
+				},
+			}
+
+			c.controllerRegistrationControl = &fakeControllerRegistrationControl{result: errors.New("")}
+			c.controllerRegistrationLister = newFakeControllerRegistrationLister(c.controllerRegistrationLister, obj, nil)
+
+			Expect(c.reconcileControllerRegistrationKey(controllerRegistrationName)).To(HaveOccurred())
+		})
+	})
+})
+
+type fakeControllerRegistrationControl struct {
+	result error
+}
+
+func (f *fakeControllerRegistrationControl) Reconcile(obj *gardencorev1beta1.ControllerRegistration) error {
+	return f.result
+}
+
+type fakeControllerRegistrationLister struct {
+	gardencorelisters.ControllerRegistrationLister
+
+	getResult *gardencorev1beta1.ControllerRegistration
+	getErr    error
+}
+
+func newFakeControllerRegistrationLister(controllerRegistrationLister gardencorelisters.ControllerRegistrationLister, getResult *gardencorev1beta1.ControllerRegistration, getErr error) *fakeControllerRegistrationLister {
+	return &fakeControllerRegistrationLister{
+		ControllerRegistrationLister: controllerRegistrationLister,
+
+		getResult: getResult,
+		getErr:    getErr,
+	}
+}
+
+func (c *fakeControllerRegistrationLister) Get(string) (*gardencorev1beta1.ControllerRegistration, error) {
+	if c.getErr != nil {
+		return nil, c.getErr
+	}
+	return c.getResult, nil
+}
+
+var _ = Describe("ControllerRegistrationControl", func() {
+	var (
+		ctrl                   *gomock.Controller
+		k8sGardenClient        *mock.MockInterface
+		k8sGardenRuntimeClient *mockclient.MockClient
+
+		gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory
+
+		d *defaultControllerRegistrationControl
+
+		ctx                        = context.TODO()
+		controllerRegistrationName = "controllerRegistration"
+		obj                        *gardencorev1beta1.ControllerRegistration
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		k8sGardenClient = mock.NewMockInterface(ctrl)
+		k8sGardenRuntimeClient = mockclient.NewMockClient(ctrl)
+
+		gardenCoreInformerFactory = gardencoreinformers.NewSharedInformerFactory(nil, 0)
+		controllerInstallationInformer := gardenCoreInformerFactory.Core().V1beta1().ControllerInstallations()
+		controllerInstallationLister := controllerInstallationInformer.Lister()
+
+		d = &defaultControllerRegistrationControl{k8sGardenClient, controllerInstallationLister}
+		obj = &gardencorev1beta1.ControllerRegistration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: controllerRegistrationName,
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#Reconcile", func() {
+		Context("deletion timestamp not set", func() {
+			It("should ensure the finalizer (error)", func() {
+				err := apierrors.NewNotFound(schema.GroupResource{}, controllerRegistrationName)
+
+				k8sGardenClient.EXPECT().Client().Return(k8sGardenRuntimeClient)
+				k8sGardenRuntimeClient.EXPECT().Get(ctx, kutil.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).Return(err)
+
+				Expect(d.Reconcile(obj)).To(HaveOccurred())
+			})
+
+			It("should ensure the finalizer (no error)", func() {
+				k8sGardenClient.EXPECT().Client().Return(k8sGardenRuntimeClient)
+				k8sGardenRuntimeClient.EXPECT().Get(ctx, kutil.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).Return(nil)
+				k8sGardenRuntimeClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).Return(nil)
+
+				Expect(d.Reconcile(obj)).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("deletion timestamp set", func() {
+			BeforeEach(func() {
+				now := metav1.Now()
+				obj.DeletionTimestamp = &now
+				obj.Finalizers = []string{FinalizerName}
+			})
+
+			It("should do nothing because finalizer is not present", func() {
+				obj.Finalizers = nil
+
+				Expect(d.Reconcile(obj)).NotTo(HaveOccurred())
+			})
+
+			It("should return an error because installation list failed", func() {
+				err := errors.New("err")
+
+				d.controllerInstallationLister = newFakeControllerInstallationLister(d.controllerInstallationLister, nil, err)
+
+				Expect(d.Reconcile(obj)).To(Equal(err))
+			})
+
+			It("should return an error because installation referencing controllerRegistration exists", func() {
+				controllerInstallationList := []*gardencorev1beta1.ControllerInstallation{
+					{
+						Spec: gardencorev1beta1.ControllerInstallationSpec{
+							RegistrationRef: corev1.ObjectReference{
+								Name: controllerRegistrationName,
+							},
+						},
+					},
+				}
+
+				d.controllerInstallationLister = newFakeControllerInstallationLister(d.controllerInstallationLister, controllerInstallationList, nil)
+
+				err := d.Reconcile(obj)
+				Expect(err.Error()).To(ContainSubstring("cannot remove finalizer"))
+			})
+
+			It("should remove the finalizer (error)", func() {
+				err := errors.New("some err")
+				d.controllerInstallationLister = newFakeControllerInstallationLister(d.controllerInstallationLister, nil, nil)
+
+				k8sGardenClient.EXPECT().Client().Return(k8sGardenRuntimeClient)
+				k8sGardenRuntimeClient.EXPECT().Get(ctx, kutil.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).Return(err)
+
+				Expect(d.Reconcile(obj)).To(HaveOccurred())
+			})
+
+			It("should remove the finalizer (no error)", func() {
+				d.controllerInstallationLister = newFakeControllerInstallationLister(d.controllerInstallationLister, nil, nil)
+
+				k8sGardenClient.EXPECT().Client().Return(k8sGardenRuntimeClient)
+				k8sGardenRuntimeClient.EXPECT().Get(ctx, kutil.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).Return(nil)
+				k8sGardenRuntimeClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).Return(nil)
+				k8sGardenRuntimeClient.EXPECT().Get(ctx, kutil.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).Return(nil)
+
+				Expect(d.Reconcile(obj)).NotTo(HaveOccurred())
+			})
+		})
+	})
+})

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
@@ -1,0 +1,456 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerregistration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/operation/common"
+	gardenpkg "github.com/gardener/gardener/pkg/operation/garden"
+	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
+	"github.com/gardener/gardener/pkg/utils"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func (c *Controller) reconcileControllerRegistrationSeedKey(key string) error {
+	_, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return err
+	}
+
+	seed, err := c.seedLister.Get(name)
+	if apierrors.IsNotFound(err) {
+		logger.Logger.Debugf("[CONTROLLERREGISTRATION SEED RECONCILE] %s - skipping because Seed has been deleted", key)
+		return nil
+	}
+	if err != nil {
+		logger.Logger.Infof("[CONTROLLERREGISTRATION SEED RECONCILE] %s - unable to retrieve object from store: %v", key, err)
+		return err
+	}
+
+	return c.controllerRegistrationSeedControl.Reconcile(seed)
+}
+
+// RegistrationSeedControlInterface implements the control logic for updating Seeds. It is implemented as an interface to allow
+// for extensions that provide different semantics. Currently, there is only one implementation.
+type RegistrationSeedControlInterface interface {
+	Reconcile(*gardencorev1beta1.Seed) error
+}
+
+// NewDefaultControllerRegistrationSeedControl returns a new instance of the default implementation ControlInterface that
+// implements the documented semantics for Seeds. You should use an instance returned from NewDefaultControllerRegistrationSeedControl()
+// for any scenario other than testing.
+func NewDefaultControllerRegistrationSeedControl(
+	k8sGardenClient kubernetes.Interface,
+	secrets map[string]*corev1.Secret,
+	backupBucketLister gardencorelisters.BackupBucketLister,
+	controllerInstallationLister gardencorelisters.ControllerInstallationLister,
+	controllerRegistrationLister gardencorelisters.ControllerRegistrationLister,
+	seedLister gardencorelisters.SeedLister,
+) RegistrationSeedControlInterface {
+	return &defaultControllerRegistrationSeedControl{k8sGardenClient, secrets, backupBucketLister, controllerInstallationLister, controllerRegistrationLister, seedLister}
+}
+
+type defaultControllerRegistrationSeedControl struct {
+	k8sGardenClient              kubernetes.Interface
+	secrets                      map[string]*corev1.Secret
+	backupBucketLister           gardencorelisters.BackupBucketLister
+	controllerInstallationLister gardencorelisters.ControllerInstallationLister
+	controllerRegistrationLister gardencorelisters.ControllerRegistrationLister
+	seedLister                   gardencorelisters.SeedLister
+}
+
+// Reconcile reconciles the ControllerInstallations for given Seed object. It computes the desired list of
+// ControllerInstallations, deploys them, and deletes all other potentially existing installation objects.
+func (c *defaultControllerRegistrationSeedControl) Reconcile(obj *gardencorev1beta1.Seed) error {
+	var (
+		ctx    = context.TODO()
+		seed   = obj.DeepCopy()
+		logger = logger.NewFieldLogger(logger.Logger, "controllerregistration-seed", seed.Name)
+	)
+
+	logger.Infof("[CONTROLLERINSTALLATION SEED] Reconciling %s", seed.Name)
+
+	controllerRegistrationList, err := c.controllerRegistrationLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	// Live lookup to prevent working on a stale cache and trying to create multiple installations for the same
+	// registration/seed combination.
+	controllerInstallationList, err := c.k8sGardenClient.GardenCore().CoreV1beta1().ControllerInstallations().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	backupBucketList, err := c.backupBucketLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	backupEntryList, err := c.k8sGardenClient.GardenCore().CoreV1beta1().BackupEntries(metav1.NamespaceAll).List(metav1.ListOptions{
+		FieldSelector: fields.SelectorFromSet(fields.Set{core.BackupEntrySeedName: seed.Name}).String(),
+	})
+	if err != nil {
+		return err
+	}
+	shootList, err := c.k8sGardenClient.GardenCore().CoreV1beta1().Shoots(metav1.NamespaceAll).List(metav1.ListOptions{
+		FieldSelector: fields.SelectorFromSet(fields.Set{core.ShootSeedName: seed.Name}).String(),
+	})
+	if err != nil {
+		return err
+	}
+
+	internalDomain, err := gardenpkg.GetInternalDomain(c.secrets)
+	if err != nil {
+		return err
+	}
+	defaultDomains, err := gardenpkg.GetDefaultDomains(c.secrets)
+	if err != nil {
+		return err
+	}
+
+	var (
+		controllerRegistrationNameToObject, kindTypeToControllerRegistrationName = computeControllerRegistrationMaps(controllerRegistrationList)
+
+		wantedKindTypeCombinationForBackupBuckets, buckets = computeKindTypesForBackupBuckets(backupBucketList, seed.Name)
+		wantedKindTypeCombinationForBackupEntries          = computeKindTypesForBackupEntries(logger, backupEntryList, buckets, seed.Name)
+		wantedKindTypeCombinationForShoots                 = computeKindTypesForShoots(ctx, logger, c.k8sGardenClient.Client(), shootList, seed, controllerRegistrationList, internalDomain, defaultDomains)
+
+		wantedKindTypeCombinations = sets.
+						NewString().
+						Union(wantedKindTypeCombinationForBackupBuckets).
+						Union(wantedKindTypeCombinationForBackupEntries).
+						Union(wantedKindTypeCombinationForShoots)
+	)
+
+	wantedControllerRegistrationNames, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, kindTypeToControllerRegistrationName)
+	if err != nil {
+		return err
+	}
+
+	registrationNameToInstallationName, err := computeRegistrationNameToInstallationNameMap(controllerInstallationList, controllerRegistrationNameToObject, seed.Name)
+	if err != nil {
+		return err
+	}
+
+	if err := deployNeededInstallations(ctx, logger, c.k8sGardenClient.Client(), seed, wantedControllerRegistrationNames, controllerRegistrationNameToObject, registrationNameToInstallationName); err != nil {
+		return err
+	}
+	return deleteUnneededInstallations(ctx, logger, c.k8sGardenClient.Client(), wantedControllerRegistrationNames, registrationNameToInstallationName)
+}
+
+// computeKindTypesForBackupBucket computes the list of wanted kind/type combinations for extension resources based on the
+// the list of existing BackupBucket resources.
+func computeKindTypesForBackupBuckets(
+	backupBucketList []*gardencorev1beta1.BackupBucket,
+	seedName string,
+) (sets.String, map[string]*gardencorev1beta1.BackupBucket) {
+	var (
+		wantedKindTypeCombinations = sets.NewString()
+		buckets                    = make(map[string]*gardencorev1beta1.BackupBucket)
+	)
+
+	for _, backupBucket := range backupBucketList {
+		buckets[backupBucket.Name] = backupBucket
+
+		if backupBucket.Spec.SeedName == nil || *backupBucket.Spec.SeedName != seedName {
+			continue
+		}
+
+		wantedKindTypeCombinations.Insert(fmt.Sprintf("%s/%s", extensionsv1alpha1.BackupBucketResource, backupBucket.Spec.Provider.Type))
+	}
+
+	return wantedKindTypeCombinations, buckets
+}
+
+// computeKindTypesForBackupEntries computes the list of wanted kind/type combinations for extension resources based on the
+// the list of existing BackupEntry resources.
+func computeKindTypesForBackupEntries(
+	logger *logrus.Entry,
+	backupEntryList *gardencorev1beta1.BackupEntryList,
+	buckets map[string]*gardencorev1beta1.BackupBucket,
+	seedName string,
+) sets.String {
+	wantedKindTypeCombinations := sets.NewString()
+
+	for _, backupEntry := range backupEntryList.Items {
+		if backupEntry.Spec.SeedName == nil || *backupEntry.Spec.SeedName != seedName {
+			continue
+		}
+
+		bucket, ok := buckets[backupEntry.Spec.BucketName]
+		if !ok {
+			logger.Errorf("couldn't find BackupBucket %q for BackupEntry %q", backupEntry.Spec.BucketName, backupEntry.Name)
+			continue
+		}
+
+		wantedKindTypeCombinations.Insert(fmt.Sprintf("%s/%s", extensionsv1alpha1.BackupEntryResource, bucket.Spec.Provider.Type))
+	}
+
+	return wantedKindTypeCombinations
+}
+
+// computeKindTypesForShoots computes the list of wanted kind/type combinations for extension resources based on the
+// the list of existing Shoot resources.
+func computeKindTypesForShoots(
+	ctx context.Context,
+	logger *logrus.Entry,
+	client client.Client,
+	shootList *gardencorev1beta1.ShootList,
+	seed *gardencorev1beta1.Seed,
+	controllerRegistrationList []*gardencorev1beta1.ControllerRegistration,
+	internalDomain *gardenpkg.Domain,
+	defaultDomains []*gardenpkg.Domain,
+) sets.String {
+	var (
+		wantedKindTypeCombinations = sets.NewString()
+
+		wg  sync.WaitGroup
+		out = make(chan sets.String)
+	)
+
+	for _, shoot := range shootList.Items {
+		if shoot.Spec.SeedName == nil || *shoot.Spec.SeedName != seed.Name {
+			continue
+		}
+
+		wg.Add(1)
+		go func(shoot *gardencorev1beta1.Shoot) {
+			defer wg.Done()
+
+			externalDomain, err := shootpkg.ConstructExternalDomain(ctx, client, shoot, &corev1.Secret{}, defaultDomains)
+			if err != nil && !(shootpkg.IsIncompleteDNSConfigError(err) && shoot.DeletionTimestamp != nil && len(shoot.Status.UID) == 0) {
+				logger.Warnf("could not determine external domain for shoot %s/%s: %+v", shoot.Namespace, shoot.Name, err)
+			}
+
+			out <- shootpkg.ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
+		}(shoot.DeepCopy())
+	}
+
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+
+	for result := range out {
+		wantedKindTypeCombinations = wantedKindTypeCombinations.Union(result)
+	}
+
+	return wantedKindTypeCombinations
+}
+
+// computeControllerRegistrationMaps computes two maps. The first map maps the name of a ControllerRegistration to
+// the *gardencorev1beta1.ControllerRegistration object. The second map maps the registered kind/type combinations
+// to the supporting *gardencorev1beta1.ControllerRegistration object.
+func computeControllerRegistrationMaps(
+	controllerRegistrationList []*gardencorev1beta1.ControllerRegistration,
+) (map[string]*gardencorev1beta1.ControllerRegistration, map[string]string) {
+	var (
+		controllerRegistrationNameToObject   = make(map[string]*gardencorev1beta1.ControllerRegistration)
+		kindTypeToControllerRegistrationName = make(map[string]string)
+	)
+
+	for _, controllerRegistration := range controllerRegistrationList {
+		controllerRegistrationNameToObject[controllerRegistration.Name] = controllerRegistration
+		for _, resource := range controllerRegistration.Spec.Resources {
+			kindTypeToControllerRegistrationName[fmt.Sprintf("%s/%s", resource.Kind, resource.Type)] = controllerRegistration.Name
+		}
+	}
+
+	return controllerRegistrationNameToObject, kindTypeToControllerRegistrationName
+}
+
+// computeWantedControllerRegistrationNames computes the list of names of ControllerRegistration objects that are desired
+// to be installed. The computation is performed based on a list of required kind/type combinations and the proper mapping
+// to existing ControllerRegistration objects.
+func computeWantedControllerRegistrationNames(
+	wantedKindTypeCombinations sets.String,
+	kindTypeToControllerRegistrationName map[string]string,
+) (sets.String, error) {
+	names := sets.NewString()
+
+	for _, requiredExtension := range wantedKindTypeCombinations.UnsortedList() {
+		name, ok := kindTypeToControllerRegistrationName[requiredExtension]
+		if !ok {
+			return nil, fmt.Errorf("need to install an extension controller for %q but no appropriate ControllerRegistration found", requiredExtension)
+		}
+
+		names.Insert(name)
+	}
+
+	return names, nil
+}
+
+// computeRegistrationNameToInstallationNameMap computes a map that maps the name of a ControllerRegistration to the name of an
+// existing ControllerInstallation object that references this registration.
+func computeRegistrationNameToInstallationNameMap(
+	controllerInstallationList *gardencorev1beta1.ControllerInstallationList,
+	controllerRegistrationNameToObject map[string]*gardencorev1beta1.ControllerRegistration,
+	seedName string,
+) (map[string]string, error) {
+	registrationNameToInstallationName := make(map[string]string)
+
+	for _, controllerInstallation := range controllerInstallationList.Items {
+		if controllerInstallation.Spec.SeedRef.Name != seedName {
+			continue
+		}
+
+		if _, ok := controllerRegistrationNameToObject[controllerInstallation.Spec.RegistrationRef.Name]; !ok {
+			return nil, fmt.Errorf("ControllerRegistration %q does not exist", controllerInstallation.Spec.RegistrationRef.Name)
+		}
+
+		registrationNameToInstallationName[controllerInstallation.Spec.RegistrationRef.Name] = controllerInstallation.Name
+	}
+
+	return registrationNameToInstallationName, nil
+}
+
+// deployNeededInstallations takes the list of required names of ControllerRegistrations, a mapping of ControllerRegistration
+// names to their actual objects, and another mapping of ControllerRegistration names to existing ControllerInstallations. It
+// creates or update ControllerInstallation objects for that reference the given seed and the various desired ControllerRegistrations.
+func deployNeededInstallations(
+	ctx context.Context,
+	logger *logrus.Entry,
+	c client.Client,
+	seed *gardencorev1beta1.Seed,
+	wantedControllerRegistrations sets.String,
+	controllerRegistrationNameToObject map[string]*gardencorev1beta1.ControllerRegistration,
+	registrationNameToInstallationName map[string]string,
+) error {
+	for _, registrationName := range wantedControllerRegistrations.UnsortedList() {
+		logger.Infof("Deploying wanted ControllerInstallation for %q", registrationName)
+
+		if err := deployNeededInstallation(ctx, c, seed, controllerRegistrationNameToObject[registrationName], registrationNameToInstallationName[registrationName]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deployNeededInstallation(
+	ctx context.Context,
+	c client.Client,
+	seed *gardencorev1beta1.Seed,
+	controllerRegistration *gardencorev1beta1.ControllerRegistration,
+	controllerInstallationName string,
+) error {
+
+	installationSpec := gardencorev1beta1.ControllerInstallationSpec{
+		SeedRef: corev1.ObjectReference{
+			Name:            seed.Name,
+			ResourceVersion: seed.ResourceVersion,
+		},
+		RegistrationRef: corev1.ObjectReference{
+			Name:            controllerRegistration.Name,
+			ResourceVersion: controllerRegistration.ResourceVersion,
+		},
+	}
+
+	seedSpecMap, err := convertObjToMap(seed.Spec)
+	if err != nil {
+		return err
+	}
+	registrationSpecMap, err := convertObjToMap(controllerRegistration.Spec)
+	if err != nil {
+		return err
+	}
+
+	var (
+		registrationSpecHash = utils.HashForMap(registrationSpecMap)[:16]
+		seedSpecHash         = utils.HashForMap(seedSpecMap)[:16]
+
+		controllerInstallation = &gardencorev1beta1.ControllerInstallation{}
+	)
+
+	mutate := func() error {
+		kutil.SetMetaDataLabel(&controllerInstallation.ObjectMeta, common.SeedSpecHash, seedSpecHash)
+		kutil.SetMetaDataLabel(&controllerInstallation.ObjectMeta, common.RegistrationSpecHash, registrationSpecHash)
+		controllerInstallation.Spec = installationSpec
+		return nil
+	}
+
+	if controllerInstallationName != "" {
+		// The installation already exists, however, we do not have the latest version of the ControllerInstallation object.
+		// Hence, we are running the `CreateOrUpdate` function as it first GETs the current objects and then runs the mutate()
+		// function before sending the UPDATE. This way we ensure that we have applied our mutations to the latest version.
+		controllerInstallation.Name = controllerInstallationName
+		_, err := controllerutil.CreateOrUpdate(ctx, c, controllerInstallation, mutate)
+		return err
+	}
+
+	// The installation does not exist yet, hence, we set `GenerateName` which will automatically append a random suffix to
+	// the name. Unfortunately, the `CreateOrUpdate` function does not support creating an object that does not specify a name
+	// but only `GenerateName`, thus, we call `Create` directly.
+	controllerInstallation.GenerateName = controllerRegistration.Name + "-"
+	_ = mutate()
+	return c.Create(ctx, controllerInstallation)
+}
+
+// deleteUnneededInstallations takes the list of required names of ControllerRegistrations, and another mapping of
+// ControllerRegistration names to existing ControllerInstallations. It deletes every existing ControllerInstallation whose
+// referenced ControllerRegistration is not part of the given list of required list.
+func deleteUnneededInstallations(
+	ctx context.Context,
+	logger *logrus.Entry,
+	c client.Client,
+	wantedControllerRegistrationNames sets.String,
+	registrationNameToInstallationName map[string]string,
+) error {
+	for registrationName, installationName := range registrationNameToInstallationName {
+		if !wantedControllerRegistrationNames.Has(registrationName) {
+			logger.Infof("Deleting unneeded ControllerInstallation %q", installationName)
+
+			if err := c.Delete(ctx, &gardencorev1beta1.ControllerInstallation{ObjectMeta: metav1.ObjectMeta{Name: installationName}}); client.IgnoreNotFound(err) != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func convertObjToMap(in interface{}) (map[string]interface{}, error) {
+	var out map[string]interface{}
+
+	data, err := json.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
@@ -1,0 +1,689 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerregistration
+
+import (
+	"context"
+	"errors"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	"github.com/gardener/gardener/pkg/logger"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	"github.com/gardener/gardener/pkg/operation/common"
+	gardenpkg "github.com/gardener/gardener/pkg/operation/garden"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("Controller", func() {
+	logger.Logger = logger.NewNopLogger()
+
+	var (
+		gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory
+
+		queue                           *fakeQueue
+		controllerRegistrationSeedQueue *fakeQueue
+		c                               *Controller
+
+		seedName = "seed"
+	)
+
+	BeforeEach(func() {
+		gardenCoreInformerFactory = gardencoreinformers.NewSharedInformerFactory(nil, 0)
+		controllerRegistrationInformer := gardenCoreInformerFactory.Core().V1beta1().ControllerRegistrations()
+		controllerRegistrationLister := controllerRegistrationInformer.Lister()
+		seedInformer := gardenCoreInformerFactory.Core().V1beta1().Seeds()
+		seedLister := seedInformer.Lister()
+
+		queue = &fakeQueue{}
+		controllerRegistrationSeedQueue = &fakeQueue{}
+
+		c = &Controller{
+			controllerRegistrationQueue:     queue,
+			controllerRegistrationLister:    controllerRegistrationLister,
+			controllerRegistrationSeedQueue: controllerRegistrationSeedQueue,
+			seedLister:                      seedLister,
+		}
+	})
+
+	Describe("#reconcileControllerRegistrationSeedKey", func() {
+		It("should return an error because the key cannot be split", func() {
+			Expect(c.reconcileControllerRegistrationSeedKey("a/b/c")).To(HaveOccurred())
+		})
+
+		It("should return nil because object not found", func() {
+			c.seedLister = newFakeSeedLister(c.seedLister, nil, nil, apierrors.NewNotFound(schema.GroupResource{}, seedName))
+
+			Expect(c.reconcileControllerRegistrationSeedKey(seedName)).NotTo(HaveOccurred())
+		})
+
+		It("should return err because object not found", func() {
+			err := errors.New("error")
+
+			c.seedLister = newFakeSeedLister(c.seedLister, nil, nil, err)
+
+			Expect(c.reconcileControllerRegistrationSeedKey(seedName)).To(Equal(err))
+		})
+
+		It("should return the result of the reconciliation (nil)", func() {
+			obj := &gardencorev1beta1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: seedName,
+				},
+			}
+
+			c.controllerRegistrationSeedControl = &fakeControllerRegistrationSeedControl{}
+			c.seedLister = newFakeSeedLister(c.seedLister, obj, nil, nil)
+
+			Expect(c.reconcileControllerRegistrationSeedKey(seedName)).NotTo(HaveOccurred())
+		})
+
+		It("should return the result of the reconciliation (error)", func() {
+			obj := &gardencorev1beta1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: seedName,
+				},
+			}
+
+			c.controllerRegistrationSeedControl = &fakeControllerRegistrationSeedControl{result: errors.New("")}
+			c.seedLister = newFakeSeedLister(c.seedLister, obj, nil, nil)
+
+			Expect(c.reconcileControllerRegistrationSeedKey(seedName)).To(HaveOccurred())
+		})
+	})
+})
+
+type fakeControllerRegistrationSeedControl struct {
+	result error
+}
+
+func (f *fakeControllerRegistrationSeedControl) Reconcile(obj *gardencorev1beta1.Seed) error {
+	return f.result
+}
+
+var _ = Describe("ControllerRegistrationSeedControl", func() {
+	var (
+		ctx       = context.TODO()
+		nopLogger = logger.NewFieldLogger(logger.NewNopLogger(), "", "")
+		seedName  = "seed"
+
+		type1  = "type1"
+		type2  = "type2"
+		type3  = "type3"
+		type4  = "type4"
+		type5  = "type5"
+		type6  = "type6"
+		type7  = "type7"
+		type8  = "type8"
+		type9  = "type9"
+		type10 = "type10"
+		type11 = "type11"
+
+		backupBucket1 = &gardencorev1beta1.BackupBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bb1",
+			},
+			Spec: gardencorev1beta1.BackupBucketSpec{
+				Provider: gardencorev1beta1.BackupBucketProvider{
+					Type: type1,
+				},
+			},
+		}
+		backupBucket2 = &gardencorev1beta1.BackupBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bb2",
+			},
+			Spec: gardencorev1beta1.BackupBucketSpec{
+				SeedName: &seedName,
+				Provider: gardencorev1beta1.BackupBucketProvider{
+					Type: type2,
+				},
+			},
+		}
+		backupBucket3 = &gardencorev1beta1.BackupBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bb3",
+			},
+			Spec: gardencorev1beta1.BackupBucketSpec{
+				SeedName: &seedName,
+				Provider: gardencorev1beta1.BackupBucketProvider{
+					Type: type3,
+				},
+			},
+		}
+		backupBucketList = []*gardencorev1beta1.BackupBucket{
+			backupBucket1,
+			backupBucket2,
+			backupBucket3,
+		}
+		buckets = map[string]*gardencorev1beta1.BackupBucket{
+			backupBucket1.Name: backupBucket1,
+			backupBucket2.Name: backupBucket2,
+			backupBucket3.Name: backupBucket3,
+		}
+
+		backupEntry1 = &gardencorev1beta1.BackupEntry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "be1",
+			},
+			Spec: gardencorev1beta1.BackupEntrySpec{
+				BucketName: backupBucket1.Name,
+			},
+		}
+		backupEntry2 = &gardencorev1beta1.BackupEntry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "be2",
+			},
+			Spec: gardencorev1beta1.BackupEntrySpec{
+				SeedName:   &seedName,
+				BucketName: backupBucket1.Name,
+			},
+		}
+		backupEntry3 = &gardencorev1beta1.BackupEntry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "be3",
+			},
+			Spec: gardencorev1beta1.BackupEntrySpec{
+				SeedName:   &seedName,
+				BucketName: backupBucket2.Name,
+			},
+		}
+		backupEntryList = &gardencorev1beta1.BackupEntryList{
+			Items: []gardencorev1beta1.BackupEntry{
+				*backupEntry1,
+				*backupEntry2,
+				*backupEntry3,
+			},
+		}
+
+		seedWithoutTaints = &gardencorev1beta1.Seed{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: seedName,
+			},
+			Spec: gardencorev1beta1.SeedSpec{
+				Provider: gardencorev1beta1.SeedProvider{
+					Type: type11,
+				},
+				Backup: &gardencorev1beta1.SeedBackup{
+					Provider: type8,
+				},
+			},
+		}
+		seedWithTaints = &gardencorev1beta1.Seed{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: seedName,
+			},
+			Spec: gardencorev1beta1.SeedSpec{
+				Provider: gardencorev1beta1.SeedProvider{
+					Type: type11,
+				},
+				Backup: &gardencorev1beta1.SeedBackup{
+					Provider: type8,
+				},
+				Taints: []gardencorev1beta1.SeedTaint{
+					{Key: gardencorev1beta1.SeedTaintDisableDNS},
+				},
+			},
+		}
+
+		shoot1 = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "s1",
+			},
+			Spec: gardencorev1beta1.ShootSpec{
+				Provider: gardencorev1beta1.Provider{
+					Type: type1,
+				},
+			},
+		}
+		shoot2 = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "s2",
+			},
+			Spec: gardencorev1beta1.ShootSpec{
+				SeedName: &seedName,
+				Provider: gardencorev1beta1.Provider{
+					Type: type2,
+					Workers: []gardencorev1beta1.Worker{
+						{
+							Machine: gardencorev1beta1.Machine{
+								Image: &gardencorev1beta1.ShootMachineImage{
+									Name: type5,
+								},
+							},
+						},
+					},
+				},
+				Networking: gardencorev1beta1.Networking{
+					Type: type3,
+				},
+				Extensions: []gardencorev1beta1.Extension{
+					{Type: type4},
+				},
+			},
+		}
+		shoot3 = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "s3",
+			},
+			Spec: gardencorev1beta1.ShootSpec{
+				SeedName: &seedName,
+				Provider: gardencorev1beta1.Provider{
+					Type: type6,
+				},
+				Networking: gardencorev1beta1.Networking{
+					Type: type3,
+				},
+				DNS: &gardencorev1beta1.DNS{
+					Providers: []gardencorev1beta1.DNSProvider{
+						{Type: &type7},
+					},
+				},
+			},
+		}
+		shootList = &gardencorev1beta1.ShootList{
+			Items: []gardencorev1beta1.Shoot{
+				*shoot1,
+				*shoot2,
+				*shoot3,
+			},
+		}
+
+		internalDomain = &gardenpkg.Domain{
+			Provider: type9,
+		}
+
+		controllerRegistration1 = &gardencorev1beta1.ControllerRegistration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cr1",
+			},
+			Spec: gardencorev1beta1.ControllerRegistrationSpec{
+				Resources: []gardencorev1beta1.ControllerResource{
+					{
+						Kind: extensionsv1alpha1.BackupBucketResource,
+						Type: type1,
+					},
+					{
+						Kind:            extensionsv1alpha1.ExtensionResource,
+						GloballyEnabled: pointer.BoolPtr(true),
+						Type:            type10,
+					},
+				},
+			},
+		}
+		controllerRegistration2 = &gardencorev1beta1.ControllerRegistration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cr2",
+			},
+			Spec: gardencorev1beta1.ControllerRegistrationSpec{
+				Resources: []gardencorev1beta1.ControllerResource{
+					{
+						Kind: extensionsv1alpha1.NetworkResource,
+						Type: type2,
+					},
+				},
+			},
+		}
+		controllerRegistration3 = &gardencorev1beta1.ControllerRegistration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cr3",
+			},
+			Spec: gardencorev1beta1.ControllerRegistrationSpec{
+				Resources: []gardencorev1beta1.ControllerResource{
+					{
+						Kind: extensionsv1alpha1.ControlPlaneResource,
+						Type: type3,
+					},
+					{
+						Kind: extensionsv1alpha1.InfrastructureResource,
+						Type: type3,
+					},
+					{
+						Kind: extensionsv1alpha1.WorkerResource,
+						Type: type3,
+					},
+				},
+			},
+		}
+		controllerRegistrationList = []*gardencorev1beta1.ControllerRegistration{
+			controllerRegistration1,
+			controllerRegistration2,
+			controllerRegistration3,
+		}
+		controllerRegistrationNameToObject = map[string]*gardencorev1beta1.ControllerRegistration{
+			controllerRegistration1.Name: controllerRegistration1,
+			controllerRegistration2.Name: controllerRegistration2,
+			controllerRegistration3.Name: controllerRegistration3,
+		}
+		kindTypeToControllerRegistrationName = map[string]string{
+			extensionsv1alpha1.BackupBucketResource + "/" + type1:   controllerRegistration1.Name,
+			extensionsv1alpha1.ExtensionResource + "/" + type10:     controllerRegistration1.Name,
+			extensionsv1alpha1.NetworkResource + "/" + type2:        controllerRegistration2.Name,
+			extensionsv1alpha1.ControlPlaneResource + "/" + type3:   controllerRegistration3.Name,
+			extensionsv1alpha1.InfrastructureResource + "/" + type3: controllerRegistration3.Name,
+			extensionsv1alpha1.WorkerResource + "/" + type3:         controllerRegistration3.Name,
+		}
+
+		controllerInstallation1 = &gardencorev1beta1.ControllerInstallation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ci1",
+			},
+			Spec: gardencorev1beta1.ControllerInstallationSpec{
+				SeedRef: corev1.ObjectReference{
+					Name: "another-seed",
+				},
+				RegistrationRef: corev1.ObjectReference{
+					Name: controllerRegistration1.Name,
+				},
+			},
+		}
+		controllerInstallation2 = &gardencorev1beta1.ControllerInstallation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ci2",
+			},
+			Spec: gardencorev1beta1.ControllerInstallationSpec{
+				SeedRef: corev1.ObjectReference{
+					Name: seedName,
+				},
+				RegistrationRef: corev1.ObjectReference{
+					Name: controllerRegistration2.Name,
+				},
+			},
+		}
+		controllerInstallation3 = &gardencorev1beta1.ControllerInstallation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ci3",
+			},
+			Spec: gardencorev1beta1.ControllerInstallationSpec{
+				SeedRef: corev1.ObjectReference{
+					Name: seedName,
+				},
+				RegistrationRef: corev1.ObjectReference{
+					Name: controllerRegistration3.Name,
+				},
+			},
+		}
+		controllerInstallationList = &gardencorev1beta1.ControllerInstallationList{
+			Items: []gardencorev1beta1.ControllerInstallation{
+				*controllerInstallation1,
+				*controllerInstallation2,
+				*controllerInstallation3,
+			},
+		}
+	)
+
+	Describe("#computeKindTypesForBackupBuckets", func() {
+		It("should return empty results for empty input", func() {
+			kindTypes, bs := computeKindTypesForBackupBuckets(nil, seedName)
+
+			Expect(kindTypes.Len()).To(BeZero())
+			Expect(bs).To(BeEmpty())
+		})
+
+		It("should correctly compute the result", func() {
+			kindTypes, bs := computeKindTypesForBackupBuckets(backupBucketList, seedName)
+
+			Expect(kindTypes).To(Equal(sets.NewString(
+				extensionsv1alpha1.BackupBucketResource+"/"+backupBucket2.Spec.Provider.Type,
+				extensionsv1alpha1.BackupBucketResource+"/"+backupBucket3.Spec.Provider.Type,
+			)))
+			Expect(bs).To(Equal(buckets))
+		})
+	})
+
+	Describe("#computeKindTypesForBackupEntries", func() {
+		It("should return empty results for empty input", func() {
+			kindTypes := computeKindTypesForBackupEntries(nopLogger, &gardencorev1beta1.BackupEntryList{}, nil, seedName)
+
+			Expect(kindTypes.Len()).To(BeZero())
+		})
+
+		It("should correctly compute the result", func() {
+			kindTypes := computeKindTypesForBackupEntries(nopLogger, backupEntryList, buckets, seedName)
+
+			Expect(kindTypes).To(Equal(sets.NewString(
+				extensionsv1alpha1.BackupEntryResource + "/" + backupBucket1.Spec.Provider.Type,
+				extensionsv1alpha1.BackupEntryResource + "/" + backupBucket2.Spec.Provider.Type,
+			)))
+		})
+	})
+
+	Describe("#computeKindTypesForShoots", func() {
+		It("should correctly compute the result for a seed without DNS taint", func() {
+			kindTypes := computeKindTypesForShoots(ctx, nopLogger, nil, shootList, seedWithoutTaints, controllerRegistrationList, internalDomain, nil)
+
+			Expect(kindTypes).To(Equal(sets.NewString(
+				// seedWithoutTaints types
+				extensionsv1alpha1.BackupBucketResource+"/"+type8,
+				extensionsv1alpha1.BackupEntryResource+"/"+type8,
+				extensionsv1alpha1.ControlPlaneResource+"/"+type11,
+
+				// shoot2 types
+				extensionsv1alpha1.ControlPlaneResource+"/"+type2,
+				extensionsv1alpha1.InfrastructureResource+"/"+type2,
+				extensionsv1alpha1.WorkerResource+"/"+type2,
+				extensionsv1alpha1.OperatingSystemConfigResource+"/"+type5,
+				extensionsv1alpha1.NetworkResource+"/"+type3,
+				extensionsv1alpha1.ExtensionResource+"/"+type4,
+
+				// shoot3 types
+				extensionsv1alpha1.ControlPlaneResource+"/"+type6,
+				extensionsv1alpha1.InfrastructureResource+"/"+type6,
+				extensionsv1alpha1.WorkerResource+"/"+type6,
+				dnsv1alpha1.DNSProviderKind+"/"+type7,
+
+				// internal domain + globally enabled extensions
+				extensionsv1alpha1.ExtensionResource+"/"+type10,
+				dnsv1alpha1.DNSProviderKind+"/"+type9,
+			)))
+		})
+
+		It("should correctly compute the result for a seed with DNS taint", func() {
+			kindTypes := computeKindTypesForShoots(ctx, nopLogger, nil, shootList, seedWithTaints, controllerRegistrationList, internalDomain, nil)
+
+			Expect(kindTypes).To(Equal(sets.NewString(
+				// seedWithTaints types
+				extensionsv1alpha1.BackupBucketResource+"/"+type8,
+				extensionsv1alpha1.BackupEntryResource+"/"+type8,
+				extensionsv1alpha1.ControlPlaneResource+"/"+type11,
+
+				// shoot2 types
+				extensionsv1alpha1.ControlPlaneResource+"/"+type2,
+				extensionsv1alpha1.InfrastructureResource+"/"+type2,
+				extensionsv1alpha1.WorkerResource+"/"+type2,
+				extensionsv1alpha1.OperatingSystemConfigResource+"/"+type5,
+				extensionsv1alpha1.NetworkResource+"/"+type3,
+				extensionsv1alpha1.ExtensionResource+"/"+type4,
+
+				// shoot3 types
+				extensionsv1alpha1.ControlPlaneResource+"/"+type6,
+				extensionsv1alpha1.InfrastructureResource+"/"+type6,
+				extensionsv1alpha1.WorkerResource+"/"+type6,
+
+				// globally enabled extensions
+				extensionsv1alpha1.ExtensionResource+"/"+type10,
+			)))
+		})
+	})
+
+	Describe("#computeControllerRegistrationMaps", func() {
+		It("should correctly compute the result", func() {
+			registrations, kindTypes := computeControllerRegistrationMaps(controllerRegistrationList)
+
+			Expect(registrations).To(Equal(controllerRegistrationNameToObject))
+			Expect(kindTypes).To(Equal(kindTypeToControllerRegistrationName))
+		})
+	})
+
+	Describe("#computeWantedControllerRegistrationNames", func() {
+		It("should correctly compute the result w/o error", func() {
+			wantedKindTypeCombinations := sets.NewString(
+				extensionsv1alpha1.NetworkResource+"/"+type2,
+				extensionsv1alpha1.ControlPlaneResource+"/"+type3,
+			)
+
+			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, kindTypeToControllerRegistrationName)
+
+			Expect(names).To(Equal(sets.NewString(controllerRegistration2.Name, controllerRegistration3.Name)))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should fail to compute the result and return error", func() {
+			wantedKindTypeCombinations := sets.NewString(
+				extensionsv1alpha1.ExtensionResource + "/foo",
+			)
+
+			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, kindTypeToControllerRegistrationName)
+
+			Expect(names).To(BeNil())
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("#computeRegistrationNameToInstallationNameMap", func() {
+		It("should correctly compute the result w/o error", func() {
+			regNameToInstallationName, err := computeRegistrationNameToInstallationNameMap(controllerInstallationList, controllerRegistrationNameToObject, seedName)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(regNameToInstallationName).To(Equal(map[string]string{
+				controllerRegistration2.Name: controllerInstallation2.Name,
+				controllerRegistration3.Name: controllerInstallation3.Name,
+			}))
+		})
+
+		It("should fail to compute the result and return error", func() {
+			regNameToInstallationName, err := computeRegistrationNameToInstallationNameMap(controllerInstallationList, map[string]*gardencorev1beta1.ControllerRegistration{}, seedName)
+
+			Expect(err).To(HaveOccurred())
+			Expect(regNameToInstallationName).To(BeNil())
+		})
+	})
+
+	Context("deployment and deletion", func() {
+		var (
+			ctrl      *gomock.Controller
+			k8sClient *mockclient.MockClient
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+
+			k8sClient = mockclient.NewMockClient(ctrl)
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		Describe("#deployNeededInstallations", func() {
+			It("should return an error", func() {
+				var (
+					wantedControllerRegistrations      = sets.NewString(controllerRegistration2.Name)
+					registrationNameToInstallationName = map[string]string{
+						controllerRegistration1.Name: controllerInstallation1.Name,
+						controllerRegistration2.Name: controllerInstallation2.Name,
+						controllerRegistration3.Name: controllerInstallation3.Name,
+					}
+					fakeErr = errors.New("err")
+				)
+
+				k8sClient.EXPECT().Get(ctx, kutil.Key(controllerInstallation2.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{})).Return(fakeErr)
+
+				err := deployNeededInstallations(ctx, nopLogger, k8sClient, seedWithoutTaints, wantedControllerRegistrations, controllerRegistrationNameToObject, registrationNameToInstallationName)
+
+				Expect(err).To(Equal(fakeErr))
+			})
+
+			It("should correctly deploy needed controller installations", func() {
+				var (
+					wantedControllerRegistrations      = sets.NewString(controllerRegistration2.Name, controllerRegistration3.Name)
+					registrationNameToInstallationName = map[string]string{
+						controllerRegistration1.Name: controllerInstallation1.Name,
+						controllerRegistration2.Name: controllerInstallation2.Name,
+						controllerRegistration3.Name: controllerInstallation3.Name,
+					}
+				)
+
+				installation2 := controllerInstallation2.DeepCopy()
+				installation2.Labels = map[string]string{
+					common.RegistrationSpecHash: "e3b0c44298fc1c14",
+					common.SeedSpecHash:         "70d90aa0670092bc",
+				}
+
+				installation3 := controllerInstallation3.DeepCopy()
+				installation3.Labels = map[string]string{
+					common.RegistrationSpecHash: "e3b0c44298fc1c14",
+					common.SeedSpecHash:         "70d90aa0670092bc",
+				}
+
+				k8sClient.EXPECT().Get(ctx, kutil.Key(controllerInstallation2.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
+				k8sClient.EXPECT().Update(ctx, installation2)
+
+				k8sClient.EXPECT().Get(ctx, kutil.Key(controllerInstallation3.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
+				k8sClient.EXPECT().Update(ctx, installation3)
+
+				err := deployNeededInstallations(ctx, nopLogger, k8sClient, seedWithoutTaints, wantedControllerRegistrations, controllerRegistrationNameToObject, registrationNameToInstallationName)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Describe("#deleteUnneededInstallations", func() {
+			It("should return an error", func() {
+				var (
+					wantedControllerRegistrationNames  = sets.NewString()
+					registrationNameToInstallationName = map[string]string{"": controllerInstallation1.Name}
+					fakeErr                            = errors.New("err")
+				)
+
+				k8sClient.EXPECT().Delete(ctx, &gardencorev1beta1.ControllerInstallation{ObjectMeta: metav1.ObjectMeta{Name: controllerInstallation1.Name}}).Return(fakeErr)
+
+				err := deleteUnneededInstallations(ctx, nopLogger, k8sClient, wantedControllerRegistrationNames, registrationNameToInstallationName)
+
+				Expect(err).To(Equal(fakeErr))
+			})
+
+			It("should correctly delete unneeded controller installations", func() {
+				var (
+					wantedControllerRegistrationNames  = sets.NewString(controllerRegistration2.Name)
+					registrationNameToInstallationName = map[string]string{
+						controllerRegistration1.Name: controllerInstallation1.Name,
+						controllerRegistration2.Name: controllerInstallation2.Name,
+						controllerRegistration3.Name: controllerInstallation3.Name,
+					}
+				)
+
+				k8sClient.EXPECT().Delete(ctx, &gardencorev1beta1.ControllerInstallation{ObjectMeta: metav1.ObjectMeta{Name: controllerInstallation1.Name}})
+				k8sClient.EXPECT().Delete(ctx, &gardencorev1beta1.ControllerInstallation{ObjectMeta: metav1.ObjectMeta{Name: controllerInstallation3.Name}})
+
+				err := deleteUnneededInstallations(ctx, nopLogger, k8sClient, wantedControllerRegistrationNames, registrationNameToInstallationName)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+})

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_suite_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_suite_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerregistration
+
+import (
+	"testing"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/util/workqueue"
+)
+
+func TestControllerRegistration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ControllerManager ControllerRegistration Controller Suite")
+}
+
+type fakeQueue struct {
+	workqueue.RateLimitingInterface
+	items []string
+}
+
+func (f *fakeQueue) Add(item interface{}) {
+	f.items = append(f.items, item.(string))
+}
+
+func (f *fakeQueue) Len() int {
+	return len(f.items)
+}
+
+type fakeControllerInstallationLister struct {
+	gardencorelisters.ControllerInstallationLister
+
+	listResult []*gardencorev1beta1.ControllerInstallation
+	listErr    error
+}
+
+func newFakeControllerInstallationLister(controllerInstallationLister gardencorelisters.ControllerInstallationLister, listResult []*gardencorev1beta1.ControllerInstallation, listErr error) *fakeControllerInstallationLister {
+	return &fakeControllerInstallationLister{
+		ControllerInstallationLister: controllerInstallationLister,
+
+		listResult: listResult,
+		listErr:    listErr,
+	}
+}
+
+func (c *fakeControllerInstallationLister) List(labels.Selector) ([]*gardencorev1beta1.ControllerInstallation, error) {
+	if c.listErr != nil {
+		return nil, c.listErr
+	}
+	return c.listResult, nil
+}
+
+type fakeSeedLister struct {
+	gardencorelisters.SeedLister
+
+	getResult  *gardencorev1beta1.Seed
+	listResult []*gardencorev1beta1.Seed
+	err        error
+}
+
+func newFakeSeedLister(seedLister gardencorelisters.SeedLister, getResult *gardencorev1beta1.Seed, listResult []*gardencorev1beta1.Seed, err error) *fakeSeedLister {
+	return &fakeSeedLister{
+		SeedLister: seedLister,
+
+		getResult:  getResult,
+		listResult: listResult,
+		err:        err,
+	}
+}
+
+func (c *fakeSeedLister) Get(string) (*gardencorev1beta1.Seed, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.getResult, nil
+}
+
+func (c *fakeSeedLister) List(labels.Selector) ([]*gardencorev1beta1.Seed, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	return c.listResult, nil
+}

--- a/pkg/controllermanager/controller/controllerregistration/seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed_control_test.go
@@ -1,0 +1,313 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerregistration
+
+import (
+	"context"
+	"errors"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	"github.com/gardener/gardener/pkg/logger"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	mock "github.com/gardener/gardener/pkg/mock/gardener/kubernetes"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ = Describe("Controller", func() {
+	logger.Logger = logger.NewNopLogger()
+
+	var (
+		gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory
+
+		queue *fakeQueue
+		c     *Controller
+
+		seedName = "seed"
+	)
+
+	BeforeEach(func() {
+		gardenCoreInformerFactory = gardencoreinformers.NewSharedInformerFactory(nil, 0)
+		seedInformer := gardenCoreInformerFactory.Core().V1beta1().Seeds()
+		seedLister := seedInformer.Lister()
+
+		queue = &fakeQueue{}
+		c = &Controller{
+			seedQueue:  queue,
+			seedLister: seedLister,
+		}
+	})
+
+	Describe("#seedAdd", func() {
+		It("should do nothing because the object key computation fails", func() {
+			obj := "foo"
+
+			c.seedAdd(obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should add the object to the queue", func() {
+			obj := &gardencorev1beta1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: seedName,
+				},
+			}
+
+			c.seedAdd(obj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+	})
+
+	Describe("#seedUpdate", func() {
+		It("should do nothing because the object key computation fails", func() {
+			obj := "foo"
+
+			c.seedUpdate(nil, obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should add the object to the queue", func() {
+			obj := &gardencorev1beta1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: seedName,
+				},
+			}
+
+			c.seedUpdate(nil, obj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+	})
+
+	Describe("#seedDelete", func() {
+		It("should do nothing because the object key computation fails", func() {
+			obj := "foo"
+
+			c.seedDelete(obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should add the object to the queue (tomb stone)", func() {
+			obj := cache.DeletedFinalStateUnknown{
+				Key: seedName,
+			}
+
+			c.seedDelete(obj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+
+		It("should add the object to the queue", func() {
+			obj := &gardencorev1beta1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: seedName,
+				},
+			}
+
+			c.seedDelete(obj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+	})
+
+	Describe("#reconcileSeedKey", func() {
+		It("should return an error because the key cannot be split", func() {
+			Expect(c.reconcileSeedKey("a/b/c")).To(HaveOccurred())
+		})
+
+		It("should return nil because object not found", func() {
+			c.seedLister = newFakeSeedLister(c.seedLister, nil, nil, apierrors.NewNotFound(schema.GroupResource{}, seedName))
+
+			Expect(c.reconcileSeedKey(seedName)).NotTo(HaveOccurred())
+		})
+
+		It("should return err because object not found", func() {
+			err := errors.New("error")
+
+			c.seedLister = newFakeSeedLister(c.seedLister, nil, nil, err)
+
+			Expect(c.reconcileSeedKey(seedName)).To(Equal(err))
+		})
+
+		It("should return the result of the reconciliation (nil)", func() {
+			obj := &gardencorev1beta1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: seedName,
+				},
+			}
+
+			c.seedControl = &fakeSeedControl{}
+			c.seedLister = newFakeSeedLister(c.seedLister, obj, nil, nil)
+
+			Expect(c.reconcileSeedKey(seedName)).To(BeNil())
+		})
+
+		It("should return the result of the reconciliation (error)", func() {
+			obj := &gardencorev1beta1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: seedName,
+				},
+			}
+
+			c.seedControl = &fakeSeedControl{result: errors.New("")}
+			c.seedLister = newFakeSeedLister(c.seedLister, obj, nil, nil)
+
+			Expect(c.reconcileSeedKey(seedName)).To(HaveOccurred())
+		})
+	})
+})
+
+type fakeSeedControl struct {
+	result error
+}
+
+func (f *fakeSeedControl) Reconcile(obj *gardencorev1beta1.Seed) error {
+	return f.result
+}
+
+var _ = Describe("SeedControl", func() {
+	var (
+		ctrl                   *gomock.Controller
+		k8sGardenClient        *mock.MockInterface
+		k8sGardenRuntimeClient *mockclient.MockClient
+
+		gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory
+
+		d *defaultSeedControl
+
+		ctx      = context.TODO()
+		seedName = "seed"
+		obj      *gardencorev1beta1.Seed
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		k8sGardenClient = mock.NewMockInterface(ctrl)
+		k8sGardenRuntimeClient = mockclient.NewMockClient(ctrl)
+
+		gardenCoreInformerFactory = gardencoreinformers.NewSharedInformerFactory(nil, 0)
+		controllerInstallationInformer := gardenCoreInformerFactory.Core().V1beta1().ControllerInstallations()
+		controllerInstallationLister := controllerInstallationInformer.Lister()
+
+		d = &defaultSeedControl{k8sGardenClient, controllerInstallationLister}
+		obj = &gardencorev1beta1.Seed{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: seedName,
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#Reconcile", func() {
+		Context("deletion timestamp not set", func() {
+			It("should ensure the finalizer (error)", func() {
+				err := apierrors.NewNotFound(schema.GroupResource{}, seedName)
+
+				k8sGardenClient.EXPECT().Client().Return(k8sGardenRuntimeClient)
+				k8sGardenRuntimeClient.EXPECT().Get(ctx, kutil.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(err)
+
+				Expect(d.Reconcile(obj)).To(HaveOccurred())
+			})
+
+			It("should ensure the finalizer (no error)", func() {
+				k8sGardenClient.EXPECT().Client().Return(k8sGardenRuntimeClient)
+				k8sGardenRuntimeClient.EXPECT().Get(ctx, kutil.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(nil)
+				k8sGardenRuntimeClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(nil)
+
+				Expect(d.Reconcile(obj)).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("deletion timestamp set", func() {
+			BeforeEach(func() {
+				now := metav1.Now()
+				obj.DeletionTimestamp = &now
+				obj.Finalizers = []string{FinalizerName}
+			})
+
+			It("should do nothing because finalizer is not present", func() {
+				obj.Finalizers = nil
+
+				Expect(d.Reconcile(obj)).NotTo(HaveOccurred())
+			})
+
+			It("should return an error because installation list failed", func() {
+				err := errors.New("err")
+
+				d.controllerInstallationLister = newFakeControllerInstallationLister(d.controllerInstallationLister, nil, err)
+
+				Expect(d.Reconcile(obj)).To(Equal(err))
+			})
+
+			It("should return an error because installation referencing seed exists", func() {
+				controllerInstallationList := []*gardencorev1beta1.ControllerInstallation{
+					{
+						Spec: gardencorev1beta1.ControllerInstallationSpec{
+							SeedRef: corev1.ObjectReference{
+								Name: seedName,
+							},
+						},
+					},
+				}
+
+				d.controllerInstallationLister = newFakeControllerInstallationLister(d.controllerInstallationLister, controllerInstallationList, nil)
+
+				err := d.Reconcile(obj)
+				Expect(err.Error()).To(ContainSubstring("cannot remove finalizer"))
+			})
+
+			It("should remove the finalizer (error)", func() {
+				err := errors.New("some err")
+				d.controllerInstallationLister = newFakeControllerInstallationLister(d.controllerInstallationLister, nil, nil)
+
+				k8sGardenClient.EXPECT().Client().Return(k8sGardenRuntimeClient)
+				k8sGardenRuntimeClient.EXPECT().Get(ctx, kutil.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(err)
+
+				Expect(d.Reconcile(obj)).To(HaveOccurred())
+			})
+
+			It("should remove the finalizer (no error)", func() {
+				d.controllerInstallationLister = newFakeControllerInstallationLister(d.controllerInstallationLister, nil, nil)
+
+				k8sGardenClient.EXPECT().Client().Return(k8sGardenRuntimeClient)
+				k8sGardenRuntimeClient.EXPECT().Get(ctx, kutil.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(nil)
+				k8sGardenRuntimeClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(nil)
+				k8sGardenRuntimeClient.EXPECT().Get(ctx, kutil.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(nil)
+
+				Expect(d.Reconcile(obj)).NotTo(HaveOccurred())
+			})
+		})
+	})
+})

--- a/pkg/controllermanager/controller/controllerregistration/shoot_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/shoot_control.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerregistration
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+)
+
+func (c *Controller) shootAdd(obj interface{}) {
+	shoot, ok := obj.(*gardencorev1beta1.Shoot)
+	if !ok {
+		return
+	}
+
+	if shoot.Spec.SeedName == nil {
+		return
+	}
+
+	c.controllerRegistrationSeedQueue.Add(*shoot.Spec.SeedName)
+}
+
+func (c *Controller) shootUpdate(oldObj, newObj interface{}) {
+	oldObject, ok := oldObj.(*gardencorev1beta1.Shoot)
+	if !ok {
+		return
+	}
+
+	newObject, ok := newObj.(*gardencorev1beta1.Shoot)
+	if !ok {
+		return
+	}
+
+	if apiequality.Semantic.DeepEqual(oldObject.Spec.SeedName, newObject.Spec.SeedName) &&
+		apiequality.Semantic.DeepEqual(oldObject.Spec.Provider.Workers, newObject.Spec.Provider.Workers) &&
+		apiequality.Semantic.DeepEqual(oldObject.Spec.Extensions, newObject.Spec.Extensions) &&
+		apiequality.Semantic.DeepEqual(oldObject.Spec.DNS, newObject.Spec.DNS) &&
+		oldObject.Spec.Networking.Type == newObject.Spec.Networking.Type &&
+		oldObject.Spec.Provider.Type == newObject.Spec.Provider.Type {
+		return
+	}
+
+	c.shootAdd(newObj)
+}
+
+func (c *Controller) shootDelete(obj interface{}) {
+	c.shootAdd(obj)
+}

--- a/pkg/controllermanager/controller/controllerregistration/shoot_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/shoot_control_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerregistration
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Controller", func() {
+	var (
+		queue *fakeQueue
+		c     *Controller
+
+		seedName = "seed"
+	)
+
+	BeforeEach(func() {
+		queue = &fakeQueue{}
+		c = &Controller{
+			controllerRegistrationSeedQueue: queue,
+		}
+	})
+
+	Describe("#shootAdd", func() {
+		It("should do nothing because object is not a Shoot", func() {
+			obj := &gardencorev1beta1.CloudProfile{}
+
+			c.shootAdd(obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should do nothing because the seedName is nil", func() {
+			obj := &gardencorev1beta1.Shoot{}
+
+			c.shootAdd(obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should add the object to the queue", func() {
+			obj := &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					SeedName: &seedName,
+				},
+			}
+
+			c.shootAdd(obj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+	})
+
+	Describe("#shootUpdate", func() {
+		It("should do nothing because old object is not a Shoot", func() {
+			oldObj := &gardencorev1beta1.CloudProfile{}
+			newObj := &gardencorev1beta1.Shoot{}
+
+			c.shootUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should do nothing because new object is not a Shoot", func() {
+			oldObj := &gardencorev1beta1.Shoot{}
+			newObj := &gardencorev1beta1.CloudProfile{}
+
+			c.shootUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should do nothing because nothing changed", func() {
+			oldObj := &gardencorev1beta1.Shoot{}
+			newObj := &gardencorev1beta1.Shoot{}
+
+			c.shootUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should add the new obj to the queue because seed name changed", func() {
+			oldObj := &gardencorev1beta1.Shoot{}
+			newObj := &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					SeedName: &seedName,
+				},
+			}
+
+			c.shootUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+
+		It("should add the new obj to the queue because workers changed", func() {
+			oldObj := &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					SeedName: &seedName,
+				},
+			}
+			newObj := oldObj.DeepCopy()
+			newObj.Spec.Provider.Workers = []gardencorev1beta1.Worker{{}}
+
+			c.shootUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+
+		It("should add the new obj to the queue because extensions changed", func() {
+			oldObj := &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					SeedName: &seedName,
+				},
+			}
+			newObj := oldObj.DeepCopy()
+			newObj.Spec.Extensions = []gardencorev1beta1.Extension{{}}
+
+			c.shootUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+
+		It("should add the new obj to the queue because dns changed", func() {
+			oldObj := &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					SeedName: &seedName,
+				},
+			}
+			newObj := oldObj.DeepCopy()
+			newObj.Spec.DNS = &gardencorev1beta1.DNS{}
+
+			c.shootUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+
+		It("should add the new obj to the queue because networking type changed", func() {
+			oldObj := &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					SeedName: &seedName,
+				},
+			}
+			newObj := oldObj.DeepCopy()
+			newObj.Spec.Networking.Type = "type"
+
+			c.shootUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+
+		It("should add the new obj to the queue because provider type changed", func() {
+			oldObj := &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					SeedName: &seedName,
+				},
+			}
+			newObj := oldObj.DeepCopy()
+			newObj.Spec.Provider.Type = "type"
+
+			c.shootUpdate(oldObj, newObj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+	})
+
+	Describe("#shootDelete", func() {
+		It("should do nothing because object is not a Shoot", func() {
+			obj := &gardencorev1beta1.CloudProfile{}
+
+			c.shootDelete(obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should do nothing because the seedName is nil", func() {
+			obj := &gardencorev1beta1.Shoot{}
+
+			c.shootDelete(obj)
+
+			Expect(queue.Len()).To(BeZero())
+		})
+
+		It("should add the object to the queue", func() {
+			obj := &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					SeedName: &seedName,
+				},
+			}
+
+			c.shootDelete(obj)
+
+			Expect(queue.Len()).To(Equal(1))
+			Expect(queue.items[0]).To(Equal(seedName))
+		})
+	})
+})

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -66,6 +66,8 @@ func NewGardenControllerFactory(k8sGardenClient kubernetes.Interface, gardenCore
 func (f *GardenControllerFactory) Run(ctx context.Context) {
 	var (
 		// Garden core informers
+		backupBucketInformer           = f.k8sGardenCoreInformers.Core().V1beta1().BackupBuckets().Informer()
+		backupEntryInformer            = f.k8sGardenCoreInformers.Core().V1beta1().BackupEntries().Informer()
 		cloudProfileInformer           = f.k8sGardenCoreInformers.Core().V1beta1().CloudProfiles().Informer()
 		controllerRegistrationInformer = f.k8sGardenCoreInformers.Core().V1beta1().ControllerRegistrations().Informer()
 		controllerInstallationInformer = f.k8sGardenCoreInformers.Core().V1beta1().ControllerInstallations().Informer()
@@ -83,7 +85,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) {
 	)
 
 	f.k8sGardenCoreInformers.Start(ctx.Done())
-	if !cache.WaitForCacheSync(ctx.Done(), controllerRegistrationInformer.HasSynced, controllerInstallationInformer.HasSynced, plantInformer.HasSynced, cloudProfileInformer.HasSynced, secretBindingInformer.HasSynced, quotaInformer.HasSynced, projectInformer.HasSynced, seedInformer.HasSynced, shootInformer.HasSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), backupBucketInformer.HasSynced, backupEntryInformer.HasSynced, controllerRegistrationInformer.HasSynced, controllerInstallationInformer.HasSynced, plantInformer.HasSynced, cloudProfileInformer.HasSynced, secretBindingInformer.HasSynced, quotaInformer.HasSynced, projectInformer.HasSynced, seedInformer.HasSynced, shootInformer.HasSynced) {
 		panic("Timed out waiting for Garden core caches to sync")
 	}
 
@@ -103,7 +105,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) {
 
 	var (
 		cloudProfileController           = cloudprofilecontroller.NewCloudProfileController(f.k8sGardenClient, f.k8sGardenCoreInformers, f.recorder)
-		controllerRegistrationController = controllerregistrationcontroller.NewController(f.k8sGardenClient, f.k8sGardenCoreInformers, f.cfg, f.recorder)
+		controllerRegistrationController = controllerregistrationcontroller.NewController(f.k8sGardenClient, f.k8sGardenCoreInformers, secrets)
 		csrController                    = csrcontroller.NewCSRController(f.k8sGardenClient, f.k8sInformers, f.recorder)
 		quotaController                  = quotacontroller.NewQuotaController(f.k8sGardenClient, f.k8sGardenCoreInformers, f.recorder)
 		plantController                  = plantcontroller.NewController(f.k8sGardenClient, f.k8sGardenCoreInformers, f.k8sInformers, f.cfg, f.recorder)

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -73,7 +73,7 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation, errorContext *er
 			})
 		}),
 		errors.ToExecute("Check required extensions exist", func() error {
-			return botanist.RequiredExtensionsExist()
+			return botanist.RequiredExtensionsExist(context.TODO())
 		}),
 		// We first check whether the namespace in the Seed cluster does exist - if it does not, then we assume that
 		// all resources have already been deleted. We can delete the Shoot resource as a consequence.

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -79,7 +79,7 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation, operationType
 			})
 		}),
 		errors.ToExecute("Check required extensions", func() error {
-			return botanist.RequiredExtensionsExist()
+			return botanist.RequiredExtensionsExist(context.TODO())
 		}),
 		errors.ToExecute("Check version constraint", func() error {
 			enableEtcdEncryption, err = versionutils.CheckVersionMeetsConstraint(botanist.Shoot.Info.Spec.Kubernetes.Version, ">= 1.13")

--- a/pkg/registry/core/backupbucket/backupbucket_suite_test.go
+++ b/pkg/registry/core/backupbucket/backupbucket_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupbucket_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBackupbucket(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Registry BackupBucket Suite")
+}

--- a/pkg/registry/core/backupbucket/storage/storage.go
+++ b/pkg/registry/core/backupbucket/storage/storage.go
@@ -19,11 +19,13 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/registry/core/backupbucket"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/storage"
 )
 
 // REST implements a RESTStorage for backupBuckets against etcd
@@ -61,7 +63,11 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 
 		TableConvertor: newTableConvertor(),
 	}
-	options := &generic.StoreOptions{RESTOptions: optsGetter}
+	options := &generic.StoreOptions{
+		RESTOptions: optsGetter,
+		AttrFunc:    backupbucket.GetAttrs,
+		TriggerFunc: map[string]storage.IndexerFunc{core.BackupBucketSeedName: backupbucket.SeedNameTriggerFunc},
+	}
 	if err := store.CompleteWithOptions(options); err != nil {
 		panic(err)
 	}

--- a/pkg/registry/core/backupbucket/strategy_test.go
+++ b/pkg/registry/core/backupbucket/strategy_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupbucket_test
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core"
+	backupbucketregistry "github.com/gardener/gardener/pkg/registry/core/backupbucket"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var _ = Describe("ToSelectableFields", func() {
+	It("should return correct fields", func() {
+		result := backupbucketregistry.ToSelectableFields(newBackupBucket("foo"))
+
+		Expect(result).To(HaveLen(3))
+		Expect(result.Has(core.BackupBucketSeedName)).To(BeTrue())
+		Expect(result.Get(core.BackupBucketSeedName)).To(Equal("foo"))
+	})
+})
+
+var _ = Describe("GetAttrs", func() {
+	It("should return error when object is not BackupBucket", func() {
+		_, _, err := backupbucketregistry.GetAttrs(&core.Seed{})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return correct result", func() {
+		ls, fs, err := backupbucketregistry.GetAttrs(newBackupBucket("foo"))
+
+		Expect(ls).To(HaveLen(1))
+		Expect(ls.Get("foo")).To(Equal("bar"))
+		Expect(fs.Get(core.BackupBucketSeedName)).To(Equal("foo"))
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("SeedNameTriggerFunc", func() {
+	It("should return spec.seedName", func() {
+		actual := backupbucketregistry.SeedNameTriggerFunc(newBackupBucket("foo"))
+		Expect(actual).To(Equal("foo"))
+	})
+})
+
+var _ = Describe("MatchBackupBucket", func() {
+	It("should return correct predicate", func() {
+		ls, _ := labels.Parse("app=test")
+		fs := fields.OneTermEqualSelector(core.BackupBucketSeedName, "foo")
+
+		result := backupbucketregistry.MatchBackupBucket(ls, fs)
+
+		Expect(result.Label).To(Equal(ls))
+		Expect(result.Field).To(Equal(fs))
+		Expect(result.IndexFields).To(ConsistOf(core.BackupBucketSeedName))
+	})
+})
+
+func newBackupBucket(seedName string) *core.BackupBucket {
+	return &core.BackupBucket{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-namespace",
+			Labels:    map[string]string{"foo": "bar"},
+		},
+		Spec: core.BackupBucketSpec{
+			SeedName: &seedName,
+		},
+	}
+}

--- a/pkg/registry/core/backupentry/backupentry_suite_test.go
+++ b/pkg/registry/core/backupentry/backupentry_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupentry_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBackupentry(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Registry BackupEntry Suite")
+}

--- a/pkg/registry/core/backupentry/storage/storage.go
+++ b/pkg/registry/core/backupentry/storage/storage.go
@@ -19,11 +19,13 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/registry/core/backupentry"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/storage"
 )
 
 // REST implements a RESTStorage for backupEntries against etcd
@@ -61,7 +63,11 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 
 		TableConvertor: newTableConvertor(),
 	}
-	options := &generic.StoreOptions{RESTOptions: optsGetter}
+	options := &generic.StoreOptions{
+		RESTOptions: optsGetter,
+		AttrFunc:    backupentry.GetAttrs,
+		TriggerFunc: map[string]storage.IndexerFunc{core.BackupEntrySeedName: backupentry.SeedNameTriggerFunc},
+	}
 	if err := store.CompleteWithOptions(options); err != nil {
 		panic(err)
 	}

--- a/pkg/registry/core/backupentry/strategy.go
+++ b/pkg/registry/core/backupentry/strategy.go
@@ -16,6 +16,7 @@ package backupentry
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/gardener/gardener/pkg/api"
@@ -25,8 +26,12 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 )
 
@@ -119,4 +124,52 @@ func (backupEntryStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old 
 
 func (backupEntryStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	return validation.ValidateBackupEntryStatusUpdate(obj.(*core.BackupEntry), old.(*core.BackupEntry))
+}
+
+// ToSelectableFields returns a field set that represents the object
+// TODO: fields are not labels, and the validation rules for them do not apply.
+func ToSelectableFields(backupEntry *core.BackupEntry) fields.Set {
+	// The purpose of allocation with a given number of elements is to reduce
+	// amount of allocations needed to create the fields.Set. If you add any
+	// field here or the number of object-meta related fields changes, this should
+	// be adjusted.
+	backupEntrySpecificFieldsSet := make(fields.Set, 3)
+	backupEntrySpecificFieldsSet[core.BackupEntrySeedName] = getSeedName(backupEntry)
+	return generic.AddObjectMetaFieldsSet(backupEntrySpecificFieldsSet, &backupEntry.ObjectMeta, true)
+}
+
+// GetAttrs returns labels and fields of a given object for filtering purposes.
+func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
+	backupEntry, ok := obj.(*core.BackupEntry)
+	if !ok {
+		return nil, nil, fmt.Errorf("not a backupEntry")
+	}
+	return labels.Set(backupEntry.ObjectMeta.Labels), ToSelectableFields(backupEntry), nil
+}
+
+// MatchBackupEntry returns a generic matcher for a given label and field selector.
+func MatchBackupEntry(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+	return storage.SelectionPredicate{
+		Label:       label,
+		Field:       field,
+		GetAttrs:    GetAttrs,
+		IndexFields: []string{core.BackupEntrySeedName},
+	}
+}
+
+// SeedNameTriggerFunc returns spec.seedName of given BackupEntry.
+func SeedNameTriggerFunc(obj runtime.Object) string {
+	backupEntry, ok := obj.(*core.BackupEntry)
+	if !ok {
+		return ""
+	}
+
+	return getSeedName(backupEntry)
+}
+
+func getSeedName(backupEntry *core.BackupEntry) string {
+	if backupEntry.Spec.SeedName == nil {
+		return ""
+	}
+	return *backupEntry.Spec.SeedName
 }

--- a/pkg/registry/core/backupentry/strategy_test.go
+++ b/pkg/registry/core/backupentry/strategy_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupentry_test
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core"
+	backupentryregistry "github.com/gardener/gardener/pkg/registry/core/backupentry"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var _ = Describe("ToSelectableFields", func() {
+	It("should return correct fields", func() {
+		result := backupentryregistry.ToSelectableFields(newBackupEntry("foo"))
+
+		Expect(result).To(HaveLen(3))
+		Expect(result.Has(core.BackupEntrySeedName)).To(BeTrue())
+		Expect(result.Get(core.BackupEntrySeedName)).To(Equal("foo"))
+	})
+})
+
+var _ = Describe("GetAttrs", func() {
+	It("should return error when object is not BackupEntry", func() {
+		_, _, err := backupentryregistry.GetAttrs(&core.Seed{})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return correct result", func() {
+		ls, fs, err := backupentryregistry.GetAttrs(newBackupEntry("foo"))
+
+		Expect(ls).To(HaveLen(1))
+		Expect(ls.Get("foo")).To(Equal("bar"))
+		Expect(fs.Get(core.BackupEntrySeedName)).To(Equal("foo"))
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("SeedNameTriggerFunc", func() {
+	It("should return spec.seedName", func() {
+		actual := backupentryregistry.SeedNameTriggerFunc(newBackupEntry("foo"))
+		Expect(actual).To(Equal("foo"))
+	})
+})
+
+var _ = Describe("MatchBackupEntry", func() {
+	It("should return correct predicate", func() {
+		ls, _ := labels.Parse("app=test")
+		fs := fields.OneTermEqualSelector(core.BackupEntrySeedName, "foo")
+
+		result := backupentryregistry.MatchBackupEntry(ls, fs)
+
+		Expect(result.Label).To(Equal(ls))
+		Expect(result.Field).To(Equal(fs))
+		Expect(result.IndexFields).To(ConsistOf(core.BackupEntrySeedName))
+	})
+})
+
+func newBackupEntry(seedName string) *core.BackupEntry {
+	return &core.BackupEntry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-namespace",
+			Labels:    map[string]string{"foo": "bar"},
+		},
+		Spec: core.BackupEntrySpec{
+			SeedName: &seedName,
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR the `ControllerRegistration` controller in the gardener-controller-manager is entirely reworked. It is now more intelligent, i.e., it will only deploy those extension controller that are required to reconcile the `BackupBucket`s, `BackupEntry`s, `Shoot`s scheduled to the respective `Seed`s. If an extension controller is no longer required (maybe because all shoots were deleted) then the `ControllerRegistration` controller will automatically delete the extension.

**Which issue(s) this PR fixes**:
Fixes #1944

**Special notes for your reviewer**:
* I added field selectors for the seed name to `BackupBucket` / `BackupEntry` resources for the `v1beta1` API version.
* I'm sometimes using actual LIST calls to the API server instead of listing from the cache as the latter one does not allow using field selectors.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Gardener will no longer deploy all extension controller to all seed clusters. Instead, it will dynamically deploy/delete them based on the scheduled `BackupBucket`s, `BackupEntry`s, and `Shoot`s.
```
