### PR TITLE
Make admission plugins configurable in gardener-apiserver chart

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -165,6 +165,12 @@ spec:
         - --audit-webhook-version={{ .Values.global.apiserver.audit.webhook.version }}
         {{- end }}
         - --authorization-always-allow-paths=/healthz
+        {{- if .Values.global.apiserver.disableAdmissionPlugins }}
+        - --disable-admission-plugins={{ .Values.global.apiserver.disableAdmissionPlugins | join "," }}
+        {{- end }}
+        {{- if .Values.global.apiserver.enableAdmissionPlugins }}
+        - --enable-admission-plugins={{ .Values.global.apiserver.enableAdmissionPlugins | join "," }}
+        {{- end }}
         {{- if .Values.global.apiserver.encryption.config }}
         - --encryption-provider-config=/etc/gardener-apiserver/encryption/encryption-config.yaml
         {{- end }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -93,6 +93,10 @@ global:
         memory:
           value: "5G"
           percentage: 80
+    # List of admission plugins that should be disabled although they are in the default enabled plugins list.
+  # disableAdmissionPlugins: []
+    # List of admission plugins to be enabled in addition to default enabled ones.
+  # enableAdmissionPlugins: []
 
     audit:
  #    dynamicConfiguration: false                             Enables dynamic audit configuration. This feature also requires the DynamicAuditing feature flag


### PR DESCRIPTION
**What this PR does / why we need it**:
Make admission plugins configurable in gardener-apiserver chart.

**Which issue(s) this PR fixes**:
Ref https://github.com/gardener/gardener/pull/2156

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
gardener-apiserver chart does now allow configuring the `--disable-admission-plugins` and  `--enable-admission-plugins` flags.
```
