### PR TITLE
Revert "Fix manifest sorting in chart renderer"

### DIFF
--- a/pkg/chartrenderer/default.go
+++ b/pkg/chartrenderer/default.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/helm/pkg/engine"
 	"k8s.io/helm/pkg/manifest"
 	chartapi "k8s.io/helm/pkg/proto/hapi/chart"
-	"k8s.io/helm/pkg/releaseutil"
 	"k8s.io/helm/pkg/timeconv"
 )
 
@@ -149,14 +148,7 @@ func (r *chartRenderer) renderResources(ch *chartapi.Chart, values chartutil.Val
 		}
 	}
 
-	manifestsMap := map[string]string{}
-	for origKey, file := range files {
-		for key, m := range releaseutil.SplitManifests(file) {
-			manifestsMap[origKey+"_"+key] = m
-		}
-	}
-
-	manifests := manifest.SplitManifests(manifestsMap)
+	manifests := manifest.SplitManifests(files)
 	manifests = SortByKind(manifests)
 
 	return &RenderedChart{


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts commit 67abd81c3c5875232bde1432ab1ee1db49118227.

Basically #1952 splits the kube-state-metrics charts into separate manifests - so it should not regress #1939.

**Which issue(s) this PR fixes**:
Fixes #2008

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue preventing to get the file content of manifest using the FileContent func of RenderedChart in the `pkg/chartrenderer` package is now fixed.
```
