### PR TITLE
external domain points to api server LB instead of internal domain

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -144,7 +144,7 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation, operationType
 		deployExternalDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Deploying external domain DNS record",
 			Fn:           flow.TaskFn(botanist.DeployExternalDomainDNSRecord).DoIf(dnsEnabled && managedExternalDNS && !o.Shoot.HibernationEnabled),
-			Dependencies: flow.NewTaskIDs(deployNamespace),
+			Dependencies: flow.NewTaskIDs(deployNamespace, waitUntilKubeAPIServerServiceIsReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying additional DNS providers",

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -72,7 +72,7 @@ func (b *Botanist) DeployExternalDomainDNSRecord(ctx context.Context) error {
 	if err := b.deployDNSProvider(ctx, DNSExternalName, DNSProviderRolePrimary, b.Shoot.ExternalDomain.Provider, b.Shoot.ExternalDomain.SecretData, sets.NewString(append(b.Shoot.ExternalDomain.IncludeDomains, *b.Shoot.ExternalClusterDomain)...).List(), b.Shoot.ExternalDomain.ExcludeDomains, b.Shoot.ExternalDomain.IncludeZones, b.Shoot.ExternalDomain.ExcludeZones); err != nil {
 		return err
 	}
-	return b.deployDNSEntry(ctx, DNSExternalName, common.GetAPIServerDomain(*b.Shoot.ExternalClusterDomain), common.GetAPIServerDomain(b.Shoot.InternalClusterDomain))
+	return b.deployDNSEntry(ctx, DNSExternalName, common.GetAPIServerDomain(*b.Shoot.ExternalClusterDomain), b.APIServerAddress)
 }
 
 // DestroyExternalDomainDNSRecord destroys the DNS record for the external cluster domain.


### PR DESCRIPTION
**What this PR does / why we need it**:

External domain points to api server Lb instead of internal domain.
Enables a  Shoot using a private hosted zone for the internal domain, to provide an external domain (e.g for the kubeconfig) of a custom dns provider. 
Current setup: External domain -> internal domain -> api server LB.   This does currently not work because the internal domain is not publicly resolvable (CNAME resolve will always fail).

Now: 
External domain  -> api server LB
Internal domain -> -> api server LB

Like today, requires public Apiserver LB of the Shoot.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
External domain now points to API Server LoadBalancer instead of the internal domain. This is helpful when a Shoot uses a private hosted zone for the internal domain.
```
