### PR TITLE
Extend the infrastructure actuator interfece with Migrate and Restore

### DIFF
--- a/extensions/pkg/controller/infrastructure/actuator.go
+++ b/extensions/pkg/controller/infrastructure/actuator.go
@@ -28,4 +28,8 @@ type Actuator interface {
 	Reconcile(context.Context, *extensionsv1alpha1.Infrastructure, *extensionscontroller.Cluster) error
 	// Delete the Infrastructure config.
 	Delete(context.Context, *extensionsv1alpha1.Infrastructure, *extensionscontroller.Cluster) error
+	// Restore takes the state of the Infrastrucure resource and applies it to the terraform pod's output state
+	Restore(context.Context, *extensionsv1alpha1.Infrastructure, *extensionscontroller.Cluster) error
+	// Migrate deletes the terraform k8s resources without deleting the corresponding resources in the IaaS provider
+	Migrate(context.Context, *extensionsv1alpha1.Infrastructure, *extensionscontroller.Cluster) error
 }

--- a/extensions/pkg/controller/infrastructure/reconciler.go
+++ b/extensions/pkg/controller/infrastructure/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/util"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
@@ -40,8 +41,12 @@ import (
 const (
 	// EventInfrastructureReconciliation an event reason to describe infrastructure reconciliation.
 	EventInfrastructureReconciliation string = "InfrastructureReconciliation"
-	// EventInfrastructureDeleton an event reason to describe infrastructure deletion.
-	EventInfrastructureDeleton string = "InfrastructureDeleton"
+	// EventInfrastructureDeletion an event reason to describe infrastructure deletion.
+	EventInfrastructureDeletion string = "InfrastructureDeletion"
+	// EventInfrastructureMigration an event reason to describe infrastructure migration.
+	EventInfrastructureMigration string = "InfrastructureMigration"
+	// EventInfrastructureRestoration an event reason to describe infrastructure restoration.
+	EventInfrastructureRestoration string = "InfrastructureRestoration"
 )
 
 type reconciler struct {
@@ -94,35 +99,38 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
-	if infrastructure.DeletionTimestamp != nil {
+	operationType := gardencorev1beta1helper.ComputeOperationType(infrastructure.ObjectMeta, infrastructure.Status.LastOperation)
+
+	switch {
+	case extensionscontroller.IsMigrated(infrastructure):
+		return reconcile.Result{}, nil
+	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
+		return r.migrate(r.ctx, infrastructure, cluster)
+	case infrastructure.DeletionTimestamp != nil:
 		return r.delete(r.ctx, infrastructure, cluster)
+	case infrastructure.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRestore:
+		return r.restore(r.ctx, infrastructure, cluster, operationType)
+	default:
+		return r.reconcile(r.ctx, infrastructure, cluster, operationType)
 	}
-	return r.reconcile(r.ctx, infrastructure, cluster)
 }
 
-func (r *reconciler) reconcile(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
+func (r *reconciler) reconcile(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster, operationType gardencorev1beta1.LastOperationType) (reconcile.Result, error) {
 	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, infrastructure); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	operationType := gardencorev1beta1helper.ComputeOperationType(infrastructure.ObjectMeta, infrastructure.Status.LastOperation)
 	if err := r.updateStatusProcessing(ctx, infrastructure, operationType, "Reconciling the infrastructure"); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	r.logger.Info("Starting the reconciliation of infrastructure", "infrastructure", infrastructure.Name)
-	r.recorder.Event(infrastructure, corev1.EventTypeNormal, EventInfrastructureReconciliation, "Reconciling the infrastructure")
+	r.logInfo(infrastructure, EventInfrastructureReconciliation, "Reconciling the infrastructure", "infrastructure", infrastructure.Name)
 	if err := r.actuator.Reconcile(ctx, infrastructure, cluster); err != nil {
-		msg := "Error reconciling infrastructure"
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), infrastructure, operationType, msg))
-		r.logger.Error(err, msg, "infrastructure", infrastructure.Name)
+		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), infrastructure, operationType, EventInfrastructureReconciliation, "Error reconciling infrastructure"))
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	msg := "Successfully reconciled infrastructure"
-	r.logger.Info(msg, "infrastructure", infrastructure.Name)
-	r.recorder.Event(infrastructure, corev1.EventTypeNormal, EventInfrastructureReconciliation, msg)
-	if err := r.updateStatusSuccess(ctx, infrastructure, operationType, msg); err != nil {
+	if err := r.updateStatusSuccess(ctx, infrastructure, operationType, EventInfrastructureReconciliation, "Successfully reconciled infrastructure"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -140,35 +148,83 @@ func (r *reconciler) delete(ctx context.Context, infrastructure *extensionsv1alp
 		return reconcile.Result{}, nil
 	}
 
-	operationType := gardencorev1beta1helper.ComputeOperationType(infrastructure.ObjectMeta, infrastructure.Status.LastOperation)
-	if err := r.updateStatusProcessing(ctx, infrastructure, operationType, "Deleting the infrastructure"); err != nil {
+	if err := r.updateStatusProcessing(ctx, infrastructure, gardencorev1beta1.LastOperationTypeDelete, "Deleting the infrastructure"); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	r.logger.Info("Starting the deletion of infrastructure", "infrastructure", infrastructure.Name)
-	r.recorder.Event(infrastructure, corev1.EventTypeNormal, EventInfrastructureDeleton, "Deleting the infrastructure")
-	if err := r.actuator.Delete(r.ctx, infrastructure, cluster); err != nil {
-		msg := "Error deleting infrastructure"
-		r.recorder.Eventf(infrastructure, corev1.EventTypeWarning, EventInfrastructureDeleton, "%s: %+v", msg, err)
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), infrastructure, operationType, msg))
-		r.logger.Error(err, msg, "infrastructure", infrastructure.Name)
+	r.logInfo(infrastructure, EventInfrastructureDeletion, "Deleting the infrastructure", "infrastructure", infrastructure.Name)
+	if err := r.actuator.Delete(ctx, infrastructure, cluster); err != nil {
+		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), infrastructure, gardencorev1beta1.LastOperationTypeDelete, EventInfrastructureDeletion, "Error deleting infrastructure"))
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	msg := "Successfully deleted infrastructure"
-	r.logger.Info(msg, "infrastructure", infrastructure.Name)
-	r.recorder.Event(infrastructure, corev1.EventTypeNormal, EventInfrastructureDeleton, msg)
-	if err := r.updateStatusSuccess(ctx, infrastructure, operationType, msg); err != nil {
+	if err := r.updateStatusSuccess(ctx, infrastructure, gardencorev1beta1.LastOperationTypeDelete, EventInfrastructureDeletion, "Successfully deleted infrastructure"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	r.logger.Info("Removing finalizer.", "infrastructure", infrastructure.Name)
 	if err := extensionscontroller.DeleteFinalizer(ctx, r.client, FinalizerName, infrastructure); err != nil {
-		r.logger.Error(err, "Error removing finalizer from Infrastructure", "infrastructure", infrastructure.Name)
+		r.logError(infrastructure, err, EventInfrastructureMigration, "Error removing finalizer from Infrastructure", "infrastructure", fmt.Sprintf("%s/%s", infrastructure.Namespace, infrastructure.Name))
 		return reconcile.Result{}, err
 	}
 
 	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) migrate(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
+	if err := r.updateStatusProcessing(ctx, infrastructure, gardencorev1beta1.LastOperationTypeMigrate, "Starting Migration of the Infrastructure"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	r.logInfo(infrastructure, EventInfrastructureMigration, "Migrating the infrastructure", "infrastructure", infrastructure.Name)
+	if err := r.actuator.Migrate(ctx, infrastructure, cluster); err != nil {
+		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), infrastructure, gardencorev1beta1.LastOperationTypeMigrate, EventInfrastructureMigration, "Error migrating infrastructure"))
+		return extensionscontroller.ReconcileErr(err)
+	}
+
+	if err := r.updateStatusSuccess(ctx, infrastructure, gardencorev1beta1.LastOperationTypeMigrate, EventInfrastructureMigration, "Successfully migrated Infrastructure"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	r.logger.Info("Removing finalizer.", "infrastructure", fmt.Sprintf("%s/%s", infrastructure.Namespace, infrastructure.Name))
+	if err := extensionscontroller.DeleteFinalizer(ctx, r.client, FinalizerName, infrastructure); err != nil {
+		r.logError(infrastructure, err, EventInfrastructureMigration, "Error removing finalizer from Infrastructure", "infrastructure", fmt.Sprintf("%s/%s", infrastructure.Namespace, infrastructure.Name))
+		return reconcile.Result{}, err
+	}
+
+	// remove operation annotation 'migrate'
+	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, infrastructure, v1beta1constants.GardenerOperation); err != nil {
+		r.logError(infrastructure, err, EventInfrastructureMigration, "Error removing annotation from Infrastructure", "annotation", fmt.Sprintf("%s/%s", v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationMigrate), "infrastructure", fmt.Sprintf("%s/%s", infrastructure.Namespace, infrastructure.Name))
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) restore(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster, operationType gardencorev1beta1.LastOperationType) (reconcile.Result, error) {
+	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, infrastructure); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.updateStatusProcessing(ctx, infrastructure, operationType, "Restoring the infrastructure"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	r.logInfo(infrastructure, EventInfrastructureRestoration, "Restoring the infrastructure", "infrastructure", infrastructure.Name)
+	if err := r.actuator.Restore(ctx, infrastructure, cluster); err != nil {
+		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), infrastructure, operationType, EventInfrastructureRestoration, "Error restoring infrastructure"))
+		return extensionscontroller.ReconcileErr(err)
+	}
+
+	// remove operation annotation 'restore'
+	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, infrastructure, v1beta1constants.GardenerOperation); err != nil {
+		r.logError(infrastructure, err, EventInfrastructureRestoration, "Error removing annotation from Infrastructure", "annotation", fmt.Sprintf("%s/%s", v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationMigrate), "infrastructure", fmt.Sprintf("%s/%s", infrastructure.Namespace, infrastructure.Name))
+		return reconcile.Result{}, err
+	}
+
+	err := r.updateStatusSuccess(ctx, infrastructure, gardencorev1beta1.LastOperationTypeMigrate, EventInfrastructureRestoration, "Successfully restored infrastructure")
+
+	return reconcile.Result{}, err
 }
 
 func (r *reconciler) updateStatusProcessing(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
@@ -178,7 +234,8 @@ func (r *reconciler) updateStatusProcessing(ctx context.Context, infrastructure 
 	})
 }
 
