### PR TITLE
Updated crd to have observedGeneration.

### DIFF
--- a/charts/seed-bootstrap/charts/etcd-druid/templates/etcd-crd.yaml
+++ b/charts/seed-bootstrap/charts/etcd-druid/templates/etcd-crd.yaml
@@ -170,8 +170,6 @@ spec:
                   - serverTLSSecretRef
                   - tlsCASecretRef
                   type: object
-              required:
-              - image
               type: object
             etcd:
               description: EtcdConfig defines parametes associated etcd deployed
@@ -276,8 +274,6 @@ spec:
                   - serverTLSSecretRef
                   - tlsCASecretRef
                   type: object
-              required:
-              - image
               type: object
             labels:
               additionalProperties:
@@ -442,6 +438,11 @@ spec:
               type: object
             lastError:
               type: string
+            observedGeneration:
+              description: ObservedGeneration is the most recent generation observed for etcd
+                this resource.
+              format: int64
+              type: integer
             ready:
               type: boolean
             readyReplicas:
@@ -458,14 +459,14 @@ spec:
           type: object
       {{- if semverCompare ">= 1.12" .Capabilities.KubeVersion.GitVersion }}
       type: object
-      {{- end }} 
+      {{- end }}
   additionalPrinterColumns:
   - name: Ready
     type: string
     JSONPath: .status.ready
   - name: Age
     type: date
-    JSONPath: .metadata.creationTimestamp  
+    JSONPath: .metadata.creationTimestamp
   version: v1alpha1
   versions:
   - name: v1alpha1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the crd of etcd resource to have optional images and an observedGeneration field in status.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
