### PR TITLE
Gardenlet detects outdated HealthCheck conditions

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
@@ -83,14 +83,14 @@ data:
         {{- if .Values.global.gardenlet.config.controllers.shoot.reconcileInMaintenanceOnly }}
         reconcileInMaintenanceOnly: {{ .Values.global.gardenlet.config.controllers.shoot.reconcileInMaintenanceOnly }}
         {{- end }}
-        {{- if .Values.global.gardenlet.config.controllers.shoot.retrySyncPeriod }}
-        retrySyncPeriod: {{ .Values.global.gardenlet.config.controllers.shoot.retrySyncPeriod }}
-        {{- end }}
         syncPeriod: {{ required ".Values.global.gardenlet.config.controllers.shoot.syncPeriod is required" .Values.global.gardenlet.config.controllers.shoot.syncPeriod }}
         retryDuration: {{ required ".Values.global.gardenlet.config.controllers.shoot.retryDuration is required" .Values.global.gardenlet.config.controllers.shoot.retryDuration }}
       shootCare:
         concurrentSyncs: {{ required ".Values.global.gardenlet.config.controllers.shootCare.concurrentSyncs is required" .Values.global.gardenlet.config.controllers.shootCare.concurrentSyncs }}
         syncPeriod: {{ required ".Values.global.gardenlet.config.controllers.shootCare.syncPeriod is required" .Values.global.gardenlet.config.controllers.shootCare.syncPeriod }}
+        {{- if .Values.global.gardenlet.config.controllers.shootCare.staleExtensionHealthCheckThreshold }}
+        staleExtensionHealthCheckThreshold: {{ .Values.global.gardenlet.config.controllers.shootCare.staleExtensionHealthCheckThreshold }}
+        {{- end }}
         conditionThresholds:
         {{- if .Values.global.gardenlet.config.controllers.shootCare.conditionThresholds }}
 {{ toYaml .Values.global.gardenlet.config.controllers.shootCare.conditionThresholds | indent 8 }}

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -82,6 +82,7 @@ global:
         shootCare:
           concurrentSyncs: 5
           syncPeriod: 30s
+          staleExtensionHealthCheckThreshold: 5m
           conditionThresholds:
           - type: APIServerAvailable
             duration: 1m

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -40,6 +40,7 @@ controllers:
   shootCare:
     concurrentSyncs: 5
     syncPeriod: 30s
+    staleExtensionHealthCheckThreshold: 5m
     conditionThresholds:
     - type: APIServerAvailable
       duration: 1m

--- a/extensions/pkg/controller/healthcheck/healtcheck_actuator.go
+++ b/extensions/pkg/controller/healthcheck/healtcheck_actuator.go
@@ -96,7 +96,7 @@ type checkResultForConditionType struct {
 func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, request types.NamespacedName) (*[]Result, error) {
 	_, shootClient, err := util.NewClientForShoot(ctx, a.seedClient, request.Namespace, client.Options{})
 	if err != nil {
-		msg := fmt.Errorf("failed to create shoot client in namespace '%s': %s", request.Namespace, err)
+		msg := fmt.Errorf("failed to create shoot client in namespace '%s': %v", request.Namespace, err)
 		a.logger.Error(err, msg.Error())
 		return nil, msg
 	}

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -181,9 +181,6 @@ type ShootControllerConfiguration struct {
 	// RetryDuration is the maximum duration how often a reconciliation will be retried
 	// in case of errors.
 	RetryDuration *metav1.Duration
-	// RetrySyncPeriod is the duration how fast Shoots with an errornous operation are
-	// re-added to the queue so that the operation can be retried. Defaults to 15s.
-	RetrySyncPeriod *metav1.Duration
 	// SyncPeriod is the duration how often the existing resources are reconciled.
 	SyncPeriod *metav1.Duration
 }
@@ -198,6 +195,10 @@ type ShootCareControllerConfiguration struct {
 	// often the health check of Shoot clusters is performed (only if no operation is
 	// already running on them).
 	SyncPeriod *metav1.Duration
+	// StaleExtensionHealthCheckThreshold configures the threshold when Gardener considers a Health check report of an
+	// Extension CRD as outdated.
+	// The StaleExtensionHealthCheckThreshold should have some leeway in case a Gardener extension is temporarily unavailable.
+	StaleExtensionHealthCheckThreshold *metav1.Duration
 	// ConditionThresholds defines the condition threshold per condition type.
 	ConditionThresholds []ConditionThreshold
 }

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -261,11 +261,6 @@ func SetDefaults_ShootControllerConfiguration(obj *ShootControllerConfiguration)
 		v := metav1.Duration{Duration: 24 * time.Hour}
 		obj.RetryDuration = &v
 	}
