### PR TITLE
Prevent kyma addon to pick to wrong kyma version

### DIFF
--- a/charts/shoot-addons-kyma/values.yaml
+++ b/charts/shoot-addons-kyma/values.yaml
@@ -1,13 +1,2 @@
 kyma:
   enabled: false
-  jobs:
-    image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20190325-ff66a3a
-    delay: 30
-  kyma:
-    version: "1.8.0"
-    subdomain: "kyma"
-  requires:
-    k8s:
-      version: "1.15"
-    gardener:
-      extensions: "shoot-cert-service,shoot-dns-service"


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the master branch of g/g tries to install kyma@1.8.0 which fails. As of #1935 the correct version should be kyma@1.10. Currently the parent `values.yaml` has 1.8.0 and the subchart ` values.yaml` has 1.10.0. Looks like the value in the parent chart is overriding the value in the subchart. 
The PR just removes the parent values to avoid double-maintenance and to have the charts applied with the correct kyma version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
An issue preventing kyma 1.10.0 to be installed is now fixed.
```
