### PR TITLE
Add  kubelet-preferred-address-types=InternalIP in metrics-server

### DIFF
--- a/charts/shoot-core/components/charts/metrics-server/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/metrics-server/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
         # nobody user only can write in home folder
         - --cert-dir=/home/certdir
         - --secure-port=8443
+        # Hostname can not be always resolved in all hyperscalers, such as Alibaba Cloud. Need to set internal IP
+        - kubelet-preferred-address-types=InternalIP
         # See https://github.com/kubernetes-incubator/metrics-server/issues/25 and https://github.com/kubernetes-incubator/metrics-server/issues/130
         # The kube-apiserver and the kubelet use different CAs, however, the metrics-server assumes the CAs are the same.
         # We should remove this flag once it is possible to specify the CA of the kubelet.


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix issue that metric-server can't scrape metrics of node in Alicloud. 
**Which issue(s) this PR fixes**:
Fixes # https://github.com/gardener/gardener-extension-provider-alicloud/issues/39

**Special notes for your reviewer**:
It is not possibe to implement a webhook to change the deployment of metrics-server. Because the deployment is managed by gardener resource manager.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Metrics-server can scrape node's metrics now.
```
