### PR TITLE
Fix etcd-druid RBAC

### DIFF
--- a/charts/seed-bootstrap/charts/etcd-druid/templates/druid-clusterrole.yaml
+++ b/charts/seed-bootstrap/charts/etcd-druid/templates/druid-clusterrole.yaml
@@ -9,6 +9,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  verbs:
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create


### PR DESCRIPTION
**What this PR does / why we need it**:

Since `etcd-druid` version `v0.1.4` the druid tries to list Pods and delete them, if they are in `CrashLoopBackOff`. See [here](https://github.com/gardener/etcd-druid/commit/e3ee828f6e3b38748143efd97daf3fa4b2079edf#diff-8e5c816f8b2f1adeef36a64d81b3e0f6R575)

Logs from `etcd-druid` in my local seed:
```
E0318 09:06:17.828232       1 reflector.go:123] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:garden:etcd-druid" cannot list resource "pods" in API group "" at the cluster scope
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
