### PR TITLE
:bug: Fix the restoration failure alert for etcd

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -118,8 +118,7 @@ groups:
 
   # etcd data restoration failure alert
   - alert: KubeEtcdRestorationFailed
-    expr: etcdbr_restoration_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",succeeded="false"} > 0
-    for: 1m
+    expr: rate(etcdbr_restoration_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",succeeded="false"}[2m]) > 0
     labels:
       service: etcd
       severity: critical


### PR DESCRIPTION
cc @shreyas-s-rao @wyb1 

**What this PR does / why we need it**:
With existing rule, even if once the restoration is failed, the alert will be raised for lifetime until the count is reset, which will occur only when container restarts. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @shreyas-s-rao

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
🐛  Fix the etcd restoration failure alert rule
```
