### PR TITLE
Restart control plane controllers during maintenance

### DIFF
--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager-svc.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager-svc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-controller-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: kubernetes
+    role: controller-manager
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: {{ include "kube-controller-manager.port" . }}
+      protocol: TCP
+  selector:
+    app: kubernetes
+    role: controller-manager

--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -1,22 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: kube-controller-manager
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: kubernetes
-    role: controller-manager
-spec:
-  type: ClusterIP
-  clusterIP: None
-  ports:
-  - name: metrics
-    port: {{ include "kube-controller-manager.port" . }}
-    protocol: TCP
-  selector:
-    app: kubernetes
-    role: controller-manager
----
 apiVersion: {{ include "deploymentversion" . }}
 kind: Deployment
 metadata:
@@ -46,6 +27,9 @@ spec:
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-shoot-apiserver: allowed
         networking.gardener.cloud/from-prometheus: allowed
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
     spec:
       tolerations:
       - effect: NoExecute

--- a/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/values.yaml
@@ -4,6 +4,7 @@ serviceNetwork: 10.0.0.0/24
 podNetwork: 192.168.0.0/16
 clusterName: shoot-foo-bar
 podAnnotations: {}
+podLabels: {}
 featureGates: {}
   # CustomResourceValidation: true
   # RotateKubeletServerCertificate: false

--- a/docs/extensions/shoot-maintenance.md
+++ b/docs/extensions/shoot-maintenance.md
@@ -1,0 +1,12 @@
+# Shoot maintenance
+Shoots configure a maintenance time window in which Gardener performs maintenance related tasks like infrastructure reconciliation, restarting pods, updating K8s or machine image versions.
+
+## Restart control plane controllers
+Gardener operators can make Gardener restart/delete certain control plane pods during a shoot's maintenance.
+This feature helps to automatically solve service denials of controllers due to stale caches, dead-locks or starving routines.
+
+Please note that these are exceptional cases but they are observed from time to time.
+Gardener, for example, takes this precautionary measure for `Kube-Controller-Manager` pods. 
+
+Extension controllers can extend the amount of pods being affected by these restarts.
+If your Gardener extension manages pods of a shoot's control plane (shoot namespace in seed) and it could potentially profit from a regular restart please consider labeling it with `maintenance.gardener.cloud/restart: true`.

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -17,6 +17,7 @@ controllers:
   # shootMonitorPeriod: 300s
   shootMaintenance:
     concurrentSyncs: 5
+  # enableShootControlPlaneRestarter: true
   shootHibernation:
     concurrentSyncs: 5
   shootQuota:

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -267,4 +267,7 @@ const (
 	// EventResourceReferenced indicates that the resource deletion is in waiting mode because the resource is still
 	// being referenced by at least one other resource (e.g. a SecretBinding is still referenced by a Shoot)
 	EventResourceReferenced = "ResourceReferenced"
+
+	// LabelPodMaintenanceRestart is a constant for a label that describes that a pod should be restarted during maintenance.
+	LabelPodMaintenanceRestart = "maintenance.gardener.cloud/restart"
 )

--- a/pkg/controllermanager/apis/config/types.go
+++ b/pkg/controllermanager/apis/config/types.go
@@ -144,6 +144,9 @@ type ShootMaintenanceControllerConfiguration struct {
 	// ConcurrentSyncs is the number of workers used for the controller to work on
 	// events.
 	ConcurrentSyncs int
+	// EnableShootControlPlaneRestarter configures whether adequate pods of the shoot control plane are restarted during maintenance.
+	// +optional
+	EnableShootControlPlaneRestarter *bool
 }
 
 // ShootQuotaControllerConfiguration defines the configuration of the

