### PR TITLE
Upgrade github.com/gardener/hvpa-controller to v0.2.4

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -220,4 +220,4 @@ images:
 - name: hvpa-controller
   sourceRepository: github.com/gardener/hvpa-controller
   repository: eu.gcr.io/gardener-project/gardener/hvpa-controller
-  tag: "v0.2.2"
+  tag: "v0.2.4"


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade github.com/gardener/hvpa-controller to v0.2.4

**Which issue(s) this PR fixes**:
Fixes [gardener/hvpa-controller#60](https://github.com/gardener/hvpa-controller/issues/60).

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
``` improvement operator github.com/gardener/hvpa-controller #62 @amshuman-kr
Ignore `minChange` configuration while overriding scale up stabilisation. This ensures that full VPA recommendations are applied in case the target pods are OOMKilled or restarted due to livenessProbe failure, no matter what.
```