### PR TITLE
Test/systemctl segfault

### DIFF
--- a/pkg/client/kubernetes/pods.go
+++ b/pkg/client/kubernetes/pods.go
@@ -15,14 +15,10 @@
 package kubernetes
 
 import (
-	"bytes"
-	"context"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gardener/gardener/pkg/utils"
@@ -30,67 +26,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
-	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/transport/spdy"
 )
-
-// NewPodExecutor returns a podExecutor
-func NewPodExecutor(config *rest.Config) PodExecutor {
-	return &podExecutor{
-		config: config,
-	}
-}
-
-// PodExecutor is the pod executor interface
-type PodExecutor interface {
-	Execute(ctx context.Context, namespace, name, containerName, command string) (io.Reader, error)
-}
-
-type podExecutor struct {
-	config *rest.Config
-}
-
-// Execute executes a command on a pod
-func (p *podExecutor) Execute(ctx context.Context, namespace, name, containerName, command string) (io.Reader, error) {
-	client, err := corev1client.NewForConfig(p.config)
-	if err != nil {
-		return nil, err
-	}
-
-	var stdout, stderr bytes.Buffer
-	request := client.RESTClient().
-		Post().
-		Resource("pods").
-		Name(name).
-		Namespace(namespace).
-		SubResource("exec").
-		Param("container", containerName).
-		Param("command", "/bin/sh").
-		Param("stdin", "true").
-		Param("stdout", "true").
-		Param("stderr", "true").
-		Param("tty", "false").
-		Context(ctx)
-
-	executor, err := remotecommand.NewSPDYExecutor(p.config, http.MethodPost, request.URL())
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialized the command exector: %v", err)
-	}
-
-	err = executor.Stream(remotecommand.StreamOptions{
-		Stdin:  strings.NewReader(command),
-		Stdout: &stdout,
-		Stderr: &stderr,
-		Tty:    false,
-	})
-	if err != nil {
-		return &stderr, err
-	}
-
-	return &stdout, nil
-}
 
 // GetPodLogs retrieves the pod logs of the pod of the given name with the given options.
 func GetPodLogs(podInterface corev1client.PodInterface, name string, options *corev1.PodLogOptions) ([]byte, error) {

--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	framework "github.com/gardener/gardener/test/framework"
+	"github.com/gardener/gardener/test/framework/resources/templates"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -43,9 +44,8 @@ const (
 	// RedisMaster is the name of the redis master deployed by the helm chart
 	RedisMaster = "redis-master"
 
-	guestBookTemplateName = "guestbook-app.yaml.tpl"
-	redisChart            = "stable/redis"
-	redisChartVersion     = "10.2.1"
+	redisChart        = "stable/redis"
+	redisChartVersion = "10.2.1"
 )
 
 // GuestBookTest is simple application tests.
@@ -155,7 +155,7 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 		t.framework.Namespace,
 		t.guestBookAppHost,
 	}
-	err = t.framework.RenderAndDeployTemplate(ctx, t.framework.ShootClient, guestBookTemplateName, guestBookParams)
+	err = t.framework.RenderAndDeployTemplate(ctx, t.framework.ShootClient, templates.GuestbookAppName, guestBookParams)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	ginkgo.By("Guestbook app was deployed successfully!")

