### PR TITLE
Remove read-only from kinaba index

### DIFF
--- a/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/curator-configmap.yaml
+++ b/charts/seed-bootstrap/charts/elastic-kibana-curator/templates/curator-es/curator-configmap.yaml
@@ -13,7 +13,7 @@ data:
       1:
         action: index_settings
         description: >-
-          Remove the selected indices from read only
+          Remove read only from indices  younger than 2 days
         options:
           index_settings:
             index:
@@ -31,6 +31,22 @@ data:
           unit: days
           unit_count: 2
           exclude: True
+      2:
+        action: index_settings
+        description: >-
+          Remove read only from kibana index
+        options:
+          index_settings:
+            index:
+              blocks:
+                read_only_allow_delete: null
+          ignore_unavailable: False
+          preserve_existing: False
+          continue_if_exception: True
+          ignore_empty_list: True
+        filters:
+        - filtertype: kibana
+          exclude: False
   config.yml: |-
     client:
       hosts:


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we remove read-only from kibana index even when it is older than 2 days.
**Which issue(s) this PR fixes**:
Fixes [#1957](https://github.com/gardener/gardener/issues/1957)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
remove read-only from kibana index
```
