### PR TITLE
Allow switching kube-proxy mode for k8s cluster > 1.16

### DIFF
--- a/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-cleanup-script.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-cleanup-script.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-proxy-cleanup-script
+  namespace: kube-system
+  labels:
+    app: kubernetes
+    gardener.cloud/role: system-component
+    origin: gardener
+    role: proxy
+data:
+  cleanup.sh: |
+    #!/bin/sh -e
+    OLD_KUBE_PROXY_MODE="$(cat "$1")"
+    if [ -z "${OLD_KUBE_PROXY_MODE}" ] || [ "${OLD_KUBE_PROXY_MODE}" = "${KUBE_PROXY_MODE}" ]; then
+      echo "${KUBE_PROXY_MODE}" >"$1"
+      echo "Nothing to cleanup - the mode didn't change."
+      exit 0
+    fi
+    {{- if semverCompare "< 1.17" .Values.kubernetesVersion }}
+    /hyperkube
+    {{- if semverCompare "< 1.15" .Values.kubernetesVersion }}
+    proxy
+    {{- else }}
+    kube-proxy
+    {{- end }}
+    {{- else }}
+    /usr/local/bin/kube-proxy
+    {{- end }} --v=2 --cleanup --proxy-mode="${OLD_KUBE_PROXY_MODE}"
+    echo "${KUBE_PROXY_MODE}" >"$1"

--- a/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -20,6 +20,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/secret-kube-proxy: {{ include (print $.Template.BasePath "/kube-proxy-secret.yaml") . | sha256sum }}
         checksum/configmap-componentconfig: {{ include (print $.Template.BasePath "/componentconfig.yaml") . | sha256sum }}
+        checksum/configmap-kube-proxy-cleanup-script: {{ include (print $.Template.BasePath "/kube-proxy-cleanup-script.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
@@ -45,6 +46,30 @@ spec:
           /sbin/sysctl -w net.ipv6.conf.all.disable_ipv6=1 || echo "IPv6 is already disabled. Doing nothing..."
         securityContext:
           privileged: true
+{{- end }}
+{{- if (semverCompare ">= 1.16" .Values.kubernetesVersion) }}
+      initContainers:
+      - name: cleanup
+        image: {{ index .Values.images "kube-proxy" }}
+        env:
+        - name: KUBE_PROXY_MODE
+          value: {{ include "kube-proxy.mode" . }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - /script/cleanup.sh /var/lib/kube-proxy/mode
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: kube-proxy-cleanup-script
+          mountPath: /script
+        - name: kernel-modules
+          mountPath: /lib/modules
+        - name: kube-proxy-dir
+          mountPath: /var/lib/kube-proxy
+        - name: kube-proxy-mode
+          mountPath: /var/lib/kube-proxy/mode
 {{- end }}
       priorityClassName: system-cluster-critical
       tolerations:
@@ -114,3 +139,15 @@ spec:
       - name: kernel-modules
         hostPath:
           path: /lib/modules
+      - name: kube-proxy-cleanup-script
+        configMap:
+          name: kube-proxy-cleanup-script
+          defaultMode: 0777
+      - name: kube-proxy-dir
+        hostPath:
+          path: /var/lib/kube-proxy
+          type: DirectoryOrCreate
+      - name: kube-proxy-mode
+        hostPath:
+          path: /var/lib/kube-proxy/mode
+          type: FileOrCreate

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -323,7 +323,7 @@ func validateKubeProxyModeUpdate(newConfig, oldConfig *core.KubeProxyConfig, ver
 	if oldConfig != nil {
 		oldMode = *oldConfig.Mode
 	}
-	if ok, _ := versionutils.CheckVersionMeetsConstraint(version, ">= 1.14.1"); ok {
+	if ok, _ := versionutils.CheckVersionMeetsConstraint(version, ">= 1.14.1, < 1.16"); ok {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newMode, oldMode, fldPath.Child("mode"))...)
 	}
 	return allErrs

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1469,10 +1469,30 @@ var _ = Describe("Shoot Validation Tests", func() {
 				mode := core.ProxyMode("IPVS")
 				shoot.Spec.Kubernetes.Version = "1.14.1"
 				shoot.Spec.Kubernetes.KubeProxy.Mode = &mode
-
 				errorList := ValidateShoot(shoot)
-
 				Expect(errorList).To(HaveLen(2))
+			})
+
+			It("should be successful when using kubernetes version 1.16.1 and proxy mode is changed", func() {
+				mode := core.ProxyMode("IPVS")
+				kubernetesConfig := core.KubernetesConfig{}
+				config := core.KubeProxyConfig{
+					KubernetesConfig: kubernetesConfig,
+					Mode:             &mode,
+				}
+				shoot.Spec.Kubernetes.KubeProxy = &config
+				shoot.Spec.Kubernetes.Version = "1.16.1"
+				oldMode := core.ProxyMode("IPTables")
+				oldConfig := core.KubeProxyConfig{
+					KubernetesConfig: kubernetesConfig,
+					Mode:             &oldMode,
+				}
+				shoot.Spec.Kubernetes.KubeProxy.Mode = &mode
+				oldShoot := shoot.DeepCopy()
+				oldShoot.Spec.Kubernetes.KubeProxy = &oldConfig
+
+				errorList := ValidateShootSpecUpdate(&shoot.Spec, &oldShoot.Spec, false, field.NewPath("spec"))
+				Expect(errorList).To(BeEmpty())
 			})
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR lifts the restrictions on `kube-proxy` to allow switching of kube-proxy mode (`IPTables`, `IPVS`) for k8s cluster > 1.16.  Further the `iptables` and `ipvs` rules of the previous mode are cleaned up in an init container before running `kube-proxy` in the new mode.

PR https://github.com/kubernetes/kubernetes/pull/78775 fixed the cleanup error in `v1.16` which led in the past to the restrictions. 

**Which issue(s) this PR fixes**:
Fixes #2225

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Restrictions on kube-proxy are lifted to allow switching of kube-proxy mode (IPTables, IPVS) for k8s cluster > 1.16. 
```
