### PR TITLE
Adding gVisor Integration tests 

### DIFF
--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -723,6 +723,13 @@ const (
 	CRINameContainerD CRIName = "containerd"
 )
 
+// ContainerRuntimeName is a type alias for the ContainerRuntime name string.
+type ContainerRuntimeName string
+
+const (
+	ContainerRuntimeGVisor ContainerRuntimeName = "gvisor"
+)
+
 // ContainerRuntime contains information about worker's available container runtime
 type ContainerRuntime struct {
 	// Type is the type of the Container Runtime.

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -880,6 +880,13 @@ const (
 	CRINameContainerD CRIName = "containerd"
 )
 
+// ContainerRuntimeName is a type alias for the ContainerRuntime name string.
+type ContainerRuntimeName string
+
+const (
+	ContainerRuntimeGVisor ContainerRuntimeName = "gvisor"
+)
+
 // ContainerRuntime contains information about worker's available container runtime
 type ContainerRuntime struct {
 	// Type is the type of the Container Runtime.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -877,6 +877,13 @@ const (
 	CRINameContainerD CRIName = "containerd"
 )
 
+// ContainerRuntimeName is a type alias for the ContainerRuntime name string.
+type ContainerRuntimeName string
+
+const (
+	ContainerRuntimeGVisor ContainerRuntimeName = "gvisor"
+)
+
 // ContainerRuntime contains information about worker's available container runtime
 type ContainerRuntime struct {
 	// Type is the type of the Container Runtime.


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding integration tests for the gVisor container runtime integration in Gardener.

To test for the first release of [gVisor extension](https://github.com/gardener/gardener-extension-runtime-gvisor) .

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Has the same suboptimal behaviour as discussed in this [PR](https://github.com/gardener/gardener/pull/2201#discussion_r411907231) - is restricted to Ubuntu OS. 
I think we can still go ahead with this PR as the already existing containerd integration test is configured the same way. As soon as there is a solution, these two integration tests can be easily adjusted. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
