### PR TITLE
Extend controller actuators for migrate and restore operations

### DIFF
--- a/extensions/pkg/controller/backupentry/actuator.go
+++ b/extensions/pkg/controller/backupentry/actuator.go
@@ -26,4 +26,8 @@ type Actuator interface {
 	Reconcile(context.Context, *extensionsv1alpha1.BackupEntry) error
 	// Delete deletes the BackupEntry.
 	Delete(context.Context, *extensionsv1alpha1.BackupEntry) error
+	// Restore restores the BackupEntry.
+	Restore(context.Context, *extensionsv1alpha1.BackupEntry) error
+	// Migrate migrates the BackupEntry.
+	Migrate(context.Context, *extensionsv1alpha1.BackupEntry) error
 }

--- a/extensions/pkg/controller/backupentry/genericactuator/actuator.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/actuator.go
@@ -108,3 +108,13 @@ func (a *actuator) deployEtcdBackupSecret(ctx context.Context, be *extensionsv1a
 func (a *actuator) Delete(ctx context.Context, be *extensionsv1alpha1.BackupEntry) error {
 	return a.backupEntryDelegate.Delete(ctx, be)
 }
+
+// Restore restores the update of a BackupEntry
+func (a *actuator) Restore(ctx context.Context, be *extensionsv1alpha1.BackupEntry) error {
+	return a.deployEtcdBackupSecret(ctx, be)
+}
+
+// Migrate migrates the BackupEntry
+func (a *actuator) Migrate(ctx context.Context, be *extensionsv1alpha1.BackupEntry) error {
+	return nil
+}

--- a/extensions/pkg/controller/backupentry/genericactuator/actuator.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/actuator.go
@@ -111,7 +111,7 @@ func (a *actuator) Delete(ctx context.Context, be *extensionsv1alpha1.BackupEntr
 
 // Restore restores the update of a BackupEntry
 func (a *actuator) Restore(ctx context.Context, be *extensionsv1alpha1.BackupEntry) error {
-	return a.deployEtcdBackupSecret(ctx, be)
+	return a.Reconcile(ctx, be)
 }
 
 // Migrate migrates the BackupEntry

--- a/extensions/pkg/controller/backupentry/reconciler.go
+++ b/extensions/pkg/controller/backupentry/reconciler.go
@@ -21,6 +21,7 @@ import (
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/util"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
@@ -41,6 +42,10 @@ const (
 	EventBackupEntryReconciliation string = "BackupEntryReconciliation"
 	// EventBackupEntryDeletion an event reason to describe backup entry deletion.
 	EventBackupEntryDeletion string = "BackupEntryDeletion"
+	// EventBackupEntryMigration an event reason to describe backup entry migration.
+	EventBackupEntryMigration string = "BackupEntryMigration"
+	// EventBackupEntryRestoration an event reason to describe backup entry restoration.
+	EventBackupEntryRestoration string = "BackupEntryRestoration"
 )
 
 type reconciler struct {
@@ -87,18 +92,27 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
-	if be.DeletionTimestamp != nil {
+	operationType := gardencorev1beta1helper.ComputeOperationType(be.ObjectMeta, be.Status.LastOperation)
+
+	switch {
+	case extensionscontroller.IsMigrated(be):
+		return reconcile.Result{}, nil
+	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
+		return r.migrate(r.ctx, be)
+	case be.DeletionTimestamp != nil:
 		return r.delete(r.ctx, be)
+	case be.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRestore:
+		return r.restore(r.ctx, be, operationType)
+	default:
+		return r.reconcile(r.ctx, be, operationType)
 	}
-	return r.reconcile(r.ctx, be)
 }
 
-func (r *reconciler) reconcile(ctx context.Context, be *extensionsv1alpha1.BackupEntry) (reconcile.Result, error) {
+func (r *reconciler) reconcile(ctx context.Context, be *extensionsv1alpha1.BackupEntry, operationType gardencorev1beta1.LastOperationType) (reconcile.Result, error) {
 	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, be); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	operationType := gardencorev1beta1helper.ComputeOperationType(be.ObjectMeta, be.Status.LastOperation)
 	if err := r.updateStatusProcessing(ctx, be, operationType, "Reconciling the backupentry"); err != nil {
 		return reconcile.Result{}, err
 	}
@@ -129,6 +143,50 @@ func (r *reconciler) reconcile(ctx context.Context, be *extensionsv1alpha1.Backu
 		return reconcile.Result{}, err
 	}
 
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) restore(ctx context.Context, be *extensionsv1alpha1.BackupEntry, operationType gardencorev1beta1.LastOperationType) (reconcile.Result, error) {
+	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, be); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.updateStatusProcessing(ctx, be, operationType, "Restoring the backupentry"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	secret, err := extensionscontroller.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
+	if err != nil {
+		r.logger.Error(err, "failed to get backup entry secret", "backupentry", be.Name)
+		return reconcile.Result{}, err
+	}
+	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, secret); err != nil {
+		r.logger.Error(err, "failed to ensure finalizer on backup entry secret", "backupentry", be.Name)
+		return reconcile.Result{}, err
+	}
+
+	r.logger.Info("Starting the restoration of backupentry", "backupentry", be.Name)
+	r.recorder.Event(be, corev1.EventTypeNormal, EventBackupEntryRestoration, "Restoring the backupentry")
+	if err := r.actuator.Restore(ctx, be); err != nil {
+		msg := "Error restoring backupentry"
+		_ = r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), be, operationType, msg)
+		r.logger.Error(err, msg, "backupentry", be.Name)
+		return extensionscontroller.ReconcileErr(err)
+	}
+
+	msg := "Successfully restored backupentry"
+	r.logger.Info(msg, "backupentry", be.Name)
+	r.recorder.Event(be, corev1.EventTypeNormal, EventBackupEntryRestoration, msg)
+	if err := r.updateStatusSuccess(ctx, be, operationType, msg); err != nil {
+		return reconcile.Result{}, err
+	}
+	// remove operation annotation 'restore'
+	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, be, v1beta1constants.GardenerOperation); err != nil {
+		msg := "Error removing annotation from BackupEntry"
+		r.recorder.Eventf(be, corev1.EventTypeWarning, EventBackupEntryMigration, "%s: %+v", msg, err)
+		r.logger.Error(err, msg, "backupentry", be.Name)
+		return reconcile.Result{}, err
+	}
 	return reconcile.Result{}, nil
 }
 
