### PR TITLE
Allow minikube node name to be "m01"

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -177,7 +177,7 @@ Alternatively, spin up a cluster with minikube with this command:
 
 ```bash
 minikube start --embed-certs #  `--embed-certs` can be omitted if minikube has already been set to create self-contained kubeconfig files.
-😄  minikube v1.5.2 on darwin (amd64)
+😄  minikube v1.8.2 on Darwin 10.15.3
 🔥  Creating virtualbox VM (CPUs=2, Memory=2048MB, Disk=20000MB) ...
 [...]
 🏄  Done! Thank you for using minikube!

--- a/hack/common
+++ b/hack/common
@@ -42,7 +42,8 @@ k8s_nodename() {
 
 k8s_env() {
     node_name=$(k8s_nodename)
-    if [[ "$node_name" == "$MINIKUBE" ]]; then
+    # for minikube >= v1.8.0 the default node name is "m01", for minikube < v1.8.0 - "minikube"
+    if [[ "$node_name" == "$MINIKUBE" || "$node_name" == "m01" ]]; then
         echo "$MINIKUBE"
         return
     fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Since minikube@v1.8.0 the default node name is `m01` (previously it was `minikube`).

**Which issue(s) this PR fixes**:
Fixes #2085

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Local setup is now compatible also with newer versions of minikube `(>= v1.8.0)`.
```
