### PR TITLE
Add hibernation column to shoot table converter

### DIFF
--- a/pkg/registry/core/shoot/storage/tableconvertor.go
+++ b/pkg/registry/core/shoot/storage/tableconvertor.go
@@ -42,6 +42,7 @@ func newTableConvertor() rest.TableConvertor {
 			{Name: "Version", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["version"]},
 			{Name: "Seed", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["seed"]},
 			{Name: "Domain", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["domain"]},
+			{Name: "Hibernation", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["hibernation"]},
 			{Name: "Operation", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["operation"]},
 			{Name: "Progress", Type: "integer", Format: "name", Description: swaggerMetadataDescriptions["progress"]},
 			{Name: "APIServer", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["apiserver"]},
@@ -91,6 +92,18 @@ func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tabl
 			cells = append(cells, *shoot.Spec.DNS.Domain)
 		} else {
 			cells = append(cells, "<none>")
+		}
+		specHibernated := shoot.Spec.Hibernation != nil && shoot.Spec.Hibernation.Enabled != nil && *shoot.Spec.Hibernation.Enabled
+		statusHibernated := shoot.Status.IsHibernated
+		switch {
+		case specHibernated && statusHibernated:
+			cells = append(cells, "Hibernated")
+		case specHibernated && !statusHibernated:
+			cells = append(cells, "Hibernating")
+		case !specHibernated && statusHibernated:
+			cells = append(cells, "Waking Up")
+		default:
+			cells = append(cells, "Awake")
 		}
 		if lastOp := shoot.Status.LastOperation; lastOp != nil {
 			cells = append(cells, lastOp.State)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a column `HIBERNATION` to the shoot table converter which will look similar to the output below. This might be useful for users/operators to check the hibernation status more easily.

```
$ k get shoots
NAME        CLOUDPROFILE   VERSION   SEED          DOMAIN                     HIBERNATION   OPERATION    PROGRESS   APISERVER   CONTROL       NODES     SYSTEM        AGE
local-aws   aws            1.17.3    staging-gcp   local-aws.default.domain   Hibernated    Succeeded    100        True        True          True      True          9d
local-gcp   gcp            1.17.3    staging-gcp   local-gcp.default.domain   Awake         Succeeded    100        True        True          True      True          9d
local-az    az             1.17.3    staging-gcp   local-az.default.domain    Waking Up     Processing   44         True        Progressing   True      Progressing   9m3s
local-os    os             1.17.3    staging-gcp   local-os.default.domain    Hibernating   Processing   34         True        Progressing   True      Progressing   9m3s
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
A column `HIBERNATION` has been added to the output of `kubectl get shoots` which shows the current hibernation status (`Awake`, `Hibernated`, `Hibernating` or `Waking Up`).
```
