### PR TITLE
Add integration test for clusterautoscaler

### DIFF
--- a/charts/seed-bootstrap/charts/hvpa/Chart.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1alpha1
+apiVersion: v1
 description: A helm chart to bootstrap the hvpa
 name: hvpa
 version: 0.1.0

--- a/charts/shoot-addons-kyma/charts/kyma/Chart.yaml
+++ b/charts/shoot-addons-kyma/charts/kyma/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1alpha1
+apiVersion: v1
 appVersion: "0.1"
 description: Temporarily experimental support for out-of-the-box installation of Kyma
 name: kyma

--- a/test/framework/resources/templates/reserve-capacity.yaml.tpl
+++ b/test/framework/resources/templates/reserve-capacity.yaml.tpl
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
+  labels:
+    app: kubernetes
+    role: reserve-capacity
+spec:
+  replicas: {{ .Replicas }}
+  selector:
+    matchLabels:
+      app: kubernetes
+      role: reserve-capacity
+  template:
+    metadata:
+      labels:
+        app: kubernetes
+        role: reserve-capacity
+    spec:
+      terminationGracePeriodSeconds: 5
+      nodeSelector:
+        worker.gardener.cloud/pool: {{ .WorkerPool }}
+      containers:
+      - name: pause-container
+        image: gcr.io/google_containers/pause-amd64:3.1
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: {{ .Requests.CPU }}
+            memory: {{ .Requests.Memory }}
+          limits:
+            cpu: {{ .Requests.CPU }}
+            memory: {{ .Requests.Memory }}

