### PR TITLE
Increase limits for metrics-server

### DIFF
--- a/charts/shoot-core/components/charts/metrics-server/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/metrics-server/templates/deployment.yaml
@@ -61,8 +61,8 @@ spec:
             cpu: 20m
             memory: 100Mi
           limits:
-            cpu: 80m
-            memory: 400Mi
+            cpu: 100m
+            memory: 1Gi
         volumeMounts:
         - name: metrics-server
           mountPath: /srv/metrics-server/tls


### PR DESCRIPTION
**What this PR does / why we need it**:
For a cluster with many pods the metrics-server will run out-of-memory. I saw that it required ~550 MB for a cluster with ~12.5k pods.
Let's increase the limits so that it can support such scenarios.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The CPU and memory limits for the metrics-server have been slightly increased to support large clusters.
```
