### PR TITLE
Remove functionless DNS providers

### DIFF
--- a/pkg/apis/core/v1alpha1/conversions.go
+++ b/pkg/apis/core/v1alpha1/conversions.go
@@ -213,11 +213,13 @@ func Convert_v1alpha1_ProjectSpec_To_core_ProjectSpec(in *ProjectSpec, out *core
 				out.Members[i].Roles = append(out.Members[i].Roles, core.ProjectMemberOwner)
 			} else {
 				// delete owner role from all other members
-				for j, role := range member.Roles {
-					if role == ProjectMemberOwner {
-						out.Members[i].Roles = append(out.Members[i].Roles[:j], out.Members[i].Roles[j+1:]...)
+				var roles []string
+				for _, role := range member.Roles {
+					if role != ProjectMemberOwner {
+						roles = append(roles, role)
 					}
 				}
+				out.Members[i].Roles = roles
 			}
 		}
 	}
@@ -244,11 +246,13 @@ func Convert_core_ProjectSpec_To_v1alpha1_ProjectSpec(in *core.ProjectSpec, out 
 				out.Members[i].Roles = append(out.Members[i].Roles, ProjectMemberOwner)
 			} else {
 				// delete owner role from all other members
-				for j, role := range member.Roles {
-					if role == ProjectMemberOwner {
-						out.Members[i].Roles = append(out.Members[i].Roles[:j], out.Members[i].Roles[j+1:]...)
+				var roles []string
+				for _, role := range member.Roles {
+					if role != ProjectMemberOwner {
+						roles = append(roles, role)
 					}
 				}
+				out.Members[i].Roles = roles
 
 				if member.Role != nil && *member.Role == ProjectMemberOwner {
 					if len(out.Members[i].Roles) > 0 {

--- a/pkg/apis/core/v1alpha1/conversions_test.go
+++ b/pkg/apis/core/v1alpha1/conversions_test.go
@@ -17,6 +17,7 @@ package v1alpha1_test
 import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	. "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	"k8s.io/utils/pointer"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -108,6 +109,13 @@ var _ = Describe("Conversion", func() {
 					Kind:     "kind",
 					Name:     "member2",
 				}
+				member3 = rbacv1.Subject{
+					APIGroup: "group",
+					Kind:     "kind",
+					Name:     "member3",
+				}
+
+				extensionRole = "extension:role"
 
 				out *core.Project
 				in  *Project
@@ -199,6 +207,10 @@ var _ = Describe("Conversion", func() {
 							Subject: member2,
 							Roles:   []string{ProjectMemberOwner},
 						},
+						{
+							Subject: member3,
+							Roles:   []string{ProjectMemberOwner, extensionRole, ProjectMemberOwner},
+						},
 					},
 				}
 
@@ -209,7 +221,7 @@ var _ = Describe("Conversion", func() {
 						Members: []core.ProjectMember{
 							{
 								Subject: member1,
-								Roles:   []string{},
+								Roles:   nil,
 							},
 							{
 								Subject: owner,
@@ -217,7 +229,11 @@ var _ = Describe("Conversion", func() {
 							},
 							{
 								Subject: member2,
-								Roles:   []string{},
+								Roles:   nil,
+							},
+							{
+								Subject: member3,
+								Roles:   []string{extensionRole},
 							},
 						},
 					},
@@ -242,7 +258,13 @@ var _ = Describe("Conversion", func() {
 					Kind:     "kind",
 					Name:     "member2",
 				}
-				ownerRole = ProjectMemberOwner
+				member3 = rbacv1.Subject{
+					APIGroup: "group",
+					Kind:     "kind",
+					Name:     "member3",
+				}
+				ownerRole     = ProjectMemberOwner
+				extensionRole = "extension:role"
 
 				out *Project
 				in  *core.Project
@@ -335,6 +357,10 @@ var _ = Describe("Conversion", func() {
 							Subject: member2,
 							Roles:   []string{core.ProjectMemberOwner},
 						},
+						{
+							Subject: member3,
+							Roles:   []string{core.ProjectMemberOwner, extensionRole, core.ProjectMemberOwner},
+						},
 					},
 				}
 
@@ -345,7 +371,7 @@ var _ = Describe("Conversion", func() {
 						Members: []ProjectMember{
 							{
 								Subject: member1,
-								Roles:   []string{},
+								Roles:   nil,
 							},
 							{
 								Subject: owner,
@@ -353,7 +379,12 @@ var _ = Describe("Conversion", func() {
 							},
 							{
 								Subject: member2,
-								Roles:   []string{},
+								Roles:   nil,
+							},
+							{
+								Subject: member3,
+								Role:    pointer.StringPtr(extensionRole),
+								Roles:   []string{extensionRole},
 							},
 						},
 					},

--- a/pkg/apis/core/v1beta1/conversions.go
+++ b/pkg/apis/core/v1beta1/conversions.go
@@ -60,11 +60,13 @@ func Convert_v1beta1_ProjectSpec_To_core_ProjectSpec(in *ProjectSpec, out *core.
 				out.Members[i].Roles = append(out.Members[i].Roles, core.ProjectMemberOwner)
 			} else {
 				// delete owner role from all other members
-				for j, role := range member.Roles {
-					if role == ProjectMemberOwner {
-						out.Members[i].Roles = append(out.Members[i].Roles[:j], out.Members[i].Roles[j+1:]...)
+				var roles []string
+				for _, role := range member.Roles {
+					if role != ProjectMemberOwner {
+						roles = append(roles, role)
 					}
 				}
+				out.Members[i].Roles = roles
 			}
 		}
 	}
@@ -91,11 +93,13 @@ func Convert_core_ProjectSpec_To_v1beta1_ProjectSpec(in *core.ProjectSpec, out *
 				out.Members[i].Roles = append(out.Members[i].Roles, ProjectMemberOwner)
 			} else {
 				// delete owner role from all other members
-				for j, role := range member.Roles {
-					if role == ProjectMemberOwner {
-						out.Members[i].Roles = append(out.Members[i].Roles[:j], out.Members[i].Roles[j+1:]...)
+				var roles []string
+				for _, role := range member.Roles {
+					if role != ProjectMemberOwner {
+						roles = append(roles, role)
 					}
 				}
+				out.Members[i].Roles = roles
 
 				if member.Role != nil && *member.Role == ProjectMemberOwner {
 					if len(out.Members[i].Roles) > 0 {

--- a/pkg/apis/core/v1beta1/conversions_test.go
+++ b/pkg/apis/core/v1beta1/conversions_test.go
@@ -17,6 +17,7 @@ package v1beta1_test
 import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	. "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"k8s.io/utils/pointer"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -57,6 +58,13 @@ var _ = Describe("Conversion", func() {
 					Kind:     "kind",
 					Name:     "member2",
 				}
+				member3 = rbacv1.Subject{
+					APIGroup: "group",
+					Kind:     "kind",
+					Name:     "member3",
+				}
+
+				extensionRole = "extension:role"
 
 				out *core.Project
 				in  *Project
@@ -148,6 +156,10 @@ var _ = Describe("Conversion", func() {
 							Subject: member2,
 							Roles:   []string{ProjectMemberOwner},
 						},
+						{
+							Subject: member3,
+							Roles:   []string{ProjectMemberOwner, extensionRole, ProjectMemberOwner},
+						},
 					},
 				}
 
@@ -158,7 +170,7 @@ var _ = Describe("Conversion", func() {
 						Members: []core.ProjectMember{
 							{
 								Subject: member1,
-								Roles:   []string{},
+								Roles:   nil,
 							},
 							{
 								Subject: owner,
@@ -166,7 +178,11 @@ var _ = Describe("Conversion", func() {
 							},
 							{
 								Subject: member2,
-								Roles:   []string{},
+								Roles:   nil,
+							},
+							{
+								Subject: member3,
+								Roles:   []string{extensionRole},
 							},
 						},
 					},
@@ -191,7 +207,13 @@ var _ = Describe("Conversion", func() {
 					Kind:     "kind",
 					Name:     "member2",
 				}
-				ownerRole = ProjectMemberOwner
+				member3 = rbacv1.Subject{
+					APIGroup: "group",
+					Kind:     "kind",
+					Name:     "member3",
+				}
+				extensionRole = "extension:role"
+				ownerRole     = ProjectMemberOwner
 
 				out *Project
 				in  *core.Project
@@ -284,6 +306,10 @@ var _ = Describe("Conversion", func() {
 							Subject: member2,
 							Roles:   []string{core.ProjectMemberOwner},
 						},
+						{
+							Subject: member3,
+							Roles:   []string{core.ProjectMemberOwner, extensionRole, core.ProjectMemberOwner},
+						},
 					},
 				}
 
@@ -294,7 +320,7 @@ var _ = Describe("Conversion", func() {
 						Members: []ProjectMember{
 							{
 								Subject: member1,
-								Roles:   []string{},
+								Roles:   nil,
 							},
 							{
 								Subject: owner,
@@ -302,7 +328,12 @@ var _ = Describe("Conversion", func() {
 							},
 							{
 								Subject: member2,
-								Roles:   []string{},
+								Roles:   nil,
+							},
+							{
+								Subject: member3,
+								Role:    pointer.StringPtr(extensionRole),
+								Roles:   []string{extensionRole},
 							},
 						},
 					},

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -23,6 +23,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/validation"
 	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/utils"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/fields"
@@ -55,6 +56,11 @@ func (shootStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 
 	shoot.Generation = 1
 	shoot.Status = core.ShootStatus{}
+
+	// DNS providers without a secret name were formerly without a function but could still be configured in the shoot.
+	// With the support of multiple DNS providers, this is not possible anymore.
+	// TODO: This can be replaced in a future version in favor of a appropriate validation.
+	updateDNSProviders(shoot.Spec.DNS)
 }
 
 func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
@@ -81,6 +87,25 @@ func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Obje
 			updateKubeletConfig(oldShoot.Spec.Provider.Workers[i].Kubernetes.Kubelet)
 		}
 	}
+
+	// DNS providers without a secret name were formerly without a function but could still be configured in the shoot.
+	// With the support of multiple DNS providers, this is not possible anymore.
+	// TODO: This can be replaced in a future version in favor of a appropriate validation.
+	updateDNSProviders(newShoot.Spec.DNS)
+	updateDNSProviders(oldShoot.Spec.DNS)
+}
+
+func updateDNSProviders(dns *core.DNS) {
+	if dns == nil {
+		return
+	}
+	var providers []core.DNSProvider
+	for _, provider := range dns.Providers {
+		if utils.IsTrue(provider.Primary) || (provider.Type != nil && provider.SecretName != nil) {
+			providers = append(providers, provider)
+		}
+	}
+	dns.Providers = providers
 }
 
 func updateKubeletConfig(kubeletConfig *core.KubeletConfig) {

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -22,13 +22,105 @@ import (
 	shootregistry "github.com/gardener/gardener/pkg/registry/core/shoot"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("Strategy", func() {
+	Context("PrepareForCreate", func() {
+		Context("dns providers", func() {
+			DescribeTable("#updateDNSProviders", func(providers []core.DNSProvider, matcher types.GomegaMatcher) {
+				shoot := newShoot("foo")
+				shoot.Spec.DNS = &core.DNS{
+					Providers: providers,
+				}
+
+				shootregistry.Strategy.PrepareForCreate(context.TODO(), shoot)
+
+				Expect(shoot.Spec.DNS.Providers).To(matcher)
+			},
+				Entry("without provider", []core.DNSProvider{}, BeEmpty()),
+				Entry("one provider",
+					[]core.DNSProvider{{Type: pointer.StringPtr("dns"), SecretName: pointer.StringPtr("secret")}},
+					ConsistOf(MatchFields(IgnoreExtras, Fields{
+						"Type":       PointTo(Equal("dns")),
+						"SecretName": PointTo(Equal("secret")),
+					}))),
+				Entry("multiple providers with one remaining",
+					[]core.DNSProvider{
+						{Type: pointer.StringPtr("dns1")},
+						{Type: pointer.StringPtr("dns2"), SecretName: pointer.StringPtr("secret")},
+						{Type: pointer.StringPtr("dns3")},
+					},
+					ConsistOf(MatchFields(IgnoreExtras, Fields{
+						"Type":       PointTo(Equal("dns2")),
+						"SecretName": PointTo(Equal("secret")),
+					}))),
+				Entry("multiple providers with multiple remaining",
+					[]core.DNSProvider{
+						{Type: pointer.StringPtr("dns1"), SecretName: pointer.StringPtr("secret")},
+						{Type: pointer.StringPtr("dns2"), SecretName: pointer.StringPtr("secret")},
+						{Type: pointer.StringPtr("dns3")},
+					},
+					ConsistOf(
+						MatchFields(IgnoreExtras, Fields{
+							"Type":       PointTo(Equal("dns1")),
+							"SecretName": PointTo(Equal("secret")),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"Type":       PointTo(Equal("dns2")),
+							"SecretName": PointTo(Equal("secret")),
+						})),
+				),
+				Entry("multiple providers with all remaining",
+					[]core.DNSProvider{
+						{Type: pointer.StringPtr("dns1"), SecretName: pointer.StringPtr("secret")},
+						{Type: pointer.StringPtr("dns2"), SecretName: pointer.StringPtr("secret")},
+						{Type: pointer.StringPtr("dns3"), SecretName: pointer.StringPtr("secret")},
+					},
+					ConsistOf(
+						MatchFields(IgnoreExtras, Fields{
+							"Type":       PointTo(Equal("dns1")),
+							"SecretName": PointTo(Equal("secret")),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"Type":       PointTo(Equal("dns2")),
+							"SecretName": PointTo(Equal("secret")),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"Type":       PointTo(Equal("dns3")),
+							"SecretName": PointTo(Equal("secret")),
+						}),
+					)),
+				Entry("multiple providers with primary",
+					[]core.DNSProvider{
+						{Type: pointer.StringPtr("dns1"), SecretName: pointer.StringPtr("secret")},
+						{Type: pointer.StringPtr("dns2"), Primary: pointer.BoolPtr(true)},
+						{Type: pointer.StringPtr("dns3"), SecretName: pointer.StringPtr("secret")},
+					},
+					ConsistOf(
+						MatchFields(IgnoreExtras, Fields{
+							"Type":       PointTo(Equal("dns1")),
+							"SecretName": PointTo(Equal("secret")),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"Type":    PointTo(Equal("dns2")),
+							"Primary": PointTo(Equal(true)),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"Type":       PointTo(Equal("dns3")),
+							"SecretName": PointTo(Equal("secret")),
+						}),
+					)),
+			)
+		})
+	})
 	Context("PrepareForUpdate", func() {
 		Context("pod pids limit", func() {
 			It("should enforce the minimum limit value", func() {
@@ -91,6 +183,93 @@ var _ = Describe("Strategy", func() {
 				Expect(*shoot.Spec.Provider.Workers[0].Kubernetes.Kubelet.PodPIDsLimit).To(Equal(highEnoughValue))
 				Expect(*oldShoot.Spec.Provider.Workers[0].Kubernetes.Kubelet.PodPIDsLimit).To(Equal(highEnoughValue))
 			})
+		})
+		Context("dns providers", func() {
+			DescribeTable("#updateDNSProviders", func(providers []core.DNSProvider, matcher types.GomegaMatcher) {
+				shoot := newShoot("foo")
+				shoot.Spec.DNS = &core.DNS{
+					Providers: providers,
+				}
+				oldShoot := shoot.DeepCopy()
+
+				shootregistry.Strategy.PrepareForUpdate(context.TODO(), shoot, oldShoot)
+
+				Expect(shoot.Spec.DNS.Providers).To(matcher)
+			},
+				Entry("without provider", []core.DNSProvider{}, BeEmpty()),
+				Entry("one provider",
+					[]core.DNSProvider{{Type: pointer.StringPtr("dns"), SecretName: pointer.StringPtr("secret")}},
+					ConsistOf(MatchFields(IgnoreExtras, Fields{
+						"Type":       PointTo(Equal("dns")),
+						"SecretName": PointTo(Equal("secret")),
+					}))),
+				Entry("multiple providers with one remaining",
+					[]core.DNSProvider{
+						{Type: pointer.StringPtr("dns1")},
+						{Type: pointer.StringPtr("dns2"), SecretName: pointer.StringPtr("secret")},
+						{Type: pointer.StringPtr("dns3")},
+					},
+					ConsistOf(MatchFields(IgnoreExtras, Fields{
+						"Type":       PointTo(Equal("dns2")),
+						"SecretName": PointTo(Equal("secret")),
+					}))),
+				Entry("multiple providers with multiple remaining",
+					[]core.DNSProvider{
+						{Type: pointer.StringPtr("dns1"), SecretName: pointer.StringPtr("secret")},
+						{Type: pointer.StringPtr("dns2"), SecretName: pointer.StringPtr("secret")},
+						{Type: pointer.StringPtr("dns3")},
+					},
+					ConsistOf(
+						MatchFields(IgnoreExtras, Fields{
+							"Type":       PointTo(Equal("dns1")),
+							"SecretName": PointTo(Equal("secret")),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"Type":       PointTo(Equal("dns2")),
+							"SecretName": PointTo(Equal("secret")),
+						})),
+				),
+				Entry("multiple providers with all remaining",
+					[]core.DNSProvider{
+						{Type: pointer.StringPtr("dns1"), SecretName: pointer.StringPtr("secret")},
+						{Type: pointer.StringPtr("dns2"), SecretName: pointer.StringPtr("secret")},
+						{Type: pointer.StringPtr("dns3"), SecretName: pointer.StringPtr("secret")},
+					},
+					ConsistOf(
+						MatchFields(IgnoreExtras, Fields{
+							"Type":       PointTo(Equal("dns1")),
+							"SecretName": PointTo(Equal("secret")),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"Type":       PointTo(Equal("dns2")),
+							"SecretName": PointTo(Equal("secret")),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"Type":       PointTo(Equal("dns3")),
+							"SecretName": PointTo(Equal("secret")),
+						}),
+					)),
+				Entry("multiple providers with primary",
+					[]core.DNSProvider{
+						{Type: pointer.StringPtr("dns1"), SecretName: pointer.StringPtr("secret")},
+						{Type: pointer.StringPtr("dns2"), Primary: pointer.BoolPtr(true)},
+						{Type: pointer.StringPtr("dns3"), SecretName: pointer.StringPtr("secret")},
+					},
+					ConsistOf(
+						MatchFields(IgnoreExtras, Fields{
+							"Type":       PointTo(Equal("dns1")),
+							"SecretName": PointTo(Equal("secret")),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"Type":    PointTo(Equal("dns2")),
+							"Primary": PointTo(Equal(true)),
+						}),
+						MatchFields(IgnoreExtras, Fields{
+							"Type":       PointTo(Equal("dns3")),
+							"SecretName": PointTo(Equal("secret")),
+						}),
+					)),
+			)
 		})
 	})
 })

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -117,3 +117,8 @@ func TestEmail(email string) bool {
 	match, _ := regexp.MatchString(`^[^@]+@(?:[a-zA-Z-0-9]+\.)+[a-zA-Z]{2,}$`, email)
 	return match
 }
+
+// IsTrue returns true if the passed bool pointer is not nil and true.
+func IsTrue(value *bool) bool {
+	return value != nil && *value
+}

--- a/pkg/utils/miscellaneous_test.go
+++ b/pkg/utils/miscellaneous_test.go
@@ -15,8 +15,11 @@ package utils_test
 
 import (
 	. "github.com/gardener/gardener/pkg/utils"
+	"github.com/onsi/gomega/types"
+	"k8s.io/utils/pointer"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -57,4 +60,12 @@ var _ = Describe("utils", func() {
 			}))
 		})
 	})
+
+	DescribeTable("#IsTrue", func(value *bool, matcher types.GomegaMatcher) {
+		Expect(IsTrue(value)).To(matcher)
+	},
+		Entry("nil", nil, BeFalse()),
+		Entry("false", pointer.BoolPtr(false), BeFalse()),
+		Entry("true", pointer.BoolPtr(true), BeTrue()),
+	)
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Before we introduced the support for multiple DNS providers #1959 a shoot with the following DNS config was valid:
```
dns:
  domain: default.domain.example.com
  providers
  - type: aws-route53
```
Although the shoot defines a **default domain** it has a provider **without** a `secretName` which means that this provider is kept in the manifest but without any function.

With this PR, Gardener removes such functionless providers when shoots are created or updated. The automatic removal is done in favor of a validation to stay compatible.

**Special notes for your reviewer**:
A panic in the conversion logic for project roles has been fixes along the way.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action user
Since Gardener now supports multiple DNS providers it's not valid to let shoot use a **default** domain and a DNS provider without a `spec.dns.providers[0].secretName`. These **functionless** providers are removed by Gardener automatically, but will be forbidden in the future. Please make sure that you **don't use a DNS provider without** `spec.dns.providers[*].secretName`.
```
