### PR TITLE
[release-v1.2] Upgrade github.com/gardener/etcd-druid

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -17,7 +17,7 @@ images:
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
   repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.1.13"
+  tag: "v0.1.14"
 - name: gardener-resource-manager
   sourceRepository: github.com/gardener/gardener-resource-manager
   repository: eu.gcr.io/gardener-project/gardener/gardener-resource-manager


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade github.com/gardener/etcd-druid from v0.1.13 to v0.1.14.

Cherry-pick of gardener/gardener#2187 into release-v1.2 branch.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
``` improvement operator github.com/gardener/etcd-druid #43 @ialidzhikov
`etcd-druid` does now accept `openstack` for spec.backup.store.provider.
```
