### PR TITLE
Fix the CRI label on the Shoot Node

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -706,8 +706,6 @@ golang.org/x/tools v0.0.0-20191203134012-c197fd4bf371/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191216173652-a0e659d51361/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20191230220329-2aa90c603ae3 h1:2+KluhQfJ1YhW+TB1KrISS2SfiG1pLEoseB0D4VF/bo=
 golang.org/x/tools v0.0.0-20191230220329-2aa90c603ae3/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20200422022333-3d57cf2e726e h1:3Dzrrxi54Io7Aoyb0PYLsI47K2TxkRQg+cqUn+m04do=
-golang.org/x/tools v0.0.0-20200422022333-3d57cf2e726e/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200422205258-72e4a01eba43 h1:Lcsc5ErIWemp8qAbYffG5vPrqjJ0zk82RTFGifeS1Pc=
 golang.org/x/tools v0.0.0-20200422205258-72e4a01eba43/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -94,11 +94,13 @@ func (b *Botanist) DeployWorker(ctx context.Context) error {
 		workerPool.Labels[v1beta1constants.LabelWorkerPoolDeprecated] = workerPool.Name
 
 		// add CRI labels selected by the RuntimeClass
-		if workerPool.CRI != nil && len(workerPool.CRI.ContainerRuntimes) > 0 {
+		if workerPool.CRI != nil {
 			workerPool.Labels[extensionsv1alpha1.CRINameWorkerLabel] = string(workerPool.CRI.Name)
-			for _, cr := range workerPool.CRI.ContainerRuntimes {
-				key := fmt.Sprintf(extensionsv1alpha1.ContainerRuntimeNameWorkerLabel, cr.Type)
-				workerPool.Labels[key] = "true"
+			if len(workerPool.CRI.ContainerRuntimes) > 0 {
+				for _, cr := range workerPool.CRI.ContainerRuntimes {
+					key := fmt.Sprintf(extensionsv1alpha1.ContainerRuntimeNameWorkerLabel, cr.Type)
+					workerPool.Labels[key] = "true"
+				}
 			}
 		}
 

--- a/vendor/golang.org/x/tools/internal/gocommand/invoke.go
+++ b/vendor/golang.org/x/tools/internal/gocommand/invoke.go
@@ -39,7 +39,7 @@ func (runner *Runner) Run(ctx context.Context, inv Invocation) (*bytes.Buffer, e
 	return stdout, friendly
 }
 
-// Run calls Innvocation.RunRaw, serializing requests if they fight over
+// RunRaw calls Invocation.runRaw, serializing requests if they fight over
 // go.mod changes.
 func (runner *Runner) RunRaw(ctx context.Context, inv Invocation) (*bytes.Buffer, *bytes.Buffer, error, error) {
 	// We want to run invocations concurrently as much as possible. However,
@@ -93,6 +93,7 @@ func (i *Invocation) runRaw(ctx context.Context) (stdout *bytes.Buffer, stderr *
 	stderr = &bytes.Buffer{}
 	rawError = i.RunPiped(ctx, stdout, stderr)
 	if rawError != nil {
+		friendlyError = rawError
 		// Check for 'go' executable not being found.
 		if ee, ok := rawError.(*exec.Error); ok && ee.Err == exec.ErrNotFound {
 			friendlyError = fmt.Errorf("go command required, not found: %v", ee)
@@ -100,7 +101,7 @@ func (i *Invocation) runRaw(ctx context.Context) (stdout *bytes.Buffer, stderr *
 		if ctx.Err() != nil {
 			friendlyError = ctx.Err()
 		}
-		friendlyError = fmt.Errorf("err: %v: stderr: %s", rawError, stderr)
+		friendlyError = fmt.Errorf("err: %v: stderr: %s", friendlyError, stderr)
 	}
 	return
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -485,7 +485,7 @@ golang.org/x/text/unicode/norm
 golang.org/x/text/width
 # golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 golang.org/x/time/rate
-# golang.org/x/tools v0.0.0-20200422022333-3d57cf2e726e
+# golang.org/x/tools v0.0.0-20200422205258-72e4a01eba43
 golang.org/x/tools/go/analysis
 golang.org/x/tools/go/analysis/passes/inspect
 golang.org/x/tools/go/ast/astutil


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the CRI label is not added to the Worker CRD if the Shoot does only specify Worker.CRI.Name, but not Worker.CRI.ContainerRuntimes
> worker.gardener.cloud/cri-name: containerd

Does not add the required label
```yaml
cri:
  name: containerd
```

Adds the required label:
```yaml
cri:
  name: containerd
  containerRuntimes:
    - type: gvisor
```

This bug was introduced [in this commit](https://github.com/gardener/gardener/commit/93f83ee4124848ac0b26564cb25aa347f8e5f10d).
In retrospective it was undetected as the testing was happening with a gVisor enabled Shoot.
On the bright side, the [recently integration tests](https://github.com/gardener/gardener/commit/8e3d17411d18ef602701212796b83c02fc3d4502) catched the issue. We need more integration tests :) 




**Which issue(s) this PR fixes**:
Fixes #2232

**Special notes for your reviewer**:

Not having the CRI label on the Shoot nodes is currently not breaking anything. However, it makes it impossible to have selectors on the containerd enabled nodes (would require knowledge about the node  pools).

Revendoring on the current master branch changed go.sum etc?
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixes a bug that prevented proper labeling of worker pool-nodes that have CRI enabled.
```
