### PR TITLE
[release-v1.1] Revise migration steps for primary DNS provider

### DIFF
--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -218,12 +218,11 @@ type DNSProvider struct {
 	Primary *bool `json:"primary,omitempty"`
 	// SecretName is a name of a secret containing credentials for the stated domain and the
 	// provider. When not specified, the Gardener will use the cloud provider credentials referenced
-	// by the Shoot and try to find respective credentials there. Specifying this field may override
+	// by the Shoot and try to find respective credentials there (primary provider only). Specifying this field may override
 	// this behavior, i.e. forcing the Gardener to only look into the given secret.
 	// +optional
 	SecretName *string `json:"secretName,omitempty"`
-	// Type is the DNS provider type for the Shoot. Only relevant if not the default domain is used for
-	// this shoot.
+	// Type is the DNS provider type.
 	// +optional
 	Type *string `json:"type,omitempty"`
 	// Zones contains information about which hosted zones shall be included/excluded for this provider.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -215,12 +215,11 @@ type DNSProvider struct {
 	Primary *bool `json:"primary,omitempty"`
 	// SecretName is a name of a secret containing credentials for the stated domain and the
 	// provider. When not specified, the Gardener will use the cloud provider credentials referenced
-	// by the Shoot and try to find respective credentials there. Specifying this field may override
+	// by the Shoot and try to find respective credentials there (primary provider only). Specifying this field may override
 	// this behavior, i.e. forcing the Gardener to only look into the given secret.
 	// +optional
 	SecretName *string `json:"secretName,omitempty"`
-	// Type is the DNS provider type for the Shoot. Only relevant if not the default domain is used for
-	// this shoot.
+	// Type is the DNS provider type.
 	// +optional
 	Type *string `json:"type,omitempty"`
 	// Zones contains information about which hosted zones shall be included/excluded for this provider.

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -16,7 +16,10 @@ package shoot
 
 import (
 	"context"
+	"fmt"
 	"time"
+
+	"k8s.io/utils/pointer"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
@@ -53,11 +56,27 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation, operationType
 		}
 	}
 
+	var dnsEnabled = !o.Shoot.DisableDNS
+
 	// TODO: timuthy - Only required for migration and can be removed in a future version
