### PR TITLE
Update Kubernetes dashboard + metrics-scraper versions

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -146,12 +146,12 @@ images:
 - name: kubernetes-dashboard
   sourceRepository: github.com/kubernetes/dashboard
   repository: kubernetesui/dashboard
-  tag: v2.0.0-beta8
+  tag: v2.0.0
   targetVersion: ">= 1.16"
 - name: kubernetes-dashboard-metrics-scraper
   sourceRepository: github.com/kubernetes/dashboard
   repository: kubernetesui/metrics-scraper
-  tag: v1.0.1
+  tag: v1.0.4
   targetVersion: ">= 1.16"
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx


### PR DESCRIPTION
**What this PR does / why we need it**:
Update Kubernetes dashboard to stable `v2.0.0` release

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The version of the Kubernetes Dashboard addon has been bumped to `v2.0.0`.
```