-func (r *reconciler) updateStatusError(ctx context.Context, err error, infrastructure *extensionsv1alpha1.Infrastructure, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+func (r *reconciler) updateStatusError(ctx context.Context, err error, infrastructure *extensionsv1alpha1.Infrastructure, lastOperationType gardencorev1beta1.LastOperationType, event, description string) error {
+	r.logError(infrastructure, err, event, description, "infrastructure", infrastructure.Name)
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, infrastructure, func() error {
 		infrastructure.Status.ObservedGeneration = infrastructure.Generation
 		infrastructure.Status.LastOperation, infrastructure.Status.LastError = extensionscontroller.ReconcileError(lastOperationType, gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, err)), 50, gardencorev1beta1helper.ExtractErrorCodes(err)...)
@@ -186,10 +243,21 @@ func (r *reconciler) updateStatusError(ctx context.Context, err error, infrastru
 	})
 }
 
-func (r *reconciler) updateStatusSuccess(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+func (r *reconciler) updateStatusSuccess(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure, lastOperationType gardencorev1beta1.LastOperationType, event, description string) error {
+	r.logInfo(infrastructure, event, description, "infrastructure", infrastructure.Name)
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, infrastructure, func() error {
 		infrastructure.Status.ObservedGeneration = infrastructure.Generation
 		infrastructure.Status.LastOperation, infrastructure.Status.LastError = extensionscontroller.ReconcileSucceeded(lastOperationType, description)
 		return nil
 	})
+}
+
+func (r *reconciler) logError(infrastructure *extensionsv1alpha1.Infrastructure, err error, event, msg string, keysAndValues ...interface{}) {
+	r.recorder.Eventf(infrastructure, corev1.EventTypeWarning, event, fmt.Sprintf("%s: %+v", msg, err))
+	r.logger.Error(err, msg, keysAndValues...)
+}
+
+func (r *reconciler) logInfo(infrastructure *extensionsv1alpha1.Infrastructure, event, msg string, keysAndValues ...interface{}) {
+	r.recorder.Eventf(infrastructure, corev1.EventTypeNormal, event, msg)
+	r.logger.Info(msg, keysAndValues...)
 }

