### PR TITLE
Enforce use of fixed size int types in the API

### DIFF
--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -978,7 +978,7 @@ QuotaSpec
 <td>
 <code>clusterLifetimeDays</code></br>
 <em>
-int
+int32
 </em>
 </td>
 <td>
@@ -4616,7 +4616,7 @@ Kubernetes meta/v1.Time
 <td>
 <code>progress</code></br>
 <em>
-int
+int32
 </em>
 </td>
 <td>
@@ -5895,7 +5895,7 @@ and the fall back path is firstly iptables and then userspace.</p>
 <td>
 <code>clusterLifetimeDays</code></br>
 <em>
-int
+int32
 </em>
 </td>
 <td>
@@ -7437,5 +7437,5 @@ KubeletConfig
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>041bf5805</code>.
+on git commit <code>17208ace4</code>.
 </em></p>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -2467,7 +2467,7 @@ string
 <td>
 <code>minimum</code></br>
 <em>
-int
+int32
 </em>
 </td>
 <td>
@@ -2478,7 +2478,7 @@ int
 <td>
 <code>maximum</code></br>
 <em>
-int
+int32
 </em>
 </td>
 <td>
@@ -3017,7 +3017,7 @@ string
 <td>
 <code>maximum</code></br>
 <em>
-int
+int32
 </em>
 </td>
 <td>
@@ -3107,7 +3107,7 @@ AMIs, &hellip;) by the provider itself.</p>
 <td>
 <code>minimum</code></br>
 <em>
-int
+int32
 </em>
 </td>
 <td>
@@ -3356,5 +3356,5 @@ the cluster-autoscaler properly.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>041bf5805</code>.
+on git commit <code>17208ace4</code>.
 </em></p>

--- a/hack/api-reference/settings.md
+++ b/hack/api-reference/settings.md
@@ -555,5 +555,5 @@ Required.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>041bf5805</code>.
+on git commit <code>17208ace4</code>.
 </em></p>

--- a/pkg/api/extensions/accessor.go
+++ b/pkg/api/extensions/accessor.go
@@ -84,6 +84,25 @@ func nestedString(obj map[string]interface{}, fields ...string) string {
 	return v
 }
 
