### PR TITLE
Update validation to allow worker.min to be 0

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -815,9 +815,6 @@ func ValidateWorker(worker core.Worker, fldPath *field.Path) field.ErrorList {
 	if worker.Maximum < worker.Minimum {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("maximum"), "maximum value must not be less or equal than minimum value"))
 	}
-	if worker.Maximum != 0 && worker.Minimum == 0 {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("minimum"), "minimum value must be >= 1 if maximum value > 0 (cluster-autoscaler cannot handle min=0)"))
-	}
 
 	allErrs = append(allErrs, ValidatePositiveIntOrPercent(worker.MaxSurge, fldPath.Child("maxSurge"))...)
 	allErrs = append(allErrs, ValidatePositiveIntOrPercent(worker.MaxUnavailable, fldPath.Child("maxUnavailable"))...)

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				MaxSurge:       &maxSurge,
 				MaxUnavailable: &maxUnavailable,
 			}
-			workerAutoScalingInvalid = core.Worker{
+			workerAutoScalingMinZero = core.Worker{
 				Name: "cpu-worker",
 				Machine: core.Machine{
 					Type: "large",
@@ -643,15 +643,12 @@ var _ = Describe("Shoot Validation Tests", func() {
 				))
 			})
 
-			It("should enforce workers min > 0 if max > 0", func() {
-				shoot.Spec.Provider.Workers = []core.Worker{workerAutoScalingInvalid, worker}
+			It("should allow workers min = 0 if max > 0", func() {
+				shoot.Spec.Provider.Workers = []core.Worker{workerAutoScalingMinZero, worker}
 
 				errorList := ValidateShoot(shoot)
 
-				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("spec.provider.workers[0].minimum"),
-				}))))
+				Expect(errorList).To(BeEmpty())
 			})
 
 			It("should allow workers having min=max=0 if at least one pool is active", func() {


### PR DESCRIPTION
**What this PR does / why we need it**: This PR updates the validation to allow setting worker.minimum to 0 when worker.Max is greater than 0. This change is motivated by the fact that cluster autoscaler now allows the scale to/from zero, only for AWS and Azure.

There is a known side effect of this change, we need to be aware of:
- This change will allow users to set worker.min to 0 for all the providers. As autoscaler can't yet scale up from zero for other providers[non-AWS/Azure], worker pools may get scaled-down to zero, but not scale up then.
- To mention, at the same time, the worker-validation is being implemented at provider-specific extension repositories, and that validation should mitigate this side-effect. eg. [openstack](https://github.com/gardener/gardener-extension-provider-openstack/pull/36), [gcp](https://github.com/gardener/gardener-extension-provider-gcp/pull/38) .
- Considering the immediate need for this feature, we could probably trade-off the side-effect knowing mitigation is on the way. Please suggest if you see an any better option, to achieve the same.

@petersutter On a side note, I am curious, if there could be any short-term mitigation we could do at the dashboard to allow setting worker.min to zero only for AWS and Azure, which could be reverted once provider-ext-repos are ready with validation. 

Related PR on CA: https://github.com/gardener/autoscaler/pull/26 

cc @rfranzke @timuthy 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**: 
- I hope, this is the only change needed to achieve what's described above, please let me know otherwise.
- I have not tested this on local gardener setup, please let me know if it's required. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Gardener now allows setting `minimum=0` for worker pools in the `Shoot`. However, not all providers might support it yet and setting it to `0` might cause undesired issues with the availability of the machines. As of today, only AWS and Azure are known to support it (will be extended to other providers in the future).
```
```action operator
As validation at the gardener now does not prevent the `worker.Minimum` to be zero while `worker.Maximum` is non-zero, it is recommended to install following provider extensions with the proper related validation enabled, to avoid incompatibility with cluster-autoscaler.  gardener-extension-provider-gcp: `v1.4.0`, gardener-extension-provider-alicloud: `v1.7.0`, gardener-extension-provider-openstack: `v1.4.0`.

```
