### PR TITLE
Introduce flow for preparing Shoot's Control Plane for migration

### DIFF
--- a/docs/usage/control_plane_migration.md
+++ b/docs/usage/control_plane_migration.md
@@ -1,0 +1,17 @@
+# Control Plane Migration
+
+## ShootState
+
+`ShootState` is an API resource which stores non-reconstructible state and data required to completely recreate a `Shoot`'s control plane on a new `Seed`.  The `ShootState` resource is created on `Shoot` creation in its `Project` namespace and the required state/data is persisted during `Shoot` creation or reconciliation.
+
+## Shoot Control Plane Migration
+
+Triggering the migration is done by changing the `Shoot`'s `.spec.seedName` to a `Seed` that differs from the `.status.seedName`, we call this `Seed` `"Destination Seed"`. If the Destination `Seed` does not have a backup and restore configuration, the change to `spec.seedName` is rejected. Additionally, this Seed must not be set for deletion and must be healthy.
+
+If the `Shoot` has different `.spec.seedName` and `.status.seedName` a process is started to prepare the Control Plane for migration:
+
+1. `.status.lastOperation` is changed to `Migrate`.
+2. Kubernetes API Server is stopped and the extension resources are annotated with `gardener.cloud/operation=migrate`.
+3. Full snapshot of the ETCD is created and terminating of the Control Plane in the `Source Seed` is initiated.
+
+If the process is successful, we update the status of the `Shoot` by setting the `.status.seedName` to the null value. That way, a restoration is triggered in the `Destination Seed` and `.status.lastOperation` is changed to `Restore`.

