### PR TITLE
Allow worker.min to be zero while deploying cluster-autoscaler

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -136,10 +136,6 @@ func (b *Botanist) DeployClusterAutoscaler(ctx context.Context) error {
 
 	var workerPools []map[string]interface{}
 	for _, worker := range b.Shoot.MachineDeployments {
-		// Skip worker pools for which min=0. Auto scaler cannot handle worker pools having a min count of 0.
-		if worker.Minimum == 0 {
-			continue
-		}
 
 		workerPools = append(workerPools, map[string]interface{}{
 			"name": worker.Name,


### PR DESCRIPTION
**What this PR does / why we need it**: Follow up to the #2045 . I missed removing this check earlier, thanks to Rafael for pointing out. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
```
