### PR TITLE
Only check default domain during shoot creation

### DIFF
--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -168,10 +168,12 @@ func (d *DNS) Admit(ctx context.Context, a admission.Attributes, o admission.Obj
 		return fmt.Errorf("error retrieving default domains: %s", err)
 	}
 
-	// Generate a Shoot domain if none is configured (at this point in time we know that the chosen seed does
-	// not disable DNS.
-	if err := assignDefaultDomainIfNeeded(shoot, d.projectLister, defaultDomains); err != nil {
-		return err
+	if a.GetOperation() == admission.Create {
+		// Generate a Shoot domain if none is configured (at this point in time we know that the chosen seed does
+		// not disable DNS.
+		if err := assignDefaultDomainIfNeeded(shoot, d.projectLister, defaultDomains); err != nil {
+			return err
+		}
 	}
 
 	// If the seed does not disable DNS and the shoot does not use the unmanaged DNS provider then we need


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an incompatible change introduced by #1959 for shoot clusters which already use a non compliant (\<shoot-name\>.\<project-name\>.\<default-domain\>) default domain.

**Special notes for your reviewer**:
/cc @danielfoehrKn @tim-ebert 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue has been fixed which caused the Gardenlet to crash for shoot clusters which already have used a non compliant default shoot domain.
```
