### PR TITLE
Allow project members to update Role and RoleBindings

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -187,6 +187,20 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 
 # Cluster role setting the permissions for a project viewer. It gets bound by a RoleBinding
 # in a respective project namespace.
@@ -244,6 +258,15 @@ rules:
   - settings.gardener.cloud
   resources:
   - openidconnectpresets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
   verbs:
   - get
   - list

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -76,10 +76,11 @@ func (f *GardenControllerFactory) Run(ctx context.Context) {
 		seedInformer                   = f.k8sGardenCoreInformers.Core().V1beta1().Seeds().Informer()
 		shootInformer                  = f.k8sGardenCoreInformers.Core().V1beta1().Shoots().Informer()
 		// Kubernetes core informers
-		configMapInformer = f.k8sInformers.Core().V1().ConfigMaps().Informer()
-		csrInformer       = f.k8sInformers.Certificates().V1beta1().CertificateSigningRequests().Informer()
-		namespaceInformer = f.k8sInformers.Core().V1().Namespaces().Informer()
-		secretInformer    = f.k8sInformers.Core().V1().Secrets().Informer()
+		configMapInformer   = f.k8sInformers.Core().V1().ConfigMaps().Informer()
+		csrInformer         = f.k8sInformers.Certificates().V1beta1().CertificateSigningRequests().Informer()
+		namespaceInformer   = f.k8sInformers.Core().V1().Namespaces().Informer()
+		secretInformer      = f.k8sInformers.Core().V1().Secrets().Informer()
+		rolebindingInformer = f.k8sInformers.Rbac().V1().RoleBindings().Informer()
 	)
 
 	f.k8sGardenCoreInformers.Start(ctx.Done())
@@ -88,7 +89,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) {
 	}
 
 	f.k8sInformers.Start(ctx.Done())
-	if !cache.WaitForCacheSync(ctx.Done(), configMapInformer.HasSynced, csrInformer.HasSynced, namespaceInformer.HasSynced, secretInformer.HasSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), configMapInformer.HasSynced, csrInformer.HasSynced, namespaceInformer.HasSynced, secretInformer.HasSynced, rolebindingInformer.HasSynced) {
 		panic("Timed out waiting for Kube caches to sync")
 	}
 

--- a/pkg/controllermanager/controller/project/project_control_test.go
+++ b/pkg/controllermanager/controller/project/project_control_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+import (
+	gardenercore "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
+	"github.com/gardener/gardener/pkg/logger"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/pointer"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("#rolebindingDelete", func() {
+	const (
+		ns = "test"
+	)
+	var (
+		c           *Controller
+		indexer     cache.Indexer
+		queue       workqueue.RateLimitingInterface
+		proj        *gardenercore.Project
+		rolebinding *rbacv1.RoleBinding
+	)
+
+	BeforeEach(func() {
+		// This should not be here!!! Hidden dependency!!!
+		logger.Logger = logger.NewNopLogger()
+
+		indexer = cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+		queue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+		proj = &gardenercore.Project{
+			ObjectMeta: metav1.ObjectMeta{Name: "project-1"},
+			Spec: gardenercore.ProjectSpec{
+				Namespace: pointer.StringPtr(ns),
+			},
+		}
+		rolebinding = &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "role-1", Namespace: ns},
+		}
+		c = &Controller{
+			projectLister: gardencorelisters.NewProjectLister(indexer),
+			projectQueue:  queue,
+		}
+	})
+
+	It("should not requeue random rolebinding", func() {
+		Expect(indexer.Add(proj)).ToNot(HaveOccurred())
+
+		c.rolebindingDelete(rolebinding)
+
+		Expect(queue.Len()).To(Equal(0), "no items in the queue")
+	})
+
+	DescribeTable("requeue when rolebinding is",
+		func(rolebindingName string) {
+			rolebinding.Name = rolebindingName
+			Expect(indexer.Add(proj)).ToNot(HaveOccurred())
+
+			c.rolebindingDelete(rolebinding)
+
+			Expect(queue.Len()).To(Equal(1), "only one item in queue")
+			actual, _ := queue.Get()
+			Expect(actual).To(Equal("project-1"))
+		},
+
+		Entry("project-member", "gardener.cloud:system:project-member"),
+		Entry("project-viewer", "gardener.cloud:system:project-viewer"),
+		Entry("custom role", "gardener.cloud:extension:project:project-1:foo"),
+	)
+
+	DescribeTable("no requeue when project is being deleted and rolebinding is",
+		func(rolebindingName string) {
+			now := metav1.Now()
+			proj.DeletionTimestamp = &now
+			rolebinding.Name = rolebindingName
+			Expect(indexer.Add(proj)).ToNot(HaveOccurred())
+
+			c.rolebindingDelete(rolebinding)
+
+			Expect(queue.Len()).To(Equal(0), "no projects in queue")
+		},
+
+		Entry("project-member", "gardener.cloud:system:project-member"),
+		Entry("project-viewer", "gardener.cloud:system:project-viewer"),
+		Entry("custom role", "gardener.cloud:extension:project:project-1:foo"),
+	)
+
+	It("should requeue multiple projects with the same namespace", func() {
+		rolebinding.Name = "gardener.cloud:system:project-member"
+		proj2 := proj.DeepCopy()
+		proj2.Name = "project-2"
+		Expect(indexer.Add(proj)).ToNot(HaveOccurred())
+		Expect(indexer.Add(proj2)).ToNot(HaveOccurred())
+
+		c.rolebindingDelete(rolebinding)
+
+		Expect(queue.Len()).To(Equal(2), "two items in queue")
+		actual, _ := queue.Get()
+		Expect(actual).To(Equal("project-1"))
+		actual, _ = queue.Get()
+		Expect(actual).To(Equal("project-2"))
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows project members to define their own `Role` and `RoleBindings`. 

Privilege escalation is prevented by the [RBAC API](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping).

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

Continuation of #1865

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Project members are now allowed to define their own `Roles` and `RoleBindings` to further customize the access to the resources in their Project namespace. 
```

```noteworthy user
Project viewers are now allowed to view `Roles` and `RoleBindings` in their Project namespace. 
```