### PR TITLE
Do not duplicate `role` to `roles` in versioned `Project` objects

### DIFF
--- a/docs/extensions/project-roles.md
+++ b/docs/extensions/project-roles.md
@@ -22,10 +22,10 @@ spec:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: alice.doe@example.com
+    role: admin
     roles:
-    - "admin"
-    - "owner"
-    - "extension:foo"
+    - owner
+    - extension:foo
 ```
 
 The project controller will, for every extension role, create a `ClusterRole` with name `name: gardener.cloud:extension:project:<projectName>:<roleName>`, i.e., for above example: `name: gardener.cloud:extension:project:dev:foo`.

--- a/example/05-project-dev.yaml
+++ b/example/05-project-dev.yaml
@@ -14,13 +14,15 @@ spec:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: alice.doe@example.com
-    roles:
-    - admin
+    role: admin
+  # roles: # Additional roles go here
+  # - viewer
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: bob.doe@example.com
-    roles:
-    - viewer
+    role: viewer
+  # roles: # Additional roles go here
+  # - extension:myrole
 # description: "This is my first project"
 # purpose: "Experimenting with Gardener"
   # The `spec.namespace` field is optional and will be initialized if unset - the resulting

--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -5449,8 +5449,9 @@ string
 </td>
 <td>
 <p>Role represents the role of this member.
-Deprecated: Use roles instead. For backwards compatibility reasons, if role is specified, it will be copied to
-the roles list during the conversion of the API server.</p>
+IMPORTANT: Be aware that this field will be removed in the <code>v1</code> version of this API in favor of the <code>roles</code>
+list.
+TODO: Remove this field in favor of the <code>owner</code> role in <code>v1</code>.</p>
 </td>
 </tr>
 <tr>
@@ -7308,5 +7309,5 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>8f4d7313c</code>.
+on git commit <code>6c2b77555</code>.
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -3102,5 +3102,5 @@ the cluster-autoscaler properly.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>8f4d7313c</code>.
+on git commit <code>6c2b77555</code>.
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,5 +555,5 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>8f4d7313c</code>.
+on git commit <code>6c2b77555</code>.
 </em></p>

--- a/pkg/apis/core/v1alpha1/defaults.go
+++ b/pkg/apis/core/v1alpha1/defaults.go
@@ -49,9 +49,8 @@ func SetDefaults_Project(obj *Project) {
 	for i, member := range obj.Spec.Members {
 		defaultSubject(&obj.Spec.Members[i].Subject)
 
-		viewer := ProjectMemberViewer
-		if member.Role == nil && len(member.Roles) == 0 {
-			obj.Spec.Members[i].Roles = []string{viewer}
+		if len(member.Role) == 0 && len(member.Roles) == 0 {
+			obj.Spec.Members[i].Role = ProjectMemberViewer
 		}
 	}
 }

--- a/pkg/apis/core/v1alpha1/defaults_test.go
+++ b/pkg/apis/core/v1alpha1/defaults_test.go
@@ -124,8 +124,8 @@ var _ = Describe("Defaults", func() {
 			SetDefaults_Project(obj)
 
 			for _, m := range obj.Spec.Members {
-				Expect(m.Roles).NotTo(BeNil())
-				Expect(m.Roles).To(ContainElement(ProjectMemberViewer))
+				Expect(m.Role).NotTo(HaveLen(0))
+				Expect(m.Role).To(Equal(ProjectMemberViewer))
 			}
 		})
 	})

--- a/pkg/apis/core/v1alpha1/types_project.go
+++ b/pkg/apis/core/v1alpha1/types_project.go
@@ -94,9 +94,10 @@ type ProjectMember struct {
 	// account that has a certain role.
 	rbacv1.Subject `json:",inline"`
 	// Role represents the role of this member.
-	// Deprecated: Use roles instead. For backwards compatibility reasons, if role is specified, it will be copied to
-	// the roles list during the conversion of the API server.
-	Role *string `json:"role,omitempty"`
+	// IMPORTANT: Be aware that this field will be removed in the `v1` version of this API in favor of the `roles`
+	// list.
+	// TODO: Remove this field in favor of the `owner` role in `v1`.
+	Role string `json:"role"`
 	// Roles represents the list of roles of this member.
 	// +optional
 	Roles []string `json:"roles,omitempty"`

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -2227,11 +2227,6 @@ func (in *ProjectList) DeepCopyObject() runtime.Object {
 func (in *ProjectMember) DeepCopyInto(out *ProjectMember) {
 	*out = *in
 	out.Subject = in.Subject
-	if in.Role != nil {
-		in, out := &in.Role, &out.Role
-		*out = new(string)
-		**out = **in
-	}
 	if in.Roles != nil {
 		in, out := &in.Roles, &out.Roles
 		*out = make([]string, len(*in))

--- a/pkg/apis/core/v1beta1/conversions.go
+++ b/pkg/apis/core/v1beta1/conversions.go
@@ -60,13 +60,7 @@ func Convert_v1beta1_ProjectSpec_To_core_ProjectSpec(in *ProjectSpec, out *core.
 				out.Members[i].Roles = append(out.Members[i].Roles, core.ProjectMemberOwner)
 			} else {
 				// delete owner role from all other members
-				var roles []string
-				for _, role := range member.Roles {
-					if role != ProjectMemberOwner {
-						roles = append(roles, role)
-					}
-				}
-				out.Members[i].Roles = roles
+				out.Members[i].Roles = removeRoleFromRoles(member.Roles, ProjectMemberOwner)
 			}
 		}
 	}
@@ -84,28 +78,36 @@ func Convert_core_ProjectSpec_To_v1beta1_ProjectSpec(in *core.ProjectSpec, out *
 		for i, member := range out.Members {
 			if member.Name == owner.Name && member.APIGroup == owner.APIGroup && member.Kind == owner.Kind {
 				// add owner role to the current project's owner if not present
+				if member.Role == core.ProjectMemberOwner {
+					// remove it from owners list if present
+					out.Members[i].Roles = removeRoleFromRoles(member.Roles, ProjectMemberOwner)
+					continue outer
+				}
 				for _, role := range member.Roles {
 					if role == ProjectMemberOwner {
 						continue outer
 					}
 				}
 
-				out.Members[i].Roles = append(out.Members[i].Roles, ProjectMemberOwner)
+				if out.Members[i].Role == "" {
+					out.Members[i].Role = core.ProjectMemberOwner
+				} else {
+					out.Members[i].Roles = append(out.Members[i].Roles, core.ProjectMemberOwner)
+				}
 			} else {
 				// delete owner role from all other members
-				var roles []string
-				for _, role := range member.Roles {
-					if role != ProjectMemberOwner {
-						roles = append(roles, role)
-					}
-				}
-				out.Members[i].Roles = roles
+				out.Members[i].Roles = removeRoleFromRoles(member.Roles, ProjectMemberOwner)
 
-				if member.Role != nil && *member.Role == ProjectMemberOwner {
-					if len(out.Members[i].Roles) > 0 {
-						out.Members[i].Role = &out.Members[i].Roles[0]
+				if member.Role == ProjectMemberOwner {
+					if len(out.Members[i].Roles) == 0 {
+						out.Members[i].Role = ""
 					} else {
-						out.Members[i].Role = nil
+						out.Members[i].Role = out.Members[i].Roles[0]
+						if len(out.Members[i].Roles) > 1 {
+							out.Members[i].Roles = out.Members[i].Roles[1:]
+						} else {
+							out.Members[i].Roles = nil
+						}
 					}
 				}
 			}
@@ -115,22 +117,23 @@ func Convert_core_ProjectSpec_To_v1beta1_ProjectSpec(in *core.ProjectSpec, out *
 	return nil
 }
 
+
 func Convert_v1beta1_ProjectMember_To_core_ProjectMember(in *ProjectMember, out *core.ProjectMember, s conversion.Scope) error {
 	if err := autoConvert_v1beta1_ProjectMember_To_core_ProjectMember(in, out, s); err != nil {
 		return err
 	}
 
-	if in.Role == nil {
+	if len(in.Role) == 0 {
 		return nil
 	}
 
-	for _, role := range in.Roles {
-		if role == *in.Role {
-			return nil
-		}
+	// delete in.Role from out.Roles to make sure it gets added to the head
+	if len(out.Roles) > 0 {
+		out.Roles = removeRoleFromRoles(out.Roles, in.Role)
 	}
 
-	out.Roles = append([]string{*in.Role}, in.Roles...)
+	// add in.Role to the head of out.Roles
+	out.Roles = append([]string{in.Role}, out.Roles...)
 
 	return nil
 }
@@ -141,8 +144,20 @@ func Convert_core_ProjectMember_To_v1beta1_ProjectMember(in *core.ProjectMember,
 	}
 
 	if len(in.Roles) > 0 {
-		out.Role = &in.Roles[0]
+		out.Role = in.Roles[0]
+		out.Roles = in.Roles[1:]
 	}
 
 	return nil
+}
+
+
+func removeRoleFromRoles(roles []string, role string) []string{
+	var newRoles []string
+	for _, r := range roles {
+		if r != role {
+			newRoles = append(newRoles, r)
+		}
+	}
+	return newRoles
 }

--- a/pkg/apis/core/v1beta1/conversions_test.go
+++ b/pkg/apis/core/v1beta1/conversions_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package v1beta1_test
 import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	. "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"k8s.io/utils/pointer"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -41,7 +40,7 @@ var _ = Describe("Conversion", func() {
 	})
 
 	Context("project conversions", func() {
-		Describe("#Convert_v1beta1_ProjectSpec_To_core_ProjectSpec", func() {
+		Describe("#Convert_v1alpha1_ProjectSpec_To_core_ProjectSpec", func() {
 			var (
 				owner = rbacv1.Subject{
 					APIGroup: "group",
@@ -62,6 +61,11 @@ var _ = Describe("Conversion", func() {
 					APIGroup: "group",
 					Kind:     "kind",
 					Name:     "member3",
+				}
+				member4 = rbacv1.Subject{
+					APIGroup: "group",
+					Kind:     "kind",
+					Name:     "member4",
 				}
 
 				extensionRole = "extension:role"
@@ -143,6 +147,35 @@ var _ = Describe("Conversion", func() {
 				}))
 			})
 
+			It("should do nothing if the owner role is already present for the owner member", func() {
+				in.Spec = ProjectSpec{
+					Owner: &owner,
+					Members: []ProjectMember{
+						{Subject: member1},
+						{
+							Subject: owner,
+							Role:   ProjectMemberOwner,
+						},
+						{Subject: member2},
+					},
+				}
+
+				Expect(scheme.Convert(in, out, nil)).To(BeNil())
+				Expect(out).To(Equal(&core.Project{
+					Spec: core.ProjectSpec{
+						Owner: &owner,
+						Members: []core.ProjectMember{
+							{Subject: member1},
+							{
+								Subject: owner,
+								Roles:   []string{ProjectMemberOwner},
+							},
+							{Subject: member2},
+						},
+					},
+				}))
+			})
+
 			It("should remove the owner role from all non-owner members", func() {
 				in.Spec = ProjectSpec{
 					Owner: &owner,
@@ -159,6 +192,10 @@ var _ = Describe("Conversion", func() {
 						{
 							Subject: member3,
 							Roles:   []string{ProjectMemberOwner, extensionRole, ProjectMemberOwner},
+						},
+						{
+							Subject: member4,
+							Role:   ProjectMemberOwner,
 						},
 					},
 				}
@@ -184,13 +221,16 @@ var _ = Describe("Conversion", func() {
 								Subject: member3,
 								Roles:   []string{extensionRole},
 							},
+							{
+								Subject: member4,
+							},
 						},
 					},
 				}))
 			})
 		})
 
-		Describe("#Convert_core_ProjectSpec_To_v1beta1_ProjectSpec", func() {
+		Describe("#Convert_core_ProjectSpec_To_v1alpha1_ProjectSpec", func() {
 			var (
 				owner = rbacv1.Subject{
 					APIGroup: "group",
@@ -212,8 +252,8 @@ var _ = Describe("Conversion", func() {
 					Kind:     "kind",
 					Name:     "member3",
 				}
-				extensionRole = "extension:role"
 				ownerRole     = ProjectMemberOwner
+				extensionRole = "extension:role"
 
 				out *Project
 				in  *core.Project
@@ -242,6 +282,33 @@ var _ = Describe("Conversion", func() {
 					Owner: &owner,
 					Members: []core.ProjectMember{
 						{Subject: member1},
+						{Subject: owner, Roles: []string{"foo"}},
+						{Subject: member2},
+					},
+				}
+
+				Expect(scheme.Convert(in, out, nil)).To(BeNil())
+				Expect(out).To(Equal(&Project{
+					Spec: ProjectSpec{
+						Owner: &owner,
+						Members: []ProjectMember{
+							{Subject: member1},
+							{
+								Subject: owner,
+								Role:   "foo",
+								Roles:   []string{ProjectMemberOwner},
+							},
+							{Subject: member2},
+						},
+					},
+				}))
+			})
+
+			It("should add the owner role to the owner member (not present yet)", func() {
+				in.Spec = core.ProjectSpec{
+					Owner: &owner,
+					Members: []core.ProjectMember{
+						{Subject: member1},
 						{Subject: owner},
 						{Subject: member2},
 					},
@@ -255,7 +322,7 @@ var _ = Describe("Conversion", func() {
 							{Subject: member1},
 							{
 								Subject: owner,
-								Roles:   []string{ProjectMemberOwner},
+								Role:   ProjectMemberOwner,
 							},
 							{Subject: member2},
 						},
@@ -284,8 +351,7 @@ var _ = Describe("Conversion", func() {
 							{Subject: member1},
 							{
 								Subject: owner,
-								Role:    &ownerRole,
-								Roles:   []string{ProjectMemberOwner},
+								Role:    ownerRole,
 							},
 							{Subject: member2},
 						},
@@ -324,7 +390,7 @@ var _ = Describe("Conversion", func() {
 							},
 							{
 								Subject: owner,
-								Roles:   []string{ProjectMemberOwner},
+								Role:   ProjectMemberOwner,
 							},
 							{
 								Subject: member2,
@@ -332,8 +398,7 @@ var _ = Describe("Conversion", func() {
 							},
 							{
 								Subject: member3,
-								Role:    pointer.StringPtr(extensionRole),
-								Roles:   []string{extensionRole},
+								Role:    extensionRole,
 							},
 						},
 					},
@@ -341,7 +406,7 @@ var _ = Describe("Conversion", func() {
 			})
 		})
 
-		Describe("#Convert_v1beta1_ProjectMember_To_core_ProjectMember", func() {
+		Describe("#Convert_v1alpha1_ProjectMember_To_core_ProjectMember", func() {
 			var (
 				role = "foo"
 
@@ -361,7 +426,7 @@ var _ = Describe("Conversion", func() {
 
 			It("should do nothing because role was found", func() {
 				in = &ProjectMember{
-					Role:  &role,
+					Role:  role,
 					Roles: []string{role, "bar"},
 				}
 
@@ -371,9 +436,33 @@ var _ = Describe("Conversion", func() {
 				}))
 			})
 
-			It("should add the role at the head of roles list", func() {
+			It("should reorder the roles list to make sure the role is at the head", func() {
 				in = &ProjectMember{
-					Role:  &role,
+					Role:  role,
+					Roles: []string{"bar", role},
+				}
+
+				Expect(scheme.Convert(in, out, nil)).To(BeNil())
+				Expect(out).To(Equal(&core.ProjectMember{
+					Roles: []string{role, "bar"},
+				}))
+			})
+
+			It("should reorder the roles list to make sure the role is at the head even if there are duplicates", func() {
+				in = &ProjectMember{
+					Role:  role,
+					Roles: []string{"bar", role, role, role, "hugo"},
+				}
+
+				Expect(scheme.Convert(in, out, nil)).To(BeNil())
+				Expect(out).To(Equal(&core.ProjectMember{
+					Roles: []string{role, "bar", "hugo"},
+				}))
+			})
+
+			It("should add the role to the head of roles list", func() {
+				in = &ProjectMember{
+					Role:  role,
 					Roles: []string{"bar"},
 				}
 
@@ -384,7 +473,7 @@ var _ = Describe("Conversion", func() {
 			})
 		})
 
-		Describe("#Convert_core_ProjectMember_To_v1beta1_ProjectMember", func() {
+		Describe("#Convert_core_ProjectMember_To_v1alpha1_ProjectMember", func() {
 			var (
 				role = "foo"
 
@@ -402,13 +491,13 @@ var _ = Describe("Conversion", func() {
 				Expect(out).To(Equal(&ProjectMember{}))
 			})
 
-			It("should add the first role to the role field", func() {
+			It("should add the first role to the role field and remove it from the list", func() {
 				in.Roles = []string{role, "bar"}
 
 				Expect(scheme.Convert(in, out, nil)).To(BeNil())
 				Expect(out).To(Equal(&ProjectMember{
-					Role:  &role,
-					Roles: []string{role, "bar"},
+					Role:  role,
+					Roles: []string{"bar"},
 				}))
 			})
 		})

--- a/pkg/apis/core/v1beta1/defaults.go
+++ b/pkg/apis/core/v1beta1/defaults.go
@@ -49,9 +49,8 @@ func SetDefaults_Project(obj *Project) {
 	for i, member := range obj.Spec.Members {
 		defaultSubject(&obj.Spec.Members[i].Subject)
 
-		viewer := ProjectMemberViewer
-		if member.Role == nil && len(member.Roles) == 0 {
-			obj.Spec.Members[i].Roles = []string{viewer}
+		if len(member.Role) == 0 && len(member.Roles) == 0 {
+			obj.Spec.Members[i].Role = ProjectMemberViewer
 		}
 	}
 }

--- a/pkg/apis/core/v1beta1/defaults_test.go
+++ b/pkg/apis/core/v1beta1/defaults_test.go
@@ -124,8 +124,8 @@ var _ = Describe("Defaults", func() {
 			SetDefaults_Project(obj)
 
 			for _, m := range obj.Spec.Members {
-				Expect(m.Roles).NotTo(BeNil())
-				Expect(m.Roles).To(ContainElement(ProjectMemberViewer))
+				Expect(m.Role).NotTo(HaveLen(0))
+				Expect(m.Role).To(Equal(ProjectMemberViewer))
 			}
 		})
 	})

--- a/pkg/apis/core/v1beta1/types_project.go
+++ b/pkg/apis/core/v1beta1/types_project.go
@@ -94,9 +94,10 @@ type ProjectMember struct {
 	// account that has a certain role.
 	rbacv1.Subject `json:",inline"`
 	// Role represents the role of this member.
-	// Deprecated: Use roles instead. For backwards compatibility reasons, if role is specified, it will be copied to
-	// the roles list during the conversion of the API server.
-	Role *string `json:"role,omitempty"`
+	// IMPORTANT: Be aware that this field will be removed in the `v1` version of this API in favor of the `roles`
+	// list.
+	// TODO: Remove this field in favor of the `owner` role in `v1`.
+	Role string `json:"role"`
 	// Roles represents the list of roles of this member.
 	// +optional
 	Roles []string `json:"roles,omitempty"`

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -2177,11 +2177,6 @@ func (in *ProjectList) DeepCopyObject() runtime.Object {
 func (in *ProjectMember) DeepCopyInto(out *ProjectMember) {
 	*out = *in
 	out.Subject = in.Subject
-	if in.Role != nil {
-		in, out := &in.Role, &out.Role
-		*out = new(string)
-		**out = **in
-	}
 	if in.Roles != nil {
 		in, out := &in.Roles, &out.Roles
 		*out = make([]string, len(*in))

--- a/pkg/apis/core/validation/project.go
+++ b/pkg/apis/core/validation/project.go
@@ -75,7 +75,7 @@ func ValidateProjectSpec(projectSpec *core.ProjectSpec, fldPath *field.Path) fie
 		for j, role := range member.Roles {
 			if role == core.ProjectMemberOwner {
 				if ownerFound {
-					allErrs = append(allErrs, field.Forbidden(idxPath.Child("roles").Index(j), role))
+					allErrs = append(allErrs, field.Forbidden(idxPath.Child("roles").Index(j), "cannot have more than one member having the owner role"))
 				} else {
 					ownerFound = true
 				}

--- a/pkg/client/core/openapi/zz_generated.openapi.go
+++ b/pkg/client/core/openapi/zz_generated.openapi.go
@@ -3616,7 +3616,7 @@ func schema_pkg_apis_core_v1alpha1_ProjectMember(ref common.ReferenceCallback) c
 					},
 					"role": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Role represents the role of this member. Deprecated: Use roles instead. For backwards compatibility reasons, if role is specified, it will be copied to the roles list during the conversion of the API server.",
+							Description: "Role represents the role of this member. IMPORTANT: Be aware that this field will be removed in the `v1` version of this API in favor of the `roles` list.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3636,7 +3636,7 @@ func schema_pkg_apis_core_v1alpha1_ProjectMember(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"kind", "name"},
+				Required: []string{"kind", "name", "role"},
 			},
 		},
 	}
@@ -8578,7 +8578,7 @@ func schema_pkg_apis_core_v1beta1_ProjectMember(ref common.ReferenceCallback) co
 					},
 					"role": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Role represents the role of this member. Deprecated: Use roles instead. For backwards compatibility reasons, if role is specified, it will be copied to the roles list during the conversion of the API server.",
+							Description: "Role represents the role of this member. IMPORTANT: Be aware that this field will be removed in the `v1` version of this API in favor of the `roles` list.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8598,7 +8598,7 @@ func schema_pkg_apis_core_v1beta1_ProjectMember(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				Required: []string{"kind", "name"},
+				Required: []string{"kind", "name", "role"},
 			},
 		},
 	}

--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -133,7 +133,9 @@ func (c *defaultControl) reconcile(project *gardencorev1beta1.Project, projectLo
 	)
 
 	for _, member := range project.Spec.Members {
-		for _, role := range member.Roles {
+		allRoles := append([]string{member.Role}, member.Roles...)
+
+		for _, role := range allRoles {
 			if role == gardencorev1beta1.ProjectMemberAdmin || role == gardencorev1beta1.ProjectMemberOwner {
 				admins = append(admins, member.Subject)
 			}

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3844,7 +3844,7 @@ func schema_pkg_apis_core_v1alpha1_ProjectMember(ref common.ReferenceCallback) c
 					},
 					"role": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Role represents the role of this member. Deprecated: Use roles instead. For backwards compatibility reasons, if role is specified, it will be copied to the roles list during the conversion of the API server.",
+							Description: "Role represents the role of this member. IMPORTANT: Be aware that this field will be removed in the `v1` version of this API in favor of the `roles` list.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3864,7 +3864,7 @@ func schema_pkg_apis_core_v1alpha1_ProjectMember(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				Required: []string{"kind", "name"},
+				Required: []string{"kind", "name", "role"},
 			},
 		},
 	}
@@ -8806,7 +8806,7 @@ func schema_pkg_apis_core_v1beta1_ProjectMember(ref common.ReferenceCallback) co
 					},
 					"role": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Role represents the role of this member. Deprecated: Use roles instead. For backwards compatibility reasons, if role is specified, it will be copied to the roles list during the conversion of the API server.",
+							Description: "Role represents the role of this member. IMPORTANT: Be aware that this field will be removed in the `v1` version of this API in favor of the `roles` list.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8826,7 +8826,7 @@ func schema_pkg_apis_core_v1beta1_ProjectMember(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				Required: []string{"kind", "name"},
+				Required: []string{"kind", "name", "role"},
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR prevents that the `.spec.members[].role` field is duplicated to the `.spec.members[].roles[]` in versioned `Project `resources.
Otherwise, the API would not be backwards compatible as changing the `.spec.members[].role` is not enough anymore (because the same value is part of the `.spec.members[].roles[]` and must be removed there as well).

Example:

```
spec:
  members:
  - name: foo
    role: admin
    roles:
    - admin
    - viewer
```

Setting `.spec.members[0].role=viewer` does still preserve the `admin` role for the user because it exists in `.spec.members[0].roles[0]`.

This PR fixes this problem in the following way:
* During conversion from `{v1beta1,v1alpha1}` to `internal`, the `.spec.members[].role` is always added to the head of `.spec.members[].roles[]`
* During conversion from `internal` to `{v1beta1,v1alpha1}`, the head of `.spec.members[].roles[]` is used for `.spec.members[].role` and then truncated.

--> In the `internal` version, the `.spec.members[].roles` always contains all the roles.
--> In the `{v1beta1,v1alpha1}` versions the first role is part of `.spec.members[].role`, and all the others are part of `.spec.members[].roles[]`.

**Special notes for your reviewer**:
/cc @petersutter @timuthy 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
