### PR TITLE
Ensure worker pools are compatible with system components

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1032,10 +1032,13 @@ func validateTaintEffect(effect *corev1.TaintEffect, allowEmpty bool, fldPath *f
 
 // ValidateWorkers validates worker objects.
 func ValidateWorkers(workers []core.Worker, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+	var (
+		allErrs = field.ErrorList{}
 
-	workerNames := make(map[string]bool)
-	atLeastOneActivePool := false
+		workerNames                        = make(map[string]bool)
+		atLeastOneActivePool               = false
+		atLeastOnePoolWithCompatibleTaints = len(workers) == 0
+	)
 
 	for i, worker := range workers {
 		if worker.Minimum != 0 && worker.Maximum != 0 {
@@ -1046,10 +1049,31 @@ func ValidateWorkers(workers []core.Worker, fldPath *field.Path) field.ErrorList
 			allErrs = append(allErrs, field.Duplicate(fldPath.Index(i).Child("name"), worker.Name))
 		}
 		workerNames[worker.Name] = true
+
+		switch {
+		case atLeastOnePoolWithCompatibleTaints:
+		case len(worker.Taints) == 0:
+			atLeastOnePoolWithCompatibleTaints = true
+		case !atLeastOnePoolWithCompatibleTaints:
+			onlyPreferNoScheduleEffectTaints := true
+			for _, taint := range worker.Taints {
+				if taint.Effect != corev1.TaintEffectPreferNoSchedule {
+					onlyPreferNoScheduleEffectTaints = false
+					break
+				}
+			}
+			if onlyPreferNoScheduleEffectTaints {
+				atLeastOnePoolWithCompatibleTaints = true
+			}
+		}
 	}
 
 	if !atLeastOneActivePool {
 		allErrs = append(allErrs, field.Forbidden(fldPath, "at least one worker pool with min>0 and max> 0 needed"))
+	}
+
+	if !atLeastOnePoolWithCompatibleTaints {
+		allErrs = append(allErrs, field.Forbidden(fldPath, fmt.Sprintf("at least one worker pool must exist having either no taints or only the %q taint", corev1.TaintEffectPreferNoSchedule)))
 	}
 
 	return allErrs


### PR DESCRIPTION
**What this PR does / why we need it**:
In order for the shoot's system components to run there must be at least one worker pool that either has no taints or only taints with `PreferNoSchedule` effect. Otherwise, end-users can exclude them from their nodes, causing the shoot reconciliation to fail:

```
Events:
  Type     Reason             Age                   From                Message
  ----     ------             ----                  ----                -------
  Warning  FailedScheduling   <unknown>             default-scheduler   0/2 nodes are available: 2 node(s) had taints that the pod didn't tolerate.
  Warning  FailedScheduling   <unknown>             default-scheduler   0/2 nodes are available: 2 node(s) had taints that the pod didn't tolerate.
  Normal   NotTriggerScaleUp  11s (x11 over 2m31s)  cluster-autoscaler  pod didn't trigger scale-up (it wouldn't fit if a new node is added): 1 node(s) had taints that the pod didn't tolerate
```

**Special notes for your reviewer**:
/cc @ggaurav10 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
It must now be ensured that the `Shoot` specification contains at least one worker pool with either no taints or only taints with `PreferNoSchedule` effect. This is to make sure that the system components (CoreDNS, vpn-shoot, etc.) can be scheduled correctly.
```
