### PR TITLE
Make image version optional

### DIFF
--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -6618,7 +6618,8 @@ string
 </em>
 </td>
 <td>
-<p>Version is the version of the shoot&rsquo;s image.</p>
+<p>Version is the version of the shoot&rsquo;s image.
+If version is not provided, it will be defaulted to the latest version.</p>
 </td>
 </tr>
 </tbody>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -460,6 +460,20 @@ string
 </tr>
 <tr>
 <td>
+<code>workerPool</code></br>
+<em>
+<a href="#extensions.gardener.cloud/v1alpha1.ContainerRuntimeWorkerPool">
+ContainerRuntimeWorkerPool
+</a>
+</em>
+</td>
+<td>
+<p>WorkerPool identifies the worker pool of the Shoot.
+For each worker pool and type, Gardener deploys a ContainerRuntime CRD.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>DefaultSpec</code></br>
 <em>
 <a href="#extensions.gardener.cloud/v1alpha1.DefaultSpec">
@@ -1676,6 +1690,20 @@ string
 </tr>
 <tr>
 <td>
+<code>workerPool</code></br>
+<em>
+<a href="#extensions.gardener.cloud/v1alpha1.ContainerRuntimeWorkerPool">
+ContainerRuntimeWorkerPool
+</a>
+</em>
+</td>
+<td>
+<p>WorkerPool identifies the worker pool of the Shoot.
+For each worker pool and type, Gardener deploys a ContainerRuntime CRD.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>DefaultSpec</code></br>
 <em>
 <a href="#extensions.gardener.cloud/v1alpha1.DefaultSpec">
@@ -1723,6 +1751,48 @@ DefaultStatus
 (Members of <code>DefaultStatus</code> are embedded into this type.)
 </p>
 <p>DefaultStatus is a structure containing common fields used by all extension resources.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="extensions.gardener.cloud/v1alpha1.ContainerRuntimeWorkerPool">ContainerRuntimeWorkerPool
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#extensions.gardener.cloud/v1alpha1.ContainerRuntimeSpec">ContainerRuntimeSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name specifies the name of the worker pool the container runtime should be available for.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>selector</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<p>Selector is the label selector used by the extension to match the nodes belonging to the worker pool.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -692,6 +692,7 @@ type ShootMachineImage struct {
 	// ProviderConfig is the shoot's individual configuration passed to an extension resource.
 	ProviderConfig *ProviderConfig
 	// Version is the version of the shoot's image.
+	// If version is not provided, it will be defaulted to the latest version.
 	Version string
 }
 

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -1612,6 +1612,7 @@ message ShootMachineImage {
   optional ProviderConfig providerConfig = 2;
 
   // Version is the version of the shoot's image.
+  // If version is not provided, it will be defaulted to the latest version.
   optional string version = 3;
 }
 

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -844,6 +844,7 @@ type ShootMachineImage struct {
 	// +optional
 	ProviderConfig *ProviderConfig `json:"providerConfig,omitempty" protobuf:"bytes,2,opt,name=providerConfig"`
 	// Version is the version of the shoot's image.
+	// If version is not provided, it will be defaulted to the latest version.
 	Version string `json:"version" protobuf:"bytes,3,opt,name=version"`
 }
 

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1582,6 +1582,7 @@ message ShootMachineImage {
   optional ProviderConfig providerConfig = 2;
 
   // Version is the version of the shoot's image.
+  // If version is not provided, it will be defaulted to the latest version.
   optional string version = 3;
 }
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -841,6 +841,7 @@ type ShootMachineImage struct {
 	// +optional
 	ProviderConfig *ProviderConfig `json:"providerConfig,omitempty" protobuf:"bytes,2,opt,name=providerConfig"`
 	// Version is the version of the shoot's image.
+	// If version is not provided, it will be defaulted to the latest version.
 	Version string `json:"version" protobuf:"bytes,3,opt,name=version"`
 }
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2186,7 +2186,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 		It("validate that container runtime has a type", func() {
 			worker := core.Worker{
-				Name:    "worker",
+				Name: "worker",
 				CRI: &core.CRI{Name: core.CRINameContainerD,
 					ContainerRuntimes: []core.ContainerRuntime{{Type: "gVisor"}, {Type: ""}}},
 			}
@@ -2202,7 +2202,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 		It("validate duplicate container runtime types", func() {
 			worker := core.Worker{
-				Name:    "worker",
+				Name: "worker",
 				CRI: &core.CRI{Name: core.CRINameContainerD,
 					ContainerRuntimes: []core.ContainerRuntime{{Type: "gVisor"}, {Type: "gVisor"}}},
 			}

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -4980,7 +4980,7 @@ func schema_pkg_apis_core_v1alpha1_ShootMachineImage(ref common.ReferenceCallbac
 					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Version is the version of the shoot's image.",
+							Description: "Version is the version of the shoot's image. If version is not provided, it will be defaulted to the latest version.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -10019,7 +10019,7 @@ func schema_pkg_apis_core_v1beta1_ShootMachineImage(ref common.ReferenceCallback
 					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Version is the version of the shoot's image.",
+							Description: "Version is the version of the shoot's image. If version is not provided, it will be defaulted to the latest version.",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:
Make image version optional

**Which issue(s) this PR fixes**:
Fixes #1960 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Now only machine image name can be specified in the shoot manifest, Gardener will default the version to the latest available version for the specified image.
```
