### PR TITLE
Accept new labels for project namespaces

### DIFF
--- a/example/00-namespace-garden-dev.yaml
+++ b/example/00-namespace-garden-dev.yaml
@@ -6,5 +6,5 @@ metadata:
   annotations:
     project.garden.sapcloud.io/owner: john.doe@example.com
   labels:
-    garden.sapcloud.io/role: project
-    project.garden.sapcloud.io/name: dev
+    gardener.cloud/role: project
+    project.gardener.cloud/name: dev

--- a/pkg/controllermanager/controller/project/project_utils.go
+++ b/pkg/controllermanager/controller/project/project_utils.go
@@ -29,10 +29,8 @@ func setProjectPhase(phase gardencorev1beta1.ProjectPhase) func(*gardencorev1bet
 
 func namespaceLabelsFromProject(project *gardencorev1beta1.Project) map[string]string {
 	return map[string]string{
-		v1beta1constants.GardenRole:           v1beta1constants.GardenRoleProject,
-		v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleProject,
-		common.ProjectName:                    project.Name,
-		common.ProjectNameDeprecated:          project.Name,
+		v1beta1constants.GardenRole: v1beta1constants.GardenRoleProject,
+		common.ProjectName:          project.Name,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes it possible to use project namespaces with labels related to Gardener's new API group:
```
gardener.cloud/role: project
project.gardener.cloud/name: <project-name>
```

This change is backwards compatible.

**Which issue(s) this PR fixes**:
Part of #1649

**Special notes for your reviewer**:
/cc @ialidzhikov

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A project related namespace can now be used with the following labels: `gardener.cloud/role: project`, `project.gardener.cloud/name: <project-name>`.
```
