### PR TITLE
Modify controllers to accept multiple OS types

### DIFF
--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/add.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/add.go
@@ -36,16 +36,16 @@ type AddOptions struct {
 
 // AddToManagerWithOptions adds a controller with the given Options to the given manager.
 // The opts.Reconciler is being set with a newly instantiated actuator.
-func AddToManagerWithOptions(mgr manager.Manager, os string, generator generator.Generator, opts AddOptions) error {
+func AddToManagerWithOptions(mgr manager.Manager, ctrlName string, osTypes []string, generator generator.Generator, opts AddOptions) error {
 	return operatingsystemconfig.Add(mgr, operatingsystemconfig.AddArgs{
-		Actuator:          actuator.NewActuator(os, generator),
+		Actuator:          actuator.NewActuator(ctrlName, generator),
 		Predicates:        operatingsystemconfig.DefaultPredicates(opts.IgnoreOperationAnnotation),
-		Types:             []string{os},
+		Types:             osTypes,
 		ControllerOptions: opts.Controller,
 	})
 }
 
 // AddToManager adds a controller with the default Options.
-func AddToManager(mgr manager.Manager, os string, generator generator.Generator) error {
-	return AddToManagerWithOptions(mgr, os, generator, DefaultAddOptions)
+func AddToManager(mgr manager.Manager, ctrlName string, osTypes []string, generator generator.Generator) error {
+	return AddToManagerWithOptions(mgr, ctrlName, osTypes, generator, DefaultAddOptions)
 }

--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/app/app.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/app/app.go
@@ -31,12 +31,12 @@ import (
 )
 
 // NewControllerCommand creates a new command for running an OS controller.
-func NewControllerCommand(ctx context.Context, osName string, generator generator.Generator) *cobra.Command {
+func NewControllerCommand(ctx context.Context, ctrlName string, osTypes []string, generator generator.Generator) *cobra.Command {
 	var (
 		restOpts = &controllercmd.RESTOptions{}
 		mgrOpts  = &controllercmd.ManagerOptions{
 			LeaderElection:          true,
-			LeaderElectionID:        controllercmd.LeaderElectionNameID(osName),
+			LeaderElectionID:        controllercmd.LeaderElectionNameID(ctrlName),
 			LeaderElectionNamespace: os.Getenv("LEADER_ELECTION_NAMESPACE"),
 		}
 		ctrlOpts = &controllercmd.ControllerOptions{
@@ -45,7 +45,7 @@ func NewControllerCommand(ctx context.Context, osName string, generator generato
 
 		reconcileOpts = &controllercmd.ReconcilerOptions{}
 
-		controllerSwitches = oscommoncmd.SwitchOptions(osName, generator)
+		controllerSwitches = oscommoncmd.SwitchOptions(ctrlName, osTypes, generator)
 
 		aggOption = controllercmd.NewOptionAggregator(
 			restOpts,
@@ -57,7 +57,7 @@ func NewControllerCommand(ctx context.Context, osName string, generator generato
 	)
 
 	cmd := &cobra.Command{
-		Use: "os-" + osName + "-controller-manager",
+		Use: "os-" + ctrlName + "-controller-manager",
 
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := aggOption.Complete(); err != nil {

--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/cmd/options.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/cmd/options.go
@@ -24,10 +24,10 @@ import (
 )
 
 // SwitchOptions are the cmd.SwitchOptions for the provider controllers.
-func SwitchOptions(os string, generator generator.Generator) *cmd.SwitchOptions {
+func SwitchOptions(ctrlName string, osTypes []string, generator generator.Generator) *cmd.SwitchOptions {
 	return cmd.NewSwitchOptions(
 		cmd.Switch(operatingsystemconfig.ControllerName, func(mgr manager.Manager) error {
-			return oscommon.AddToManager(mgr, os, generator)
+			return oscommon.AddToManager(mgr, ctrlName, osTypes, generator)
 		}),
 	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR modifies controllers to accept multiple OS types.
Currently we need it, because we want our `suse-extension` to work with both names: `suse-jeos` and `suse-chost`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@vpnachev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The `oscommon` package for `OperatingSystemConfig` extension does now work for one or multiple extension types.
```
