### PR TITLE
Add test-infra-maintainers as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,6 @@
 # gardener maintainers
 *   @gardener/gardener-maintainers
+
+# test-related directory maintainers
+/.test-defs   @gardener/gardener-maintainers @gardener/test-infra-maintainers
+/test         @gardener/gardener-maintainers @gardener/test-infra-maintainers


### PR DESCRIPTION
**What this PR does / why we need it**:
Add @gardener/test-infra-maintainers as CODEOWNERS for the `.test-defs` and `test` directories to enable them to easily merge test-related pull requests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
