### PR TITLE
Do not try to sync extension resources if cluster object cannot be found

### DIFF
--- a/pkg/gardenlet/controller/federatedseed/shootstate/shootstate_sync_control.go
+++ b/pkg/gardenlet/controller/federatedseed/shootstate/shootstate_sync_control.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -195,16 +194,10 @@ func newShootRetriever() *ShootRetriever {
 }
 
 // FromCluster retrieves the shoot resource from the Cluster resource
-func (s *ShootRetriever) FromCluster(ctx context.Context, clusterName string, seedClient kubernetes.Interface) (*gardencorev1beta1.Shoot, error) {
-	cluster := &extensionsv1alpha1.Cluster{}
-
-	if err := seedClient.Client().Get(ctx, kutil.Key(clusterName), cluster); err != nil {
-		return nil, fmt.Errorf("could not get cluster with name %s : %v", clusterName, err)
-	}
+func (s *ShootRetriever) FromCluster(cluster *extensionsv1alpha1.Cluster) (*gardencorev1beta1.Shoot, error) {
 	shoot := &gardencorev1beta1.Shoot{}
-
 	if cluster.Spec.Shoot.Raw == nil {
-		return nil, fmt.Errorf("cluster resource %s doesn't contain shoot resource in raw format", clusterName)
+		return nil, fmt.Errorf("cluster resource %s doesn't contain shoot resource in raw format", cluster.Name)
 	}
 	if _, _, err := s.Decode(cluster.Spec.Shoot.Raw, nil, shoot); err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes it so that extensions resources are not synced by the ShootState sync controller if the corresponding `Cluster` resource does not exist. This means that the Shoot and ShootState have most likely been deleted.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Extension resources are no longer synced by the ShootState Sync Controller if the corresponding `Cluster` resource does not exist.
```