--- a/extensions/pkg/controller/reconciler.go
+++ b/extensions/pkg/controller/reconciler.go
@@ -74,6 +74,10 @@ func (o *operationAnnotationWrapper) Reconcile(request reconcile.Request) (recon
 	}
 
 	annotations := acc.GetAnnotations()
+	if annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationWaitForState {
+		return reconcile.Result{}, nil
+	}
+
 	if annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationReconcile {
 		withOpAnnotation := obj.DeepCopyObject()
 		delete(annotations, v1beta1constants.GardenerOperation)

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -53,8 +53,8 @@ func (f factory) New(logger logrus.FieldLogger, client client.Client, coreV1Clie
 	return New(logger, client, coreV1Client, purpose, namespace, name, image)
 }
 
-func (f factory) DefaultInitializer(c client.Client, main, variables string, tfVars []byte, state string) Initializer {
-	return DefaultInitializer(c, main, variables, tfVars, state)
+func (f factory) DefaultInitializer(c client.Client, main, variables string, tfVars []byte, stateInitializer StateConfigMapInitializer) Initializer {
+	return DefaultInitializer(c, main, variables, tfVars, stateInitializer)
 }
 
 // DefaultFactory returns the default factory.

--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -113,5 +113,19 @@ type Initializer interface {
 type Factory interface {
 	NewForConfig(logger logrus.FieldLogger, config *rest.Config, purpose, namespace, name, image string) (Terraformer, error)
 	New(logger logrus.FieldLogger, client client.Client, coreV1Client corev1client.CoreV1Interface, purpose, namespace, name, image string) Terraformer
-	DefaultInitializer(c client.Client, main, variables string, tfVars []byte, state string) Initializer
+	DefaultInitializer(c client.Client, main, variables string, tfVars []byte, stateInitializer StateConfigMapInitializer) Initializer
+}
+
+// StateConfigMapInitializer initialize terraformer state ConfigMap
+type StateConfigMapInitializer interface {
+	Initialize(ctx context.Context, c client.Client, namespace, name string) error
+}
+
+// StateConfigMapInitializerFunc implements StateConfigMapInitializer
+type StateConfigMapInitializerFunc func(ctx context.Context, c client.Client, namespace, name string) error
+
+// CreateOrUpdateState implements StateConfigMapInitializer.
+// It use it field state for creating or updating the state ConfigMap
+type CreateOrUpdateState struct {
+	State *string
 }

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	go.uber.org/zap v1.13.0
 	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
-	golang.org/x/tools v0.0.0-20200422022333-3d57cf2e726e // indirect
+	golang.org/x/tools v0.0.0-20200422205258-72e4a01eba43 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.0.1
 	google.golang.org/grpc v1.26.0
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.sum
+++ b/go.sum
@@ -708,6 +708,8 @@ golang.org/x/tools v0.0.0-20191230220329-2aa90c603ae3 h1:2+KluhQfJ1YhW+TB1KrISS2
 golang.org/x/tools v0.0.0-20191230220329-2aa90c603ae3/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200422022333-3d57cf2e726e h1:3Dzrrxi54Io7Aoyb0PYLsI47K2TxkRQg+cqUn+m04do=
 golang.org/x/tools v0.0.0-20200422022333-3d57cf2e726e/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200422205258-72e4a01eba43 h1:Lcsc5ErIWemp8qAbYffG5vPrqjJ0zk82RTFGifeS1Pc=
+golang.org/x/tools v0.0.0-20200422205258-72e4a01eba43/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -109,6 +109,8 @@ const (
 	// GardenerOperationRestore is a constant for the value of the operation annotation describing a restoration
 	// operation.
 	GardenerOperationRestore = "restore"
+	// GardenerOperationWaitForState is a constant for the value of the operation annotation for waiting a state
+	GardenerOperationWaitForState = "wait-for-state"
 
 	// DeprecatedGardenRole is the key for an annotation on a Kubernetes object indicating what it is used for.
 	//

--- a/pkg/mock/gardener/extensions/terraformer/mocks.go
+++ b/pkg/mock/gardener/extensions/terraformer/mocks.go
@@ -305,7 +305,7 @@ func (m *MockFactory) EXPECT() *MockFactoryMockRecorder {
 }
 
 // DefaultInitializer mocks base method
-func (m *MockFactory) DefaultInitializer(arg0 client.Client, arg1, arg2 string, arg3 []byte, arg4 string) terraformer.Initializer {
+func (m *MockFactory) DefaultInitializer(arg0 client.Client, arg1, arg2 string, arg3 []byte, arg4 terraformer.StateConfigMapInitializer) terraformer.Initializer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DefaultInitializer", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(terraformer.Initializer)


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we add new functionality to Infrastructure actuator interface consisting of Migrate and Restore. Each provider must implement the corresponding functions.
Migrate must remove all related resources of the shoot control plane without deleting the IaaS resources.
Restore must read the state from Infrastructure.Status.State and base on it to make the proper shoot control plane resources(e.g config maps and secrets)
**Which issue(s) this PR fixes**:
Part of [# 1631](https://github.com/gardener/gardener/issues/1631) 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Extend the infrastructure actuator interface with Migrate and Restore
```
