### PR TITLE
Fix a small typo: `apiserverResources` to `apiServerResources`

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -790,7 +790,7 @@ func (b *Botanist) DeployKubeAPIServer() error {
 		for k := range deployment.Spec.Template.Spec.Containers {
 			v := &deployment.Spec.Template.Spec.Containers[k]
 			if v.Name == "kube-apiserver" {
-				defaultValues["apiserverResources"] = v.Resources.DeepCopy()
+				defaultValues["apiServerResources"] = v.Resources.DeepCopy()
 				break
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a small typo: `apiserverResources` to `apiServerResources`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixed a bug that caused Gardener to override kube-apiserver deployment's `resources` field on every reconcile, thus, overriding the values set by HVPA controller.
```
