### PR TITLE
Set Node Labels via Worker instead of kubelet-flags

### DIFF
--- a/charts/seed-operatingsystemconfig/original/templates/containerd/_node-cri.labels
+++ b/charts/seed-operatingsystemconfig/original/templates/containerd/_node-cri.labels
@@ -1,3 +1,0 @@
-{{- define "node-cri-labels" -}}
-{{- if .Values.worker.cri }}{{ .Values.osc.cri.labels.workerLabel }}={{ .Values.worker.cri.name }}{{- end -}}
-{{- end -}}

--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.flags
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.flags
@@ -19,11 +19,6 @@
 --pod-infra-container-image={{ index .Values.images "pause-container" }}
 --kubeconfig=/var/lib/kubelet/kubeconfig-real
 --network-plugin=cni
-{{- if semverCompare "< 1.15" .Values.kubernetes.version }}
---node-labels="kubernetes.io/role=node,node-role.kubernetes.io/node=,worker.garden.sapcloud.io/group={{ required "worker.name is required" .Values.worker.name }},worker.gardener.cloud/pool={{ required "worker.name is required" .Values.worker.name }},{{ include "node-cri-labels" . }}"
-{{- else }}
---node-labels="node.kubernetes.io/role=node,worker.garden.sapcloud.io/group={{ required "worker.name is required" .Values.worker.name }},worker.gardener.cloud/pool={{ required "worker.name is required" .Values.worker.name }},{{ include "node-cri-labels" . }}"
-{{- end }}
 {{- if semverCompare "< 1.11" .Values.kubernetes.version }}
 --rotate-certificates=true
 {{- end }}

--- a/charts/seed-operatingsystemconfig/original/values.yaml
+++ b/charts/seed-operatingsystemconfig/original/values.yaml
@@ -6,8 +6,6 @@ osc:
   sshKey: "ssh-rsa"
   cri:
     containerRuntimesBinaryPath: /var/bin/containerruntimes
-    labels:
-      workerLabel: worker.gardener.cloud/cri-name
     names:
       containerd: containerd
 

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -170,14 +170,9 @@ func (b *Botanist) deployOperatingSystemConfigsForWorker(ctx context.Context, ma
 		"containerd": extensionsv1alpha1.CRINameContainerD,
 	}
 
-	workerNameLabel := map[string]interface{}{
-		"workerLabel": extensionsv1alpha1.CRINameWorkerLabel,
-	}
-
 	criConfig := map[string]interface{}{
 		"containerRuntimesBinaryPath": extensionsv1alpha1.ContainerDRuntimeContainersBinFolder,
 		"names":                       criNamesConfig,
-		"labels":                      workerNameLabel,
 	}
 
 	originalConfig["osc"] = map[string]interface{}{


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, the default Node labels (k8s node role, worker pool name and cri name) are added via the Worker resource instead of setting them via a kubelet flag.
Gardener add these labels that were previously added via kubelet flags directly to the worker spec and the provider extensions will be responsible for adding the specified labels to the worker nodes.
All extensions using the generic Worker actuator to create MachineDeployments will properly set the labels on the MachineDeployments out of the box, which will then be propagated to the Node objects by mcm.

This enables endusers to properly use the scale-from-zero feature when running scaled workload with label selectors for the default worker pool labels (`worker.gardener.cloud/pool`). (see https://github.com/gardener/gardener/pull/2160#discussion_r405358138)
cc @hardikdr 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @danielfoehrKn Please check, if the the CRI labels are still set correctly.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Gardener now sets the default Node labels via the Worker CRD instead of via kubelet flags.
```
```improvement developer
Gardener now sets the default Node labels via the Worker CRD instead of via kubelet flags. Please make sure that your worker controller properly propagates the specified labels to the Node objects.
```