### PR TITLE
[release-v1.1] Prevent kyma addon to pick to wrong kyma version

### DIFF
--- a/charts/shoot-addons-kyma/values.yaml
+++ b/charts/shoot-addons-kyma/values.yaml
@@ -1,13 +1,2 @@
 kyma:
   enabled: false
-  jobs:
-    image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20190325-ff66a3a
-    delay: 30
-  kyma:
-    version: "1.8.0"
-    subdomain: "kyma"
-  requires:
-    k8s:
-      version: "1.15"
-    gardener:
-      extensions: "shoot-cert-service,shoot-dns-service"


### PR DESCRIPTION
]**What this PR does / why we need it**:
Cherry-pick of #2028 into release-v1.1.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
An issue preventing kyma 1.10.0 to be installed is now fixed.
```