--- a/pkg/controllermanager/controller/shoot/shoot.go
+++ b/pkg/controllermanager/controller/shoot/shoot.go
@@ -83,7 +83,7 @@ func NewShootController(k8sGardenClient kubernetes.Interface, k8sGardenCoreInfor
 
 		config:                      config,
 		recorder:                    recorder,
-		maintenanceControl:          NewDefaultMaintenanceControl(k8sGardenClient, gardenCoreV1beta1Informer, recorder),
+		maintenanceControl:          NewDefaultMaintenanceControl(k8sGardenClient, gardenCoreV1beta1Informer, config.Controllers.ShootMaintenance, recorder),
 		quotaControl:                NewDefaultQuotaControl(k8sGardenClient, gardenCoreV1beta1Informer),
 		hibernationScheduleRegistry: NewHibernationScheduleRegistry(),
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -991,6 +991,9 @@ func (b *Botanist) DeployKubeControllerManager(ctx context.Context) error {
 			"checksum/secret-kube-controller-manager-server": b.CheckSums[common.KubeControllerManagerServerName],
 			"checksum/secret-service-account-key":            b.CheckSums["service-account-key"],
 		},
+		"podLabels": map[string]interface{}{
+			v1beta1constants.LabelPodMaintenanceRestart: "true",
+		},
 	}
 
 	if b.Shoot.HibernationEnabled == b.Shoot.Info.Status.IsHibernated {
@@ -1300,4 +1303,14 @@ func determineSchedule(shoot *gardencorev1beta1.Shoot, schedule string, f func(*
 	creationMinute := shoot.CreationTimestamp.Minute()
 	creationHour := shoot.CreationTimestamp.Hour()
 	return fmt.Sprintf(schedule, creationMinute, creationHour), nil
+}
+
+// RestartControlPlanePods restarts (deletes) pods of the shoot control plane.
+func (b *Botanist) RestartControlPlanePods(ctx context.Context) error {
+	return b.K8sSeedClient.Client().DeleteAllOf(
+		ctx,
+		&corev1.Pod{},
+		client.InNamespace(b.Shoot.SeedNamespace),
+		client.MatchingLabels{v1beta1constants.LabelPodMaintenanceRestart: "true"},
+	)
 }

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -349,6 +349,9 @@ const (
 	// ShootTaskDeployInfrastructure is a name for a Shoot's infrastructure deployment task.
 	ShootTaskDeployInfrastructure = "deployInfrastructure"
 
+	// ShootTaskRestartControlPlanePods is a name for a Shoot task which is dedicated to restart related control plane pods.
+	ShootTaskRestartControlPlanePods = "restartControlPlanePods"
+
 	// ShootOperationRetry is a constant for an annotation on a Shoot indicating that a failed Shoot reconciliation shall be retried.
 	ShootOperationRetry = "retry"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the possibility to restart control plane pods by:
1.) manually adding the shoot task `shoot.gardener.cloud/tasks: restartControlPlanePods`
2.) automatically during the shoot's maintenance time window

Contract:
Every pod in the shoot namespace of the seed which is labeled with `maintenance.gardener.cloud/restart: true` is affected by this restart (Pod deletion).

**Which issue(s) this PR fixes**:
Fixes #1862

**Special notes for your reviewer**:
PRs which label the CCM will follow in the corresponding extension provider repository.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Control plane controllers of shoot clusters can now be automatically restarted during the shoot's maintenance time window. This is used to refresh the state and cache of probably long running containers and thus can circumvent potential dead-locks or starving routines. The feature can be enabled via the `ControllerManagerConfiguration` under `.controllers.shootMaintecance.enableShootControlPlaneRestarter` (see `example/20-componentconfig-gardener-controller-manager.yaml`).
```
```noteworthy developer
Gardener now deletes every pod of the shoot control plane with the label `maintenance.gardener.cloud/restart: true` if a shoot is assigned the task annotation `shoot.gardener.cloud/tasks: restartControlPlanePods`. This is used to refresh the state and cache of probably long running containers and thus can circumvent potential dead-locks or starving routines. If you are a developer of a Gardener extension please check the necessity and possibility of labelling such pods. For example, a running instance of the Cloud-Controller-Manager can safely be deleted/restarted while the shoot profits from a refreshed instance. More information can be found in `docs/extensions/shoot-maintenance.md`
```