### PR TITLE
Health checker computes error codes where applicable

### DIFF
--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -51,7 +51,7 @@ var (
 	insufficientPrivilegesRegexp = regexp.MustCompile(`(?i)(AccessDenied|Forbidden|deny|denied)`)
 	dependenciesRegexp           = regexp.MustCompile(`(?i)(PendingVerification|Access Not Configured|accessNotConfigured|DependencyViolation|OptInRequired|DeleteConflict|Conflict|inactive billing state|ReadOnlyDisabledSubscription|is already being used|InUseSubnetCannotBeDeleted|VnetInUse)`)
 	resourcesDepletedRegexp      = regexp.MustCompile(`(?i)(not available in the current hardware cluster|InsufficientInstanceCapacity|SkuNotAvailable|ZonalAllocationFailed)`)
-	configurationProblemRegexp   = regexp.MustCompile(`(?i)(AzureBastionSubnet|not supported in your requested Availability Zone|InvalidParameterValue|notFound|NetcfgInvalidSubnet|InvalidSubnet|Invalid value)`)
+	configurationProblemRegexp   = regexp.MustCompile(`(?i)(AzureBastionSubnet|not supported in your requested Availability Zone|InvalidParameterValue|notFound|NetcfgInvalidSubnet|InvalidSubnet|Invalid value|KubeletHasInsufficientMemory|KubeletHasDiskPressure|KubeletHasInsufficientPID)`)
 )
 
 // DetermineError determines the Garden error code for the given error and creates a new error with the given message.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adapts the health checker used by the shoot care controller to compute error codes where applicable.
Concretely,

1. the `.status.lastError` in `Etcd` resources is evaluated
1. the `.status.conditions[].message`s in `Node` resources are evaluated
1. node conditions indicating disk/memory/pid pressure result in `ERR_CONFIGURATION_PROBLEM`

Also, the conditions are now always pardoned if the shoot is in creation/deletion process (earlier, the first error occurred during such reconciliations did not pardon the conditions anymore).

**Special notes for your reviewer**:
* The error codes computed by extension health check controllers are already taken into consideration (was implemented as part of #2212).
* The migration logic due to introduction of etcd-druid has been removed now

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The shoot health check controller has been improved to produce error codes (if applicable) to the `.status.conditions[].codes` that help categorizing observed problems.
```