-	if o.Shoot.ExternalClusterDomain != nil && garden.DomainIsDefaultDomain(*o.Shoot.ExternalClusterDomain, o.Garden.DefaultDomains) != nil {
-		o.Logger.Info("Migration step - setting primary DNS provider")
-		if err := kutil.SubmitEmptyPatch(context.TODO(), o.K8sGardenClient.Client(), o.Shoot.Info); err != nil {
-			return gardencorev1beta1helper.NewWrappedLastErrors(gardencorev1beta1helper.FormatLastErrDescription(err), err)
+	if dnsEnabled {
+		var (
+			primaryDNSProvider = gardencorev1beta1helper.FindPrimaryDNSProvider(o.Shoot.Info.Spec.DNS.Providers)
+			usesDefaultDomain  = o.Shoot.ExternalClusterDomain != nil && garden.DomainIsDefaultDomain(*o.Shoot.ExternalClusterDomain, o.Garden.DefaultDomains) != nil
+		)
+		if !usesDefaultDomain && primaryDNSProvider != nil && primaryDNSProvider.Primary == nil {
+			o.Logger.Info("Migration step - setting primary DNS provider field")
+			if err := kutil.TryUpdate(context.TODO(), retry.DefaultBackoff, c.k8sGardenClient.Client(), o.Shoot.Info, func() error {
+				for i, provider := range o.Shoot.Info.Spec.DNS.Providers {
+					if provider.Type == primaryDNSProvider.Type && provider.SecretName == primaryDNSProvider.SecretName {
+						o.Shoot.Info.Spec.DNS.Providers[i].Primary = pointer.BoolPtr(true)
+						return nil
+					}
+				}
+				return fmt.Errorf("migration error - wanted to set primary DNS provider but it was not found: %+v", *primaryDNSProvider)
+			}); err != nil {
+				return gardencorev1beta1helper.NewWrappedLastErrors(gardencorev1beta1helper.FormatLastErrDescription(err), err)
+			}
 		}
 	}
 
@@ -94,7 +113,6 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation, operationType
 	var (
 		defaultTimeout     = 30 * time.Second
 		defaultInterval    = 5 * time.Second
-		dnsEnabled         = !o.Shoot.DisableDNS
 		managedExternalDNS = o.Shoot.ExternalDomain != nil && o.Shoot.ExternalDomain.Provider != "unmanaged"
 		managedInternalDNS = o.Garden.InternalDomain != nil && o.Garden.InternalDomain.Provider != "unmanaged"
 		allowBackup        = o.Seed.Info.Spec.Backup != nil

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -110,7 +110,7 @@ func constructDomainFromSecret(secret *corev1.Secret) (*Domain, error) {
 // DomainIsDefaultDomain identifies whether the given domain is a default domain.
 func DomainIsDefaultDomain(domain string, defaultDomains []*Domain) *Domain {
 	for _, defaultDomain := range defaultDomains {
-		if strings.HasSuffix(domain, defaultDomain.Domain) {
+		if strings.HasSuffix(domain, "."+defaultDomain.Domain) {
 			return defaultDomain
 		}
 	}

--- a/pkg/operation/garden/garden_test.go
+++ b/pkg/operation/garden/garden_test.go
@@ -169,5 +169,6 @@ var _ = Describe("Garden", func() {
 
 		Entry("no default domain", "foo.bar.com", nil, BeNil()),
 		Entry("default domain", "foo.bar.com", []*garden.Domain{defaultDomain}, Equal(defaultDomain)),
+		Entry("no default domain but with same suffix", "foo.foobar.com", []*garden.Domain{defaultDomain}, BeNil()),
 	)
 })

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -117,3 +117,8 @@ func TestEmail(email string) bool {
 	match, _ := regexp.MatchString(`^[^@]+@(?:[a-zA-Z-0-9]+\.)+[a-zA-Z]{2,}$`, email)
 	return match
 }
+
+// IsTrue returns true if the passed bool pointer is not nil and true.
+func IsTrue(value *bool) bool {
+	return value != nil && *value
+}

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -117,8 +117,3 @@ func TestEmail(email string) bool {
 	match, _ := regexp.MatchString(`^[^@]+@(?:[a-zA-Z-0-9]+\.)+[a-zA-Z]{2,}$`, email)
 	return match
 }
-
-// IsTrue returns true if the passed bool pointer is not nil and true.
-func IsTrue(value *bool) bool {
-	return value != nil && *value
-}

--- a/pkg/utils/miscellaneous_test.go
+++ b/pkg/utils/miscellaneous_test.go
@@ -15,11 +15,8 @@ package utils_test
 
 import (
 	. "github.com/gardener/gardener/pkg/utils"
-	"github.com/onsi/gomega/types"
-	"k8s.io/utils/pointer"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -60,12 +57,4 @@ var _ = Describe("utils", func() {
 			}))
 		})
 	})
-
-	DescribeTable("#IsTrue", func(value *bool, matcher types.GomegaMatcher) {
-		Expect(IsTrue(value)).To(matcher)
-	},
-		Entry("nil", nil, BeFalse()),
-		Entry("false", pointer.BoolPtr(false), BeFalse()),
-		Entry("true", pointer.BoolPtr(true), BeTrue()),
-	)
 })

--- a/pkg/utils/miscellaneous_test.go
+++ b/pkg/utils/miscellaneous_test.go
@@ -17,7 +17,10 @@ import (
 	. "github.com/gardener/gardener/pkg/utils"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/types"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("utils", func() {
@@ -57,4 +60,12 @@ var _ = Describe("utils", func() {
 			}))
 		})
 	})
