### PR TITLE
Persist etcd encryption in shootstate

### DIFF
--- a/pkg/apis/core/v1alpha1/helper/shootstate_list.go
+++ b/pkg/apis/core/v1alpha1/helper/shootstate_list.go
@@ -60,3 +60,37 @@ func matchesExtensionResourceState(extensionResourceState *gardencorev1alpha1.Ex
 	}
 	return false
 }
+
+// GardenerResourceDataList defines function
+type GardenerResourceDataList []gardencorev1alpha1.GardenerResourceData
+
+// Delete deletes an item from the list
+func (g *GardenerResourceDataList) Delete(name string) {
+	for i, e := range *g {
+		if e.Name == name {
+			*g = append((*g)[:i], (*g)[i+1:]...)
+		}
+	}
+}
+
+// Get returns the item from the list
+func (g *GardenerResourceDataList) Get(name string) *gardencorev1alpha1.GardenerResourceData {
+	for _, resourceDataEntry := range *g {
+		if resourceDataEntry.Name == name {
+			return &resourceDataEntry
+		}
+	}
+	return nil
+}
+
+// Upsert inserts a new element or updates an existing one
+func (g *GardenerResourceDataList) Upsert(data *gardencorev1alpha1.GardenerResourceData) {
+	for i, obj := range *g {
+		if obj.Name == data.Name {
+			(*g)[i].Type = data.Type
+			(*g)[i].Data = data.Data
+			return
+		}
+	}
+	*g = append(*g, *data)
+}

