### PR TITLE
Write UID to shoot status after operation creation

### DIFF
--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -90,7 +90,7 @@ func New(k8sGardenClient kubernetes.Interface, k8sGardenCoreInformers gardencore
 
 	// Determine information about external domain for shoot cluster.
 	externalDomain, err := ConstructExternalDomain(context.TODO(), k8sGardenClient.Client(), shoot, secret, defaultDomains)
-	if err != nil && !(IsIncompleteDNSConfigError(err) && shoot.DeletionTimestamp != nil && len(shoot.Status.UID) == 0) {
+	if err != nil {
 		return nil, err
 	}
 	shootObj.ExternalDomain = externalDomain


### PR DESCRIPTION
**What this PR does / why we need it**:
The following PR improves a few points before a shoot is considered for reconciliation / deletion:
- The shoot `uid` is written to the shoot `status` right after the operation for the shoot could be initialized
- `shoot.spec.seedName == nil` conditions are removed since a filter is already applied before calling the event handlers https://github.com/gardener/gardener/blob/b375d42f6006d863a2f5cf1ec835a46c23174ce1/pkg/gardenlet/controller/shoot/shoot.go#L120

**Which issue(s) this PR fixes**:
Fixes #1926

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Shoot clusters for which an operation could never be created (e.g. because of invalid DNS configuration) can now be deleted right away.
```
