### PR TITLE
Enhance generic control plane mutator webhook

### DIFF
--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -71,7 +71,7 @@ type Ensurer interface {
 	// "old" might be "nil" and must always be checked.
 	EnsureKubernetesGeneralConfiguration(ctx context.Context, etcx EnsurerContext, new, old *string) error
 	// ShouldProvisionKubeletCloudProviderConfig returns true if the cloud provider config file should be added to the kubelet configuration.
-	ShouldProvisionKubeletCloudProviderConfig() bool
+	ShouldProvisionKubeletCloudProviderConfig(ctx context.Context, etcx EnsurerContext) bool
 	// EnsureKubeletCloudProviderConfig ensures that the cloud provider config file content conforms to the provider requirements.
 	EnsureKubeletCloudProviderConfig(context.Context, EnsurerContext, *string, string) error
 	// EnsureAdditionalUnits ensures additional systemd units
@@ -285,7 +285,7 @@ func (m *mutator) mutateOperatingSystemConfig(ctx context.Context, ectx EnsurerC
 	}
 
 	// Check if cloud provider config needs to be ensured
-	if m.ensurer.ShouldProvisionKubeletCloudProviderConfig() {
+	if m.ensurer.ShouldProvisionKubeletCloudProviderConfig(ctx, ectx) {
 		if err := m.ensureKubeletCloudProviderConfig(ctx, ectx, osc); err != nil {
 			return err
 		}

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -368,7 +368,7 @@ var _ = Describe("Mutator", func() {
 					return nil
 				})
 
-			ensurer.EXPECT().ShouldProvisionKubeletCloudProviderConfig().Return(true)
+			ensurer.EXPECT().ShouldProvisionKubeletCloudProviderConfig(context.TODO(), gomock.Any()).Return(true)
 			ensurer.EXPECT().EnsureKubeletCloudProviderConfig(context.TODO(), gomock.Any(), gomock.Any(), newOSC.Namespace).DoAndReturn(
 				func(ctx context.Context, ectx genericmutator.EnsurerContext, data *string, _ string) error {
 					*data = cloudproviderconf

--- a/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
@@ -71,7 +71,7 @@ func (e *NoopEnsurer) EnsureKubernetesGeneralConfiguration(ctx context.Context, 
 }
 
 // ShouldProvisionKubeletCloudProviderConfig returns if the cloud provider config file should be added to the kubelet configuration.
-func (e *NoopEnsurer) ShouldProvisionKubeletCloudProviderConfig() bool {
+func (e *NoopEnsurer) ShouldProvisionKubeletCloudProviderConfig(context.Context, EnsurerContext) bool {
 	return false
 }
 

--- a/pkg/mock/gardener/extensions/webhook/controlplane/genericmutator/mocks.go
+++ b/pkg/mock/gardener/extensions/webhook/controlplane/genericmutator/mocks.go
@@ -196,15 +196,15 @@ func (mr *MockEnsurerMockRecorder) EnsureKubernetesGeneralConfiguration(arg0, ar
 }
 
 // ShouldProvisionKubeletCloudProviderConfig mocks base method
-func (m *MockEnsurer) ShouldProvisionKubeletCloudProviderConfig() bool {
+func (m *MockEnsurer) ShouldProvisionKubeletCloudProviderConfig(arg0 context.Context, arg1 genericmutator.EnsurerContext) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ShouldProvisionKubeletCloudProviderConfig")
+	ret := m.ctrl.Call(m, "ShouldProvisionKubeletCloudProviderConfig", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // ShouldProvisionKubeletCloudProviderConfig indicates an expected call of ShouldProvisionKubeletCloudProviderConfig
-func (mr *MockEnsurerMockRecorder) ShouldProvisionKubeletCloudProviderConfig() *gomock.Call {
+func (mr *MockEnsurerMockRecorder) ShouldProvisionKubeletCloudProviderConfig(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldProvisionKubeletCloudProviderConfig", reflect.TypeOf((*MockEnsurer)(nil).ShouldProvisionKubeletCloudProviderConfig))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldProvisionKubeletCloudProviderConfig", reflect.TypeOf((*MockEnsurer)(nil).ShouldProvisionKubeletCloudProviderConfig), arg0, arg1)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The `ShouldProvisionKubeletCloudProviderConfig` does now take the the `context.Context` and the `EnsurerContext` to allow making sophisticated decisions.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
