### PR TITLE
Allow v1.18 clients to be created

### DIFF
--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -228,6 +228,7 @@ var supportedKubernetesVersions = []string{
 	"1.15",
 	"1.16",
 	"1.17",
+	"1.18",
 }
 
 func checkIfSupportedKubernetesVersion(gitVersion string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR allows Gardener components to run against v1.18 Kubernetes cluster (for example minikube v1.18 cluster for the local setup).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