--- a/pkg/apis/core/v1alpha1/helper/shootstate_list_test.go
+++ b/pkg/apis/core/v1alpha1/helper/shootstate_list_test.go
@@ -23,94 +23,181 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-var _ = Describe("ExtensionResourceStateList", func() {
-	fooString := "foo"
-	var (
-		shootState       *gardencorev1alpha1.ShootState
-		extensionKind    = fooString
-		extensionName    = &fooString
-		extensionPurpose = &fooString
-		extensionData    = runtime.RawExtension{Raw: []byte("data")}
-	)
+var _ = Describe("ShootStateList", func() {
 
-	BeforeEach(func() {
-		shootState = &gardencorev1alpha1.ShootState{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "foo",
-			},
-			Spec: gardencorev1alpha1.ShootStateSpec{
-				Extensions: []gardencorev1alpha1.ExtensionResourceState{
-					{
-						Kind:    extensionKind,
-						Name:    extensionName,
-						Purpose: extensionPurpose,
-						State:   extensionData,
+	Describe("ExtensionResourceStateList", func() {
+		fooString := "foo"
+		var (
+			shootState       *gardencorev1alpha1.ShootState
+			extensionKind    = fooString
+			extensionName    = &fooString
+			extensionPurpose = &fooString
+			extensionData    = runtime.RawExtension{Raw: []byte("data")}
+		)
+
+		BeforeEach(func() {
+			shootState = &gardencorev1alpha1.ShootState{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo",
+				},
+				Spec: gardencorev1alpha1.ShootStateSpec{
+					Extensions: []gardencorev1alpha1.ExtensionResourceState{
+						{
+							Kind:    extensionKind,
+							Name:    extensionName,
+							Purpose: extensionPurpose,
+							State:   extensionData,
+						},
 					},
 				},
-			},
-		}
-	})
-
-	Context("#Get", func() {
-		It("should return the correct extension resource state", func() {
-			list := ExtensionResourceStateList(shootState.Spec.Extensions)
-			resource := list.Get(extensionKind, extensionName, extensionPurpose)
-			Expect(resource.Kind).To(Equal(extensionKind))
-			Expect(resource.Name).To(Equal(extensionName))
-			Expect(resource.Purpose).To(Equal(extensionPurpose))
-			Expect(resource.State).To(Equal(extensionData))
-		})
-
-		It("should return nil if extension resource state cannot be found", func() {
-			list := ExtensionResourceStateList(shootState.Spec.Extensions)
-			barString := "bar"
-			resource := list.Get(barString, &barString, &barString)
-			Expect(resource).To(BeNil())
-		})
-	})
-
-	Context("#Delete", func() {
-		It("should delete the extension resource state when it can be found", func() {
-			list := ExtensionResourceStateList(shootState.Spec.Extensions)
-			list.Delete(extensionKind, extensionName, extensionPurpose)
-			Expect(len(list)).To(Equal(0))
-		})
-
-		It("should do nothing if extension resource state cannot be found", func() {
-			list := ExtensionResourceStateList(shootState.Spec.Extensions)
-			barString := "bar"
-			list.Delete(barString, &barString, &barString)
-			Expect(len(list)).To(Equal(1))
-		})
-	})
-
-	Context("#Upsert", func() {
-		It("should append new extension resource state to the list", func() {
-			list := ExtensionResourceStateList(shootState.Spec.Extensions)
-			barString := "bar"
-			newResource := &gardencorev1alpha1.ExtensionResourceState{
-				Kind:    barString,
-				Name:    &barString,
-				Purpose: &barString,
-				State:   runtime.RawExtension{Raw: []byte("state")},
 			}
-			list.Upsert(newResource)
-			Expect(len(list)).To(Equal(2))
 		})
 
-		It("should update an extension resource state in the list if it already exists", func() {
-			list := ExtensionResourceStateList(shootState.Spec.Extensions)
-			newState := runtime.RawExtension{Raw: []byte("new state")}
-			updatedResource := &gardencorev1alpha1.ExtensionResourceState{
-				Kind:    extensionKind,
-				Name:    extensionName,
-				Purpose: extensionPurpose,
-				State:   newState,
-			}
-			list.Upsert(updatedResource)
-			Expect(len(list)).To(Equal(1))
-			Expect(list[0].State).To(Equal(newState))
+		Context("#Get", func() {
+			It("should return the correct extension resource state", func() {
+				list := ExtensionResourceStateList(shootState.Spec.Extensions)
+				resource := list.Get(extensionKind, extensionName, extensionPurpose)
+				Expect(resource.Kind).To(Equal(extensionKind))
+				Expect(resource.Name).To(Equal(extensionName))
+				Expect(resource.Purpose).To(Equal(extensionPurpose))
+				Expect(resource.State).To(Equal(extensionData))
+			})
+
+			It("should return nil if extension resource state cannot be found", func() {
+				list := ExtensionResourceStateList(shootState.Spec.Extensions)
+				barString := "bar"
+				resource := list.Get(barString, &barString, &barString)
+				Expect(resource).To(BeNil())
+			})
+		})
+
+		Context("#Delete", func() {
+			It("should delete the extension resource state when it can be found", func() {
+				list := ExtensionResourceStateList(shootState.Spec.Extensions)
+				list.Delete(extensionKind, extensionName, extensionPurpose)
+				Expect(len(list)).To(Equal(0))
+			})
+
+			It("should do nothing if extension resource state cannot be found", func() {
+				list := ExtensionResourceStateList(shootState.Spec.Extensions)
+				barString := "bar"
+				list.Delete(barString, &barString, &barString)
+				Expect(len(list)).To(Equal(1))
+			})
+		})
+
+		Context("#Upsert", func() {
+			It("should append new extension resource state to the list", func() {
+				list := ExtensionResourceStateList(shootState.Spec.Extensions)
+				barString := "bar"
+				newResource := &gardencorev1alpha1.ExtensionResourceState{
+					Kind:    barString,
+					Name:    &barString,
+					Purpose: &barString,
+					State:   runtime.RawExtension{Raw: []byte("state")},
+				}
+				list.Upsert(newResource)
+				Expect(len(list)).To(Equal(2))
+			})
+
+			It("should update an extension resource state in the list if it already exists", func() {
+				list := ExtensionResourceStateList(shootState.Spec.Extensions)
+				newState := runtime.RawExtension{Raw: []byte("new state")}
+				updatedResource := &gardencorev1alpha1.ExtensionResourceState{
+					Kind:    extensionKind,
+					Name:    extensionName,
+					Purpose: extensionPurpose,
+					State:   newState,
+				}
+				list.Upsert(updatedResource)
+				Expect(len(list)).To(Equal(1))
+				Expect(list[0].State).To(Equal(newState))
+			})
 		})
 	})
+
+	Describe("GardenerResourceDataList", func() {
+		var (
+			shootState           *gardencorev1alpha1.ShootState
+			dataName             = "foo"
+			dataType             = "foo"
+			gardenerResourceData = runtime.RawExtension{Raw: []byte("data")}
+		)
+
+		BeforeEach(func() {
+			shootState = &gardencorev1alpha1.ShootState{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo",
+				},
+				Spec: gardencorev1alpha1.ShootStateSpec{
+					Gardener: []gardencorev1alpha1.GardenerResourceData{
+						{
+							Name: dataName,
+							Type: dataType,
+							Data: gardenerResourceData,
+						},
+					},
+				},
+			}
+		})
+
+		Context("#Get", func() {
+			It("should return the correct extension resource state", func() {
+				list := GardenerResourceDataList(shootState.Spec.Gardener)
+				resource := list.Get(dataName)
+				Expect(resource.Name).To(Equal(dataName))
+				Expect(resource.Type).To(Equal(dataType))
+				Expect(resource.Data).To(Equal(gardenerResourceData))
+			})
+
+			It("should return nil if extension resource state cannot be found", func() {
+				list := GardenerResourceDataList(shootState.Spec.Gardener)
+				resource := list.Get("bar")
+				Expect(resource).To(BeNil())
+			})
+		})
+
+		Context("#Delete", func() {
+			It("should delete the extension resource state when it can be found", func() {
+				list := GardenerResourceDataList(shootState.Spec.Gardener)
+				list.Delete(dataName)
+				Expect(len(list)).To(Equal(0))
+			})
+
+			It("should do nothing if extension resource state cannot be found", func() {
+				list := GardenerResourceDataList(shootState.Spec.Gardener)
+				list.Delete("bar")
+				Expect(len(list)).To(Equal(1))
+			})
+		})
+
+		Context("#Upsert", func() {
+			It("should append new extension resource state to the list", func() {
+				list := GardenerResourceDataList(shootState.Spec.Gardener)
+				newResource := &gardencorev1alpha1.GardenerResourceData{
+					Name: "bar",
+					Type: "bar",
+					Data: runtime.RawExtension{Raw: []byte("data")},
+				}
+				list.Upsert(newResource)
+				Expect(len(list)).To(Equal(2))
+			})
+
+			It("should update an extension resource state in the list if it already exists", func() {
+				list := GardenerResourceDataList(shootState.Spec.Gardener)
+				newData := runtime.RawExtension{Raw: []byte("new data")}
+				updatedResource := &gardencorev1alpha1.GardenerResourceData{
+					Name: dataName,
+					Type: dataType,
+					Data: newData,
+				}
+				list.Upsert(updatedResource)
+				Expect(len(list)).To(Equal(1))
+				Expect(list[0].Data).To(Equal(newData))
+			})
+		})
+	})
+
 })

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -131,8 +131,8 @@ const (
 	// is accepted.
 	GardenerDeletionProtected = "gardener.cloud/deletion-protected"
 
-	// ETCDSecretsEncryptionConfigDataName is the name of ShootState data entry holding the current key and encryption state used to encrypt shoot secrets
-	ETCDSecretsEncryptionConfigDataName = "etcdSecretsEncryptionConfiguration"
+	// ETCDEncryptionConfigDataName is the name of ShootState data entry holding the current key and encryption state used to encrypt shoot resources
+	ETCDEncryptionConfigDataName = "etcdEncryptionConfiguration"
 
 	// GardenRoleDefaultDomain is the value of the GardenRole key indicating type 'default-domain'.
 	GardenRoleDefaultDomain = "default-domain"

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -131,6 +131,9 @@ const (
 	// is accepted.
 	GardenerDeletionProtected = "gardener.cloud/deletion-protected"
 
+	// ETCDSecretsEncryptionConfigDataName is the name of ShootState data entry holding the current key and encryption state used to encrypt shoot secrets
+	ETCDSecretsEncryptionConfigDataName = "etcdSecretsEncryptionConfiguration"
+
 	// GardenRoleDefaultDomain is the value of the GardenRole key indicating type 'default-domain'.
 	GardenRoleDefaultDomain = "default-domain"
 

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -610,9 +610,9 @@ func EffectiveShootMaintenanceTimeWindow(shoot *gardencorev1beta1.Shoot) *utils.
 	return EffectiveMaintenanceTimeWindow(timeWindow)
 }
 
-// GardenEtcdEncryptionSecretKey is the key to the 'backup' of the etcd encryption secret in the Garden cluster.
-func GardenEtcdEncryptionSecretKey(shootNamespace, shootName string) client.ObjectKey {
-	return kutil.Key(shootNamespace, fmt.Sprintf("%s.%s", shootName, EtcdEncryptionSecretName))
+// GardenEtcdEncryptionSecretName returns the name to the 'backup' of the etcd encryption secret in the Garden cluster.
+func GardenEtcdEncryptionSecretName(shootName string) string {
+	return fmt.Sprintf("%s.%s", shootName, EtcdEncryptionSecretName)
 }
 
 // ReadServiceAccountSigningKeySecret reads the signing key secret to extract the signing key.

--- a/pkg/operation/etcdencryption/encryptionconfiguration.go
+++ b/pkg/operation/etcdencryption/encryptionconfiguration.go
@@ -18,8 +18,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gardener/gardener/pkg/operation/common"
@@ -48,6 +46,37 @@ func init() {
 		apiserverconfigv1.SchemeGroupVersion)
 }
 
+// NewEncryptionConfiguration creates an EncryptionConfiguration from the key and state
+func NewEncryptionConfiguration(encryptionConfig *ETCDEncryptionConfig) *apiserverconfigv1.EncryptionConfiguration {
+	encryptionKeys := make([]apiserverconfigv1.Key, len(encryptionConfig.EncryptionKeys))
+	for i, keyData := range encryptionConfig.EncryptionKeys {
+		encryptionKeys[i].Name = keyData.Name
+		encryptionKeys[i].Secret = keyData.Key
+	}
+	aesConfiguration := &apiserverconfigv1.AESConfiguration{Keys: encryptionKeys}
+
+	aescbcProviderConfiguration := apiserverconfigv1.ProviderConfiguration{AESCBC: aesConfiguration}
+	identityProviderConfiguration := apiserverconfigv1.ProviderConfiguration{Identity: &apiserverconfigv1.IdentityConfiguration{}}
+
+	providerConfigs := []apiserverconfigv1.ProviderConfiguration{}
+	if !encryptionConfig.ForcePlainTextResources {
+		providerConfigs = append(providerConfigs, aescbcProviderConfiguration, identityProviderConfiguration)
+	} else {
+		providerConfigs = append(providerConfigs, identityProviderConfiguration, aescbcProviderConfiguration)
+	}
+
+	resourceConfig := apiserverconfigv1.ResourceConfiguration{
+		Resources: []string{common.EtcdEncryptionEncryptedResourceSecrets},
+		Providers: providerConfigs,
+	}
+
+	conf := &apiserverconfigv1.EncryptionConfiguration{
+		Resources: []apiserverconfigv1.ResourceConfiguration{resourceConfig},
+	}
+
+	return conf
+}
+
 // NewEncryptionKey creates a new random encryption key with a name containing the timestamp.
 // The reader should return random data suitable for cryptographic use, otherwise the security
 // of encryption might be compromised.
@@ -69,20 +98,6 @@ func NewEncryptionKeyName(t time.Time) string {
 	return fmt.Sprintf("%s%d", common.EtcdEncryptionKeyPrefix, t.Unix())
 }
 
-// ParseEncryptionKeyName parses the key name.
-func ParseEncryptionKeyName(keyName string) (time.Time, error) {
-	if strings.HasPrefix(common.EtcdEncryptionKeyPrefix, keyName) {
-		return time.Time{}, fmt.Errorf("key does not start with prefix %s", common.EtcdEncryptionKeyPrefix)
-	}
-
-	n, err := strconv.ParseInt(strings.TrimPrefix(keyName, common.EtcdEncryptionKeyPrefix), 10, 64)
-	if err != nil {
-		return time.Time{}, err
-	}
-
-	return time.Unix(n, 0), nil
-}
-
 // NewEncryptionKeySecret reads common.EtcdEncryptionSecretLen bytes from the given reader
 // and base-64 encodes the data.
 // The reader should return random data suitable for cryptographic use, otherwise the security
@@ -95,49 +110,6 @@ func NewEncryptionKeySecret(r io.Reader) (string, error) {
 
 	sEnc := base64.StdEncoding.EncodeToString(buf)
 	return sEnc, nil
-}
-
-// NewPassiveConfiguration creates an initial configuration for etcd encryption
-// The list of encryption providers contains identity as first provider, which has
-// the effect, that this configuration does not yet encrypt written secrets. The
-// configuration has to be activated to actually encrypt written secrets.
-// Nevertheless, an encryption provider aescbc is already contained in the configuration
-// at the second position in the list of providers. A key is created for aescbc with
-// the key's name containing the given time.
-//
-// apiVersion: apiserver.config.k8s.io/v1
-// kind: EncryptionConfiguration
-// resources:
-// - providers:
-//   - identity: {}
-//   - aescbc:
-//       keys:
-//       - name: key1559747207815249000
-//         secret: Y8LEzbtK/2mdXrw6W/faAxNLu+mTCmcQeWojShAJGEg=
-//   resources:
-//     metadata:
-//   - secrets
-func NewPassiveConfiguration(t time.Time, r io.Reader) (*apiserverconfigv1.EncryptionConfiguration, error) {
-	key, err := NewEncryptionKey(t, r)
-	if err != nil {
-		return nil, err
-	}
-
-	return &apiserverconfigv1.EncryptionConfiguration{
-		Resources: []apiserverconfigv1.ResourceConfiguration{
-			{
-				Resources: []string{common.EtcdEncryptionEncryptedResourceSecrets},
-				Providers: []apiserverconfigv1.ProviderConfiguration{
-					{Identity: &apiserverconfigv1.IdentityConfiguration{}},
-					{AESCBC: &apiserverconfigv1.AESConfiguration{
-						Keys: []apiserverconfigv1.Key{
-							*key,
-						},
-					}},
-				},
-			},
-		},
-	}, nil
 }
 
 // Load decodes an EncryptionConfiguration from the given data.
@@ -155,10 +127,6 @@ func Write(ec *apiserverconfigv1.EncryptionConfiguration) ([]byte, error) {
 	return runtime.Encode(codec, ec)
 }
 
-func isEncryptingProviderConfiguration(conf *apiserverconfigv1.ProviderConfiguration) bool {
-	return conf.Identity == nil
-}
-
 func findResourceConfigurationForResource(configs []apiserverconfigv1.ResourceConfiguration, resource string) (*apiserverconfigv1.ResourceConfiguration, error) {
 	for _, config := range configs {
 		for _, r := range config.Resources {
@@ -168,30 +136,6 @@ func findResourceConfigurationForResource(configs []apiserverconfigv1.ResourceCo
 		}
 	}
 	return nil, fmt.Errorf("no resource configuration found for resource %q", resource)
-}
-
-// SetResourceEncryption sets the EncryptionConfiguration to active or non-active (passive) state.
-// State active means that provider aescbc is the first in the list of providers.
-// State non-active (passive) means that provider identity is the first in the list of providers.
-func SetResourceEncryption(c *apiserverconfigv1.EncryptionConfiguration, resource string, encrypted bool) error {
-	conf, err := findResourceConfigurationForResource(c.Resources, resource)
-	if err != nil {
-		return err
-	}
-
-	for i := 0; i < len(conf.Providers); i++ {
-		if isEncryptingProviderConfiguration(&conf.Providers[i]) == encrypted {
-			if i == 0 {
-				return nil
-			}
-
-			tmp := conf.Providers[0]
-			conf.Providers[0] = conf.Providers[i]
-			conf.Providers[i] = tmp
-			return nil
-		}
-	}
-	return fmt.Errorf("no encryption provider configuration found for to set encryption of resource %q to %t", resource, encrypted)
 }
 
 var errConfigurationNotFound = fmt.Errorf("no encryption configuration at %s", common.EtcdEncryptionSecretFileName)
@@ -232,4 +176,20 @@ func UpdateSecret(secret *corev1.Secret, conf *apiserverconfigv1.EncryptionConfi
 
 	secret.Data[common.EtcdEncryptionSecretFileName] = confData
 	return nil
+}
+
+// GetSecretKeyForResources returns the AESCBC key name and AESCBC key secret which is used to encrypt the resource.
+// If the AESCBC is not found then it returns empty strings.
+func GetSecretKeyForResources(config *apiserverconfigv1.EncryptionConfiguration, resources string) (string, string, error) {
+	conf, err := findResourceConfigurationForResource(config.Resources, resources)
+	if err != nil {
+		return "", "", err
+	}
+
+	for _, providerConfig := range conf.Providers {
+		if providerConfig.AESCBC != nil {
+			return providerConfig.AESCBC.Keys[0].Name, providerConfig.AESCBC.Keys[0].Secret, nil
+		}
+	}
+	return "", "", nil
 }

--- a/pkg/operation/etcdencryption/encryptionconfiguration.go
+++ b/pkg/operation/etcdencryption/encryptionconfiguration.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package encryptionconfiguration
+package etcdencryption
 
 import (
 	"encoding/base64"
@@ -47,7 +47,7 @@ func init() {
 }
 
 // NewEncryptionConfiguration creates an EncryptionConfiguration from the key and state
-func NewEncryptionConfiguration(encryptionConfig *ETCDEncryptionConfig) *apiserverconfigv1.EncryptionConfiguration {
+func NewEncryptionConfiguration(encryptionConfig *EncryptionConfig) *apiserverconfigv1.EncryptionConfiguration {
 	encryptionKeys := make([]apiserverconfigv1.Key, len(encryptionConfig.EncryptionKeys))
 	for i, keyData := range encryptionConfig.EncryptionKeys {
 		encryptionKeys[i].Name = keyData.Name
@@ -70,11 +70,9 @@ func NewEncryptionConfiguration(encryptionConfig *ETCDEncryptionConfig) *apiserv
 		Providers: providerConfigs,
 	}
 
-	conf := &apiserverconfigv1.EncryptionConfiguration{
+	return &apiserverconfigv1.EncryptionConfiguration{
 		Resources: []apiserverconfigv1.ResourceConfiguration{resourceConfig},
 	}
-
-	return conf
 }
 
 // NewEncryptionKey creates a new random encryption key with a name containing the timestamp.

--- a/pkg/operation/etcdencryption/encryptionconfiguration_test.go
+++ b/pkg/operation/etcdencryption/encryptionconfiguration_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Encryption Configuration", func() {
 		r                     io.Reader
 		randomBase64          string
 		t                     time.Time
+		keyName               string
 		yamlString            string
 		yamlData              []byte
 		identityConfiguration apiserverconfigv1.ProviderConfiguration
@@ -56,6 +57,7 @@ var _ = Describe("Encryption Configuration", func() {
 		randomBytes = bytes.Repeat([]byte{1}, common.EtcdEncryptionKeySecretLen)
 		r = bytes.NewReader(randomBytes)
 		randomBase64 = base64.StdEncoding.EncodeToString(randomBytes)
+		keyName = NewEncryptionKeyName(t)
 		yamlString = fmt.Sprintf(
 			`apiVersion: %s
 kind: %s
@@ -74,7 +76,7 @@ resources:
 		aescbcConfiguration = apiserverconfigv1.ProviderConfiguration{AESCBC: &apiserverconfigv1.AESConfiguration{
 			Keys: []apiserverconfigv1.Key{
 				{
-					Name:   NewEncryptionKeyName(t),
+					Name:   keyName,
 					Secret: randomBase64,
 				},
 			},
@@ -130,23 +132,40 @@ resources:
 		})
 	})
 
-	Describe("#ParseEncryptionKeyName", func() {
-		It("should parse the creation time of the encryption key", func() {
-			keyName := NewEncryptionKeyName(t)
+	Describe("#NewEncryptionConfiguration", func() {
+		var etcdEncryption *ETCDEncryptionConfig
 
-			t, err := ParseEncryptionKeyName(keyName)
+		BeforeEach(func() {
+			etcdEncryption = &ETCDEncryptionConfig{
+				EncryptionKeys: []ETCDEncryptionKey{
+					{
+						Name: keyName,
+						Key:  randomBase64,
+					},
+				},
+			}
+		})
+		It("should create a new active encryption configuration with AESCBC and identity providers", func() {
+			actual := NewEncryptionConfiguration(etcdEncryption)
 
-			Expect(err).NotTo(HaveOccurred())
-			Expect(t).To(Equal(t))
+			Expect(actual).To(Equal(activeConf))
+		})
+
+		It("should create a new passive configuration with identity and AESCBC providers", func() {
+			etcdEncryption.ForcePlainTextResources = true
+			actual := NewEncryptionConfiguration(etcdEncryption)
+
+			Expect(actual).To(Equal(passiveConf))
 		})
 	})
 
-	Describe("#NewPassiveConfiguration", func() {
-		It("should create a new encryption configuration with identity and AESCBC", func() {
-			actual, err := NewPassiveConfiguration(t, r)
+	Describe("#GetSecretKeyForResources", func() {
+		It("should get the secret key and name for the provided list of resources", func() {
+			name, key, err := GetSecretKeyForResources(activeConf, common.EtcdEncryptionEncryptedResourceSecrets)
 
-			Expect(err).NotTo(HaveOccurred())
-			Expect(actual).To(Equal(passiveConf))
+			Expect(err).To(BeNil())
+			Expect(name).To(Equal(keyName))
+			Expect(key).To(Equal(randomBase64))
 		})
 	})
 
@@ -166,38 +185,6 @@ resources:
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(actual).To(Equal(yamlData))
-		})
-	})
-
-	Describe("#SetResourceEncryption", func() {
-		It("should enable the resource encryption for secrets", func() {
-			conf := passiveConf.DeepCopy()
-			Expect(SetResourceEncryption(conf, common.EtcdEncryptionEncryptedResourceSecrets, true)).
-				To(Succeed())
-			Expect(conf).To(Equal(activeConf))
-		})
-
-		It("should disable the resource encryption for secrets", func() {
-			conf := activeConf.DeepCopy()
-			Expect(SetResourceEncryption(conf, common.EtcdEncryptionEncryptedResourceSecrets, false)).
-				To(Succeed())
-			Expect(conf).To(Equal(passiveConf))
-		})
-
-		It("should error if there is no configuration for a resource", func() {
-			Expect(SetResourceEncryption(passiveConf, "configmaps", true)).To(HaveOccurred())
-		})
-
-		It("should error if there is no encrypting provider and encrypted is true", func() {
-			conf := passiveConf.DeepCopy()
-			conf.Resources[0].Providers = []apiserverconfigv1.ProviderConfiguration{identityConfiguration}
-			Expect(SetResourceEncryption(conf, common.EtcdEncryptionEncryptedResourceSecrets, true)).To(HaveOccurred())
-		})
-
-		It("should error if there is no identity provider and encrypted is false", func() {
-			conf := passiveConf.DeepCopy()
-			conf.Resources[0].Providers = []apiserverconfigv1.ProviderConfiguration{aescbcConfiguration}
-			Expect(SetResourceEncryption(conf, common.EtcdEncryptionEncryptedResourceSecrets, false)).To(HaveOccurred())
 		})
 	})
 

--- a/pkg/operation/etcdencryption/encryptionconfiguration_test.go
+++ b/pkg/operation/etcdencryption/encryptionconfiguration_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package encryptionconfiguration_test
+package etcdencryption_test
 
 import (
 	"bytes"
@@ -133,11 +133,11 @@ resources:
 	})
 
 	Describe("#NewEncryptionConfiguration", func() {
-		var etcdEncryption *ETCDEncryptionConfig
+		var etcdEncryption *EncryptionConfig
 
 		BeforeEach(func() {
-			etcdEncryption = &ETCDEncryptionConfig{
-				EncryptionKeys: []ETCDEncryptionKey{
+			etcdEncryption = &EncryptionConfig{
+				EncryptionKeys: []EncryptionKey{
 					{
 						Name: keyName,
 						Key:  randomBase64,

--- a/pkg/operation/etcdencryption/etcdencryption_suite_test.go
+++ b/pkg/operation/etcdencryption/etcdencryption_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package encryptionconfiguration_test
+package etcdencryption_test
 
 import (
 	"testing"

--- a/pkg/operation/etcdencryption/etcdencryptiondata.go
+++ b/pkg/operation/etcdencryption/etcdencryptiondata.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package encryptionconfiguration
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/utils/infodata"
+)
+
+// ETCDEncryptionDataType is the type used to denote an ETCDKeyData structure in the ShootState
+const ETCDEncryptionDataType = infodata.TypeVersion("etcdEncryption")
+
+// ETCDEncryptionStateDataType is the type used to denote an ETCDEncryptionStateData structure in the ShootState
+//const ETCDEncryptionStateDataType = infodata.TypeVersion("etcdEncryptionStateData")
+
+func init() {
+	infodata.Register(ETCDEncryptionDataType, ETCDEncryptionUnmarshal)
+}
+
+// ETCDEncryptionKeyData holds the key and its name used to encrypt resources in ETCD
+type ETCDEncryptionKeyData struct {
+	Key  string `json:"key"`
+	Name string `json:"name"`
+}
+
+// ETCDEncryptionConfigData holds information whether a key is active or not and whether resources should be forcefully kept in plain text
+type ETCDEncryptionConfigData struct {
+	EncryptionKeys          []ETCDEncryptionKeyData `json:"encryptionKeys"`
+	ForcePlainTextResources bool                    `json:"forcePlainTextResources"`
+	RewriteResources        bool                    `json:"rewriteResources"`
+}
+
+// ETCDEncryptionUnmarshal unmarshals an ETCDKeyData json.
+func ETCDEncryptionUnmarshal(bytes []byte) (infodata.InfoData, error) {
+	if bytes == nil {
+		return nil, fmt.Errorf("no data given")
+	}
+	data := &ETCDEncryptionConfigData{}
+	err := json.Unmarshal(bytes, data)
+	if err != nil {
+		return nil, err
+	}
+
+	encryptionKeys := make([]ETCDEncryptionKey, len(data.EncryptionKeys))
+	for i, encryptionKey := range data.EncryptionKeys {
+		encryptionKeys[i].Key = encryptionKey.Key
+		encryptionKeys[i].Name = encryptionKey.Name
+	}
+
+	return NewETCDEncryption(encryptionKeys, data.ForcePlainTextResources, data.RewriteResources)
+}

--- a/pkg/operation/etcdencryption/etcdencryptiondata.go
+++ b/pkg/operation/etcdencryption/etcdencryptiondata.go
@@ -16,7 +16,7 @@
  *
  */
 
-package encryptionconfiguration
+package etcdencryption
 
 import (
 	"encoding/json"
@@ -32,38 +32,38 @@ const ETCDEncryptionDataType = infodata.TypeVersion("etcdEncryption")
 //const ETCDEncryptionStateDataType = infodata.TypeVersion("etcdEncryptionStateData")
 
 func init() {
-	infodata.Register(ETCDEncryptionDataType, ETCDEncryptionUnmarshal)
+	infodata.Register(ETCDEncryptionDataType, Unmarshal)
 }
 
-// ETCDEncryptionKeyData holds the key and its name used to encrypt resources in ETCD
-type ETCDEncryptionKeyData struct {
+// EncryptionKeyData holds the key and its name used to encrypt resources in ETCD
+type EncryptionKeyData struct {
 	Key  string `json:"key"`
 	Name string `json:"name"`
 }
 
-// ETCDEncryptionConfigData holds information whether a key is active or not and whether resources should be forcefully kept in plain text
-type ETCDEncryptionConfigData struct {
-	EncryptionKeys          []ETCDEncryptionKeyData `json:"encryptionKeys"`
-	ForcePlainTextResources bool                    `json:"forcePlainTextResources"`
-	RewriteResources        bool                    `json:"rewriteResources"`
+// EncryptionConfigData holds a list of keys and information whether resources should be forcefully persisted in plain text and rewritten if the configuration changes.
+type EncryptionConfigData struct {
+	EncryptionKeys          []EncryptionKeyData `json:"encryptionKeys"`
+	ForcePlainTextResources bool                `json:"forcePlainTextResources"`
+	RewriteResources        bool                `json:"rewriteResources"`
 }
 
-// ETCDEncryptionUnmarshal unmarshals an ETCDKeyData json.
-func ETCDEncryptionUnmarshal(bytes []byte) (infodata.InfoData, error) {
+// Unmarshal unmarshals an ETCDKeyData json.
+func Unmarshal(bytes []byte) (infodata.InfoData, error) {
 	if bytes == nil {
 		return nil, fmt.Errorf("no data given")
 	}
-	data := &ETCDEncryptionConfigData{}
+	data := &EncryptionConfigData{}
 	err := json.Unmarshal(bytes, data)
 	if err != nil {
 		return nil, err
 	}
 
-	encryptionKeys := make([]ETCDEncryptionKey, len(data.EncryptionKeys))
+	encryptionKeys := make([]EncryptionKey, len(data.EncryptionKeys))
 	for i, encryptionKey := range data.EncryptionKeys {
 		encryptionKeys[i].Key = encryptionKey.Key
 		encryptionKeys[i].Name = encryptionKey.Name
 	}
 
-	return NewETCDEncryption(encryptionKeys, data.ForcePlainTextResources, data.RewriteResources)
+	return NewEncryptionConfig(encryptionKeys, data.ForcePlainTextResources, data.RewriteResources)
 }

--- a/pkg/operation/etcdencryption/etcdencryptiondata_test.go
+++ b/pkg/operation/etcdencryption/etcdencryptiondata_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package encryptionconfiguration_test
+
+import (
+	. "github.com/gardener/gardener/pkg/operation/etcdencryption"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ETCD Encryption Data", func() {
+	var (
+		etcdEncryptionDataJson = []byte("{\"encryptionKeys\":[{\"key\":\"foo\",\"name\":\"bar\"}],\"forcePlainTextResources\":true,\"rewriteResources\":true}")
+		etcdEncryptionConfig   = &ETCDEncryptionConfig{
+			EncryptionKeys: []ETCDEncryptionKey{
+				{
+					Key:  "foo",
+					Name: "bar",
+				},
+			},
+			ForcePlainTextResources: true,
+			RewriteResources:        true,
+		}
+	)
+	It("should correctly unmarshal ETCDEncryptionConfigData struct into ETCDEncryptionConfig", func() {
+		data, err := ETCDEncryptionUnmarshal([]byte(etcdEncryptionDataJson))
+		Expect(err).NotTo(HaveOccurred())
+
+		etcdKey, ok := data.(*ETCDEncryptionConfig)
+		Expect(ok).To(BeTrue())
+		Expect(etcdKey).To(Equal(etcdEncryptionConfig))
+	})
+})

--- a/pkg/operation/etcdencryption/etcdencryptiondata_test.go
+++ b/pkg/operation/etcdencryption/etcdencryptiondata_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package encryptionconfiguration_test
+package etcdencryption_test
 
 import (
 	. "github.com/gardener/gardener/pkg/operation/etcdencryption"
@@ -24,8 +24,8 @@ import (
 var _ = Describe("ETCD Encryption Data", func() {
 	var (
 		etcdEncryptionDataJson = []byte("{\"encryptionKeys\":[{\"key\":\"foo\",\"name\":\"bar\"}],\"forcePlainTextResources\":true,\"rewriteResources\":true}")
-		etcdEncryptionConfig   = &ETCDEncryptionConfig{
-			EncryptionKeys: []ETCDEncryptionKey{
+		etcdEncryptionConfig   = &EncryptionConfig{
+			EncryptionKeys: []EncryptionKey{
 				{
 					Key:  "foo",
 					Name: "bar",
@@ -35,11 +35,11 @@ var _ = Describe("ETCD Encryption Data", func() {
 			RewriteResources:        true,
 		}
 	)
-	It("should correctly unmarshal ETCDEncryptionConfigData struct into ETCDEncryptionConfig", func() {
-		data, err := ETCDEncryptionUnmarshal([]byte(etcdEncryptionDataJson))
+	It("should correctly unmarshal EncryptionConfigData struct into EncryptionConfig", func() {
+		data, err := Unmarshal([]byte(etcdEncryptionDataJson))
 		Expect(err).NotTo(HaveOccurred())
 
-		etcdKey, ok := data.(*ETCDEncryptionConfig)
+		etcdKey, ok := data.(*EncryptionConfig)
 		Expect(ok).To(BeTrue())
 		Expect(etcdKey).To(Equal(etcdEncryptionConfig))
 	})

--- a/pkg/operation/etcdencryption/etcdencryptioninfodata.go
+++ b/pkg/operation/etcdencryption/etcdencryptioninfodata.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package encryptionconfiguration
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/utils/infodata"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ETCDEncryptionKey holds the the key and its name used to encrypt resources in ETCD.
+type ETCDEncryptionKey struct {
+	Key  string
+	Name string
+}
+
+// ETCDEncryptionConfig holds information whether a key is active or not and whether resources should be forcefully kept in plain text
+type ETCDEncryptionConfig struct {
+	EncryptionKeys          []ETCDEncryptionKey
+	ForcePlainTextResources bool
+	RewriteResources        bool
+}
+
+// TypeVersion implements InfoData
+func (e *ETCDEncryptionConfig) TypeVersion() infodata.TypeVersion {
+	return ETCDEncryptionDataType
+}
+
+// Marshal ETCDEncryption InfoData
+func (e *ETCDEncryptionConfig) Marshal() ([]byte, error) {
+	encryptionKeysData := make([]ETCDEncryptionKeyData, len(e.EncryptionKeys))
+	for i, encryptionKey := range e.EncryptionKeys {
+		encryptionKeysData[i].Key = encryptionKey.Key
+		encryptionKeysData[i].Name = encryptionKey.Name
+	}
+	return json.Marshal(&ETCDEncryptionConfigData{EncryptionKeys: encryptionKeysData, ForcePlainTextResources: e.ForcePlainTextResources, RewriteResources: e.RewriteResources})
+}
+
+// NewETCDEncryption creates a new ETCDEncryptionKey from a given key and name
+func NewETCDEncryption(keys []ETCDEncryptionKey, forcePlainTextResources, rewriteResources bool) (*ETCDEncryptionConfig, error) {
+	return &ETCDEncryptionConfig{keys, forcePlainTextResources, rewriteResources}, nil
+}
+
+// AddEncryptionKeyFromSecret gets the active etcd encryption key from the secret object and adds it to the ETCDEncryptionConfig.
+func (e *ETCDEncryptionConfig) AddEncryptionKeyFromSecret(secret *corev1.Secret) error {
+	conf, err := ReadSecret(secret)
+	if err != nil {
+		return err
+	}
+	name, key, err := GetSecretKeyForResources(conf, common.EtcdEncryptionEncryptedResourceSecrets)
+	if err != nil {
+		return err
+	}
+
+	etcdKey := ETCDEncryptionKey{
+		Key:  key,
+		Name: name,
+	}
+	e.EncryptionKeys = append(e.EncryptionKeys, etcdKey)
+	return nil
+}
+
+// AddNewEncryptionKey generates a new etcd encryption key and adds it to the ETCDEncryptionConfig.
+func (e *ETCDEncryptionConfig) AddNewEncryptionKey() error {
+	key, err := NewEncryptionKey(time.Now(), rand.Reader)
+	if err != nil {
+		return err
+	}
+	etcdKey := ETCDEncryptionKey{
+		Key:  key.Secret,
+		Name: key.Name,
+	}
+	e.EncryptionKeys = append(e.EncryptionKeys, etcdKey)
+	return nil
+}
+
+// SetForcePlainTextResources sets whether resources should be encrypted or not.
+// If the configuration changes RewriteResource is set to true.
+func (e *ETCDEncryptionConfig) SetForcePlainTextResources(forcePlainTextResources bool) {
+	if e.ForcePlainTextResources != forcePlainTextResources {
+		e.RewriteResources = true
+	}
+	e.ForcePlainTextResources = forcePlainTextResources
+}
+
+// GetETCDEncryptionConfig retrieves the ETCDEncryptionConfig from the gardenerResourceDataList.
+func GetETCDEncryptionConfig(gardenerResourceDataList gardencorev1alpha1helper.GardenerResourceDataList) (*ETCDEncryptionConfig, error) {
+	infoData, err := infodata.GetInfoData(gardenerResourceDataList, common.ETCDSecretsEncryptionConfigDataName)
+	if err != nil {
+		return nil, err
+	}
+	if infoData == nil {
+		return nil, nil
+	}
+
+	encryptionConfig, ok := infoData.(*ETCDEncryptionConfig)
+	if !ok {
+		return nil, fmt.Errorf("could not convert GardenerResourceData entry %s to ETCDEncryptionConfig", common.ETCDSecretsEncryptionConfigDataName)
+	}
+	return encryptionConfig, nil
+}

--- a/pkg/operation/etcdencryption/etcdencryptioninfodata_test.go
+++ b/pkg/operation/etcdencryption/etcdencryptioninfodata_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package encryptionconfiguration_test
+package etcdencryption_test
 
 import (
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
@@ -41,16 +41,16 @@ resources:
 const jsonData = "{\"encryptionKeys\":[{\"key\":\"foo\",\"name\":\"bar\"}],\"forcePlainTextResources\":false,\"rewriteResources\":false}"
 
 var _ = Describe("ETCD Encryption InfoData", func() {
-	Describe("ETCDEncryptionConfig", func() {
+	Describe("EncryptionConfig", func() {
 		var (
 			etcdEncryptionDataJson []byte
-			etcdEncryptionConfig   *ETCDEncryptionConfig
+			etcdEncryptionConfig   *EncryptionConfig
 		)
 
 		BeforeEach(func() {
 			etcdEncryptionDataJson = []byte(jsonData)
-			etcdEncryptionConfig = &ETCDEncryptionConfig{
-				EncryptionKeys: []ETCDEncryptionKey{
+			etcdEncryptionConfig = &EncryptionConfig{
+				EncryptionKeys: []EncryptionKey{
 					{
 						Key:  "foo",
 						Name: "bar",
@@ -61,7 +61,7 @@ var _ = Describe("ETCD Encryption InfoData", func() {
 			}
 		})
 		Describe("#Marshal", func() {
-			It("should marshal ETCDEncryptionConfig InfoData into correct json format", func() {
+			It("should marshal EncryptionConfig InfoData into correct json format", func() {
 				data, err := etcdEncryptionConfig.Marshal()
 
 				Expect(err).NotTo(HaveOccurred())
@@ -79,16 +79,16 @@ var _ = Describe("ETCD Encryption InfoData", func() {
 
 	Context("ETCD Encryptyion InfoData Utility functions", func() {
 		var (
-			gardenerResourceDataList     gardencorev1alpha1helper.GardenerResourceDataList
-			secret                       *corev1.Secret
-			expectedETCDEncryptionConfig *ETCDEncryptionConfig
-			expectedEncryptionKey        ETCDEncryptionKey
+			gardenerResourceDataList gardencorev1alpha1helper.GardenerResourceDataList
+			secret                   *corev1.Secret
+			expectedEncryptionConfig *EncryptionConfig
+			expectedEncryptionKey    EncryptionKey
 		)
 
 		BeforeEach(func() {
 			gardenerResourceDataList = gardencorev1alpha1helper.GardenerResourceDataList{
 				{
-					Name: common.ETCDSecretsEncryptionConfigDataName,
+					Name: common.ETCDEncryptionConfigDataName,
 					Type: string(ETCDEncryptionDataType),
 					Data: runtime.RawExtension{Raw: []byte(jsonData)},
 				},
@@ -105,13 +105,13 @@ var _ = Describe("ETCD Encryption InfoData", func() {
 				},
 			}
 
-			expectedEncryptionKey = ETCDEncryptionKey{
+			expectedEncryptionKey = EncryptionKey{
 				Key:  "foo",
 				Name: "bar",
 			}
 
-			expectedETCDEncryptionConfig = &ETCDEncryptionConfig{
-				EncryptionKeys: []ETCDEncryptionKey{
+			expectedEncryptionConfig = &EncryptionConfig{
+				EncryptionKeys: []EncryptionKey{
 					expectedEncryptionKey,
 				},
 				ForcePlainTextResources: false,
@@ -120,29 +120,29 @@ var _ = Describe("ETCD Encryption InfoData", func() {
 		})
 
 		Describe("#GetETCDEncryption", func() {
-			It("should retrieve ETCDEncryptionConfig when it exists in the gardener resource data list", func() {
-				etcdEncryption, err := GetETCDEncryptionConfig(gardenerResourceDataList)
+			It("should retrieve EncryptionConfig when it exists in the gardener resource data list", func() {
+				etcdEncryption, err := GetEncryptionConfig(gardenerResourceDataList)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(etcdEncryption).To(Equal(expectedETCDEncryptionConfig))
+				Expect(etcdEncryption).To(Equal(expectedEncryptionConfig))
 			})
-			It("should return nil when ETCDEncryptionConfig does not exists in the gardener resource data list", func() {
-				etcdEncryption, err := GetETCDEncryptionConfig(gardencorev1alpha1helper.GardenerResourceDataList{})
+			It("should return nil when EncryptionConfig does not exists in the gardener resource data list", func() {
+				etcdEncryption, err := GetEncryptionConfig(gardencorev1alpha1helper.GardenerResourceDataList{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(etcdEncryption).To(BeNil())
 			})
 		})
 		Describe("Generate Encryption Key", func() {
-			var etcdEncryptionConfig *ETCDEncryptionConfig
+			var etcdEncryptionConfig *EncryptionConfig
 
 			BeforeEach(func() {
-				etcdEncryptionConfig = &ETCDEncryptionConfig{}
+				etcdEncryptionConfig = &EncryptionConfig{}
 			})
 			It("should sync the encryption key from an already existing secret", func() {
 				err := etcdEncryptionConfig.AddEncryptionKeyFromSecret(secret)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(etcdEncryptionConfig.EncryptionKeys[0]).To(Equal(expectedEncryptionKey))
 			})
-			It("should generate a new etcd encryption key", func() {
+			It("should generate a new encryption key", func() {
 				err := etcdEncryptionConfig.AddNewEncryptionKey()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(etcdEncryptionConfig.EncryptionKeys[0]).ToNot(BeNil())

--- a/pkg/operation/etcdencryption/etcdencryptioninfodata_test.go
+++ b/pkg/operation/etcdencryption/etcdencryptioninfodata_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package encryptionconfiguration_test
+
+import (
+	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	"github.com/gardener/gardener/pkg/operation/common"
+	. "github.com/gardener/gardener/pkg/operation/etcdencryption"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const yamlString = `apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+- providers:
+  - aescbc:
+      keys:
+      - name: bar
+        secret: foo
+  - identity: {}
+  resources:
+  - secrets`
+
+const jsonData = "{\"encryptionKeys\":[{\"key\":\"foo\",\"name\":\"bar\"}],\"forcePlainTextResources\":false,\"rewriteResources\":false}"
+
+var _ = Describe("ETCD Encryption InfoData", func() {
+	Describe("ETCDEncryptionConfig", func() {
+		var (
+			etcdEncryptionDataJson []byte
+			etcdEncryptionConfig   *ETCDEncryptionConfig
+		)
+
+		BeforeEach(func() {
+			etcdEncryptionDataJson = []byte(jsonData)
+			etcdEncryptionConfig = &ETCDEncryptionConfig{
+				EncryptionKeys: []ETCDEncryptionKey{
+					{
+						Key:  "foo",
+						Name: "bar",
+					},
+				},
+				ForcePlainTextResources: false,
+				RewriteResources:        false,
+			}
+		})
+		Describe("#Marshal", func() {
+			It("should marshal ETCDEncryptionConfig InfoData into correct json format", func() {
+				data, err := etcdEncryptionConfig.Marshal()
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(data).To(Equal(etcdEncryptionDataJson))
+			})
+		})
+		Describe("#SetForcePlainTextResources", func() {
+			It("should set ForcePlainTextResources and RewriteResources fields to true", func() {
+				etcdEncryptionConfig.SetForcePlainTextResources(true)
+				Expect(etcdEncryptionConfig.ForcePlainTextResources).To(Equal(true))
+				Expect(etcdEncryptionConfig.RewriteResources).To(Equal(true))
+			})
+		})
+	})
+
+	Context("ETCD Encryptyion InfoData Utility functions", func() {
+		var (
+			gardenerResourceDataList     gardencorev1alpha1helper.GardenerResourceDataList
+			secret                       *corev1.Secret
+			expectedETCDEncryptionConfig *ETCDEncryptionConfig
+			expectedEncryptionKey        ETCDEncryptionKey
+		)
+
+		BeforeEach(func() {
+			gardenerResourceDataList = gardencorev1alpha1helper.GardenerResourceDataList{
+				{
+					Name: common.ETCDSecretsEncryptionConfigDataName,
+					Type: string(ETCDEncryptionDataType),
+					Data: runtime.RawExtension{Raw: []byte(jsonData)},
+				},
+			}
+
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						common.EtcdEncryptionForcePlaintextAnnotationName: "true",
+					},
+				},
+				Data: map[string][]byte{
+					common.EtcdEncryptionSecretFileName: []byte(yamlString),
+				},
+			}
+
+			expectedEncryptionKey = ETCDEncryptionKey{
+				Key:  "foo",
+				Name: "bar",
+			}
+
+			expectedETCDEncryptionConfig = &ETCDEncryptionConfig{
+				EncryptionKeys: []ETCDEncryptionKey{
+					expectedEncryptionKey,
+				},
+				ForcePlainTextResources: false,
+				RewriteResources:        false,
+			}
+		})
+
+		Describe("#GetETCDEncryption", func() {
+			It("should retrieve ETCDEncryptionConfig when it exists in the gardener resource data list", func() {
+				etcdEncryption, err := GetETCDEncryptionConfig(gardenerResourceDataList)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(etcdEncryption).To(Equal(expectedETCDEncryptionConfig))
+			})
+			It("should return nil when ETCDEncryptionConfig does not exists in the gardener resource data list", func() {
+				etcdEncryption, err := GetETCDEncryptionConfig(gardencorev1alpha1helper.GardenerResourceDataList{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(etcdEncryption).To(BeNil())
+			})
+		})
+		Describe("Generate Encryption Key", func() {
+			var etcdEncryptionConfig *ETCDEncryptionConfig
+
+			BeforeEach(func() {
+				etcdEncryptionConfig = &ETCDEncryptionConfig{}
+			})
+			It("should sync the encryption key from an already existing secret", func() {
+				err := etcdEncryptionConfig.AddEncryptionKeyFromSecret(secret)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(etcdEncryptionConfig.EncryptionKeys[0]).To(Equal(expectedEncryptionKey))
+			})
+			It("should generate a new etcd encryption key", func() {
+				err := etcdEncryptionConfig.AddNewEncryptionKey()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(etcdEncryptionConfig.EncryptionKeys[0]).ToNot(BeNil())
+			})
+		})
+	})
+})

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
@@ -31,6 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/operation/etcdencryption"
 	"github.com/gardener/gardener/pkg/operation/garden"
 	"github.com/gardener/gardener/pkg/operation/seed"
 	"github.com/gardener/gardener/pkg/operation/shoot"
@@ -440,7 +442,9 @@ func (o *Operation) EnsureShootStateExists(ctx context.Context) error {
 	}
 
 	o.ShootState = shootState
-	return nil
+	gardenerResourceList := gardencorev1alpha1helper.GardenerResourceDataList(shootState.Spec.Gardener)
+	o.Shoot.ETCDEncryption, err = etcdencryption.GetEncryptionConfig(gardenerResourceList)
+	return err
 }
 
 // DeleteClusterResourceFromSeed deletes the `Cluster` extension resource for the shoot in the seed cluster.

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -20,7 +20,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	etcdencryptionconfig "github.com/gardener/gardener/pkg/operation/etcdencryption"
+	"github.com/gardener/gardener/pkg/operation/etcdencryption"
 	"github.com/gardener/gardener/pkg/operation/garden"
 
 	corev1 "k8s.io/api/core/v1"
@@ -53,7 +53,7 @@ type Shoot struct {
 	ControlPlaneStatus        []byte
 	MachineDeployments        []extensionsv1alpha1.MachineDeployment
 
-	ETCDEncryption *etcdencryptionconfig.ETCDEncryptionConfig
+	ETCDEncryption *etcdencryption.EncryptionConfig
 }
 
 // Networks contains pre-calculated subnets and IP address for various components.

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -20,6 +20,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	etcdencryptionconfig "github.com/gardener/gardener/pkg/operation/etcdencryption"
 	"github.com/gardener/gardener/pkg/operation/garden"
 
 	corev1 "k8s.io/api/core/v1"
@@ -51,6 +52,8 @@ type Shoot struct {
 	InfrastructureStatus      []byte
 	ControlPlaneStatus        []byte
 	MachineDeployments        []extensionsv1alpha1.MachineDeployment
+
+	ETCDEncryption *etcdencryptionconfig.ETCDEncryptionConfig
 }
 
 // Networks contains pre-calculated subnets and IP address for various components.

--- a/pkg/utils/infodata/infodata.go
+++ b/pkg/utils/infodata/infodata.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package infodata
+
+import (
+	"fmt"
+	"sync"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// TypeVersion is the potentially versioned type name of an InfoData representation.
+type TypeVersion string
+
+// Unmarshaller is a factory to create a dedicated InfoData object from a byte stream
+type Unmarshaller func(data []byte) (InfoData, error)
+
+// InfoData is an interface
+type InfoData interface {
+	TypeVersion() TypeVersion
+	Marshal() ([]byte, error)
+}
+
+var lock sync.Mutex
+var types = map[TypeVersion]Unmarshaller{}
+
+// Register is used to register new InfoData type versions
+func Register(typeversion TypeVersion, unmarshaller Unmarshaller) {
+	lock.Lock()
+	defer lock.Unlock()
+	types[typeversion] = unmarshaller
+}
+
+// GetUnmarshaller returns an Unmarshaller for the given typeName.
+func GetUnmarshaller(typeName TypeVersion) Unmarshaller {
+	lock.Lock()
+	defer lock.Unlock()
+	return types[typeName]
+}
+
+// Unmarshal unmarshals a GardenerResourceData into its respective Go struct representation
+func Unmarshal(entry *gardencorev1alpha1.GardenerResourceData) (InfoData, error) {
+	unmarshaller := GetUnmarshaller(TypeVersion(entry.Type))
+	if unmarshaller == nil {
+		return nil, fmt.Errorf("unknown info data type %q", entry.Type)
+	}
+	data, err := unmarshaller(entry.Data.Raw)
+	if err != nil {
+		return nil, fmt.Errorf("cannot unmarshal data set %q of type %q: %s", entry.Name, entry.Type, err)
+	}
+	return data, nil
+}
+
+// GetInfoData retrieves the go representation of an object from the GardenerResourceDataList
+func GetInfoData(resourceDataList gardencorev1alpha1helper.GardenerResourceDataList, name string) (InfoData, error) {
+	resourceData := resourceDataList.Get(name)
+	if resourceData == nil {
+		return nil, nil
+	}
+
+	return Unmarshal(resourceData)
+}
+
+// UpsertInfoData updates or inserts an InfoData object into the GardenerResourceDataList
+func UpsertInfoData(resourceDataList *gardencorev1alpha1helper.GardenerResourceDataList, name string, data InfoData) error {
+	bytes, err := data.Marshal()
+	if err != nil {
+		return err
+	}
+
+	gardenerResourceData := &gardencorev1alpha1.GardenerResourceData{
+		Name: name,
+		Type: string(data.TypeVersion()),
+		Data: runtime.RawExtension{Raw: bytes},
+	}
+
+	resourceDataList.Upsert(gardenerResourceData)
+	return nil
+}

--- a/pkg/utils/infodata/infodata_suite_test.go
+++ b/pkg/utils/infodata/infodata_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infodata_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEtcdEncryption(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "InfoData Suite")
+}

--- a/pkg/utils/infodata/infodata_test.go
+++ b/pkg/utils/infodata/infodata_test.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infodata_test
+
+import (
+	"encoding/json"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	. "github.com/gardener/gardener/pkg/utils/infodata"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type TestInfoData struct {
+	Name string `json:"name"`
+}
+
+func (t *TestInfoData) Marshal() ([]byte, error) {
+	return json.Marshal(t)
+}
+
+const TestInfoDataType = "testInfoDataType"
+
+func (t *TestInfoData) TypeVersion() TypeVersion {
+	return TypeVersion(TestInfoDataType)
+}
+
+var _ = Describe("InfoData", func() {
+	Describe("Register and Get Unmarshaller", func() {
+		It("should register and then return unmarshaller properly", func() {
+			typeVersion := TypeVersion("testRegisterAndUnregister")
+			passed := false
+
+			unmarshaller := func(data []byte) (InfoData, error) {
+				passed = true
+				return nil, nil
+			}
+
+			Register(typeVersion, unmarshaller)
+			registeredUnmarshaller := GetUnmarshaller(typeVersion)
+			_, err := registeredUnmarshaller(nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(passed).To(BeTrue())
+		})
+	})
+
+	Context("InfoData marshalling and unmarshalling", func() {
+		var expectedInfoData *TestInfoData
+
+		Register(TestInfoDataType, func(data []byte) (InfoData, error) {
+			infoData := &TestInfoData{}
+			err := json.Unmarshal(data, infoData)
+			return infoData, err
+		})
+
+		BeforeEach(func() {
+			expectedInfoData = &TestInfoData{
+				Name: "value",
+			}
+		})
+
+		Describe("#Unmarshal", func() {
+			It("should unmarshal gardener data entry", func() {
+				gardenerResourceDataEntry := &gardencorev1alpha1.GardenerResourceData{
+					Name: "testResourceData",
+					Type: TestInfoDataType,
+					Data: runtime.RawExtension{Raw: []byte("{\"name\":\"value\"}")},
+				}
+
+				infoData, err := Unmarshal(gardenerResourceDataEntry)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(infoData).To(Equal(expectedInfoData))
+			})
+
+			It("should return error if there is no unmarshaller for gardener data entry type", func() {
+				gardenerResourceDataEntry := &gardencorev1alpha1.GardenerResourceData{
+					Name: "testResourceData",
+					Type: "invalidType",
+					Data: runtime.RawExtension{Raw: []byte("{\"name\":\"value\"}")},
+				}
+
+				_, err := Unmarshal(gardenerResourceDataEntry)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should return error if gardener data entry is not the correct format", func() {
+				gardenerResourceDataEntry := &gardencorev1alpha1.GardenerResourceData{
+					Name: "testResourceData",
+					Type: "testInfoDataType",
+					Data: runtime.RawExtension{Raw: []byte("\"name\":\"value\"")},
+				}
+
+				_, err := Unmarshal(gardenerResourceDataEntry)
+				Expect(err).To(HaveOccurred())
+			})
+
+		})
+
+		Describe("#GetInfoData", func() {
+			It("should return unmarshalled infodata", func() {
+				gardenerResourceDataList := []gardencorev1alpha1.GardenerResourceData{
+					{
+						Name: "testResourceData",
+						Type: "testInfoDataType",
+						Data: runtime.RawExtension{Raw: []byte("{\"name\":\"value\"}")},
+					},
+				}
+
+				infoData, err := GetInfoData(gardenerResourceDataList, "testResourceData")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(infoData).To(Equal(expectedInfoData))
+			})
+
+			It("should return nil if gardener entry cannot be found", func() {
+				gardenerResourceDataList := []gardencorev1alpha1.GardenerResourceData{}
+
+				infoData, err := GetInfoData(gardenerResourceDataList, "testResourceData")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(infoData).To(BeNil())
+			})
+		})
+
+		Describe("#UpsertInfoData", func() {
+			It("should marshal and upsert infodata into gardener resource data list  ", func() {
+				gardenerResourceDataList := gardencorev1alpha1helper.GardenerResourceDataList([]gardencorev1alpha1.GardenerResourceData{})
+
+				err := UpsertInfoData(&gardenerResourceDataList, "testResourceData", expectedInfoData)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(gardenerResourceDataList)).To(Equal(1))
+			})
+		})
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes it so that ETCD encryption data is generated and saved in the shoot state and can then be used to generate and  deploy an ETCD encryption secret.

**Which issue(s) this PR fixes**:
Fixes first part of #1578
Part of #1631 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
ETCD encryption data is persisted in the ShootState
```
