### PR TITLE
Remove shoot tasks only if executed

### DIFF
--- a/pkg/controllerutils/miscellaneous_test.go
+++ b/pkg/controllerutils/miscellaneous_test.go
@@ -27,18 +27,39 @@ import (
 
 var _ = Describe("controller", func() {
 	Describe("utils", func() {
-		DescribeTable("#AddTask",
+		DescribeTable("#GetTasks",
+			func(existingTasks map[string]string, expectedResult []string) {
+				result := controllerutils.GetTasks(existingTasks)
+				Expect(result).To(Equal(expectedResult))
+			},
+
+			Entry("absent task annotation", map[string]string{}, nil),
+			Entry("empty task list", map[string]string{common.ShootTasks: ""}, nil),
+			Entry("task list", map[string]string{common.ShootTasks: "some-task" + "," + common.ShootTaskDeployInfrastructure},
+				[]string{"some-task", common.ShootTaskDeployInfrastructure}),
+		)
+
+		DescribeTable("#AddTasks",
 			func(existingTasks map[string]string, tasks []string, expectedTasks []string) {
 				controllerutils.AddTasks(existingTasks, tasks...)
-				shootTasks := existingTasks[common.ShootTasks]
-				Expect(strings.Split(shootTasks, ",")).To(Equal(expectedTasks))
+
+				if expectedTasks == nil {
+					Expect(existingTasks[common.ShootTasks]).To(BeEmpty())
+				} else {
+					Expect(strings.Split(existingTasks[common.ShootTasks], ",")).To(Equal(expectedTasks))
+				}
 			},
+
 			Entry("task to absent annotation", map[string]string{},
 				[]string{common.ShootTaskDeployInfrastructure}, []string{common.ShootTaskDeployInfrastructure}),
 			Entry("tasks to empty list", map[string]string{},
 				[]string{common.ShootTaskDeployInfrastructure}, []string{common.ShootTaskDeployInfrastructure}),
-			Entry("task to empty list", map[string]string{common.ShootTaskDeployInfrastructure: ""},
+			Entry("task to empty list", map[string]string{"foo": "bar"},
 				[]string{common.ShootTaskDeployInfrastructure}, []string{common.ShootTaskDeployInfrastructure}),
+			Entry("no task to empty list", map[string]string{},
+				[]string{}, nil),
+			Entry("no task to empty list", map[string]string{"foo": "bar"},
+				[]string{}, nil),
 			Entry("task to empty list twice", map[string]string{},
 				[]string{common.ShootTaskDeployInfrastructure, common.ShootTaskDeployInfrastructure}, []string{common.ShootTaskDeployInfrastructure}),
 			Entry("tasks to filled list", map[string]string{common.ShootTasks: common.ShootTaskDeployInfrastructure},
@@ -47,11 +68,43 @@ var _ = Describe("controller", func() {
 				[]string{"some-task", common.ShootTaskDeployInfrastructure}, []string{common.ShootTaskDeployInfrastructure, "some-task"}),
 		)
 
+		DescribeTable("#RemoveTasks",
+			func(existingTasks map[string]string, tasks []string, expectedTasks []string) {
+				controllerutils.RemoveTasks(existingTasks, tasks...)
+
+				if expectedTasks == nil {
+					Expect(existingTasks[common.ShootTasks]).To(BeEmpty())
+				} else {
+					Expect(strings.Split(existingTasks[common.ShootTasks], ",")).To(Equal(expectedTasks))
+				}
+			},
+
+			Entry("task from absent annotation", map[string]string{},
+				[]string{common.ShootTaskDeployInfrastructure}, nil),
+			Entry("tasks from empty list", map[string]string{},
+				[]string{common.ShootTaskDeployInfrastructure}, nil),
+			Entry("task from empty list", map[string]string{"foo": "bar"},
+				[]string{common.ShootTaskDeployInfrastructure}, nil),
+			Entry("no task from empty list", map[string]string{},
+				[]string{}, nil),
+			Entry("no task from empty list", map[string]string{"foo": "bar"},
+				[]string{}, nil),
+			Entry("task from empty list twice", map[string]string{},
+				[]string{common.ShootTaskDeployInfrastructure, common.ShootTaskDeployInfrastructure}, nil),
+			Entry("non-existing tasks from filled list", map[string]string{common.ShootTasks: common.ShootTaskDeployInfrastructure},
+				[]string{"some-task"}, []string{common.ShootTaskDeployInfrastructure}),
+			Entry("existing task from filled list", map[string]string{common.ShootTasks: common.ShootTaskDeployInfrastructure + ",foo"},
+				[]string{common.ShootTaskDeployInfrastructure}, []string{"foo"}),
+			Entry("all existing tasks from filled list", map[string]string{common.ShootTasks: common.ShootTaskDeployInfrastructure + ",foo"},
+				[]string{"foo", common.ShootTaskDeployInfrastructure}, nil),
+		)
+
 		DescribeTable("#HasTask",
 			func(existingTasks map[string]string, task string, expectedResult bool) {
 				result := controllerutils.HasTask(existingTasks, task)
 				Expect(result).To(Equal(expectedResult))
 			},
+
 			Entry("absent task annotation", map[string]string{}, common.ShootTaskDeployInfrastructure, false),
 			Entry("empty task list", map[string]string{common.ShootTasks: ""}, common.ShootTaskDeployInfrastructure, false),
 			Entry("task not in list", map[string]string{common.ShootTasks: "some-task" + "," + "dummyTask"}, common.ShootTaskDeployInfrastructure, false),


### PR DESCRIPTION
**What this PR does / why we need it**:
The shoot reconciliation flow was removing the tasks annotation at the end of a successful shoot reconciliation, no matter whether it actually respected it in this shoot reconciliation.
This lead to race conditions if new tasks were added while an existing reconciliation is in progress. Concretely, sometimes the shoot-maintenance was not executed completely. The shoot reconciliation started a second time, however, without any tasks as they were removed from the first reconcilation.
This PR changes the behaviour so that only tasks are removed if they were really executed.

**Which issue(s) this PR fixes**:
Fixes #2228

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A race condition that led to incomplete maintenance operations for shoot clusters has been fixed.
```