--- a/test/integration/shoots/operations/clusterautoscaler.go
+++ b/test/integration/shoots/operations/clusterautoscaler.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+	Overview
+		- Tests Shoot cluster autoscaling
+
+	AfterSuite
+		- Cleanup Workload in Shoot
+
+	Test:
+		1. Create a deployment with Pods each requesting half the capacity of a single node
+		2. Scale up the deployment and see one node added
+		3. Scale down the deployment and see one node removed (after spec.kubernetes.clusterAutoscaler.scaleDownUnneededTime|scaleDownDelayAfterAdd
+	Expected Output
+		- Scale-up/down should work properly
+ **/
+
+package operations
+
+import (
+	"context"
+	"time"
+
+	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/test/framework"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+const (
+	reserveCapacityTemplateName        = "reserve-capacity.yaml.tpl"
+	reserveCapacityDeploymentName      = "reserve-capacity"
+	reserveCapacityDeploymentNamespace = metav1.NamespaceDefault
+
+	scaleDownDelayAfterAdd = 1 * time.Minute
+	scaleDownUnneededTime  = 1 * time.Minute
+	testTimeout            = 60 * time.Minute
+	scaleUpTimeout         = 20 * time.Minute
+	scaleDownTimeout       = 20 * time.Minute
+)
+
+var _ = ginkgo.Describe("Shoot clusterautoscaler testing", func() {
+
+	f := framework.NewShootFramework(nil)
+
+	f.Beta().Serial().CIt("should autoscale a single worker group", func(ctx context.Context) {
+		var (
+			shoot = f.Shoot
+
+			origClusterAutoscalerConfig = shoot.Spec.Kubernetes.ClusterAutoscaler.DeepCopy()
+			workerPoolName              = shoot.Spec.Provider.Workers[0].Name
+			origMinWorkers              = shoot.Spec.Provider.Workers[0].Minimum
+			origMaxWorkers              = shoot.Spec.Provider.Workers[0].Maximum
+		)
+
+		ginkgo.By("updating shoot spec for test")
+		// set clusterautoscaler params to lower values so we don't have to wait too long
+		// and ensure the worker pool has maximum > minimum
+		err := f.UpdateShoot(ctx, func(s *corev1beta1.Shoot) error {
+			if s.Spec.Kubernetes.ClusterAutoscaler == nil {
+				s.Spec.Kubernetes.ClusterAutoscaler = &corev1beta1.ClusterAutoscaler{}
+			}
+			s.Spec.Kubernetes.ClusterAutoscaler.ScaleDownDelayAfterAdd = &metav1.Duration{Duration: scaleDownDelayAfterAdd}
+			s.Spec.Kubernetes.ClusterAutoscaler.ScaleDownUnneededTime = &metav1.Duration{Duration: scaleDownUnneededTime}
+
+			if origMaxWorkers != origMinWorkers+1 {
+				s.Spec.Provider.Workers[0].Maximum = origMinWorkers + 1
+			}
+
+			return nil
+		})
+		framework.ExpectNoError(err)
+
+		// reset shoot spec to original values after test
+		defer func() {
+			ginkgo.By("reverting shoot spec changes by test")
+			err := f.UpdateShoot(ctx, func(s *corev1beta1.Shoot) error {
+				s.Spec.Kubernetes.ClusterAutoscaler = origClusterAutoscalerConfig
+				s.Spec.Provider.Workers[0].Maximum = origMaxWorkers
+
+				return nil
+			})
+			framework.ExpectNoError(err)
+		}()
+
+		nodeList, err := framework.GetAllNodesInWorkerPool(ctx, f.ShootClient, &workerPoolName)
+		framework.ExpectNoError(err)
+
+		origNodeCount := len(nodeList.Items)
+		gomega.Expect(origNodeCount).To(gomega.BeEquivalentTo(origMinWorkers), "shoot should have minimum node count before the test")
+
+		ginkgo.By("creating reserve-capacity deployment")
+		// take half the node allocatable capacity as requests for the deployment
+		nodeAllocatable := nodeList.Items[0].Status.Allocatable
+		requestCPUMilli := nodeAllocatable.Cpu().ScaledValue(resource.Milli) / 2
+		requestMemoryMegs := nodeAllocatable.Memory().ScaledValue(resource.Mega) / 2
+
+		values := reserveCapacityValues{
+			Name:      reserveCapacityDeploymentName,
+			Namespace: reserveCapacityDeploymentNamespace,
+			Replicas:  origMinWorkers,
+			Requests: struct {
+				CPU    string
+				Memory string
+			}{
+				CPU:    resource.NewScaledQuantity(requestCPUMilli, resource.Milli).String(),
+				Memory: resource.NewScaledQuantity(requestMemoryMegs, resource.Mega).String(),
+			},
+			WorkerPool: workerPoolName,
+		}
+		err = f.RenderAndDeployTemplate(ctx, f.ShootClient, reserveCapacityTemplateName, values)
+		framework.ExpectNoError(err)
+
+		defer func() {
+			ginkgo.By("deleting reserve-capacity deployment")
+			err = framework.DeleteResource(ctx, f.ShootClient, &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: reserveCapacityDeploymentNamespace,
+					Name:      reserveCapacityDeploymentName,
+				},
+			})
+			framework.ExpectNoError(err)
+		}()
+
+		err = f.WaitUntilDeploymentIsReady(ctx, values.Name, values.Namespace, f.ShootClient)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("scaling up reserve-capacity deployment")
+		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.Client(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, origMinWorkers+1)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("one node should be added to the worker pool")
+		err = framework.WaitForNNodesToBeHealthyInWorkerPool(ctx, f.ShootClient, int(origMinWorkers+1), &workerPoolName, scaleUpTimeout)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("reserve-capacity deployment should get healthy again")
+		err = f.WaitUntilDeploymentIsReady(ctx, values.Name, values.Namespace, f.ShootClient)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("scaling down reserve-capacity deployment")
+		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.Client(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, origMinWorkers)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("one node should be removed from the worker pool")
+		err = framework.WaitForNNodesToBeHealthyInWorkerPool(ctx, f.ShootClient, int(origMinWorkers), &workerPoolName, scaleDownTimeout)
+		framework.ExpectNoError(err)
+	}, testTimeout)
+
+})
+
+type reserveCapacityValues struct {
+	Name      string
+	Namespace string
+	Replicas  int32
+	Requests  struct {
+		CPU    string
+		Memory string
+	}
+	WorkerPool string
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a clusterautoscaler test to the shoot integration test suite.

The test creates a `reserve-capacity` deployment, which requests half of the Node's allocatable capacity. It then scales up the deployment and waits for one new node to be added to the cluster. And then it scales down the deployment again and waits for one node to be removed from the cluster.

**Which issue(s) this PR fixes**:
Part of #1564

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
