### PR TITLE
respect http proxy settings in test framework utils

### DIFF
--- a/test/framework/http_utils.go
+++ b/test/framework/http_utils.go
@@ -18,14 +18,20 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/pkg/errors"
 	"net/http"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // HTTPGet performs an HTTP GET request with context
 func HTTPGet(ctx context.Context, url string) (*http.Response, error) {
-	httpClient := http.Client{}
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}
+	httpClient := http.Client{
+		Transport: transport,
+	}
 	httpRequest, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -53,6 +59,7 @@ func TestHTTPEndpointWithToken(ctx context.Context, url, token string) error {
 func testHTTPEndpointWith(ctx context.Context, url string, mutator func(*http.Request)) error {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	httpClient := http.Client{


### PR DESCRIPTION
**What this PR does / why we need it**:
If in the context of integration tests the shoot cluster is only reachable via an HTTP proxy, the TestGardenerSuite started with the
test machinery fails even if HTTP_PROXY/HTTPS_PROXY environment variables are set.
```
Get https://api.tm87h-wns.it.shoot.dev.k8s-hana.ondemand.com/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```
I assume, the problem is the missing proxy settings in the HTTP client, which is fixed in the standard way with this PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
