### PR TITLE
Add ContainerRuntime resources to the care controller

### DIFF
--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -1030,6 +1030,7 @@ func (b *Botanist) getAllExtensionConditions(ctx context.Context) ([]ExtensionCo
 		&extensionsv1alpha1.NetworkList{},
 		&extensionsv1alpha1.OperatingSystemConfigList{},
 		&extensionsv1alpha1.WorkerList{},
+		&extensionsv1alpha1.ContainerRuntimeList{},
 	} {
 		listKind := listObj.GetObjectKind().GroupVersionKind().Kind
 		if err := b.K8sSeedClient.Client().List(ctx, listObj, client.InNamespace(b.Shoot.SeedNamespace)); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently ContainerRuntime resource health check reports do not contribute to the Shoot health condition. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
