### PR TITLE
Shoot controller waits until required extension ready

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -73,7 +73,7 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation, errorContext *er
 			})
 		}),
 		errors.ToExecute("Check required extensions exist", func() error {
-			return botanist.RequiredExtensionsExist(context.TODO())
+			return botanist.WaitUntilRequiredExtensionsReady(context.TODO())
 		}),
 		// We first check whether the namespace in the Seed cluster does exist - if it does not, then we assume that
 		// all resources have already been deleted. We can delete the Shoot resource as a consequence.

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -71,7 +71,7 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation, operationType
 			})
 		}),
 		errors.ToExecute("Check required extensions", func() error {
-			return botanist.RequiredExtensionsExist(context.TODO())
+			return botanist.WaitUntilRequiredExtensionsReady(context.TODO())
 		}),
 		errors.ToExecute("Check version constraint", func() error {
 			enableEtcdEncryption, err = versionutils.CheckVersionMeetsConstraint(botanist.Shoot.Info.Spec.Kubernetes.Version, ">= 1.13")

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -60,8 +60,8 @@ func New(o *operation.Operation) (*Botanist, error) {
 	return b, nil
 }
 
-// RequiredExtensionsExist checks whether all required extensions needed for an shoot operation exist.
-func (b *Botanist) RequiredExtensionsExist(ctx context.Context) error {
+// RequiredExtensionsReady checks whether all required extensions needed for a shoot operation exist and are ready.
+func (b *Botanist) RequiredExtensionsReady(ctx context.Context) error {
 	controllerRegistrationList := &gardencorev1beta1.ControllerRegistrationList{}
 	if err := b.K8sGardenClient.Client().List(ctx, controllerRegistrationList); err != nil {
 		return err

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -375,3 +375,14 @@ func (b *Botanist) WaitUntilBackupEntryInGardenReconciled(ctx context.Context) e
 		return retry.MinorError(fmt.Errorf("backup entry %q has not yet been reconciled", be.Name))
 	})
 }
+
+// WaitUntilRequiredExtensionsReady waits until all the extensions required for a shoot reconciliation are ready
+func (b *Botanist) WaitUntilRequiredExtensionsReady(ctx context.Context) error {
+	return retry.UntilTimeout(ctx, 5*time.Second, time.Minute, func(ctx context.Context) (done bool, err error) {
+		if err := b.RequiredExtensionsReady(ctx); err != nil {
+			b.Logger.Infof("Waiting until all the required extension controllers are ready (%+v)", err)
+			return retry.MinorError(err)
+		}
+		return retry.Ok()
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The shoot controller does now wait for a minute until all the required extensions are ready before returning an error. After the on-demand deployment of extensions with #1993 it might take some time until all the controllers are up and running. Without this PR an early/immediate return will lead to fast requeueing of the shoot keys and, eventually, a prolonged exponential backoff. The backoff often lasts way longer than the time needed to deploy the extensions, hence, the shoot creation is unnecessarily delayed.

**Special notes for your reviewer**:
/cc @MartinWeindel @mandelsoft and thanks for reporting/bringing this up

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
