### PR TITLE
Make kubelet flag --image-pull-progress-deadline configurable

### DIFF
--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.flags
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.flags
@@ -6,6 +6,7 @@
 --config=/var/lib/kubelet/config/kubelet
 --cni-bin-dir=/opt/cni/bin/
 --cni-conf-dir=/etc/cni/net.d/
+--image-pull-progress-deadline={{ .Values.worker.kubelet.imagePullProgressDeadline }}
 {{- if semverCompare "< 1.12" .Values.kubernetes.version }}
 --cadvisor-port=0
 {{- end }}

--- a/charts/seed-operatingsystemconfig/original/values.yaml
+++ b/charts/seed-operatingsystemconfig/original/values.yaml
@@ -21,6 +21,7 @@ worker:
     cpuCFSQuota: true
     cpuManagerPolicy: none
   # podPIDsLimit: 24
+    imagePullProgressDeadline: 1m
     maxPods: 110
     evictionPressureTransitionPeriod: 4m0s
     evictionMaxPodGracePeriod: 90

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -58,6 +58,7 @@ spec:
     #     cpuCFSQuota: true
     #     cpuManagerPolicy: none
     #     podPidsLimit: 10
+    #     imagePullProgressDeadline: 1m
     #     maxPods: 110
     #     evictionPressureTransitionPeriod: 4m0s
     #     evictionMaxPodGracePeriod: 90
@@ -150,6 +151,7 @@ spec:
   #   cpuCFSQuota: true
   #   cpuManagerPolicy: none
   #   podPidsLimit: 10
+  #   imagePullProgressDeadline: 1m
   #   maxPods: 110
   #   evictionPressureTransitionPeriod: 4m0s
   #   evictionMaxPodGracePeriod: 90

--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -3854,6 +3854,21 @@ int64
 <p>PodPIDsLimit is the maximum number of process IDs per pod allowed by the kubelet.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>imagePullProgressDeadline</code></br>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ImagePullProgressDeadline describes the time limit under which if no pulling progress is made, the image pulling will be cancelled.
+Default: 1m</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="core.gardener.cloud/v1beta1.KubeletConfigEviction">KubeletConfigEviction
@@ -7309,5 +7324,5 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>8e6cde607</code>.
+on git commit <code>c29ab655e</code>.
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -3102,5 +3102,5 @@ the cluster-autoscaler properly.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>8e6cde607</code>.
+on git commit <code>c29ab655e</code>.
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,5 +555,5 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>8e6cde607</code>.
+on git commit <code>c29ab655e</code>.
 </em></p>

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -492,6 +492,9 @@ type KubeletConfig struct {
 	MaxPods *int32
 	// PodPIDsLimit is the maximum number of process IDs per pod allowed by the kubelet.
 	PodPIDsLimit *int64
+	// ImagePullProgressDeadline describes the time limit under which if no pulling progress is made, the image pulling will be cancelled.
+	// Default: 1m
+	ImagePullProgressDeadline *metav1.Duration
 }
 
 // KubeletConfigEviction contains kubelet eviction thresholds supporting either a resource.Quantity or a percentage based value.

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -601,6 +601,10 @@ type KubeletConfig struct {
 	// PodPIDsLimit is the maximum number of process IDs per pod allowed by the kubelet.
 	// +optional
 	PodPIDsLimit *int64 `json:"podPidsLimit,omitempty"`
+	// ImagePullProgressDeadline describes the time limit under which if no pulling progress is made, the image pulling will be cancelled.
+	// +optional
+	// Default: 1m
+	ImagePullProgressDeadline *metav1.Duration `json:"imagePullProgressDeadline,omitempty"`
 }
 
 // KubeletConfigEviction contains kubelet eviction thresholds supporting either a resource.Quantity or a percentage based value.

