### PR TITLE
[hotfix] Prevent CA from downscaling node running etcd pod

### DIFF
--- a/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd-statefulset.yaml
@@ -1,8 +1,6 @@
 apiVersion: {{ include "statefulsetversion" . }}
 kind: StatefulSet
 metadata:
-  annotations:
-    "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
   name: etcd-{{ .Values.role }}
   namespace: {{ .Release.Namespace }}
   labels:
@@ -21,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
         checksum/configmap-etcd-bootstrap-config: {{ include (print $.Template.BasePath "/configmap-etcd-bootstrap.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**What this PR does / why we need it**:
This hotfix PR adds annotation `"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"` to etcd pod (instead of etcd sts) so that cluster-autoscaler does not downscale any node running etcd pod.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This will cause the etcd pods to restart, but only in maintenance window.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Prevent cluster-autoscaler from downscaling any node running etcd pod.
```
