### PR TITLE
add network policies

### DIFF
--- a/charts/shoot-core/components/charts/metrics-server/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/metrics-server/templates/deployment.yaml
@@ -17,6 +17,10 @@ spec:
     metadata:
       name: metrics-server
       labels:
+        networking.gardener.cloud/from-seed: allowed
+        networking.gardener.cloud/to-apiserver: allowed
+        networking.gardener.cloud/to-dns: allowed
+        networking.gardener.cloud/to-kubelet: allowed
         garden.sapcloud.io/role: system-component
         k8s-app: metrics-server
         origin: gardener

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -43,6 +43,8 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
       labels:
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/from-seed: allowed
         garden.sapcloud.io/role: monitoring
         origin: gardener
         component: node-exporter

--- a/charts/shoot-core/components/charts/network-policies/templates/allow-from-to-nginx.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-from-to-nginx.yaml
@@ -1,0 +1,21 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  annotations:
+    gardener.cloud/description: |
+      Allows all Egress and Ingress for the nginx-controller
+  name: gardener.cloud--allow-to-from-nginx
+  namespace: kube-system
+  labels:
+    origin: gardener
+spec:
+  podSelector:
+    matchLabels:
+      app: nginx-ingress
+  policyTypes:
+  - Ingress
+  - Egress
+  egress:
+  - {}
+  ingress:
+  - {}

--- a/charts/shoot-core/components/charts/network-policies/templates/allow-to-api-server.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-to-api-server.yaml
@@ -1,0 +1,20 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  annotations:
+    gardener.cloud/description: |
+      Allows traffic to api server in TCP Port 443
+  name: gardener.cloud--allow-to-apiserver
+  namespace: kube-system
+  labels:
+    origin: gardener
+spec:
+  podSelector:
+    matchLabels:
+      networking.gardener.cloud/to-apiserver: allowed
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+  policyTypes:
+  - Egress

--- a/charts/shoot-core/components/charts/network-policies/templates/allow-to-kubelet.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-to-kubelet.yaml
@@ -1,0 +1,20 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  annotations:
+    gardener.cloud/description: |
+      Allows traffic to kubelet in TCP Port 10250
+  name: gardener.cloud--allow-to-kubelet
+  namespace: kube-system
+  labels:
+    origin: gardener
+spec:
+  podSelector:
+    matchLabels:
+      networking.gardener.cloud/to-kubelet: allowed
+  egress:
+  - ports:
+    - port: 10250
+      protocol: TCP
+  policyTypes:
+  - Egress


### PR DESCRIPTION
**What this PR does / why we need it**:
add network policies for following direction:
 - nginx-controller - from/to all

**Which issue(s) this PR fixes**:
Ref #565 (part of fixing)

**Special notes for your reviewer**:
cc @dansible 

**Release note**:

```noteworthy user
Every shoot cluster does now contain `NetworkPolicies` that allow the necessary traffic directions for the nginx-ingress-controller, metrics-server, and node-exporter.
```
