### PR TITLE
Adding integration test for gardenlet care controller 

### DIFF
--- a/test/integration/shoots/care/shoot_care.go
+++ b/test/integration/shoots/care/shoot_care.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+	Overview
+		- Tests the Care Controller in the Gardenlet
+
+	Prerequisite
+		- Shoot Cluster with  Condition "APIServerAvailable" equals true
+
+	Test: Scale down API Server deployment of the Shoot in the Seed
+	Expected Output
+		- Shoot Condition "APIServerAvailable" becomes unhealthy
+ **/
+
+package care
+
+import (
+	"context"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	testframework "github.com/gardener/gardener/test/framework"
+	"github.com/gardener/gardener/test/integration/framework"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+const (
+	timeout = 10 * time.Minute
+)
+
+var _ = ginkgo.Describe("Shoot Care testing", func() {
+
+	f := testframework.NewShootFramework(nil)
+
+	f.Default().Serial().Release().CIt("Should observe failed health condition in the Shoot when scaling down the API Server of the Shoot", func(ctx context.Context) {
+		var (
+			origReplicas *int32
+			err          error
+		)
+
+		defer func(ctx context.Context) {
+			if origReplicas != nil {
+				f.Logger.Infof("Test cleanup: Scale API Server to '%d' replicas again", *origReplicas)
+				origReplicas, err = framework.ScaleDeployment(timeout, f.SeedClient.Client(), origReplicas, gardencorev1beta1constants.DeploymentNameKubeAPIServer, f.ShootSeedNamespace())
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				// wait for healthy condition
+				f.Logger.Infof("Test cleanup: wait for Shoot Health condition '%s' to become healthy again", gardencorev1beta1.ShootAPIServerAvailable)
+				err = f.WaitForShootCondition(ctx, 20*time.Second, 5*time.Minute, gardencorev1beta1.ShootAPIServerAvailable, gardencorev1beta1.ConditionTrue)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+				f.Logger.Info("Test cleanup successful")
+			}
+		}(ctx)
+
+		cond := helper.GetCondition(f.Shoot.Status.Conditions, gardencorev1beta1.ShootAPIServerAvailable)
+		gomega.Expect(cond).ToNot(gomega.BeNil())
+		gomega.Expect(cond.Status).To(gomega.Equal(gardencorev1beta1.ConditionTrue))
+
+		zero := int32(0)
+		origReplicas, err = framework.ScaleDeployment(timeout, f.SeedClient.Client(), &zero, gardencorev1beta1constants.DeploymentNameKubeAPIServer, f.ShootSeedNamespace())
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		// wait for unhealthy condition
+		err = f.WaitForShootCondition(ctx, 20*time.Second, 5*time.Minute, gardencorev1beta1.ShootAPIServerAvailable, gardencorev1beta1.ConditionFalse)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	}, timeout)
+})

--- a/test/suites/shoot/run_suite_test.go
+++ b/test/suites/shoot/run_suite_test.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/gardener/gardener/test/integration/shoots/applications"
 	_ "github.com/gardener/gardener/test/integration/shoots/logging"
 	_ "github.com/gardener/gardener/test/integration/shoots/operations"
+	_ "github.com/gardener/gardener/test/integration/shoots/care"
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding integration test for gardenlet care controller 

- Scales down the API Server of the Shoot in the Seed
- Waits for Condition to become unhealthy (Type: APIServerAvailable: false)
- Cleanup to restore state after test

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
