### PR TITLE
Use GO111MODULE=off to prevent changes in go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ install-requirements:
 	@go install -mod=vendor github.com/ahmetb/gen-crd-api-reference-docs
 	@go install -mod=vendor github.com/golang/mock/mockgen
 	@GO111MODULE=off go get github.com/prometheus/prometheus/cmd/promtool
-	@go get golang.org/x/tools/cmd/goimports
+	@GO111MODULE=off go get golang.org/x/tools/cmd/goimports
 	@./hack/install-requirements.sh
 
 .PHONY: revendor


### PR DESCRIPTION
**What this PR does / why we need it**:
Current running `make check-generate` after `make install-requirements` fails with:
```
$ make check-generate
> Generate Check
Error during calling make generate: > Generate
go: inconsistent vendoring in /Users/i331370/go/src/github.com/gardener/gardener:
	golang.org/x/tools@v0.0.0-20200428021058-7ae4988eb4d9: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	golang.org/x/tools@v0.0.0-20200422205258-72e4a01eba43: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod

run 'go mod vendor' to sync, or use -mod=mod or -mod=readonly to ignore the vendor directory
make[1]: *** [generate] Error 1
make: *** [check-generate] Error 1
```

Using `GO111MODULE=off` to go get the goimports binary should prevent the go tool to do any changes to go.mod.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
