### PR TITLE
ControllerInstallation care controller caters with non-existing MR objects

### DIFF
--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_care_control.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_care_control.go
@@ -59,6 +59,10 @@ func (c *Controller) reconcileControllerInstallationCareKey(key string) error {
 		return err
 	}
 
+	if controllerInstallation.DeletionTimestamp != nil {
+		return nil
+	}
+
 	if err := c.careControl.Care(controllerInstallation, key); err != nil {
 		return err
 	}

--- a/plugin/pkg/global/extensionvalidation/admission_test.go
+++ b/plugin/pkg/global/extensionvalidation/admission_test.go
@@ -248,7 +248,7 @@ var _ = Describe("ExtensionValidator", func() {
 						},
 						{
 							CRI: &core.CRI{Name: "cri",
-								ContainerRuntimes: []core.ContainerRuntime{{Type: "cr1",}, {Type: "cr2",}}},
+								ContainerRuntimes: []core.ContainerRuntime{{Type: "cr1"}, {Type: "cr2"}}},
 							Machine: core.Machine{
 								Image: &core.ShootMachineImage{
 									Name: "foo6",


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent undesired/unhelpful logs like

```
time="2020-03-19T11:09:18Z" level=error msg="managedresources.resources.gardener.cloud \"my-extension-4qw9n\" not found" controllerinstallation-care=my-extension-4qw9n
```

when a `ControllerInstallation` gets deleted / an extension controller gets undeployed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
