### PR TITLE
Fix project controller test

### DIFF
--- a/pkg/controllermanager/controller/project/project_control_test.go
+++ b/pkg/controllermanager/controller/project/project_control_test.go
@@ -62,6 +62,10 @@ var _ = Describe("#rolebindingDelete", func() {
 		}
 	})
 
+	AfterEach(func() {
+		queue.ShutDown()
+	})
+
 	It("should not requeue random rolebinding", func() {
 		Expect(indexer.Add(proj)).ToNot(HaveOccurred())
 
@@ -115,8 +119,10 @@ var _ = Describe("#rolebindingDelete", func() {
 
 		Expect(queue.Len()).To(Equal(2), "two items in queue")
 		actual, _ := queue.Get()
-		Expect(actual).To(Equal("project-1"))
+		Expect(actual).To(SatisfyAny(Equal("project-1"), Equal("project-2")))
 		actual, _ = queue.Get()
-		Expect(actual).To(Equal("project-2"))
+		Expect(actual).To(SatisfyAny(Equal("project-1"), Equal("project-2")))
+		Expect(queue.NumRequeues(proj)).To(Equal(0), "project-1 should not be requeued")
+		Expect(queue.NumRequeues(proj2)).To(Equal(0), "project-2 should not be requeued")
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Ordering of items in the queue is not guaranteed, because the list of projects is not always guaranteed to be in the same order.

**Which issue(s) this PR fixes**:
Related https://github.com/gardener/gardener/pull/2060

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
