### PR TITLE
Ignore endpoints not reconciled by kcm during hibernation

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -36,7 +36,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/pkg/utils/version"
-	"k8s.io/apimachinery/pkg/types"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
@@ -50,6 +49,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	audit_internal "k8s.io/apiserver/pkg/apis/audit"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the "check if endpoints referencing Pod IPs exist" check, which is run during hibernation. Now, gardener checks if the Endpoints object is reconciled by `kube-controller-manager`, otherwise it ignores and does not block the hibernation. This is done to support hibernating shoot clusters with custom operators, which reconcile Endpoints objects themselves (e.g. knative).

**Which issue(s) this PR fixes**:
Part of #1751

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Gardener does not block hibernation of a Shoot Cluster anymore, in case it contains Endpoints objects that are reconciled by a custom operator (e.g. knative).
```
