### PR TITLE
Refactor create shoot test to make it reuseable

### DIFF
--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -90,6 +90,9 @@ func (f *GardenerFramework) CreateShoot(ctx context.Context, shoot *gardencorev1
 
 	err = retry.UntilTimeout(ctx, 20*time.Second, 5*time.Minute, func(ctx context.Context) (done bool, err error) {
 		err = f.GardenClient.Client().Create(ctx, shoot)
+		if apierrors.IsInvalid(err) || apierrors.IsForbidden(err) {
+			return retry.SevereError(err)
+		}
 		if err != nil {
 			f.Logger.Debugf("unable to create shoot %s: %s", shoot.Name, err.Error())
 			return retry.MinorError(err)

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -1,0 +1,421 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	"github.com/onsi/ginkgo"
+)
+
+var shootCreationCfg *ShootCreationConfig
+
+// ShootCreationConfig is the configuration for a shoot creation framework
+type ShootCreationConfig struct {
+	GardenerConfig *GardenerConfig
+
+	shootKubeconfigPath          string
+	seedKubeconfigPath           string
+	testShootName                string
+	testShootPrefix              string
+	shootMachineImageName        string
+	shootMachineType             string
+	shootMachineImageVersion     string
+	cloudProfile                 string
+	seedName                     string
+	shootRegion                  string
+	secretBinding                string
+	shootProviderType            string
+	shootK8sVersion              string
+	externalDomain               string
+	workerZone                   string
+	networkingPods               string
+	networkingServices           string
+	networkingNodes              string
+	startHibernatedFlag          string
+	startHibernated              bool
+	infrastructureProviderConfig string
+	controlPlaneProviderConfig   string
+	networkingProviderConfig     string
+	workersConfig                string
+	shootYamlPath                string
+}
+
+// ShootCreationFramework represents the shoot test framework that includes
+// test functions that can be executed ona specific shoot
+type ShootCreationFramework struct {
+	*GardenerFramework
+	TestDescription
+	Config *ShootCreationConfig
+
+	Shoot *gardencorev1beta1.Shoot
+
+	shootFramework *ShootFramework
+}
+
+// NewShootCreationFramework creates a new simple Shoot creation framework
+func NewShootCreationFramework(cfg *ShootCreationConfig) *ShootCreationFramework {
+	f := &ShootCreationFramework{
+		GardenerFramework: NewGardenerFrameworkFromConfig(nil),
+		TestDescription:   NewTestDescription("SHOOTCREATION"),
+		Config:            cfg,
+	}
+
+	ginkgo.BeforeEach(func() {
+		f.GardenerFramework.BeforeEach()
+		f.BeforeEach()
+	})
+	CAfterEach(f.AfterEach, 10*time.Minute)
+	return f
+}
+
+// NewShootCreationFrameworkFromConfig creates a new Shoot creation framework from a shoot creation configuration
+// without registering ginkgo specific functions
+func NewShootCreationFrameworkFromConfig(cfg *ShootCreationConfig) (*ShootCreationFramework, error) {
+	var gardenerConfig *GardenerConfig
+	if cfg != nil {
+		gardenerConfig = cfg.GardenerConfig
+	}
+	f := &ShootCreationFramework{
+		GardenerFramework: NewGardenerFramework(gardenerConfig),
+		TestDescription:   NewTestDescription("SHOOTCREATION"),
+		Config:            cfg,
+	}
+	return f, nil
+}
+
+// BeforeEach should be called in ginkgo's BeforeEach.
+// It sets up the shoot creation framework.
+func (f *ShootCreationFramework) BeforeEach() {
+	f.Config = mergeShootCreationConfig(f.Config, shootCreationCfg)
+	validateShootCreationConfig(f.Config)
+}
+
+// AfterEach should be called in ginkgo's AfterEach.
+// Cleans up resources and dumps the shoot state if the test failed
+func (f *ShootCreationFramework) AfterEach(ctx context.Context) {
+	if ginkgo.CurrentGinkgoTestDescription().Failed {
+		f.DumpState(ctx)
+	}
+}
+
+func validateShootCreationConfig(cfg *ShootCreationConfig) {
+	if cfg == nil {
+		ginkgo.Fail("no shoot creation framework configuration provided")
+	}
+
+	if !StringSet(cfg.shootProviderType) {
+		ginkgo.Fail("you need to specify provider type of the shoot")
+	}
+
+	if StringSet(cfg.shootMachineImageName) && !StringSet(cfg.shootMachineImageVersion) {
+		ginkgo.Fail("shootMachineImageVersion has to be defined if shootMachineImageName is set")
+	}
+
+	if StringSet(cfg.shootMachineImageVersion) && !StringSet(cfg.shootMachineImageName) {
+		ginkgo.Fail("shootMachineImageName has to be defined if shootMachineImageVersion is set")
+	}
+
+	if StringSet(cfg.startHibernatedFlag) {
+		parsedBool, err := strconv.ParseBool(cfg.startHibernatedFlag)
+		if err != nil {
+			ginkgo.Fail("startHibernated is not a boolean value")
+		}
+		cfg.startHibernated = parsedBool
+	}
+
+	if !StringSet(cfg.infrastructureProviderConfig) {
+		ginkgo.Fail(fmt.Sprintf("you need to specify the filepath to the infrastructureProviderConfig for the provider '%s'", cfg.shootProviderType))
+	}
+
+	if !FileExists(cfg.infrastructureProviderConfig) {
+		ginkgo.Fail("path to the infrastructureProviderConfig of the Shoot is invalid")
+	}
+
+	if StringSet(cfg.controlPlaneProviderConfig) {
+		if !FileExists(cfg.controlPlaneProviderConfig) {
+			ginkgo.Fail("path to the controlPlaneProviderConfig of the Shoot is invalid")
+		}
+	}
+
+	if StringSet(cfg.networkingProviderConfig) {
+		if !FileExists(cfg.networkingProviderConfig) {
+			ginkgo.Fail("path to the networkingProviderConfig of the Shoot is invalid")
+		}
+	}
+
+	if StringSet(cfg.workersConfig) {
+		if !FileExists(cfg.workersConfig) {
+			ginkgo.Fail("path to the worker config of the Shoot is invalid")
+		}
+	}
+}
+
+func mergeShootCreationConfig(base, overwrite *ShootCreationConfig) *ShootCreationConfig {
+	if base == nil {
+		return overwrite
+	}
+	if overwrite == nil {
+		return base
+	}
+
+	if overwrite.GardenerConfig != nil {
+		base.GardenerConfig = mergeGardenerConfig(base.GardenerConfig, overwrite.GardenerConfig)
+	}
+
+	if StringSet(overwrite.shootKubeconfigPath) {
+		base.shootKubeconfigPath = overwrite.shootKubeconfigPath
+	}
+
+	if StringSet(overwrite.seedKubeconfigPath) {
+		base.seedKubeconfigPath = overwrite.seedKubeconfigPath
+	}
+
+	if StringSet(overwrite.testShootName) {
+		base.testShootName = overwrite.testShootName
+	}
+
+	if StringSet(overwrite.testShootPrefix) {
+		base.testShootPrefix = overwrite.testShootPrefix
+	}
+
+	if StringSet(overwrite.shootMachineImageName) {
+		base.shootMachineImageName = overwrite.shootMachineImageName
+	}
+
+	if StringSet(overwrite.shootMachineType) {
+		base.shootMachineType = overwrite.shootMachineType
+	}
+
+	if StringSet(overwrite.shootMachineImageVersion) {
+		base.shootMachineImageVersion = overwrite.shootMachineImageVersion
+	}
+
+	if StringSet(overwrite.cloudProfile) {
+		base.cloudProfile = overwrite.cloudProfile
+	}
+
+	if StringSet(overwrite.seedName) {
+		base.seedName = overwrite.seedName
+	}
+
+	if StringSet(overwrite.shootRegion) {
+		base.shootRegion = overwrite.shootRegion
+	}
+
+	if StringSet(overwrite.secretBinding) {
+		base.secretBinding = overwrite.secretBinding
+	}
+
+	if StringSet(overwrite.shootProviderType) {
+		base.shootProviderType = overwrite.shootProviderType
+	}
+
+	if StringSet(overwrite.shootK8sVersion) {
+		base.shootK8sVersion = overwrite.shootK8sVersion
+	}
+
+	if StringSet(overwrite.externalDomain) {
+		base.externalDomain = overwrite.externalDomain
+	}
+
+	if StringSet(overwrite.workerZone) {
+		base.workerZone = overwrite.workerZone
+	}
+
+	if StringSet(overwrite.networkingPods) {
+		base.networkingPods = overwrite.networkingPods
+	}
+
+	if StringSet(overwrite.networkingServices) {
+		base.networkingServices = overwrite.networkingServices
+	}
+
+	if StringSet(overwrite.networkingNodes) {
+		base.networkingNodes = overwrite.networkingNodes
+	}
+
+	if StringSet(overwrite.startHibernatedFlag) {
+		base.startHibernatedFlag = overwrite.startHibernatedFlag
+	}
+
+	if overwrite.startHibernated {
+		base.startHibernated = overwrite.startHibernated
+	}
+
+	if StringSet(overwrite.infrastructureProviderConfig) {
+		base.infrastructureProviderConfig = overwrite.infrastructureProviderConfig
+	}
+
+	if StringSet(overwrite.controlPlaneProviderConfig) {
+		base.controlPlaneProviderConfig = overwrite.controlPlaneProviderConfig
+	}
+
+	if StringSet(overwrite.networkingProviderConfig) {
+		base.networkingProviderConfig = overwrite.networkingProviderConfig
+	}
+
+	if StringSet(overwrite.workersConfig) {
+		base.workersConfig = overwrite.workersConfig
+	}
+
+	if StringSet(overwrite.shootYamlPath) {
+		base.shootYamlPath = overwrite.shootYamlPath
+	}
+
+	return base
+}
+
+// RegisterShootCreationFrameworkFlags adds all flags that are needed to configure a shoot creation framework to the provided flagset.
+func RegisterShootCreationFrameworkFlags() *ShootCreationConfig {
+	_ = RegisterGardenerFrameworkFlags()
+
+	newCfg := &ShootCreationConfig{}
+
+	flag.StringVar(&newCfg.shootKubeconfigPath, "shoot-kubecfg-path", "", "the path to where the Kubeconfig of the Shoot cluster will be downloaded to.")
+	flag.StringVar(&newCfg.seedKubeconfigPath, "seed-kubecfg-path", "", "the path to where the Kubeconfig of the Seed cluster will be downloaded to.")
+	flag.StringVar(&newCfg.testShootName, "shoot-name", "", "unique name to use for test shoots. Used by test-machinery.")
+	flag.StringVar(&newCfg.testShootPrefix, "prefix", "", "prefix for generated shoot name. Usually used locally to auto generate a unique name.")
+	flag.StringVar(&newCfg.shootMachineImageName, "machine-image-name", "", "the Machine Image Name of the test shoot. Defaults to first machine image in the CloudProfile.")
+	flag.StringVar(&newCfg.shootMachineType, "machine-type", "", "the Machine type of the first worker of the test shoot. Needs to match the machine types for that Provider available in the CloudProfile.")
+	flag.StringVar(&newCfg.shootMachineImageVersion, "machine-image-version", "", "the Machine Image version of the first worker of the test shoot. Needs to be set when the MachineImageName is set.")
+	flag.StringVar(&newCfg.cloudProfile, "cloud-profile", "", "cloudProfile to use for the shoot.")
+	flag.StringVar(&newCfg.seedName, "seed", "", "Name of the seed to use for the shoot.")
+	flag.StringVar(&newCfg.shootRegion, "region", "", "region to use for the shoot. Must be compatible with the infrastructureProvider.Zone.")
+	flag.StringVar(&newCfg.secretBinding, "secret-binding", "", "the secretBinding for the provider account of the shoot.")
+	flag.StringVar(&newCfg.shootProviderType, "provider-type", "", "the type of the cloud provider where the shoot is deployed to. e.g gcp, aws,azure,alicloud.")
+	flag.StringVar(&newCfg.shootK8sVersion, "k8s-version", "", "kubernetes version to use for the shoot.")
+	flag.StringVar(&newCfg.externalDomain, "external-domain", "", "external domain to use for the shoot. If not set, will use the default domain.")
+	flag.StringVar(&newCfg.workerZone, "worker-zone", "", "zone to use for every worker of the shoot.")
+	flag.StringVar(&newCfg.networkingPods, "networking-pods", "", "the spec.networking.pods to use for this shoot. Optional.")
+	flag.StringVar(&newCfg.networkingServices, "networking-services", "", "the spec.networking.services to use for this shoot. Optional.")
+	flag.StringVar(&newCfg.networkingNodes, "networking-nodes", "", "the spec.networking.nodes to use for this shoot. Optional.")
+	flag.StringVar(&newCfg.startHibernatedFlag, "start-hibernated", "", "the spec.hibernation.enabled to use for this shoot. Optional.")
+	newCfg.startHibernated = false
+
+	// ProviderConfigs flags
+	flag.StringVar(&newCfg.infrastructureProviderConfig, "infrastructure-provider-config-filepath", "", "filepath to the provider specific infrastructure config.")
+	flag.StringVar(&newCfg.controlPlaneProviderConfig, "controlplane-provider-config-filepath", "", "filepath to the provider specific infrastructure config.")
+	flag.StringVar(&newCfg.networkingProviderConfig, "networking-provider-config-filepath", "", "filepath to the provider specific infrastructure config.")
+	flag.StringVar(&newCfg.workersConfig, "workers-config-filepath", "", "filepath to the worker config.")
+
+	// other
+	flag.StringVar(&newCfg.shootYamlPath, "shoot-template-path", "default-shoot.yaml", "Specify the path to the shoot template that should be used to create the shoot")
+
+	shootCreationCfg = newCfg
+	return shootCreationCfg
+}
+
+func (f *ShootCreationFramework) CreateShoot(ctx context.Context) (*gardencorev1beta1.Shoot, error) {
+	if err := f.prepareShoot(ctx); err != nil {
+		return nil, err
+	}
+
+	f.Logger.Infof("Creating shoot %s in namespace %s", f.Shoot.GetName(), f.ProjectNamespace)
+	if err := PrettyPrintObject(f.Shoot); err != nil {
+		f.Logger.Fatalf("Cannot decode shoot %s: %s", f.Shoot.GetName(), err)
+		return nil, err
+	}
+
+	if err := f.GardenerFramework.CreateShoot(ctx, f.Shoot); err != nil {
+		f.Logger.Fatalf("Cannot create shoot %s: %s", f.Shoot.GetName(), err.Error())
+		shootFramework, err2 := f.newShootFramework()
+		if err2 != nil {
+			f.Logger.Fatalf("Cannot dump shoot state %s: %s", f.Shoot.GetName(), err.Error())
+		} else {
+			shootFramework.DumpState(ctx)
+		}
+		return nil, err
+	}
+
+	f.Logger.Infof("Successfully created shoot %s", f.Shoot.GetName())
+	shootFramework, err := f.newShootFramework()
+	if err != nil {
+		return nil, err
+	}
+	f.shootFramework = shootFramework
+
+	if err := DownloadKubeconfig(ctx, shootFramework.GardenClient, f.ProjectNamespace, shootFramework.ShootKubeconfigSecretName(), f.Config.shootKubeconfigPath); err != nil {
+		f.Logger.Fatalf("Cannot download shoot kubeconfig: %s", err.Error())
+		return nil, err
+	}
+
+	if err := DownloadKubeconfig(ctx, shootFramework.GardenClient, shootFramework.Seed.Spec.SecretRef.Namespace, shootFramework.Seed.Spec.SecretRef.Name, f.Config.seedKubeconfigPath); err != nil {
+		f.Logger.Fatalf("Cannot download seed kubeconfig: %s", err.Error())
+		return nil, err
+	}
+
+	f.Logger.Infof("Finished creating shoot %s", f.Shoot.GetName())
+
+	return f.Shoot, nil
+}
+
+func (f *ShootCreationFramework) prepareShoot(ctx context.Context) error {
+	// if running in test machinery, test will be executed from root of the project
+	if !FileExists(fmt.Sprintf(".%s", f.Config.shootYamlPath)) {
+		// locally, we need find the example shoot
+		f.Config.shootYamlPath = filepath.Join(f.TemplatesDir, f.Config.shootYamlPath)
+		if !FileExists(f.Config.shootYamlPath) {
+			return fmt.Errorf("shoot template should exist")
+		}
+	}
+
+	// parse shoot yaml into shoot object and generate random test names for shoots
+	_, shootObject, err := CreateShootTestArtifacts(f.Config, f.ProjectNamespace, true, true)
+	if err != nil {
+		return err
+	}
+	f.Shoot = shootObject
+
+	// set ProviderConfigs
+	err = SetProviderConfigsFromFilepath(shootObject, f.Config.infrastructureProviderConfig, f.Config.controlPlaneProviderConfig, f.Config.networkingProviderConfig)
+	if err != nil {
+		return err
+	}
+
+	// set worker settings
+	cloudProfile, err := f.GetCloudProfile(ctx, shootObject.Spec.CloudProfileName)
+	if err != nil {
+		return err
+	}
+
+	if err = setShootWorkerSettings(shootObject, f.Config, cloudProfile); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// newShootFramework creates a new ShootFramework with the Shoot created by the ShootCreationFramework
+func (f *ShootCreationFramework) newShootFramework() (*ShootFramework, error) {
+	shootFramework, err := f.GardenerFramework.NewShootFramework(f.Shoot)
+	if err != nil {
+		return nil, err
+	}
+
+	return shootFramework, nil
+}
+
+// GetShootFramework returns a ShootFramework for the Shoot created by the ShootCreationFramework
+func (f *ShootCreationFramework) GetShootFramework() *ShootFramework {
+	return f.shootFramework
+}

--- a/test/framework/shootframework.go
+++ b/test/framework/shootframework.go
@@ -84,7 +84,8 @@ func NewShootFramework(cfg *ShootConfig) *ShootFramework {
 	return f
 }
 
-// NewShootFrameworkFromConfig creates a new Shoot framework from a shoot configuration
+// NewShootFrameworkFromConfig creates a new Shoot framework from a shoot configuration without registering ginkgo
+// specific functions
 func NewShootFrameworkFromConfig(cfg *ShootConfig) (*ShootFramework, error) {
 	var gardenerConfig *GardenerConfig
 	if cfg != nil {
@@ -109,7 +110,7 @@ func (f *ShootFramework) BeforeEach() {
 	ctx := context.Background()
 	defer ctx.Done()
 	f.Config = mergeShootConfig(f.Config, shootCfg)
-	validateFlags(f.Config)
+	validateShootConfig(f.Config)
 	err := f.AddShoot(ctx, f.Config.ShootName, f.ProjectNamespace)
 	ExpectNoError(err)
 
@@ -226,7 +227,7 @@ func (f *ShootFramework) AddShoot(ctx context.Context, shootName, shootNamespace
 	return nil
 }
 
-func validateFlags(cfg *ShootConfig) {
+func validateShootConfig(cfg *ShootConfig) {
 	if cfg == nil {
 		ginkgo.Fail("no shoot framework configuration provided")
 	}

--- a/test/system/shoot_creation/create_test.go
+++ b/test/system/shoot_creation/create_test.go
@@ -28,51 +28,10 @@ package shoot_creation
 
 import (
 	"context"
-	"flag"
-	"fmt"
-	"path/filepath"
-	"strconv"
+	"github.com/gardener/gardener/test/framework"
 	"time"
 
-	"github.com/gardener/gardener/test/framework"
-
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-)
-
-var (
-	// flags
-	shootKubeconfigPath      = flag.String("shoot-kubecfg-path", "", "the path to where the Kubeconfig of the Shoot cluster will be downloaded to.")
-	seedKubeconfigPath       = flag.String("seed-kubecfg-path", "", "the path to where the Kubeconfig of the Seed cluster will be downloaded to.")
-	testShootName            = flag.String("shoot-name", "", "unique name to use for test shoots. Used by test-machinery.")
-	testShootPrefix          = flag.String("prefix", "", "prefix for generated shoot name. Usually used locally to auto generate a unique name.")
-	shootMachineImageName    = flag.String("machine-image-name", "", "the Machine Image Name of the test shoot. Defaults to first machine image in the CloudProfile.")
-	shootMachineType         = flag.String("machine-type", "", "the Machine type of the first worker of the test shoot. Needs to match the machine types for that Provider available in the CloudProfile.")
-	shootMachineImageVersion = flag.String("machine-image-version", "", "the Machine Image version of the first worker of the test shoot. Needs to be set when the MachineImageName is set.")
-	cloudProfile             = flag.String("cloud-profile", "", "cloudProfile to use for the shoot.")
-	seedName                 = flag.String("seed", "", "Name of the seed to use for the shoot.")
-	shootRegion              = flag.String("region", "", "region to use for the shoot. Must be compatible with the infrastructureProvider.Zone.")
-	secretBinding            = flag.String("secret-binding", "", "the secretBinding for the provider account of the shoot.")
-	shootProviderType        = flag.String("provider-type", "", "the type of the cloud provider where the shoot is deployed to. e.g gcp, aws,azure,alicloud.")
-	shootK8sVersion          = flag.String("k8s-version", "", "kubernetes version to use for the shoot.")
-	externalDomain           = flag.String("external-domain", "", "external domain to use for the shoot. If not set, will use the default domain.")
-	workerZone               = flag.String("worker-zone", "", "zone to use for every worker of the shoot.")
-	networkingPods           = flag.String("networking-pods", "", "the spec.networking.pods to use for this shoot. Optional.")
-	networkingServices       = flag.String("networking-services", "", "the spec.networking.services to use for this shoot. Optional.")
-	networkingNodes          = flag.String("networking-nodes", "", "the spec.networking.nodes to use for this shoot. Optional.")
-	startHibernatedFlag      = flag.String("start-hibernated", "", "the spec.hibernation.enabled to use for this shoot. Optional.")
-	startHibernated          = false
-
-	// ProviderConfigs flags
-	infrastructureProviderConfig = flag.String("infrastructure-provider-config-filepath", "", "filepath to the provider specific infrastructure config.")
-	controlPlaneProviderConfig   = flag.String("controlplane-provider-config-filepath", "", "filepath to the provider specific infrastructure config.")
-	networkingProviderConfig     = flag.String("networking-provider-config-filepath", "", "filepath to the provider specific infrastructure config.")
-	workersConfig                = flag.String("workers-config-filepath", "", "filepath to the worker config.")
-
-	// other
-	shootYamlPath = flag.String("shoot-template-path", "default-shoot.yaml", "Specify the path to the shoot template that should be used to create the shoot")
 )
 
 const (
@@ -80,171 +39,21 @@ const (
 )
 
 func init() {
-	framework.RegisterGardenerFrameworkFlags()
-}
-
-func validateFlags() {
-
-	if !framework.StringSet(*shootProviderType) {
-		Fail("you need to specify provider type of the shoot")
-	}
-
-	if framework.StringSet(*shootMachineImageName) && !framework.StringSet(*shootMachineImageVersion) {
-		Fail("shootMachineImageVersion has to be defined if shootMachineImageName is set")
-	}
-
-	if framework.StringSet(*shootMachineImageVersion) && !framework.StringSet(*shootMachineImageName) {
-		Fail("shootMachineImageName has to be defined if shootMachineImageVersion is set")
-	}
-
-	if framework.StringSet(*startHibernatedFlag) {
-		parsedBool, err := strconv.ParseBool(*startHibernatedFlag)
-		if err != nil {
-			Fail("startHibernated is not a boolean value")
-		}
-		startHibernated = parsedBool
-	}
-
-	if !framework.StringSet(*infrastructureProviderConfig) {
-		Fail(fmt.Sprintf("you need to specify the filepath to the infrastructureProviderConfig for the provider '%s'", *shootProviderType))
-	}
-
-	if !framework.FileExists(*infrastructureProviderConfig) {
-		Fail("path to the infrastructureProviderConfig of the Shoot is invalid")
-	}
-
-	if framework.StringSet(*controlPlaneProviderConfig) {
-		if !framework.FileExists(*controlPlaneProviderConfig) {
-			Fail("path to the controlPlaneProviderConfig of the Shoot is invalid")
-		}
-	}
-
-	if framework.StringSet(*networkingProviderConfig) {
-		if !framework.FileExists(*networkingProviderConfig) {
-			Fail("path to the networkingProviderConfig of the Shoot is invalid")
-		}
-	}
-
-	if framework.StringSet(*workersConfig) {
-		if !framework.FileExists(*workersConfig) {
-			Fail("path to the worker config of the Shoot is invalid")
-		}
-	}
+	framework.RegisterShootCreationFrameworkFlags()
 }
 
 var _ = Describe("Shoot Creation testing", func() {
 
-	f := framework.NewGardenerFramework(&framework.GardenerConfig{
-		CommonConfig: &framework.CommonConfig{
-			ResourceDir: "../../framework/resources",
+	f := framework.NewShootCreationFramework(&framework.ShootCreationConfig{
+		GardenerConfig: &framework.GardenerConfig{
+			CommonConfig: &framework.CommonConfig{
+				ResourceDir: "../../framework/resources",
+			},
 		},
 	})
 
-	framework.CIt("Create and Reconcile Shoot", func(ctx context.Context) {
-		validateFlags()
-
-		shoot := prepareShoot(ctx, f)
-
-		// override default worker settings with flags
-		if shootMachineType != nil && len(*shootMachineType) > 0 {
-			for i := range shoot.Spec.Provider.Workers {
-				shoot.Spec.Provider.Workers[i].Machine.Type = *shootMachineType
-			}
-		}
-
-		if shootMachineImageName != nil && len(*shootMachineImageName) > 0 {
-			for i := range shoot.Spec.Provider.Workers {
-				shoot.Spec.Provider.Workers[i].Machine.Image.Name = *shootMachineImageName
-			}
-		}
-
-		if shootMachineImageVersion != nil && len(*shootMachineImageVersion) > 0 {
-			for i := range shoot.Spec.Provider.Workers {
-				shoot.Spec.Provider.Workers[i].Machine.Image.Version = shootMachineImageVersion
-			}
-		}
-
-		if framework.StringSet(*seedName) {
-			shoot.Spec.SeedName = seedName
-		}
-
-		f.Logger.Infof("Creating shoot %s in namespace %s", shoot.GetName(), f.ProjectNamespace)
-		if err := framework.PrettyPrintObject(shoot); err != nil {
-			f.Logger.Fatalf("Cannot decode shoot %s: %s", shoot.GetName(), err)
-		}
-
-		err := f.CreateShoot(ctx, shoot)
-		if err != nil {
-			if shoot != nil {
-				shootFramework, err := f.NewShootFramework(shoot)
-				framework.ExpectNoError(err)
-				shootFramework.DumpState(ctx)
-			}
-			f.Logger.Fatalf("Cannot create shoot %s: %s", shoot.GetName(), err.Error())
-		}
-		f.Logger.Infof("Successfully created shoot %s", shoot.GetName())
-		shootFramework, err := f.NewShootFramework(shoot)
+	f.CIt("Create and Reconcile Shoot", func(ctx context.Context) {
+		_, err := f.CreateShoot(ctx)
 		framework.ExpectNoError(err)
-
-		if err := framework.DownloadKubeconfig(ctx, shootFramework.GardenClient, f.ProjectNamespace, shootFramework.ShootKubeconfigSecretName(), *shootKubeconfigPath); err != nil {
-			f.Logger.Fatalf("Cannot download shoot kubeconfig: %s", err.Error())
-		}
-
-		if err := framework.DownloadKubeconfig(ctx, shootFramework.GardenClient, shootFramework.Seed.Spec.SecretRef.Namespace, shootFramework.Seed.Spec.SecretRef.Name, *seedKubeconfigPath); err != nil {
-			f.Logger.Fatalf("Cannot download seed kubeconfig: %s", err.Error())
-		}
-
-		f.Logger.Infof("Finished creating shoot %s", shoot.GetName())
 	}, CreateAndReconcileTimeout)
 })
-
-func prepareShoot(ctx context.Context, f *framework.GardenerFramework) *gardencorev1beta1.Shoot {
-	// if running in test machinery, test will be executed from root of the project
-	if !framework.FileExists(fmt.Sprintf(".%s", *shootYamlPath)) {
-		// locally, we need find the example shoot
-		*shootYamlPath = filepath.Join(f.TemplatesDir, *shootYamlPath)
-		Expect(framework.FileExists(*shootYamlPath)).To(Equal(true), "shoot template should exist")
-	}
-
-	// parse shoot yaml into shoot object and generate random test names for shoots
-	_, shootObject, err := framework.CreateShootTestArtifacts(*shootYamlPath, testShootPrefix, &f.ProjectNamespace, shootRegion, cloudProfile, secretBinding, shootProviderType, shootK8sVersion, externalDomain, true, true)
-	Expect(err).ToNot(HaveOccurred())
-
-	if testShootName != nil && len(*testShootName) > 0 {
-		shootObject.Name = *testShootName
-	}
-
-	cloudprofile, err := f.GetCloudProfile(ctx, shootObject.Spec.CloudProfileName)
-	Expect(err).ToNot(HaveOccurred())
-
-	if networkingPods != nil && len(*networkingPods) > 0 {
-		shootObject.Spec.Networking.Pods = networkingPods
-	}
-
-	if networkingServices != nil && len(*networkingServices) > 0 {
-		shootObject.Spec.Networking.Services = networkingServices
-	}
-
-	if networkingNodes != nil && len(*networkingNodes) > 0 {
-		shootObject.Spec.Networking.Nodes = networkingNodes
-	}
-
-	if startHibernated {
-		if shootObject.Spec.Hibernation == nil {
-			shootObject.Spec.Hibernation = &gardencorev1beta1.Hibernation{}
-		}
-		shootObject.Spec.Hibernation.Enabled = &startHibernated
-	}
-
-	// set ProviderConfigs
-	err = framework.SetProviderConfigsFromFilepath(shootObject, infrastructureProviderConfig, controlPlaneProviderConfig, networkingProviderConfig, workersConfig)
-	Expect(err).To(BeNil())
-
-	if len(*workersConfig) == 0 {
-		err := framework.SetupShootWorker(shootObject, cloudprofile, workerZone)
-		Expect(err).To(BeNil())
-		Expect(len(shootObject.Spec.Provider.Workers)).Should(BeNumerically("==", 1))
-	}
-
-	return shootObject
-}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors the `CreateShoot` integration test to make it reusable in other tests.
Other test can now leverage the new `ShootCreationFramework` to easily create a Shoot just like the `CreateShoot` test does.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @schrodit 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
