### PR TITLE
Enable ScheduleDaemonSetPods featuregate by default for v1.11

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/_helpers.tpl
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/_helpers.tpl
@@ -8,7 +8,7 @@
 {{- if semverCompare "< 1.12" .Values.kubernetesVersion }}
 - --feature-gates=TokenRequest=true
 {{- end }}
-{{- if semverCompare "1.11" .Values.kubernetesVersion }}
+{{- if semverCompare "1.11.x" .Values.kubernetesVersion }}
 - --feature-gates=TokenRequestProjection=true
 {{- end }}
 {{- end -}}

--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/_helpers.tpl
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/_helpers.tpl
@@ -2,6 +2,9 @@
 {{- if .Values.featureGates }}
 - --feature-gates={{ range $feature, $enabled := .Values.featureGates }}{{ $feature }}={{ $enabled }},{{ end }}
 {{- end }}
+{{- if semverCompare "1.11.x" .Values.kubernetesVersion }}
+- --feature-gates=ScheduleDaemonSetPods=true
+{{- end }}
 {{- end -}}
 
 {{- define "kube-controller-manager.port" -}}

--- a/charts/seed-controlplane/charts/kube-scheduler/templates/_helpers.tpl
+++ b/charts/seed-controlplane/charts/kube-scheduler/templates/_helpers.tpl
@@ -5,6 +5,9 @@
 {{- if semverCompare "< 1.11" .Values.kubernetesVersion }}
 - --feature-gates=PodPriority=true
 {{- end }}
+{{- if semverCompare "1.11.x" .Values.kubernetesVersion }}
+- --feature-gates=ScheduleDaemonSetPods=true
+{{- end }}
 {{- end -}}
 
 {{- define "kube-scheduler.componentconfigversion" -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
For < 1.12 shoot clusters the daemon set pods are not scheduled by the kube-scheduler but by the kube-controller-manager. This can lead to situations where pods with a high priority cannot be started properly. This PR adds `ScheduleDaemonSetPods` by default for  v1.11 clusters. 

**Which issue(s) this PR fixes**:
Fixes #2076 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
ScheduleDaemonSetPods feature gate is now enabled by default for 1.11 clusters to ensure correct scheduling of system-critical-pods
```
