### PR TITLE
Validate project namespace is not in use

### DIFF
--- a/pkg/controllermanager/controller/project/project_control.go
+++ b/pkg/controllermanager/controller/project/project_control.go
@@ -97,6 +97,7 @@ func (c *Controller) rolebindingDelete(obj interface{}) {
 
 			if ns := proj.Spec.Namespace; ns != nil && *ns == rolens {
 				c.projectQueue.Add(proj.Name)
+				break
 			}
 		}
 	}

--- a/pkg/controllermanager/controller/project/project_control_test.go
+++ b/pkg/controllermanager/controller/project/project_control_test.go
@@ -107,22 +107,4 @@ var _ = Describe("#rolebindingDelete", func() {
 		Entry("project-viewer", "gardener.cloud:system:project-viewer"),
 		Entry("custom role", "gardener.cloud:extension:project:project-1:foo"),
 	)
-
-	It("should requeue multiple projects with the same namespace", func() {
-		rolebinding.Name = "gardener.cloud:system:project-member"
-		proj2 := proj.DeepCopy()
-		proj2.Name = "project-2"
-		Expect(indexer.Add(proj)).ToNot(HaveOccurred())
-		Expect(indexer.Add(proj2)).ToNot(HaveOccurred())
-
-		c.rolebindingDelete(rolebinding)
-
-		Expect(queue.Len()).To(Equal(2), "two items in queue")
-		actual, _ := queue.Get()
-		Expect(actual).To(SatisfyAny(Equal("project-1"), Equal("project-2")))
-		actual, _ = queue.Get()
-		Expect(actual).To(SatisfyAny(Equal("project-1"), Equal("project-2")))
-		Expect(queue.NumRequeues(proj)).To(Equal(0), "project-1 should not be requeued")
-		Expect(queue.NumRequeues(proj2)).To(Equal(0), "project-2 should not be requeued")
-	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR checks that a namespace specified in projects resources (`project.spec.namespace`) is not already taken by another project.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Gardener now checks that a namespace specified in project resources (`project.spec.namespace`) is not already taken by another project.
```
