### PR TITLE
Fix kubelet monitor script

### DIFF
--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet-monitor.service
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet-monitor.service
@@ -11,5 +11,10 @@
     [Service]
     Restart=always
     EnvironmentFile=/etc/environment
+    {{- if semverCompare "< 1.17" .Values.kubernetes.version }}
+    ExecStartPre=/usr/bin/docker run --rm -v /opt/bin:/opt/bin:rw {{ required "images.hyperkube is required" .Values.images.hyperkube }} /bin/sh -c "cp /usr/local/bin/kubectl /opt/bin"
+    {{- else }}
+    ExecStartPre=/usr/bin/docker run --rm -v /opt/bin:/opt/bin:rw --entrypoint /bin/sh {{ required "images.hyperkube is required" .Values.images.hyperkube }} -c "cp /usr/local/bin/kubectl /opt/bin"
+    {{- end }}
     ExecStart=/opt/bin/health-monitor kubelet
 {{- end -}}

--- a/charts/shoot-cloud-config/templates/scripts/_cloud-config-script.sh
+++ b/charts/shoot-cloud-config/templates/scripts/_cloud-config-script.sh
@@ -53,12 +53,6 @@ format-data-device
 docker-preload "{{ $name }}" "{{ $image }}"
 {{ end }}
 
-{{- if semverCompare "< 1.17" .kubernetesVersion }}
-docker run --rm -v /opt/bin:/opt/bin:rw {{ required "images.hyperkube is required" .images.hyperkube }} /bin/sh -c "cp /usr/local/bin/kubectl /opt/bin"
-{{- else }}
-docker run --rm -v /opt/bin:/opt/bin:rw --entrypoint /bin/sh {{ required "images.hyperkube is required" .images.hyperkube }} -c "cp /usr/local/bin/kubectl /opt/bin"
-{{- end }}
-
 cat << 'EOF' | base64 -d > "$PATH_CLOUDCONFIG"
 {{ .worker.cloudConfig | b64enc }}
 EOF


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the kubelet-monitor health script. Earlier it couldn't start because of

```
Apr 20 16:20:36 shoot--foo--bar-cpu-worker-z1-c65448758-b6hcb health-monitor[9137]: /opt/bin/health-monitor: line 36: /opt/bin/kubectl: Text file busy
Apr 20 16:20:36 shoot--foo--bar-cpu-worker-z1-c65448758-b6hcb health-monitor[9137]: Node object for this hostname not found in the system, waiting.
Apr 20 16:28:18 shoot--foo--bar-cpu-worker-z1-c65448758-b6hcb health-monitor[9137]: /opt/bin/health-monitor: line 36: /opt/bin/kubectl: Text file busy
Apr 20 16:28:18 shoot--foo--bar-cpu-worker-z1-c65448758-b6hcb health-monitor[9137]: Node object for this hostname not found in the system, waiting.
Apr 20 16:54:10 shoot--foo--bar-cpu-worker-z1-c65448758-b6hcb health-monitor[9137]: /opt/bin/health-monitor: line 36: /opt/bin/kubectl: Text file busy
```

**Special notes for your reviewer**:
There was a similar PR for the `kubelet` binary, https://github.com/gardener/gardener/pull/1850, but we missed to do the same for `kubectl`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The kubelet-monitor script running on every worker node is now fixed and properly monitors the kubelet again.
```
