### PR TITLE
Improve Cluster synchronization to seed

### DIFF
--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -297,7 +297,11 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 	// Initialize conditions based on the current status.
 	conditionSeedBootstrapped := gardencorev1beta1helper.GetOrInitCondition(seed.Status.Conditions, gardencorev1beta1.SeedBootstrapped)
 
-	seedObj, err := seedpkg.New(c.k8sGardenClient, c.k8sGardenCoreInformers.Core().V1beta1(), seed)
+	seedObj, err := seedpkg.
+		NewBuilder().
+		WithSeedObject(seed).
+		WithSeedSecretFromClient(ctx, c.k8sGardenClient.Client()).
+		Build()
 	if err != nil {
 		message := fmt.Sprintf("Failed to create a Seed object (%s).", err.Error())
 		conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionUnknown, gardencorev1beta1.ConditionCheckError, message)

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -134,7 +134,17 @@ func (c *defaultCareControl) Care(shootObj *gardencorev1beta1.Shoot, key string)
 
 	shootLogger.Debugf("[SHOOT CARE] %s", key)
 
-	operation, err := operation.New(shoot, c.config, shootLogger, c.k8sGardenClient, c.k8sGardenCoreInformers, c.identity, c.secrets, c.imageVector)
+	operation, err := operation.
+		NewBuilder().
+		WithLogger(shootLogger).
+		WithConfig(c.config).
+		WithGardenerInfo(c.identity).
+		WithSecrets(c.secrets).
+		WithImageVector(c.imageVector).
+		WithGardenFrom(c.k8sGardenCoreInformers, shoot.Namespace).
+		WithSeedFrom(c.k8sGardenCoreInformers, *shoot.Spec.SeedName).
+		WithShootFrom(c.k8sGardenCoreInformers, shoot).
+		Build(context.TODO(), c.k8sGardenClient)
 	if err != nil {
 		shootLogger.Errorf("could not initialize a new operation: %s", err.Error())
 		return nil // We do not want to run in the exponential backoff for the condition checks.

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -201,7 +201,17 @@ func (c *Controller) deleteShoot(shoot *gardencorev1beta1.Shoot, logger *logrus.
 		return reconcile.Result{}, c.updateShootStatusDeleteSuccess(shoot)
 	}
 
-	o, err := operation.New(shoot, c.config, logger, c.k8sGardenClient, c.k8sGardenCoreInformers.Core().V1beta1(), c.identity, c.secrets, c.imageVector)
+	o, err := operation.
+		NewBuilder().
+		WithLogger(logger).
+		WithConfig(c.config).
+		WithGardenerInfo(c.identity).
+		WithSecrets(c.secrets).
+		WithImageVector(c.imageVector).
+		WithGardenFrom(c.k8sGardenCoreInformers.Core().V1beta1(), shoot.Namespace).
+		WithSeedFrom(c.k8sGardenCoreInformers.Core().V1beta1(), *shoot.Spec.SeedName).
+		WithShootFrom(c.k8sGardenCoreInformers.Core().V1beta1(), shoot).
+		Build(context.TODO(), c.k8sGardenClient)
 	if err != nil {
 		return reconcile.Result{}, utilerrors.WithSuppressed(err, c.updateShootStatusError(shoot, fmt.Sprintf("Could not initialize a new operation for Shoot deletion: %s", err.Error())))
 	}
@@ -303,7 +313,17 @@ func (c *Controller) reconcileShoot(shoot *gardencorev1beta1.Shoot, logger *logr
 	// make sure that the latest version of the shoot object is used as the basis for next operations
 	shoot = updatedShoot
 
-	o, err := operation.New(shoot, c.config, logger, c.k8sGardenClient, c.k8sGardenCoreInformers.Core().V1beta1(), c.identity, c.secrets, c.imageVector)
+	o, err := operation.
+		NewBuilder().
+		WithLogger(logger).
+		WithConfig(c.config).
+		WithGardenerInfo(c.identity).
+		WithSecrets(c.secrets).
+		WithImageVector(c.imageVector).
+		WithGardenFrom(c.k8sGardenCoreInformers.Core().V1beta1(), shoot.Namespace).
+		WithSeedFrom(c.k8sGardenCoreInformers.Core().V1beta1(), *shoot.Spec.SeedName).
+		WithShootFrom(c.k8sGardenCoreInformers.Core().V1beta1(), shoot).
+		Build(context.TODO(), c.k8sGardenClient)
 	if err != nil {
 		if failedOrIgnored {
 			// do not set error from operation initialization in Shoot status if Shoot would not be reconciled anyways

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -23,11 +23,14 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/garden"
+	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
+	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils"
 	utilerrors "github.com/gardener/gardener/pkg/utils/errors"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -37,11 +40,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -98,9 +103,68 @@ func confineSpecUpdateRollout(maintenance *gardencorev1beta1.Maintenance) bool {
 	return maintenance != nil && maintenance.ConfineSpecUpdateRollout != nil && *maintenance.ConfineSpecUpdateRollout
 }
 
-func (c *Controller) checkSeedAndSyncClusterResource(shoot *gardencorev1beta1.Shoot, o *operation.Operation) error {
+// SyncClusterResourceToSeed creates or updates the `Cluster` extension resource for the shoot in the seed cluster.
+// It contains the shoot, seed, and cloudprofile specification.
+func (c *Controller) syncClusterResourceToSeed(ctx context.Context, shoot *gardencorev1beta1.Shoot, project *gardencorev1beta1.Project, cloudProfile *gardencorev1beta1.CloudProfile, seed *gardencorev1beta1.Seed) error {
+	if shoot.Spec.SeedName == nil {
+		return nil
+	}
+
+	k8sSeedClient, err := seedpkg.GetSeedClient(ctx, c.k8sGardenClient.Client(), c.config.SeedClientConnection.ClientConnectionConfiguration, c.config.SeedSelector == nil, *shoot.Spec.SeedName)
+	if err != nil {
+		return fmt.Errorf("could not initialize a new Kubernetes client for the seed cluster: %+v", err)
+	}
+
+	var (
+		cluster = &extensionsv1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: shootpkg.ComputeTechnicalID(project.Name, shoot),
+			},
+		}
+
+		cloudProfileObj = cloudProfile.DeepCopy()
+		seedObj         = seed.DeepCopy()
+		shootObj        = shoot.DeepCopy()
+	)
+
+	cloudProfileObj.TypeMeta = metav1.TypeMeta{
+		APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+		Kind:       "CloudProfile",
+	}
+	seedObj.TypeMeta = metav1.TypeMeta{
+		APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+		Kind:       "Seed",
+	}
+	shootObj.TypeMeta = metav1.TypeMeta{
+		APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+		Kind:       "Shoot",
+	}
+
+	// TODO: Workaround for the issue that was fixed with https://github.com/gardener/gardener/pull/2265. It adds a
+	//       fake "last operation" in case it is not set yet. This prevents the ShootNotFailed predicate in the
+	//       extensions library from reacting false negatively. This fake status is only internally and will not be
+	//       reported in the Shoot object in the garden cluster.
+	//       This code can be removed in a future version after giving extension controllers enough time to revendor
+	//       Gardener's extensions library.
+	if shoot.Status.LastOperation == nil {
+		shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{
+			Type:  gardencorev1beta1.LastOperationTypeCreate,
+			State: gardencorev1beta1.LastOperationStateSucceeded,
+		}
+	}
+
+	_, err = controllerutil.CreateOrUpdate(ctx, k8sSeedClient.Client(), cluster, func() error {
+		cluster.Spec.CloudProfile = runtime.RawExtension{Object: cloudProfileObj}
+		cluster.Spec.Seed = runtime.RawExtension{Object: seedObj}
+		cluster.Spec.Shoot = runtime.RawExtension{Object: shootObj}
+		return nil
+	})
+	return err
+}
+
+func (c *Controller) checkSeedAndSyncClusterResource(ctx context.Context, shoot *gardencorev1beta1.Shoot, project *gardencorev1beta1.Project, cloudProfile *gardencorev1beta1.CloudProfile, seed *gardencorev1beta1.Seed) error {
 	seedName := shoot.Spec.SeedName
-	if seedName == nil || o.Seed == nil {
+	if seedName == nil || seed == nil {
 		return nil
 	}
 
@@ -118,11 +182,31 @@ func (c *Controller) checkSeedAndSyncClusterResource(shoot *gardencorev1beta1.Sh
 		}
 	}
 
-	if err := o.SyncClusterResourceToSeed(context.TODO()); err != nil {
+	if err := c.syncClusterResourceToSeed(ctx, shoot, project, cloudProfile, seed); err != nil {
 		return fmt.Errorf("could not sync cluster resource to seed: %v", err)
 	}
 
 	return nil
+}
+
+// deleteClusterResourceFromSeed deletes the `Cluster` extension resource for the shoot in the seed cluster.
+func (c *Controller) deleteClusterResourceFromSeed(ctx context.Context, shoot *gardencorev1beta1.Shoot, projectName string) error {
+	if shoot.Spec.SeedName == nil {
+		return nil
+	}
+
+	k8sSeedClient, err := seedpkg.GetSeedClient(ctx, c.k8sGardenClient.Client(), c.config.SeedClientConnection.ClientConnectionConfiguration, c.config.SeedSelector == nil, *shoot.Spec.SeedName)
+	if err != nil {
+		return fmt.Errorf("could not initialize a new Kubernetes client for the seed cluster: %s", err.Error())
+	}
+
+	cluster := &extensionsv1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: shootpkg.ComputeTechnicalID(projectName, shoot),
+		},
+	}
+
+	return client.IgnoreNotFound(k8sSeedClient.Client().Delete(ctx, cluster))
 }
 
 func (c *Controller) reconcileShootRequest(req reconcile.Request) (reconcile.Result, error) {
@@ -137,10 +221,24 @@ func (c *Controller) reconcileShootRequest(req reconcile.Request) (reconcile.Res
 		return reconcile.Result{}, err
 	}
 
-	if shoot.DeletionTimestamp != nil {
-		return c.deleteShoot(shoot, log)
+	// fetch related objects required for shoot operation
+	project, err := common.ProjectForNamespace(c.k8sGardenCoreInformers.Core().V1beta1().Projects().Lister(), shoot.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
 	}
-	return c.reconcileShoot(shoot, log)
+	cloudProfile, err := c.k8sGardenCoreInformers.Core().V1beta1().CloudProfiles().Lister().Get(shoot.Spec.CloudProfileName)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	seed, err := c.k8sGardenCoreInformers.Core().V1beta1().Seeds().Lister().Get(*shoot.Spec.SeedName)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if shoot.DeletionTimestamp != nil {
+		return c.deleteShoot(log, shoot, project, cloudProfile, seed)
+	}
+	return c.reconcileShoot(log, shoot, project, cloudProfile, seed)
 }
 
 func (c *Controller) updateShootStatusError(shoot *gardencorev1beta1.Shoot, message string) error {
@@ -173,23 +271,64 @@ func (c *Controller) updateShootStatusProcessing(shoot *gardencorev1beta1.Shoot,
 	return err
 }
 
-func (c *Controller) durationUntilNextShootSync(shoot *gardencorev1beta1.Shoot) time.Duration {
-	syncPeriod := common.SyncPeriodOfShoot(c.respectSyncPeriodOverwrite(), c.config.Controllers.Shoot.SyncPeriod.Duration, shoot)
-	if !c.reconcileInMaintenanceOnly() && !confineSpecUpdateRollout(shoot.Spec.Maintenance) {
-		return syncPeriod
+func (c *Controller) initializeOperation(ctx context.Context, logger *logrus.Entry, shoot *gardencorev1beta1.Shoot, project *gardencorev1beta1.Project, cloudProfile *gardencorev1beta1.CloudProfile, seed *gardencorev1beta1.Seed) (*operation.Operation, error) {
+	gardenObj, err := garden.
+		NewBuilder().
+		WithProject(project).
+		WithInternalDomainFromSecrets(c.secrets).
+		WithDefaultDomainsFromSecrets(c.secrets).
+		Build()
+	if err != nil {
+		return nil, err
 	}
 
-	now := time.Now()
-	window := common.EffectiveShootMaintenanceTimeWindow(shoot)
-
-	if !window.Contains(now.Add(syncPeriod)) {
-		return window.RandomDurationUntilNext(now)
+	seedObj, err := seedpkg.
+		NewBuilder().
+		WithSeedObject(seed).
+		WithSeedSecretFromClient(ctx, c.k8sGardenClient.Client()).
+		Build()
+	if err != nil {
+		return nil, err
 	}
-	return syncPeriod
+
+	shootObj, err := shootpkg.
+		NewBuilder().
+		WithShootObject(shoot).
+		WithCloudProfileObject(cloudProfile).
+		WithShootSecretFromSecretBindingLister(c.k8sGardenCoreInformers.Core().V1beta1().SecretBindings().Lister()).
+		WithProjectName(project.Name).
+		WithDisableDNS(gardencorev1beta1helper.TaintsHave(seedObj.Info.Spec.Taints, gardencorev1beta1.SeedTaintDisableDNS)).
+		WithInternalDomain(gardenObj.InternalDomain).
+		WithDefaultDomains(gardenObj.DefaultDomains).
+		Build(ctx, c.k8sGardenClient.Client())
+	if err != nil {
+		return nil, err
+	}
+
+	return operation.
+		NewBuilder().
+		WithLogger(logger).
+		WithConfig(c.config).
+		WithGardenerInfo(c.identity).
+		WithSecrets(c.secrets).
+		WithImageVector(c.imageVector).
+		WithGarden(gardenObj).
+		WithSeed(seedObj).
+		WithShoot(shootObj).
+		Build(ctx, c.k8sGardenClient)
 }
 
-func (c *Controller) deleteShoot(shoot *gardencorev1beta1.Shoot, logger *logrus.Entry) (reconcile.Result, error) {
-	if shoot.DeletionTimestamp != nil && !controllerutils.HasFinalizer(shoot, gardencorev1beta1.GardenerName) {
+func (c *Controller) deleteShoot(logger *logrus.Entry, shoot *gardencorev1beta1.Shoot, project *gardencorev1beta1.Project, cloudProfile *gardencorev1beta1.CloudProfile, seed *gardencorev1beta1.Seed) (reconcile.Result, error) {
+	var (
+		ctx = context.TODO()
+
+		respectSyncPeriodOverwrite = c.respectSyncPeriodOverwrite()
+		failed                     = common.IsShootFailed(shoot)
+		ignored                    = common.ShouldIgnoreShoot(respectSyncPeriodOverwrite, shoot)
+		failedOrIgnored            = failed || ignored
+	)
+
+	if !controllerutils.HasFinalizer(shoot, gardencorev1beta1.GardenerName) {
 		return reconcile.Result{}, nil
 	}
 
@@ -198,60 +337,25 @@ func (c *Controller) deleteShoot(shoot *gardencorev1beta1.Shoot, logger *logrus.
 	// We accept the deletion.
 	if len(shoot.Status.UID) == 0 {
 		logger.Info("`.status.uid` is empty, assuming Shoot cluster did never exist. Deletion accepted.")
-		return reconcile.Result{}, c.updateShootStatusDeleteSuccess(shoot)
+		c.recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventDeleted, "Deleted Shoot cluster")
+		return c.finalizeShootDeletion(ctx, logger, shoot, project.Name)
 	}
 
-	o, err := operation.
-		NewBuilder().
-		WithLogger(logger).
-		WithConfig(c.config).
-		WithGardenerInfo(c.identity).
-		WithSecrets(c.secrets).
-		WithImageVector(c.imageVector).
-		WithGardenFrom(c.k8sGardenCoreInformers.Core().V1beta1(), shoot.Namespace).
-		WithSeedFrom(c.k8sGardenCoreInformers.Core().V1beta1(), *shoot.Spec.SeedName).
-		WithShootFrom(c.k8sGardenCoreInformers.Core().V1beta1(), shoot).
-		Build(context.TODO(), c.k8sGardenClient)
+	// If shoot is failed or ignored then sync the Cluster resource so that extension controllers running in the seed
+	// get to know of the shoot's status.
+	if failedOrIgnored {
+		if err := c.syncClusterResourceToSeed(ctx, shoot, project, cloudProfile, seed); err != nil {
+			logger.WithError(err).Infof("Not allowed to update Shoot with error, trying to sync Cluster resource again")
+			return reconcile.Result{}, utilerrors.WithSuppressed(err, c.updateShootStatusDeleteError(logger, shoot, err.Error(), shoot.Status.LastErrors...))
+		}
+
+		logger.Info("Shoot is failed or ignored")
+		return reconcile.Result{}, nil
+	}
+
+	o, err := c.initializeOperation(ctx, logger, shoot, project, cloudProfile, seed)
 	if err != nil {
 		return reconcile.Result{}, utilerrors.WithSuppressed(err, c.updateShootStatusError(shoot, fmt.Sprintf("Could not initialize a new operation for Shoot deletion: %s", err.Error())))
-	}
-
-	var tasksWithErrors []string
-
-	for _, lastError := range o.Shoot.Info.Status.LastErrors {
-		if lastError.TaskID != nil {
-			tasksWithErrors = append(tasksWithErrors, *lastError.TaskID)
-		}
-	}
-
-	errorContext := utilerrors.NewErrorContext("Shoot deletion", tasksWithErrors)
-
-	err = utilerrors.HandleErrors(errorContext,
-		func(errorID string) error {
-			o.CleanShootTaskError(context.TODO(), errorID)
-			return nil
-		},
-		func(errorID string, err error) error {
-			lastErr := gardencorev1beta1helper.LastErrorWithTaskID(fmt.Sprintf("Could not check and sync Shoot with Seed: %v", err), errorID)
-			c.recorder.Event(shoot, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, lastErr.Description)
-			return utilerrors.WithSuppressed(err, c.updateShootStatusDeleteError(o, lastErr.Description, *lastErr))
-		},
-		utilerrors.ToExecute("Check and sync Shoot with Seed", func() error {
-			return c.checkSeedAndSyncClusterResource(shoot, o)
-		}),
-	)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	if common.IsShootFailed(shoot) {
-		o.Logger.Info("Shoot is failed")
-		return reconcile.Result{}, nil
-	}
-
-	if common.ShouldIgnoreShoot(c.respectSyncPeriodOverwrite(), shoot) {
-		o.Logger.Info("Shoot is being ignored")
-		return reconcile.Result{}, nil
 	}
 
 	// Trigger regular shoot deletion flow.
@@ -260,29 +364,45 @@ func (c *Controller) deleteShoot(shoot *gardencorev1beta1.Shoot, logger *logrus.
 		return reconcile.Result{}, err
 	}
 
-	if err := c.runDeleteShootFlow(o, errorContext); err != nil {
+	// At this point the deletion is allowed, hence, check if the seed is up-to-date, then sync the Cluster resource
+	// initialize a new operation and, eventually, start the deletion flow.
+	if err := c.checkSeedAndSyncClusterResource(ctx, shoot, project, cloudProfile, seed); err != nil {
+		message := fmt.Sprintf("Shoot cannot be synced with Seed: %v", err)
+		c.recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventOperationPending, message)
+
+		if err := c.updateShootStatusProcessing(shoot, message); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{
+			Requeue:      true,
+			RequeueAfter: 15 * time.Second, // prevent ddos-ing the seed
+		}, nil
+	}
+
+	if err := c.runDeleteShootFlow(o); err != nil {
 		c.recorder.Event(shoot, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, err.Description)
-		return reconcile.Result{}, utilerrors.WithSuppressed(errors.New(err.Description), c.updateShootStatusDeleteError(o, err.Description, err.LastErrors...))
+		return reconcile.Result{}, utilerrors.WithSuppressed(errors.New(err.Description), c.updateShootStatusDeleteError(logger, shoot, err.Description, err.LastErrors...))
 	}
 
 	c.recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventDeleted, "Deleted Shoot cluster")
-	return c.finalizeShootDeletion(shoot, o)
+	return c.finalizeShootDeletion(ctx, logger, shoot, project.Name)
 }
 
-func (c *Controller) finalizeShootDeletion(shoot *gardencorev1beta1.Shoot, o *operation.Operation) (reconcile.Result, error) {
-	if len(o.Shoot.Info.Status.UID) > 0 {
-		if err := o.DeleteClusterResourceFromSeed(context.TODO()); err != nil {
-			lastErr := gardencorev1beta1helper.LastError(fmt.Sprintf("Could not delete Cluster resource in seed: %s", err))
-			c.recorder.Event(shoot, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, lastErr.Description)
-			return reconcile.Result{}, utilerrors.WithSuppressed(errors.New(lastErr.Description), c.updateShootStatusDeleteError(o, lastErr.Description, *lastErr))
-		}
+func (c *Controller) finalizeShootDeletion(ctx context.Context, logger *logrus.Entry, shoot *gardencorev1beta1.Shoot, projectName string) (reconcile.Result, error) {
+	if err := c.deleteClusterResourceFromSeed(ctx, shoot, projectName); err != nil {
+		lastErr := gardencorev1beta1helper.LastError(fmt.Sprintf("Could not delete Cluster resource in seed: %s", err))
+		c.recorder.Event(shoot, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, lastErr.Description)
+		return reconcile.Result{}, utilerrors.WithSuppressed(errors.New(lastErr.Description), c.updateShootStatusDeleteError(logger, shoot, lastErr.Description, *lastErr))
 	}
 
-	return reconcile.Result{}, c.updateShootStatusDeleteSuccess(o.Shoot.Info)
+	return reconcile.Result{}, c.updateShootStatusDeleteSuccess(shoot)
 }
 
-func (c *Controller) reconcileShoot(shoot *gardencorev1beta1.Shoot, logger *logrus.Entry) (reconcile.Result, error) {
+func (c *Controller) reconcileShoot(logger *logrus.Entry, shoot *gardencorev1beta1.Shoot, project *gardencorev1beta1.Project, cloudProfile *gardencorev1beta1.CloudProfile, seed *gardencorev1beta1.Seed) (reconcile.Result, error) {
 	var (
+		ctx = context.TODO()
+
 		operationType                              = gardencorev1beta1helper.ComputeOperationType(shoot.ObjectMeta, shoot.Status.LastOperation)
 		respectSyncPeriodOverwrite                 = c.respectSyncPeriodOverwrite()
 		failed                                     = common.IsShootFailed(shoot)
@@ -291,9 +411,9 @@ func (c *Controller) reconcileShoot(shoot *gardencorev1beta1.Shoot, logger *logr
 		reconcileInMaintenanceOnly                 = c.reconcileInMaintenanceOnly()
 		isUpToDate                                 = common.IsObservedAtLatestGenerationAndSucceeded(shoot)
 		isNowInEffectiveShootMaintenanceTimeWindow = common.IsNowInEffectiveShootMaintenanceTimeWindow(shoot)
-		reconcileAllowed                           = (!reconcileInMaintenanceOnly && !confineSpecUpdateRollout(shoot.Spec.Maintenance)) || !isUpToDate || isNowInEffectiveShootMaintenanceTimeWindow
-		allowedToUpdate                            = !failedOrIgnored && reconcileAllowed
+		reconcileAllowed                           = !failedOrIgnored && ((!reconcileInMaintenanceOnly && !confineSpecUpdateRollout(shoot.Spec.Maintenance)) || !isUpToDate || isNowInEffectiveShootMaintenanceTimeWindow)
 	)
+
 	// need retry logic, because the scheduler is acting on it at the same time and cached object might not be up to date
 	updatedShoot, err := kutil.TryUpdateShoot(c.k8sGardenClient.GardenCore(), retry.DefaultBackoff, shoot.ObjectMeta, func(curShoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
 		finalizers := sets.NewString(curShoot.Finalizers...)
@@ -306,46 +426,10 @@ func (c *Controller) reconcileShoot(shoot *gardencorev1beta1.Shoot, logger *logr
 
 		return curShoot, nil
 	})
-
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not add finalizer to Shoot: %s", err.Error())
 	}
-	// make sure that the latest version of the shoot object is used as the basis for next operations
 	shoot = updatedShoot
-
-	o, err := operation.
-		NewBuilder().
-		WithLogger(logger).
-		WithConfig(c.config).
-		WithGardenerInfo(c.identity).
-		WithSecrets(c.secrets).
-		WithImageVector(c.imageVector).
-		WithGardenFrom(c.k8sGardenCoreInformers.Core().V1beta1(), shoot.Namespace).
-		WithSeedFrom(c.k8sGardenCoreInformers.Core().V1beta1(), *shoot.Spec.SeedName).
-		WithShootFrom(c.k8sGardenCoreInformers.Core().V1beta1(), shoot).
-		Build(context.TODO(), c.k8sGardenClient)
-	if err != nil {
-		if failedOrIgnored {
-			// do not set error from operation initialization in Shoot status if Shoot would not be reconciled anyways
-			logger.Infof("Shoot is failed or ignored, but error occurred while initializing a new operation: %s", err.Error())
-			return reconcile.Result{}, nil
-		}
-
-		return reconcile.Result{}, utilerrors.WithSuppressed(err, c.updateShootStatusError(shoot, fmt.Sprintf("Could not initialize a new operation for Shoot reconciliation: %s", err.Error())))
-	}
-
-	// write UID to status when operation was created successfully once
-	if len(shoot.Status.UID) == 0 {
-		_, err := kutil.TryUpdateShootStatus(c.k8sGardenClient.GardenCore(), retry.DefaultRetry, shoot.ObjectMeta,
-			func(shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
-				shoot.Status.UID = shoot.UID
-				return shoot, nil
-			})
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		return reconcile.Result{}, nil
-	}
 
 	logger.WithFields(logrus.Fields{
 		"operationType":              operationType,
@@ -357,37 +441,43 @@ func (c *Controller) reconcileShoot(shoot *gardencorev1beta1.Shoot, logger *logr
 		"isUpToDate":                 isUpToDate,
 		"isNowInEffectiveShootMaintenanceTimeWindow": isNowInEffectiveShootMaintenanceTimeWindow,
 		"reconcileAllowed":                           reconcileAllowed,
-		"allowedToUpdate":                            allowedToUpdate,
 	}).Info("Checking if Shoot can be reconciled")
 
-	if err := c.checkSeedAndSyncClusterResource(shoot, o); err != nil {
-		message := fmt.Sprintf("Shoot cannot be synced with Seed: %v", err)
-		c.recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventOperationPending, message)
-		if !allowedToUpdate {
-			o.Logger.WithError(err).Infof("Not allowed to update Shoot with error")
-			return reconcile.Result{}, err
-		}
-
-		if err := c.updateShootStatusProcessing(shoot, message); err != nil {
-			return reconcile.Result{}, err
-		}
-
-		return reconcile.Result{
-			Requeue:      true,
-			RequeueAfter: 30 * time.Second,
-		}, nil
-	}
-
+	// If shoot is failed or ignored then sync the Cluster resource so that extension controllers running in the seed
+	// get to know of the shoot's status.
 	if failedOrIgnored {
-		o.Logger.Info("Shoot is failed or ignored")
+		if err := c.syncClusterResourceToSeed(ctx, shoot, project, cloudProfile, seed); err != nil {
+			logger.WithError(err).Infof("Not allowed to update Shoot with error, trying to sync Cluster resource again")
+			return reconcile.Result{}, utilerrors.WithSuppressed(err, c.updateShootStatusReconcileError(shoot, operationType, err.Error(), shoot.Status.LastErrors...))
+		}
+
+		logger.Info("Shoot is failed or ignored")
 		return reconcile.Result{}, nil
 	}
 
+	// If reconciliation is not allowed then compute the duration until the next sync and requeue.
 	if !reconcileAllowed {
 		durationUntilNextSync := c.durationUntilNextShootSync(shoot)
-		message := fmt.Sprintf("Scheduled next queuing time for Shoot in %s (%s)", durationUntilNextSync, time.Now().UTC().Add(durationUntilNextSync))
+		message := fmt.Sprintf("Reconciliation not allowed, scheduling next sync in %s (%s)", durationUntilNextSync, time.Now().UTC().Add(durationUntilNextSync))
 		c.recorder.Event(shoot, corev1.EventTypeNormal, "ScheduledNextSync", message)
+		logger.Infof(message)
 		return reconcile.Result{RequeueAfter: durationUntilNextSync}, nil
+	}
+
+	o, err := c.initializeOperation(ctx, logger, shoot, project, cloudProfile, seed)
+	if err != nil {
+		return reconcile.Result{}, utilerrors.WithSuppressed(err, c.updateShootStatusError(shoot, fmt.Sprintf("Could not initialize a new operation for Shoot reconciliation: %s", err.Error())))
+	}
+
+	// write UID to status when operation was created successfully once
+	if len(shoot.Status.UID) == 0 {
+		_, err := kutil.TryUpdateShootStatus(c.k8sGardenClient.GardenCore(), retry.DefaultRetry, shoot.ObjectMeta,
+			func(shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
+				shoot.Status.UID = shoot.UID
+				return shoot, nil
+			},
+		)
+		return reconcile.Result{}, err
 	}
 
 	c.recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Reconciling Shoot cluster state")
@@ -395,11 +485,28 @@ func (c *Controller) reconcileShoot(shoot *gardencorev1beta1.Shoot, logger *logr
 		return reconcile.Result{}, err
 	}
 
+	// At this point the reconciliation is allowed, hence, check if the seed is up-to-date, then sync the Cluster resource
+	// initialize a new operation and, eventually, start the reconciliation flow.
+	if err := c.checkSeedAndSyncClusterResource(ctx, shoot, project, cloudProfile, seed); err != nil {
+		message := fmt.Sprintf("Shoot cannot be synced with Seed: %v", err)
+		c.recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventOperationPending, message)
+
+		if err := c.updateShootStatusProcessing(shoot, message); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{
+			Requeue:      true,
+			RequeueAfter: 15 * time.Second, // prevent ddos-ing the seed
+		}, nil
+	}
+
 	var dnsEnabled = !o.Shoot.DisableDNS
 
-	// TODO: timuthy - Only required for migration and can be removed in a future version
+	// TODO: timuthy - Only required for migration and can be removed in a future version once admission plugin
+	// forbids to create functionless DNS providers.
 	if dnsEnabled && o.Shoot.Info.Spec.DNS != nil {
-		updated, err := migrateDNSProviders(context.TODO(), c.k8sGardenClient.Client(), o)
+		updated, err := migrateDNSProviders(ctx, c.k8sGardenClient.Client(), o)
 		if err != nil {
 			message := "Cannot reconcile Shoot: Migrating DNS providers failed"
 			c.recorder.Event(shoot, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, message)
@@ -413,9 +520,9 @@ func (c *Controller) reconcileShoot(shoot *gardencorev1beta1.Shoot, logger *logr
 		}
 	}
 
-	if err := c.runReconcileShootFlow(o, operationType); err != nil {
+	if err := c.runReconcileShootFlow(o); err != nil {
 		c.recorder.Event(shoot, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, err.Description)
-		return reconcile.Result{}, utilerrors.WithSuppressed(errors.New(err.Description), c.updateShootStatusReconcileError(o, operationType, err.Description, err.LastErrors...))
+		return reconcile.Result{}, utilerrors.WithSuppressed(errors.New(err.Description), c.updateShootStatusReconcileError(shoot, operationType, err.Description, err.LastErrors...))
 	}
 
 	c.recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventReconciled, "Reconciled Shoot cluster state")
@@ -423,10 +530,30 @@ func (c *Controller) reconcileShoot(shoot *gardencorev1beta1.Shoot, logger *logr
 		return reconcile.Result{}, err
 	}
 
+	if err := c.syncClusterResourceToSeed(ctx, o.Shoot.Info, project, cloudProfile, seed); err != nil {
+		logger.WithError(err).Infof("Cluster resource sync to shoot failed")
+		return reconcile.Result{}, utilerrors.WithSuppressed(err, c.updateShootStatusReconcileError(o.Shoot.Info, operationType, err.Error(), shoot.Status.LastErrors...))
+	}
+
 	durationUntilNextSync := c.durationUntilNextShootSync(shoot)
 	message := fmt.Sprintf("Scheduled next queuing time for Shoot in %s (%s)", durationUntilNextSync, time.Now().UTC().Add(durationUntilNextSync))
 	c.recorder.Event(shoot, corev1.EventTypeNormal, "ScheduledNextSync", message)
 	return reconcile.Result{RequeueAfter: durationUntilNextSync}, nil
+}
+
+func (c *Controller) durationUntilNextShootSync(shoot *gardencorev1beta1.Shoot) time.Duration {
+	syncPeriod := common.SyncPeriodOfShoot(c.respectSyncPeriodOverwrite(), c.config.Controllers.Shoot.SyncPeriod.Duration, shoot)
+	if !c.reconcileInMaintenanceOnly() && !confineSpecUpdateRollout(shoot.Spec.Maintenance) {
+		return syncPeriod
+	}
+
+	now := time.Now()
+	window := common.EffectiveShootMaintenanceTimeWindow(shoot)
+
+	if !window.Contains(now.Add(syncPeriod)) {
+		return window.RandomDurationUntilNext(now)
+	}
+	return syncPeriod
 }
 
 func migrateDNSProviders(ctx context.Context, c client.Client, o *operation.Operation) (bool, error) {

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -39,28 +39,75 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// New creates a new Garden object (based on a Shoot object).
-func New(projectLister gardencorelisters.ProjectLister, namespace string, secrets map[string]*corev1.Secret) (*Garden, error) {
-	project, err := common.ProjectForNamespace(projectLister, namespace)
+// NewBuilder returns a new Builder.
+func NewBuilder() *Builder {
+	return &Builder{
+		projectFunc:        func() (*gardencorev1beta1.Project, error) { return nil, fmt.Errorf("project is required but not set") },
+		internalDomainFunc: func() (*Domain, error) { return nil, fmt.Errorf("internal domain is required but not set") },
+	}
+}
+
+// WithProject sets the projectFunc attribute at the Builder.
+func (b *Builder) WithProject(project *gardencorev1beta1.Project) *Builder {
+	b.projectFunc = func() (*gardencorev1beta1.Project, error) { return project, nil }
+	return b
+}
+
+// WithProjectFromLister sets the projectFunc attribute after fetching it from the lister.
+func (b *Builder) WithProjectFromLister(projectLister gardencorelisters.ProjectLister, namespace string) *Builder {
+	b.projectFunc = func() (*gardencorev1beta1.Project, error) {
+		return common.ProjectForNamespace(projectLister, namespace)
+	}
+	return b
+}
+
+// WithInternalDomain sets the internalDomainFunc attribute at the Builder.
+func (b *Builder) WithInternalDomain(internalDomain *Domain) *Builder {
+	b.internalDomainFunc = func() (*Domain, error) { return internalDomain, nil }
+	return b
+}
+
+// WithInternalDomainFromSecrets sets the internalDomainFunc attribute at the Builder based on the given secrets map.
+func (b *Builder) WithInternalDomainFromSecrets(secrets map[string]*corev1.Secret) *Builder {
+	b.internalDomainFunc = func() (*Domain, error) { return GetInternalDomain(secrets) }
+	return b
+}
+
+// WithDefaultDomains sets the defaultDomainsFunc attribute at the Builder.
+func (b *Builder) WithDefaultDomains(defaultDomains []*Domain) *Builder {
+	b.defaultDomainsFunc = func() ([]*Domain, error) { return defaultDomains, nil }
+	return b
+}
+
+// WithDefaultDomains sets the defaultDomainsFunc attribute at the Builder based on the given secrets map.
+func (b *Builder) WithDefaultDomainsFromSecrets(secrets map[string]*corev1.Secret) *Builder {
+	b.defaultDomainsFunc = func() ([]*Domain, error) { return GetDefaultDomains(secrets) }
+	return b
+}
+
+// Build initializes a new Garden object.
+func (b *Builder) Build() (*Garden, error) {
+	garden := &Garden{}
+
+	project, err := b.projectFunc()
 	if err != nil {
 		return nil, err
 	}
+	garden.Project = project
 
-	internalDomain, err := GetInternalDomain(secrets)
+	internalDomain, err := b.internalDomainFunc()
 	if err != nil {
 		return nil, err
 	}
+	garden.InternalDomain = internalDomain
 
-	defaultDomains, err := GetDefaultDomains(secrets)
+	defaultDomains, err := b.defaultDomainsFunc()
 	if err != nil {
 		return nil, err
 	}
+	garden.DefaultDomains = defaultDomains
 
-	return &Garden{
-		Project:        project,
-		InternalDomain: internalDomain,
-		DefaultDomains: defaultDomains,
-	}, nil
+	return garden, nil
 }
 
 // GetDefaultDomains finds all the default domain secrets within the given map and returns a list of
@@ -199,7 +246,6 @@ func ReadGardenSecrets(k8sInformers kubeinformers.SharedInformerFactory, k8sGard
 	}
 
 	for _, secret := range secretsGardenRole {
-
 		// Retrieve the alerting secret to configure alerting. Either in cluster email alerting or
 		// external alertmanager configuration.
 		if secret.Labels[v1beta1constants.GardenRole] == common.GardenRoleAlerting {

--- a/pkg/operation/garden/types.go
+++ b/pkg/operation/garden/types.go
@@ -18,6 +18,13 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
 
+// Builder is an object that builds Garden objects.
+type Builder struct {
+	projectFunc        func() (*gardencorev1beta1.Project, error)
+	internalDomainFunc func() (*Domain, error)
+	defaultDomainsFunc func() ([]*Domain, error)
+}
+
 // Garden is an object containing Garden cluster specific data.
 type Garden struct {
 	Project        *gardencorev1beta1.Project

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -26,7 +26,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -50,100 +49,200 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// New creates a new operation object with a Shoot resource object.
-func New(shoot *gardencorev1beta1.Shoot, config *config.GardenletConfiguration, logger *logrus.Entry, k8sGardenClient kubernetes.Interface, k8sGardenCoreInformers gardencoreinformers.Interface, gardenerInfo *gardencorev1beta1.Gardener, secretsMap map[string]*corev1.Secret, imageVector imagevector.ImageVector) (*Operation, error) {
-	return newOperation(config, logger, k8sGardenClient, k8sGardenCoreInformers, gardenerInfo, secretsMap, imageVector, shoot.Namespace, shoot.Spec.SeedName, shoot)
+// NewBuilder returns a new Builder.
+func NewBuilder() *Builder {
+	return &Builder{
+		configFunc: func() (*config.GardenletConfiguration, error) {
+			return nil, fmt.Errorf("config is required but not set")
+		},
+		gardenFunc: func(map[string]*corev1.Secret) (*garden.Garden, error) {
+			return nil, fmt.Errorf("garden object is required but not set")
+		},
+		gardenerInfoFunc: func() (*gardencorev1beta1.Gardener, error) {
+			return nil, fmt.Errorf("gardener info is required but not set")
+		},
+		imageVectorFunc: func() (imagevector.ImageVector, error) {
+			return nil, fmt.Errorf("image vector is required but not set")
+		},
+		loggerFunc: func() (*logrus.Entry, error) {
+			return nil, fmt.Errorf("logger is required but not set")
+		},
+		secretsFunc: func() (map[string]*corev1.Secret, error) {
+			return nil, fmt.Errorf("secrets map is required but not set")
+		},
+		seedFunc: func(context.Context, client.Client) (*seed.Seed, error) {
+			return nil, fmt.Errorf("seed object is required but not set")
+		},
+		shootFunc: func(context.Context, client.Client, *garden.Garden, *seed.Seed) (*shoot.Shoot, error) {
+			return nil, fmt.Errorf("shoot object is required but not set")
+		},
+	}
 }
 
-func newOperation(
-	config *config.GardenletConfiguration,
-	logger *logrus.Entry,
-	k8sGardenClient kubernetes.Interface,
-	k8sGardenCoreInformers gardencoreinformers.Interface,
-	gardenerInfo *gardencorev1beta1.Gardener,
-	secretsMap map[string]*corev1.Secret,
-	imageVector imagevector.ImageVector,
-	namespace string,
-	seedName *string,
-	shoot *gardencorev1beta1.Shoot,
-) (*Operation, error) {
+// WithConfig sets the configFunc attribute at the Builder.
+func (b *Builder) WithConfig(cfg *config.GardenletConfiguration) *Builder {
+	b.configFunc = func() (*config.GardenletConfiguration, error) { return cfg, nil }
+	return b
+}
 
+// WithGarden sets the gardenFunc attribute at the Builder.
+func (b *Builder) WithGarden(g *garden.Garden) *Builder {
+	b.gardenFunc = func(_ map[string]*corev1.Secret) (*garden.Garden, error) { return g, nil }
+	return b
+}
+
+// WithGardenFrom sets the gardenFunc attribute at the Builder which will build a new Garden object.
+func (b *Builder) WithGardenFrom(k8sGardenCoreInformers gardencoreinformers.Interface, namespace string) *Builder {
+	b.gardenFunc = func(secrets map[string]*corev1.Secret) (*garden.Garden, error) {
+		return garden.
+			NewBuilder().
+			WithProjectFromLister(k8sGardenCoreInformers.Projects().Lister(), namespace).
+			WithInternalDomainFromSecrets(secrets).
+			WithDefaultDomainsFromSecrets(secrets).
+			Build()
+	}
+	return b
+}
+
+// WithGardenerInfo sets the gardenerInfoFunc attribute at the Builder.
+func (b *Builder) WithGardenerInfo(gardenerInfo *gardencorev1beta1.Gardener) *Builder {
+	b.gardenerInfoFunc = func() (*gardencorev1beta1.Gardener, error) { return gardenerInfo, nil }
+	return b
+}
+
+// WithImageVector sets the imageVectorFunc attribute at the Builder.
+func (b *Builder) WithImageVector(imageVector imagevector.ImageVector) *Builder {
+	b.imageVectorFunc = func() (imagevector.ImageVector, error) { return imageVector, nil }
+	return b
+}
+
+// WithLogger sets the loggerFunc attribute at the Builder.
+func (b *Builder) WithLogger(logger *logrus.Entry) *Builder {
+	b.loggerFunc = func() (*logrus.Entry, error) { return logger, nil }
+	return b
+}
+
+// WithSecrets sets the secretsFunc attribute at the Builder.
+func (b *Builder) WithSecrets(secrets map[string]*corev1.Secret) *Builder {
+	b.secretsFunc = func() (map[string]*corev1.Secret, error) { return secrets, nil }
+	return b
+}
+
+// WithSeed sets the seedFunc attribute at the Builder.
+func (b *Builder) WithSeed(s *seed.Seed) *Builder {
+	b.seedFunc = func(_ context.Context, _ client.Client) (*seed.Seed, error) { return s, nil }
+	return b
+}
+
+// WithSeedFrom sets the seedFunc attribute at the Builder which will build a new Seed object.
+func (b *Builder) WithSeedFrom(k8sGardenCoreInformers gardencoreinformers.Interface, seedName string) *Builder {
+	b.seedFunc = func(ctx context.Context, c client.Client) (*seed.Seed, error) {
+		return seed.
+			NewBuilder().
+			WithSeedObjectFromLister(k8sGardenCoreInformers.Seeds().Lister(), seedName).
+			WithSeedSecretFromClient(context.TODO(), c).
+			Build()
+	}
+	return b
+}
+
+// WithShoot sets the shootFunc attribute at the Builder.
+func (b *Builder) WithShoot(s *shoot.Shoot) *Builder {
+	b.shootFunc = func(_ context.Context, _ client.Client, _ *garden.Garden, _ *seed.Seed) (*shoot.Shoot, error) {
+		return s, nil
+	}
+	return b
+}
+
+// WithShoot sets the shootFunc attribute at the Builder which will build a new Shoot object.
+func (b *Builder) WithShootFrom(k8sGardenCoreInformers gardencoreinformers.Interface, s *gardencorev1beta1.Shoot) *Builder {
+	b.shootFunc = func(ctx context.Context, c client.Client, gardenObj *garden.Garden, seedObj *seed.Seed) (*shoot.Shoot, error) {
+		return shootpkg.
+			NewBuilder().
+			WithShootObject(s).
+			WithCloudProfileObjectFromLister(k8sGardenCoreInformers.CloudProfiles().Lister()).
+			WithShootSecretFromSecretBindingLister(k8sGardenCoreInformers.SecretBindings().Lister()).
+			WithProjectName(gardenObj.Project.Name).
+			WithDisableDNS(gardencorev1beta1helper.TaintsHave(seedObj.Info.Spec.Taints, gardencorev1beta1.SeedTaintDisableDNS)).
+			WithInternalDomain(gardenObj.InternalDomain).
+			WithDefaultDomains(gardenObj.DefaultDomains).
+			Build(ctx, c)
+	}
+	return b
+}
+
+// Build initializes a new Operation object.
+func (b *Builder) Build(ctx context.Context, k8sGardenClient kubernetes.Interface) (*Operation, error) {
+	operation := &Operation{
+		K8sGardenClient: k8sGardenClient,
+		CheckSums:       make(map[string]string),
+	}
+
+	config, err := b.configFunc()
+	if err != nil {
+		return nil, err
+	}
+	operation.Config = config
+
+	secretsMap, err := b.secretsFunc()
+	if err != nil {
+		return nil, err
+	}
 	secrets := make(map[string]*corev1.Secret)
 	for k, v := range secretsMap {
 		secrets[k] = v
 	}
+	operation.Secrets = secrets
 
-	gardenObj, err := garden.New(k8sGardenCoreInformers.Projects().Lister(), namespace, secrets)
+	garden, err := b.gardenFunc(secrets)
 	if err != nil {
 		return nil, err
 	}
+	operation.Garden = garden
 
-	var (
-		seedObj    *seed.Seed
-		disableDNS bool
-	)
-	if seedName != nil {
-		seedObj, err = seed.NewFromName(k8sGardenClient, k8sGardenCoreInformers, *seedName)
-		if err != nil {
-			return nil, err
-		}
-		disableDNS = gardencorev1beta1helper.TaintsHave(seedObj.Info.Spec.Taints, gardencorev1beta1.SeedTaintDisableDNS)
-	}
-
-	renderer, err := chartrenderer.NewForConfig(k8sGardenClient.RESTConfig())
+	gardenerInfo, err := b.gardenerInfoFunc()
 	if err != nil {
 		return nil, err
 	}
-	applier, err := kubernetes.NewApplierForConfig(k8sGardenClient.RESTConfig())
+	operation.GardenerInfo = gardenerInfo
+
+	imageVector, err := b.imageVectorFunc()
 	if err != nil {
 		return nil, err
 	}
+	operation.ImageVector = imageVector
 
-	operation := &Operation{
-		Config:                 config,
-		Logger:                 logger,
-		GardenerInfo:           gardenerInfo,
-		Secrets:                secrets,
-		ImageVector:            imageVector,
-		CheckSums:              make(map[string]string),
-		Garden:                 gardenObj,
-		Seed:                   seedObj,
-		K8sGardenClient:        k8sGardenClient,
-		K8sGardenCoreInformers: k8sGardenCoreInformers,
-		ChartApplierGarden:     kubernetes.NewChartApplier(renderer, applier),
+	logger, err := b.loggerFunc()
+	if err != nil {
+		return nil, err
 	}
+	operation.Logger = logger
 
-	if shoot != nil {
-		shootObj, err := shootpkg.New(k8sGardenClient, k8sGardenCoreInformers, shoot, gardenObj.Project.Name, disableDNS, gardenObj.InternalDomain, gardenObj.DefaultDomains)
-		if err != nil {
-			return nil, err
-		}
-		operation.Shoot = shootObj
-		operation.Shoot.IgnoreAlerts = gardencorev1beta1helper.ShootIgnoresAlerts(shoot)
-		operation.Shoot.WantsAlertmanager = shootWantsAlertmanager(shoot, secrets) && !operation.Shoot.IgnoreAlerts
+	seed, err := b.seedFunc(ctx, k8sGardenClient.Client())
+	if err != nil {
+		return nil, err
+	}
+	operation.Seed = seed
 
-		shootedSeed, err := gardencorev1beta1helper.ReadShootedSeed(shoot)
-		if err != nil {
-			logger.Warnf("Cannot use shoot %s/%s as shooted seed: %+v", shoot.Namespace, shoot.Name, err)
-		} else {
-			operation.ShootedSeed = shootedSeed
-		}
+	shoot, err := b.shootFunc(ctx, k8sGardenClient.Client(), garden, seed)
+	if err != nil {
+		return nil, err
+	}
+	operation.Shoot = shoot
+
+	shootedSeed, err := gardencorev1beta1helper.ReadShootedSeed(shoot.Info)
+	if err != nil {
+		logger.Warnf("Cannot use shoot %s/%s as shooted seed: %+v", shoot.Info.Namespace, shoot.Info.Name, err)
+	} else {
+		operation.ShootedSeed = shootedSeed
 	}
 
 	return operation, nil
-}
-
-func shootWantsAlertmanager(shoot *gardencorev1beta1.Shoot, secrets map[string]*corev1.Secret) bool {
-	if shoot.Spec.Monitoring != nil && shoot.Spec.Monitoring.Alerting != nil && len(shoot.Spec.Monitoring.Alerting.EmailReceivers) > 0 {
-		return true
-	}
-	return false
 }
 
 // InitializeSeedClients will use the Garden Kubernetes client to read the Seed Secret in the Garden

--- a/pkg/operation/seed/types.go
+++ b/pkg/operation/seed/types.go
@@ -16,8 +16,15 @@ package seed
 
 import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
 	corev1 "k8s.io/api/core/v1"
 )
+
+// Builder is an object that builds Seed objects.
+type Builder struct {
+	seedObjectFunc func() (*gardencorev1beta1.Seed, error)
+	seedSecretFunc func(*corev1.SecretReference) (*corev1.Secret, error)
+}
 
 // Seed is an object containing information about a Seed cluster.
 type Seed struct {

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -15,6 +15,7 @@
 package shoot
 
 import (
+	"context"
 	"net"
 	"time"
 
@@ -24,7 +25,19 @@ import (
 	"github.com/gardener/gardener/pkg/operation/garden"
 
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// Builder is an object that builds Shoot objects.
+type Builder struct {
+	shootObjectFunc  func() (*gardencorev1beta1.Shoot, error)
+	cloudProfileFunc func(string) (*gardencorev1beta1.CloudProfile, error)
+	shootSecretFunc  func(context.Context, client.Client, string, string) (*corev1.Secret, error)
+	projectName      string
+	internalDomain   *garden.Domain
+	defaultDomains   []*garden.Domain
+	disableDNS       bool
+}
 
 // Shoot is an object containing information about a Shoot cluster.
 type Shoot struct {

--- a/pkg/operation/types.go
+++ b/pkg/operation/types.go
@@ -15,6 +15,7 @@
 package operation
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"net/http"
@@ -22,7 +23,6 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/operation/garden"
@@ -34,7 +34,20 @@ import (
 	prometheusclient "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// Builder is an object that builds Operation objects.
+type Builder struct {
+	configFunc       func() (*config.GardenletConfiguration, error)
+	gardenFunc       func(map[string]*corev1.Secret) (*garden.Garden, error)
+	gardenerInfoFunc func() (*gardencorev1beta1.Gardener, error)
+	imageVectorFunc  func() (imagevector.ImageVector, error)
+	loggerFunc       func() (*logrus.Entry, error)
+	secretsFunc      func() (map[string]*corev1.Secret, error)
+	seedFunc         func(context.Context, client.Client) (*seed.Seed, error)
+	shootFunc        func(context.Context, client.Client, *garden.Garden, *seed.Seed) (*shoot.Shoot, error)
+}
 
 // Operation contains all data required to perform an operation on a Shoot cluster.
 type Operation struct {
@@ -50,10 +63,8 @@ type Operation struct {
 	ShootState                *gardencorev1alpha1.ShootState
 	ShootedSeed               *gardencorev1beta1helper.ShootedSeed
 	K8sGardenClient           kubernetes.Interface
-	K8sGardenCoreInformers    gardencoreinformers.Interface
 	K8sSeedClient             kubernetes.Interface
 	K8sShootClient            kubernetes.Interface
-	ChartApplierGarden        kubernetes.ChartApplier
 	ChartApplierSeed          kubernetes.ChartApplier
 	ChartApplierShoot         kubernetes.ChartApplier
 	APIServerAddress          string


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors the `Cluster` synchronization to the seed when a shoot shall be reconciled or deleted. Earlier it was possible that the shoot's status is set to `Error` in case the `Cluster` sync failed even if the shoot is outside of its maintenance time window.

With this PR, we have refactored the way how `Garden`, `Seed`, `Shoot`, and `Operation` objects are built (using the builder pattern). Also, we have refactored the shoot controller to only sync the `Cluster` resource right before the reconciliation starts. In the `reconcileShoot` function it's also synced right after the reconciliation succeeded. Also, if a cluster has `Failed` status or shall be ignored the `Cluster` resource is synced in order to allow the extension controllers to get to know about this status.

/cc @timuthy

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
An issue that caused the `Shoot`'s `.status.lastOperation.state` to be set to `Error` although no actual reconciliation operation is executed for the `Shoot` has been fixed.
```
