### PR TITLE
Make the pod affinity of `fluentd` preferred.

### DIFF
--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-statefulset.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluentd-es-statefulset.yaml
@@ -29,18 +29,20 @@ spec:
       {{- if gt (int .Values.fluentd.replicaCount ) 1 }}
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - fluentd-es
-              - key: role
-                operator: In
-                values:
-                - logging
-            topologyKey: "kubernetes.io/hostname"
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - fluentd-es
+                  - key: role
+                    operator: In
+                    values:
+                    - logging
+              topologyKey: "kubernetes.io/hostname"
       {{- end }}
       containers:
       - name: fluentd-es


### PR DESCRIPTION
**What this PR does / why we need it**:
Make the pod affinity of `fluentd` preferred.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@vlvasilev @vpnachev @ialidzhikov 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `podAntiAffinity` of the `fluentd` statefulset deployed in the seed clusters is now a soft requirement.
```
