### PR TITLE
Reduce Prometheus terminationGracePeriodSeconds to 60s.

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -228,7 +228,7 @@ spec:
         - mountPath: /etc/prometheus/rules
           name: rules
           readOnly: true
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 60
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
**What this PR does / why we need it**:
Whenever prometheus restarts, its VPN does not get terminated properly and prometheus hangs until terminationGracePeriod is exceeded. The grace period is reduced to 1 minute to allow prometheus to come back up faster until https://github.com/gardener/vpn/issues/55 is fixed.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `terminationGracePeriodSeconds` setting for the Prometheus instance in shoot control planes has been lowered from `300` to `60`.
```
