### PR TITLE
Fix the default dns assignment issue of `metadata.generateName`

### DIFF
--- a/plugin/pkg/shoot/dns/admission_test.go
+++ b/plugin/pkg/shoot/dns/admission_test.go
@@ -471,6 +471,91 @@ var _ = Describe("dns", func() {
 
 				Expect(err).To(MatchError(apierrors.NewBadRequest("shoot domain field .spec.dns.domain must be set if provider != unmanaged and assigned to a seed which does not disable DNS")))
 			})
+
+			Context("#Shoot GenerateName used", func() {
+				BeforeEach(func() {
+					shoot.Name = ""
+					shoot.GenerateName = "demo-"
+				})
+
+				It("should set different default domain for multiple shoots with same generate name", func() {
+					shootCopy := shoot.DeepCopy()
+
+					Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&defaultDomainSecret)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+					Expect(err).To(Not(HaveOccurred()))
+
+					Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&defaultDomainSecret)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					attrs = admission.NewAttributesRecord(shootCopy, nil, core.Kind("Shoot").WithVersion("version"), shootCopy.Namespace, shootCopy.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+					err = admissionHandler.Admit(context.TODO(), attrs, nil)
+
+					Expect(err).To(Not(HaveOccurred()))
+
+					Expect(*shoot.Spec.DNS.Domain).NotTo(Equal(*shootCopy.Spec.DNS.Domain))
+				})
+
+				It("should generate a default domain with shoot name for the shoot (no domain)", func() {
+					shoot.Name = "foo"
+					Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&defaultDomainSecret)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(shoot.Spec.DNS.Providers).To(BeNil())
+					Expect(*shoot.Spec.DNS.Domain).To(Equal(fmt.Sprintf("%s.%s.%s", shoot.Name, projectName, domain)))
+				})
+
+				It("should pass because a default domain was generated for the shoot (no domain)", func() {
+					Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&defaultDomainSecret)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(shoot.Spec.DNS.Providers).To(BeNil())
+					Expect(*shoot.Spec.DNS.Domain).To(HaveSuffix(fmt.Sprintf(".%s.%s", projectName, domain)))
+				})
+
+				It("should reject because a default domain was already used for the shoot but is invalid (with domain)", func() {
+					shootDomain := fmt.Sprintf("%s.other-project.%s", shoot.Name, domain)
+					shoot.Spec.DNS.Domain = &shootDomain
+
+					Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&defaultDomainSecret)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("should not reject shoots using a non compliant default domain on updates", func() {
+					shootDomain := fmt.Sprintf("%s.other-project.%s", shoot.Name, domain)
+					shoot.Spec.DNS.Domain = &shootDomain
+
+					Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(&defaultDomainSecret)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					attrs := admission.NewAttributesRecord(&shoot, &shoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+					Expect(err).To(Not(HaveOccurred()))
+				})
+			})
 		})
 	})
 })

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -200,8 +200,15 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 		// project name. These checks should only be performed for CREATE operations (we do not want to reject changes to existing
 		// Shoots in case the limits are changed in the future).
 		var lengthLimit = 21
-		if len(project.Name+shoot.Name) > lengthLimit {
-			return apierrors.NewBadRequest(fmt.Sprintf("the length of the shoot name and the project name must not exceed %d characters (project: %s; shoot: %s)", lengthLimit, project.Name, shoot.Name))
+		if len(shoot.Name) == 0 && len(shoot.GenerateName) > 0 {
+			var randomLength = 5
+			if len(project.Name+shoot.GenerateName) > lengthLimit-randomLength {
+				return apierrors.NewBadRequest(fmt.Sprintf("the length of the shoot generateName and the project name must not exceed %d characters (project: %s; shoot with generateName: %s)", lengthLimit-randomLength, project.Name, shoot.GenerateName))
+			}
+		} else {
+			if len(project.Name+shoot.Name) > lengthLimit {
+				return apierrors.NewBadRequest(fmt.Sprintf("the length of the shoot name and the project name must not exceed %d characters (project: %s; shoot: %s)", lengthLimit, project.Name, shoot.Name))
+			}
 		}
 		if strings.Contains(project.Name, "--") {
 			return apierrors.NewBadRequest(fmt.Sprintf("the project name must not contain two consecutive hyphens (project: %s)", project.Name))


### PR DESCRIPTION
**What this PR does / why we need it**:
- - Shoot name length limit restriction is applied on `generateName` with random suffix length fixed to 5 as in the kubernetes. 
- Default DNS  name is generated using same name generator for shoot. But it will differ from generated shoot name, cause the generated name is not available at the time DNS admission. And generator function will generate different name in each attempt, So, Dns name and shoot name will differ. Currently i don't see the good way to sync these two. Suggestions are welcome.

**Which issue(s) this PR fixes**:
Fixes #1783 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Issues for Shoot with `metadata.generateName` are fixed. Shoot name length limit restriction is applied on `generateName` with random suffix length fixed to 5 as in the kubernetes. Default DNS  name is generated using same name generator for shoot. ⚠️ But it will differ from generated shoot name.  
```
