### PR TITLE
Added HPA metrics to kube-state-metrics in garden ns.

### DIFF
--- a/charts/seed-bootstrap/charts/kube-state-metrics/templates/clusterrole.yaml
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/templates/clusterrole.yaml
@@ -33,3 +33,7 @@ rules:
       - cronjobs
       - jobs
     verbs: ["list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["list", "watch"]

--- a/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - /kube-state-metrics
         - --port=8080
         - --telemetry-port=8081
-        - --collectors=deployments,pods,statefulsets,nodes
+        - --collectors=deployments,pods,statefulsets,nodes,horizontalpodautoscalers
         ports:
         - name: metrics
           containerPort: 8080

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -92,6 +92,11 @@ allowedMetrics:
   - kube_statefulset_status_replicas_current
   - kube_statefulset_status_replicas_ready
   - kube_statefulset_status_replicas_updated
+  - kube_hpa_spec_max_replicas
+  - kube_hpa_spec_min_replicas
+  - kube_hpa_status_condition
+  - kube_hpa_status_current_replicas
+  - kube_hpa_status_desired_replicas
 
   fluentd: []
   fluentbit: []


### PR DESCRIPTION
**What this PR does / why we need it**:
Added HPA metrics to kube-state-metrics in garden ns. These can help in analysing HPA behaviour and in analysing the benefits and impact of reducing HPA scale down stabilization period (currently `24h`) to a lower value. Ideally, we should redule the HPA scale down stabilization duration to resource utilization and to avoid over-provisioning for longer periods.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
For the time being, I have not added any aggregate rules. If I find something useful as an aggregate metrics, I will file a separate PR later.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Added HPA metrics to kube-state-metrics in garden ns. These can help in analysing HPA behaviour and in analysing the benefits and impact of reducing HPA scale down stabilization period (currently `24h`) to a lower value.
```