@@ -178,6 +236,55 @@ func (r *reconciler) delete(ctx context.Context, be *extensionsv1alpha1.BackupEn
 	r.logger.Info("Removing finalizer.", "backupentry", be.Name)
 	if err := extensionscontroller.DeleteFinalizer(ctx, r.client, FinalizerName, be); err != nil {
 		r.logger.Error(err, "Error removing finalizer from backupentry", "backupentry", be.Name)
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) migrate(ctx context.Context, be *extensionsv1alpha1.BackupEntry) (reconcile.Result, error) {
+	if err := r.updateStatusProcessing(ctx, be, gardencorev1beta1.LastOperationTypeMigrate, "Migrating the backupentry"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	r.logger.Info("Starting the migration of backupentry", "backupentry", be.Name)
+	r.recorder.Event(be, corev1.EventTypeNormal, EventBackupEntryMigration, "Migrating the backupentry")
+	if err := r.actuator.Migrate(r.ctx, be); err != nil {
+		msg := "Error migrating backupentry"
+		r.recorder.Eventf(be, corev1.EventTypeWarning, EventBackupEntryMigration, "%s: %+v", msg, err)
+		_ = r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), be, gardencorev1beta1.LastOperationTypeMigrate, msg)
+		r.logger.Error(err, msg, "backupentry", be.Name)
+		return extensionscontroller.ReconcileErr(err)
+	}
+
+	msg := "Successfully migrated backupentry"
+	r.logger.Info(msg, "backupentry", be.Name)
+	r.recorder.Event(be, corev1.EventTypeNormal, EventBackupEntryMigration, msg)
+	if err := r.updateStatusSuccess(ctx, be, gardencorev1beta1.LastOperationTypeMigrate, msg); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	secret, err := extensionscontroller.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
+	if err != nil {
+		r.logger.Error(err, "failed to get backup entry secret", "backupentry", be.Name)
+		return reconcile.Result{}, err
+	}
+	if err := extensionscontroller.DeleteFinalizer(ctx, r.client, FinalizerName, secret); err != nil {
+		r.logger.Error(err, "failed to remove finalizer on backup entry secret", "backupentry", be.Name)
+		return reconcile.Result{}, err
+	}
+
+	r.logger.Info("Removing all finalizers.", "backupentry", be.Name)
+	if err := extensionscontroller.DeleteAllFinalizers(ctx, r.client, be); err != nil {
+		r.logger.Error(err, "Error removing all finalizers from backupentry", "backupentry", be.Name)
+		return reconcile.Result{}, err
+	}
+
+	// remove operation annotation 'migrate'
+	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, be, v1beta1constants.GardenerOperation); err != nil {
+		msg := "Error removing annotation from BackupEntry"
+		r.recorder.Eventf(be, corev1.EventTypeWarning, EventBackupEntryMigration, "%s: %+v", msg, err)
+		r.logger.Error(err, msg, "backupentry", be.Name)
 		return reconcile.Result{}, err
 	}
 

