### PR TITLE
Add elastic-search-service-account

### DIFF
--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/elasticsearch-logging-role-binding.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/elasticsearch-logging-role-binding.yaml
@@ -1,0 +1,17 @@
+apiVersion: {{ include "rbacversion" . }}
+kind: RoleBinding
+metadata:
+  name: elasticsearch-logging
+  namespace: {{ .Release.Namespace }}
+  labels:
+    garden.sapcloud.io/role: logging
+    app: elasticsearch-logging
+    role: logging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: elasticsearch-logging
+subjects:
+- kind: ServiceAccount
+  name: elasticsearch-logging
+  namespace: {{ .Release.Namespace }}

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/elasticsearch-logging-role.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/elasticsearch-logging-role.yaml
@@ -1,0 +1,24 @@
+apiVersion: {{ include "rbacversion" . }}
+kind: Role
+metadata:
+  name: elasticsearch-logging
+  namespace: {{ .Release.Namespace }}
+  labels:
+    garden.sapcloud.io/role: logging
+    app: elasticsearch-logging
+    role: logging
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["get", "list", "watch"]
+  resourceNames:
+  - es-configmap
+  - searchguard-config
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["get", "list", "watch"]
+  resourceNames:
+  - elasticsearch-logging-server
+  - sg-admin-client

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/elasticsearch-logging-service-account.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/elasticsearch-logging-service-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: elasticsearch-logging
+  namespace: {{ .Release.Namespace }}
+  labels:
+    garden.sapcloud.io/role: logging
+    app: elasticsearch-logging
+    role: logging

--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/statefulset.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/elasticsearch/statefulset.yaml
@@ -133,6 +133,7 @@ spec:
           {{- toYaml .Values.elasticsearch.metricsExporter.livenessProbe | nindent 10 }}
         readinessProbe:
           {{- toYaml .Values.elasticsearch.metricsExporter.readinessProbe | nindent 10 }}
+      serviceAccountName: elasticsearch-logging
       volumes:
       - name: config
         configMap:

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -328,6 +328,8 @@ func DeleteLoggingStack(ctx context.Context, k8sClient client.Client, namespace 
 		&batchv1beta1.CronJobList{},
 		&rbacv1.ClusterRoleList{},
 		&rbacv1.ClusterRoleBindingList{},
+		&rbacv1.RoleList{},
+		&rbacv1.RoleBindingList{},
 		&appsv1.DaemonSetList{},
 		&appsv1.DeploymentList{},
 		&autoscalingv2beta1.HorizontalPodAutoscalerList{},


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we add dedicated service account for the elastic-search pods.
**Which issue(s) this PR fixes**:
Fixes [#1975](https://github.com/gardener/gardener/issues/1975)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
NONE
```
