### PR TITLE
update kyma addon to kyma 1.11.0

### DIFF
--- a/charts/shoot-addons-kyma/charts/kyma/values.yaml
+++ b/charts/shoot-addons-kyma/charts/kyma/values.yaml
@@ -10,8 +10,7 @@ jobs:
       cpu: 50m
       memory: 64Mi
 kyma:
-  version: "1.10.0"
-  subdomain: "kyma"
+  version: "1.11.0"
 requires:
   k8s:
     version: "1.16"


### PR DESCRIPTION
**What this PR does / why we need it**:
- Updates the kyma addon to Kyma 1.11.0
- Removes unused values.yaml variable

**Which issue(s) this PR fixes**:
Follow-Up on #1754

**Special notes for your reviewer**:
none

**Release note**:
```improvement operator
Update of the temporary, experimental Kyma addon to latest Kyma version 1.11.0. It can be installed onto shoot clusters out-of-the-box by annotating the `Shoot` with `experimental.addons.shoot.gardener.cloud/kyma=enabled`. Be aware that we won't provide upgrades or customization, and that this addon is temporary and will be removed in a future version of Gardener again. Its purpose is to ease the Kyma installation and to show-case which features it provides. It is by no means a production-ready setup. Also, please note that, once enabled, the Kyma addon can never be disabled again. The only way to get rid of it is to delete the shoot cluster. You can check the status of the installation by using `kubectl get installation/kyma-installation -o jsonpath="{'Status: '}{.status.state}{', description: '}{.status.description}"`.
```
