### PR TITLE
Revert "Optimize apiserver HVPA minAllowed config."

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hvpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/kube-apiserver-hvpa.yaml
@@ -75,7 +75,7 @@ spec:
                 cpu: "8"
               minAllowed:
                 memory: 400M
-                cpu: 100m
+                cpu: 300m
             - containerName: vpn-seed
               mode: "Off"
             - containerName: blackbox-exporter


### PR DESCRIPTION
Reverts gardener/gardener#2056

To sum up the problem:

1. API server Pod/container is started with `100m` CPU requests + limits.
1. API server starts to do post-start hooks (fixing bootstrap ClusterRole / ClusterRoleBinding).
1. Previous operation is throttled due to low CPU.
1. Liveness checks fail because 2. is not finished.
1. Kubelet restarts the API server container which is still doing 2. (`Container kube-apiserver failed liveness probe, will be restarted`)
1. Go to 1.

Deadlock. See bellow for full details:

API servers fail to start and getting constantly restarted, because their healthcheck is failing with:

```
[+]ping ok
[+]etcd ok
[+]poststarthook/generic-apiserver-start-informers ok
[+]poststarthook/start-apiextensions-informers ok
[+]poststarthook/start-apiextensions-controllers ok
[+]poststarthook/bootstrap-controller ok
[-]poststarthook/rbac/bootstrap-roles failed: reason withheld
[+]poststarthook/ca-registration ok
[+]poststarthook/start-kube-apiserver-informers ok
[+]poststarthook/start-kube-aggregator-informers ok
[+]poststarthook/apiservice-registration-controller ok
[+]poststarthook/apiservice-status-available-controller ok
[+]poststarthook/apiservice-openapi-controller ok
[+]poststarthook/kube-apiserver-autoregistration ok
[+]autoregister-completion ok
healthz check failed
```

It takese quite a while for the API server to sync its RBAC roles, because it was CPU throttled - the initial CPU usage is quite high when the API server starts, but after that it goes down significantly.  Those poststart hooks are quite CPU intensive.

So this is a `kube-apiserver` which I started with `100` CPU requests and limits and I've modified it to have `120` seconds delay before `liveness` probe starts.

In this case we get:

```
  Normal   Scheduled  2m56s                 default-scheduler    Successfully assigned some-namespace/kube-apiserver-79b4b67ddb-7sjvg to someworker
  Normal   Pulled     2m54s                 kubelet, someworker  Container image "alpine-iptables:3.10.3" already present on machine
  Normal   Created    2m54s                 kubelet, someworker  Created container set-iptable-rules
  Normal   Started    2m54s                 kubelet, someworker  Started container set-iptable-rules
  Normal   Pulled     2m53s                 kubelet, someworker  Container image "hyperkube:v1.16.8" already present on machine
  Normal   Created    2m53s                 kubelet, someworker  Created container kube-apiserver
  Normal   Started    2m53s                 kubelet, someworker  Started container kube-apiserver
  Normal   Pulled     2m53s                 kubelet, someworker  Container image "vpn-seed:0.19.0" already present on machine
  Normal   Created    2m53s                 kubelet, someworker  Created container vpn-seed
  Normal   Started    2m52s                 kubelet, someworker  Started container vpn-seed
  Normal   Pulled     2m52s                 kubelet, someworker  Container image "blackbox-exporter:v0.14.0" already present on machine
  Normal   Created    2m52s                 kubelet, someworker  Created container blackbox-exporter
  Normal   Started    2m52s                 kubelet, someworker  Started container blackbox-exporter
  Warning  Unhealthy  117s (x4 over 2m27s)  kubelet, someworker  Readiness probe failed: Get https://10.243.134.156:443/readyz: net/http: TLS handshake timeout
  Warning  Unhealthy  107s (x2 over 107s)   kubelet, someworker  Readiness probe failed: HTTP probe failed with statuscode: 403
  Warning  Unhealthy  97s                   kubelet, someworker  Readiness probe failed: HTTP probe failed with statuscode: 500
```

The API server is started at `14:26:14` and in `14:27:40` it's finally ready to receive traffic - thats `1min25seconds` at total. Due to the CPU throttle it also cannot process etcd requests fast enough.

```
Trace[1115816413]: [604.129594ms] [604.087033ms] About to write a response
I0410 14:27:56.156940       1 trace.go:116] Trace[1452932951]: "List" url:/apis/apps/v1/replicasets (started: 2020-04-10 14:27:54.655208619 +0000 UTC m=+101.999995275) (total time: 1.501696367s):
Trace[1452932951]: [1.501668669s] [1.501520386s] Writing http response done count:35
I0410 14:27:56.555983       1 trace.go:116] Trace[309562480]: "Get" url:/api/v1/namespaces/kube-system/endpoints/kube-scheduler (started: 2020-04-10 14:27:55.65545853 +0000 UTC m=+103.000245189) (total time: 900.480233ms):
````

I then updated the Pod and kept `100m` CPU request, but bumped the limit to `400m`. This improved the start time of the API server. It was started at `14:41:33` and it became ready at `14:41:53` - only `20seconds` later.

```improvement operator
Revert minimum amount of CPU for `kube-apiserver` container to `300m` as it caused boot crash loopback. 
```