### PR TITLE
Care controller: adjusting test framework label

### DIFF
--- a/test/integration/shoots/care/shoot_care.go
+++ b/test/integration/shoots/care/shoot_care.go
@@ -48,7 +48,7 @@ var _ = ginkgo.Describe("Shoot Care testing", func() {
 
 	f := testframework.NewShootFramework(nil)
 
-	f.Default().Serial().Release().CIt("Should observe failed health condition in the Shoot when scaling down the API Server of the Shoot", func(ctx context.Context) {
+	f.Beta().Serial().CIt("Should observe failed health condition in the Shoot when scaling down the API Server of the Shoot", func(ctx context.Context) {
 		var (
 			origReplicas *int32
 			err          error


### PR DESCRIPTION
**What this PR does / why we need it**:
The relatively new care controller integration test sporadically seems to have issues and needs some investigation. In order to not block the release, the test should be labeled as beta().
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
