### PR TITLE
[GEP-5] Changes to the Shoot Maintenance Controller

### DIFF
--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -16,17 +16,16 @@ package helper
 
 import (
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/logger"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
 	"github.com/Masterminds/semver"
-	errors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -579,17 +578,6 @@ func ShootUsesUnmanagedDNS(shoot *gardencorev1beta1.Shoot) bool {
 	return shoot.Spec.DNS != nil && len(shoot.Spec.DNS.Providers) > 0 && shoot.Spec.DNS.Providers[0].Type != nil && *shoot.Spec.DNS.Providers[0].Type == "unmanaged"
 }
 
-// GetMachineImagesFor returns a list of all machine images for a given shoot.
-func GetMachineImagesFor(shoot *gardencorev1beta1.Shoot) []*gardencorev1beta1.ShootMachineImage {
-	var workerMachineImages []*gardencorev1beta1.ShootMachineImage
-	for _, worker := range shoot.Spec.Provider.Workers {
-		if worker.Machine.Image != nil {
-			workerMachineImages = append(workerMachineImages, worker.Machine.Image)
-		}
-	}
-	return workerMachineImages
-}
-
 // DetermineMachineImageForName finds the cloud specific machine images in the <cloudProfile> for the given <name> and
 // region. In case it does not find the machine image with the <name>, it returns false. Otherwise, true and the
 // cloud-specific machine image will be returned.
@@ -617,33 +605,18 @@ func ShootMachineImageVersionExists(constraint gardencorev1beta1.MachineImage, i
 	return false, 0
 }
 
-// DetermineLatestMachineImageVersion determines the latest MachineImageVersion from a MachineImage
-func DetermineLatestMachineImageVersion(image gardencorev1beta1.MachineImage) (*semver.Version, gardencorev1beta1.ExpirableVersion, error) {
-	var (
-		latestSemVerVersion       *semver.Version
-		latestMachineImageVersion gardencorev1beta1.ExpirableVersion
-	)
-
-	for _, imageVersion := range image.Versions {
-		v, err := semver.NewVersion(imageVersion.Version)
-		if err != nil {
-			return nil, gardencorev1beta1.ExpirableVersion{}, fmt.Errorf("error while parsing machine image version '%s' of machine image '%s': version not valid: %s", imageVersion.Version, image.Name, err.Error())
-		}
-		if latestSemVerVersion == nil || v.GreaterThan(latestSemVerVersion) {
-			latestSemVerVersion = v
-			latestMachineImageVersion = imageVersion
-		}
-	}
-	return latestSemVerVersion, latestMachineImageVersion, nil
-}
-
-// GetShootMachineImageFromLatestMachineImageVersion determines the latest version in a machine image and returns that as a ShootMachineImage
-func GetShootMachineImageFromLatestMachineImageVersion(image gardencorev1beta1.MachineImage) (*semver.Version, gardencorev1beta1.ShootMachineImage, error) {
-	latestSemVerVersion, latestImage, err := DetermineLatestMachineImageVersion(image)
+// GetLatestQualifyingShootMachineImage determines the latest qualifying version in a machine image and returns that as a ShootMachineImage
+// A version qualifies if its classification is not preview and the version is not expired.
+func GetLatestQualifyingShootMachineImage(image gardencorev1beta1.MachineImage, predicates ...VersionPredicate) (bool, *gardencorev1beta1.ShootMachineImage, error) {
+	predicates = append(predicates, FilterExpiredVersion())
+	qualifyingVersionFound, latestImageVersion, err := GetLatestQualifyingVersion(image.Versions, predicates...)
 	if err != nil {
-		return nil, gardencorev1beta1.ShootMachineImage{}, err
+		return false, nil, err
 	}
-	return latestSemVerVersion, gardencorev1beta1.ShootMachineImage{Name: image.Name, Version: &latestImage.Version}, nil
+	if !qualifyingVersionFound {
+		return false, nil, nil
+	}
+	return true, &gardencorev1beta1.ShootMachineImage{Name: image.Name, Version: &latestImageVersion.Version}, nil
 }
 
 // UpdateMachineImages updates the machine images in place.
@@ -651,7 +624,6 @@ func UpdateMachineImages(workers []gardencorev1beta1.Worker, machineImages []*ga
 	for _, machineImage := range machineImages {
 		for idx, worker := range workers {
 			if worker.Machine.Image != nil && machineImage.Name == worker.Machine.Image.Name {
-				logger.Logger.Infof("Updating worker images of worker '%s' from version %s to version %s", worker.Name, *worker.Machine.Image.Version, *machineImage.Version)
 				workers[idx].Machine.Image = machineImage
 			}
 		}
@@ -670,58 +642,6 @@ func KubernetesVersionExistsInCloudProfile(cloudProfile *gardencorev1beta1.Cloud
 		}
 	}
 	return false, gardencorev1beta1.ExpirableVersion{}, nil
-}
-
-// DetermineLatestKubernetesPatchVersion finds the latest Kubernetes patch version in the <cloudProfile> compared
-// to the given <currentVersion>. In case it does not find a newer patch version, it returns false. Otherwise,
-// true and the found version will be returned.
-func DetermineLatestKubernetesPatchVersion(cloudProfile *gardencorev1beta1.CloudProfile, currentVersion string) (bool, string, error) {
-	ok, newerVersions, _, err := determineNextKubernetesVersions(cloudProfile, currentVersion, "~")
-	if err != nil || !ok {
-		return ok, "", err
-	}
-	sort.Strings(newerVersions)
-	return true, newerVersions[len(newerVersions)-1], nil
-}
-
-// DetermineNextKubernetesMinorVersion finds the next available Kubernetes minor version in the <cloudProfile> compared
-// to the given <currentVersion>. In case it does not find a newer minor version, it returns false. Otherwise,
-// true and the found version will be returned.
-func DetermineNextKubernetesMinorVersion(cloudProfile *gardencorev1beta1.CloudProfile, currentVersion string) (bool, string, error) {
-	ok, newerVersions, _, err := determineNextKubernetesVersions(cloudProfile, currentVersion, "^")
-	if err != nil || !ok {
-		return ok, "", err
-	}
-	sort.Strings(newerVersions)
-	return true, newerVersions[0], nil
-}
-
-// determineKubernetesVersions finds newer Kubernetes versions in the <cloudProfile> compared
-// with the <operator> to the given <currentVersion>. The <operator> has to be a github.com/Masterminds/semver
-// range comparison symbol. In case it does not find a newer version, it returns false. Otherwise,
-// true and the found version will be returned.
-func determineNextKubernetesVersions(cloudProfile *gardencorev1beta1.CloudProfile, currentVersion, operator string) (bool, []string, []gardencorev1beta1.ExpirableVersion, error) {
-	var (
-		newerVersions       = []gardencorev1beta1.ExpirableVersion{}
-		newerVersionsString = []string{}
-	)
-
-	for _, version := range cloudProfile.Spec.Kubernetes.Versions {
-		ok, err := versionutils.CompareVersions(version.Version, operator, currentVersion)
-		if err != nil {
-			return false, []string{}, []gardencorev1beta1.ExpirableVersion{}, err
-		}
-		if version.Version != currentVersion && ok {
-			newerVersions = append(newerVersions, version)
-			newerVersionsString = append(newerVersionsString, version.Version)
-		}
-	}
-
-	if len(newerVersions) == 0 {
-		return false, []string{}, []gardencorev1beta1.ExpirableVersion{}, nil
-	}
-
-	return true, newerVersionsString, newerVersions, nil
 }
 
 // SetMachineImageVersionsToMachineImage sets imageVersions to the matching imageName in the machineImages.
@@ -781,4 +701,155 @@ func FindPrimaryDNSProvider(providers []gardencorev1beta1.DNSProvider) *gardenco
 		return &providers[0]
 	}
 	return nil
+}
+
+type VersionPredicate func(expirableVersion gardencorev1beta1.ExpirableVersion, version *semver.Version) (bool, error)
+
+// GetKubernetesVersionForPatchUpdate finds the latest Kubernetes patch version for its minor version in the <cloudProfile> compared
+// to the given <currentVersion>. Preview and expired versions do not qualify for the kubernetes patch update. In case it does not find a newer patch version, it returns false. Otherwise,
+// true and the found version will be returned.
+func GetKubernetesVersionForPatchUpdate(cloudProfile *gardencorev1beta1.CloudProfile, currentVersion string) (bool, string, error) {
+	currentSemVerVersion, err := semver.NewVersion(currentVersion)
+	if err != nil {
+		return false, "", err
+	}
+
+	qualifyingVersionFound, latestVersion, err := GetLatestQualifyingVersion(cloudProfile.Spec.Kubernetes.Versions, FilterDifferentMajorMinorVersion(*currentSemVerVersion), FilterSameVersion(*currentSemVerVersion), FilterExpiredVersion())
+	if err != nil {
+		return false, "", err
+	}
+	// latest version cannot be found. Do not return an error, but allow for minor upgrade if Shoot's machine image version is expired.
+	if !qualifyingVersionFound {
+		return false, "", nil
+	}
+
+	return true, latestVersion.Version, nil
+}
+
+// GetKubernetesVersionForMinorUpdate finds a Kubernetes version in the <cloudProfile> that qualifies for a Kubernetes minor level update given a <currentVersion>.
+// A qualifying version is a non-preview version having the minor version increased by exactly one version.
+// In case the consecutive minor version has only expired versions, picks the latest expired version (will do another minor update during the next maintenance time)
+// If a version can be found, returns true and the qualifying patch version of the next minor version.
+// In case it does not find a version, it returns false.
+func GetKubernetesVersionForMinorUpdate(cloudProfile *gardencorev1beta1.CloudProfile, currentVersion string) (bool, string, error) {
+	currentSemVerVersion, err := semver.NewVersion(currentVersion)
+	if err != nil {
+		return false, "", err
+	}
+
+	qualifyingVersionFound, latestVersion, err := GetLatestQualifyingVersion(cloudProfile.Spec.Kubernetes.Versions, FilterNonConsecutiveMinorVersion(*currentSemVerVersion), FilterSameVersion(*currentSemVerVersion), FilterExpiredVersion())
+	if err != nil {
+		return false, "", err
+	}
+	if !qualifyingVersionFound {
+		// in case there are only expired versions in the consecutive minor version, pick the latest expired version
+		qualifyingVersionFound, latestVersion, err = GetLatestQualifyingVersion(cloudProfile.Spec.Kubernetes.Versions, FilterNonConsecutiveMinorVersion(*currentSemVerVersion), FilterSameVersion(*currentSemVerVersion))
+		if err != nil {
+			return false, "", err
+		}
+		if !qualifyingVersionFound {
+			return false, "", nil
+		}
+	}
+
+	return true, latestVersion.Version, nil
+}
+
+// GetLatestQualifyingVersion returns the latest expirable version from a set of expirable versions
+// A version qualifies if its classification is not preview and the optional predicate does not filter out the version.
+// If the predicate returns true, the version is not considered for the latest qualifying version.
+func GetLatestQualifyingVersion(versions []gardencorev1beta1.ExpirableVersion, predicate ...VersionPredicate) (qualifyingVersionFound bool, latest *gardencorev1beta1.ExpirableVersion, err error) {
+	latestSemanticVersion := &semver.Version{}
+	var latestVersion *gardencorev1beta1.ExpirableVersion
+OUTER:
+	for _, v := range versions {
+		if v.Classification != nil && *v.Classification == gardencorev1beta1.ClassificationPreview {
+			continue
+		}
+
+		semver, err := semver.NewVersion(v.Version)
+		if err != nil {
+			return false, nil, fmt.Errorf("error while parsing version '%s': %s", v.Version, err.Error())
+		}
+
+		for _, p := range predicate {
+			if p == nil {
+				continue
+			}
+
+			shouldFilter, err := p(v, semver)
+			if err != nil {
+				return false, nil, fmt.Errorf("error while evaluation predicate: '%s'", err.Error())
+			}
+			if shouldFilter {
+				continue OUTER
+			}
+		}
+
+		if semver.GreaterThan(latestSemanticVersion) {
+			latestSemanticVersion = semver
+			// avoid DeepCopy
+			latest := v
+			latestVersion = &latest
+		}
+	}
+	// unable to find qualified versions
+	if latestVersion == nil {
+		return false, nil, nil
+	}
+	return true, latestVersion, nil
+}
+
+// FilterDifferentMajorMinorVersion returns a VersionPredicate(closure) that evaluates whether a given version v has a different same major.minor version compared to the currentSemVerVersion
+// returns true if v has a different major.minor version
+func FilterDifferentMajorMinorVersion(currentSemVerVersion semver.Version) VersionPredicate {
+	return func(_ gardencorev1beta1.ExpirableVersion, v *semver.Version) (bool, error) {
+		isWithinRange, err := versionutils.CompareVersions(v.String(), "~", currentSemVerVersion.String())
+		if err != nil {
+			return true, err
+		}
+		return !isWithinRange, nil
+	}
+}
+
+// FilterNonConsecutiveMinorVersion returns a VersionPredicate(closure) that evaluates whether a given version v has a consecutive minor version compared to the currentSemVerVersion
+// returns true if v does not have a consecutive minor version
+func FilterNonConsecutiveMinorVersion(currentSemVerVersion semver.Version) VersionPredicate {
+	return func(_ gardencorev1beta1.ExpirableVersion, v *semver.Version) (bool, error) {
+		isWithinRange, err := versionutils.CompareVersions(v.String(), "^", currentSemVerVersion.String())
+		if err != nil {
+			return true, err
+		}
+
+		if !isWithinRange {
+			return true, nil
+		}
+
+		hasIncorrectMinor := currentSemVerVersion.Minor()+1 != v.Minor()
+		return hasIncorrectMinor, nil
+	}
+}
+
+// FilterSameVersion returns a VersionPredicate(closure) that evaluates whether a given version v is equal to the currentSemVerVersion
+// returns true it it is equal
+func FilterSameVersion(currentSemVerVersion semver.Version) VersionPredicate {
+	return func(_ gardencorev1beta1.ExpirableVersion, v *semver.Version) (bool, error) {
+		return v.Equal(&currentSemVerVersion), nil
+	}
+}
+
+// FilterLowerVersion returns a VersionPredicate(closure) that evaluates whether a given version v is lower than the currentSemVerVersion
+// returns true if it is lower
+func FilterLowerVersion(currentSemVerVersion semver.Version) VersionPredicate {
+	return func(_ gardencorev1beta1.ExpirableVersion, v *semver.Version) (bool, error) {
+		return v.LessThan(&currentSemVerVersion), nil
+	}
+}
+
+// FilterExpiredVersion returns a closure that evaluates whether a given expirable version is expired
+// returns true it it is expired
+func FilterExpiredVersion() func(expirableVersion gardencorev1beta1.ExpirableVersion, version *semver.Version) (bool, error) {
+	return func(expirableVersion gardencorev1beta1.ExpirableVersion, _ *semver.Version) (bool, error) {
+		return expirableVersion.ExpirationDate != nil && (time.Now().UTC().After(expirableVersion.ExpirationDate.UTC()) || time.Now().UTC().Equal(expirableVersion.ExpirationDate.UTC())), nil
+	}
 }