--- a/test/framework/pod_executor.go
+++ b/test/framework/pod_executor.go
@@ -1,0 +1,78 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// NewPodExecutor returns a podExecutor
+func NewPodExecutor(client kubernetes.Interface) PodExecutor {
+	return &podExecutor{
+		client: client,
+	}
+}
+
+// PodExecutor is the pod executor interface
+type PodExecutor interface {
+	Execute(ctx context.Context, namespace, name, containerName, command string) (io.Reader, error)
+}
+
+type podExecutor struct {
+	client kubernetes.Interface
+}
+
+// Execute executes a command on a pod
+func (p *podExecutor) Execute(ctx context.Context, namespace, name, containerName, command string) (io.Reader, error) {
+	var stdout, stderr bytes.Buffer
+	request := p.client.Kubernetes().CoreV1().RESTClient().
+		Post().
+		Resource("pods").
+		Name(name).
+		Namespace(namespace).
+		SubResource("exec").
+		Param("container", containerName).
+		Param("command", "/bin/sh").
+		Param("stdin", "true").
+		Param("stdout", "true").
+		Param("stderr", "true").
+		Param("tty", "false").
+		Context(ctx)
+
+	executor, err := remotecommand.NewSPDYExecutor(p.client.RESTConfig(), http.MethodPost, request.URL())
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialized the command exector: %v", err)
+	}
+
+	err = executor.Stream(remotecommand.StreamOptions{
+		Stdin:  strings.NewReader(command),
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	if err != nil {
+		return &stderr, err
+	}
+
+	return &stdout, nil
+}

--- a/test/framework/resources/templates/simple-load-deployment.yaml.tpl
+++ b/test/framework/resources/templates/simple-load-deployment.yaml.tpl
@@ -1,0 +1,22 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: load
+  template:
+    metadata:
+      labels:
+        app: load
+    spec:
+      containers:
+      - image: alpine:3.11
+        name: load
+        command: ["sh", "-c"]
+        nodeName: {{ .nodeName }}
+        args:
+        - while true; do echo "testing"; done;

--- a/test/framework/resources/templates/templates.go
+++ b/test/framework/resources/templates/templates.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package templates
+
+// SimpleLoadDeploymentName is the name of the simple load deployment template
+const SimpleLoadDeploymentName = "simple-load-deployment.yaml.tpl"
+
+// NginxDaemonSetName is the name of the nginx deamonset template
+const NginxDaemonSetName = "network-nginx-deamonset.yaml.tpl"
+
+// GuestbookAppName is the name if the guestbook app deployment template
+const GuestbookAppName = "guestbook-app.yaml.tpl"
+
+// LoggerAppName is the name of the logger app deployment template
+const LoggerAppName = "logger-app.yaml.tpl"
+
+// ReserveCapacityName is the name of the reserve capacity template
+const ReserveCapacityName = "reserve-capacity.yaml.tpl"

--- a/test/framework/rootpod_executor.go
+++ b/test/framework/rootpod_executor.go
@@ -1,0 +1,129 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/mock/go/context"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RootPodExecutor enables the execution of command on the operating system of a node.
+// The executor deploys a pod with root privileged on a specified node.
+// This pod is then used to execute commands on the host operating system.
+type RootPodExecutor interface {
+	Execute(ctx context.Context, command string) ([]byte, error)
+	Clean(ctx context.Context) error
+}
+
+// rootPodExecutor is the RootPodExecutor implementation
+type rootPodExecutor struct {
+	logger   *logrus.Logger
+	client   kubernetes.Interface
+	executor PodExecutor
+
+	nodeName  *string
+	namespace string
+
+	Pod *corev1.Pod
+}
+
+// NewRootPodExecutor creates a new root pod executor to run commands on a node.
+func NewRootPodExecutor(logger *logrus.Logger, c kubernetes.Interface, nodeName *string, namespace string) RootPodExecutor {
+	executor := NewPodExecutor(c)
+	return &rootPodExecutor{
+		logger:    logger,
+		client:    c,
+		executor:  executor,
+		nodeName:  nodeName,
+		namespace: namespace,
+	}
+}
+
+// Clean delete the deployed pod
+func (e *rootPodExecutor) Clean(ctx context.Context) error {
+	if e.Pod == nil {
+		return nil
+	}
+
+	return DeleteAndWaitForResource(ctx, e.client, e.Pod, 2*time.Minute)
+}
+
+// Execute executes a command on the node the root pod is running
+func (e *rootPodExecutor) Execute(ctx context.Context, command string) ([]byte, error) {
+	isRunning, err := e.checkPodRunning(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !isRunning {
+		if err := e.deploy(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	command = fmt.Sprintf("chroot /hostroot %s", command)
+	reader, err := e.executor.Execute(ctx, e.Pod.Namespace, e.Pod.Name, e.Pod.Spec.Containers[0].Name, command)
+	if err != nil {
+		return nil, err
+	}
+	response, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+// deploy deploys a root pod on the specified node and waits until it is running
+func (e *rootPodExecutor) deploy(ctx context.Context) error {
+	rootPod, err := DeployRootPod(ctx, e.client.Client(), e.namespace, e.nodeName)
+	if err != nil {
+		return err
+	}
+	if err := WaitUntilPodIsRunning(ctx, e.logger, rootPod.Name, rootPod.Namespace, e.client); err != nil {
+		return err
+	}
+
+	e.Pod = rootPod
+	return nil
+}
+
+// checkPodRunning checks if the root pod is still running.
+func (e *rootPodExecutor) checkPodRunning(ctx context.Context) (bool, error) {
+	if e.Pod == nil {
+		return false, nil
+	}
+
+	pod := e.Pod.DeepCopy()
+	key, err := client.ObjectKeyFromObject(e.Pod)
+	if err != nil {
+		return false, err
+	}
+	if err := e.client.Client().Get(ctx, key, pod); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}

--- a/test/integration/framework/garden_operation.go
+++ b/test/integration/framework/garden_operation.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
+	"github.com/gardener/gardener/test/framework"
 
 	"github.com/onsi/ginkgo"
 	"github.com/pkg/errors"
@@ -525,7 +526,7 @@ func (o *GardenerTestOperation) PodExecByLabel(ctx context.Context, podLabels la
 		return nil, err
 	}
 
-	return kubernetes.NewPodExecutor(client.RESTConfig()).Execute(ctx, pod.Namespace, pod.Name, podContainer, command)
+	return framework.NewPodExecutor(client).Execute(ctx, pod.Namespace, pod.Name, podContainer, command)
 }
 
 // GetDashboardPodIP gets the dashboard IP

--- a/test/integration/shoots/logging/seed_log.go
+++ b/test/integration/shoots/logging/seed_log.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/test/framework"
+	"github.com/gardener/gardener/test/framework/resources/templates"
 
 	"github.com/onsi/ginkgo"
 	appsv1 "k8s.io/api/apps/v1"
@@ -29,8 +30,6 @@ import (
 
 const (
 	logsCount uint64 = 10000
-
-	loggingAppTemplateName = "logger-app.yaml.tpl"
 
 	initializationTimeout           = 15 * time.Minute
 	kibanaAvailableTimeout          = 10 * time.Second
@@ -75,7 +74,7 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 			logsCount,
 		}
 
-		err = f.RenderAndDeployTemplate(ctx, f.SeedClient, loggingAppTemplateName, loggerParams)
+		err = f.RenderAndDeployTemplate(ctx, f.SeedClient, templates.LoggerAppName, loggerParams)
 		framework.ExpectNoError(err)
 
 		defer func() {

--- a/test/integration/shoots/operatingsystem/os.go
+++ b/test/integration/shoots/operatingsystem/os.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+	Overview
+		- Tests that there is no segfault in journalctl under load
+
+	Test: deploy load to a node
+	Expected Output
+		- No segfault in the journalctl logs
+
+ **/
+
+package operatingsystem
+
+import (
+	"context"
+	"time"
+
+	"github.com/gardener/gardener/test/framework"
+	"github.com/gardener/gardener/test/framework/resources/templates"
+
+	"github.com/onsi/ginkgo"
+	g "github.com/onsi/gomega"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = ginkgo.Describe("Operating system testing", func() {
+
+	f := framework.NewShootFramework(&framework.ShootConfig{
+		CreateTestNamespace: true,
+	})
+
+	ginkgo.Context("OperatingSystem load", func() {
+
+		const deploymentName = "os-loadtest"
+
+		var rootPodExecutor framework.RootPodExecutor
+
+		f.Beta().Serial().CIt("should not segfault", func(ctx context.Context) {
+
+			// choose random node
+			nodes := &corev1.NodeList{}
+			err := f.ShootClient.Client().List(ctx, nodes)
+			framework.ExpectNoError(err)
+
+			if len(nodes.Items) == 0 {
+				ginkgo.Fail("at least one node is needed")
+			}
+
+			err = f.RenderAndDeployTemplate(ctx, f.ShootClient, templates.SimpleLoadDeploymentName, map[string]string{
+				"name":      deploymentName,
+				"namespace": f.Namespace,
+				"nodeName":  nodes.Items[0].Name,
+			})
+			framework.ExpectNoError(err)
+
+			err = f.WaitUntilDeploymentIsReady(ctx, deploymentName, f.Namespace, f.ShootClient)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("wait 10 seconds for the deployment to generate load")
+			time.Sleep(10 * time.Second)
+
+			// deploy root pod on the node with the load
+			rootPodExecutor = framework.NewRootPodExecutor(f.Logger, f.ShootClient, &nodes.Items[0].Name, f.Namespace)
+
+			response, err := rootPodExecutor.Execute(ctx, "journalctl --no-pager")
+			framework.ExpectNoError(err)
+			g.Expect(response).ToNot(g.BeNil())
+
+			ginkgo.By("Expect no segfault")
+
+			journalctlValidation := framework.TextValidation{"segfault": "expect no systemctl segfault"}
+			err = journalctlValidation.ValidateAsBlacklist(response)
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Expect systemctl to respond")
+			_, err = rootPodExecutor.Execute(ctx, "systemctl")
+			framework.ExpectNoError(err)
+		}, 30*time.Minute)
+
+		framework.CAfterEach(func(ctx context.Context) {
+			err := rootPodExecutor.Clean(ctx)
+			framework.ExpectNoError(err)
+
+			deployment := &v1.Deployment{}
+			deployment.Name = deploymentName
+			deployment.Namespace = f.Namespace
+			err = framework.DeleteAndWaitForResource(ctx, f.ShootClient, deployment, 5*time.Minute)
+			framework.ExpectNoError(err)
+		}, 5*time.Minute)
+	})
+
+})

--- a/test/integration/shoots/operations/clusterautoscaler.go
+++ b/test/integration/shoots/operations/clusterautoscaler.go
@@ -36,6 +36,7 @@ import (
 	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/test/framework"
+	"github.com/gardener/gardener/test/framework/resources/templates"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -48,7 +49,6 @@ import (
 )
 
 const (
-	reserveCapacityTemplateName        = "reserve-capacity.yaml.tpl"
 	reserveCapacityDeploymentName      = "reserve-capacity"
 	reserveCapacityDeploymentNamespace = metav1.NamespaceDefault
 
@@ -128,7 +128,7 @@ var _ = ginkgo.Describe("Shoot clusterautoscaler testing", func() {
 			},
 			WorkerPool: workerPoolName,
 		}
-		err = f.RenderAndDeployTemplate(ctx, f.ShootClient, reserveCapacityTemplateName, values)
+		err = f.RenderAndDeployTemplate(ctx, f.ShootClient, templates.ReserveCapacityName, values)
 		framework.ExpectNoError(err)
 
 		defer func() {
@@ -258,7 +258,7 @@ var _ = ginkgo.Describe("Shoot clusterautoscaler testing", func() {
 			WorkerPool:    testWorkerPoolName,
 			TolerationKey: testWorkerPoolName,
 		}
-		err = f.RenderAndDeployTemplate(ctx, f.ShootClient, reserveCapacityTemplateName, values)
+		err = f.RenderAndDeployTemplate(ctx, f.ShootClient, templates.ReserveCapacityName, values)
 		framework.ExpectNoError(err)
 
 		defer func() {

--- a/test/suites/shoot/run_suite_test.go
+++ b/test/suites/shoot/run_suite_test.go
@@ -17,10 +17,10 @@ package shoot_suite_test
 import (
 	"flag"
 	"fmt"
-	"github.com/gardener/gardener/test/framework/config"
 	"os"
 
 	"github.com/gardener/gardener/test/framework"
+	"github.com/gardener/gardener/test/framework/config"
 	"github.com/gardener/gardener/test/framework/reporter"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -31,6 +31,7 @@ import (
 	_ "github.com/gardener/gardener/test/integration/shoots/applications"
 	_ "github.com/gardener/gardener/test/integration/shoots/care"
 	_ "github.com/gardener/gardener/test/integration/shoots/logging"
+	_ "github.com/gardener/gardener/test/integration/shoots/operatingsystem"
 	_ "github.com/gardener/gardener/test/integration/shoots/operations"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Added a integration that checks if `journalctl` on a node contains any `segfaults`.
It also verifies that `systemctl` is working on the node.

**Special notes for your reviewer**:

cc @marwinski @gehoern

Is the load really needed as in your demo today it was also during kubelet startup?
So would it be enough to just check journalctl and systemctl?

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Added a test to validate if systemctl on the node's operating system runs without errors.
```
