### PR TITLE
ExtensionValidation admission plugin

### DIFF
--- a/.ci/test
+++ b/.ci/test
@@ -50,6 +50,7 @@ if [[ ! -z "$COVERAGE" ]]; then
   COVER_FLAG="-cover"
 fi
 
+echo "Running ginkgo..."
 GO111MODULE=on ginkgo ${COVER_FLAG} -r -mod=vendor cmd pkg plugin
 
 ###############################################################################

--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gardener/gardener/pkg/version"
 	controllerregistrationresources "github.com/gardener/gardener/plugin/pkg/controllerregistration/resources"
 	"github.com/gardener/gardener/plugin/pkg/global/deletionconfirmation"
+	"github.com/gardener/gardener/plugin/pkg/global/extensionvalidation"
 	"github.com/gardener/gardener/plugin/pkg/global/resourcereferencemanager"
 	plantvalidator "github.com/gardener/gardener/plugin/pkg/plant"
 	shootdns "github.com/gardener/gardener/plugin/pkg/shoot/dns"
@@ -145,6 +146,7 @@ func (o *Options) complete() error {
 	// Admission plugin registration
 	resourcereferencemanager.Register(o.Recommended.Admission.Plugins)
 	deletionconfirmation.Register(o.Recommended.Admission.Plugins)
+	extensionvalidation.Register(o.Recommended.Admission.Plugins)
 	shootquotavalidator.Register(o.Recommended.Admission.Plugins)
 	shootdns.Register(o.Recommended.Admission.Plugins)
 	shootvalidator.Register(o.Recommended.Admission.Plugins)
@@ -156,6 +158,7 @@ func (o *Options) complete() error {
 
 	allOrderedPlugins := []string{
 		resourcereferencemanager.PluginName,
+		extensionvalidation.PluginName,
 		shootdns.PluginName,
 		shootquotavalidator.PluginName,
 		shootvalidator.PluginName,

--- a/pkg/apis/core/v1alpha1/helper/helper.go
+++ b/pkg/apis/core/v1alpha1/helper/helper.go
@@ -156,7 +156,7 @@ func IsResourceSupported(resources []gardencorev1alpha1.ControllerResource, reso
 func IsControllerInstallationSuccessful(controllerInstallation gardencorev1alpha1.ControllerInstallation) bool {
 	var (
 		installed bool
-		healthy bool
+		healthy   bool
 	)
 
 	for _, condition := range controllerInstallation.Status.Conditions {

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -155,7 +155,7 @@ func IsResourceSupported(resources []gardencorev1beta1.ControllerResource, resou
 func IsControllerInstallationSuccessful(controllerInstallation gardencorev1beta1.ControllerInstallation) bool {
 	var (
 		installed bool
-		healthy bool
+		healthy   bool
 	)
 
 	for _, condition := range controllerInstallation.Status.Conditions {

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -69,7 +69,7 @@ type OperatingSystemConfigList struct {
 type OperatingSystemConfigSpec struct {
 	// CRI config is a structure contains configurations of the CRI library
 	// +optional
-	CRIConfig *CRIConfig  `json:"criConfig,omitempty"`
+	CRIConfig *CRIConfig `json:"criConfig,omitempty"`
 	// DefaultSpec is a structure containing common fields used by all extension resources.
 	DefaultSpec `json:",inline"`
 	// Purpose describes how the result of this OperatingSystemConfig is used by Gardener. Either it

--- a/plugin/pkg/global/extensionvalidation/admission.go
+++ b/plugin/pkg/global/extensionvalidation/admission.go
@@ -1,0 +1,311 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensionvalidation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	corev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
+
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
+	"github.com/hashicorp/go-multierror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const (
+	// PluginName is the name of this admission plugin.
+	PluginName = "ExtensionValidator"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, NewFactory)
+}
+
+// NewFactory creates a new PluginFactory.
+func NewFactory(config io.Reader) (admission.Interface, error) {
+	return New()
+}
+
+// ExtensionValidator contains listers and admission handler.
+type ExtensionValidator struct {
+	*admission.Handler
+	controllerRegistrationLister corev1beta1listers.ControllerRegistrationLister
+	backupBucketLister           corev1beta1listers.BackupBucketLister
+	readyFunc                    admission.ReadyFunc
+}
+
+var (
+	_ = admissioninitializer.WantsExternalCoreInformerFactory(&ExtensionValidator{})
+
+	readyFuncs []admission.ReadyFunc
+)
+
+// New creates a new ExtensionValidator admission plugin.
+func New() (*ExtensionValidator, error) {
+	return &ExtensionValidator{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+	}, nil
+}
+
+// AssignReadyFunc assigns the ready function to the admission handler.
+func (e *ExtensionValidator) AssignReadyFunc(f admission.ReadyFunc) {
+	e.readyFunc = f
+	e.SetReadyFunc(f)
+}
+
+// SetExternalCoreInformerFactory sets the external garden core informer factory.
+func (e *ExtensionValidator) SetExternalCoreInformerFactory(f externalcoreinformers.SharedInformerFactory) {
+	controllerRegistrationInformer := f.Core().V1beta1().ControllerRegistrations()
+	e.controllerRegistrationLister = controllerRegistrationInformer.Lister()
+
+	backupBucketInformer := f.Core().V1beta1().BackupBuckets()
+	e.backupBucketLister = backupBucketInformer.Lister()
+
+	readyFuncs = append(readyFuncs, controllerRegistrationInformer.Informer().HasSynced, backupBucketInformer.Informer().HasSynced)
+}
+
+func (e *ExtensionValidator) waitUntilReady(attrs admission.Attributes) error {
+	// Wait until the caches have been synced
+	if e.readyFunc == nil {
+		e.AssignReadyFunc(func() bool {
+			for _, readyFunc := range readyFuncs {
+				if !readyFunc() {
+					return false
+				}
+			}
+			return true
+		})
+	}
+
+	if !e.WaitForReady() {
+		return admission.NewForbidden(attrs, errors.New("not yet ready to handle request"))
+	}
+
+	return nil
+}
+
+// ValidateInitialization checks whether the plugin was correctly initialized.
+func (e *ExtensionValidator) ValidateInitialization() error {
+	if e.controllerRegistrationLister == nil {
+		return errors.New("missing ControllerRegistration lister")
+	}
+	if e.backupBucketLister == nil {
+		return errors.New("missing BackupBucket lister")
+	}
+	return nil
+}
+
+var _ admission.ValidationInterface = &ExtensionValidator{}
+
+// Validate makes admissions decisions based on the extension types.
+func (e *ExtensionValidator) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	if err := e.waitUntilReady(a); err != nil {
+		return fmt.Errorf("err while waiting for ready %v", err)
+	}
+
+	switch a.GetKind().GroupKind() {
+	case core.Kind("BackupBucket"), core.Kind("BackupEntry"), core.Kind("Seed"), core.Kind("Shoot"):
+	default:
+		return nil
+	}
+
+	controllerRegistrationList, err := e.controllerRegistrationLister.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+
+	var (
+		kindToTypesMap  = computeRegisteredExtensionKindTypes(controllerRegistrationList)
+		validationError error
+	)
+
+	switch a.GetKind().GroupKind() {
+	case core.Kind("BackupBucket"):
+		backupBucket, ok := a.GetObject().(*core.BackupBucket)
+		if !ok {
+			return apierrors.NewBadRequest("could not convert resource into BackupBucket object")
+		}
+		validationError = e.validateBackupBucket(kindToTypesMap, backupBucket.Spec)
+
+	case core.Kind("BackupEntry"):
+		backupEntry, ok := a.GetObject().(*core.BackupEntry)
+		if !ok {
+			return apierrors.NewBadRequest("could not convert resource into BackupEntry object")
+		}
+		backupBucket, err := e.backupBucketLister.Get(backupEntry.Spec.BucketName)
+		if err != nil {
+			return err
+		}
+		validationError = e.validateBackupEntry(kindToTypesMap, backupBucket.Spec.Provider.Type)
+
+	case core.Kind("Seed"):
+		seed, ok := a.GetObject().(*core.Seed)
+		if !ok {
+			return apierrors.NewBadRequest("could not convert resource into Seed object")
+		}
+		validationError = e.validateSeed(kindToTypesMap, seed.Spec)
+
+	case core.Kind("Shoot"):
+		shoot, ok := a.GetObject().(*core.Shoot)
+		if !ok {
+			return apierrors.NewBadRequest("could not convert resource into Shoot object")
+		}
+		validationError = e.validateShoot(kindToTypesMap, shoot.Spec)
+	}
+
+	if validationError != nil {
+		return admission.NewForbidden(a, validationError)
+	}
+
+	return nil
+}
+
+func (e *ExtensionValidator) validateBackupBucket(kindToTypesMap map[string]sets.String, spec core.BackupBucketSpec) error {
+	return isExtensionRegistered(
+		kindToTypesMap,
+		extensionsv1alpha1.BackupBucketResource,
+		spec.Provider.Type,
+		"given BackupBucket uses non-registered provider type: "+field.NewPath("spec", "provider", "type").String(),
+	)
+}
+
+func (e *ExtensionValidator) validateBackupEntry(kindToTypesMap map[string]sets.String, bucketType string) error {
+	return isExtensionRegistered(
+		kindToTypesMap,
+		extensionsv1alpha1.BackupEntryResource,
+		bucketType,
+		fmt.Sprintf("given BackupEntry references bucket (%s) using non-registered provider type", field.NewPath("spec", "bucketName")),
+	)
+}
+
+func (e *ExtensionValidator) validateSeed(kindToTypesMap map[string]sets.String, spec core.SeedSpec) error {
+	var (
+		message = "given Seed uses non-registered"
+
+		requiredExtensions = requiredExtensions{
+			{extensionsv1alpha1.ControlPlaneResource, spec.Provider.Type, fmt.Sprintf("%s provider type: %s", message, field.NewPath("spec", "provider", "type"))},
+		}
+	)
+
+	if spec.Backup != nil {
+		msg := fmt.Sprintf("%s backup provider type: %s", message, field.NewPath("spec", "backup", "provider"))
+		requiredExtensions = append(
+			requiredExtensions,
+			requiredExtension{extensionsv1alpha1.BackupBucketResource, spec.Backup.Provider, msg},
+			requiredExtension{extensionsv1alpha1.BackupEntryResource, spec.Backup.Provider, msg},
+		)
+	}
+
+	return requiredExtensions.areRegistered(kindToTypesMap)
+}
+
+func (e *ExtensionValidator) validateShoot(kindToTypesMap map[string]sets.String, spec core.ShootSpec) error {
+	var (
+		message         = "given Shoot uses non-registered"
+		providerTypeMsg = fmt.Sprintf("%s provider type: %s", message, field.NewPath("spec", "provider", "type"))
+
+		requiredExtensions = requiredExtensions{
+			{extensionsv1alpha1.ControlPlaneResource, spec.Provider.Type, providerTypeMsg},
+			{extensionsv1alpha1.InfrastructureResource, spec.Provider.Type, providerTypeMsg},
+			{extensionsv1alpha1.WorkerResource, spec.Provider.Type, providerTypeMsg},
+			{extensionsv1alpha1.NetworkResource, spec.Networking.Type, fmt.Sprintf("%s networking type: %s", message, field.NewPath("spec", "networking", "type"))},
+		}
+	)
+
+	if spec.DNS != nil {
+		for i, provider := range spec.DNS.Providers {
+			if provider.Type == nil {
+				continue
+			}
+
+			requiredExtensions = append(requiredExtensions, requiredExtension{dnsv1alpha1.DNSProviderKind, *provider.Type, fmt.Sprintf("%s dns type: %s", message, field.NewPath("spec", "dns", "providers").Index(i).Child("type"))})
+		}
+	}
+
+	for i, extension := range spec.Extensions {
+		requiredExtensions = append(requiredExtensions, requiredExtension{extensionsv1alpha1.ExtensionResource, extension.Type, fmt.Sprintf("%s extension type: %s", message, field.NewPath("spec", "extensions").Index(i).Child("type"))})
+	}
+
+	for i, worker := range spec.Provider.Workers {
+		if worker.Machine.Image == nil {
+			continue
+		}
+
+		requiredExtensions = append(requiredExtensions, requiredExtension{extensionsv1alpha1.OperatingSystemConfigResource, worker.Machine.Image.Name, fmt.Sprintf("%s operating system type: %s", message, field.NewPath("spec", "provider", "workers").Index(i).Child("machine", "image", "name"))})
+	}
+
+	return requiredExtensions.areRegistered(kindToTypesMap)
+}
+
+// Helper functions
+
+type requiredExtension struct {
+	extensionKind string
+	extensionType string
+	message       string
+}
+
+type requiredExtensions []requiredExtension
+
+func (r requiredExtensions) areRegistered(kindToTypesMap map[string]sets.String) error {
+	var result error
+
+	for _, requiredExtension := range r {
+		if err := isExtensionRegistered(kindToTypesMap, requiredExtension.extensionKind, requiredExtension.extensionType, requiredExtension.message); err != nil {
+			result = multierror.Append(result, err)
+		}
+	}
+
+	return result
+}
+
+// isExtensionRegistered takes a map of registered kinds to a set of types and a kind/type to verify. If the provided
+// kind/type combination is registered then it returns nil, otherwise it returns an error with the given message.
+func isExtensionRegistered(kindToTypesMap map[string]sets.String, extensionKind, extensionType, message string) error {
+	if types, ok := kindToTypesMap[extensionKind]; !ok || !types.Has(extensionType) {
+		return fmt.Errorf("%s (%q)", message, extensionType)
+	}
+	return nil
+}
+
+// computeRegisteredExtensionKindTypes computes a map that maps the extension kind to the set of types that are
+// registered, e.g. {ControlPlane=>{foo,bar,baz}, Network=>{a,b,c}}.
+func computeRegisteredExtensionKindTypes(controllerRegistrationList []*gardencorev1beta1.ControllerRegistration) map[string]sets.String {
+	out := map[string]sets.String{}
+
+	for _, controllerRegistration := range controllerRegistrationList {
+		for _, resource := range controllerRegistration.Spec.Resources {
+			if _, ok := out[resource.Kind]; !ok {
+				out[resource.Kind] = sets.NewString()
+			}
+			out[resource.Kind].Insert(resource.Type)
+		}
+	}
+
+	return out
+}

--- a/plugin/pkg/global/extensionvalidation/admission_test.go
+++ b/plugin/pkg/global/extensionvalidation/admission_test.go
@@ -1,0 +1,381 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensionvalidation_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	. "github.com/gardener/gardener/plugin/pkg/global/extensionvalidation"
+
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("ExtensionValidator", func() {
+	var (
+		gardenExternalCoreInformerFactory externalcoreinformers.SharedInformerFactory
+		admissionHandler                  *ExtensionValidator
+	)
+
+	BeforeEach(func() {
+		admissionHandler, _ = New()
+		admissionHandler.AssignReadyFunc(func() bool { return true })
+
+		gardenExternalCoreInformerFactory = externalcoreinformers.NewSharedInformerFactory(nil, 0)
+		admissionHandler.SetExternalCoreInformerFactory(gardenExternalCoreInformerFactory)
+	})
+
+	It("should do nothing because the resource is not BackupBucket, BackupEntry, Seed, or Shoot", func() {
+		attrs := admission.NewAttributesRecord(nil, nil, core.Kind("Foo").WithVersion("version"), "", "", core.Resource("foos").WithVersion("version"), "", admission.Create, &metav1.DeleteOptions{}, false, nil)
+
+		err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("BackupBucket", func() {
+		var backupBucket = &core.BackupBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bb",
+			},
+			Spec: core.BackupBucketSpec{
+				Provider: core.BackupBucketProvider{
+					Type: "foo",
+				},
+			},
+		}
+
+		It("should allow to create the object", func() {
+			controllerRegistration := createControllerRegistrationForKindType(extensionsv1alpha1.BackupBucketResource, backupBucket.Spec.Provider.Type)
+			gardenExternalCoreInformerFactory.Core().V1beta1().ControllerRegistrations().Informer().GetStore().Add(controllerRegistration)
+
+			attrs := admission.NewAttributesRecord(backupBucket, nil, core.Kind("BackupBucket").WithVersion("version"), backupBucket.Namespace, backupBucket.Name, core.Resource("backupbuckets").WithVersion("version"), "", admission.Create, &metav1.DeleteOptions{}, false, nil)
+
+			err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should prevent the object from being created because extension type is not registered", func() {
+			controllerRegistration := createControllerRegistrationForKindType(extensionsv1alpha1.BackupBucketResource, "some-other-type")
+			gardenExternalCoreInformerFactory.Core().V1beta1().ControllerRegistrations().Informer().GetStore().Add(controllerRegistration)
+
+			attrs := admission.NewAttributesRecord(backupBucket, nil, core.Kind("BackupBucket").WithVersion("version"), backupBucket.Namespace, backupBucket.Name, core.Resource("backupbuckets").WithVersion("version"), "", admission.Create, &metav1.DeleteOptions{}, false, nil)
+
+			err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should prevent the object from being created because extension type is not registered", func() {
+			attrs := admission.NewAttributesRecord(backupBucket, nil, core.Kind("BackupBucket").WithVersion("version"), backupBucket.Namespace, backupBucket.Name, core.Resource("backupbuckets").WithVersion("version"), "", admission.Create, &metav1.DeleteOptions{}, false, nil)
+
+			err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("BackupEntry", func() {
+		var (
+			backupBucket = &gardencorev1beta1.BackupBucket{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bb",
+				},
+				Spec: gardencorev1beta1.BackupBucketSpec{
+					Provider: gardencorev1beta1.BackupBucketProvider{
+						Type: "foo",
+					},
+				},
+			}
+			backupEntry = &core.BackupEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "be",
+				},
+				Spec: core.BackupEntrySpec{
+					BucketName: backupBucket.Name,
+				},
+			}
+		)
+
+		It("should allow to create the object", func() {
+			controllerRegistration := createControllerRegistrationForKindType(extensionsv1alpha1.BackupEntryResource, backupBucket.Spec.Provider.Type)
+			gardenExternalCoreInformerFactory.Core().V1beta1().ControllerRegistrations().Informer().GetStore().Add(controllerRegistration)
+			gardenExternalCoreInformerFactory.Core().V1beta1().BackupBuckets().Informer().GetStore().Add(backupBucket)
+
+			attrs := admission.NewAttributesRecord(backupEntry, nil, core.Kind("BackupEntry").WithVersion("version"), backupEntry.Namespace, backupEntry.Name, core.Resource("backupentries").WithVersion("version"), "", admission.Create, &metav1.DeleteOptions{}, false, nil)
+
+			err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should prevent the object from being created because extension type is not registered", func() {
+			controllerRegistration := createControllerRegistrationForKindType(extensionsv1alpha1.BackupEntryResource, "some-other-type")
+			gardenExternalCoreInformerFactory.Core().V1beta1().ControllerRegistrations().Informer().GetStore().Add(controllerRegistration)
+
+			attrs := admission.NewAttributesRecord(backupEntry, nil, core.Kind("BackupEntry").WithVersion("version"), backupEntry.Namespace, backupEntry.Name, core.Resource("backupentries").WithVersion("version"), "", admission.Create, &metav1.DeleteOptions{}, false, nil)
+
+			err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should prevent the object from being created because extension type is not registered", func() {
+			attrs := admission.NewAttributesRecord(backupEntry, nil, core.Kind("BackupEntry").WithVersion("version"), backupEntry.Namespace, backupEntry.Name, core.Resource("backupentries").WithVersion("version"), "", admission.Create, &metav1.DeleteOptions{}, false, nil)
+
+			err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("Seed", func() {
+		var seed = &core.Seed{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "seed",
+			},
+			Spec: core.SeedSpec{
+				Provider: core.SeedProvider{
+					Type: "foo",
+				},
+				Backup: &core.SeedBackup{
+					Provider: "bar",
+				},
+			},
+		}
+
+		var (
+			kindToTypes = []struct {
+				extensionKind, extensionType string
+			}{
+				{extensionsv1alpha1.ControlPlaneResource, seed.Spec.Provider.Type},
+				{extensionsv1alpha1.BackupBucketResource, seed.Spec.Backup.Provider},
+				{extensionsv1alpha1.BackupEntryResource, seed.Spec.Backup.Provider},
+			}
+			registerAllExtensions = func() {
+				for _, registration := range kindToTypes {
+					controllerRegistration := createControllerRegistrationForKindType(registration.extensionKind, registration.extensionType)
+					gardenExternalCoreInformerFactory.Core().V1beta1().ControllerRegistrations().Informer().GetStore().Add(controllerRegistration)
+				}
+			}
+		)
+
+		It("should allow to create the object", func() {
+			registerAllExtensions()
+
+			attrs := admission.NewAttributesRecord(seed, nil, core.Kind("Seed").WithVersion("version"), seed.Namespace, seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Create, &metav1.DeleteOptions{}, false, nil)
+
+			err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should prevent the object from being created because some extension is not registered", func() {
+			for _, registration := range kindToTypes {
+				registerAllExtensions()
+
+				controllerRegistration := createControllerRegistrationForKindType(registration.extensionKind, registration.extensionType)
+				gardenExternalCoreInformerFactory.Core().V1beta1().ControllerRegistrations().Informer().GetStore().Delete(controllerRegistration)
+
+				attrs := admission.NewAttributesRecord(seed, nil, core.Kind("Seed").WithVersion("version"), seed.Namespace, seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Create, &metav1.DeleteOptions{}, false, nil)
+
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred(), fmt.Sprintf("expected that extension %s is not registered", controllerRegistration.Name))
+				Expect(err.Error()).To(ContainSubstring(registration.extensionType))
+			}
+		})
+
+		It("should prevent the object from being created because no extension type is registered", func() {
+			attrs := admission.NewAttributesRecord(seed, nil, core.Kind("Seed").WithVersion("version"), seed.Namespace, seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Create, &metav1.DeleteOptions{}, false, nil)
+
+			err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("Shoot", func() {
+		var shoot = &core.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "shoot",
+			},
+			Spec: core.ShootSpec{
+				DNS: &core.DNS{
+					Providers: []core.DNSProvider{
+						{Type: pointer.StringPtr("foo-1")},
+						{Type: pointer.StringPtr("foo0")},
+					},
+				},
+				Extensions: []core.Extension{
+					{Type: "foo1"},
+					{Type: "foo2"},
+				},
+				Networking: core.Networking{
+					Type: "foo3",
+				},
+				Provider: core.Provider{
+					Type: "foo4",
+					Workers: []core.Worker{
+						{
+							Machine: core.Machine{
+								Image: &core.ShootMachineImage{
+									Name: "foo5",
+								},
+							},
+						},
+						{
+							Machine: core.Machine{
+								Image: &core.ShootMachineImage{
+									Name: "foo6",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var (
+			kindToTypes = []struct {
+				extensionKind, extensionType string
+			}{
+				{dnsv1alpha1.DNSProviderKind, *shoot.Spec.DNS.Providers[0].Type},
+				{dnsv1alpha1.DNSProviderKind, *shoot.Spec.DNS.Providers[1].Type},
+				{extensionsv1alpha1.ControlPlaneResource, shoot.Spec.Provider.Type},
+				{extensionsv1alpha1.ExtensionResource, shoot.Spec.Extensions[0].Type},
+				{extensionsv1alpha1.ExtensionResource, shoot.Spec.Extensions[1].Type},
+				{extensionsv1alpha1.InfrastructureResource, shoot.Spec.Provider.Type},
+				{extensionsv1alpha1.NetworkResource, shoot.Spec.Networking.Type},
+				{extensionsv1alpha1.OperatingSystemConfigResource, shoot.Spec.Provider.Workers[0].Machine.Image.Name},
+				{extensionsv1alpha1.OperatingSystemConfigResource, shoot.Spec.Provider.Workers[1].Machine.Image.Name},
+				{extensionsv1alpha1.WorkerResource, shoot.Spec.Provider.Type},
+			}
+			registerAllExtensions = func() {
+				for _, registration := range kindToTypes {
+					controllerRegistration := createControllerRegistrationForKindType(registration.extensionKind, registration.extensionType)
+					gardenExternalCoreInformerFactory.Core().V1beta1().ControllerRegistrations().Informer().GetStore().Add(controllerRegistration)
+				}
+			}
+		)
+
+		It("should allow to create the object", func() {
+			registerAllExtensions()
+
+			attrs := admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.DeleteOptions{}, false, nil)
+
+			err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should prevent the object from being created because some extension is not registered", func() {
+			for _, registration := range kindToTypes {
+				registerAllExtensions()
+
+				controllerRegistration := createControllerRegistrationForKindType(registration.extensionKind, registration.extensionType)
+				gardenExternalCoreInformerFactory.Core().V1beta1().ControllerRegistrations().Informer().GetStore().Delete(controllerRegistration)
+
+				attrs := admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.DeleteOptions{}, false, nil)
+
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred(), fmt.Sprintf("expected that extension %s is not registered", controllerRegistration.Name))
+				Expect(err.Error()).To(ContainSubstring(registration.extensionType))
+			}
+		})
+
+		It("should prevent the object from being created because no extension type is registered", func() {
+			attrs := admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.DeleteOptions{}, false, nil)
+
+			err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("#Register", func() {
+		It("should register the plugin", func() {
+			plugins := admission.NewPlugins()
+			Register(plugins)
+
+			registered := plugins.Registered()
+			Expect(registered).To(HaveLen(1))
+			Expect(registered).To(ContainElement(PluginName))
+		})
+	})
+
+	Describe("#NewFactory", func() {
+		It("should create a new PluginFactory", func() {
+			f, err := NewFactory(nil)
+
+			Expect(f).NotTo(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("#New", func() {
+		It("should only handle CREATE + UPDATE operations", func() {
+			dr, err := New()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dr.Handles(admission.Create)).To(BeTrue())
+			Expect(dr.Handles(admission.Update)).To(BeTrue())
+			Expect(dr.Handles(admission.Connect)).NotTo(BeTrue())
+			Expect(dr.Handles(admission.Delete)).NotTo(BeTrue())
+		})
+	})
+
+	Describe("#ValidateInitialization", func() {
+		It("should return error if no ControllerRegistrationLister and BackupBucketLister are set", func() {
+			dr, _ := New()
+			err := dr.ValidateInitialization()
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should not return error if ControllerRegistrationLister, BackupBucketLister and core client are set", func() {
+			dr, _ := New()
+			dr.SetExternalCoreInformerFactory(externalcoreinformers.NewSharedInformerFactory(nil, 0))
+			err := dr.ValidateInitialization()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})
+
+func createControllerRegistrationForKindType(extensionKind, extensionType string) *gardencorev1beta1.ControllerRegistration {
+	return &gardencorev1beta1.ControllerRegistration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: extensionKind + extensionType,
+		},
+		Spec: gardencorev1beta1.ControllerRegistrationSpec{
+			Resources: []gardencorev1beta1.ControllerResource{
+				{
+					Kind: extensionKind,
+					Type: extensionType,
+				},
+			},
+		},
+	}
+}

--- a/plugin/pkg/global/extensionvalidation/extensionvalidation_suite_test.go
+++ b/plugin/pkg/global/extensionvalidation/extensionvalidation_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensionvalidation_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestExtensionvalidation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Admission ExtensionValidation Suite")
+}

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -700,22 +700,6 @@ var _ = Describe("validator", func() {
 			Expect(apierrors.IsBadRequest(err)).To(BeTrue())
 		})
 
-		It("should reject because the provider type was changed", func() {
-			shoot2 := shoot.DeepCopy()
-			shoot.Spec.Provider.Type = "aws"
-			shoot2.Spec.Provider.Type = "gcp"
-
-			coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)
-			coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)
-			coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)
-			attrs := admission.NewAttributesRecord(&shoot, shoot2, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
-
-			err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(apierrors.NewBadRequest("shoot provider type was changed which is not allowed")))
-		})
-
 		Context("tests for infrastructure update", func() {
 			var (
 				oldShoot *core.Shoot


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we add a new `ExtensionValidation` admission plugin to the Gardener API server. The admission plugin is creating on `CREATE` and `UPDATE` operations of `BackupBucket`s, `BackupEntry`s, `Seed`s, and `Shoot`s. It validates for the various extension types in the respective `spec`s that a corresponding `ControllerRegistration` exists whose `spec` indicates that it is responsible for the extension type(s).

**Which issue(s) this PR fixes**:
Fixes #1844

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
It is no longer possible to submit `BackupBucket, `BackupEntry`, or `Seed` resources whose specifications target extension types that are not registered in the system.
```
```improvement user
It is no longer possible to submit `Shoot` resources whose specification targets extension types that are not registered in the system.
```
