### PR TITLE
Fix prometheus-config-reloader failing to start

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus-vpa.yaml
@@ -10,3 +10,13 @@ spec:
     name: prometheus
   updatePolicy:
     updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+    # Due to CVE-2019-5736 runC is initially loaded into memory when the container starts.
+    # After some time VPA recommends less memory (2,3Mb) than the size of of runC binary (about 10Mb).
+    # This results in an error when trying to start the container:
+    # failed to write 2485760 to memory.limit_in_bytes in /sys/fs/cgroup/memory/kubepods/prometheus-config-reloader/memory.limit_in_bytes: device or resource busy
+    # https://github.com/lxc/lxc/commit/6400238d08cdf1ca20d49bafb85f4e224348bf9d
+    # https://github.com/helm/charts/issues/11447#issuecomment-464716379
+    - containerName: prometheus-config-reloader
+      mode: "Off"

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -217,10 +217,10 @@ spec:
         resources:
           requests:
             cpu: 5m
-            memory: 10Mi
+            memory: 25Mi
           limits:
             cpu: 10m
-            memory: 20Mi
+            memory: 25Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config


### PR DESCRIPTION
**What this PR does / why we need it**:

Due to [CVE-2019-5736](https://nvd.nist.gov/vuln/detail/CVE-2019-5736) runC is now initially loaded into memory when the container starts.

After some time VPA recommends less memory (2,3Mb) than the size of of runC binary (about 10Mb).

This results in an error when trying to start (due to VPA action / pod deletion) the container:

```
failed to write 2485760 to memory.limit_in_bytes in /sys/fs/cgroup/memory/kubepods/prometheus-config-reloader/memory.limit_in_bytes: device or resource busy
```

see:
https://github.com/lxc/lxc/commit/6400238d08cdf1ca20d49bafb85f4e224348bf9d
https://github.com/helm/charts/issues/11447#issuecomment-464716379

**Which issue(s) this PR fixes**:
Fixes #2163 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
VPA recommendations are now disabled for Prometheus's prometheus-config-reloader container.
```

/cc @amshuman-kr 
/cc @dansible 
