### PR TITLE
Aggregate metrics for containers at scaling and limiting threshold.

### DIFF
--- a/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
+++ b/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
@@ -36,6 +36,182 @@ groups:
   - record: seed:hvpa_status_applied_vpa_recommendation_target:sum_by_container
     expr: sum(hvpa_status_applied_vpa_recommendation{recommendation="target"}) by (container, resource)
 
+  # Recording rules for the count of apiserver containers which have CPU usage at or above 80% of their request.
+  # 1. This helps evaluate if memory-based HPA should be re-introduced at 120%. And if it is re-opened what will be the impact on the avg number of replicas per active shoot in the seed clusters.
+  # 2. This helps evaluate the benefit in reducing HPA scale down stabilization period (currently, 24h) to gain better resource utilization.
+  - record: seed:apiserver_containers_over_cpu_scaling_threshold_total:count_by_container
+    expr: count(sum(rate(container_cpu_usage_seconds_total{container="kube-apiserver"}[5m])) by (namespace) / sum(kube_pod_container_resource_requests_cpu_cores{container="kube-apiserver"}) by (namespace) >= 0.8)
+
+  # Recording rules for the count of apiserver containers which have memory usage at or above 120% of their request.
+  # 1. This helps evaluate if memory-based HPA should be re-introduced at 120%. And if it is re-opened what will be the impact on the avg number of replicas per active shoot in the seed clusters.
+  # 2. This helps evaluate the benefit in reducing HPA scale down stabilization period (currently, 24h) to gain better resource utilization.
+  - record: seed:apiserver_containers_over_memory_scaling_threshold_total:count_by_container
+    expr: count(sum(container_memory_working_set_bytes{container="kube-apiserver"}) by (namespace) / sum(kube_pod_container_resource_requests_memory_bytes{container="kube-apiserver"}) by (namespace) >= 1.2)
+
+  # Recording rules for the count of containers which have CPU usage below 80% of their limits, aggregated by containers.
+  # How many shoots and components are not at risk of being affected (CPU-throttled or OOMKilled) if scaling (horizontally or vertically) is blocked due to any reason (bug, deliberate or wrong configuration).
+  - record: seed:containers_below_cpu_limiting_threshold_total:count_by_container
+    expr: count(max(rate(container_cpu_usage_seconds_total[5m])) by (container, namespace) / max(kube_pod_container_resource_limits_cpu_cores) by (container, namespace) < 0.8) by (container)
+
+  # Recording rules for the count of containers which have memory usage below 80% of their limits, aggregated by containers.
+  # How many shoots and components are not at risk of being affected (CPU-throttled or OOMKilled) if scaling (horizontally or vertically) is blocked due to any reason (bug, deliberate or wrong configuration).
+  - record: seed:containers_below_memory_limiting_threshold_total:count_by_container
+    expr: count(max(container_memory_working_set_bytes) by (container, namespace) / max(kube_pod_container_resource_limits_memory_bytes) by (container, namespace) < 0.8) by (container)
+
+  # Recording rules for the count of containers which have CPU usage below 100% of their VPA recommendations, aggregated by containers.
+  # How many shoots and components are not affected by the observed case where VPA was not recommending higher values even when usage was consistently above the present VPA recommendation.
+  - record: seed:containers_below_cpu_recommendation_total:count_by_container
+    expr: count(max(rate(container_cpu_usage_seconds_total[5m])) by (container, namespace) / max(vpa_status_recommendation{recommendation="target", resource="cpu"}) by (container, namespace) < 1) by (container)
+
+  # Recording rules for the count of containers which have memory usage below 100% of their VPA recommendations, aggregated by containers.
+  # How many shoots and components are not affected by the observed case where VPA was not recommending higher values even when usage was consistently above the present VPA recommendation.
+  - record: seed:containers_below_memory_recommendation_total:count_by_container
+    expr: count(max(container_memory_working_set_bytes) by (container, namespace) / max(vpa_status_recommendation{recommendation="target", resource="memory"}) by (container, namespace) < 1) by (container)
+
+  # Recording rules for the count of containers which have CPU usage at or above 80% of their limits, aggregated by containers.
+  # How many shoots and components are at risk of being affected (CPU-throttled or OOMKilled) if scaling (horizontally or vertically) is blocked due to any reason (bug, deliberate or wrong configuration).
+  - record: seed:containers_over_cpu_limiting_threshold_total:count_by_container
+    expr: count(max(rate(container_cpu_usage_seconds_total[5m])) by (container, namespace) / max(kube_pod_container_resource_limits_cpu_cores) by (container, namespace) >= 0.8) by (container)
+
+  # Recording rules for the count of containers which have memory usage at or above 80% of their limits, aggregated by containers.
+  # How many shoots and components are at risk of being affected (CPU-throttled or OOMKilled) if scaling (horizontally or vertically) is blocked due to any reason (bug, deliberate or wrong configuration).
+  - record: seed:containers_over_memory_limiting_threshold_total:count_by_container
+    expr: count(max(container_memory_working_set_bytes) by (container, namespace) / max(kube_pod_container_resource_limits_memory_bytes) by (container, namespace) >= 0.8) by (container)
+
+  # Recording rules for the count of containers which have CPU usage at or above 100% of their VPA recommendations, aggregated by containers.
+  # How many shoots and components are affected by the observed case where VPA was not recommending higher values even when usage was consistently above the present VPA recommendation.
+  - record: seed:containers_over_cpu_recommendation_total:count_by_container
+    expr: count(max(rate(container_cpu_usage_seconds_total[5m])) by (container, namespace) / max(vpa_status_recommendation{recommendation="target", resource="cpu"}) by (container, namespace) >= 1) by (container)
+
+  # Recording rules for the count of containers which have memory usage at or above 100% of their VPA recommendations, aggregated by containers.
+  # How many shoots and components are affected by the observed case where VPA was not recommending higher values even when usage was consistently above the present VPA recommendation.
+  - record: seed:containers_over_memory_recommendation_total:count_by_container
+    expr: count(max(container_memory_working_set_bytes) by (container, namespace) / max(vpa_status_recommendation{recommendation="target", resource="memory"}) by (container, namespace) >= 1) by (container)
+
+  # Recording rules for the count of containers which have CPU requests below 100% of their VPA recommendations, aggregated by containers.
+  # How many shoots and components are adversely affected by any delay in scaling up (due to bugs or deliberate/wrong configuration of HPA, VPA, HVPA).
+  - record: seed:containers_cpu_scale_up_pending_total:count_by_container
+    expr: count(max(kube_pod_container_resource_requests_cpu_cores) by (container, namespace) / max(vpa_status_recommendation{recommendation="target", resource="cpu"}) by (container, namespace) < 1) by (container)
+
+  # Recording rules for the count of containers which have memory requests below 100% of their VPA recommendations, aggregated by containers.
+  # How many shoots and components are adversely affected by any delay in scaling up (due to bugs or deliberate/wrong configuration of HPA, VPA, HVPA).
+  - record: seed:containers_memory_scale_up_pending_total:count_by_container
+    expr: count(max(kube_pod_container_resource_requests_memory_bytes) by (container, namespace) / max(vpa_status_recommendation{recommendation="target", resource="memory"}) by (container, namespace) < 1) by (container)
+
+  # Recording rules for the count of containers which have CPU requests above 100% of their VPA recommendations, aggregated by containers.
+  # How many shoots and components are costing extra resources by any delay in scaling down (due to bugs or deliberate/wrong configuration of HPA, VPA, HVPA).
+  - record: seed:containers_cpu_scale_down_pending_total:count_by_container
+    expr: count(max(kube_pod_container_resource_requests_cpu_cores) by (container, namespace) / max(vpa_status_recommendation{recommendation="target", resource="cpu"}) by (container, namespace) > 1) by (container)
+
+  # Recording rules for the count of containers which have memory requests at or above 100% of their VPA recommendations, aggregated by containers.
+  # How many shoots and components are costing extra resources by any delay in scaling down (due to bugs or deliberate/wrong configuration of HPA, VPA, HVPA).
+  - record: seed:containers_memory_scale_down_pending_total:count_by_container
+    expr: count(max(kube_pod_container_resource_requests_memory_bytes) by (container, namespace) / max(vpa_status_recommendation{recommendation="target", resource="memory"}) by (container, namespace) > 1) by (container)
+
+  # Recording rules for the count of containers which have CPU requests below 60% of their VPA maxAllowed configuration, aggregated by containers.
+  # How many shoots are below 60% of the configured maxAllowed VPA recommendations.
+  - record: seed:containers_below_cpu_max_allowed_threshold_total:count_by_container
+    expr: count(max(kube_pod_container_resource_requests_cpu_cores) by (container, namespace) / max(vpa_spec_container_resource_policy_allowed{allowed="max", resource="cpu"}) by (container, namespace) < 0.6) by (container)
+
+  # Recording rules for the count of containers which have memory requests below 60% of their VPA maxAllowed configuration, aggregated by containers.
+  # How many shoots are below 60% of the configured maxAllowed VPA recommendations.
+  - record: seed:containers_below_memory_max_allowed_threshold_total:count_by_container
+    expr: count(max(kube_pod_container_resource_requests_memory_bytes) by (container, namespace) / max(vpa_spec_container_resource_policy_allowed{allowed="max", resource="memory"}) by (container, namespace) < 0.6) by (container)
+
+  # Recording rules for the count of containers which have CPU requests at or above 60% of their VPA maxAllowed configuration, aggregated by containers.
+  # How many shoots are above 60% of the configured maxAllowed VPA recommendations. We need to know early if our end-users start getting close to the limits of the scale of the cluster that we have tested the performance so far.
+  - record: seed:containers_over_cpu_max_allowed_threshold_total:count_by_container
+    expr: count(max(kube_pod_container_resource_requests_cpu_cores) by (container, namespace) / max(vpa_spec_container_resource_policy_allowed{allowed="max", resource="cpu"}) by (container, namespace) >= 0.6) by (container)
+
+  # Recording rules for the count of containers which have memory requests at or above 60% of their VPA maxAllowed configuration, aggregated by containers.
+  # How many shoots are above 60% of the configured maxAllowed VPA recommendations. We need to know early if our end-users start getting close to the limits of the scale of the cluster that we have tested the performance so far.
+  - record: seed:containers_over_memory_max_allowed_threshold_total:count_by_container
+    expr: count(max(kube_pod_container_resource_requests_memory_bytes) by (container, namespace) / max(vpa_spec_container_resource_policy_allowed{allowed="max", resource="memory"}) by (container, namespace) >= 0.6) by (container)
+
+  # Recording rules for the minimum CPU usage aggregated by container
+  # 1. How far down can we configure VPA minAllowed for the different components. We have some components that can be scaled down further.
+  # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
+  - record: seed:container_cpu_usage_seconds_total:min_by_container
+    expr: min(rate(container_cpu_usage_seconds_total[5m])) by (container)
+
+  # Recording rules for the minimum memory usage aggregated by container
+  # 1. How far down can we configure VPA minAllowed for the different components. We have some components that can be scaled down further.
+  # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
+  - record: seed:container_memory_working_set_bytes:min_by_container
+    expr: min(container_memory_working_set_bytes) by (container)
+
+  # Recording rules for the minimum CPU requests aggregated by container
+  # 1. How far down can we configure VPA minAllowed for the different components. We have some components that can be scaled down further.
+  # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
+  - record: seed:kube_pod_container_resource_requests_cpu_cores:min_by_container
+    expr: min(kube_pod_container_resource_requests_cpu_cores) by (container)
+
+  # Recording rules for the minimum memory requests aggregated by container
+  # 1. How far down can we configure VPA minAllowed for the different components. We have some components that can be scaled down further.
+  # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
+  - record: seed:kube_pod_container_resource_requests_memory_bytes:min_by_container
+    expr: min(kube_pod_container_resource_requests_memory_bytes) by (container)
+
+  # Recording rules for the minimum CPU limits aggregated by container
+  # 1. How far down can we configure VPA minAllowed for the different components. We have some components that can be scaled down further.
+  # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
+  - record: seed:kube_pod_container_resource_limits_cpu_cores:min_by_container
+    expr: min(kube_pod_container_resource_limits_cpu_cores) by (container)
+
+  # Recording rules for the minimum memory limits aggregated by container
+  # 1. How far down can we configure VPA minAllowed for the different components. We have some components that can be scaled down further.
+  # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
+  - record: seed:kube_pod_container_resource_limits_memory_bytes:min_by_container
+    expr: min(kube_pod_container_resource_limits_memory_bytes) by (container)
+
+  # Recording rules for the minimum VPA recommendations aggregated by container and resource
+  # 1. How far down can we configure VPA minAllowed for the different components. We have some components that can be scaled down further.
+  # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
+  - record: seed:vpa_status_recommendation:min_by_container
+    expr: min(vpa_status_recommendation{recommendation="target"}) by (container, resource)
+
+  # Recording rules for the maximum CPU usage aggregated by container
+  # 1. How far down can we configure VPA maxAllowed for the different components. We have some components (especially, the non-shoot workload) that need to be scaled up more.
+  # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
+  - record: seed:container_cpu_usage_seconds_total:max_by_container
+    expr: max(rate(container_cpu_usage_seconds_total[5m])) by (container)
+
+  # Recording rules for the maximum memory usage aggregated by container
+  # 1. How far down can we configure VPA maxAllowed for the different components. We have some components (especially, the non-shoot workload) that need to be scaled up more.
+  # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
+  - record: seed:container_memory_working_set_bytes:max_by_container
+    expr: max(container_memory_working_set_bytes) by (container)
+
+  # Recording rules for the maximum CPU requests aggregated by container
+  # 1. How far down can we configure VPA maxAllowed for the different components. We have some components (especially, the non-shoot workload) that need to be scaled up more.
+  # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
+  - record: seed:kube_pod_container_resource_requests_cpu_cores:max_by_container
+    expr: max(kube_pod_container_resource_requests_cpu_cores) by (container)
+
+  # Recording rules for the maximum memory requests aggregated by container
+  # 1. How far down can we configure VPA maxAllowed for the different components. We have some components (especially, the non-shoot workload) that need to be scaled up more.
+  # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
+  - record: seed:kube_pod_container_resource_requests_memory_bytes:max_by_container
+    expr: max(kube_pod_container_resource_requests_memory_bytes) by (container)
+
+  # Recording rules for the maximum CPU limits aggregated by container
+  # 1. How far down can we configure VPA maxAllowed for the different components. We have some components (especially, the non-shoot workload) that need to be scaled up more.
+  # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
+  - record: seed:kube_pod_container_resource_limits_cpu_cores:max_by_container
+    expr: max(kube_pod_container_resource_limits_cpu_cores) by (container)
+
+  # Recording rules for the maximum memory limits aggregated by container
+  # 1. How far down can we configure VPA maxAllowed for the different components. We have some components (especially, the non-shoot workload) that need to be scaled up more.
+  # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
+  - record: seed:kube_pod_container_resource_limits_memory_bytes:max_by_container
+    expr: max(kube_pod_container_resource_limits_memory_bytes) by (container)
+
+  # Recording rules for the maximum VPA recommendations aggregated by container and resource
+  # 1. How far down can we configure VPA maxAllowed for the different components. We have some components (especially, the non-shoot workload) that need to be scaled up more.
+  # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
+  - record: seed:vpa_status_recommendation:max_by_container
+    expr: max(vpa_status_recommendation{recommendation="target"}) by (container, resource)
+
   # Recording rules for container count per container
   - record: seed:kube_pod_container_info:count_by_container
     expr: count(kube_pod_container_info) by (container)


### PR DESCRIPTION
**What this PR does / why we need it**:
Added the following aggregate metrics (by containers).

1. To keep track of the number of containers whose resource usage is over scaling, limiting thresholds, vpa recommendations.
1. To keep track of the number containers which have pending scale down or scale up recommendations.
1. To keep track of minimum and maximum values for usage, requests, limits and VPA recommendations for containers across the cluster.
1. To keep track of the number of containers that have requests over a threshold percentage of their VPA maxAllowed configuration.

This can help evaluation and analyse different aspects and performance of horizontal and vertical scaling.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Added the following aggregate metrics (by containers). Firstly, to keep track of the number of containers whose resource usage is over scaling, limiting thresholds, vpa recommendations. Secondly, to keep track of the number containers which have pending scale down or scale up recommendations. Thirdly, to keep track of minimum and maximum values for usage, requests, limits and VPA recommendations for containers across the cluster. Fourthly, to keep track of the number of containers that have requests over a threshold percentage of their VPA maxAllowed configuration.
```
