### PR TITLE
Allow injecting image vector overwrite into etcd-druid

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/configmap-imagevector-overwrite-components.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/configmap-imagevector-overwrite-components.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.global.gardenlet.enabled .Values.global.gardenlet.componentImageVectorOverwrites }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gardenlet-imagevector-overwrite-components
+  namespace: garden
+  labels:
+    app: gardener
+    role: gardenlet
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  components.yaml: |
+{{ .Values.global.gardenlet.componentImageVectorOverwrites | indent 4 }}
+{{- end }}

--- a/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
         {{- if .Values.global.gardenlet.imageVectorOverwrite }}
         checksum/configmap-gardenlet-imagevector-overwrite: {{ include (print $.Template.BasePath "/configmap-imagevector-overwrite.yaml") . | sha256sum }}
         {{- end }}
+        {{- if .Values.global.gardenlet.componentImageVectorOverwrites }}
+        checksum/configmap-gardenlet-imagevector-overwrite-components: {{ include (print $.Template.BasePath "/configmap-imagevector-overwrite-components.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig }}
         checksum/secret-gardenlet-kubeconfig-garden-bootstrap: {{ include (print $.Template.BasePath "/secret-kubeconfig-garden-bootstrap.yaml") . | sha256sum }}
         {{- end }}
@@ -71,11 +74,15 @@ spec:
         command:
         - /gardenlet
         - --config=/etc/gardenlet/config/config.yaml
-        {{- if or .Values.global.gardenlet.env .Values.global.gardenlet.imageVectorOverwrite }}
+        {{- if or .Values.global.gardenlet.env .Values.global.gardenlet.imageVectorOverwrite .Values.global.gardenlet.componentImageVectorOverwrites }}
         env:
         {{- if .Values.global.gardenlet.imageVectorOverwrite }}
         - name: IMAGEVECTOR_OVERWRITE
           value: /charts_overwrite/images_overwrite.yaml
+        {{- end }}
+        {{- if .Values.global.gardenlet.componentImageVectorOverwrites }}
+        - name: IMAGEVECTOR_OVERWRITE_COMPONENTS
+          value: /charts_overwrite_components/components.yaml
         {{- end }}
         {{- range $index, $value := .Values.global.gardenlet.env }}
         {{- if not (empty $value) }}
@@ -110,6 +117,11 @@ spec:
           mountPath: /charts_overwrite
           readOnly: true
         {{- end }}
+        {{- if .Values.global.gardenlet.componentImageVectorOverwrites }}
+        - name: gardenlet-imagevector-overwrite-components
+          mountPath: /charts_overwrite_components
+          readOnly: true
+        {{- end }}
         - name: gardenlet-config
           mountPath: /etc/gardenlet/config
 {{- if .Values.global.gardenlet.additionalVolumeMounts }}
@@ -131,6 +143,11 @@ spec:
       - name: gardenlet-imagevector-overwrite
         configMap:
           name: gardenlet-imagevector-overwrite
+      {{- end }}
+      {{- if .Values.global.gardenlet.componentImageVectorOverwrites }}
+      - name: gardenlet-imagevector-overwrite-components
+        configMap:
+          name: gardenlet-imagevector-overwrite-components
       {{- end }}
       - name: gardenlet-config
         configMap:

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -24,6 +24,8 @@ global:
     vpa: false
   # imageVectorOverwrite: |
   #  Please find documentation in docs/deployment/image_vector.md
+  # componentImageVectorOverwrites: |
+  #  Please find documentation in docs/deployment/image_vector.md
     config:
       gardenClientConnection:
         acceptContentTypes: application/json

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -14,12 +14,31 @@ images:
   sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
   repository: gcr.io/google_containers/pause-amd64
   tag: "3.1"
+- name: etcd-druid
+  sourceRepository: github.com/gardener/etcd-druid
+  repository: eu.gcr.io/gardener-project/gardener/etcd-druid
+  tag: "v0.1.3"
+- name: gardener-resource-manager
+  sourceRepository: github.com/gardener/gardener-resource-manager
+  repository: eu.gcr.io/gardener-project/gardener/gardener-resource-manager
+  tag: "v0.12.0"
+- name: dependency-watchdog
+  sourceRepository: github.com/gardener/dependency-watchdog
+  repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog
+  tag: "0.4.0"
 
 # Seed controlplane
 - name: etcd
   sourceRepository: github.com/etcd-io/etcd
   repository: quay.io/coreos/etcd
   tag: v3.3.17
+- name: etcd-backup-restore
+  sourceRepository: github.com/gardener/etcd-backup-restore
+  repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
+  tag: "0.8.0"
+- name: hyperkube # used for kubectl + kubelet binaries on the worker nodes
+  sourceRepository: github.com/kubernetes/kubernetes
+  repository: k8s.gcr.io/hyperkube
 - name: kube-apiserver
   sourceRepository: github.com/kubernetes/kubernetes
   repository: k8s.gcr.io/hyperkube
@@ -52,33 +71,14 @@ images:
   sourceRepository: github.com/kubernetes/kubernetes
   repository: k8s.gcr.io/kube-proxy
   targetVersion: ">= 1.17"
-- name: etcd-backup-restore
-  sourceRepository: github.com/gardener/etcd-backup-restore
-  repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "0.8.0"
-- name: etcd-druid
-  sourceRepository: github.com/gardener/etcd-druid
-  repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.1.3"
-- name: hyperkube # used for kubectl + kubelet binaries on the worker nodes
-  sourceRepository: github.com/kubernetes/kubernetes
-  repository: k8s.gcr.io/hyperkube
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
   tag: "0.7.0"
-- name: gardener-resource-manager
-  sourceRepository: github.com/gardener/gardener-resource-manager
-  repository: eu.gcr.io/gardener-project/gardener/gardener-resource-manager
-  tag: "v0.12.0"
 - name: vpn-seed
   sourceRepository: github.com/gardener/vpn
   repository: eu.gcr.io/gardener-project/gardener/vpn-seed
   tag: "0.19.0"
-- name: dependency-watchdog
-  sourceRepository: github.com/gardener/dependency-watchdog
-  repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog
-  tag: "0.4.0"
 
 # Monitoring
 - name: alertmanager

--- a/charts/seed-bootstrap/charts/etcd-druid/templates/configmap-imagevector-overwrite.yaml
+++ b/charts/seed-bootstrap/charts/etcd-druid/templates/configmap-imagevector-overwrite.yaml
@@ -1,0 +1,14 @@
+{{- if index .Values.global "imageVectorOverwrites" }}
+{{- if index .Values.global.imageVectorOverwrites "etcd-druid" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etcd-druid-imagevector-overwrite
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ toYaml .Values.labels | indent 4 }}
+data:
+  images_overwrite.yaml: |
+{{ (index .Values.global.imageVectorOverwrites "etcd-druid") | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/seed-bootstrap/charts/etcd-druid/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/etcd-druid/templates/controller-deployment.yaml
@@ -15,6 +15,11 @@ spec:
     metadata:
       labels:
         gardener.cloud/role: etcd-druid
+        {{- if index .Values.global "imageVectorOverwrites" }}
+        {{- if index .Values.global.imageVectorOverwrites "etcd-druid" }}
+        checksum/configmap-imagevector-overwrite: {{ include (print $.Template.BasePath "/configmap-imagevector-overwrite.yaml") . | sha256sum | trunc 63 }}
+        {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: etcd-druid
       containers:
@@ -22,8 +27,15 @@ spec:
         image: {{ index .Values.global.images "etcd-druid" }}
         imagePullPolicy: IfNotPresent
         command:
-          - /bin/etcd-druid
-          - --enable-leader-election=true
+        - /bin/etcd-druid
+        - --enable-leader-election=true
+        {{- if index .Values.global "imageVectorOverwrites" }}
+        {{- if index .Values.global.imageVectorOverwrites "etcd-druid" }}
+        env:
+        - name: IMAGEVECTOR_OVERWRITE
+          value: /charts_overwrite/images_overwrite.yaml
+        {{- end }}
+        {{- end }}
         resources:
           limits:
             cpu: 500m
@@ -33,3 +45,19 @@ spec:
             memory: 256Mi
         ports:
         - containerPort: 9569
+        {{- if index .Values.global "imageVectorOverwrites" }}
+        {{- if index .Values.global.imageVectorOverwrites "etcd-druid" }}
+        volumeMounts:
+        - name: imagevector-overwrite
+          mountPath: /charts_overwrite
+          readOnly: true
+        {{- end }}
+        {{- end }}
+      {{- if index .Values.global "imageVectorOverwrites" }}
+      {{- if index .Values.global.imageVectorOverwrites "etcd-druid" }}
+      volumes:
+      - name: imagevector-overwrite
+        configMap:
+          name: etcd-druid-imagevector-overwrite
+      {{- end }}
+      {{- end }}

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -156,6 +156,10 @@ global:
     vpa-updater: image-repository:image-tag
     hvpa-controller: image-repository:image-tag
 
+  imageVectorOverwrites: {}
+#   etcd-druid: |
+#     Please find documentation in docs/deployment/image_vector.md
+
   elasticsearchPorts:
     db: 9200
     transport: 9300

--- a/docs/deployment/image_vector.md
+++ b/docs/deployment/image_vector.md
@@ -86,3 +86,25 @@ spec:
           name: gardenlet-images-overwrite
   ...
 ```
+
+## Image vectors for dependent components
+
+The gardenlet is deploying a lot of different components that might deploy other images themselves.
+These components might use an image vector as well.
+Operators might want to customize the image locations for these transitive images as well, hence, they might need to specify an image vector overwrite for the components directly deployed by Gardener.
+
+It is possible to specify the `IMAGEVECTOR_OVERWRITE_COMPONENTS` environment variable to the gardenlet that points to a file with the following content:
+
+```yaml
+components:
+- name: etcd-druid
+  imageVectorOverwrite: |
+    images:
+    - name: etcd
+      tag: v1.2.3
+      repository: etcd/etcd
+...
+``` 
+
+The gardenlet will, if supported by the directly deployed component (`etcd-druid` in this example), inject the given `imageVectorOverwrite` into the `Deployment` manifest.
+The respective component is responsible for using the overwritten images instead of its defaults.

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
@@ -466,8 +466,8 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 			kindTypes := computeKindTypesForBackupEntries(nopLogger, backupEntryList, buckets, seedName)
 
 			Expect(kindTypes).To(Equal(sets.NewString(
-				extensionsv1alpha1.BackupEntryResource + "/" + backupBucket1.Spec.Provider.Type,
-				extensionsv1alpha1.BackupEntryResource + "/" + backupBucket2.Spec.Provider.Type,
+				extensionsv1alpha1.BackupEntryResource+"/"+backupBucket1.Spec.Provider.Type,
+				extensionsv1alpha1.BackupEntryResource+"/"+backupBucket2.Spec.Provider.Type,
 			)))
 		})
 	})

--- a/pkg/gardenlet/controller/seed/seed.go
+++ b/pkg/gardenlet/controller/seed/seed.go
@@ -80,6 +80,7 @@ func NewSeedController(
 	kubeInformerFactory kubeinformers.SharedInformerFactory,
 	secrets map[string]*corev1.Secret,
 	imageVector imagevector.ImageVector,
+	componentImageVectors imagevector.ComponentImageVectors,
 	identity *gardencorev1beta1.Gardener,
 	config *config.GardenletConfiguration,
 	recorder record.EventRecorder,
@@ -100,7 +101,7 @@ func NewSeedController(
 	seedController := &Controller{
 		k8sGardenClient:         k8sGardenClient,
 		k8sGardenCoreInformers:  gardenCoreInformerFactory,
-		control:                 NewDefaultControl(k8sGardenClient, gardenCoreInformerFactory, secrets, imageVector, identity, recorder, config, secretLister, shootLister),
+		control:                 NewDefaultControl(k8sGardenClient, gardenCoreInformerFactory, secrets, imageVector, componentImageVectors, identity, recorder, config, secretLister, shootLister),
 		heartbeatControl:        NewDefaultHeartbeatControl(k8sGardenClient, gardenCoreV1beta1Informer, identity, config),
 		extensionCheckControl:   NewDefaultExtensionCheckControl(k8sGardenClient.GardenCore(), controllerInstallationLister, metav1.Now),
 		config:                  config,

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -122,6 +122,7 @@ func NewDefaultControl(
 	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory,
 	secrets map[string]*corev1.Secret,
 	imageVector imagevector.ImageVector,
+	componentImageVectors imagevector.ComponentImageVectors,
 	identity *gardencorev1beta1.Gardener,
 	recorder record.EventRecorder,
 	config *config.GardenletConfiguration,
@@ -133,6 +134,7 @@ func NewDefaultControl(
 		k8sGardenCoreInformers,
 		secrets,
 		imageVector,
+		componentImageVectors,
 		identity,
 		recorder,
 		config,
@@ -146,6 +148,7 @@ type defaultControl struct {
 	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory
 	secrets                map[string]*corev1.Secret
 	imageVector            imagevector.ImageVector
+	componentImageVectors  imagevector.ComponentImageVectors
 	identity               *gardencorev1beta1.Gardener
 	recorder               record.EventRecorder
 	config                 *config.GardenletConfiguration
@@ -323,7 +326,7 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 	if gardencorev1beta1helper.TaintsHave(seedObj.Info.Spec.Taints, gardencorev1beta1.SeedTaintDisableCapacityReservation) {
 		seedObj.MustReserveExcessCapacity(false)
 	}
-	if err := seedpkg.BootstrapCluster(c.k8sGardenClient, seedObj, c.config, c.secrets, c.imageVector); err != nil {
+	if err := seedpkg.BootstrapCluster(c.k8sGardenClient, seedObj, c.config, c.secrets, c.imageVector, c.componentImageVectors); err != nil {
 		conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "BootstrappingFailed", err.Error())
 		c.updateSeedStatus(seed, seedKubernetesVersion, conditionSeedBootstrapped)
 		seedLogger.Errorf("Seed bootstrapping failed: %+v", err)

--- a/pkg/gardenlet/controller/shoot/seed_registration_control.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control.go
@@ -590,6 +590,15 @@ func deployGardenlet(ctx context.Context, k8sGardenClient kubernetes.Interface, 
 		imageVectorOverwrite = string(data)
 	}
 
+	var componentImageVectorOverwrites string
+	if overWritePath := os.Getenv(imagevector.ComponentOverrideEnv); len(overWritePath) > 0 {
+		data, err := ioutil.ReadFile(overWritePath)
+		if err != nil {
+			return err
+		}
+		componentImageVectorOverwrites = string(data)
+	}
+
 	var (
 		repository = gardenletImage.String()
 		tag        = version.Get().GitVersion
@@ -606,9 +615,10 @@ func deployGardenlet(ctx context.Context, k8sGardenClient kubernetes.Interface, 
 					"repository": repository,
 					"tag":        tag,
 				},
-				"revisionHistoryLimit": 0,
-				"vpa":                  true,
-				"imageVectorOverwrite": imageVectorOverwrite,
+				"revisionHistoryLimit":           0,
+				"vpa":                            true,
+				"imageVectorOverwrite":           imageVectorOverwrite,
+				"componentImageVectorOverwrites": componentImageVectorOverwrites,
 				"config": map[string]interface{}{
 					"gardenClientConnection": map[string]interface{}{
 						"acceptContentTypes":   externalConfig.GardenClientConnection.AcceptContentTypes,

--- a/pkg/utils/imagevector/imagevector_components.go
+++ b/pkg/utils/imagevector/imagevector_components.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package imagevector
+
+import (
+	"io"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	// ComponentOverrideEnv is the name of the environment variable for image vector overrides of components deployed
+	// by Gardener.
+	ComponentOverrideEnv = "IMAGEVECTOR_OVERWRITE_COMPONENTS"
+)
+
+// ReadComponentOverwrite reads an ComponentImageVector from the given io.Reader.
+func ReadComponentOverwrite(r io.Reader) (ComponentImageVectors, error) {
+	data := struct {
+		Components []ComponentImageVector `json:"components" yaml:"components"`
+	}{}
+
+	if err := yaml.NewDecoder(r).Decode(&data); err != nil {
+		return nil, err
+	}
+
+	out := make(ComponentImageVectors, len(data.Components))
+	for _, component := range data.Components {
+		out[component.Name] = component.ImageVectorOverwrite
+	}
+
+	return out, nil
+}
+
+// ReadComponentOverwriteFile reads an ComponentImageVector from the file with the given name.
+func ReadComponentOverwriteFile(name string) (ComponentImageVectors, error) {
+	file, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	return ReadComponentOverwrite(file)
+}

--- a/pkg/utils/imagevector/imagevector_components_test.go
+++ b/pkg/utils/imagevector/imagevector_components_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package imagevector_test
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/gardener/gardener/pkg/utils/imagevector"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("imagevector", func() {
+	Describe("#ComponentImageVectors", func() {
+		var (
+			component1     = "foo"
+			componentData1 = "some-data"
+
+			component2     = "bar"
+			componentData2 = "some-other-data"
+
+			componentImageVectors = ComponentImageVectors{
+				component1: componentData1,
+				component2: componentData2,
+			}
+
+			componentImagesJSON = fmt.Sprintf(`
+{
+	"components": [
+		{
+			"name": "%s",
+			"imageVectorOverwrite": "%s"
+		},
+		{
+			"name": "%s",
+			"imageVectorOverwrite": "%s"
+		},
+	]
+}`, component1, componentData1, component2, componentData2)
+
+			componentImagesYAML = fmt.Sprintf(`
+components:
+- name: %s
+  imageVectorOverwrite: %s
+- name: %s
+  imageVectorOverwrite: %s
+`, component1, componentData1, component2, componentData2)
+		)
+
+		Describe("#Read", func() {
+			It("should successfully read a JSON image vector", func() {
+				vector, err := ReadComponentOverwrite(strings.NewReader(componentImagesJSON))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(vector).To(Equal(componentImageVectors))
+			})
+
+			It("should successfully read a YAML image vector", func() {
+				vector, err := ReadComponentOverwrite(strings.NewReader(componentImagesYAML))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(vector).To(Equal(componentImageVectors))
+			})
+		})
+
+		Describe("#ReadFile", func() {
+			It("should successfully read the file and close it", func() {
+				tmpFile, cleanup := withTempFile("component imagevector", []byte(componentImagesJSON))
+				defer cleanup()
+
+				vector, err := ReadComponentOverwriteFile(tmpFile.Name())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(vector).To(Equal(componentImageVectors))
+			})
+		})
+	})
+})

--- a/pkg/utils/imagevector/imagevector_test.go
+++ b/pkg/utils/imagevector/imagevector_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("imagevector", func() {
@@ -361,7 +362,7 @@ images:
 					}
 				)
 
-				image := source.ToImage(stringPtr("1.8.0"))
+				image := source.ToImage(pointer.StringPtr("1.8.0"))
 
 				Expect(image).To(Equal(&Image{
 					Name:       name,
@@ -387,7 +388,7 @@ images:
 				Expect(image).To(Equal(&Image{
 					Name:       name,
 					Repository: repository,
-					Tag:        stringPtr(fmt.Sprintf("v%s", version)),
+					Tag:        pointer.StringPtr(fmt.Sprintf("v%s", version)),
 				}))
 			})
 		})
@@ -407,8 +408,4 @@ func withTempFile(pattern string, data []byte) (*os.File, func()) {
 			GinkgoT().Logf("Could not delete temp file %q: %v", tmpFile.Name(), err)
 		}
 	}
-}
-
-func stringPtr(s string) *string {
-	return &s
 }

--- a/pkg/utils/imagevector/types.go
+++ b/pkg/utils/imagevector/types.go
@@ -40,6 +40,15 @@ type Image struct {
 // ImageVector is a list of image sources.
 type ImageVector []*ImageSource
 
+// ComponentImageVector contains an image vector overwrite for a component deployed by Gardener.
+type ComponentImageVector struct {
+	Name                 string `json:"name" yaml:"name"`
+	ImageVectorOverwrite string `json:"imageVectorOverwrite" yaml:"imageVectorOverwrite"`
+}
+
+// ComponentImageVectors maps a component with a given name (key) to the image vector overwrite content (value).
+type ComponentImageVectors map[string]string
+
 // FindOptions are options that can be supplied during either `FindImage` or `FindImages`.
 type FindOptions struct {
 	RuntimeVersion *string


### PR DESCRIPTION
**What this PR does / why we need it**:
With #1762 we have introduced the etcd-druid in `v0.1.3` which is responsible for deploying the etcd `StatefulSet`s, `ConfigMap`s, etc. However, we are still controlling both etcd and the backup-restore sidecar image versions in our `charts/images.yaml`. This is quite dangerous as these versions might not fit to the manifests/configuration applied by the etcd-druid. Instead, it's better to let the etcd-druid control the versions.

@georgekuruvillak is working on etcd-druid side to also support an image vector, similar to Gardener. Consequently, it would also support an image vector overwrite in case an operator wants to customize the image locations. However, so far there is no mechanism to provide such an image vector overwrite to components that are deployed by Gardener.

This PR allows to specify image vector overwrites for components directly deployed by Gardenlet that support image vector overwritings (planned only for etcd-druid, right now).

**Special notes for your reviewer**:
In its current `v0.1.3` version, the etcd-druid is not yet capable of picking up the images from the provided overwrite. @georgekuruvillak is working on introducing the same, and once a new etcd-druid lands in g/g we can remove both `etcd` and `backup-restore` images from our `charts/images.yaml`. Together with this change the `Etcd` will no longer contain `.spec.etcd.image` and `.spec.backup.image` - instead, the druid will implicitly control which images are deployed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
It is now possible to specify an image vector overwrite for image vectors of components directly deployed by Gardener (e.g., the etcd-druid will have its own image vector in the future that operators might want to overwrite with custom image locations). Please consult [this document](https://github.com/gardener/gardener/blob/master/docs/deployment/image_vector.md#image-vectors-for-dependent-components) to get more information.
```