--- a/pkg/api/extensions/utils.go
+++ b/pkg/api/extensions/utils.go
@@ -19,8 +19,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// GetAllGardenerExtensionsLists returns empty extension list struct for each Gardener Extension CRD
-func GetAllGardenerExtensionsLists() []runtime.Object {
+// GetShootCRsLists returns an empty CR list struct, for each CR used for Shoot managment
+func GetShootCRsLists() []runtime.Object {
 	return []runtime.Object{
 		&extensionsv1alpha1.BackupEntryList{},
 		&extensionsv1alpha1.ControlPlaneList{},

--- a/pkg/api/extensions/utils.go
+++ b/pkg/api/extensions/utils.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// GetAllGardenerExtensionsLists returns empty extension list struct for each Gardener Extension CRD
+func GetAllGardenerExtensionsLists() []runtime.Object {
+	return []runtime.Object{
+		&extensionsv1alpha1.BackupEntryList{},
+		&extensionsv1alpha1.ControlPlaneList{},
+		&extensionsv1alpha1.ExtensionList{},
+		&extensionsv1alpha1.InfrastructureList{},
+		&extensionsv1alpha1.NetworkList{},
+		&extensionsv1alpha1.OperatingSystemConfigList{},
+		&extensionsv1alpha1.WorkerList{},
+		&extensionsv1alpha1.ContainerRuntimeList{},
+	}
+}

--- a/pkg/apis/core/types_common.go
+++ b/pkg/apis/core/types_common.go
@@ -59,6 +59,8 @@ const (
 	LastOperationTypeReconcile LastOperationType = "Reconcile"
 	// LastOperationTypeDelete indicates a 'delete' operation.
 	LastOperationTypeDelete LastOperationType = "Delete"
+	// LastOperationTypeRestore indicates a 'restore' operation.
+	LastOperationTypeRestore LastOperationType = "Restore"
 )
 
 // LastOperationState is a string alias.

--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -103,6 +103,9 @@ const (
 	// GardenerOperationRestore is a constant for the value of the operation annotation describing a restoration
 	// operation.
 	GardenerOperationRestore = "restore"
+	// GardenerOperationWaitForState is a constant for the value of the operation annotation describing a wait
+	// operation.
+	GardenerOperationWaitForState = "wait-for-state"
 
 	// DeprecatedGardenRole is the key for an annotation on a Kubernetes object indicating what it is used for.
 	//

--- a/pkg/apis/core/v1alpha1/helper/helper.go
+++ b/pkg/apis/core/v1alpha1/helper/helper.go
@@ -174,17 +174,23 @@ func IsControllerInstallationSuccessful(controllerInstallation gardencorev1alpha
 	return installed && healthy
 }
 
-// ComputeOperationType checksthe <lastOperation> and determines whether is it is Create operation or reconcile operation
+// ComputeOperationType checks the <lastOperation> and determines whether it is Create, Delete, Reconcile, Migrate or Restore operation
 func ComputeOperationType(meta metav1.ObjectMeta, lastOperation *gardencorev1alpha1.LastOperation) gardencorev1alpha1.LastOperationType {
 	switch {
 	case meta.Annotations[v1alpha1constants.GardenerOperation] == v1alpha1constants.GardenerOperationMigrate:
 		return gardencorev1alpha1.LastOperationTypeMigrate
+	case meta.Annotations[v1alpha1constants.GardenerOperation] == v1alpha1constants.GardenerOperationRestore:
+		return gardencorev1alpha1.LastOperationTypeRestore
 	case meta.DeletionTimestamp != nil:
 		return gardencorev1alpha1.LastOperationTypeDelete
 	case lastOperation == nil:
 		return gardencorev1alpha1.LastOperationTypeCreate
 	case (lastOperation.Type == gardencorev1alpha1.LastOperationTypeCreate && lastOperation.State != gardencorev1alpha1.LastOperationStateSucceeded):
 		return gardencorev1alpha1.LastOperationTypeCreate
+	case (lastOperation.Type == gardencorev1alpha1.LastOperationTypeMigrate && lastOperation.State != gardencorev1alpha1.LastOperationStateSucceeded):
+		return gardencorev1alpha1.LastOperationTypeMigrate
+	case (lastOperation.Type == gardencorev1alpha1.LastOperationTypeRestore && lastOperation.State != gardencorev1alpha1.LastOperationStateSucceeded):
+		return gardencorev1alpha1.LastOperationTypeRestore
 	}
 	return gardencorev1alpha1.LastOperationTypeReconcile
 }

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -63,6 +63,8 @@ const (
 	LastOperationTypeDelete LastOperationType = "Delete"
 	// LastOperationTypeMigrate indicates a 'migrate' operation.
 	LastOperationTypeMigrate LastOperationType = "Migrate"
+	// LastOperationTypeRestore indicates a 'restore' operation.
+	LastOperationTypeRestore LastOperationType = "Restore"
 )
 
 // LastOperationState is a string alias.
@@ -137,4 +139,10 @@ const (
 	EventDeleteError = "DeleteError"
 	// EventOperationPending
 	EventOperationPending = "OperationPending"
+	// EventPrepareMigration indicates that a Prepare Migration operation started.
+	EventPrepareMigration = "PrepareMigration"
+	// EventMigrationPrepared indicates that Migration preparation was successful.
+	EventMigrationPrepared = "MigrationPrepared"
+	// EventMigrationPreparationFailed indicates that Migration preparation failed.
+	EventMigrationPreparationFailed = "MigrationPreparationFailed"
 )

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -112,7 +112,8 @@ const (
 	// GardenerOperationRestore is a constant for the value of the operation annotation describing a restoration
 	// operation.
 	GardenerOperationRestore = "restore"
-	// GardenerOperationWaitForState is a constant for the value of the operation annotation for waiting a state
+	// GardenerOperationWaitForState is a constant for the value of the operation annotation describing a wait
+	// operation.
 	GardenerOperationWaitForState = "wait-for-state"
 
 	// DeprecatedGardenRole is the key for an annotation on a Kubernetes object indicating what it is used for.

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -182,7 +182,7 @@ func IsControllerInstallationRequired(controllerInstallation gardencorev1beta1.C
 	return false
 }
 
-// ComputeOperationType checks the <lastOperation> and determines whether is it is Create operation or reconcile operation
+// ComputeOperationType checks the <lastOperation> and determines whether it is Create, Delete, Reconcile, Migrate or Restore operation
 func ComputeOperationType(meta metav1.ObjectMeta, lastOperation *gardencorev1beta1.LastOperation) gardencorev1beta1.LastOperationType {
 	switch {
 	case meta.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationMigrate:
@@ -195,6 +195,8 @@ func ComputeOperationType(meta metav1.ObjectMeta, lastOperation *gardencorev1bet
 		return gardencorev1beta1.LastOperationTypeCreate
 	case lastOperation.Type == gardencorev1beta1.LastOperationTypeMigrate && lastOperation.State != gardencorev1beta1.LastOperationStateSucceeded:
 		return gardencorev1beta1.LastOperationTypeMigrate
+	case (lastOperation.Type == gardencorev1beta1.LastOperationTypeRestore && lastOperation.State != gardencorev1beta1.LastOperationStateSucceeded):
+		return gardencorev1beta1.LastOperationTypeRestore
 	}
 	return gardencorev1beta1.LastOperationTypeReconcile
 }

--- a/pkg/apis/core/v1beta1/types_common.go
+++ b/pkg/apis/core/v1beta1/types_common.go
@@ -63,6 +63,8 @@ const (
 	LastOperationTypeDelete LastOperationType = "Delete"
 	// LastOperationTypeMigrate indicates a 'migrate' operation.
 	LastOperationTypeMigrate LastOperationType = "Migrate"
+	// LastOperationTypeRestore indicates a 'restore' operation.
+	LastOperationTypeRestore LastOperationType = "Restore"
 )
 
 // LastOperationState is a string alias.
@@ -137,4 +139,10 @@ const (
 	EventDeleteError = "DeleteError"
 	// EventOperationPending
 	EventOperationPending = "OperationPending"
+	// EventPrepareMigration indicates that a Prepare Migration operation started.
+	EventPrepareMigration = "PrepareMigration"
+	// EventMigrationPrepared indicates that Migration preparation was successful.
+	EventMigrationPrepared = "MigrationPrepared"
+	// EventMigrationPreparationFailed indicates that Migration preparation failed.
+	EventMigrationPreparationFailed = "MigrationPreparationFailed"
 )

--- a/pkg/client/kubernetes/pods.go
+++ b/pkg/client/kubernetes/pods.go
@@ -45,7 +45,7 @@ func NewPodExecutor(config *rest.Config) PodExecutor {
 
 // PodExecutor is the pod executor interface
 type PodExecutor interface {
-	Execute(ctx context.Context, namespace, name, containerName, command string) (io.Reader, error)
+	Execute(ctx context.Context, namespace, name, containerName, command, commandArg string) (io.Reader, error)
 }
 
 type podExecutor struct {
@@ -53,7 +53,7 @@ type podExecutor struct {
 }
 
 // Execute executes a command on a pod
-func (p *podExecutor) Execute(ctx context.Context, namespace, name, containerName, command string) (io.Reader, error) {
+func (p *podExecutor) Execute(ctx context.Context, namespace, name, containerName, command, commandArg string) (io.Reader, error) {
 	client, err := corev1client.NewForConfig(p.config)
 	if err != nil {
 		return nil, err
@@ -67,7 +67,7 @@ func (p *podExecutor) Execute(ctx context.Context, namespace, name, containerNam
 		Namespace(namespace).
 		SubResource("exec").
 		Param("container", containerName).
-		Param("command", "/bin/sh").
+		Param("command", command).
 		Param("stdin", "true").
 		Param("stdout", "true").
 		Param("stderr", "true").
@@ -80,7 +80,7 @@ func (p *podExecutor) Execute(ctx context.Context, namespace, name, containerNam
 	}
 
 	err = executor.Stream(remotecommand.StreamOptions{
-		Stdin:  strings.NewReader(command),
+		Stdin:  strings.NewReader(commandArg),
 		Stdout: &stdout,
 		Stderr: &stderr,
 		Tty:    false,

--- a/pkg/client/kubernetes/pods.go
+++ b/pkg/client/kubernetes/pods.go
@@ -15,10 +15,14 @@
 package kubernetes
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gardener/gardener/pkg/utils"
@@ -26,9 +30,67 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/transport/spdy"
 )
+
+// NewPodExecutor returns a podExecutor
+func NewPodExecutor(config *rest.Config) PodExecutor {
+	return &podExecutor{
+		config: config,
+	}
+}
+
+// PodExecutor is the pod executor interface
+type PodExecutor interface {
+	Execute(ctx context.Context, namespace, name, containerName, command string) (io.Reader, error)
+}
+
+type podExecutor struct {
+	config *rest.Config
+}
+
+// Execute executes a command on a pod
+func (p *podExecutor) Execute(ctx context.Context, namespace, name, containerName, command string) (io.Reader, error) {
+	client, err := corev1client.NewForConfig(p.config)
+	if err != nil {
+		return nil, err
+	}
+
+	var stdout, stderr bytes.Buffer
+	request := client.RESTClient().
+		Post().
+		Resource("pods").
+		Name(name).
+		Namespace(namespace).
+		SubResource("exec").
+		Param("container", containerName).
+		Param("command", "/bin/sh").
+		Param("stdin", "true").
+		Param("stdout", "true").
+		Param("stderr", "true").
+		Param("tty", "false").
+		Context(ctx)
+
+	executor, err := remotecommand.NewSPDYExecutor(p.config, http.MethodPost, request.URL())
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialized the command exector: %v", err)
+	}
+
+	err = executor.Stream(remotecommand.StreamOptions{
+		Stdin:  strings.NewReader(command),
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	if err != nil {
+		return &stderr, err
+	}
+
+	return &stdout, nil
+}
 
 // GetPodLogs retrieves the pod logs of the pod of the given name with the given options.
 func GetPodLogs(podInterface corev1client.PodInterface, name string, options *corev1.PodLogOptions) ([]byte, error) {

--- a/pkg/controllerutils/seedfilter.go
+++ b/pkg/controllerutils/seedfilter.go
@@ -56,9 +56,15 @@ func ShootFilterFunc(seedName string, seedLister gardencorelisters.SeedLister, l
 			return false
 		}
 		if len(seedName) > 0 {
-			return *shoot.Spec.SeedName == seedName
+			if shoot.Status.SeedName == nil || *shoot.Spec.SeedName == *shoot.Status.SeedName {
+				return *shoot.Spec.SeedName == seedName
+			}
+			return *shoot.Status.SeedName == seedName
 		}
-		return SeedLabelsMatch(seedLister, *shoot.Spec.SeedName, labelSelector)
+		if shoot.Status.SeedName == nil || *shoot.Spec.SeedName == *shoot.Status.SeedName {
+			return SeedLabelsMatch(seedLister, *shoot.Spec.SeedName, labelSelector)
+		}
+		return SeedLabelsMatch(seedLister, *shoot.Status.SeedName, labelSelector)
 	}
 }
 

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -242,8 +242,8 @@ func (c *Controller) reconcileShootRequest(req reconcile.Request) (reconcile.Res
 	}
 
 	if shouldPrepareShootForMigration(shoot) {
-		if !c.isSeedAvailable(seed, log) {
-			return reconcile.Result{}, fmt.Errorf("target Seed is not available to host the Control Plane of Shoot %s", shoot.GetName())
+		if err := c.isSeedAvailable(seed, log); err != nil {
+			return reconcile.Result{}, fmt.Errorf("target Seed is not available to host the Control Plane of Shoot %s: %v", shoot.GetName(), err)
 		}
 
 		sourceSeed, err := c.k8sGardenCoreInformers.Core().V1beta1().Seeds().Lister().Get(*shoot.Status.SeedName)
@@ -311,6 +311,7 @@ func (c *Controller) deleteShoot(logger *logrus.Entry, shoot *gardencorev1beta1.
 		ctx = context.TODO()
 		err error
 
+		operationType              = gardencorev1beta1helper.ComputeOperationType(shoot.ObjectMeta, shoot.Status.LastOperation)
 		respectSyncPeriodOverwrite = c.respectSyncPeriodOverwrite()
 		failed                     = common.IsShootFailed(shoot)
 		ignored                    = common.ShouldIgnoreShoot(respectSyncPeriodOverwrite, shoot)
@@ -335,7 +336,7 @@ func (c *Controller) deleteShoot(logger *logrus.Entry, shoot *gardencorev1beta1.
 	if failedOrIgnored {
 		if syncErr := c.syncClusterResourceToSeed(ctx, shoot, project, cloudProfile, seed); syncErr != nil {
 			logger.WithError(syncErr).Infof("Not allowed to update Shoot with error, trying to sync Cluster resource again")
-			_, updateErr := c.updateShootStatusOperationError(shoot, syncErr.Error(), shoot.Status.LastErrors...)
+			_, updateErr := c.updateShootStatusOperationError(shoot, syncErr.Error(), operationType, shoot.Status.LastErrors...)
 			return reconcile.Result{}, utilerrors.WithSuppressed(syncErr, updateErr)
 		}
 
@@ -345,13 +346,13 @@ func (c *Controller) deleteShoot(logger *logrus.Entry, shoot *gardencorev1beta1.
 
 	o, operationErr := c.initializeOperation(ctx, logger, shoot, project, cloudProfile, seed)
 	if operationErr != nil {
-		_, updateErr := c.updateShootStatusOperationError(shoot, fmt.Sprintf("Could not initialize a new operation for Shoot deletion: %s", operationErr.Error()), shoot.Status.LastErrors...)
+		_, updateErr := c.updateShootStatusOperationError(shoot, fmt.Sprintf("Could not initialize a new operation for Shoot deletion: %s", operationErr.Error()), operationType, shoot.Status.LastErrors...)
 		return reconcile.Result{}, utilerrors.WithSuppressed(operationErr, updateErr)
 	}
 
 	// Trigger regular shoot deletion flow.
 	c.recorder.Event(o.Shoot.Info, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, "Deleting Shoot cluster")
-	o.Shoot.Info, err = c.updateShootStatusOperationStart(o.Shoot.Info, o.Shoot.SeedNamespace)
+	o.Shoot.Info, err = c.updateShootStatusOperationStart(o.Shoot.Info, o.Shoot.SeedNamespace, operationType)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -364,7 +365,7 @@ func (c *Controller) deleteShoot(logger *logrus.Entry, shoot *gardencorev1beta1.
 
 	if flowErr := c.runDeleteShootFlow(o); flowErr != nil {
 		c.recorder.Event(o.Shoot.Info, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, flowErr.Description)
-		_, updateErr := c.updateShootStatusOperationError(o.Shoot.Info, flowErr.Description, flowErr.LastErrors...)
+		_, updateErr := c.updateShootStatusOperationError(o.Shoot.Info, flowErr.Description, operationType, flowErr.LastErrors...)
 		return reconcile.Result{}, utilerrors.WithSuppressed(errors.New(flowErr.Description), updateErr)
 	}
 
@@ -375,7 +376,7 @@ func (c *Controller) deleteShoot(logger *logrus.Entry, shoot *gardencorev1beta1.
 func (c *Controller) finalizeShootDeletion(ctx context.Context, logger *logrus.Entry, shoot *gardencorev1beta1.Shoot, projectName string) (reconcile.Result, error) {
 	if cleanErr := c.deleteClusterResourceFromSeed(ctx, shoot, projectName); cleanErr != nil {
 		lastErr := gardencorev1beta1helper.LastError(fmt.Sprintf("Could not delete Cluster resource in seed: %s", cleanErr))
-		_, updateErr := c.updateShootStatusOperationError(shoot, lastErr.Description, *lastErr)
+		_, updateErr := c.updateShootStatusOperationError(shoot, lastErr.Description, gardencorev1beta1.LastOperationTypeDelete, *lastErr)
 		c.recorder.Event(shoot, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, lastErr.Description)
 		return reconcile.Result{}, utilerrors.WithSuppressed(errors.New(lastErr.Description), updateErr)
 	}
@@ -383,17 +384,12 @@ func (c *Controller) finalizeShootDeletion(ctx context.Context, logger *logrus.E
 	return reconcile.Result{}, c.removeFinalizerFrom(shoot)
 }
 
-func (c *Controller) isSeedAvailable(seed *gardencorev1beta1.Seed, logger *logrus.Entry) bool {
+func (c *Controller) isSeedAvailable(seed *gardencorev1beta1.Seed, logger *logrus.Entry) error {
 	if seed.DeletionTimestamp != nil {
-		return false
+		return fmt.Errorf("seed is set for deletion")
 	}
 
-	if err := health.CheckSeed(seed, c.identity); err != nil {
-		logger.Debugf("seed is not yet ready: %v", err)
-		return false
-	}
-
-	return true
+	return health.CheckSeed(seed, c.identity)
 }
 
 func (c *Controller) reconcileShoot(logger *logrus.Entry, shoot *gardencorev1beta1.Shoot, project *gardencorev1beta1.Project, cloudProfile *gardencorev1beta1.CloudProfile, seed *gardencorev1beta1.Seed) (reconcile.Result, error) {
@@ -445,7 +441,7 @@ func (c *Controller) reconcileShoot(logger *logrus.Entry, shoot *gardencorev1bet
 	if failedOrIgnored {
 		if syncErr := c.syncClusterResourceToSeed(ctx, shoot, project, cloudProfile, seed); syncErr != nil {
 			logger.WithError(syncErr).Infof("Not allowed to update Shoot with error, trying to sync Cluster resource again")
-			_, updateErr := c.updateShootStatusOperationError(shoot, syncErr.Error(), shoot.Status.LastErrors...)
+			_, updateErr := c.updateShootStatusOperationError(shoot, syncErr.Error(), operationType, shoot.Status.LastErrors...)
 			return reconcile.Result{}, utilerrors.WithSuppressed(syncErr, updateErr)
 		}
 
@@ -464,7 +460,7 @@ func (c *Controller) reconcileShoot(logger *logrus.Entry, shoot *gardencorev1bet
 
 	o, operationErr := c.initializeOperation(ctx, logger, shoot, project, cloudProfile, seed)
 	if operationErr != nil {
-		_, updateErr := c.updateShootStatusOperationError(shoot, fmt.Sprintf("Could not initialize a new operation for Shoot reconciliation: %s", operationErr.Error()), shoot.Status.LastErrors...)
+		_, updateErr := c.updateShootStatusOperationError(shoot, fmt.Sprintf("Could not initialize a new operation for Shoot reconciliation: %s", operationErr.Error()), operationType, shoot.Status.LastErrors...)
 		return reconcile.Result{}, utilerrors.WithSuppressed(operationErr, updateErr)
 	}
 
@@ -480,7 +476,7 @@ func (c *Controller) reconcileShoot(logger *logrus.Entry, shoot *gardencorev1bet
 	}
 
 	c.recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Reconciling Shoot cluster state")
-	o.Shoot.Info, err = c.updateShootStatusOperationStart(o.Shoot.Info, o.Shoot.SeedNamespace)
+	o.Shoot.Info, err = c.updateShootStatusOperationStart(o.Shoot.Info, o.Shoot.SeedNamespace, operationType)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -499,7 +495,7 @@ func (c *Controller) reconcileShoot(logger *logrus.Entry, shoot *gardencorev1bet
 		updated, migrateErr := migrateDNSProviders(ctx, c.k8sGardenClient.Client(), o)
 		if migrateErr != nil {
 			c.recorder.Event(o.Shoot.Info, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, "Cannot reconcile Shoot: Migrating DNS providers failed")
-			_, updateErr := c.updateShootStatusOperationError(o.Shoot.Info, migrateErr.Error(), o.Shoot.Info.Status.LastErrors...)
+			_, updateErr := c.updateShootStatusOperationError(o.Shoot.Info, migrateErr.Error(), operationType, o.Shoot.Info.Status.LastErrors...)
 			return reconcile.Result{}, utilerrors.WithSuppressed(fmt.Errorf("migrating dns providers failed: %v", migrateErr), updateErr)
 		}
 		if updated {
@@ -512,19 +508,19 @@ func (c *Controller) reconcileShoot(logger *logrus.Entry, shoot *gardencorev1bet
 
 	if flowErr := c.runReconcileShootFlow(o); flowErr != nil {
 		c.recorder.Event(o.Shoot.Info, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, flowErr.Description)
-		_, updateErr := c.updateShootStatusOperationError(o.Shoot.Info, flowErr.Description, flowErr.LastErrors...)
+		_, updateErr := c.updateShootStatusOperationError(o.Shoot.Info, flowErr.Description, operationType, flowErr.LastErrors...)
 		return reconcile.Result{}, utilerrors.WithSuppressed(errors.New(flowErr.Description), updateErr)
 	}
 
 	c.recorder.Event(o.Shoot.Info, corev1.EventTypeNormal, gardencorev1beta1.EventReconciled, "Reconciled Shoot cluster state")
-	o.Shoot.Info, err = c.updateShootStatusOperationSuccess(o.Shoot.Info, o.Seed.Info.Name)
+	o.Shoot.Info, err = c.updateShootStatusOperationSuccess(o.Shoot.Info, o.Seed.Info.Name, operationType)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if syncErr := c.syncClusterResourceToSeed(ctx, o.Shoot.Info, project, cloudProfile, seed); syncErr != nil {
 		logger.WithError(syncErr).Infof("Cluster resource sync to shoot failed")
-		_, updateErr := c.updateShootStatusOperationError(o.Shoot.Info, syncErr.Error(), o.Shoot.Info.Status.LastErrors...)
+		_, updateErr := c.updateShootStatusOperationError(o.Shoot.Info, syncErr.Error(), operationType, o.Shoot.Info.Status.LastErrors...)
 		return reconcile.Result{}, utilerrors.WithSuppressed(syncErr, updateErr)
 	}
 
@@ -569,10 +565,9 @@ func (c *Controller) updateShootStatusAndRequeueOnSyncError(shoot *gardencorev1b
 	}, nil
 }
 
-func (c *Controller) updateShootStatusOperationStart(shoot *gardencorev1beta1.Shoot, shootNamespace string) (*gardencorev1beta1.Shoot, error) {
+func (c *Controller) updateShootStatusOperationStart(shoot *gardencorev1beta1.Shoot, shootNamespace string, operationType gardencorev1beta1.LastOperationType) (*gardencorev1beta1.Shoot, error) {
 	var (
 		now                   = metav1.NewTime(time.Now().UTC())
-		operationType         = gardencorev1beta1helper.ComputeOperationType(shoot.ObjectMeta, shoot.Status.LastOperation)
 		operationTypeSwitched bool
 		description           string
 	)
@@ -614,11 +609,10 @@ func (c *Controller) updateShootStatusOperationStart(shoot *gardencorev1beta1.Sh
 		})
 }
 
-func (c *Controller) updateShootStatusOperationSuccess(shoot *gardencorev1beta1.Shoot, seedName string) (*gardencorev1beta1.Shoot, error) {
+func (c *Controller) updateShootStatusOperationSuccess(shoot *gardencorev1beta1.Shoot, seedName string, operationType gardencorev1beta1.LastOperationType) (*gardencorev1beta1.Shoot, error) {
 	var (
-		now           = metav1.NewTime(time.Now().UTC())
-		operationType = gardencorev1beta1helper.ComputeOperationType(shoot.ObjectMeta, shoot.Status.LastOperation)
-		description   string
+		now         = metav1.NewTime(time.Now().UTC())
+		description string
 	)
 
 	switch operationType {
@@ -647,12 +641,11 @@ func (c *Controller) updateShootStatusOperationSuccess(shoot *gardencorev1beta1.
 	)
 }
 
-func (c *Controller) updateShootStatusOperationError(shoot *gardencorev1beta1.Shoot, description string, lastErrors ...gardencorev1beta1.LastError) (*gardencorev1beta1.Shoot, error) {
+func (c *Controller) updateShootStatusOperationError(shoot *gardencorev1beta1.Shoot, description string, operationType gardencorev1beta1.LastOperationType, lastErrors ...gardencorev1beta1.LastError) (*gardencorev1beta1.Shoot, error) {
 	var (
-		now           = metav1.NewTime(time.Now().UTC())
-		operationType = gardencorev1beta1helper.ComputeOperationType(shoot.ObjectMeta, shoot.Status.LastOperation)
-		state         = gardencorev1beta1.LastOperationStateError
-		willNotRetry  = gardencorev1beta1helper.HasNonRetryableErrorCode(lastErrors...) || utils.TimeElapsed(shoot.Status.RetryCycleStartTime, c.config.Controllers.Shoot.RetryDuration.Duration)
+		now          = metav1.NewTime(time.Now().UTC())
+		state        = gardencorev1beta1.LastOperationStateError
+		willNotRetry = gardencorev1beta1helper.HasNonRetryableErrorCode(lastErrors...) || utils.TimeElapsed(shoot.Status.RetryCycleStartTime, c.config.Controllers.Shoot.RetryDuration.Duration)
 	)
 
 	newShoot, err := kutil.TryUpdateShootStatus(c.k8sGardenClient.GardenCore(), retry.DefaultRetry, shoot.ObjectMeta,

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -483,7 +483,7 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation) *gardencorev1bet
 }
 
 func (c *Controller) removeFinalizerFrom(shoot *gardencorev1beta1.Shoot) error {
-	newShoot, err := c.updateShootStatusOperationSuccess(shoot, "")
+	newShoot, err := c.updateShootStatusOperationSuccess(shoot, "", gardencorev1beta1.LastOperationTypeDelete)
 	if err != nil {
 		return err
 	}

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -22,10 +22,14 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/common"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -122,4 +126,36 @@ func (b *Botanist) RequiredExtensionsReady(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// CreateETCDSnapshot executes to the ETCD main Pod and triggers snapshot.
+func (b *Botanist) CreateETCDSnapshot(ctx context.Context) error {
+	executor := kubernetes.NewPodExecutor(b.K8sSeedClient.RESTConfig())
+	namespace := b.Shoot.SeedNamespace
+	etcdMainSelector := getETCDMainLabelSelector()
+
+	podsList := &v1.PodList{}
+	if err := b.K8sSeedClient.Client().List(ctx, podsList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: etcdMainSelector}); err != nil {
+		return err
+	}
+
+	if podsList == nil {
+		return fmt.Errorf("Didn't find any pods for selector: %v", etcdMainSelector)
+	}
+
+	if len(podsList.Items) > 1 {
+		return fmt.Errorf("Multiple ETCD Pods found. Pod list found: %v", podsList.Items)
+	}
+	etcdMainPod := podsList.Items[0]
+
+	_, err := executor.Execute(ctx, b.Shoot.SeedNamespace, etcdMainPod.GetName(), "backup-restore", "curl -k https://etcd-main-local:8080/snapshot/full")
+	return err
+}
+
+func getETCDMainLabelSelector() labels.Selector {
+	selector := labels.NewSelector()
+	roleIsMain, _ := labels.NewRequirement("role", selection.Equals, []string{"main"})
+	appIsETCD, _ := labels.NewRequirement("app", selection.Equals, []string{"etcd-statefulset"})
+
+	return selector.Add(*roleIsMain, *appIsETCD)
 }

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/common"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -134,12 +134,12 @@ func (b *Botanist) CreateETCDSnapshot(ctx context.Context) error {
 	namespace := b.Shoot.SeedNamespace
 	etcdMainSelector := getETCDMainLabelSelector()
 
-	podsList := &v1.PodList{}
+	podsList := &corev1.PodList{}
 	if err := b.K8sSeedClient.Client().List(ctx, podsList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: etcdMainSelector}); err != nil {
 		return err
 	}
 
-	if podsList == nil {
+	if len(podsList.Items) == 0 {
 		return fmt.Errorf("Didn't find any pods for selector: %v", etcdMainSelector)
 	}
 
@@ -148,7 +148,7 @@ func (b *Botanist) CreateETCDSnapshot(ctx context.Context) error {
 	}
 	etcdMainPod := podsList.Items[0]
 
-	_, err := executor.Execute(ctx, b.Shoot.SeedNamespace, etcdMainPod.GetName(), "backup-restore", "curl -k https://etcd-main-local:8080/snapshot/full")
+	_, err := executor.Execute(ctx, b.Shoot.SeedNamespace, etcdMainPod.GetName(), "backup-restore", "/bin/sh", "curl -k https://etcd-main-local:8080/snapshot/full")
 	return err
 }
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -276,15 +276,8 @@ func (b *Botanist) HibernateControlPlane(ctx context.Context) error {
 		}
 	}
 
-	deployments := []string{
-		v1beta1constants.DeploymentNameGardenerResourceManager,
-		v1beta1constants.DeploymentNameKubeControllerManager,
-		v1beta1constants.DeploymentNameKubeAPIServer,
-	}
-	for _, deployment := range deployments {
-		if err := kubernetes.ScaleDeployment(ctx, c, kutil.Key(b.Shoot.SeedNamespace, deployment), 0); client.IgnoreNotFound(err) != nil {
-			return err
-		}
+	if err := b.scaleControlPlaneDeploymentsToZero(ctx, c); err != nil {
+		return err
 	}
 
 	if err := c.Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: b.Shoot.SeedNamespace}}, kubernetes.DefaultDeleteOptions...); err != nil {
@@ -300,8 +293,51 @@ func (b *Botanist) HibernateControlPlane(ctx context.Context) error {
 
 	}
 
+	return client.IgnoreNotFound(b.ScaleETCDToZero(ctx))
+}
+
+// ScaleETCDToZero scales ETCD main and events to zero
+func (b *Botanist) ScaleETCDToZero(ctx context.Context) error {
 	for _, etcd := range []string{v1beta1constants.ETCDEvents, v1beta1constants.ETCDMain} {
-		if err := kubernetes.ScaleEtcd(ctx, c, kutil.Key(b.Shoot.SeedNamespace, etcd), 0); client.IgnoreNotFound(err) != nil {
+		if err := kubernetes.ScaleEtcd(ctx, b.K8sSeedClient.Client(), kutil.Key(b.Shoot.SeedNamespace, etcd), 0); client.IgnoreNotFound(err) != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ScaleETCDToOne scales ETCD main and events replicas to one
+func (b *Botanist) ScaleETCDToOne(ctx context.Context) error {
+	for _, etcd := range []string{v1beta1constants.ETCDEvents, v1beta1constants.ETCDMain} {
+		if err := kubernetes.ScaleEtcd(ctx, b.K8sSeedClient.Client(), kutil.Key(b.Shoot.SeedNamespace, etcd), 1); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ScaleGardenerResourceManagerToOne scales the gardener-resource-manager delpoyment
+func (b *Botanist) ScaleGardenerResourceManagerToOne(ctx context.Context) error {
+	return kubernetes.ScaleDeployment(ctx, b.K8sSeedClient.Client(), kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameGardenerResourceManager), 1)
+}
+
+// PrepareControlPlaneDeploymentsForMigration scales the kube-apiserver, kube-controller-manager and gardener-resource-manager to zero and deletes the hvpa for the kube-apiserver
+func (b *Botanist) PrepareControlPlaneDeploymentsForMigration(ctx context.Context) error {
+	if err := b.K8sSeedClient.Client().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: b.Shoot.SeedNamespace}}, kubernetes.DefaultDeleteOptions...); err != nil && !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
+		return err
+	}
+
+	return b.scaleControlPlaneDeploymentsToZero(ctx, b.K8sSeedClient.Client())
+}
+
+func (b *Botanist) scaleControlPlaneDeploymentsToZero(ctx context.Context, c client.Client) error {
+	deployments := []string{
+		v1beta1constants.DeploymentNameGardenerResourceManager,
+		v1beta1constants.DeploymentNameKubeControllerManager,
+		v1beta1constants.DeploymentNameKubeAPIServer,
+	}
+	for _, deployment := range deployments {
+		if err := kubernetes.ScaleDeployment(ctx, c, kutil.Key(b.Shoot.SeedNamespace, deployment), 0); client.IgnoreNotFound(err) != nil {
 			return err
 		}
 	}
@@ -317,7 +353,9 @@ const ControlPlaneDefaultTimeout = 3 * time.Minute
 // cluster. Gardener waits until an external controller did reconcile the cluster successfully.
 func (b *Botanist) DeployControlPlane(ctx context.Context) error {
 	var (
-		cp = &extensionsv1alpha1.ControlPlane{
+		restorePhase      = b.isRestorePhase()
+		gardenerOperation = v1beta1constants.GardenerOperationReconcile
+		cp                = &extensionsv1alpha1.ControlPlane{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      b.Shoot.Info.Name,
 				Namespace: b.Shoot.SeedNamespace,
@@ -332,8 +370,12 @@ func (b *Botanist) DeployControlPlane(ctx context.Context) error {
 		}
 	}
 
+	if restorePhase {
+		gardenerOperation = v1beta1constants.GardenerOperationWaitForState
+	}
+
 	_, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), cp, func() error {
-		metav1.SetMetaDataAnnotation(&cp.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+		metav1.SetMetaDataAnnotation(&cp.ObjectMeta, v1beta1constants.GardenerOperation, gardenerOperation)
 		metav1.SetMetaDataAnnotation(&cp.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
 
 		cp.Spec = extensionsv1alpha1.ControlPlaneSpec{
@@ -352,7 +394,15 @@ func (b *Botanist) DeployControlPlane(ctx context.Context) error {
 		}
 		return nil
 	})
-	return err
+	if err != nil {
+		return err
+	}
+
+	if restorePhase {
+		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), cp, &cp.ObjectMeta, &cp.Status.DefaultStatus, extensionsv1alpha1.ControlPlaneResource, cp.Name, cp.Spec.DefaultSpec.GetExtensionPurpose())
+	}
+
+	return nil
 }
 
 const controlPlaneExposureSuffix = "-exposure"
@@ -361,7 +411,9 @@ const controlPlaneExposureSuffix = "-exposure"
 // namespace in the seed cluster. Gardener waits until an external controller did reconcile the cluster successfully.
 func (b *Botanist) DeployControlPlaneExposure(ctx context.Context) error {
 	var (
-		cp = &extensionsv1alpha1.ControlPlane{
+		restorePhase      = b.isRestorePhase()
+		gardenerOperation = v1beta1constants.GardenerOperationReconcile
+		cp                = &extensionsv1alpha1.ControlPlane{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      b.Shoot.Info.Name + controlPlaneExposureSuffix,
 				Namespace: b.Shoot.SeedNamespace,
@@ -372,10 +424,13 @@ func (b *Botanist) DeployControlPlaneExposure(ctx context.Context) error {
 	purpose := new(extensionsv1alpha1.Purpose)
 	*purpose = extensionsv1alpha1.Exposure
 
-	_, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), cp, func() error {
-		metav1.SetMetaDataAnnotation(&cp.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-		metav1.SetMetaDataAnnotation(&cp.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
+	if restorePhase {
+		gardenerOperation = v1beta1constants.GardenerOperationWaitForState
+	}
 
+	_, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), cp, func() error {
+		metav1.SetMetaDataAnnotation(&cp.ObjectMeta, v1beta1constants.GardenerOperation, gardenerOperation)
+		metav1.SetMetaDataAnnotation(&cp.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
 		cp.Spec = extensionsv1alpha1.ControlPlaneSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
 				Type: b.Seed.Info.Spec.Provider.Type,
@@ -389,7 +444,14 @@ func (b *Botanist) DeployControlPlaneExposure(ctx context.Context) error {
 		}
 		return nil
 	})
-	return err
+	if err != nil {
+		return err
+	}
+
+	if restorePhase {
+		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), cp, &cp.ObjectMeta, &cp.Status.DefaultStatus, extensionsv1alpha1.ControlPlaneResource, cp.Name, cp.Spec.DefaultSpec.GetExtensionPurpose())
+	}
+	return nil
 }
 
 // DestroyControlPlane deletes the `ControlPlane` extension resource in the shoot namespace in the seed cluster,
@@ -517,6 +579,9 @@ func (b *Botanist) DeployBackupEntryInGarden(ctx context.Context) error {
 
 		// If backupEntry doesn't already exists, we have to assign backupBucket to backupEntry.
 		bucketName = string(b.Seed.Info.UID)
+		seedName = &b.Seed.Info.Name
+	} else if b.isRestorePhase() {
+		bucketName = backupEntry.Spec.BucketName
 		seedName = &b.Seed.Info.Name
 	} else {
 		bucketName = backupEntry.Spec.BucketName

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -316,17 +316,16 @@ func (b *Botanist) ScaleETCDToOne(ctx context.Context) error {
 	return nil
 }
 
-// ScaleGardenerResourceManagerToOne scales the gardener-resource-manager delpoyment
+// ScaleGardenerResourceManagerToOne scales the gardener-resource-manager deployment
 func (b *Botanist) ScaleGardenerResourceManagerToOne(ctx context.Context) error {
 	return kubernetes.ScaleDeployment(ctx, b.K8sSeedClient.Client(), kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameGardenerResourceManager), 1)
 }
 
 // PrepareControlPlaneDeploymentsForMigration scales the kube-apiserver, kube-controller-manager and gardener-resource-manager to zero and deletes the hvpa for the kube-apiserver
 func (b *Botanist) PrepareControlPlaneDeploymentsForMigration(ctx context.Context) error {
-	if err := b.K8sSeedClient.Client().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: b.Shoot.SeedNamespace}}, kubernetes.DefaultDeleteOptions...); err != nil && !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
+	if err := b.K8sSeedClient.Client().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: b.Shoot.SeedNamespace}}); client.IgnoreNotFound(err) != nil && !meta.IsNoMatchError(err) {
 		return err
 	}
-
 	return b.scaleControlPlaneDeploymentsToZero(ctx, b.K8sSeedClient.Client())
 }
 

--- a/pkg/operation/botanist/migration.go
+++ b/pkg/operation/botanist/migration.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gardener/gardener/pkg/api/extensions"
+	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/utils/flow"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sretry "k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AnnotateExtensionCRsForMigration annotates extension CRs with migrate operation annotation
+func (b *Botanist) AnnotateExtensionCRsForMigration(ctx context.Context) (err error) {
+	var fns []flow.TaskFn
+	fns, err = b.applyFuncToAllExtensionCRs(ctx, annotateObjectForMigrationFunc(ctx, b.K8sSeedClient.Client()))
+	if err != nil {
+		return err
+	}
+
+	return flow.Parallel(fns...)(ctx)
+}
+
+func annotateObjectForMigrationFunc(ctx context.Context, client client.Client) func(runtime.Object) error {
+	return func(obj runtime.Object) error {
+		return kutil.TryUpdate(ctx, k8sretry.DefaultBackoff, client, obj, func() error {
+			acc, err := extensions.Accessor(obj)
+			if err != nil {
+				return err
+			}
+
+			kutil.SetMetaDataAnnotation(acc, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationMigrate)
+			return nil
+		})
+	}
+}
+
+// DeleteAllExtensionCRs deletes all extension CRs from the Shoot namespace
+func (b *Botanist) DeleteAllExtensionCRs(ctx context.Context) error {
+	fns, err := b.applyFuncToAllExtensionCRs(ctx, func(obj runtime.Object) error {
+		if err := common.ConfirmDeletion(ctx, b.K8sSeedClient.Client(), obj); err != nil {
+			return err
+		}
+
+		if err := client.IgnoreNotFound(b.K8sSeedClient.Client().Delete(ctx, obj, kubernetes.DefaultDeleteOptions...)); err != nil {
+			accObj, err := meta.Accessor(obj)
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("couldn't delete CR %s with name %s: %v", obj.GetObjectKind(), accObj.GetName(), err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return flow.Parallel(fns...)(ctx)
+}
+
+// WaitForExtensionsOperationMigrateToSucceed waits until extension CRs has lastOperation Migrate Succeeded
+func (b *Botanist) WaitForExtensionsOperationMigrateToSucceed(ctx context.Context) error {
+	fns, err := b.applyFuncToAllExtensionCRs(ctx, func(obj runtime.Object) error {
+		return retry.UntilTimeout(ctx, 5*time.Second, 300*time.Second, func(ctx context.Context) (done bool, err error) {
+			acc, err := extensions.Accessor(obj)
+			if err != nil {
+				return retry.SevereError(err)
+			}
+
+			exrtensionObjStatus := acc.GetExtensionStatus()
+			if exrtensionObjStatus != nil && exrtensionObjStatus.GetLastOperation() != nil {
+				lastOperation := exrtensionObjStatus.GetLastOperation()
+				if lastOperation.Type == gardencorev1beta1.LastOperationTypeMigrate && lastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
+					return retry.Ok()
+				}
+			}
+
+			var exetnsionType string
+			if extensionSpec := acc.GetExtensionSpec(); extensionSpec != nil {
+				exetnsionType = extensionSpec.GetExtensionType()
+			}
+			return retry.MinorError(fmt.Errorf("extension CR %s with type %s lastOperation was not Migrate=Succeeded", acc.GetName(), exetnsionType))
+		})
+	})
+	if err != nil {
+		return err
+	}
+
+	return flow.Parallel(fns...)(ctx)
+}
+
+func (b *Botanist) applyFuncToAllExtensionCRs(ctx context.Context, applyFunc func(obj runtime.Object) error) ([]flow.TaskFn, error) {
+	var fns []flow.TaskFn
+	for _, listObj := range extensions.GetAllGardenerExtensionsLists() {
+		listObjCopy := listObj
+		if err := b.K8sSeedClient.Client().List(ctx, listObjCopy, client.InNamespace(b.Shoot.SeedNamespace)); err != nil {
+			return nil, err
+		}
+		fns = append(fns, func(ctx context.Context) error {
+			return meta.EachListItem(listObjCopy, applyFunc)
+		})
+	}
+
+	return fns, nil
+}
+
+func (b *Botanist) restoreExtensionObject(ctx context.Context, client client.Client, obj runtime.Object, objMeta *metav1.ObjectMeta, objStatus *extensionsv1alpha1.DefaultStatus, resourceKind, resourceName string, purpose *string) error {
+	if err := b.restoreExtensionObjectState(ctx, client, obj, objStatus, resourceKind, objMeta.GetName(), purpose); err != nil {
+		return err
+	}
+	return b.annotateExtensionObjectWithOperationRestore(ctx, client, obj, objMeta)
+}
+
+func (b *Botanist) restoreExtensionObjectState(ctx context.Context, client client.Client, extensionObj runtime.Object, objStatus *extensionsv1alpha1.DefaultStatus, resourceKind, resourceName string, purpose *string) error {
+	return kutil.TryUpdateStatus(ctx, k8sretry.DefaultBackoff, client, extensionObj, func() error {
+		if b.ShootState.Spec.Extensions != nil {
+			list := gardencorev1alpha1helper.ExtensionResourceStateList(b.ShootState.Spec.Extensions)
+			еxtensionResourceState := list.Get(resourceKind, &resourceName, purpose)
+			if еxtensionResourceState != nil {
+				objStatus.State = &еxtensionResourceState.State
+			}
+		}
+		return nil
+	})
+}
+
+func (b *Botanist) annotateExtensionObjectWithOperationRestore(ctx context.Context, client client.Client, extensionObj runtime.Object, objMeta *metav1.ObjectMeta) error {
+	return kutil.TryUpdate(ctx, k8sretry.DefaultBackoff, client, extensionObj, func() error {
+		metav1.SetMetaDataAnnotation(objMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationRestore)
+		return nil
+	})
+}
+
+func (b *Botanist) isRestorePhase() bool {
+	if b.Shoot == nil {
+		return false
+	}
+
+	if lastOperation := b.Shoot.Info.Status.LastOperation; lastOperation != nil {
+		return lastOperation.Type == gardencorev1beta1.LastOperationTypeRestore
+	}
+	return false
+}

--- a/pkg/operation/botanist/migration_test.go
+++ b/pkg/operation/botanist/migration_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist_test
+
+import (
+	"context"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	extensionsclient "github.com/gardener/gardener/pkg/client/extensions/clientset/versioned/scheme"
+	mock "github.com/gardener/gardener/pkg/mock/gardener/client/kubernetes"
+	"github.com/gardener/gardener/pkg/operation"
+	"github.com/gardener/gardener/pkg/operation/botanist"
+	"github.com/gardener/gardener/pkg/operation/shoot"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("control plane migration", func() {
+	var (
+		ctrl              *gomock.Controller
+		k8sSeedClient     *mock.MockInterface
+		testSeedNamespace = "test-seed-namespace"
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		k8sSeedClient = mock.NewMockInterface(ctrl)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#AnnotateExtensionCRDsForMigration()", func() {
+		It("should annotate all extension objects", func() {
+			var (
+				ctx   = context.TODO()
+				shoot = &shoot.Shoot{
+					SeedNamespace: testSeedNamespace,
+				}
+				extensionClientFake = fake.NewFakeClientWithScheme(extensionsclient.Scheme, &extensionsv1alpha1.Worker{ObjectMeta: v1.ObjectMeta{
+					Name:      "test-worker",
+					Namespace: testSeedNamespace,
+				}})
+			)
+
+			k8sSeedClient.EXPECT().Client().Return(extensionClientFake).AnyTimes()
+			op := &operation.Operation{
+				K8sSeedClient: k8sSeedClient,
+				Shoot:         shoot,
+			}
+
+			botanist := botanist.Botanist{Operation: op}
+			err := botanist.AnnotateExtensionCRsForMigration(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			actualWorker := &extensionsv1alpha1.Worker{}
+			err = extensionClientFake.Get(ctx, types.NamespacedName{
+				Name:      "test-worker",
+				Namespace: testSeedNamespace,
+			}, actualWorker)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(actualWorker.GetAnnotations()).NotTo(BeNil())
+			Expect(actualWorker.GetAnnotations()[v1beta1constants.GardenerOperation]).To(Equal(v1beta1constants.GardenerOperationMigrate))
+		})
+	})
+})

--- a/pkg/operation/botanist/migration_test.go
+++ b/pkg/operation/botanist/migration_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -56,7 +56,7 @@ var _ = Describe("control plane migration", func() {
 				shoot = &shoot.Shoot{
 					SeedNamespace: testSeedNamespace,
 				}
-				extensionClientFake = fake.NewFakeClientWithScheme(extensionsclient.Scheme, &extensionsv1alpha1.Worker{ObjectMeta: v1.ObjectMeta{
+				extensionClientFake = fake.NewFakeClientWithScheme(extensionsclient.Scheme, &extensionsv1alpha1.Worker{ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-worker",
 					Namespace: testSeedNamespace,
 				}})

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -20,9 +20,11 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/pkg/operation/botanist/constants"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
 
 	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	k8sretry "k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -59,4 +61,66 @@ func (b *Botanist) WaitUntilManagedResourcesDeleted(ctx context.Context) error {
 		b.Logger.Infof("Waiting until all managed resources have been deleted in the shoot cluster...")
 		return retry.MinorError(fmt.Errorf("not all managed resources have been deleted in the shoot cluster (still existing: %s)", names))
 	})
+}
+
+// WaitUntilAllManagedResourcesDeleted waits until all managed resources are gone or the context is cancelled.
+func (b *Botanist) WaitUntilAllManagedResourcesDeleted(ctx context.Context) error {
+	return b.waitUntilManagedResourceAreDeleted(ctx, client.InNamespace(b.Shoot.SeedNamespace))
+}
+func (b *Botanist) waitUntilManagedResourceAreDeleted(ctx context.Context, listOpt ...client.ListOption) error {
+	return retry.Until(ctx, 5*time.Second, func(ctx context.Context) (done bool, err error) {
+		managedResources := &resourcesv1alpha1.ManagedResourceList{}
+		if err := b.K8sSeedClient.Client().List(ctx,
+			managedResources,
+			listOpt...); err != nil {
+			return retry.SevereError(err)
+		}
+
+		if len(managedResources.Items) == 0 {
+			return retry.Ok()
+		}
+
+		names := make([]string, 0, len(managedResources.Items))
+		for _, resource := range managedResources.Items {
+			names = append(names, resource.Name)
+		}
+
+		b.Logger.Infof("Waiting until all managed resources have been deleted in the shoot cluster...")
+		return retry.MinorError(fmt.Errorf("not all managed resources have been deleted in the shoot cluster (still existing: %s)", names))
+	})
+}
+
+// KeepManagedResourcesObjects sets ManagedResource.Spec.KeepObjects to true.
+func (b *Botanist) KeepManagedResourcesObjects(ctx context.Context) error {
+	managedResources := &resourcesv1alpha1.ManagedResourceList{}
+	if err := b.K8sSeedClient.Client().List(ctx,
+		managedResources,
+		client.InNamespace(b.Shoot.SeedNamespace),
+	); err != nil {
+		return fmt.Errorf("failed to list all managed resource, %v", err)
+	}
+
+	if len(managedResources.Items) == 0 {
+		return nil
+	}
+
+	for _, resource := range managedResources.Items {
+		if err := kutil.TryUpdate(ctx, k8sretry.DefaultRetry, b.K8sSeedClient.Client(), &resource, func() error {
+			keepObj := true
+			resource.Spec.KeepObjects = &keepObj
+			return nil
+		}); client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("failed to update managed resource %q, %v", resource.GetName(), err)
+		}
+	}
+	return nil
+}
+
+// DeleteAllManagedResourcesObjects sets ManagedResource.Spec.KeepObjects to true.
+func (b *Botanist) DeleteAllManagedResourcesObjects(ctx context.Context) error {
+	return b.K8sSeedClient.Client().DeleteAllOf(
+		ctx,
+		&resourcesv1alpha1.ManagedResource{},
+		client.InNamespace(b.Shoot.SeedNamespace),
+	)
 }

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -118,6 +118,16 @@ func (b *Botanist) WaitUntilEtcdReady(ctx context.Context) error {
 	})
 }
 
+// WaitUntilKubeAPIServerScaledDown waits until the kube-apiserver pod(s) are scaled to zero.
+func (b *Botanist) WaitUntilKubeAPIServerScaledDown(ctx context.Context) error {
+	return common.WaitUntilDeploymentScaledToDesiredReplicas(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer, 0)
+}
+
+// WaitUntilGardenerResourceManagerScalesDown waits until the gardener-resource-manager pod(s) are scaled to zero.
+func (b *Botanist) WaitUntilGardenerResourceManagerScalesDown(ctx context.Context) error {
+	return common.WaitUntilDeploymentScaledToDesiredReplicas(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameGardenerResourceManager, 0)
+}
+
 // WaitUntilKubeAPIServerReady waits until the kube-apiserver pod(s) indicate readiness in their statuses.
 func (b *Botanist) WaitUntilKubeAPIServerReady(ctx context.Context) error {
 	return retry.UntilTimeout(ctx, 5*time.Second, 300*time.Second, func(ctx context.Context) (done bool, err error) {

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -120,12 +120,12 @@ func (b *Botanist) WaitUntilEtcdReady(ctx context.Context) error {
 
 // WaitUntilKubeAPIServerScaledDown waits until the kube-apiserver pod(s) are scaled to zero.
 func (b *Botanist) WaitUntilKubeAPIServerScaledDown(ctx context.Context) error {
-	return common.WaitUntilDeploymentScaledToDesiredReplicas(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer, 0)
+	return WaitUntilDeploymentScaledToDesiredReplicas(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer, 0)
 }
 
 // WaitUntilGardenerResourceManagerScalesDown waits until the gardener-resource-manager pod(s) are scaled to zero.
 func (b *Botanist) WaitUntilGardenerResourceManagerScalesDown(ctx context.Context) error {
-	return common.WaitUntilDeploymentScaledToDesiredReplicas(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameGardenerResourceManager, 0)
+	return WaitUntilDeploymentScaledToDesiredReplicas(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameGardenerResourceManager, 0)
 }
 
 // WaitUntilKubeAPIServerReady waits until the kube-apiserver pod(s) indicate readiness in their statuses.
@@ -430,5 +430,30 @@ func (b *Botanist) WaitUntilRequiredExtensionsReady(ctx context.Context) error {
 			return retry.MinorError(err)
 		}
 		return retry.Ok()
+	})
+}
+
+// WaitUntilDeploymentScaledToDesiredReplicas waits for the number of available replicas to be equal to the deployment's desired replicas count.
+func WaitUntilDeploymentScaledToDesiredReplicas(ctx context.Context, client client.Client, namespace, name string, desiredReplicas int32) error {
+	return retry.UntilTimeout(ctx, 5*time.Second, 300*time.Second, func(ctx context.Context) (done bool, err error) {
+		deployment := &appsv1.Deployment{}
+		if err := client.Get(ctx, kutil.Key(namespace, name), deployment); err != nil {
+			return retry.SevereError(err)
+		}
+
+		if deployment.Generation != deployment.Status.ObservedGeneration {
+			return retry.MinorError(fmt.Errorf("%q not observed at latest generation (%d/%d)", name,
+				deployment.Status.ObservedGeneration, deployment.Generation))
+		}
+
+		if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != desiredReplicas {
+			return retry.SevereError(fmt.Errorf("waiting for deployment %q to scale failed. spec.replicas does not match the desired replicas", name))
+		}
+
+		if deployment.Status.Replicas == desiredReplicas && deployment.Status.AvailableReplicas == desiredReplicas {
+			return retry.Ok()
+		}
+
+		return retry.MinorError(fmt.Errorf("deployment %q currently has '%d' replicas. Desired: %d", name, deployment.Status.AvailableReplicas, desiredReplicas))
 	})
 }

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/pkg/version"
 
 	jsoniter "github.com/json-iterator/go"
@@ -49,7 +50,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
-	"k8s.io/client-go/util/retry"
+	k8sretry "k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -722,7 +723,7 @@ func annotationRequiredError() error {
 
 // ConfirmDeletion adds Gardener's deletion confirmation annotation to the given object and sends an UPDATE request.
 func ConfirmDeletion(ctx context.Context, c client.Client, obj runtime.Object) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	return k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
 		key, err := client.ObjectKeyFromObject(obj)
 		if err != nil {
 			return err
@@ -755,4 +756,29 @@ func ConfirmDeletion(ctx context.Context, c client.Client, obj runtime.Object) e
 // ExtensionID returns an identifier for the given extension kind/type.
 func ExtensionID(extensionKind, extensionType string) string {
 	return fmt.Sprintf("%s/%s", extensionKind, extensionType)
+}
+
+// WaitUntilDeploymentScaledToDesiredReplicas waits for the number of available replicas to be equal to the deployment's desired replicas count.
+func WaitUntilDeploymentScaledToDesiredReplicas(ctx context.Context, client client.Client, namespace, name string, desiredReplicas int32) error {
+	return retry.UntilTimeout(ctx, 5*time.Second, 300*time.Second, func(ctx context.Context) (done bool, err error) {
+		deployment := &appsv1.Deployment{}
+		if err := client.Get(ctx, kutil.Key(namespace, name), deployment); err != nil {
+			return retry.SevereError(err)
+		}
+
+		if deployment.Generation != deployment.Status.ObservedGeneration {
+			return retry.MinorError(fmt.Errorf("%q not observed at latest generation (%d/%d)", name,
+				deployment.Status.ObservedGeneration, deployment.Generation))
+		}
+
+		if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != desiredReplicas {
+			return retry.SevereError(fmt.Errorf("waiting for deployment %q to scale failed. spec.replicas does not match the desired replicas", name))
+		}
+
+		if deployment.Status.Replicas == desiredReplicas && deployment.Status.AvailableReplicas == desiredReplicas {
+			return retry.Ok()
+		}
+
+		return retry.MinorError(fmt.Errorf("deployment %q currently has '%d' replicas. Desired: %d", name, deployment.Status.AvailableReplicas, desiredReplicas))
+	})
 }

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -524,20 +524,11 @@ func (o *Operation) DeleteClusterResourceFromSeed(ctx context.Context) error {
 		return err
 	}
 
-	if err := o.K8sSeedClient.Client().Delete(ctx, &extensionsv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: o.Shoot.SeedNamespace}}); err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	return nil
+	return client.IgnoreNotFound(o.K8sSeedClient.Client().Delete(ctx, &extensionsv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: o.Shoot.SeedNamespace}}))
 }
 
 // SwitchBackupEntryToTargetSeed changes the BackupEntry in the Garden cluster to the Target Seed and removes it from the Source Seed
 func (o *Operation) SwitchBackupEntryToTargetSeed(ctx context.Context) error {
-	if err := o.InitializeSeedClients(); err != nil {
-		o.Logger.Errorf("Could not initialize a new Kubernetes client for the seed cluster: %s", err.Error())
-		return err
-	}
-
 	var (
 		name              = common.GenerateBackupEntryName(o.Shoot.Info.Status.TechnicalID, o.Shoot.Info.Status.UID)
 		gardenBackupEntry = &gardencorev1beta1.BackupEntry{

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -98,6 +98,10 @@ func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
 			if val, ok := common.GetShootOperationAnnotation(newShoot.Annotations); ok && val == common.ShootOperationRetry {
 				mustIncrease = true
 			}
+		case core.LastOperationStatePending:
+			if newShoot.Status.LastOperation.Type == core.LastOperationTypeRestore {
+				mustIncrease = true
+			}
 		default:
 			// The shoot state is not failed and the reconcile or rotate-credentials annotation is set.
 			if val, ok := common.GetShootOperationAnnotation(newShoot.Annotations); ok {

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -231,6 +231,10 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 		return admission.NewForbidden(a, fmt.Errorf("cannot create shoot '%s' on seed '%s' already marked for deletion", shoot.Name, seed.Name))
 	}
 
+	if !apiequality.Semantic.DeepEqual(shoot.Spec.SeedName, oldShoot.Spec.SeedName) && seed != nil && seed.Spec.Backup == nil {
+		return admission.NewForbidden(a, fmt.Errorf("cannot change seed name, because seed backup is not configured, for shoot %q", shoot.Name))
+	}
+
 	if shoot.Spec.Provider.Type != cloudProfile.Spec.Type {
 		return apierrors.NewBadRequest(fmt.Sprintf("cloud provider in shoot (%s) is not equal to cloud provider in profile (%s)", shoot.Spec.Provider.Type, cloudProfile.Spec.Type))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds additional flow to the Shoot's lifecycle which is going to prepare the Shoot's Control plane for migration, and adapts the reconciliation flow to restore Shoot's extension resources from the ShootState.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
1. The API Server still doesn't permit changes to the Seed name. We will change this when everything around the CPM is merged.
2. The adaptation of the reconciliation flow is partial, because secrets are done in another PR. This one is only for the Extension Resources

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```