### PR TITLE
Upgrade HVPA version to 0.2.2

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -220,4 +220,4 @@ images:
 - name: hvpa-controller
   sourceRepository: github.com/gardener/hvpa-controller
   repository: eu.gcr.io/gardener-project/gardener/hvpa-controller
-  tag: "v0.2.1"
+  tag: "v0.2.2"


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade HVPA version to 0.2.2

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
``` improvement operator github.com/gardener/hvpa-controller #58 @ggaurav10
Consider HPA to be limited if we have seen oomkill or liveness probe fails already. This change makes HVPA controller scale the app vertically more actively, ignoring the HPA's status condition type `ScalingLimited`.
```
