### PR TITLE
Skip the containerd test for non-ubuntu worker pool

### DIFF
--- a/example/05-project-dev.yaml
+++ b/example/05-project-dev.yaml
@@ -27,6 +27,6 @@ spec:
 # purpose: "Experimenting with Gardener"
   # The `spec.namespace` field is optional and will be initialized if unset - the resulting
   # namespace will be generated and look like "garden-dev-<random-chars>", e.g. "garden-dev-5z43z".
-  # If the namespace is set then the namespace must be labelled with `garden.sapcloud.io/role: project`
-  # and `project.garden.sapcloud.io/name: <project-name>` (<project-name>=dev in this case).
+  # If the namespace is set then the namespace must be labelled with `gardener.cloud/role: project`
+  # and `project.gardener.cloud/name: <project-name>` (<project-name>=dev in this case).
   namespace: garden-dev

--- a/test/framework/test_description.go
+++ b/test/framework/test_description.go
@@ -1,11 +1,26 @@
+// Copyright 2020 Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package framework
 
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/onsi/ginkgo"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"time"
 )
 
 // TestDescription labels tests according to the provided labels in the expected order.

--- a/test/framework/utils.go
+++ b/test/framework/utils.go
@@ -16,17 +16,18 @@ package framework
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"regexp"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/hashicorp/go-multierror"
 	"github.com/onsi/ginkgo"
 	"github.com/pkg/errors"
-	"io/ioutil"
 	apimachineryRuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"os"
-	"reflect"
-	"regexp"
 	"sigs.k8s.io/yaml"
 )
 

--- a/test/framework/utils_test.go
+++ b/test/framework/utils_test.go
@@ -15,12 +15,13 @@
 package framework_test
 
 import (
+	"io/ioutil"
+	"os"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/test/framework"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"io/ioutil"
-	"os"
 )
 
 var _ = Describe("Utils tests", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Skip the containerd test for non-ubuntu worker pool.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The `containerd` test is now skipped for worker pools that are not using the `ubuntu` operating system.
```