-
-	if obj.RetrySyncPeriod == nil {
-		v := metav1.Duration{Duration: 15 * time.Second}
-		obj.RetrySyncPeriod = &v
-	}
 }
 
 // SetDefaults_ShootCareControllerConfiguration sets defaults for the shoot care controller.
@@ -278,6 +273,11 @@ func SetDefaults_ShootCareControllerConfiguration(obj *ShootCareControllerConfig
 	if obj.SyncPeriod == nil {
 		v := metav1.Duration{Duration: time.Minute}
 		obj.SyncPeriod = &v
+	}
+
+	if obj.StaleExtensionHealthCheckThreshold == nil {
+		v := metav1.Duration{Duration: 5 * time.Minute}
+		obj.StaleExtensionHealthCheckThreshold = &v
 	}
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -228,10 +228,6 @@ type ShootControllerConfiguration struct {
 	// in case of errors.
 	// +optional
 	RetryDuration *metav1.Duration `json:"retryDuration,omitempty"`
-	// RetrySyncPeriod is the duration how fast Shoots with an errornous operation are
-	// re-added to the queue so that the operation can be retried. Defaults to 15s.
-	// +optional
-	RetrySyncPeriod *metav1.Duration `json:"retrySyncPeriod,omitempty"`
 	// SyncPeriod is the duration how often the existing resources are reconciled.
 	// +optional
 	SyncPeriod *metav1.Duration `json:"syncPeriod,omitempty"`
@@ -249,6 +245,12 @@ type ShootCareControllerConfiguration struct {
 	// already running on them).
 	// +optional
 	SyncPeriod *metav1.Duration `json:"syncPeriod,omitempty"`
+	// StaleExtensionHealthCheckThreshold configures the threshold when Gardener considers a Health check report of an
+	// Extension CRD as outdated.
+	// The StaleExtensionHealthCheckThreshold should have some leeway in case a Gardener extension is temporarily unavailable.
+	// Defaults to 5 minutes.
+	// +optional
+	StaleExtensionHealthCheckThreshold *metav1.Duration `json:"staleExtensionHealthCheckThreshold,omitempty"`
 	// ConditionThresholds defines the condition threshold per condition type.
 	// +optional
 	ConditionThresholds []ConditionThreshold `json:"conditionThresholds,omitempty"`

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -647,6 +647,7 @@ func Convert_config_SeedControllerConfiguration_To_v1alpha1_SeedControllerConfig
 func autoConvert_v1alpha1_ShootCareControllerConfiguration_To_config_ShootCareControllerConfiguration(in *ShootCareControllerConfiguration, out *config.ShootCareControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = (*int)(unsafe.Pointer(in.ConcurrentSyncs))
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
+	out.StaleExtensionHealthCheckThreshold = (*v1.Duration)(unsafe.Pointer(in.StaleExtensionHealthCheckThreshold))
 	if in.ConditionThresholds != nil {
 		in, out := &in.ConditionThresholds, &out.ConditionThresholds
 		*out = make([]config.ConditionThreshold, len(*in))
@@ -669,6 +670,7 @@ func Convert_v1alpha1_ShootCareControllerConfiguration_To_config_ShootCareContro
 func autoConvert_config_ShootCareControllerConfiguration_To_v1alpha1_ShootCareControllerConfiguration(in *config.ShootCareControllerConfiguration, out *ShootCareControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = (*int)(unsafe.Pointer(in.ConcurrentSyncs))
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
+	out.StaleExtensionHealthCheckThreshold = (*v1.Duration)(unsafe.Pointer(in.StaleExtensionHealthCheckThreshold))
 	if in.ConditionThresholds != nil {
 		in, out := &in.ConditionThresholds, &out.ConditionThresholds
 		*out = make([]ConditionThreshold, len(*in))
@@ -717,7 +719,6 @@ func autoConvert_v1alpha1_ShootControllerConfiguration_To_config_ShootController
 	out.ReconcileInMaintenanceOnly = (*bool)(unsafe.Pointer(in.ReconcileInMaintenanceOnly))
 	out.RespectSyncPeriodOverwrite = (*bool)(unsafe.Pointer(in.RespectSyncPeriodOverwrite))
 	out.RetryDuration = (*v1.Duration)(unsafe.Pointer(in.RetryDuration))
-	out.RetrySyncPeriod = (*v1.Duration)(unsafe.Pointer(in.RetrySyncPeriod))
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
 	return nil
 }
@@ -732,7 +733,6 @@ func autoConvert_config_ShootControllerConfiguration_To_v1alpha1_ShootController
 	out.ReconcileInMaintenanceOnly = (*bool)(unsafe.Pointer(in.ReconcileInMaintenanceOnly))
 	out.RespectSyncPeriodOverwrite = (*bool)(unsafe.Pointer(in.RespectSyncPeriodOverwrite))
 	out.RetryDuration = (*v1.Duration)(unsafe.Pointer(in.RetryDuration))
-	out.RetrySyncPeriod = (*v1.Duration)(unsafe.Pointer(in.RetrySyncPeriod))
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
 	return nil
 }

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -449,6 +449,11 @@ func (in *ShootCareControllerConfiguration) DeepCopyInto(out *ShootCareControlle
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.StaleExtensionHealthCheckThreshold != nil {
+		in, out := &in.StaleExtensionHealthCheckThreshold, &out.StaleExtensionHealthCheckThreshold
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.ConditionThresholds != nil {
 		in, out := &in.ConditionThresholds, &out.ConditionThresholds
 		*out = make([]ConditionThreshold, len(*in))
@@ -504,11 +509,6 @@ func (in *ShootControllerConfiguration) DeepCopyInto(out *ShootControllerConfigu
 	}
 	if in.RetryDuration != nil {
 		in, out := &in.RetryDuration, &out.RetryDuration
-		*out = new(v1.Duration)
-		**out = **in
-	}
-	if in.RetrySyncPeriod != nil {
-		in, out := &in.RetrySyncPeriod, &out.RetrySyncPeriod
 		*out = new(v1.Duration)
 		**out = **in
 	}

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -453,6 +453,11 @@ func (in *ShootCareControllerConfiguration) DeepCopyInto(out *ShootCareControlle
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.StaleExtensionHealthCheckThreshold != nil {
+		in, out := &in.StaleExtensionHealthCheckThreshold, &out.StaleExtensionHealthCheckThreshold
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.ConditionThresholds != nil {
 		in, out := &in.ConditionThresholds, &out.ConditionThresholds
 		*out = make([]ConditionThreshold, len(*in))
@@ -510,11 +515,6 @@ func (in *ShootControllerConfiguration) DeepCopyInto(out *ShootControllerConfigu
 	}
 	if in.RetryDuration != nil {
 		in, out := &in.RetryDuration, &out.RetryDuration
-		*out = new(v1.Duration)
-		**out = **in
-	}
-	if in.RetrySyncPeriod != nil {
-		in, out := &in.RetrySyncPeriod, &out.RetrySyncPeriod
 		*out = new(v1.Duration)
 		**out = **in
 	}

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -190,6 +190,7 @@ func (c *defaultCareControl) Care(shootObj *gardencorev1beta1.Shoot, key string)
 			conditionAPIServerAvailable, conditionControlPlaneHealthy, conditionEveryNodeReady, conditionSystemComponentsHealthy = botanist.HealthChecks(
 				initializeShootClients,
 				c.conditionThresholdsToProgressingMapping(),
+				c.config.Controllers.ShootCare.StaleExtensionHealthCheckThreshold,
 				conditionAPIServerAvailable,
 				conditionControlPlaneHealthy,
 				conditionEveryNodeReady,

--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -76,7 +76,8 @@ var Now = time.Now
 
 // HealthChecker contains the condition thresholds.
 type HealthChecker struct {
-	conditionThresholds map[gardencorev1beta1.ConditionType]time.Duration
+	conditionThresholds                map[gardencorev1beta1.ConditionType]time.Duration
+	staleExtensionHealthCheckThreshold metav1.Duration
 }
 
 func (b *HealthChecker) checkRequiredDeployments(condition gardencorev1beta1.Condition, requiredNames sets.String, objects []*appsv1.Deployment) *gardencorev1beta1.Condition {
@@ -350,7 +351,7 @@ func (b *HealthChecker) FailedCondition(condition gardencorev1beta1.Condition, r
 			return gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionFalse, reason, message, codes...)
 		}
 
-		delta := Now().Sub(condition.LastTransitionTime.Time)
+		delta := Now().UTC().Sub(condition.LastTransitionTime.Time.UTC())
 		if delta > threshold {
 			return gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionFalse, reason, message, codes...)
 		}
@@ -616,10 +617,14 @@ func (b *HealthChecker) CheckLoggingControlPlane(
 }
 
 // CheckExtensionCondition checks whether the conditions provided by extensions are healthy.
-func (b *HealthChecker) CheckExtensionCondition(condition gardencorev1beta1.Condition, extensionsCondition []extensionCondition) *gardencorev1beta1.Condition {
-	for _, cond := range extensionsCondition {
-		if cond.condition.Status == gardencorev1beta1.ConditionFalse || cond.condition.Status == gardencorev1beta1.ConditionUnknown {
-			c := b.FailedCondition(condition, fmt.Sprintf("%sUnhealthyReport", cond.extensionType), fmt.Sprintf("%q CRD (%s/%s) reports failing health check: %s", cond.extensionType, cond.extensionNamespace, cond.extensionName, cond.condition.Message), cond.condition.Codes...)
+func (b *HealthChecker) CheckExtensionCondition(condition gardencorev1beta1.Condition, extensionsConditions []ExtensionCondition) *gardencorev1beta1.Condition {
+	for _, cond := range extensionsConditions {
+		if Now().UTC().Sub(cond.Condition.LastUpdateTime.UTC()) > b.staleExtensionHealthCheckThreshold.Duration {
+			c := gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionUnknown, fmt.Sprintf("%sOutdatedHealthCheckReport", cond.ExtensionType), fmt.Sprintf("%q CRD (%s/%s) reports an outdated health status (last updated: %s ago at %s).", cond.ExtensionType, cond.ExtensionNamespace, cond.ExtensionName, time.Now().UTC().Sub(cond.Condition.LastUpdateTime.UTC()).Round(time.Minute).String(), cond.Condition.LastUpdateTime.UTC().Round(time.Minute).String()), cond.Condition.Codes...)
+			return &c
+		}
+		if cond.Condition.Status == gardencorev1beta1.ConditionFalse || cond.Condition.Status == gardencorev1beta1.ConditionUnknown {
+			c := b.FailedCondition(condition, fmt.Sprintf("%sUnhealthyReport", cond.ExtensionType), fmt.Sprintf("%q CRD (%s/%s) reports failing health check: %s", cond.ExtensionType, cond.ExtensionNamespace, cond.ExtensionName, cond.Condition.Message), cond.Condition.Codes...)
 			return &c
 		}
 	}
@@ -634,7 +639,7 @@ func (b *Botanist) checkControlPlane(
 	seedStatefulSetLister kutil.StatefulSetLister,
 	seedEtcdLister kutil.EtcdLister,
 	seedWorkerLister kutil.WorkerLister,
-	extensionConditions []extensionCondition,
+	extensionConditions []ExtensionCondition,
 ) (*gardencorev1beta1.Condition, error) {
 
 	if exitCondition, err := checker.CheckControlPlane(b.Shoot.Info.Status.Gardener.Version, b.Shoot.Info, b.Shoot.SeedNamespace, condition, seedDeploymentLister, seedStatefulSetLister, seedEtcdLister, seedWorkerLister); err != nil || exitCondition != nil {
@@ -663,7 +668,7 @@ func (b *Botanist) checkSystemComponents(
 	condition gardencorev1beta1.Condition,
 	shootDeploymentLister kutil.DeploymentLister,
 	shootDaemonSetLister kutil.DaemonSetLister,
-	extensionConditions []extensionCondition,
+	extensionConditions []ExtensionCondition,
 ) (*gardencorev1beta1.Condition, error) {
 
 	if exitCondition, err := checker.CheckSystemComponents(metav1.NamespaceSystem, condition, shootDeploymentLister, shootDaemonSetLister); err != nil || exitCondition != nil {
@@ -697,7 +702,7 @@ func (b *Botanist) checkClusterNodes(
 	checker *HealthChecker,
 	condition gardencorev1beta1.Condition,
 	shootNodeLister kutil.NodeLister,
-	extensionConditions []extensionCondition,
+	extensionConditions []ExtensionCondition,
 ) (*gardencorev1beta1.Condition, error) {
 	if exitCondition, err := checker.CheckClusterNodes(b.Shoot.Info.Spec.Provider.Workers, condition, shootNodeLister); err != nil || exitCondition != nil {
 		return exitCondition, err
@@ -890,13 +895,14 @@ var (
 )
 
 // NewHealthChecker creates a new health checker.
-func NewHealthChecker(conditionThresholds map[gardencorev1beta1.ConditionType]time.Duration) *HealthChecker {
+func NewHealthChecker(conditionThresholds map[gardencorev1beta1.ConditionType]time.Duration, healthCheckOutdatedThreshold metav1.Duration) *HealthChecker {
 	return &HealthChecker{
-		conditionThresholds: conditionThresholds,
+		conditionThresholds:                conditionThresholds,
+		staleExtensionHealthCheckThreshold: healthCheckOutdatedThreshold,
 	}
 }
 
-func (b *Botanist) healthChecks(initializeShootClients func() error, thresholdMappings map[gardencorev1beta1.ConditionType]time.Duration, apiserverAvailability, controlPlane, nodes, systemComponents gardencorev1beta1.Condition) (gardencorev1beta1.Condition, gardencorev1beta1.Condition, gardencorev1beta1.Condition, gardencorev1beta1.Condition) {
+func (b *Botanist) healthChecks(initializeShootClients func() error, thresholdMappings map[gardencorev1beta1.ConditionType]time.Duration, healthCheckOutdatedThreshold *metav1.Duration, apiserverAvailability, controlPlane, nodes, systemComponents gardencorev1beta1.Condition) (gardencorev1beta1.Condition, gardencorev1beta1.Condition, gardencorev1beta1.Condition, gardencorev1beta1.Condition) {
 	if b.Shoot.HibernationEnabled || b.Shoot.Info.Status.IsHibernated {
 		return shootHibernatedCondition(apiserverAvailability), shootHibernatedCondition(controlPlane), shootHibernatedCondition(nodes), shootHibernatedCondition(systemComponents)
 	}
@@ -907,7 +913,7 @@ func (b *Botanist) healthChecks(initializeShootClients func() error, thresholdMa
 		seedEtcdLister        = makeEtcdLister(b.K8sSeedClient.Client(), b.Shoot.SeedNamespace)
 		seedWorkerLister      = makeWorkerLister(b.K8sSeedClient.Client(), b.Shoot.SeedNamespace)
 
-		checker = NewHealthChecker(thresholdMappings)
+		checker = NewHealthChecker(thresholdMappings, *healthCheckOutdatedThreshold)
 	)
 
 	extensionConditionsControlPlaneHealthy, extensionConditionsEveryNodeReady, extensionConditionsSystemComponentsHealthy, err := b.getAllExtensionConditions(context.TODO())
@@ -984,8 +990,8 @@ func (b *Botanist) pardonCondition(condition gardencorev1beta1.Condition) garden
 }
 
 // HealthChecks conducts the health checks on all the given conditions.
-func (b *Botanist) HealthChecks(initializeShootClients func() error, thresholdMappings map[gardencorev1beta1.ConditionType]time.Duration, apiserverAvailability, controlPlane, nodes, systemComponents gardencorev1beta1.Condition) (gardencorev1beta1.Condition, gardencorev1beta1.Condition, gardencorev1beta1.Condition, gardencorev1beta1.Condition) {
-	apiServerAvailable, controlPlaneHealthy, everyNodeReady, systemComponentsHealthy := b.healthChecks(initializeShootClients, thresholdMappings, apiserverAvailability, controlPlane, nodes, systemComponents)
+func (b *Botanist) HealthChecks(initializeShootClients func() error, thresholdMappings map[gardencorev1beta1.ConditionType]time.Duration, healthCheckOutdatedThreshold *metav1.Duration, apiserverAvailability, controlPlane, nodes, systemComponents gardencorev1beta1.Condition) (gardencorev1beta1.Condition, gardencorev1beta1.Condition, gardencorev1beta1.Condition, gardencorev1beta1.Condition) {
+	apiServerAvailable, controlPlaneHealthy, everyNodeReady, systemComponentsHealthy := b.healthChecks(initializeShootClients, thresholdMappings, healthCheckOutdatedThreshold, apiserverAvailability, controlPlane, nodes, systemComponents)
 	return b.pardonCondition(apiServerAvailable), b.pardonCondition(controlPlaneHealthy), b.pardonCondition(everyNodeReady), b.pardonCondition(systemComponentsHealthy)
 }
 
@@ -1002,18 +1008,18 @@ func (b *Botanist) MonitoringHealthChecks(checker *HealthChecker, inactiveAlerts
 	return b.checkAlerts(checker, inactiveAlerts)
 }
 
-type extensionCondition struct {
-	condition          gardencorev1beta1.Condition
-	extensionType      string
-	extensionName      string
-	extensionNamespace string
+type ExtensionCondition struct {
+	Condition          gardencorev1beta1.Condition
+	ExtensionType      string
+	ExtensionName      string
+	ExtensionNamespace string
 }
 
-func (b *Botanist) getAllExtensionConditions(ctx context.Context) ([]extensionCondition, []extensionCondition, []extensionCondition, error) {
+func (b *Botanist) getAllExtensionConditions(ctx context.Context) ([]ExtensionCondition, []ExtensionCondition, []ExtensionCondition, error) {
 	var (
-		conditionsControlPlaneHealthy     []extensionCondition
-		conditionsEveryNodeReady          []extensionCondition
-		conditionsSystemComponentsHealthy []extensionCondition
+		conditionsControlPlaneHealthy     []ExtensionCondition
+		conditionsEveryNodeReady          []ExtensionCondition
+		conditionsSystemComponentsHealthy []ExtensionCondition
 	)
 
 	for _, listObj := range []runtime.Object{
@@ -1043,11 +1049,11 @@ func (b *Botanist) getAllExtensionConditions(ctx context.Context) ([]extensionCo
 			for _, condition := range acc.GetExtensionStatus().GetConditions() {
 				switch condition.Type {
 				case gardencorev1beta1.ShootControlPlaneHealthy:
-					conditionsControlPlaneHealthy = append(conditionsControlPlaneHealthy, extensionCondition{condition, kind, name, namespace})
+					conditionsControlPlaneHealthy = append(conditionsControlPlaneHealthy, ExtensionCondition{condition, kind, name, namespace})
 				case gardencorev1beta1.ShootEveryNodeReady:
-					conditionsEveryNodeReady = append(conditionsEveryNodeReady, extensionCondition{condition, kind, name, namespace})
+					conditionsEveryNodeReady = append(conditionsEveryNodeReady, ExtensionCondition{condition, kind, name, namespace})
 				case gardencorev1beta1.ShootSystemComponentsHealthy:
-					conditionsSystemComponentsHealthy = append(conditionsSystemComponentsHealthy, extensionCondition{condition, kind, name, namespace})
+					conditionsSystemComponentsHealthy = append(conditionsSystemComponentsHealthy, ExtensionCondition{condition, kind, name, namespace})
 				}
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The Gardenlet should detect outdated HealthCheck conditions in the Extension CRDs in the seed.

Introduces a configurable (in the Gardenlet config)  threshold that defaults to 5 minutes.

**Which issue(s) this PR fixes**:
Fixes #2197

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The gardenlet detects outdated health check reports on extension CRDs with a default threshold of 5 minutes in case Gardener extensions stop performing health checks. The threshold can be configured in the Gardenlet configuration.
```
```improvement operator
Remove unused RetrySyncPeriod field (controllers.shoot.retrySyncPeriod) from the Gardenlet configuration.
```
