### PR TITLE
Add alpha scaling annotation to circumvent node criteria

### DIFF
--- a/pkg/operation/botanist/controlplane_test.go
+++ b/pkg/operation/botanist/controlplane_test.go
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package botanist_test
+package botanist
 
 import (
-	. "github.com/gardener/gardener/pkg/operation/botanist"
-
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
@@ -26,81 +25,111 @@ import (
 )
 
 var _ = Describe("controlplane", func() {
-	Context("Shoot", func() {
+	Describe("#ValidateAuditPolicyApiGroupVersionKind", func() {
+		var (
+			kind = "Policy"
+		)
 
-		Describe("#ValidateAuditPolicyApiGroupVersionKind", func() {
-			var (
-				kind = "Policy"
-			)
+		It("should return false without error because of version incompatibility", func() {
+			incompatibilityMatrix := map[string][]schema.GroupVersionKind{
+				"1.10.0": {
+					auditv1.SchemeGroupVersion.WithKind(kind),
+				},
+				"1.11.0": {
+					auditv1.SchemeGroupVersion.WithKind(kind),
+				},
+			}
 
-			It("should return false without error because of version incompatibility", func() {
-				incompatibilityMatrix := map[string][]schema.GroupVersionKind{
-					"1.10.0": {
-						auditv1.SchemeGroupVersion.WithKind(kind),
-					},
-					"1.11.0": {
-						auditv1.SchemeGroupVersion.WithKind(kind),
-					},
+			for shootVersion, gvks := range incompatibilityMatrix {
+				for _, gvk := range gvks {
+					ok, err := IsValidAuditPolicyVersion(shootVersion, &gvk)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ok).To(BeFalse())
 				}
+			}
+		})
 
-				for shootVersion, gvks := range incompatibilityMatrix {
-					for _, gvk := range gvks {
-						ok, err := IsValidAuditPolicyVersion(shootVersion, &gvk)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(ok).To(BeFalse())
-					}
+		It("should return true without error because of version compatibility", func() {
+			compatibilityMatrix := map[string][]schema.GroupVersionKind{
+				"1.10.0": {
+					auditv1alpha1.SchemeGroupVersion.WithKind(kind),
+					auditv1beta1.SchemeGroupVersion.WithKind(kind),
+				},
+				"1.11.0": {
+					auditv1alpha1.SchemeGroupVersion.WithKind(kind),
+					auditv1beta1.SchemeGroupVersion.WithKind(kind),
+				},
+				"1.12.0": {
+					auditv1alpha1.SchemeGroupVersion.WithKind(kind),
+					auditv1beta1.SchemeGroupVersion.WithKind(kind),
+					auditv1.SchemeGroupVersion.WithKind(kind),
+				},
+				"1.13.0": {
+					auditv1alpha1.SchemeGroupVersion.WithKind(kind),
+					auditv1beta1.SchemeGroupVersion.WithKind(kind),
+					auditv1.SchemeGroupVersion.WithKind(kind),
+				},
+				"1.14.0": {
+					auditv1alpha1.SchemeGroupVersion.WithKind(kind),
+					auditv1beta1.SchemeGroupVersion.WithKind(kind),
+					auditv1.SchemeGroupVersion.WithKind(kind),
+				},
+				"1.15.0": {
+					auditv1alpha1.SchemeGroupVersion.WithKind(kind),
+					auditv1beta1.SchemeGroupVersion.WithKind(kind),
+					auditv1.SchemeGroupVersion.WithKind(kind),
+				},
+			}
+
+			for shootVersion, gvks := range compatibilityMatrix {
+				for _, gvk := range gvks {
+					ok, err := IsValidAuditPolicyVersion(shootVersion, &gvk)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ok).To(BeTrue())
 				}
-			})
+			}
+		})
 
-			It("should return true without error because of version compatibility", func() {
-				compatibilityMatrix := map[string][]schema.GroupVersionKind{
-					"1.10.0": {
-						auditv1alpha1.SchemeGroupVersion.WithKind(kind),
-						auditv1beta1.SchemeGroupVersion.WithKind(kind),
-					},
-					"1.11.0": {
-						auditv1alpha1.SchemeGroupVersion.WithKind(kind),
-						auditv1beta1.SchemeGroupVersion.WithKind(kind),
-					},
-					"1.12.0": {
-						auditv1alpha1.SchemeGroupVersion.WithKind(kind),
-						auditv1beta1.SchemeGroupVersion.WithKind(kind),
-						auditv1.SchemeGroupVersion.WithKind(kind),
-					},
-					"1.13.0": {
-						auditv1alpha1.SchemeGroupVersion.WithKind(kind),
-						auditv1beta1.SchemeGroupVersion.WithKind(kind),
-						auditv1.SchemeGroupVersion.WithKind(kind),
-					},
-					"1.14.0": {
-						auditv1alpha1.SchemeGroupVersion.WithKind(kind),
-						auditv1beta1.SchemeGroupVersion.WithKind(kind),
-						auditv1.SchemeGroupVersion.WithKind(kind),
-					},
-					"1.15.0": {
-						auditv1alpha1.SchemeGroupVersion.WithKind(kind),
-						auditv1beta1.SchemeGroupVersion.WithKind(kind),
-						auditv1.SchemeGroupVersion.WithKind(kind),
-					},
-				}
+		It("should return false with error because of not valid semver version", func() {
+			shootVersion := "1.ab.0"
+			gvk := auditv1.SchemeGroupVersion.WithKind(kind)
 
-				for shootVersion, gvks := range compatibilityMatrix {
-					for _, gvk := range gvks {
-						ok, err := IsValidAuditPolicyVersion(shootVersion, &gvk)
-						Expect(err).ToNot(HaveOccurred())
-						Expect(ok).To(BeTrue())
-					}
-				}
-			})
-
-			It("should return false with error because of not valid semver version", func() {
-				shootVersion := "1.ab.0"
-				gvk := auditv1.SchemeGroupVersion.WithKind(kind)
-
-				ok, err := IsValidAuditPolicyVersion(shootVersion, &gvk)
-				Expect(err).To(HaveOccurred())
-				Expect(ok).To(BeFalse())
-			})
+			ok, err := IsValidAuditPolicyVersion(shootVersion, &gvk)
+			Expect(err).To(HaveOccurred())
+			Expect(ok).To(BeFalse())
 		})
 	})
+
+	DescribeTable("#getResourcesForAPIServer",
+		func(nodes int, storageClass, expectedCPURequest, expectedMemoryRequest, expectedCPULimit, expectedMemoryLimit string) {
+			cpuRequest, memoryRequest, cpuLimit, memoryLimit := getResourcesForAPIServer(int32(nodes), storageClass)
+
+			Expect(cpuRequest).To(Equal(expectedCPURequest))
+			Expect(memoryRequest).To(Equal(expectedMemoryRequest))
+			Expect(cpuLimit).To(Equal(expectedCPULimit))
+			Expect(memoryLimit).To(Equal(expectedMemoryLimit))
+		},
+
+		// nodes tests
+		Entry("nodes <= 2", 2, "", "800m", "800Mi", "1000m", "1200Mi"),
+		Entry("nodes <= 10", 10, "", "1000m", "1100Mi", "1200m", "1900Mi"),
+		Entry("nodes <= 50", 50, "", "1200m", "1600Mi", "1500m", "3900Mi"),
+		Entry("nodes <= 100", 100, "", "2500m", "5200Mi", "3000m", "5900Mi"),
+		Entry("nodes > 100", 1000, "", "3000m", "5200Mi", "4000m", "7800Mi"),
+
+		// scaling class tests
+		Entry("scaling class small", -1, "small", "800m", "800Mi", "1000m", "1200Mi"),
+		Entry("scaling class medium", -1, "medium", "1000m", "1100Mi", "1200m", "1900Mi"),
+		Entry("scaling class large", -1, "large", "1200m", "1600Mi", "1500m", "3900Mi"),
+		Entry("scaling class xlarge", -1, "xlarge", "2500m", "5200Mi", "3000m", "5900Mi"),
+		Entry("scaling class 2xlarge", -1, "2xlarge", "3000m", "5200Mi", "4000m", "7800Mi"),
+
+		// scaling class always decides if provided
+		Entry("nodes > 100, scaling class small", 100, "small", "800m", "800Mi", "1000m", "1200Mi"),
+		Entry("nodes <= 100, scaling class medium", 100, "medium", "1000m", "1100Mi", "1200m", "1900Mi"),
+		Entry("nodes <= 50, scaling class large", 50, "large", "1200m", "1600Mi", "1500m", "3900Mi"),
+		Entry("nodes <= 10, scaling class xlarge", 10, "xlarge", "2500m", "5200Mi", "3000m", "5900Mi"),
+		Entry("nodes <= 2, scaling class 2xlarge", 2, "2xlarge", "3000m", "5200Mi", "4000m", "7800Mi"),
+	)
+
 })

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -290,6 +290,13 @@ const (
 	// SecretRefChecksumAnnotation is the annotation key for checksum of referred secret in resource spec.
 	SecretRefChecksumAnnotation = "checksum/secret.data"
 
+	// ShootAlphaScalingAPIServerClass is a constant for an annotation on the shoot stating the initial API server class.
+	// It influences the size of the initial resource requests/limits.
+	// Possible values are [small, medium, large, xlarge, 2xlarge].
+	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
+	// what you do.
+	ShootAlphaScalingAPIServerClass = "alpha.kube-apiserver.scaling.shoot.gardener.cloud/class"
+
 	// ShootExperimentalAddonKyma is a constant for an annotation on the shoot stating that Kyma shall be installed.
 	// TODO: Just a temporary solution. Remove this in a future version once Kyma is moved out again.
 	ShootExperimentalAddonKyma = "experimental.addons.shoot.gardener.cloud/kyma"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an alpha annotation that can be used for shoots in order to decide the initial kube-apiserver size. As of today this is decided based on the minimum or maximum number of worker nodes. Though, this is only an approximation and does not work generally. Eventually, HVPA (if activated) takes care of scaling, though, for some use-cases an initially largely proportioned API server is required.

**Special notes for your reviewer**:
/cc @ggaurav10 @amshuman-kr 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