+
+	DescribeTable("#IsTrue", func(value *bool, matcher GomegaMatcher) {
+		Expect(IsTrue(value)).To(matcher)
+	},
+		Entry("nil", nil, BeFalse()),
+		Entry("false", pointer.BoolPtr(false), BeFalse()),
+		Entry("true", pointer.BoolPtr(true), BeTrue()),
+	)
 })

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -136,15 +136,44 @@ func (d *DNS) Admit(ctx context.Context, a admission.Attributes, o admission.Obj
 	if a.GetKind().GroupKind() != core.Kind("Shoot") {
 		return nil
 	}
+	// Ignore updates to shoot status or other subresources
+	if a.GetSubresource() != "" {
+		return nil
+	}
 	shoot, ok := a.GetObject().(*core.Shoot)
 	if !ok {
 		return apierrors.NewBadRequest("could not convert resource into Shoot object")
 	}
 
+	defaultDomains, err := getDefaultDomains(d.secretLister)
+	if err != nil {
+		return fmt.Errorf("error retrieving default domains: %s", err)
+	}
+
+	if err := checkPrimaryDNSProvider(shoot.Spec.DNS, defaultDomains); err != nil {
+		return err
+	}
+
 	// If a shoot is newly created and not yet assigned to a seed we do nothing. We need to know the seed
 	// in order to check whether it's tainted to not use DNS.
-	if shoot.Spec.SeedName == nil {
-		return nil
+	switch a.GetOperation() {
+	case admission.Create:
+		if shoot.Spec.SeedName == nil {
+			return nil
+		}
+
+	case admission.Update:
+		oldShoot, ok := a.GetOldObject().(*core.Shoot)
+		if !ok {
+			return apierrors.NewBadRequest("could not convert old resource into Shoot object")
+		}
+
+		if shoot.Spec.SeedName == nil {
+			return nil
+		}
+		if oldShoot.Spec.SeedName != nil {
+			return nil
+		}
 	}
 
 	dnsDisabled, err := seedDisablesDNS(d.seedLister, *shoot.Spec.SeedName)
@@ -158,40 +187,16 @@ func (d *DNS) Admit(ctx context.Context, a admission.Attributes, o admission.Obj
 		return nil
 	}
 
-	// If the Shoot manifest specifies the 'unmanaged' DNS provider, then we do nothing.
-	if helper.ShootUsesUnmanagedDNS(shoot) {
-		return nil
-	}
-
-	defaultDomains, err := getDefaultDomains(d.secretLister)
-	if err != nil {
-		return fmt.Errorf("error retrieving default domains: %s", err)
-	}
-
 	// Generate a Shoot domain if none is configured (at this point in time we know that the chosen seed does
 	// not disable DNS.
-	switch a.GetOperation() {
-	case admission.Create:
+	if !helper.ShootUsesUnmanagedDNS(shoot) {
 		if err := assignDefaultDomainIfNeeded(shoot, d.projectLister, defaultDomains); err != nil {
 			return err
 		}
-	case admission.Update:
-		oldShoot, ok := a.GetOldObject().(*core.Shoot)
-		if !ok {
-			return apierrors.NewBadRequest("could not convert old resource into Shoot object")
-		}
-		seedGotAssigned := oldShoot.Spec.SeedName == nil && shoot.Spec.SeedName != nil
-		if seedGotAssigned {
-			if err := assignDefaultDomainIfNeeded(shoot, d.projectLister, defaultDomains); err != nil {
-				return err
-			}
-		}
-	}
 
-	// If the seed does not disable DNS and the shoot does not use the unmanaged DNS provider then we need
-	// a configured domain.
-	if shoot.Spec.DNS == nil || shoot.Spec.DNS.Domain == nil {
-		return apierrors.NewBadRequest(fmt.Sprintf("shoot domain field .spec.dns.domain must be set if provider != %s and assigned to a seed which does not disable DNS", core.DNSUnmanaged))
+		if shoot.Spec.DNS == nil || shoot.Spec.DNS.Domain == nil {
+			return apierrors.NewBadRequest(fmt.Sprintf("shoot domain field .spec.dns.domain must be set if provider != %s and assigned to a seed which does not disable DNS", core.DNSUnmanaged))
+		}
 	}
 
 	if err := managePrimaryDNSProvider(shoot.Spec.DNS, defaultDomains); err != nil {
@@ -201,27 +206,46 @@ func (d *DNS) Admit(ctx context.Context, a admission.Attributes, o admission.Obj
 	return nil
 }
 
-func managePrimaryDNSProvider(dns *core.DNS, defaultDomains []string) error {
-	var usesDefaultDomain bool
-	for _, domain := range defaultDomains {
-		if strings.HasSuffix(*dns.Domain, "."+domain) {
-			usesDefaultDomain = true
-			break
-		}
-	}
-	primary := helper.FindPrimaryDNSProvider(dns.Providers)
-
-	if usesDefaultDomain {
-		if primary != nil {
-			return apierrors.NewBadRequest("primary dns provider must not be set when default domain is used")
-		}
+func checkPrimaryDNSProvider(dns *core.DNS, defaultDomains []string) error {
+	if dns == nil || dns.Domain == nil || len(dns.Providers) == 0 {
 		return nil
 	}
 
+	var defaultDomain = isDefaultDomain(*dns.Domain, defaultDomains)
+	if defaultDomain {
+		primary := helper.FindPrimaryDNSProvider(dns.Providers)
+		if primary != nil {
+			return apierrors.NewBadRequest("primary dns provider must not be set when default domain is used")
+		}
+	}
+	return nil
+}
+
+func isDefaultDomain(domain string, defaultDomains []string) bool {
+	for _, defaultDomain := range defaultDomains {
+		if strings.HasSuffix(domain, "."+defaultDomain) {
+			return true
+		}
+	}
+	return false
+}
+
+func managePrimaryDNSProvider(dns *core.DNS, defaultDomains []string) error {
+	if dns == nil {
+		return nil
+	}
+	if err := checkPrimaryDNSProvider(dns, defaultDomains); err != nil {
+		return err
+	}
+
+	if dns.Domain != nil && isDefaultDomain(*dns.Domain, defaultDomains) {
+		return nil
+	}
+
+	primary := helper.FindPrimaryDNSProvider(dns.Providers)
 	if primary == nil && len(dns.Providers) > 0 {
 		dns.Providers[0].Primary = pointer.BoolPtr(true)
 	}
-
 	return nil
 }
 

--- a/plugin/pkg/shoot/dns/admission_test.go
+++ b/plugin/pkg/shoot/dns/admission_test.go
@@ -114,7 +114,7 @@ var _ = Describe("dns", func() {
 			seed = seedBase
 		})
 
-		It("should do nothing because the shoot does not specify a seed (create)", func() {
+		It("should do nothing because the shoot status is updated", func() {
 			shootCopy := shoot.DeepCopy()
 			shootCopy.Spec.SeedName = nil
 			shootBefore := shootCopy.DeepCopy()
@@ -127,7 +127,7 @@ var _ = Describe("dns", func() {
 			Expect(*shootCopy).To(Equal(*shootBefore))
 		})
 
-		It("should do nothing because the shoot status is updated", func() {
+		It("should do nothing because the shoot does not specify a seed (create)", func() {
 			shootCopy := shoot.DeepCopy()
 			shootCopy.Spec.SeedName = nil
 			shootBefore := shootCopy.DeepCopy()

--- a/plugin/pkg/shoot/dns/admission_test.go
+++ b/plugin/pkg/shoot/dns/admission_test.go
@@ -119,6 +119,19 @@ var _ = Describe("dns", func() {
 			shootCopy.Spec.SeedName = nil
 			shootBefore := shootCopy.DeepCopy()
 
+			attrs := admission.NewAttributesRecord(shootCopy, nil, core.Kind("Shoot").WithVersion("version"), shootCopy.Namespace, shootCopy.Name, core.Resource("shoots").WithVersion("version"), "status", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+			err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*shootCopy).To(Equal(*shootBefore))
+		})
+
+		It("should do nothing because the shoot status is updated", func() {
+			shootCopy := shoot.DeepCopy()
+			shootCopy.Spec.SeedName = nil
+			shootBefore := shootCopy.DeepCopy()
+
 			attrs := admission.NewAttributesRecord(shootCopy, nil, core.Kind("Shoot").WithVersion("version"), shootCopy.Namespace, shootCopy.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
 			err := admissionHandler.Admit(context.TODO(), attrs, nil)
@@ -168,8 +181,9 @@ var _ = Describe("dns", func() {
 			Expect(err).To(MatchError(apierrors.NewBadRequest("shoot's .spec.dns section must be nil if seed with disabled DNS is chosen")))
 		})
 
-		It("should do nothing because the shoot specifies the 'unmanaged' dns provider", func() {
+		It("should set the 'unmanaged' dns provider as the primary one", func() {
 			shootBefore := shoot.DeepCopy()
+			shootBefore.Spec.DNS.Providers[0].Primary = pointer.BoolPtr(true)
 
 			coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
 			attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
@@ -291,6 +305,32 @@ var _ = Describe("dns", func() {
 			})
 
 			It("should forbid setting a primary provider because a default domain was generated for the shoot (no domain)", func() {
+				shoot.Spec.DNS.Providers = []core.DNSProvider{
+					{
+						Type:       &providerType,
+						SecretName: &secretName,
+						Primary:    pointer.BoolPtr(true),
+					},
+				}
+
+				kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&defaultDomainSecret)
+				coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)
+				coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
+				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(PointTo(MatchFields(IgnoreExtras, Fields{
+					"ErrStatus": MatchFields(IgnoreExtras, Fields{
+						"Code":    Equal(int32(http.StatusBadRequest)),
+						"Message": Equal("primary dns provider must not be set when default domain is used"),
+					}),
+				})))
+			})
+
+			It("should forbid setting a primary provider because a default domain was manually configured for the shoot", func() {
+				shootDomain := fmt.Sprintf("%s.%s.%s", shoot.Name, project.Name, domain)
+				shoot.Spec.DNS.Domain = &shootDomain
 				shoot.Spec.DNS.Providers = []core.DNSProvider{
 					{
 						Type:       &providerType,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR revises the migration logic for setting the primary DNS provider of shoot clusters introduced by #1959. Primary DNS providers are now set right before the reconcile flow instead of setting it through an admission plugin. The motivation for this change is to guarantee the "reconcile in maintenance only" feature.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
