### PR TITLE
Eliminate useless extensionsv1alpha1.Last{Operation,Error} interfaces

### DIFF
--- a/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/extensions/pkg/controller/healthcheck/reconciler.go
@@ -229,6 +229,5 @@ func isInMigration(accessor extensionsv1alpha1.Object) bool {
 	}
 
 	lastOperation := status.GetLastOperation()
-
-	return lastOperation != nil && lastOperation.GetType() == gardencorev1beta1.LastOperationTypeMigrate
+	return lastOperation != nil && lastOperation.Type == gardencorev1beta1.LastOperationTypeMigrate
 }

--- a/extensions/pkg/controller/utils.go
+++ b/extensions/pkg/controller/utils.go
@@ -360,6 +360,6 @@ func IsMigrated(obj runtime.Object) bool {
 
 	lastOp := acc.GetExtensionStatus().GetLastOperation()
 	return lastOp != nil &&
-		lastOp.GetType() == gardencorev1beta1.LastOperationTypeMigrate &&
-		lastOp.GetState() == gardencorev1beta1.LastOperationStateSucceeded
+		lastOp.Type == gardencorev1beta1.LastOperationTypeMigrate &&
+		lastOp.State == gardencorev1beta1.LastOperationStateSucceeded
 }

--- a/extensions/pkg/controller/worker/reconciler.go
+++ b/extensions/pkg/controller/worker/reconciler.go
@@ -240,6 +240,6 @@ func removeAnnotation(ctx context.Context, c client.Client, worker *extensionsv1
 
 func isWorkerMigrated(worker *extensionsv1alpha1.Worker) bool {
 	return worker.Status.LastOperation != nil &&
-		worker.Status.LastOperation.GetType() == gardencorev1beta1.LastOperationTypeMigrate &&
-		worker.Status.LastOperation.GetState() == gardencorev1beta1.LastOperationStateSucceeded
+		worker.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeMigrate &&
+		worker.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded
 }

--- a/extensions/pkg/predicate/predicate.go
+++ b/extensions/pkg/predicate/predicate.go
@@ -175,7 +175,7 @@ func LastOperationNotSuccessful() predicate.Predicate {
 
 		lastOp := acc.GetExtensionStatus().GetLastOperation()
 		return lastOp == nil ||
-			lastOp.GetState() != gardencorev1beta1.LastOperationStateSucceeded
+			lastOp.State != gardencorev1beta1.LastOperationStateSucceeded
 	}
 
 	return predicate.Funcs{

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -2495,16 +2495,6 @@ be statically defined in the Shoot resource but must be computed dynamically.</p
 </tr>
 </tbody>
 </table>
-<h3 id="extensions.gardener.cloud/v1alpha1.LastError">LastError
-</h3>
-<p>
-<p>LastError is the last error on an object.</p>
-</p>
-<h3 id="extensions.gardener.cloud/v1alpha1.LastOperation">LastOperation
-</h3>
-<p>
-<p>LastOperation is the last operation on an object.</p>
-</p>
 <h3 id="extensions.gardener.cloud/v1alpha1.MachineDeployment">MachineDeployment
 </h3>
 <p>

--- a/pkg/api/extensions/accessor.go
+++ b/pkg/api/extensions/accessor.go
@@ -20,7 +20,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -52,28 +51,12 @@ type unstructuredAccessor struct {
 	*unstructured.Unstructured
 }
 
-type unstructuredStatusAccessor struct {
-	*unstructured.Unstructured
-}
-
-type unstructuredLastOperationAccessor struct {
-	*unstructured.Unstructured
-}
-
-type unstructuredLastErrorAccessor struct {
-	*unstructured.Unstructured
-}
-
 type unstructuredSpecAccessor struct {
 	*unstructured.Unstructured
 }
 
-func nestedStringSlice(obj map[string]interface{}, fields ...string) []string {
-	v, ok, err := unstructured.NestedStringSlice(obj, fields...)
-	if err != nil || !ok {
-		return nil
-	}
-	return v
+type unstructuredStatusAccessor struct {
+	*unstructured.Unstructured
 }
 
 func nestedString(obj map[string]interface{}, fields ...string) string {
@@ -82,25 +65,6 @@ func nestedString(obj map[string]interface{}, fields ...string) string {
 		return ""
 	}
 	return v
-}
-
-func nestedInt32(obj map[string]interface{}, fields ...string) int32 {
-	v, ok, err := unstructured.NestedFieldNoCopy(obj, fields...)
-	if err != nil || !ok {
-		return 0
-	}
-
-	switch x := v.(type) {
-	case int64:
-		// safe, as the DefaultUnstructuredConverter uses int64 to store int16, int32, etc.
-		return int32(x)
-	case int32:
-		return x
-	case int:
-		return int32(x)
-	default:
-		return 0
-	}
 }
 
 func nestedInt64(obj map[string]interface{}, fields ...string) int64 {
@@ -139,45 +103,9 @@ func nestedRawExtension(obj map[string]interface{}, fields ...string) *runtime.R
 	return rawExtension
 }
 
-// Get implements LastOperation.
-func (u unstructuredLastOperationAccessor) Get() *gardencorev1beta1.LastOperation {
-	val, ok, err := unstructured.NestedFieldNoCopy(u.UnstructuredContent(), "status", "lastOperation")
-	if err != nil || !ok {
-		return nil
-	}
-
-	lastOperation := &gardencorev1beta1.LastOperation{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(val.(map[string]interface{}), lastOperation); err != nil {
-		return nil
-	}
-	return lastOperation
-}
-
-// GetDescription implements LastOperation.
-func (u unstructuredLastOperationAccessor) GetDescription() string {
-	return nestedString(u.UnstructuredContent(), "status", "lastOperation", "description")
-}
-
-// GetLastUpdateTime implements LastOperation.
-func (u unstructuredLastOperationAccessor) GetLastUpdateTime() metav1.Time {
-	var timestamp metav1.Time
-	_ = timestamp.UnmarshalQueryParameter(nestedString(u.UnstructuredContent(), "status", "lastOperation", "lastUpdateTime"))
-	return timestamp
-}
-
-// GetProgress implements LastOperation.
-func (u unstructuredLastOperationAccessor) GetProgress() int32 {
-	return nestedInt32(u.UnstructuredContent(), "status", "lastOperation", "progress")
-}
-
-// GetState implements LastOperation.
-func (u unstructuredLastOperationAccessor) GetState() gardencorev1beta1.LastOperationState {
-	return gardencorev1beta1.LastOperationState(nestedString(u.UnstructuredContent(), "status", "lastOperation", "state"))
-}
-
-// GetType implements LastOperation.
-func (u unstructuredLastOperationAccessor) GetType() gardencorev1beta1.LastOperationType {
-	return gardencorev1beta1.LastOperationType(nestedString(u.UnstructuredContent(), "status", "lastOperation", "type"))
+// GetExtensionSpec implements Object.
+func (u unstructuredAccessor) GetExtensionSpec() extensionsv1alpha1.Spec {
+	return unstructuredSpecAccessor(u)
 }
 
 // GetExtensionType implements Spec.
@@ -195,9 +123,61 @@ func (u unstructuredSpecAccessor) GetProviderConfig() *runtime.RawExtension {
 	return nestedRawExtension(u.UnstructuredContent(), "spec", "providerConfig")
 }
 
+// GetExtensionStatus implements Object.
+func (u unstructuredAccessor) GetExtensionStatus() extensionsv1alpha1.Status {
+	return unstructuredStatusAccessor(u)
+}
+
 // GetProviderStatus implements Status.
 func (u unstructuredStatusAccessor) GetProviderStatus() *runtime.RawExtension {
 	return nestedRawExtension(u.UnstructuredContent(), "status", "providerStatus")
+}
+
+// GetLastOperation implements Status.
+func (u unstructuredStatusAccessor) GetLastOperation() *gardencorev1beta1.LastOperation {
+	val, ok, err := unstructured.NestedFieldNoCopy(u.UnstructuredContent(), "status", "lastOperation")
+	if err != nil || !ok {
+		return nil
+	}
+
+	lastOperation := &gardencorev1beta1.LastOperation{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(val.(map[string]interface{}), lastOperation); err != nil {
+		return nil
+	}
+	return lastOperation
+}
+
+// GetLastError implements Status.
+func (u unstructuredStatusAccessor) GetLastError() *gardencorev1beta1.LastError {
+	val, ok, err := unstructured.NestedFieldNoCopy(u.UnstructuredContent(), "status", "lastError")
+	if err != nil || !ok {
+		return nil
+	}
+
+	lastError := &gardencorev1beta1.LastError{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(val.(map[string]interface{}), lastError); err != nil {
+		return nil
+	}
+	return lastError
+}
+
+// GetObservedGeneration implements Status.
+func (u unstructuredStatusAccessor) GetObservedGeneration() int64 {
+	return nestedInt64(u.Object, "status", "observedGeneration")
+}
+
+// GetState implements Status.
+func (u unstructuredStatusAccessor) GetState() *runtime.RawExtension {
+	val, ok, err := unstructured.NestedFieldNoCopy(u.UnstructuredContent(), "status", "state")
+	if err != nil || !ok {
+		return nil
+	}
+	raw := &runtime.RawExtension{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(val.(map[string]interface{}), raw)
+	if err != nil {
+		return nil
+	}
+	return raw
 }
 
 // GetConditions implements Status.
@@ -233,102 +213,4 @@ func (u unstructuredStatusAccessor) SetConditions(conditions []gardencorev1beta1
 	if err != nil {
 		return
 	}
-}
-
-// GetLastOperation implements Status.
-func (u unstructuredStatusAccessor) GetLastOperation() extensionsv1alpha1.LastOperation {
-	if _, ok, err := unstructured.NestedFieldNoCopy(u.UnstructuredContent(), "status", "lastOperation"); err != nil || !ok {
-		return nil
-	}
-	return unstructuredLastOperationAccessor(u)
-}
-
-// GetObservedGeneration implements Status.
-func (u unstructuredStatusAccessor) GetObservedGeneration() int64 {
-	return nestedInt64(u.Object, "status", "observedGeneration")
-}
-
-// GetState implements Status.
-func (u unstructuredStatusAccessor) GetState() *runtime.RawExtension {
-	val, ok, err := unstructured.NestedFieldNoCopy(u.UnstructuredContent(), "status", "state")
-	if err != nil || !ok {
-		return nil
-	}
-	raw := &runtime.RawExtension{}
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(val.(map[string]interface{}), raw)
-	if err != nil {
-		return nil
-	}
-	return raw
-}
-
-// Get implements LastError.
-func (u unstructuredLastErrorAccessor) Get() *gardencorev1beta1.LastError {
-	val, ok, err := unstructured.NestedFieldNoCopy(u.UnstructuredContent(), "status", "lastError")
-	if err != nil || !ok {
-		return nil
-	}
-
-	lastError := &gardencorev1beta1.LastError{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(val.(map[string]interface{}), lastError); err != nil {
-		return nil
-	}
-	return lastError
-}
-
-// GetDescription implements LastError.
-func (u unstructuredLastErrorAccessor) GetDescription() string {
-	return nestedString(u.Object, "status", "lastError", "description")
-}
-
-// GetTaskID implements LastError
-func (u unstructuredLastErrorAccessor) GetTaskID() *string {
-	s, ok, err := unstructured.NestedString(u.Object, "status", "lastError", "taskID")
-	if err != nil || !ok {
-		return nil
-	}
-
-	return &s
-}
-
-// GetCodes implements LastError.
-func (u unstructuredLastErrorAccessor) GetCodes() []gardencorev1beta1.ErrorCode {
-	codeStrings := nestedStringSlice(u.Object, "status", "lastError", "codes")
-	var codes []gardencorev1beta1.ErrorCode
-	for _, codeString := range codeStrings {
-		codes = append(codes, gardencorev1beta1.ErrorCode(codeString))
-	}
-	return codes
-}
-
-// GetLastUpdateTime implements LastError.
-func (u unstructuredLastErrorAccessor) GetLastUpdateTime() *metav1.Time {
-	s, ok, err := unstructured.NestedString(u.Object, "status", "lastError", "lastUpdateTime")
-	if err != nil || !ok {
-		return nil
-	}
-
-	var timestamp metav1.Time
-	if err := timestamp.UnmarshalQueryParameter(s); err != nil {
-		return nil
-	}
-	return &timestamp
-}
-
-// GetLastError implements Status.
-func (u unstructuredStatusAccessor) GetLastError() extensionsv1alpha1.LastError {
-	if _, ok, err := unstructured.NestedFieldNoCopy(u.UnstructuredContent(), "status", "lastError"); err != nil || !ok {
-		return nil
-	}
-	return unstructuredLastErrorAccessor(u)
-}
-
-// GetExtensionStatus implements Object.
-func (u unstructuredAccessor) GetExtensionStatus() extensionsv1alpha1.Status {
-	return unstructuredStatusAccessor(u)
-}
-
-// GetExtensionSpec implements Object.
-func (u unstructuredAccessor) GetExtensionSpec() extensionsv1alpha1.Spec {
-	return unstructuredSpecAccessor(u)
 }

--- a/pkg/api/extensions/accessor_test.go
+++ b/pkg/api/extensions/accessor_test.go
@@ -52,10 +52,6 @@ func mkUnstructuredAccessorWithStatus(status extensionsv1alpha1.DefaultStatus) e
 	return mkUnstructuredAccessor(&extensionsv1alpha1.Infrastructure{Status: extensionsv1alpha1.InfrastructureStatus{DefaultStatus: status}}).GetExtensionStatus()
 }
 
-func mkUnstructuredAccessorWithLastOperation(lastOperation *gardencorev1beta1.LastOperation) extensionsv1alpha1.LastOperation {
-	return mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{LastOperation: lastOperation}).GetLastOperation()
-}
-
 var _ = Describe("Accessor", func() {
 	Describe("#Accessor", func() {
 		It("should create an accessor for extensions", func() {
@@ -138,106 +134,72 @@ var _ = Describe("Accessor", func() {
 				})
 			})
 
-			Context("#GetLastOperation", func() {
-				Describe("#GetDescription", func() {
-					It("should get the description", func() {
-						var (
-							desc = "desc"
-							acc  = mkUnstructuredAccessorWithLastOperation(&gardencorev1beta1.LastOperation{Description: desc})
-						)
+			Describe("#GetLastOperation", func() {
+				It("should get the last operation", func() {
+					var (
+						desc = "desc"
+						acc  = mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{LastOperation: &gardencorev1beta1.LastOperation{Description: "desc"}})
+					)
 
-						Expect(acc.GetDescription()).To(Equal(desc))
-					})
+					Expect(acc.GetLastOperation()).To(Equal(&gardencorev1beta1.LastOperation{Description: desc}))
 				})
+			})
 
-				Describe("#GetLastUpdateTime", func() {
-					It("should get the last update time", func() {
-						var (
-							t   = metav1.NewTime(time.Unix(50, 0))
-							acc = mkUnstructuredAccessorWithLastOperation(&gardencorev1beta1.LastOperation{LastUpdateTime: t})
-						)
+			Describe("#GetLastError", func() {
+				It("should get the last error", func() {
+					var (
+						desc = "desc"
+						acc  = mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{LastError: &gardencorev1beta1.LastError{Description: "desc"}})
+					)
 
-						Expect(acc.GetLastUpdateTime()).To(Equal(t))
-					})
+					Expect(acc.GetLastError()).To(Equal(&gardencorev1beta1.LastError{Description: desc}))
 				})
+			})
 
-				Describe("#GetProgress", func() {
-					It("should get the progress", func() {
-						var (
-							progress int32 = 10
-							acc            = mkUnstructuredAccessorWithLastOperation(&gardencorev1beta1.LastOperation{Progress: progress})
-						)
-
-						Expect(acc.GetProgress()).To(Equal(progress))
-					})
+			Describe("#GetConditions", func() {
+				It("should get the conditions", func() {
+					var (
+						conditions = []gardencorev1beta1.Condition{
+							{
+								Type:           "ABC",
+								Status:         gardencorev1beta1.ConditionTrue,
+								Reason:         "reason",
+								Message:        "message",
+								LastUpdateTime: metav1.NewTime(metav1.Now().Round(time.Second)),
+							},
+						}
+						acc = mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{Conditions: conditions})
+					)
+					getConditions := acc.GetConditions()
+					Expect(getConditions).To(Equal(conditions))
 				})
+			})
 
-				Describe("#GetState", func() {
-					It("should get the state", func() {
-						var (
-							state = gardencorev1beta1.LastOperationStateSucceeded
-							acc   = mkUnstructuredAccessorWithLastOperation(&gardencorev1beta1.LastOperation{State: state})
-						)
-
-						Expect(acc.GetState()).To(Equal(state))
-					})
+			Describe("#GetState", func() {
+				It("should get the extensions state", func() {
+					state := &runtime.RawExtension{Raw: []byte("{\"raw\":\"ext\"}")}
+					acc := mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{State: state})
+					Expect(acc.GetState()).To(Equal(state))
 				})
+			})
 
-				Describe("#GetType", func() {
-					It("should get the type", func() {
-						var (
-							t   = gardencorev1beta1.LastOperationTypeReconcile
-							acc = mkUnstructuredAccessorWithLastOperation(&gardencorev1beta1.LastOperation{Type: t})
-						)
-
-						Expect(acc.GetType()).To(Equal(t))
-					})
-				})
-				Describe("#Get Conditions", func() {
-					It("should get the conditions", func() {
-						var (
-							conditions = []gardencorev1beta1.Condition{
-								{
-									Type:           "ABC",
-									Status:         gardencorev1beta1.ConditionTrue,
-									Reason:         "reason",
-									Message:        "message",
-									LastUpdateTime: metav1.NewTime(metav1.Now().Round(time.Second)),
-								},
-							}
-							acc = mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{Conditions: conditions})
-						)
-						getConditions := acc.GetConditions()
-						Expect(getConditions).To(Equal(conditions))
-					})
-				})
-
-				Describe("#GetState", func() {
-					It("should get the extensions state", func() {
-						state := &runtime.RawExtension{Raw: []byte("{\"raw\":\"ext\"}")}
-						acc := mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{State: state})
-						Expect(acc.GetState()).To(Equal(state))
-					})
-				})
-
-				Describe("#Set Conditions", func() {
-					It("should set the conditions", func() {
-						var (
-							acc        = mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{})
-							conditions = []gardencorev1beta1.Condition{
-								{
-									Type:           "ABC",
-									Status:         gardencorev1beta1.ConditionTrue,
-									Reason:         "reason",
-									Message:        "message",
-									LastUpdateTime: metav1.NewTime(metav1.Now().Round(time.Second)),
-								},
-							}
-						)
-						acc.SetConditions(conditions)
-						getConditions := acc.GetConditions()
-						Expect(getConditions).To(Equal(conditions))
-					})
+			Describe("#SetConditions", func() {
+				It("should set the conditions", func() {
+					var (
+						acc        = mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{})
+						conditions = []gardencorev1beta1.Condition{
+							{
+								Type:           "ABC",
+								Status:         gardencorev1beta1.ConditionTrue,
+								Reason:         "reason",
+								Message:        "message",
+								LastUpdateTime: metav1.NewTime(metav1.Now().Round(time.Second)),
+							},
+						}
+					)
+					acc.SetConditions(conditions)
+					getConditions := acc.GetConditions()
+					Expect(getConditions).To(Equal(conditions))
 				})
 			})
 		})

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -51,26 +51,6 @@ type LastError struct {
 	LastUpdateTime *metav1.Time `json:"lastUpdateTime,omitempty" protobuf:"bytes,4,opt,name=lastUpdateTime"`
 }
 
-// GetDescription implements LastError.
-func (l *LastError) GetDescription() string {
-	return l.Description
-}
-
-// GetTaskID implements LastError
-func (l *LastError) GetTaskID() *string {
-	return l.TaskID
-}
-
-// GetCodes implements LastError.
-func (l *LastError) GetCodes() []ErrorCode {
-	return l.Codes
-}
-
-// GetLastUpdateTime implements LastError.
-func (l *LastError) GetLastUpdateTime() *metav1.Time {
-	return l.LastUpdateTime
-}
-
 // LastOperationType is a string alias.
 type LastOperationType string
 
@@ -116,31 +96,6 @@ type LastOperation struct {
 	State LastOperationState `json:"state" protobuf:"bytes,4,opt,name=state,casttype=LastOperationState"`
 	// Type of the last operation, one of Create, Reconcile, Delete.
 	Type LastOperationType `json:"type" protobuf:"bytes,5,opt,name=type,casttype=LastOperationType"`
-}
-
-// GetDescription implements LastOperation.
-func (l *LastOperation) GetDescription() string {
-	return l.Description
-}
-
-// GetLastUpdateTime implements LastOperation.
-func (l *LastOperation) GetLastUpdateTime() metav1.Time {
-	return l.LastUpdateTime
-}
-
-// GetProgress implements LastOperation.
-func (l *LastOperation) GetProgress() int32 {
-	return l.Progress
-}
-
-// GetState implements LastOperation.
-func (l *LastOperation) GetState() LastOperationState {
-	return l.State
-}
-
-// GetType implements LastOperation.
-func (l *LastOperation) GetType() LastOperationType {
-	return l.Type
 }
 
 // Gardener holds the information about the Gardener version that operated a resource.

--- a/pkg/apis/core/v1beta1/types_common.go
+++ b/pkg/apis/core/v1beta1/types_common.go
@@ -51,31 +51,6 @@ type LastError struct {
 	LastUpdateTime *metav1.Time `json:"lastUpdateTime,omitempty" protobuf:"bytes,4,opt,name=lastUpdateTime"`
 }
 
-// Get implements LastError.
-func (l *LastError) Get() *LastError {
-	return l
-}
-
-// GetDescription implements LastError.
-func (l *LastError) GetDescription() string {
-	return l.Description
-}
-
-// GetTaskID implements LastError
-func (l *LastError) GetTaskID() *string {
-	return l.TaskID
-}
-
-// GetCodes implements LastError.
-func (l *LastError) GetCodes() []ErrorCode {
-	return l.Codes
-}
-
-// GetLastUpdateTime implements LastError.
-func (l *LastError) GetLastUpdateTime() *metav1.Time {
-	return l.LastUpdateTime
-}
-
 // LastOperationType is a string alias.
 type LastOperationType string
 
@@ -121,36 +96,6 @@ type LastOperation struct {
 	State LastOperationState `json:"state" protobuf:"bytes,4,opt,name=state,casttype=LastOperationState"`
 	// Type of the last operation, one of Create, Reconcile, Delete.
 	Type LastOperationType `json:"type" protobuf:"bytes,5,opt,name=type,casttype=LastOperationType"`
-}
-
-// Get implements LastOperation.
-func (l *LastOperation) Get() *LastOperation {
-	return l
-}
-
-// GetDescription implements LastOperation.
-func (l *LastOperation) GetDescription() string {
-	return l.Description
-}
-
-// GetLastUpdateTime implements LastOperation.
-func (l *LastOperation) GetLastUpdateTime() metav1.Time {
-	return l.LastUpdateTime
-}
-
-// GetProgress implements LastOperation.
-func (l *LastOperation) GetProgress() int32 {
-	return l.Progress
-}
-
-// GetState implements LastOperation.
-func (l *LastOperation) GetState() LastOperationState {
-	return l.State
-}
-
-// GetType implements LastOperation.
-func (l *LastOperation) GetType() LastOperationType {
-	return l.Type
 }
 
 // Gardener holds the information about the Gardener version that operated a resource.

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -31,42 +31,14 @@ type Status interface {
 	SetConditions([]gardencorev1beta1.Condition)
 	// GetLastOperation retrieves the LastOperation of a status.
 	// LastOperation may be nil.
-	GetLastOperation() LastOperation
+	GetLastOperation() *gardencorev1beta1.LastOperation
 	// GetObservedGeneration retrieves the last generation observed by the extension controller.
 	GetObservedGeneration() int64
 	// GetLastError retrieves the LastError of a status.
 	// LastError may be nil.
-	GetLastError() LastError
+	GetLastError() *gardencorev1beta1.LastError
 	// GetState retrieves the State of the extension
 	GetState() *runtime.RawExtension
-}
-
-// LastOperation is the last operation on an object.
-type LastOperation interface {
-	Get() *gardencorev1beta1.LastOperation
-	// GetDescription returns the description of the last operation.
-	GetDescription() string
-	// GetLastUpdateTime returns the last update time of the last operation.
-	GetLastUpdateTime() metav1.Time
-	// GetProgress returns progress of the last operation.
-	GetProgress() int32
-	// GetState returns the LastOperationState of the last operation.
-	GetState() gardencorev1beta1.LastOperationState
-	// GetType returns the LastOperationType of the last operation.
-	GetType() gardencorev1beta1.LastOperationType
-}
-
-// LastError is the last error on an object.
-type LastError interface {
-	Get() *gardencorev1beta1.LastError
-	// GetDescription gets the description of the last occurred error.
-	GetDescription() string
-	// GetTaskID gets the task ID of the last error.
-	GetTaskID() *string
-	// GetCodes gets the error codes of the last error.
-	GetCodes() []gardencorev1beta1.ErrorCode
-	// GetLastUpdateTime retrieves the last time the error was updated.
-	GetLastUpdateTime() *metav1.Time
 }
 
 // Spec is the spec section of an Object.
@@ -84,8 +56,8 @@ type Object interface {
 	metav1.Object
 	runtime.Object
 
-	// GetExtensionStatus retrieves the object's status.
-	GetExtensionStatus() Status
 	// GetExtensionSpec retrieves the object's spec.
 	GetExtensionSpec() Spec
+	// GetExtensionStatus retrieves the object's status.
+	GetExtensionStatus() Status
 }

--- a/pkg/apis/extensions/v1alpha1/types_defaults.go
+++ b/pkg/apis/extensions/v1alpha1/types_defaults.go
@@ -81,18 +81,12 @@ func (d *DefaultStatus) SetConditions(c []gardencorev1beta1.Condition) {
 }
 
 // GetLastOperation implements Status.
-func (d *DefaultStatus) GetLastOperation() LastOperation {
-	if d.LastOperation == nil {
-		return nil
-	}
+func (d *DefaultStatus) GetLastOperation() *gardencorev1beta1.LastOperation {
 	return d.LastOperation
 }
 
 // GetLastError implements Status.
-func (d *DefaultStatus) GetLastError() LastError {
-	if d.LastError == nil {
-		return nil
-	}
+func (d *DefaultStatus) GetLastError() *gardencorev1beta1.LastError {
 	return d.LastError
 }
 

--- a/pkg/operation/common/extensions.go
+++ b/pkg/operation/common/extensions.go
@@ -241,8 +241,8 @@ func WaitUntilExtensionCRDeleted(
 		}
 
 		if lastErr := acc.GetExtensionStatus().GetLastError(); lastErr != nil {
-			logger.Errorf("%s did not get deleted yet, lastError is: %s", extensionKey(kind, namespace, name), lastErr.GetDescription())
-			lastError = lastErr.Get()
+			logger.Errorf("%s did not get deleted yet, lastError is: %s", extensionKey(kind, namespace, name), lastErr.Description)
+			lastError = lastErr
 		}
 
 		logger.Infof("Waiting for %s %s/%s to be deleted...", kind, namespace, name)

--- a/pkg/utils/kubernetes/health/health.go
+++ b/pkg/utils/kubernetes/health/health.go
@@ -271,20 +271,8 @@ func CheckExtensionObject(o runtime.Object) error {
 		return fmt.Errorf("expected extensionsv1alpha1.Object but got %T", o)
 	}
 
-	var (
-		status        = obj.GetExtensionStatus()
-		lastError     *gardencorev1beta1.LastError
-		lastOperation *gardencorev1beta1.LastOperation
-	)
-
-	if status.GetLastError() != nil {
-		lastError = status.GetLastError().Get()
-	}
-	if status.GetLastOperation() != nil {
-		lastOperation = status.GetLastOperation().Get()
-	}
-
-	return checkExtensionObject(obj.GetGeneration(), status.GetObservedGeneration(), obj.GetAnnotations(), lastError, lastOperation)
+	status := obj.GetExtensionStatus()
+	return checkExtensionObject(obj.GetGeneration(), status.GetObservedGeneration(), obj.GetAnnotations(), status.GetLastError(), status.GetLastOperation())
 }
 
 // CheckBackupBucket checks if an backup bucket Object is healthy or not.

--- a/test/framework/dump.go
+++ b/test/framework/dump.go
@@ -203,9 +203,9 @@ func (f *GardenerFramework) dumpGardenerExtension(extension v1alpha1.Object) {
 	} else {
 		f.Logger.Printf("%s of type %s is %s", extension.GetName(), extension.GetExtensionSpec().GetExtensionType(), healthy)
 	}
-	f.Logger.Printf("At %v - last operation %s %s: %s", extension.GetExtensionStatus().GetLastOperation().GetLastUpdateTime(), extension.GetExtensionStatus().GetLastOperation().GetType(), extension.GetExtensionStatus().GetLastOperation().GetState(), extension.GetExtensionStatus().GetLastOperation().GetDescription())
+	f.Logger.Printf("At %v - last operation %s %s: %s", extension.GetExtensionStatus().GetLastOperation().LastUpdateTime, extension.GetExtensionStatus().GetLastOperation().Type, extension.GetExtensionStatus().GetLastOperation().State, extension.GetExtensionStatus().GetLastOperation().Description)
 	if extension.GetExtensionStatus().GetLastError() != nil {
-		f.Logger.Printf("At %v - last error: %s", extension.GetExtensionStatus().GetLastError().GetLastUpdateTime(), extension.GetExtensionStatus().GetLastError().GetDescription())
+		f.Logger.Printf("At %v - last error: %s", extension.GetExtensionStatus().GetLastError().LastUpdateTime, extension.GetExtensionStatus().GetLastError().Description)
 	}
 }
 

--- a/test/integration/framework/dump.go
+++ b/test/integration/framework/dump.go
@@ -190,9 +190,9 @@ func (o *GardenerTestOperation) dumpGardenerExtension(extension v1alpha1.Object)
 	} else {
 		o.Logger.Printf("%s of type %s is %s", extension.GetName(), extension.GetExtensionSpec().GetExtensionType(), healthy)
 	}
-	o.Logger.Printf("At %v - last operation %s %s: %s", extension.GetExtensionStatus().GetLastOperation().GetLastUpdateTime(), extension.GetExtensionStatus().GetLastOperation().GetType(), extension.GetExtensionStatus().GetLastOperation().GetState(), extension.GetExtensionStatus().GetLastOperation().GetDescription())
+	o.Logger.Printf("At %v - last operation %s %s: %s", extension.GetExtensionStatus().GetLastOperation().LastUpdateTime, extension.GetExtensionStatus().GetLastOperation().Type, extension.GetExtensionStatus().GetLastOperation().State, extension.GetExtensionStatus().GetLastOperation().Description)
 	if extension.GetExtensionStatus().GetLastError() != nil {
-		o.Logger.Printf("At %v - last error: %s", extension.GetExtensionStatus().GetLastError().GetLastUpdateTime(), extension.GetExtensionStatus().GetLastError().GetDescription())
+		o.Logger.Printf("At %v - last error: %s", extension.GetExtensionStatus().GetLastError().LastUpdateTime, extension.GetExtensionStatus().GetLastError().Description)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The `extensionsv1alpha1.LastOperation` and `extensionv1alpha1.LastError` interfaces were useless as there is (now and in the foreseeable future) only one type/implementation of the `LastOperation`/`LastError` types.
This PR cleans them up and adapts the code that were using them.

**Special notes for your reviewer**:
/cc @timuthy 
/kind/cleanup

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The `extensionsv1alpha1.Last{Operation,Error}` interfaces were removed - the respective `GetLast{Operation,Error}()` functions do now return the objects directly instead of the old interfaces.
```
