### PR TITLE
Wait for extension resources to be deleted

### DIFF
--- a/pkg/operation/common/extensions.go
+++ b/pkg/operation/common/extensions.go
@@ -144,11 +144,13 @@ func DeleteExtensionCRs(
 			return fmt.Errorf("expected extensionsv1alpha1.Object but got %T", obj)
 		}
 
-		if predicateFunc != nil && predicateFunc(o) {
-			fns = append(fns, func(ctx context.Context) error {
-				return DeleteExtensionCR(ctx, c, newObjFunc, o.GetNamespace(), o.GetName())
-			})
+		if predicateFunc != nil && !predicateFunc(o) {
+			return nil
 		}
+
+		fns = append(fns, func(ctx context.Context) error {
+			return DeleteExtensionCR(ctx, c, newObjFunc, o.GetNamespace(), o.GetName())
+		})
 
 		return nil
 	}); err != nil {
@@ -188,21 +190,23 @@ func WaitUntilExtensionCRsDeleted(
 			return nil
 		}
 
-		if predicateFunc != nil && predicateFunc(o) {
-			fns = append(fns, func(ctx context.Context) error {
-				return WaitUntilExtensionCRDeleted(
-					ctx,
-					c,
-					logger,
-					newObjFunc,
-					kind,
-					o.GetNamespace(),
-					o.GetName(),
-					interval,
-					timeout,
-				)
-			})
+		if predicateFunc != nil && !predicateFunc(o) {
+			return nil
 		}
+
+		fns = append(fns, func(ctx context.Context) error {
+			return WaitUntilExtensionCRDeleted(
+				ctx,
+				c,
+				logger,
+				newObjFunc,
+				kind,
+				o.GetNamespace(),
+				o.GetName(),
+				interval,
+				timeout,
+			)
+		})
 
 		return nil
 	}); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix bug that prevented the Shoot reconciliation to wait for the deletion of Extension CRDs.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fix bug that prevented the Shoot reconciliation to wait for the deletion of Extension CRDs.
```