--- a/pkg/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.conversion.go
@@ -2496,6 +2496,7 @@ func autoConvert_v1alpha1_KubeletConfig_To_core_KubeletConfig(in *KubeletConfig,
 	out.EvictionSoftGracePeriod = (*core.KubeletConfigEvictionSoftGracePeriod)(unsafe.Pointer(in.EvictionSoftGracePeriod))
 	out.MaxPods = (*int32)(unsafe.Pointer(in.MaxPods))
 	out.PodPIDsLimit = (*int64)(unsafe.Pointer(in.PodPIDsLimit))
+	out.ImagePullProgressDeadline = (*metav1.Duration)(unsafe.Pointer(in.ImagePullProgressDeadline))
 	return nil
 }
 
@@ -2518,6 +2519,7 @@ func autoConvert_core_KubeletConfig_To_v1alpha1_KubeletConfig(in *core.KubeletCo
 	out.EvictionSoftGracePeriod = (*KubeletConfigEvictionSoftGracePeriod)(unsafe.Pointer(in.EvictionSoftGracePeriod))
 	out.MaxPods = (*int32)(unsafe.Pointer(in.MaxPods))
 	out.PodPIDsLimit = (*int64)(unsafe.Pointer(in.PodPIDsLimit))
+	out.ImagePullProgressDeadline = (*metav1.Duration)(unsafe.Pointer(in.ImagePullProgressDeadline))
 	return nil
 }
 

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1393,6 +1393,11 @@ func (in *KubeletConfig) DeepCopyInto(out *KubeletConfig) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.ImagePullProgressDeadline != nil {
+		in, out := &in.ImagePullProgressDeadline, &out.ImagePullProgressDeadline
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -598,6 +598,10 @@ type KubeletConfig struct {
 	// PodPIDsLimit is the maximum number of process IDs per pod allowed by the kubelet.
 	// +optional
 	PodPIDsLimit *int64 `json:"podPidsLimit,omitempty"`
+	// ImagePullProgressDeadline describes the time limit under which if no pulling progress is made, the image pulling will be cancelled.
+	// +optional
+	// Default: 1m
+	ImagePullProgressDeadline *metav1.Duration `json:"imagePullProgressDeadline,omitempty"`
 }
 
 // KubeletConfigEviction contains kubelet eviction thresholds supporting either a resource.Quantity or a percentage based value.

--- a/pkg/apis/core/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1beta1/zz_generated.conversion.go
@@ -2314,6 +2314,7 @@ func autoConvert_v1beta1_KubeletConfig_To_core_KubeletConfig(in *KubeletConfig, 
 	out.EvictionSoftGracePeriod = (*core.KubeletConfigEvictionSoftGracePeriod)(unsafe.Pointer(in.EvictionSoftGracePeriod))
 	out.MaxPods = (*int32)(unsafe.Pointer(in.MaxPods))
 	out.PodPIDsLimit = (*int64)(unsafe.Pointer(in.PodPIDsLimit))
+	out.ImagePullProgressDeadline = (*metav1.Duration)(unsafe.Pointer(in.ImagePullProgressDeadline))
 	return nil
 }
 
@@ -2336,6 +2337,7 @@ func autoConvert_core_KubeletConfig_To_v1beta1_KubeletConfig(in *core.KubeletCon
 	out.EvictionSoftGracePeriod = (*KubeletConfigEvictionSoftGracePeriod)(unsafe.Pointer(in.EvictionSoftGracePeriod))
 	out.MaxPods = (*int32)(unsafe.Pointer(in.MaxPods))
 	out.PodPIDsLimit = (*int64)(unsafe.Pointer(in.PodPIDsLimit))
+	out.ImagePullProgressDeadline = (*metav1.Duration)(unsafe.Pointer(in.ImagePullProgressDeadline))
 	return nil
 }
 

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -1343,6 +1343,11 @@ func (in *KubeletConfig) DeepCopyInto(out *KubeletConfig) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.ImagePullProgressDeadline != nil {
+		in, out := &in.ImagePullProgressDeadline, &out.ImagePullProgressDeadline
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -866,6 +866,9 @@ func ValidateKubeletConfig(kubeletConfig core.KubeletConfig, fldPath *field.Path
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("podPIDsLimit"), *value, fmt.Sprintf("podPIDsLimit value must be at least %d", PodPIDsLimitMinimum)))
 		}
 	}
