### PR TITLE
Re-add ChartApplierForConfig function

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -167,4 +167,3 @@ func FindWorkerByName(workers []core.Worker, name string) *core.Worker {
 	}
 	return nil
 }
-

--- a/pkg/apis/core/v1alpha1/conversions.go
+++ b/pkg/apis/core/v1alpha1/conversions.go
@@ -270,7 +270,6 @@ func Convert_core_ProjectSpec_To_v1alpha1_ProjectSpec(in *core.ProjectSpec, out 
 	return nil
 }
 
-
 func Convert_v1alpha1_ProjectMember_To_core_ProjectMember(in *ProjectMember, out *core.ProjectMember, s conversion.Scope) error {
 	if err := autoConvert_v1alpha1_ProjectMember_To_core_ProjectMember(in, out, s); err != nil {
 		return err
@@ -304,8 +303,7 @@ func Convert_core_ProjectMember_To_v1alpha1_ProjectMember(in *core.ProjectMember
 	return nil
 }
 
-
-func removeRoleFromRoles(roles []string, role string) []string{
+func removeRoleFromRoles(roles []string, role string) []string {
 	var newRoles []string
 	for _, r := range roles {
 		if r != role {

--- a/pkg/apis/core/v1alpha1/conversions_test.go
+++ b/pkg/apis/core/v1alpha1/conversions_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Conversion", func() {
 						{Subject: member1},
 						{
 							Subject: owner,
-							Role:   ProjectMemberOwner,
+							Role:    ProjectMemberOwner,
 						},
 						{Subject: member2},
 					},
@@ -246,7 +246,7 @@ var _ = Describe("Conversion", func() {
 						},
 						{
 							Subject: member4,
-							Role:   ProjectMemberOwner,
+							Role:    ProjectMemberOwner,
 						},
 					},
 				}
@@ -346,7 +346,7 @@ var _ = Describe("Conversion", func() {
 							{Subject: member1},
 							{
 								Subject: owner,
-								Role:   "foo",
+								Role:    "foo",
 								Roles:   []string{ProjectMemberOwner},
 							},
 							{Subject: member2},
@@ -373,7 +373,7 @@ var _ = Describe("Conversion", func() {
 							{Subject: member1},
 							{
 								Subject: owner,
-								Role:   ProjectMemberOwner,
+								Role:    ProjectMemberOwner,
 							},
 							{Subject: member2},
 						},
@@ -441,7 +441,7 @@ var _ = Describe("Conversion", func() {
 							},
 							{
 								Subject: owner,
-								Role:   ProjectMemberOwner,
+								Role:    ProjectMemberOwner,
 							},
 							{
 								Subject: member2,

--- a/pkg/apis/core/v1beta1/conversions.go
+++ b/pkg/apis/core/v1beta1/conversions.go
@@ -117,7 +117,6 @@ func Convert_core_ProjectSpec_To_v1beta1_ProjectSpec(in *core.ProjectSpec, out *
 	return nil
 }
 
-
 func Convert_v1beta1_ProjectMember_To_core_ProjectMember(in *ProjectMember, out *core.ProjectMember, s conversion.Scope) error {
 	if err := autoConvert_v1beta1_ProjectMember_To_core_ProjectMember(in, out, s); err != nil {
 		return err
@@ -151,8 +150,7 @@ func Convert_core_ProjectMember_To_v1beta1_ProjectMember(in *core.ProjectMember,
 	return nil
 }
 
-
-func removeRoleFromRoles(roles []string, role string) []string{
+func removeRoleFromRoles(roles []string, role string) []string {
 	var newRoles []string
 	for _, r := range roles {
 		if r != role {

--- a/pkg/apis/core/v1beta1/conversions_test.go
+++ b/pkg/apis/core/v1beta1/conversions_test.go
@@ -154,7 +154,7 @@ var _ = Describe("Conversion", func() {
 						{Subject: member1},
 						{
 							Subject: owner,
-							Role:   ProjectMemberOwner,
+							Role:    ProjectMemberOwner,
 						},
 						{Subject: member2},
 					},
@@ -195,7 +195,7 @@ var _ = Describe("Conversion", func() {
 						},
 						{
 							Subject: member4,
-							Role:   ProjectMemberOwner,
+							Role:    ProjectMemberOwner,
 						},
 					},
 				}
@@ -295,7 +295,7 @@ var _ = Describe("Conversion", func() {
 							{Subject: member1},
 							{
 								Subject: owner,
-								Role:   "foo",
+								Role:    "foo",
 								Roles:   []string{ProjectMemberOwner},
 							},
 							{Subject: member2},
@@ -322,7 +322,7 @@ var _ = Describe("Conversion", func() {
 							{Subject: member1},
 							{
 								Subject: owner,
-								Role:   ProjectMemberOwner,
+								Role:    ProjectMemberOwner,
 							},
 							{Subject: member2},
 						},
@@ -390,7 +390,7 @@ var _ = Describe("Conversion", func() {
 							},
 							{
 								Subject: owner,
-								Role:   ProjectMemberOwner,
+								Role:    ProjectMemberOwner,
 							},
 							{
 								Subject: member2,

--- a/pkg/client/kubernetes/chartapplier.go
+++ b/pkg/client/kubernetes/chartapplier.go
@@ -18,6 +18,8 @@ import (
 	"context"
 
 	"github.com/gardener/gardener/pkg/chartrenderer"
+
+	"k8s.io/client-go/rest"
 )
 
 // ChartApplier is an interface that describes needed methods that render and apply
@@ -37,6 +39,19 @@ type chartApplier struct {
 // NewChartApplier returns a new chart applier.
 func NewChartApplier(renderer chartrenderer.Interface, applier ApplierInterface) ChartApplier {
 	return &chartApplier{renderer, applier}
+}
+
+// NewChartApplierForConfig returns a new chart applier based on the given REST config.
+func NewChartApplierForConfig(config *rest.Config) (ChartApplier, error) {
+	renderer, err := chartrenderer.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	applier, err := NewApplierForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return NewChartApplier(renderer, applier), nil
 }
 
 // Apply takes a path to a chart <chartPath>, name of the release <name>,

--- a/test/suites/shoot/run_suite_test.go
+++ b/test/suites/shoot/run_suite_test.go
@@ -29,9 +29,9 @@ import (
 
 	_ "github.com/gardener/gardener/test/integration/plants"
 	_ "github.com/gardener/gardener/test/integration/shoots/applications"
+	_ "github.com/gardener/gardener/test/integration/shoots/care"
 	_ "github.com/gardener/gardener/test/integration/shoots/logging"
 	_ "github.com/gardener/gardener/test/integration/shoots/operations"
-	_ "github.com/gardener/gardener/test/integration/shoots/care"
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
The `kubernetes.NewChartApplierForConfig` function was removed with #1969 (https://github.com/gardener/gardener/commit/84e49d513831d1d7f853a1f456f1275983b48e80#diff-14be17a955b812b7a5c0b57661b54c11L46-L58) because it's not used in g/g, though, it's used in the extensions and generally reasonable to offer.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
