### PR TITLE
GEP 10 - Container runtime extensions - addded cr config validation

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1271,7 +1271,7 @@ func ValidateContainerRuntimesConfigurations(workers []core.Worker, fldPath *fie
 		if worker.CRI != nil {
 			for j, cr := range worker.CRI.ContainerRuntimes {
 				if val, ok := definedContainerRuntimesMap[cr.Type]; ok {
-					if &cr.ProviderConfig != &val.ProviderConfig {
+					if !apiequality.Semantic.DeepEqual(cr.ProviderConfig, val.ProviderConfig) {
 						allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("cri", "containerRuntimes").Index(j).Child("providerConfig"), &cr.ProviderConfig, fmt.Sprintf("must specify same provider config for all the ContainerRuntimes from type %s", cr.Type)))
 					}
 				} else {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2186,7 +2186,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 		It("validate that container runtime has a type", func() {
 			worker := core.Worker{
-				Name:    "worker",
+				Name: "worker",
 				CRI: &core.CRI{Name: core.CRINameContainerD,
 					ContainerRuntimes: []core.ContainerRuntime{{Type: "gVisor"}, {Type: ""}}},
 			}
@@ -2202,7 +2202,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 		It("validate duplicate container runtime types", func() {
 			worker := core.Worker{
-				Name:    "worker",
+				Name: "worker",
 				CRI: &core.CRI{Name: core.CRINameContainerD,
 					ContainerRuntimes: []core.ContainerRuntime{{Type: "gVisor"}, {Type: "gVisor"}}},
 			}
@@ -2307,6 +2307,29 @@ var _ = Describe("Shoot Validation Tests", func() {
 				[]corev1.Taint{{Effect: corev1.TaintEffectNoSchedule}},
 			),
 		)
+
+		Describe("validate configurations of container runtime", func() {
+			workers := []core.Worker{
+				{
+					CRI: &core.CRI{
+						ContainerRuntimes: []core.ContainerRuntime{{Type: "t1", ProviderConfig: &core.ProviderConfig{RawExtension: runtime.RawExtension{Raw: []byte("test")}}}},
+					},
+				},
+				{
+					CRI: &core.CRI{
+						ContainerRuntimes: []core.ContainerRuntime{{Type: "t1", ProviderConfig: &core.ProviderConfig{RawExtension: runtime.RawExtension{Raw: []byte("test2")}}}},
+					},
+				},
+			}
+			errorList := ValidateContainerRuntimesConfigurations(workers, field.NewPath("workers"))
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("workers[1].cri.containerRuntimes[0].providerConfig"),
+				})),
+			))
+		})
 	})
 
 	Describe("#ValidateKubeletConfiguration", func() {


### PR DESCRIPTION
Left over from: https://github.com/gardener/gardener/pull/2035
Part of #1454
Check that container runtimes with the same type can't have different configurations