+	if kubeletConfig.ImagePullProgressDeadline != nil {
+		allErrs = append(allErrs, ValidatePositiveDuration(kubeletConfig.ImagePullProgressDeadline, fldPath.Child("imagePullProgressDeadline"))...)
+	}
 	if kubeletConfig.EvictionPressureTransitionPeriod != nil {
 		allErrs = append(allErrs, ValidatePositiveDuration(kubeletConfig.EvictionPressureTransitionPeriod, fldPath.Child("evictionPressureTransitionPeriod"))...)
 	}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2360,6 +2360,26 @@ var _ = Describe("Shoot Validation Tests", func() {
 			)),
 		)
 
+		DescribeTable("validate the kubelet configuration - ImagePullProgressDeadline",
+			func(imagePullProgressDeadline metav1.Duration, matcher gomegatypes.GomegaMatcher) {
+				kubeletConfig := core.KubeletConfig{
+					ImagePullProgressDeadline: &imagePullProgressDeadline,
+				}
+
+				errList := ValidateKubeletConfig(kubeletConfig, nil)
+
+				Expect(errList).To(matcher)
+			},
+
+			Entry("valid configuration", validDuration, HaveLen(0)),
+			Entry("only allow positive Duration", invalidDuration, ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal(field.NewPath("imagePullProgressDeadline").String()),
+				})),
+			)),
+		)
+
 		DescribeTable("validate the kubelet configuration - EvictionMaxPodGracePeriod",
 			func(evictionMaxPodGracePeriod int32, matcher gomegatypes.GomegaMatcher) {
 				kubeletConfig := core.KubeletConfig{

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -1393,6 +1393,11 @@ func (in *KubeletConfig) DeepCopyInto(out *KubeletConfig) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.ImagePullProgressDeadline != nil {
+		in, out := &in.ImagePullProgressDeadline, &out.ImagePullProgressDeadline
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2599,6 +2599,12 @@ func schema_pkg_apis_core_v1alpha1_KubeletConfig(ref common.ReferenceCallback) c
 							Format:      "int64",
 						},
 					},
+					"imagePullProgressDeadline": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ImagePullProgressDeadline describes the time limit under which if no pulling progress is made, the image pulling will be cancelled. Default: 1m",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
+						},
+					},
 				},
 			},
 		},
@@ -7559,6 +7565,12 @@ func schema_pkg_apis_core_v1beta1_KubeletConfig(ref common.ReferenceCallback) co
 							Description: "PodPIDsLimit is the maximum number of process IDs per pod allowed by the kubelet.",
 							Type:        []string{"integer"},
 							Format:      "int64",
+						},
+					},
+					"imagePullProgressDeadline": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ImagePullProgressDeadline describes the time limit under which if no pulling progress is made, the image pulling will be cancelled. Default: 1m",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
 				},

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -290,6 +290,9 @@ func (b *Botanist) deployOperatingSystemConfigsForWorker(ctx context.Context, ma
 		if podPIDsLimit := kubeletConfig.PodPIDsLimit; podPIDsLimit != nil {
 			kubelet["podPIDsLimit"] = *podPIDsLimit
 		}
+		if imagePullProgressDeadline := kubeletConfig.ImagePullProgressDeadline; imagePullProgressDeadline != nil {
+			kubelet["imagePullProgressDeadline"] = *imagePullProgressDeadline
+		}
 		if cpuCFSQuota := kubeletConfig.CPUCFSQuota; cpuCFSQuota != nil {
 			kubelet["cpuCFSQuota"] = *cpuCFSQuota
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
the `--image-pull-progress-deadline` kubelet flag is set to default 1m. If a container image size is very large or the docker image repo is very slow, then image pull can fail.
Refer https://github.com/kubernetes/kubernetes/issues/59376 for more details.
The flag can be made configurable so that users can decide themselves according to the expected image sizes in node groups.

**Which issue(s) this PR fixes**:
Fixes #2001 

**Special notes for your reviewer**:
The `--image-pull-progress-deadline` flag is not configurable through config file. Refer:
https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubelet/config/v1beta1/types.go#L74
Thus adding it to` _kubelet.flags` file instead of `_kubelet-config-file`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Make kubelet flag --image-pull-progress-deadline configurable. Default: 1m
```
