### PR TITLE
Prevent shoot-flow when writing UID to status

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -378,9 +378,6 @@ func (c *Controller) updateShootStatusReconcile(o *operation.Operation, operatio
 
 	newShoot, err := kutil.TryUpdateShootStatus(c.k8sGardenClient.GardenCore(), retry.DefaultRetry, o.Shoot.Info.ObjectMeta,
 		func(shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
-			if len(status.UID) == 0 {
-				shoot.Status.UID = shoot.UID
-			}
 			if len(status.TechnicalID) == 0 {
 				shoot.Status.TechnicalID = o.Shoot.SeedNamespace
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue introduced by #2118 which disregards the `reconcileInMaintenanceOnly` feature.

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
