### PR TITLE
Bump version of nodeless garden cluster to v1.17.3

### DIFF
--- a/docs/usage/supported_k8s_versions.md
+++ b/docs/usage/supported_k8s_versions.md
@@ -4,9 +4,8 @@ Currently, the Gardener supports the following Kubernetes versions:
 
 ## Garden cluster version
 
-:warning: The Kubernetes version of a garden cluster that can be used to run Gardener must be in the range of **`1.10.x`** to  **`1.15.x`**.
+:warning: The minimum version of the garden cluster that can be used to run Gardener is **`1.10.x`**.
 The reason for that is that the least supported Kubernetes version in Gardener is `1.10`.
-Furthermore, Gardener's [extension API server](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/) does not support version >= `1.16` yet.
 
 ## Seed cluster versions
 

--- a/hack/local-garden/run-kube-apiserver
+++ b/hack/local-garden/run-kube-apiserver
@@ -11,14 +11,13 @@ LABEL=${1:-local-garden}
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-IMAGE=k8s.gcr.io/hyperkube:v1.15.11
+IMAGE=k8s.gcr.io/kube-apiserver:v1.17.3
 MOUNTS="-v $SCRIPTPATH/certificates/certs:/certs -v $SCRIPTPATH/certificates/keys:/keys"
 ETCD_PORT=12379
 LISTEN_PORT="2443"
 
 echo "Starting gardener-dev kube-apiserver..!"
-docker run -d --name kube-apiserver -l $LABEL --add-host $HOSTS_LINE --network gardener-dev --rm -p $LISTEN_PORT:$LISTEN_PORT $MOUNTS  $IMAGE /hyperkube \
-  kube-apiserver \
+docker run -d --name kube-apiserver -l $LABEL --add-host $HOSTS_LINE --network gardener-dev --rm -p $LISTEN_PORT:$LISTEN_PORT $MOUNTS $IMAGE /usr/local/bin/kube-apiserver \
   --etcd-servers="https://etcd:$ETCD_PORT" \
   --storage-media-type='application/json' \
   --authorization-mode="Node,RBAC" \

--- a/hack/local-garden/run-kube-controller-manager
+++ b/hack/local-garden/run-kube-controller-manager
@@ -4,13 +4,12 @@ LABEL=${1:-local-garden}
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-IMAGE=k8s.gcr.io/hyperkube:v1.15.11
+IMAGE=k8s.gcr.io/kube-controller-manager:v1.17.3
 MOUNTS="-v $SCRIPTPATH/certificates/certs:/certs -v $SCRIPTPATH/certificates/keys:/keys -v $SCRIPTPATH/kubeconfigs/default-controller-manager.conf:/kubeconfig"
 
 
 echo "Starting gardener-dev kube-controller-manager..!"
-docker run -d --name kube-controller-manager -l $LABEL --network gardener-dev --rm $MOUNTS  $IMAGE /hyperkube \
-  kube-controller-manager \
+docker run -d --name kube-controller-manager -l $LABEL --network gardener-dev --rm $MOUNTS $IMAGE /usr/local/bin/kube-controller-manager \
   --authentication-kubeconfig="/kubeconfig" \
   --authorization-kubeconfig="/kubeconfig" \
   --cluster-signing-cert-file="/certs/ca.crt" \


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump version of nodeless garden cluster to v1.17.3

**Which issue(s) this PR fixes**:
✅ Depends on https://github.com/gardener/gardener/pull/2113

**Special notes for your reviewer**:
This is roughly a revert of https://github.com/gardener/gardener/commit/1ca6ce67e2da83e2a087b9cf86ff2eee2d8401f5, but uses `v1.17.3` instead of `v1.17.1` and switches back to upstream images like `k8s.gcr.io/kube-apiserver`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The version of the nodeless garden cluster is bumped to `v1.17.3`.
```
