### PR TITLE
Edited rbac roles to include get,list,watch etcd resources by vpa actors

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/templates/vpa-rbac.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/vpa-rbac.yaml
@@ -200,6 +200,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - "druid.gardener.cloud"
+  resources:
+  - etcds
+  - etcds/scale
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding


### PR DESCRIPTION
**What this PR does / why we need it**:
VPA for etcd statefulset errors out because of RBAC role not including etcd resources

**Which issue(s) this PR fixes**:
Fixes #2203

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Edited VPA specific RBAC roles to include get,list and watch for etcd resources by VPA actors
```
