### PR TITLE
Revert "Add alert if backup sidecar metrics are not scarraped"

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -25,17 +25,6 @@ groups:
     annotations:
       description: Etcd3 cluster events is unavailable or cannot be scraped. Cluster events cannot be collected.
       summary: Etcd3 events cluster down.
-  - alert: KubeEtcdBackupMetricsDown
-    expr: (absent(etcdbr_snapshot_required{job="kube-etcd3-backup-restore",kind="Incr",role="main"}) == bool 1) + (changes(etcd_debugging_mvcc_current_revision{job="kube-etcd3",role="main"}) >= bool 1) == 2
-    for: 15m
-    labels:
-      service: etcd
-      severity: warning
-      type: seed
-      visibility: operator
-    annotations:
-      description: Backup sidecar for Etcd3 cluster main is unavailable or cannot be scraped.
-      summary: Etcd3 main backup sidecar cannot be scrapped.
   # etcd leader alerts
   - alert: KubeEtcd3MainNoLeader
     expr: sum(etcd_server_has_leader{job="kube-etcd3",role="main"}) < count(etcd_server_has_leader{job="kube-etcd3",role="main"})
@@ -138,3 +127,4 @@ groups:
     annotations:
       description: Etcd data restoration was triggered, but has failed.
       summary: Etcd data restoration failure.
+

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -84,7 +84,6 @@ allowedMetrics:
   - process_max_fds
   - process_open_fds
   kubeETCD3:
-  - etcd_debugging_mvcc_current_revision
   - etcd_disk_backend_commit_duration_seconds_bucket
   - etcd_disk_wal_fsync_duration_seconds_bucket
   - etcd_mvcc_db_total_size_in_bytes


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts commit b69d2d5f18f5bbfc879e3429d1723894fade626b.

**Which issue(s) this PR fixes**:
Fixes gardener/gardener#2208

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
