### PR TITLE
Delete DNS entries when shoot is hibernated

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -277,7 +277,7 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation, operationType
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Ensuring ingress DNS record",
-			Fn:           flow.TaskFn(botanist.EnsureIngressDNSRecord).DoIf(dnsEnabled && managedExternalDNS).RetryUntilTimeout(defaultInterval, 10*time.Minute),
+			Fn:           flow.TaskFn(botanist.EnsureIngressDNSRecord).DoIf(dnsEnabled && managedExternalDNS && !o.Shoot.HibernationEnabled).RetryUntilTimeout(defaultInterval, 10*time.Minute),
 			Dependencies: flow.NewTaskIDs(deployManagedResources),
 		})
 		waitUntilVPNConnectionExists = g.Add(flow.Task{

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -40,7 +40,7 @@ const DNSIngressName = "ingress"
 
 // EnsureIngressDNSRecord creates the respective wildcard DNS record for the nginx-ingress-controller.
 func (b *Botanist) EnsureIngressDNSRecord(ctx context.Context) error {
-	if !b.Shoot.NginxIngressEnabled() || b.Shoot.HibernationEnabled {
+	if !b.Shoot.NginxIngressEnabled() {
 		return b.DestroyIngressDNSRecord(ctx)
 	}
 

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -32,7 +32,6 @@ import (
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -232,7 +231,7 @@ func (b *Botanist) waitUntilDNSProviderReady(ctx context.Context, name string) e
 }
 
 func (b *Botanist) deleteDNSProvider(ctx context.Context, name string) error {
-	if err := b.K8sSeedClient.Client().Delete(ctx, &dnsv1alpha1.DNSProvider{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: name}}); err != nil && !apierrors.IsNotFound(err) {
+	if err := b.K8sSeedClient.Client().Delete(ctx, &dnsv1alpha1.DNSProvider{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: name}}); client.IgnoreNotFound(err) != nil {
 		return err
 	}
 
@@ -287,7 +286,7 @@ func (b *Botanist) waitUntilDNSEntryReady(ctx context.Context, name string) erro
 }
 
 func (b *Botanist) deleteDNSEntry(ctx context.Context, name string) error {
-	if err := b.K8sSeedClient.Client().Delete(ctx, &dnsv1alpha1.DNSEntry{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: name}}); err != nil && !apierrors.IsNotFound(err) {
+	if err := b.K8sSeedClient.Client().Delete(ctx, &dnsv1alpha1.DNSEntry{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: name}}); client.IgnoreNotFound(err) != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR deletes DNS entries when a shoot enters hibernation.

**Which issue(s) this PR fixes**:
Fixes #2039

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
DNS entries are now deleted when a shoot enters hibernation which prevents outdated DNS records.
```
