### PR TITLE
Increase node-exporter timeout

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -433,6 +433,7 @@ data:
 
     - job_name: node-exporter
       honor_labels: false
+      scrape_timeout: 30s
       kubernetes_sd_configs:
       - role: endpoints
         api_server: https://kube-apiserver:443


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase the node-exporter scrape timeout to 30s. Should prevent the alert `PrometheusCantScrape` from firing for the node-exporter. I did not find any node exporters that took longer than 30s to respond so this should be a good timeout.

**Which issue(s) this PR fixes**:
Fixes #2063

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Increase the node-exporter scrape timeout from 10s to 30s.
```
