### PR TITLE
Optimize apiserver HVPA minAllowed config.

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hvpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hvpa.yaml
@@ -75,7 +75,7 @@ spec:
                 cpu: "8"
               minAllowed:
                 memory: 400M
-                cpu: 300m
+                cpu: 100m
             - containerName: vpn-seed
               mode: "Off"
             - containerName: blackbox-exporter


### PR DESCRIPTION
**What this PR does / why we need it**:
~80% of the shoot `kube-apiserver`s have CPU utilization consistently well below the currently configured `minAllowed` of `300m`. Reducing this will improve CPU utilization in the seed clusters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Optimize apiserver HVPA minAllowed config to a lower value to improve overall CPU utilization in the seed clusters.
```
