### PR TITLE
Fix health check library predicates

### DIFF
--- a/extensions/pkg/controller/healthcheck/actuator.go
+++ b/extensions/pkg/controller/healthcheck/actuator.go
@@ -41,8 +41,13 @@ import (
 	More sophisticated checks should be implemented in the extension itself by using the HealthCheck interface.
 */
 
-// GetExtensionObjectFunc returns the extension object that should be registered with the health check controller
+// GetExtensionObjectFunc returns the extension object that should be registered with the health check controller.
+// For example: func() runtime.Object {return &extensionsv1alpha1.Worker{}}
 type GetExtensionObjectFunc = func() runtime.Object
+
+// GetExtensionObjectFunc returns the extension object that should be registered with the health check controller. Has to be a List.
+// For example: func() runtime.Object {return &extensionsv1alpha1.WorkerList{}}
+type GetExtensionObjectListFunc = func() runtime.Object
 
 // PreCheckFunc checks whether the health check shall be performed based on the given object and cluster.
 type PreCheckFunc = func(runtime.Object, *extensionscontroller.Cluster) bool
@@ -60,14 +65,14 @@ type ConditionTypeToHealthCheck struct {
 type HealthCheckActuator interface {
 	// ExecuteHealthCheckFunctions is regularly called by the health check controller
 	// Executes all registered Health Checks and aggregates the result
-	// Returns Result for each healthConditionType registered with the individual health checks.
+	// Returns Result for each healthConditionTypes registered with the individual health checks.
 	// returns an error if it could not execute the health checks
 	// returning an error results in a condition with with type "Unknown" with reason "ConditionCheckError"
 	ExecuteHealthCheckFunctions(context.Context, types.NamespacedName) (*[]Result, error)
 }
 
 // Result represents an aggregated health status for the health checks performed on the dependent API Objects of an extension resource.
-// An Result refers to a single healthConditionType (e.g SystemComponentsHealthy) of an extension Resource.
+// An Result refers to a single healthConditionTypes (e.g SystemComponentsHealthy) of an extension Resource.
 type Result struct {
 	// HealthConditionType is being used as the .type field of the Condition that the HealthCheck controller writes to the extension Resource.
 	// To contribute to the Shoot's health, the Gardener checks each extension for a Health Condition Type of SystemComponentsHealthy, EveryNodeReady, ControlPlaneHealthy.

--- a/extensions/pkg/controller/healthcheck/controller.go
+++ b/extensions/pkg/controller/healthcheck/controller.go
@@ -18,11 +18,12 @@ import (
 	"fmt"
 
 	healthcheckconfig "github.com/gardener/gardener/extensions/pkg/controller/healthcheck/config"
+	extensionshandler "github.com/gardener/gardener/extensions/pkg/handler"
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
-
 	"github.com/gardener/gardener/pkg/api/extensions"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -56,6 +57,8 @@ type AddArgs struct {
 	// The Gardenlet reads the conditions on the extension Resource.
 	// Through this mechanism, the extension can contribute to the Shoot's HealthStatus.
 	registeredExtension *RegisteredExtension
+	// GetExtensionObjListFunc returns a list of the runtime.Object representation of the extension to register
+	GetExtensionObjListFunc GetExtensionObjectListFunc
 }
 
 // DefaultAddArgs are the default Args for the health check controller.
@@ -68,35 +71,36 @@ type DefaultAddArgs struct {
 
 // RegisteredExtension is a registered extensions that the HealthCheck Controller watches.
 // The field extension  contains any extension object
-// The field healthConditionType contains all distinct healthCondition types (extracted from the healthCheck).
+// The field healthConditionTypes contains all distinct healthCondition types (extracted from the healthCheck).
 // They are being used as the .type field of the Condition that the HealthCheck controller writes to the extension Resource.
 // The field groupVersionKind stores the GroupVersionKind of the extension resource
 type RegisteredExtension struct {
-	extension           extensionsv1alpha1.Object
-	getExtensionObjFunc GetExtensionObjectFunc
-	healthConditionType []string
-	groupVersionKind    schema.GroupVersionKind
+	extension            extensionsv1alpha1.Object
+	getExtensionObjFunc  GetExtensionObjectFunc
+	healthConditionTypes []string
+	groupVersionKind     schema.GroupVersionKind
 }
 
 // DefaultRegistration configures the default health check NewActuator to execute the provided health checks and adds it to the provided controller-runtime manager.
-// the NewActuator reconciles a single extension with a specific type and writes conditions for each distinct healthConditionType.
+// the NewActuator reconciles a single extension with a specific type and writes conditions for each distinct healthConditionTypes.
 // extensionType (e.g aws) defines the spec.type of the extension to watch
 // kind defines the GroupVersionKind of the extension
-// register returns a runtime.Object representation of the extension to register
+// GetExtensionObjListFunc returns a list of the runtime.Object representation of the extension to register
+// getExtensionObjFunc returns a runtime.Object representation of the extension to register
 // mgr is the controller runtime manager
 // opts contain config for the healthcheck controller
 // custom predicates allow for fine-grained control which resources to watch
-// healthChecks defines the checks to execute mapped to the healthConditionType its contributing to (e.g checkDeployment in Seed -> ControlPlaneHealthy).
+// healthChecks defines the checks to execute mapped to the healthConditionTypes its contributing to (e.g checkDeployment in Seed -> ControlPlaneHealthy).
 // register returns a runtime representation of the extension resource to register it with the controller-runtime
-func DefaultRegistration(extensionType string, kind schema.GroupVersionKind, getExtensionObjFunc GetExtensionObjectFunc, mgr manager.Manager, opts DefaultAddArgs, customPredicates []predicate.Predicate, healthChecks []ConditionTypeToHealthCheck) error {
-	predicates := DefaultPredicates()
-	predicates = append(predicates, customPredicates...)
+func DefaultRegistration(extensionType string, kind schema.GroupVersionKind, getExtensionObjListFunc GetExtensionObjectListFunc, getExtensionObjFunc GetExtensionObjectFunc, mgr manager.Manager, opts DefaultAddArgs, customPredicates []predicate.Predicate, healthChecks []ConditionTypeToHealthCheck) error {
+	predicates := append([]predicate.Predicate{}, customPredicates...)
 
 	args := AddArgs{
-		ControllerOptions: opts.Controller,
-		Predicates:        predicates,
-		Type:              extensionType,
-		SyncPeriod:        opts.HealthCheckConfig.SyncPeriod,
+		ControllerOptions:       opts.Controller,
+		Predicates:              predicates,
+		Type:                    extensionType,
+		SyncPeriod:              opts.HealthCheckConfig.SyncPeriod,
+		GetExtensionObjListFunc: getExtensionObjListFunc,
 	}
 
 	if err := args.RegisterExtension(getExtensionObjFunc, getHealthCheckTypes(healthChecks), kind); err != nil {
@@ -119,26 +123,16 @@ func (a *AddArgs) RegisterExtension(getExtensionObjFunc GetExtensionObjectFunc, 
 	}
 
 	a.registeredExtension = &RegisteredExtension{
-		extension:           acc,
-		healthConditionType: conditionTypes,
-		groupVersionKind:    kind,
-		getExtensionObjFunc: getExtensionObjFunc,
+		extension:            acc,
+		healthConditionTypes: conditionTypes,
+		groupVersionKind:     kind,
+		getExtensionObjFunc:  getExtensionObjFunc,
 	}
 	return nil
 }
 
 func (a *AddArgs) GetExtensionGroupVersionKind() schema.GroupVersionKind {
 	return a.registeredExtension.groupVersionKind
-}
-
-// DefaultPredicates returns the default predicates.
-func DefaultPredicates() []predicate.Predicate {
-	return []predicate.Predicate{
-		extensionspredicate.ShootNotFailed(),
-		// watch: only requeue on spec change to prevent infinite loop
-		// health checks are being executed every 'sync period' anyways
-		predicate.GenerationChangedPredicate{},
-	}
 }
 
 // Register the extension resource. Must be of type extensionsv1alpha1.Object
@@ -161,11 +155,21 @@ func add(mgr manager.Manager, args AddArgs) error {
 	if err != nil {
 		return err
 	}
+
+	log.Log.Info("Registered health check controller", "kind", args.registeredExtension.groupVersionKind.Kind, "type", args.Type, "health check type", args.registeredExtension.healthConditionTypes, "sync period", args.SyncPeriod.Duration.String())
+
+	// add type predicate to only watch registered resource (e.g ControlPlane) with a certain type (e.g aws)
 	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
 
-	log.Log.Info("Registered health check controller", "Kind", args.registeredExtension.groupVersionKind.Kind, "type", args.Type, "health check type", args.registeredExtension.healthConditionType, "sync period", args.SyncPeriod.Duration.String())
+	if err := ctrl.Watch(&source.Kind{Type: args.registeredExtension.getExtensionObjFunc()}, &handler.EnqueueRequestForObject{}, predicates...); err != nil {
+		return err
+	}
 
-	return ctrl.Watch(&source.Kind{Type: args.registeredExtension.getExtensionObjFunc()}, &handler.EnqueueRequestForObject{}, predicates...)
+	// watch Cluster of Shoot provider type (e.g aws)
+	// this is to be notified when the Shoot is being hibernated (stop health checks) and wakes up (start health checks again)
+	return ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.Cluster{}}, &extensionshandler.EnqueueRequestsFromMapFunc{
+		ToRequests: extensionshandler.SimpleMapper(extensionshandler.ClusterToObjectMapper(args.GetExtensionObjListFunc, predicates), extensionshandler.UpdateWithNew),
+	})
 }
 
 func getHealthCheckTypes(healthChecks []ConditionTypeToHealthCheck) []string {

--- a/extensions/pkg/controller/healthcheck/healtcheck_actuator.go
+++ b/extensions/pkg/controller/healthcheck/healtcheck_actuator.go
@@ -147,7 +147,7 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, request type
 				}
 
 				if !preCheckFunc(obj, cluster) {
-					a.logger.Info("Skipping health check as pre check function returned false", "conditionType", healthConditionType)
+					a.logger.V(6).Info("Skipping health check as pre check function returned false", "condition type", healthConditionType)
 					channel <- channelResult{
 						healthCheckResult: &SingleCheckResult{
 							IsHealthy: true,


### PR DESCRIPTION
**What this PR does / why we need it**:

With the improvement gardenlet to detect outdated healthcheck conditions (ref #2197) we noticed that after hibernation the healthcheck actuator do no longer requeue the extension CR.
Fixes the health check predicates to stop performing health checks when the shoot should be hibernated and starts the checks again when it has fully woken up. 

**Which issue(s) this PR fixes**:
Fixes #2241

**Special notes for your reviewer**:
Needs adjustments in extensions during the healthcheck registration.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixed a bug in the healthcheck library that prevents checks after a Shoot has been woken up from hibernation. Gardener extensions require a minor change during the healthcheck registration.
```
