### PR TITLE
Re-enable memory-based HPA for apiserver at 120 percent average utilisation.

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -91,7 +91,7 @@ minReplicas: 1
 hpa:
   targetAverageUtilizationCpu: 80
   memoryMetricForHpaEnabled: false
-  targetAverageUtilizationMemory: 80
+  targetAverageUtilizationMemory: 120
 
 auditConfig:
   auditPolicy: ""

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -659,7 +659,7 @@ func (b *Botanist) DeployKubeAPIServerService(ctx context.Context) error {
 // DeployKubeAPIServer deploys kube-apiserver deployment.
 func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 	hvpaEnabled := gardenletfeatures.FeatureGate.Enabled(features.HVPA)
-	memoryMetricForHpaEnabled := false
+	memoryMetricForHpaEnabled := true
 
 	if b.ShootedSeed != nil {
 		// Override for shooted seeds


### PR DESCRIPTION
**What this PR does / why we need it**:
#1968 disabled memory-based HPA for shoot `kube-apiserver` to improve resource utilisation. But there are some usage patterns where memory utilisation can increase without a proportionate increase in CPU utilisation which can lead to `kube-apiserver` pods getting `OOMKilled`. Though [the](https://github.com/gardener/hvpa-controller/pull/57) [recent](https://github.com/gardener/hvpa-controller/pull/61) [improvements](https://github.com/gardener/hvpa-controller/pull/63) in [gardener/hvpa-controller](https://github.com/gardener/hvpa-controller) have made sure that the `kube-apiserver` recovers from such `OOMKills`, there is still some adverse affect on some usage patterns where memory utilisation is disproportionate to the CPU utilisation.

This PR re-enables memory-based HPA for kube-apiserver but at 120 percent average utilisation. This is to still avoid horizontally scaling for trivial loads but still scale horizontally if memory load is disproportionate to the CPU load.

The CPU utilisation configuration remains unchanged.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
It would be preferable release this PR with #2070.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Re-enabled memory-based HPA for apiserver but at 120 percent average utilisation. This is to still avoid horizontally scaling for trivial loads but still scale horizontally if memory load is disproportionate to the CPU load. The CPU utilisation configuration remains unchanged.
```
