### PR TITLE
Refactor interaction with extension CRs

### DIFF
--- a/pkg/api/extensions/accessor.go
+++ b/pkg/api/extensions/accessor.go
@@ -139,6 +139,20 @@ func nestedRawExtension(obj map[string]interface{}, fields ...string) *runtime.R
 	return rawExtension
 }
 
+// Get implements LastOperation.
+func (u unstructuredLastOperationAccessor) Get() *gardencorev1beta1.LastOperation {
+	val, ok, err := unstructured.NestedFieldNoCopy(u.UnstructuredContent(), "status", "lastOperation")
+	if err != nil || !ok {
+		return nil
+	}
+
+	lastOperation := &gardencorev1beta1.LastOperation{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(val.(map[string]interface{}), lastOperation); err != nil {
+		return nil
+	}
+	return lastOperation
+}
+
 // GetDescription implements LastOperation.
 func (u unstructuredLastOperationAccessor) GetDescription() string {
 	return nestedString(u.UnstructuredContent(), "status", "lastOperation", "description")
@@ -246,6 +260,20 @@ func (u unstructuredStatusAccessor) GetState() *runtime.RawExtension {
 		return nil
 	}
 	return raw
+}
+
+// Get implements LastError.
+func (u unstructuredLastErrorAccessor) Get() *gardencorev1beta1.LastError {
+	val, ok, err := unstructured.NestedFieldNoCopy(u.UnstructuredContent(), "status", "lastError")
+	if err != nil || !ok {
+		return nil
+	}
+
+	lastError := &gardencorev1beta1.LastError{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(val.(map[string]interface{}), lastError); err != nil {
+		return nil
+	}
+	return lastError
 }
 
 // GetDescription implements LastError.

--- a/pkg/apis/core/v1beta1/types_common.go
+++ b/pkg/apis/core/v1beta1/types_common.go
@@ -47,6 +47,11 @@ type LastError struct {
 	LastUpdateTime *metav1.Time `json:"lastUpdateTime,omitempty" protobuf:"bytes,4,opt,name=lastUpdateTime"`
 }
 
+// Get implements LastError.
+func (l *LastError) Get() *LastError {
+	return l
+}
+
 // GetDescription implements LastError.
 func (l *LastError) GetDescription() string {
 	return l.Description
@@ -112,6 +117,11 @@ type LastOperation struct {
 	State LastOperationState `json:"state" protobuf:"bytes,4,opt,name=state,casttype=LastOperationState"`
 	// Type of the last operation, one of Create, Reconcile, Delete.
 	Type LastOperationType `json:"type" protobuf:"bytes,5,opt,name=type,casttype=LastOperationType"`
+}
+
+// Get implements LastOperation.
+func (l *LastOperation) Get() *LastOperation {
+	return l
 }
 
 // GetDescription implements LastOperation.

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -43,6 +43,7 @@ type Status interface {
 
 // LastOperation is the last operation on an object.
 type LastOperation interface {
+	Get() *gardencorev1beta1.LastOperation
 	// GetDescription returns the description of the last operation.
 	GetDescription() string
 	// GetLastUpdateTime returns the last update time of the last operation.
@@ -57,6 +58,7 @@ type LastOperation interface {
 
 // LastError is the last error on an object.
 type LastError interface {
+	Get() *gardencorev1beta1.LastError
 	// GetDescription gets the description of the last occurred error.
 	GetDescription() string
 	// GetTaskID gets the task ID of the last error.
@@ -80,6 +82,8 @@ type Spec interface {
 // Object is an extension object resource.
 type Object interface {
 	metav1.Object
+	runtime.Object
+
 	// GetExtensionStatus retrieves the object's status.
 	GetExtensionStatus() Status
 	// GetExtensionSpec retrieves the object's spec.

--- a/pkg/operation/botanist/containerruntime.go
+++ b/pkg/operation/botanist/containerruntime.go
@@ -16,27 +16,18 @@ package botanist
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/flow"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
-	"github.com/gardener/gardener/pkg/utils/retry"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -44,34 +35,36 @@ import (
 // cluster. Deploys one resource per CRI per Worker.
 // Gardener waits until an external controller has reconciled the resources successfully.
 func (b *Botanist) DeployContainerRuntimeResources(ctx context.Context) error {
-	fns := []flow.TaskFn{}
-	for _, worker := range b.Shoot.Info.Spec.Provider.Workers {
-		if worker.CRI != nil {
-			for _, containerRuntime := range worker.CRI.ContainerRuntimes {
-				cr := containerRuntime
-				workerName := worker.Name
-				toApply := extensionsv1alpha1.ContainerRuntime{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      getContainerRuntimeKey(cr.Type, workerName),
-						Namespace: b.Shoot.SeedNamespace,
-					},
-				}
+	var fns []flow.TaskFn
 
-				fns = append(fns, func(ctx context.Context) error {
-					_, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), &toApply, func() error {
-						metav1.SetMetaDataAnnotation(&toApply.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-						toApply.Spec.BinaryPath = extensionsv1alpha1.ContainerDRuntimeContainersBinFolder
-						toApply.Spec.Type = cr.Type
-						if cr.ProviderConfig != nil {
-							toApply.Spec.ProviderConfig = &cr.ProviderConfig.RawExtension
-						}
-						toApply.Spec.WorkerPool.Name = workerName
-						toApply.Spec.WorkerPool.Selector.MatchLabels = map[string]string{gardencorev1beta1constants.LabelWorkerPool: workerName, gardencorev1beta1constants.LabelWorkerPoolDeprecated: workerName}
-						return nil
-					})
-					return err
-				})
+	for _, worker := range b.Shoot.Info.Spec.Provider.Workers {
+		if worker.CRI == nil {
+			continue
+		}
+
+		for _, containerRuntime := range worker.CRI.ContainerRuntimes {
+			cr := containerRuntime
+			toApply := extensionsv1alpha1.ContainerRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      getContainerRuntimeKey(cr.Type, worker.Name),
+					Namespace: b.Shoot.SeedNamespace,
+				},
 			}
+
+			fns = append(fns, func(ctx context.Context) error {
+				_, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), &toApply, func() error {
+					metav1.SetMetaDataAnnotation(&toApply.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+					toApply.Spec.BinaryPath = extensionsv1alpha1.ContainerDRuntimeContainersBinFolder
+					toApply.Spec.Type = cr.Type
+					if cr.ProviderConfig != nil {
+						toApply.Spec.ProviderConfig = &cr.ProviderConfig.RawExtension
+					}
+					toApply.Spec.WorkerPool.Name = worker.Name
+					toApply.Spec.WorkerPool.Selector.MatchLabels = map[string]string{gardencorev1beta1constants.LabelWorkerPool: worker.Name, gardencorev1beta1constants.LabelWorkerPoolDeprecated: worker.Name}
+					return nil
+				})
+				return err
+			})
 		}
 	}
 
@@ -86,34 +79,27 @@ func getContainerRuntimeKey(criType, workerName string) string {
 // The state must be reported before the passed context is cancelled or a container runtime's timeout has been reached.
 // As soon as one timeout has been overstepped the function returns an error, further waits on container runtime will be aborted.
 func (b *Botanist) WaitUntilContainerRuntimeResourcesReady(ctx context.Context) error {
-	fns := []flow.TaskFn{}
-
+	var fns []flow.TaskFn
 	for _, worker := range b.Shoot.Info.Spec.Provider.Workers {
-		if worker.CRI != nil {
-			for _, containerRuntime := range worker.CRI.ContainerRuntimes {
-				var (
-					name      = getContainerRuntimeKey(containerRuntime.Type, worker.Name)
-					namespace = b.Shoot.SeedNamespace
+		if worker.CRI == nil {
+			continue
+		}
+
+		for _, containerRuntime := range worker.CRI.ContainerRuntimes {
+			fns = append(fns, func(ctx context.Context) error {
+				return common.WaitUntilExtensionCRReady(
+					ctx,
+					b.K8sSeedClient.Client(),
+					b.Logger,
+					func() runtime.Object { return &extensionsv1alpha1.ContainerRuntime{} },
+					"ContainerRuntime",
+					b.Shoot.SeedNamespace,
+					getContainerRuntimeKey(containerRuntime.Type, worker.Name),
+					DefaultInterval,
+					shoot.ExtensionDefaultTimeout,
+					nil,
 				)
-				fns = append(fns, func(ctx context.Context) error {
-					if err := retry.UntilTimeout(ctx, DefaultInterval, shoot.ExtensionDefaultTimeout, func(ctx context.Context) (bool, error) {
-						req := &extensionsv1alpha1.ContainerRuntime{}
-						if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(namespace, name), req); err != nil {
-							return retry.SevereError(err)
-						}
-
-						if err := health.CheckExtensionObject(req); err != nil {
-							b.Logger.WithError(err).Errorf("Container runtime %s/%s did not get ready yet", namespace, name)
-							return retry.MinorError(err)
-						}
-
-						return retry.Ok()
-					}); err != nil {
-						return gardencorev1beta1helper.DetermineError(err, fmt.Sprintf("failed waiting for container runtime %s to be ready: %v", name, err))
-					}
-					return nil
-				})
-			}
+			})
 		}
 	}
 
@@ -140,83 +126,34 @@ func (b *Botanist) DeleteAllContainerRuntimeResources(ctx context.Context) error
 }
 
 func (b *Botanist) deleteContainerRuntimeResources(ctx context.Context, wantedContainerRuntimeTypes sets.String) error {
-	deployedContainerRuntimes := &extensionsv1alpha1.ContainerRuntimeList{}
-	if err := b.K8sSeedClient.Client().List(ctx, deployedContainerRuntimes, client.InNamespace(b.Shoot.SeedNamespace)); err != nil {
-		return err
-	}
-
-	fns := make([]flow.TaskFn, 0, meta.LenList(deployedContainerRuntimes))
-	for _, deployedContainerRuntime := range deployedContainerRuntimes.Items {
-		key := getContainerRuntimeKey(deployedContainerRuntime.Spec.Type, deployedContainerRuntime.Spec.WorkerPool.Name)
-		if !wantedContainerRuntimeTypes.Has(key) {
-			toDelete := &extensionsv1alpha1.ContainerRuntime{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      deployedContainerRuntime.Name,
-					Namespace: deployedContainerRuntime.Namespace,
-				},
+	return common.DeleteExtensionCRs(
+		ctx,
+		b.K8sSeedClient.Client(),
+		&extensionsv1alpha1.ContainerRuntimeList{},
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ContainerRuntime{} },
+		b.Shoot.SeedNamespace,
+		func(obj extensionsv1alpha1.Object) bool {
+			cr, ok := obj.(*extensionsv1alpha1.ContainerRuntime)
+			if !ok {
+				return false
 			}
-
-			fns = append(fns, func(ctx context.Context) error {
-				if err := common.ConfirmDeletion(ctx, b.K8sSeedClient.Client(), toDelete); err != nil {
-					return err
-				}
-
-				return client.IgnoreNotFound(b.K8sSeedClient.Client().Delete(ctx, toDelete, kubernetes.DefaultDeleteOptions...))
-			})
-		}
-	}
-
-	return flow.Parallel(fns...)(ctx)
+			return !wantedContainerRuntimeTypes.Has(getContainerRuntimeKey(cr.Spec.Type, cr.Spec.WorkerPool.Name))
+		},
+	)
 }
 
 // WaitUntilContainerRuntimeResourcesDeleted waits until all container runtime resources are gone or the context is cancelled.
 func (b *Botanist) WaitUntilContainerRuntimeResourcesDeleted(ctx context.Context) error {
-	var (
-		lastError         *gardencorev1beta1.LastError
-		containerRuntimes = &extensionsv1alpha1.ContainerRuntimeList{}
+	return common.WaitUntilExtensionCRsDeleted(
+		ctx,
+		b.K8sSeedClient.Client(),
+		b.Logger,
+		&extensionsv1alpha1.ContainerRuntimeList{},
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ContainerRuntime{} },
+		"ContainerRuntime",
+		b.Shoot.SeedNamespace,
+		DefaultInterval,
+		shoot.ExtensionDefaultTimeout,
+		nil,
 	)
-
-	if err := b.K8sSeedClient.Client().List(ctx, containerRuntimes, client.InNamespace(b.Shoot.SeedNamespace)); err != nil {
-		return err
-	}
-
-	fns := make([]flow.TaskFn, 0, len(containerRuntimes.Items))
-	for _, containerRuntime := range containerRuntimes.Items {
-		if containerRuntime.GetDeletionTimestamp() == nil {
-			continue
-		}
-
-		var (
-			name      = containerRuntime.Name
-			namespace = containerRuntime.Namespace
-		)
-
-		fns = append(fns, func(ctx context.Context) error {
-			if err := retry.UntilTimeout(ctx, DefaultInterval, shoot.ExtensionDefaultTimeout, func(ctx context.Context) (bool, error) {
-				retrievedContainerRuntime := extensionsv1alpha1.ContainerRuntime{}
-				if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(namespace, name), &retrievedContainerRuntime); err != nil {
-					if apierrors.IsNotFound(err) {
-						return retry.Ok()
-					}
-					return retry.SevereError(err)
-				}
-
-				if lastErr := retrievedContainerRuntime.Status.LastError; lastErr != nil {
-					b.Logger.Errorf("Container runtime %s did not get deleted yet, lastError is: %s", name, lastErr.Description)
-					lastError = lastErr
-				}
-
-				return retry.MinorError(gardencorev1beta1helper.WrapWithLastError(fmt.Errorf("container runtime %s is still present", name), lastError))
-			}); err != nil {
-				message := "Failed waiting for container runtime delete"
-				if lastError != nil {
-					return gardencorev1beta1helper.DetermineError(errors.New(lastError.Description), fmt.Sprintf("%s: %s", message, lastError.Description))
-				}
-				return gardencorev1beta1helper.DetermineError(err, fmt.Sprintf("%s: %s", message, err.Error()))
-			}
-			return nil
-		})
-	}
-
-	return flow.Parallel(fns...)(ctx)
 }

--- a/pkg/operation/botanist/extension.go
+++ b/pkg/operation/botanist/extension.go
@@ -16,26 +16,16 @@ package botanist
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/flow"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
-	"github.com/gardener/gardener/pkg/utils/retry"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -76,27 +66,19 @@ func (b *Botanist) DeployExtensionResources(ctx context.Context) error {
 func (b *Botanist) WaitUntilExtensionResourcesReady(ctx context.Context) error {
 	fns := make([]flow.TaskFn, 0, len(b.Shoot.Extensions))
 	for _, extension := range b.Shoot.Extensions {
-		var (
-			name      = extension.Name
-			namespace = extension.Namespace
-		)
 		fns = append(fns, func(ctx context.Context) error {
-			if err := retry.UntilTimeout(ctx, DefaultInterval, shoot.ExtensionDefaultTimeout, func(ctx context.Context) (bool, error) {
-				req := &extensionsv1alpha1.Extension{}
-				if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(namespace, name), req); err != nil {
-					return retry.SevereError(err)
-				}
-
-				if err := health.CheckExtensionObject(req); err != nil {
-					b.Logger.WithError(err).Errorf("Extension %s/%s did not get ready yet", namespace, name)
-					return retry.MinorError(err)
-				}
-
-				return retry.Ok()
-			}); err != nil {
-				return gardencorev1beta1helper.DetermineError(err, fmt.Sprintf("failed waiting for extension %s to be ready: %v", name, err))
-			}
-			return nil
+			return common.WaitUntilExtensionCRReady(
+				ctx,
+				b.K8sSeedClient.Client(),
+				b.Logger,
+				func() runtime.Object { return &extensionsv1alpha1.Extension{} },
+				"Extension",
+				extension.Namespace,
+				extension.Name,
+				DefaultInterval,
+				shoot.ExtensionDefaultTimeout,
+				nil,
+			)
 		})
 	}
 
@@ -118,82 +100,30 @@ func (b *Botanist) DeleteAllExtensionResources(ctx context.Context) error {
 }
 
 func (b *Botanist) deleteExtensionResources(ctx context.Context, wantedExtensionTypes sets.String) error {
-	deployedExtensions := &extensionsv1alpha1.ExtensionList{}
-	if err := b.K8sSeedClient.Client().List(ctx, deployedExtensions, client.InNamespace(b.Shoot.SeedNamespace)); err != nil {
-		return err
-	}
-
-	fns := make([]flow.TaskFn, 0, meta.LenList(deployedExtensions))
-	for _, deployedExtension := range deployedExtensions.Items {
-		if !wantedExtensionTypes.Has(deployedExtension.Spec.Type) {
-			toDelete := &extensionsv1alpha1.Extension{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      deployedExtension.Name,
-					Namespace: deployedExtension.Namespace,
-				},
-			}
-
-			fns = append(fns, func(ctx context.Context) error {
-				if err := common.ConfirmDeletion(ctx, b.K8sSeedClient.Client(), toDelete); err != nil {
-					return err
-				}
-
-				return client.IgnoreNotFound(b.K8sSeedClient.Client().Delete(ctx, toDelete, kubernetes.DefaultDeleteOptions...))
-			})
-		}
-	}
-
-	return flow.Parallel(fns...)(ctx)
+	return common.DeleteExtensionCRs(
+		ctx,
+		b.K8sSeedClient.Client(),
+		&extensionsv1alpha1.ExtensionList{},
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Extension{} },
+		b.Shoot.SeedNamespace,
+		func(obj extensionsv1alpha1.Object) bool {
+			return !wantedExtensionTypes.Has(obj.GetExtensionSpec().GetExtensionType())
+		},
+	)
 }
 
 // WaitUntilExtensionResourcesDeleted waits until all extension resources are gone or the context is cancelled.
 func (b *Botanist) WaitUntilExtensionResourcesDeleted(ctx context.Context) error {
-	var (
-		lastError  *gardencorev1beta1.LastError
-		extensions = &extensionsv1alpha1.ExtensionList{}
+	return common.WaitUntilExtensionCRsDeleted(
+		ctx,
+		b.K8sSeedClient.Client(),
+		b.Logger,
+		&extensionsv1alpha1.ExtensionList{},
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Extension{} },
+		"Extension",
+		b.Shoot.SeedNamespace,
+		DefaultInterval,
+		shoot.ExtensionDefaultTimeout,
+		nil,
 	)
-
-	if err := b.K8sSeedClient.Client().List(ctx, extensions, client.InNamespace(b.Shoot.SeedNamespace)); err != nil {
-		return err
-	}
-
-	fns := make([]flow.TaskFn, 0, len(extensions.Items))
-	for _, extension := range extensions.Items {
-		if extension.GetDeletionTimestamp() == nil {
-			continue
-		}
-
-		var (
-			name      = extension.Name
-			namespace = extension.Namespace
-			status    = extension.Status
-		)
-
-		fns = append(fns, func(ctx context.Context) error {
-			if err := retry.UntilTimeout(ctx, DefaultInterval, shoot.ExtensionDefaultTimeout, func(ctx context.Context) (bool, error) {
-				if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(namespace, name), &extensionsv1alpha1.Extension{}); err != nil {
-					if apierrors.IsNotFound(err) {
-						return retry.Ok()
-					}
-					return retry.SevereError(err)
-				}
-
-				if lastErr := status.LastError; lastErr != nil {
-					b.Logger.Errorf("Extension %s did not get deleted yet, lastError is: %s", name, lastErr.Description)
-					lastError = lastErr
-				}
-
-				return retry.MinorError(gardencorev1beta1helper.WrapWithLastError(fmt.Errorf("extension %s is still present", name), lastError))
-			}); err != nil {
-				message := "Failed waiting for extension delete"
-				if lastError != nil {
-					return gardencorev1beta1helper.DetermineError(errors.New(lastError.Description), fmt.Sprintf("%s: %s", message, lastError.Description))
-				}
-				return gardencorev1beta1helper.DetermineError(err, fmt.Sprintf("%s: %s", message, err.Error()))
-			}
-			return nil
-		})
-	}
-
-	return flow.Parallel(fns...)(ctx)
 }

--- a/pkg/operation/common/extensions.go
+++ b/pkg/operation/common/extensions.go
@@ -1,0 +1,263 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/gardener/gardener/pkg/api/extensions"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/flow"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	"github.com/gardener/gardener/pkg/utils/retry"
+
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// WaitUntilExtensionCRReady waits until the given extension resource has become ready.
+func WaitUntilExtensionCRReady(
+	ctx context.Context,
+	c client.Client,
+	logger *logrus.Entry,
+	newObjFunc func() runtime.Object,
+	kind string,
+	namespace string,
+	name string,
+	interval time.Duration,
+	timeout time.Duration,
+	postReadyFunc func(runtime.Object) error,
+) error {
+	return WaitUntilObjectReadyWithHealthFunction(
+		ctx,
+		c,
+		logger,
+		health.CheckExtensionObject,
+		newObjFunc,
+		kind,
+		namespace,
+		name,
+		interval,
+		timeout,
+		postReadyFunc,
+	)
+}
+
+// WaitUntilObjectReadyWithHealthFunction waits until the given resource has become ready. It takes the health check
+// function that should be executed.
+func WaitUntilObjectReadyWithHealthFunction(
+	ctx context.Context,
+	c client.Client,
+	logger *logrus.Entry,
+	healthFunc func(obj runtime.Object) error,
+	newObjFunc func() runtime.Object,
+	kind string,
+	namespace string,
+	name string,
+	interval time.Duration,
+	timeout time.Duration,
+	postReadyFunc func(runtime.Object) error,
+) error {
+	if err := retry.UntilTimeout(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
+		obj := newObjFunc()
+		if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj); err != nil {
+			return retry.SevereError(err)
+		}
+
+		if err := healthFunc(obj); err != nil {
+			logger.WithError(err).Errorf("%s did not get ready yet", extensionKey(kind, namespace, name))
+			return retry.MinorError(err)
+		}
+
+		if postReadyFunc != nil {
+			if err := postReadyFunc(obj); err != nil {
+				return retry.SevereError(err)
+			}
+		}
+
+		return retry.Ok()
+	}); err != nil {
+		return gardencorev1beta1helper.DetermineError(err, fmt.Sprintf("Error while waiting for %s to become ready: %v", extensionKey(kind, namespace, name), err))
+	}
+	return nil
+}
+
+// DeleteExtensionCR deletes an extension resource.
+func DeleteExtensionCR(
+	ctx context.Context,
+	c client.Client,
+	newObjFunc func() extensionsv1alpha1.Object,
+	namespace string,
+	name string,
+) error {
+	obj := newObjFunc()
+	obj.SetNamespace(namespace)
+	obj.SetName(name)
+
+	if err := ConfirmDeletion(ctx, c, obj); err != nil {
+		return err
+	}
+
+	return client.IgnoreNotFound(c.Delete(ctx, obj, kubernetes.DefaultDeleteOptions...))
+}
+
+// DeleteExtensionCRs lists all extension resources and loops over them. It executes the given <predicateFunc> for each
+// of them, and if it evaluates to true then the resource will be deleted.
+func DeleteExtensionCRs(
+	ctx context.Context,
+	c client.Client,
+	listObj runtime.Object,
+	newObjFunc func() extensionsv1alpha1.Object,
+	namespace string,
+	predicateFunc func(obj extensionsv1alpha1.Object) bool,
+) error {
+	if err := c.List(ctx, listObj, client.InNamespace(namespace)); err != nil {
+		return err
+	}
+
+	fns := make([]flow.TaskFn, 0, meta.LenList(listObj))
+
+	if err := meta.EachListItem(listObj, func(obj runtime.Object) error {
+		o, ok := obj.(extensionsv1alpha1.Object)
+		if !ok {
+			return fmt.Errorf("expected extensionsv1alpha1.Object but got %T", obj)
+		}
+
+		if predicateFunc != nil && predicateFunc(o) {
+			fns = append(fns, func(ctx context.Context) error {
+				return DeleteExtensionCR(ctx, c, newObjFunc, o.GetNamespace(), o.GetName())
+			})
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return flow.Parallel(fns...)(ctx)
+}
+
+// WaitUntilExtensionCRsDeleted lists all extension resources and loops over them. It executes the given <predicateFunc>
+// for each of them, and if it evaluates to true then it waits for the resource to be deleted.
+func WaitUntilExtensionCRsDeleted(
+	ctx context.Context,
+	c client.Client,
+	logger *logrus.Entry,
+	listObj runtime.Object,
+	newObjFunc func() extensionsv1alpha1.Object,
+	kind string,
+	namespace string,
+	interval time.Duration,
+	timeout time.Duration,
+	predicateFunc func(obj extensionsv1alpha1.Object) bool,
+) error {
+	if err := c.List(ctx, listObj, client.InNamespace(namespace)); err != nil {
+		return err
+	}
+
+	fns := make([]flow.TaskFn, 0, meta.LenList(listObj))
+
+	if err := meta.EachListItem(listObj, func(obj runtime.Object) error {
+		o, ok := obj.(extensionsv1alpha1.Object)
+		if !ok {
+			return fmt.Errorf("expected extensionsv1alpha1.Object but got %T", obj)
+		}
+
+		if o.GetDeletionTimestamp() == nil {
+			return nil
+		}
+
+		if predicateFunc != nil && predicateFunc(o) {
+			fns = append(fns, func(ctx context.Context) error {
+				return WaitUntilExtensionCRDeleted(
+					ctx,
+					c,
+					logger,
+					newObjFunc,
+					kind,
+					o.GetNamespace(),
+					o.GetName(),
+					interval,
+					timeout,
+				)
+			})
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return flow.Parallel(fns...)(ctx)
+}
+
+// WaitUntilExtensionCRDeleted waits until an extension resource is deleted from the system.
+func WaitUntilExtensionCRDeleted(
+	ctx context.Context,
+	c client.Client,
+	logger *logrus.Entry,
+	newObjFunc func() extensionsv1alpha1.Object,
+	kind string,
+	namespace string,
+	name string,
+	interval time.Duration,
+	timeout time.Duration,
+) error {
+	var lastError *gardencorev1beta1.LastError
+
+	if err := retry.UntilTimeout(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
+		obj := newObjFunc()
+		if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj); err != nil {
+			if apierrors.IsNotFound(err) {
+				return retry.Ok()
+			}
+			return retry.SevereError(err)
+		}
+
+		acc, err := extensions.Accessor(obj)
+		if err != nil {
+			return retry.SevereError(err)
+		}
+
+		if lastErr := acc.GetExtensionStatus().GetLastError(); lastErr != nil {
+			logger.Errorf("%s did not get deleted yet, lastError is: %s", extensionKey(kind, namespace, name), lastErr.GetDescription())
+			lastError = lastErr.Get()
+		}
+
+		logger.Infof("Waiting for %s %s/%s to be deleted...", kind, namespace, name)
+		return retry.MinorError(gardencorev1beta1helper.WrapWithLastError(fmt.Errorf("%s is still present", extensionKey(kind, namespace, name)), lastError))
+	}); err != nil {
+		message := fmt.Sprintf("Failed to delete %s", extensionKey(kind, namespace, name))
+		if lastError != nil {
+			return gardencorev1beta1helper.DetermineError(errors.New(lastError.Description), fmt.Sprintf("%s: %s", message, lastError.Description))
+		}
+		return gardencorev1beta1helper.DetermineError(err, fmt.Sprintf("%s: %s", message, err.Error()))
+	}
+
+	return nil
+}
+
+func extensionKey(kind, namespace, name string) string {
+	return fmt.Sprintf("%s %s/%s", kind, namespace, name)
+}

--- a/pkg/utils/kubernetes/health/health_suite_test.go
+++ b/pkg/utils/kubernetes/health/health_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestHealth(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Health Suite")
+}

--- a/pkg/utils/kubernetes/health/health_test.go
+++ b/pkg/utils/kubernetes/health/health_test.go
@@ -15,8 +15,6 @@
 package health_test
 
 import (
-	"testing"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -34,11 +32,6 @@ import (
 
 func replicas(i int32) *int32 {
 	return &i
-}
-
-func TestHealth(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Health Suite")
 }
 
 var _ = Describe("health", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
We had duplicated the logic for deletion, waiting for readiness, and waiting for deletion multiple times for the various extension resources. This PR maintains the relevant code only once and makes it callable/reusable to prevent this duplication.

**Special notes for your reviewer**:
/kind cleanup

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