--- a/pkg/controllermanager/controller/shoot/shoot_hibernation_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_hibernation_control.go
@@ -29,10 +29,7 @@ import (
 )
 
 func hibernationLogger(key string) logrus.FieldLogger {
-	return gardenlogger.Logger.WithFields(logrus.Fields{
-		"controller": "shoot-hibernation",
-		"key":        key,
-	})
+	return gardenlogger.NewFieldLogger(gardenlogger.Logger, "shoot-hibernation", key)
 }
 
 func getShootHibernationSchedules(shoot *gardencorev1beta1.Shoot) []gardencorev1beta1.HibernationSchedule {
@@ -192,8 +189,6 @@ func (c *Controller) deleteShootCron(logger logrus.FieldLogger, key string) {
 
 func (c *Controller) reconcileShootHibernationKey(key string) error {
 	logger := hibernationLogger(key)
-	logger.Info("Shoot Hibernation")
-
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
@@ -209,6 +204,8 @@ func (c *Controller) reconcileShootHibernationKey(key string) error {
 		logger.Debugf("Unable to retrieve object from store: %v", key, err)
 		return err
 	}
+
+	logger.Info("[SHOOT HIBERNATION]")
 
 	if shoot.DeletionTimestamp != nil {
 		c.deleteShootCron(logger, key)

--- a/test/integration/framework/common.go
+++ b/test/integration/framework/common.go
@@ -236,15 +236,19 @@ func AddWorkerForName(shoot *gardencorev1beta1.Shoot, cloudProfile *gardencorev1
 
 // AddWorker adds a valid default worker to the shoot for the given machineImage and CloudProfile.
 func AddWorker(shoot *gardencorev1beta1.Shoot, cloudProfile *gardencorev1beta1.CloudProfile, machineImage gardencorev1beta1.MachineImage, workerZone *string) error {
-	_, shootMachineImage, err := helper.GetShootMachineImageFromLatestMachineImageVersion(machineImage)
-	if err != nil {
-		return err
-	}
-
 	if len(cloudProfile.Spec.MachineTypes) == 0 {
 		return fmt.Errorf("no MachineTypes configured in the Cloudprofile '%s'", cloudProfile.Name)
 	}
 	machineType := cloudProfile.Spec.MachineTypes[0]
+
+	qualifyingVersionFound, shootMachineImage, err := helper.GetLatestQualifyingShootMachineImage(machineImage)
+	if err != nil {
+		return err
+	}
+
+	if !qualifyingVersionFound {
+		return fmt.Errorf("could not add worker. No latest qualifying Shoot machine image could be determined for machine image %q. Make sure the machine image in the CloudProfile has at least one version that is not expired and not in preview", machineImage.Name)
+	}
 
 	workerName, err := generateRandomWorkerName(fmt.Sprintf("%s-", shootMachineImage.Name))
 	if err != nil {
@@ -257,7 +261,7 @@ func AddWorker(shoot *gardencorev1beta1.Shoot, cloudProfile *gardencorev1beta1.C
 		Minimum: 2,
 		Machine: gardencorev1beta1.Machine{
 			Type:  machineType.Name,
-			Image: &shootMachineImage,
+			Image: shootMachineImage,
 		},
 	})
 

--- a/test/integration/framework/shoot_maintenance_operations.go
+++ b/test/integration/framework/shoot_maintenance_operations.go
@@ -70,11 +70,14 @@ func getLatestShootMachineImagePossible(shootMachineImageName *string, profile g
 	}
 
 	// Determine the latest version of the shoots image.
-	_, latestMachineImage, err := helper.GetShootMachineImageFromLatestMachineImageVersion(machineImageFromCloudProfile)
+	qualifyingVersionFound, latestMachineImage, err := helper.GetLatestQualifyingShootMachineImage(machineImageFromCloudProfile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine latest machine image in cloud profile: %s", err.Error())
 	}
-	return &latestMachineImage, nil
+	if !qualifyingVersionFound {
+		return nil, fmt.Errorf("could not get latest version of the shoot's machine image. No latest qualifying Shoot machine image could be determined for machine image %q. Make sure the machine image in the CloudProfile has at least one version that is not expired and not in preview", machineImageFromCloudProfile.Name)
+	}
+	return latestMachineImage, nil
 }
 
 // CreateShoot creates a Shoot Resource

--- a/test/system/shoot_update/update_test.go
+++ b/test/system/shoot_update/update_test.go
@@ -32,10 +32,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gardener/gardener/test/framework"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/test/framework"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -61,13 +60,15 @@ var _ = Describe("Shoot update testing", func() {
 		}
 		if newVersion == "" {
 			var (
-				err error
-				ok  bool
+				err                       error
+				ok                        bool
+				consecutiveMinorAvailable bool
 			)
 			cloudprofile, err := f.GetCloudProfile(ctx)
 			Expect(err).ToNot(HaveOccurred())
-			ok, newVersion, err = helper.DetermineNextKubernetesMinorVersion(cloudprofile, currentVersion)
+			consecutiveMinorAvailable, newVersion, err = gardencorev1beta1helper.GetKubernetesVersionForMinorUpdate(cloudprofile, currentVersion)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(consecutiveMinorAvailable).To(BeTrue())
 			if !ok {
 				Skip("no new version found")
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is part of GEP5 .
Introduce changes to the Shoot Maintenance Controller.
- allows force upgrades of the minor version
- sends events on the Shoot stating which version have been upgraded and why 

I recommend checking out the documentation under docs/operations that is [included here](https://github.com/gardener/gardener/pull/2107).

**Which issue(s) this PR fixes**:
Part of #1577

**Special notes for your reviewer**:
✅ Depends on #2105

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Shoot clusters can now receive forceful minor upgrades when using an expired Kubernetes version. Versions with `preview` classification are excluded from auto-update functionality for Kubernetes and machine image versions.
```