### PR TITLE
Revert "GEP 10 - Container runtime extensions - addded cr config validation"

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1076,8 +1076,6 @@ func ValidateWorkers(workers []core.Worker, fldPath *field.Path) field.ErrorList
 		allErrs = append(allErrs, field.Forbidden(fldPath, fmt.Sprintf("at least one worker pool must exist having either no taints or only the %q taint", corev1.TaintEffectPreferNoSchedule)))
 	}
 
-	allErrs = append(allErrs, ValidateContainerRuntimesConfigurations(workers, fldPath.Child("workers"))...)
-
 	return allErrs
 }
 
@@ -1258,28 +1256,6 @@ func ValidateContainerRuntimes(containerRuntime []core.ContainerRuntime, fldPath
 			allErrs = append(allErrs, field.Duplicate(fldPath.Index(i).Child("type"), fmt.Sprintf("must specify different type, %s already exist", cr.Type)))
 		}
 		crSet[cr.Type] = true
-	}
-
-	return allErrs
-}
-
-// ValidateContainerRuntimesConfigurations checks that all container runtimes with the same type have the same configurations.
-func ValidateContainerRuntimesConfigurations(workers []core.Worker, fldPath *field.Path) field.ErrorList {
-	definedContainerRuntimesMap := map[string]core.ContainerRuntime{}
-	allErrs := field.ErrorList{}
-
-	for i, worker := range workers {
-		if worker.CRI != nil {
-			for j, cr := range worker.CRI.ContainerRuntimes {
-				if val, ok := definedContainerRuntimesMap[cr.Type]; ok {
-					if !apiequality.Semantic.DeepEqual(cr.ProviderConfig, val.ProviderConfig) {
-						allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("cri", "containerRuntimes").Index(j).Child("providerConfig"), &cr.ProviderConfig, fmt.Sprintf("must specify same provider config for all the ContainerRuntimes from type %s", cr.Type)))
-					}
-				} else {
-					definedContainerRuntimesMap[cr.Type] = cr
-				}
-			}
-		}
 	}
 
 	return allErrs

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2186,7 +2186,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 		It("validate that container runtime has a type", func() {
 			worker := core.Worker{
-				Name: "worker",
+				Name:    "worker",
 				CRI: &core.CRI{Name: core.CRINameContainerD,
 					ContainerRuntimes: []core.ContainerRuntime{{Type: "gVisor"}, {Type: ""}}},
 			}
@@ -2202,7 +2202,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 		It("validate duplicate container runtime types", func() {
 			worker := core.Worker{
-				Name: "worker",
+				Name:    "worker",
 				CRI: &core.CRI{Name: core.CRINameContainerD,
 					ContainerRuntimes: []core.ContainerRuntime{{Type: "gVisor"}, {Type: "gVisor"}}},
 			}
@@ -2307,31 +2307,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 				[]corev1.Taint{{Effect: corev1.TaintEffectNoSchedule}},
 			),
 		)
-
-		Describe("validate configurations of container runtimes", func() {
-			It("should not allow different configurations for the same runtime types", func() {
-				workers := []core.Worker{
-					{
-						CRI: &core.CRI{
-							ContainerRuntimes: []core.ContainerRuntime{{Type: "t1", ProviderConfig: &core.ProviderConfig{RawExtension: runtime.RawExtension{Raw: []byte("test")}}}},
-						},
-					},
-					{
-						CRI: &core.CRI{
-							ContainerRuntimes: []core.ContainerRuntime{{Type: "t1", ProviderConfig: &core.ProviderConfig{RawExtension: runtime.RawExtension{Raw: []byte("test2")}}}},
-						},
-					},
-				}
-				errorList := ValidateContainerRuntimesConfigurations(workers, field.NewPath("workers"))
-
-				Expect(errorList).To(ConsistOf(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
-						"Field": Equal("workers[1].cri.containerRuntimes[0].providerConfig"),
-					})),
-				))
-			})
-		})
 	})
 
 	Describe("#ValidateKubeletConfiguration", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This [PR](https://github.com/gardener/gardener/pull/2128) introduces the deployment of on ContainerRuntime CRD per WorkerPool per runtime.
WorkerPools can have different provider configs, so this check is not needed any more.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