+func nestedInt32(obj map[string]interface{}, fields ...string) int32 {
+	v, ok, err := unstructured.NestedFieldNoCopy(obj, fields...)
+	if err != nil || !ok {
+		return 0
+	}
+
+	switch x := v.(type) {
+	case int64:
+		// safe, as the DefaultUnstructuredConverter uses int64 to store int16, int32, etc.
+		return int32(x)
+	case int32:
+		return x
+	case int:
+		return int32(x)
+	default:
+		return 0
+	}
+}
+
 func nestedInt64(obj map[string]interface{}, fields ...string) int64 {
 	v, ok, err := unstructured.NestedInt64(obj, fields...)
 	if err != nil || !ok {
@@ -99,24 +118,6 @@ func nestedStringReference(obj map[string]interface{}, fields ...string) *string
 	}
 
 	return &v
-}
-
-func nestedInt(obj map[string]interface{}, fields ...string) int {
-	v, ok, err := unstructured.NestedFieldNoCopy(obj, fields...)
-	if err != nil || !ok {
-		return 0
-	}
-
-	switch x := v.(type) {
-	case int64:
-		return int(x)
-	case int32:
-		return int(x)
-	case int:
-		return x
-	default:
-		return 0
-	}
 }
 
 func nestedRawExtension(obj map[string]interface{}, fields ...string) *runtime.RawExtension {
@@ -151,8 +152,8 @@ func (u unstructuredLastOperationAccessor) GetLastUpdateTime() metav1.Time {
 }
 
 // GetProgress implements LastOperation.
-func (u unstructuredLastOperationAccessor) GetProgress() int {
-	return nestedInt(u.UnstructuredContent(), "status", "lastOperation", "progress")
+func (u unstructuredLastOperationAccessor) GetProgress() int32 {
+	return nestedInt32(u.UnstructuredContent(), "status", "lastOperation", "progress")
 }
 
 // GetState implements LastOperation.

--- a/pkg/api/extensions/accessor_test.go
+++ b/pkg/api/extensions/accessor_test.go
@@ -164,8 +164,8 @@ var _ = Describe("Accessor", func() {
 				Describe("#GetProgress", func() {
 					It("should get the progress", func() {
 						var (
-							progress = 10
-							acc      = mkUnstructuredAccessorWithLastOperation(&gardencorev1beta1.LastOperation{Progress: progress})
+							progress int32 = 10
+							acc            = mkUnstructuredAccessorWithLastOperation(&gardencorev1beta1.LastOperation{Progress: progress})
 						)
 
 						Expect(acc.GetProgress()).To(Equal(progress))

--- a/pkg/apis/core/types_common.go
+++ b/pkg/apis/core/types_common.go
@@ -81,7 +81,7 @@ type LastOperation struct {
 	// Last time the operation state transitioned from one to another.
 	LastUpdateTime metav1.Time
 	// The progress in percentage (0-100) of the last operation.
-	Progress int
+	Progress int32
 	// Status of the last operation, one of Aborted, Processing, Succeeded, Error, Failed.
 	State LastOperationState
 	// Type of the last operation, one of Create, Reconcile, Delete.

--- a/pkg/apis/core/types_quota.go
+++ b/pkg/apis/core/types_quota.go
@@ -44,7 +44,7 @@ type QuotaList struct {
 // QuotaSpec is the specification of a Quota.
 type QuotaSpec struct {
 	// ClusterLifetimeDays is the lifetime of a Shoot cluster in days before it will be terminated automatically.
-	ClusterLifetimeDays *int
+	ClusterLifetimeDays *int32
 	// Metrics is a list of resources which will be put under constraints.
 	Metrics corev1.ResourceList
 	// Scope is the scope of the Quota object, either 'project' or 'secret'.

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -105,7 +105,7 @@ type LastOperation struct {
 	// Last time the operation state transitioned from one to another.
 	LastUpdateTime metav1.Time `json:"lastUpdateTime"`
 	// The progress in percentage (0-100) of the last operation.
-	Progress int `json:"progress"`
+	Progress int32 `json:"progress"`
 	// Status of the last operation, one of Aborted, Processing, Succeeded, Error, Failed.
 	State LastOperationState `json:"state"`
 	// Type of the last operation, one of Create, Reconcile, Delete.
@@ -123,7 +123,7 @@ func (l *LastOperation) GetLastUpdateTime() metav1.Time {
 }
 
 // GetProgress implements LastOperation.
-func (l *LastOperation) GetProgress() int {
+func (l *LastOperation) GetProgress() int32 {
 	return l.Progress
 }
 

--- a/pkg/apis/core/v1alpha1/types_quota.go
+++ b/pkg/apis/core/v1alpha1/types_quota.go
@@ -48,7 +48,7 @@ type QuotaList struct {
 type QuotaSpec struct {
 	// ClusterLifetimeDays is the lifetime of a Shoot cluster in days before it will be terminated automatically.
 	// +optional
-	ClusterLifetimeDays *int `json:"clusterLifetimeDays,omitempty"`
+	ClusterLifetimeDays *int32 `json:"clusterLifetimeDays,omitempty"`
 	// Metrics is a list of resources which will be put under constraints.
 	Metrics corev1.ResourceList `json:"metrics"`
 	// Scope is the scope of the Quota object, either 'project' or 'secret'.

--- a/pkg/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.conversion.go
@@ -3494,7 +3494,7 @@ func Convert_core_QuotaList_To_v1alpha1_QuotaList(in *core.QuotaList, out *Quota
 }
 
 func autoConvert_v1alpha1_QuotaSpec_To_core_QuotaSpec(in *QuotaSpec, out *core.QuotaSpec, s conversion.Scope) error {
-	out.ClusterLifetimeDays = (*int)(unsafe.Pointer(in.ClusterLifetimeDays))
+	out.ClusterLifetimeDays = (*int32)(unsafe.Pointer(in.ClusterLifetimeDays))
 	out.Metrics = *(*v1.ResourceList)(unsafe.Pointer(&in.Metrics))
 	out.Scope = in.Scope
 	return nil
@@ -3506,7 +3506,7 @@ func Convert_v1alpha1_QuotaSpec_To_core_QuotaSpec(in *QuotaSpec, out *core.Quota
 }
 
 func autoConvert_core_QuotaSpec_To_v1alpha1_QuotaSpec(in *core.QuotaSpec, out *QuotaSpec, s conversion.Scope) error {
-	out.ClusterLifetimeDays = (*int)(unsafe.Pointer(in.ClusterLifetimeDays))
+	out.ClusterLifetimeDays = (*int32)(unsafe.Pointer(in.ClusterLifetimeDays))
 	out.Metrics = *(*v1.ResourceList)(unsafe.Pointer(&in.Metrics))
 	out.Scope = in.Scope
 	return nil

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -2467,7 +2467,7 @@ func (in *QuotaSpec) DeepCopyInto(out *QuotaSpec) {
 	*out = *in
 	if in.ClusterLifetimeDays != nil {
 		in, out := &in.ClusterLifetimeDays, &out.ClusterLifetimeDays
-		*out = new(int)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.Metrics != nil {

--- a/pkg/apis/core/v1beta1/types_common.go
+++ b/pkg/apis/core/v1beta1/types_common.go
@@ -107,7 +107,7 @@ type LastOperation struct {
 	// Last time the operation state transitioned from one to another.
 	LastUpdateTime metav1.Time `json:"lastUpdateTime"`
 	// The progress in percentage (0-100) of the last operation.
-	Progress int `json:"progress"`
+	Progress int32 `json:"progress"`
 	// Status of the last operation, one of Aborted, Processing, Succeeded, Error, Failed.
 	State LastOperationState `json:"state"`
 	// Type of the last operation, one of Create, Reconcile, Delete.
@@ -125,7 +125,7 @@ func (l *LastOperation) GetLastUpdateTime() metav1.Time {
 }
 
 // GetProgress implements LastOperation.
-func (l *LastOperation) GetProgress() int {
+func (l *LastOperation) GetProgress() int32 {
 	return l.Progress
 }
 

--- a/pkg/apis/core/v1beta1/types_quota.go
+++ b/pkg/apis/core/v1beta1/types_quota.go
@@ -48,7 +48,7 @@ type QuotaList struct {
 type QuotaSpec struct {
 	// ClusterLifetimeDays is the lifetime of a Shoot cluster in days before it will be terminated automatically.
 	// +optional
-	ClusterLifetimeDays *int `json:"clusterLifetimeDays,omitempty"`
+	ClusterLifetimeDays *int32 `json:"clusterLifetimeDays,omitempty"`
 	// Metrics is a list of resources which will be put under constraints.
 	Metrics corev1.ResourceList `json:"metrics"`
 	// Scope is the scope of the Quota object, either 'project' or 'secret'.

--- a/pkg/apis/core/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1beta1/zz_generated.conversion.go
@@ -3314,7 +3314,7 @@ func Convert_core_QuotaList_To_v1beta1_QuotaList(in *core.QuotaList, out *QuotaL
 }
 
 func autoConvert_v1beta1_QuotaSpec_To_core_QuotaSpec(in *QuotaSpec, out *core.QuotaSpec, s conversion.Scope) error {
-	out.ClusterLifetimeDays = (*int)(unsafe.Pointer(in.ClusterLifetimeDays))
+	out.ClusterLifetimeDays = (*int32)(unsafe.Pointer(in.ClusterLifetimeDays))
 	out.Metrics = *(*v1.ResourceList)(unsafe.Pointer(&in.Metrics))
 	out.Scope = in.Scope
 	return nil
@@ -3326,7 +3326,7 @@ func Convert_v1beta1_QuotaSpec_To_core_QuotaSpec(in *QuotaSpec, out *core.QuotaS
 }
 
 func autoConvert_core_QuotaSpec_To_v1beta1_QuotaSpec(in *core.QuotaSpec, out *QuotaSpec, s conversion.Scope) error {
-	out.ClusterLifetimeDays = (*int)(unsafe.Pointer(in.ClusterLifetimeDays))
+	out.ClusterLifetimeDays = (*int32)(unsafe.Pointer(in.ClusterLifetimeDays))
 	out.Metrics = *(*v1.ResourceList)(unsafe.Pointer(&in.Metrics))
 	out.Scope = in.Scope
 	return nil

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -2423,7 +2423,7 @@ func (in *QuotaSpec) DeepCopyInto(out *QuotaSpec) {
 	*out = *in
 	if in.ClusterLifetimeDays != nil {
 		in, out := &in.ClusterLifetimeDays, &out.ClusterLifetimeDays
-		*out = new(int)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.Metrics != nil {

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -2467,7 +2467,7 @@ func (in *QuotaSpec) DeepCopyInto(out *QuotaSpec) {
 	*out = *in
 	if in.ClusterLifetimeDays != nil {
 		in, out := &in.ClusterLifetimeDays, &out.ClusterLifetimeDays
-		*out = new(int)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.Metrics != nil {

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -48,7 +48,7 @@ type LastOperation interface {
 	// GetLastUpdateTime returns the last update time of the last operation.
 	GetLastUpdateTime() metav1.Time
 	// GetProgress returns progress of the last operation.
-	GetProgress() int
+	GetProgress() int32
 	// GetState returns the LastOperationState of the last operation.
 	GetState() gardencorev1beta1.LastOperationState
 	// GetType returns the LastOperationType of the last operation.

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -88,7 +88,7 @@ type WorkerPool struct {
 	// MachineType contains information about the machine type that should be used for this worker pool.
 	MachineType string `json:"machineType"`
 	// Maximum is the maximum size of the worker pool.
-	Maximum int `json:"maximum"`
+	Maximum int32 `json:"maximum"`
 	// MaxSurge is maximum number of VMs that are created during an update.
 	MaxSurge intstr.IntOrString `json:"maxSurge"`
 	// MaxUnavailable is the maximum number of VMs that can be unavailable during an update.
@@ -107,7 +107,7 @@ type WorkerPool struct {
 	// AMIs, ...) by the provider itself.
 	MachineImage MachineImage `json:"machineImage,omitempty"`
 	// Minimum is the minimum size of the worker pool.
-	Minimum int `json:"minimum"`
+	Minimum int32 `json:"minimum"`
 	// Name is the name of this worker pool.
 	Name string `json:"name"`
 	// ProviderConfig is a provider specific configuration for the worker pool.
@@ -171,7 +171,7 @@ type MachineDeployment struct {
 	// Name is the name of the `MachineDeployment` resource.
 	Name string `json:"name"`
 	// Minimum is the minimum number for this machine deployment.
-	Minimum int `json:"minimum"`
+	Minimum int32 `json:"minimum"`
 	// Maximum is the maximum number for this machine deployment.
-	Maximum int `json:"maximum"`
+	Maximum int32 `json:"maximum"`
 }

--- a/pkg/controllermanager/controller/shoot/shoot_quota_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_quota_control.go
@@ -77,7 +77,7 @@ type defaultQuotaControl struct {
 
 func (c *defaultQuotaControl) CheckQuota(shootObj *gardencorev1beta1.Shoot, key string) error {
 	var (
-		clusterLifeTime *int
+		clusterLifeTime *int32
 		shoot           = shootObj.DeepCopy()
 		shootLogger     = logger.NewShootLogger(logger.Logger, shoot.Name, shoot.Namespace)
 	)

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
@@ -232,7 +232,7 @@ func (r *reconciler) deleteBackupBucket(backupBucket *gardencorev1beta1.BackupBu
 	return reconcile.Result{}, controllerutils.RemoveGardenerFinalizer(r.ctx, r.client, backupBucket)
 }
 
-func (r *reconciler) updateBackupBucketStatusProcessing(bb *gardencorev1beta1.BackupBucket, message string, progress int) error {
+func (r *reconciler) updateBackupBucketStatusProcessing(bb *gardencorev1beta1.BackupBucket, message string, progress int32) error {
 	return kutil.TryUpdateStatus(r.ctx, retry.DefaultRetry, r.client, bb, func() error {
 		bb.Status.LastOperation = &gardencorev1beta1.LastOperation{
 			Type:           gardencorev1beta1helper.ComputeOperationType(bb.ObjectMeta, bb.Status.LastOperation),
@@ -247,7 +247,7 @@ func (r *reconciler) updateBackupBucketStatusProcessing(bb *gardencorev1beta1.Ba
 
 func (r *reconciler) updateBackupBucketStatusError(bb *gardencorev1beta1.BackupBucket, message string, lastError *gardencorev1beta1.LastError) error {
 	return kutil.TryUpdateStatus(r.ctx, retry.DefaultRetry, r.client, bb, func() error {
-		progress := 1
+		var progress int32 = 1
 		if bb.Status.LastOperation != nil {
 			progress = bb.Status.LastOperation.Progress
 		}
@@ -265,7 +265,7 @@ func (r *reconciler) updateBackupBucketStatusError(bb *gardencorev1beta1.BackupB
 
 func (r *reconciler) updateBackupBucketStatusPending(bb *gardencorev1beta1.BackupBucket, message string) error {
 	return kutil.TryUpdateStatus(r.ctx, retry.DefaultRetry, r.client, bb, func() error {
-		progress := 1
+		var progress int32 = 1
 		if bb.Status.LastOperation != nil {
 			progress = bb.Status.LastOperation.Progress
 		}

--- a/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
@@ -177,7 +177,7 @@ func (r *reconciler) deleteBackupEntry(backupEntry *gardencorev1beta1.BackupEntr
 	return reconcile.Result{}, nil
 }
 
-func (r *reconciler) updateBackupEntryStatusProcessing(be *gardencorev1beta1.BackupEntry, message string, progress int) error {
+func (r *reconciler) updateBackupEntryStatusProcessing(be *gardencorev1beta1.BackupEntry, message string, progress int32) error {
 	return kutil.TryUpdateStatus(r.ctx, retry.DefaultRetry, r.client, be, func() error {
 		be.Status.LastOperation = &gardencorev1beta1.LastOperation{
 			Type:           gardencorev1beta1helper.ComputeOperationType(be.ObjectMeta, be.Status.LastOperation),
@@ -192,7 +192,7 @@ func (r *reconciler) updateBackupEntryStatusProcessing(be *gardencorev1beta1.Bac
 
 func (r *reconciler) updateBackupEntryStatusError(be *gardencorev1beta1.BackupEntry, message string, lastError *gardencorev1beta1.LastError) error {
 	return kutil.TryUpdateStatus(r.ctx, retry.DefaultRetry, r.client, be, func() error {
-		progress := 1
+		var progress int32 = 1
 		if be.Status.LastOperation != nil {
 			progress = be.Status.LastOperation.Progress
 		}

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -449,10 +449,10 @@ func (c *Controller) updateShootStatusReconcileSuccess(o *operation.Operation, o
 
 func (c *Controller) updateShootStatusReconcileError(o *operation.Operation, operationType gardencorev1beta1.LastOperationType, description string, lastErrors ...gardencorev1beta1.LastError) error {
 	var (
-		state         = gardencorev1beta1.LastOperationStateFailed
-		lastOperation = o.Shoot.Info.Status.LastOperation
-		progress      = 1
-		willRetry     = !utils.TimeElapsed(o.Shoot.Info.Status.RetryCycleStartTime, c.config.Controllers.Shoot.RetryDuration.Duration)
+		state               = gardencorev1beta1.LastOperationStateFailed
+		lastOperation       = o.Shoot.Info.Status.LastOperation
+		progress      int32 = 1
+		willRetry           = !utils.TimeElapsed(o.Shoot.Info.Status.RetryCycleStartTime, c.config.Controllers.Shoot.RetryDuration.Duration)
 	)
 
 	newShoot, err := kutil.TryUpdateShootStatus(c.k8sGardenClient.GardenCore(), retry.DefaultRetry, o.Shoot.Info.ObjectMeta,

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -86,8 +86,8 @@ func (b *Botanist) DeployWorker(ctx context.Context) error {
 
 		pools = append(pools, extensionsv1alpha1.WorkerPool{
 			Name:           worker.Name,
-			Minimum:        int(worker.Minimum),
-			Maximum:        int(worker.Maximum),
+			Minimum:        worker.Minimum,
+			Maximum:        worker.Maximum,
 			MaxSurge:       *worker.MaxSurge,
 			MaxUnavailable: *worker.MaxUnavailable,
 			Annotations:    worker.Annotations,

--- a/pkg/utils/flow/flow.go
+++ b/pkg/utils/flow/flow.go
@@ -132,8 +132,9 @@ type Stats struct {
 }
 
 // ProgressPercent retrieves the progress of a Flow execution in percent.
-func (s *Stats) ProgressPercent() int {
-	return (100 * s.Succeeded.Len()) / s.All.Len()
+func (s *Stats) ProgressPercent() int32 {
+	progress := (100 * s.Succeeded.Len()) / s.All.Len()
+	return int32(progress)
 }
 
 // Copy deeply copies a Stats object.

--- a/plugin/pkg/shoot/quotavalidator/admission.go
+++ b/plugin/pkg/shoot/quotavalidator/admission.go
@@ -163,7 +163,7 @@ func (q *QuotaValidator) Validate(ctx context.Context, a admission.Attributes, o
 
 	var (
 		oldShoot         *core.Shoot
-		maxShootLifetime *int
+		maxShootLifetime *int32
 		checkLifetime    = false
 		checkQuota       = false
 	)

--- a/plugin/pkg/shoot/quotavalidator/admission_test.go
+++ b/plugin/pkg/shoot/quotavalidator/admission_test.go
@@ -85,8 +85,8 @@ var _ = Describe("quotavalidator", func() {
 				},
 			}
 
-			quotaProjectLifetime = 1
-			quotaProjectBase     = core.Quota{
+			quotaProjectLifetime int32 = 1
+			quotaProjectBase           = core.Quota{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: trialNamespace,
 					Name:      "project-quota",
@@ -108,8 +108,8 @@ var _ = Describe("quotavalidator", func() {
 				},
 			}
 
-			quotaSecretLifetime = 7
-			quotaSecretBase     = core.Quota{
+			quotaSecretLifetime int32 = 7
+			quotaSecretBase           = core.Quota{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: trialNamespace,
 					Name:      "secret-quota",


### PR DESCRIPTION
**What this PR does / why we need it**:
Enforce use of fixed size int types in the API.

From https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md:
```
All public integer fields MUST use the Go (u)int32 or Go (u)int64 types, not (u)int (which is ambiguous depending on target platform). Internal types may use (u)int.
```

**Which issue(s) this PR fixes**:
Required for #1605

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
core.(v1alpha1/v1beta1).QuotaSpec.ClusterLifetimeDays, core.(v1alpha1,v1beta1).LastOperation.Progress, extensions.v1alpha1.WorkerPool.Maximum, extensions.v1alpha1.WorkerPool.Minimum, extensions.v1alpha1.MachineDeployment.Maximum, extensions.v1alpha1.MachineDeployment.Minimum fields types changed from `int` to `int32`.
```
