### PR TITLE
Adapt etcd-druid limits + deployment of Etcd resources

### DIFF
--- a/charts/seed-bootstrap/charts/etcd-druid/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/etcd-druid/templates/controller-deployment.yaml
@@ -40,11 +40,11 @@ spec:
         {{- end }}
         resources:
           limits:
-            cpu: 500m
+            cpu: 300m
             memory: 512Mi
           requests:
-            cpu: 200m
-            memory: 256Mi
+            cpu: 50m
+            memory: 128Mi
         ports:
         - containerPort: 9569
         {{- if index .Values.global "imageVectorOverwrites" }}

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -1100,15 +1100,14 @@ func (b *Botanist) DeployETCD(ctx context.Context) error {
 		return err
 	}
 
-	var (
-		etcdValues    = make(map[string]interface{})
-		sidecarValues = make(map[string]interface{})
-		hvpaValues    = make(map[string]interface{})
-	)
-
 	for _, role := range []string{common.EtcdRoleMain, common.EtcdRoleEvents} {
-		name := fmt.Sprintf("etcd-%s", role)
-		values["role"] = role
+		var (
+			etcdValues    = make(map[string]interface{})
+			sidecarValues = make(map[string]interface{})
+			hvpaValues    = make(map[string]interface{})
+
+			name = fmt.Sprintf("etcd-%s", role)
+		)
 
 		foundEtcd := true
 		etcd := &druidv1alpha1.Etcd{}
@@ -1221,6 +1220,7 @@ func (b *Botanist) DeployETCD(ctx context.Context) error {
 			}
 		}
 
+		values["role"] = role
 		values["etcd"] = etcdValues
 		values["sidecar"] = sidecarValues
 		values["hvpa"] = hvpaValues


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adapt resource requests/limits for etcd-druid
- Prevent injection of backup sidecar into etcd-events

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NOE
```
