### PR TITLE
Add ContainerRuntime to extension healthcheck

### DIFF
--- a/extensions/test/integration/healthcheck/healthcheck_operation.go
+++ b/extensions/test/integration/healthcheck/healthcheck_operation.go
@@ -40,8 +40,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ControlPlaneHealthCheckWithManagedResource is a convenience function to tests that an unhealthy condition in a given ManagedResource leads to an unhealthy health check condition in the given ControlPlane CRD.
 func ControlPlaneHealthCheckWithManagedResource(ctx context.Context, timeout time.Duration, f *framework.ShootFramework, managedResourceName string, healthConditionType gardencorev1beta1.ConditionType) error {
-	return testHealthCheckWithManagedResource(
+	return TestHealthCheckWithManagedResource(
 		ctx,
 		timeout,
 		f,
@@ -51,8 +52,9 @@ func ControlPlaneHealthCheckWithManagedResource(ctx context.Context, timeout tim
 		healthConditionType)
 }
 
+// WorkerHealthCheckWithManagedResource is a convenience function to tests that an unhealthy condition in a given ManagedResource leads to an unhealthy health check condition in the given Worker CRD.
 func WorkerHealthCheckWithManagedResource(ctx context.Context, timeout time.Duration, f *framework.ShootFramework, managedResourceName string, healthConditionType gardencorev1beta1.ConditionType) error {
-	return testHealthCheckWithManagedResource(
+	return TestHealthCheckWithManagedResource(
 		ctx,
 		timeout,
 		f,
@@ -62,8 +64,9 @@ func WorkerHealthCheckWithManagedResource(ctx context.Context, timeout time.Dura
 		healthConditionType)
 }
 
+// NetworkHealthCheckWithManagedResource is a convenience function to tests that an unhealthy condition in a given ManagedResource leads to an unhealthy health check condition in the given Network CRD.
 func NetworkHealthCheckWithManagedResource(ctx context.Context, timeout time.Duration, f *framework.ShootFramework, managedResourceName string, healthConditionType gardencorev1beta1.ConditionType) error {
-	return testHealthCheckWithManagedResource(
+	return TestHealthCheckWithManagedResource(
 		ctx,
 		timeout,
 		f,
@@ -73,8 +76,9 @@ func NetworkHealthCheckWithManagedResource(ctx context.Context, timeout time.Dur
 		healthConditionType)
 }
 
+// ExtensionHealthCheckWithManagedResource is a convenience function to tests that an unhealthy condition in a given ManagedResource leads to an unhealthy health check condition in the given Extension CRD.
 func ExtensionHealthCheckWithManagedResource(ctx context.Context, timeout time.Duration, f *framework.ShootFramework, extensionName string, managedResourceName string, healthConditionType gardencorev1beta1.ConditionType) error {
-	return testHealthCheckWithManagedResource(
+	return TestHealthCheckWithManagedResource(
 		ctx,
 		timeout,
 		f,
@@ -84,7 +88,23 @@ func ExtensionHealthCheckWithManagedResource(ctx context.Context, timeout time.D
 		healthConditionType)
 }
 
-func testHealthCheckWithManagedResource(ctx context.Context, timeout time.Duration, f *framework.ShootFramework, extensionKind schema.GroupVersionKind, extensionName string, managedResourceName string, healthConditionType gardencorev1beta1.ConditionType) error {
+// ContainerRuntimeHealthCheckWithManagedResource is a convenience function to tests that an unhealthy condition in a given ManagedResource leads to an unhealthy health check condition in the given ContainerRuntime CRD.
+func ContainerRuntimeHealthCheckWithManagedResource(ctx context.Context, timeout time.Duration, f *framework.ShootFramework, extensionName string, managedResourceName string, healthConditionType gardencorev1beta1.ConditionType) error {
+	return TestHealthCheckWithManagedResource(
+		ctx,
+		timeout,
+		f,
+		extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.ContainerRuntimeResource),
+		extensionName,
+		managedResourceName,
+		healthConditionType)
+}
+
+// TestHealthCheckWithManagedResource tests that an unhealthy condition in a given ManagedResource leads to an unhealthy health check condition in the given CRD.
+// To be able to manipulate the ManagedResource with an unhealthy condition, the function needs to scale down the Gardener Resource Manager.
+// After the unhealthy condition is observed in the Extension CRD, the function scales up the Gardener Resource Manager again and waits for the ManagedResource to be healthy.
+// This function is used by integration tests of Gardener extensions to check their health checks on ManagedResources.
+func TestHealthCheckWithManagedResource(ctx context.Context, timeout time.Duration, f *framework.ShootFramework, extensionKind schema.GroupVersionKind, extensionName string, managedResourceName string, healthConditionType gardencorev1beta1.ConditionType) error {
 	var (
 		err                                              error
 		resourceManagerDeploymentReplicasBeforeScaledown *int32


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding the function ContainerRuntimeHealthCheckWithManagedResource() that can be used from gardener-extensions that reconcile ContainerRuntimes to create HealthChecks for managed resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Also exporting function ContainerRuntimeHealthCheckWithManagedResource() as I do not see a reason to hide it - in case an extension wants to call it directly.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