--- a/extensions/pkg/controller/controlplane/actuator.go
+++ b/extensions/pkg/controller/controlplane/actuator.go
@@ -28,4 +28,8 @@ type Actuator interface {
 	Reconcile(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) (bool, error)
 	// Delete deletes the ControlPlane.
 	Delete(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) error
+	// Restore restores the ControlPlane.
+	Restore(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) (bool, error)
+	// Migrate migrates the ControlPlane.
+	Migrate(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) error
 }

--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -508,6 +508,8 @@ func marshalWebhooks(webhooks []admissionregistrationv1beta1.MutatingWebhook, na
 	return buf.Bytes(), nil
 }
 
+// Restore reconciles the given controlplane and cluster, restoring the additional Shoot
+// control plane components as needed.
 func (a *actuator) Restore(
 	ctx context.Context,
 	cp *extensionsv1alpha1.ControlPlane,
@@ -516,6 +518,8 @@ func (a *actuator) Restore(
 	return a.Reconcile(ctx, cp, cluster)
 }
 
+// Migrate reconciles the given controlplane and cluster, deleting the additional
+// control plane components as needed.
 func (a *actuator) Migrate(
 	ctx context.Context,
 	cp *extensionsv1alpha1.ControlPlane,

--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -507,3 +507,19 @@ func marshalWebhooks(webhooks []admissionregistrationv1beta1.MutatingWebhook, na
 
 	return buf.Bytes(), nil
 }
+
+func (a *actuator) Restore(
+	ctx context.Context,
+	cp *extensionsv1alpha1.ControlPlane,
+	cluster *extensionscontroller.Cluster,
+) (bool, error) {
+	return a.Reconcile(ctx, cp, cluster)
+}
+
+func (a *actuator) Migrate(
+	ctx context.Context,
+	cp *extensionsv1alpha1.ControlPlane,
+	cluster *extensionscontroller.Cluster,
+) error {
+	return a.Delete(ctx, cp, cluster)
+}

--- a/extensions/pkg/controller/operatingsystemconfig/actuator.go
+++ b/extensions/pkg/controller/operatingsystemconfig/actuator.go
@@ -26,4 +26,8 @@ type Actuator interface {
 	Reconcile(context.Context, *extensionsv1alpha1.OperatingSystemConfig) ([]byte, *string, []string, error)
 	// Delete the operating system config.
 	Delete(context.Context, *extensionsv1alpha1.OperatingSystemConfig) error
+	// Restore the operating system config.
+	Restore(context.Context, *extensionsv1alpha1.OperatingSystemConfig) ([]byte, *string, []string, error)
+	// Migrate the operating system config.
+	Migrate(context.Context, *extensionsv1alpha1.OperatingSystemConfig) error
 }

--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_migrate.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_migrate.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actuator
+
+import (
+	"context"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+)
+
+// Migrate ignores the deletion of OperatingSystemConfig
+func (a *Actuator) Migrate(ctx context.Context, config *extensionsv1alpha1.OperatingSystemConfig) error {
+	return nil
+}

--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_restore.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_restore.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package actuator
+
+import (
+	"context"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+)
+
+// Restore reconciles the update of a OperatingSystemConfig regenerating the os-specific format
+func (a *Actuator) Restore(ctx context.Context, config *extensionsv1alpha1.OperatingSystemConfig) ([]byte, *string, []string, error) {
+	return a.Reconcile(ctx, config)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Extends the generic actuators, for the extension controllers of Control Plane, Backup Entry and Operation System Config custom resorces (CR), with operations restore and migrate.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Later a PR for each provider extension and operating system extension will be filled that will revendor those changes.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
ControlPlane, BackupEntry and OperatingSystemConfig controllers support operations for migrate and restore.
```
