### PR TITLE
Add K8S gomega error matchers.

### DIFF
--- a/pkg/client/kubernetes/apply_test.go
+++ b/pkg/client/kubernetes/apply_test.go
@@ -21,14 +21,13 @@ import (
 	"sync"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	. "github.com/gardener/gardener/test/framework"
+	. "github.com/gardener/gardener/test/gomega"
 
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -751,14 +750,12 @@ spec:
 
 			It("should delete configmap", func() {
 				err := c.Get(context.TODO(), client.ObjectKey{Name: "test-cm"}, &corev1.ConfigMap{})
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsNotFound(err)).To(BeTrue())
+				Expect(err).To(BeNotFoundError())
 			})
 
 			It("should delete pod", func() {
 				err := c.Get(context.TODO(), client.ObjectKey{Name: "test-pod"}, &corev1.Pod{})
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsNotFound(err)).To(BeTrue())
+				Expect(err).To(BeNotFoundError())
 			})
 
 			It("should keep configmap which should not be deleted", func() {

--- a/pkg/client/kubernetes/chartapplier_test.go
+++ b/pkg/client/kubernetes/chartapplier_test.go
@@ -22,14 +22,13 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/golang/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/helm/pkg/engine"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	. "github.com/gardener/gardener/test/framework"
+	. "github.com/gardener/gardener/test/gomega"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -176,8 +175,7 @@ var _ = Describe("chart applier", func() {
 			actual := &corev1.ConfigMap{}
 			err := c.Get(context.TODO(), client.ObjectKey{Name: cmName, Namespace: cns}, actual)
 
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			Expect(err).To(BeNotFoundError())
 		})
 
 		It("deletes the chart with custom values", func() {
@@ -216,8 +214,7 @@ var _ = Describe("chart applier", func() {
 			actual := &corev1.ConfigMap{}
 			err := c.Get(context.TODO(), client.ObjectKey{Name: cmName, Namespace: cns}, actual)
 
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			Expect(err).To(BeNotFoundError())
 		})
 	})
 })

--- a/plugin/pkg/controllerregistration/resources/admission_test.go
+++ b/plugin/pkg/controllerregistration/resources/admission_test.go
@@ -21,9 +21,10 @@ import (
 	"github.com/gardener/gardener/pkg/client/core/clientset/internalversion/fake"
 	. "github.com/gardener/gardener/plugin/pkg/controllerregistration/resources"
 
+	. "github.com/gardener/gardener/test/gomega"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
@@ -110,8 +111,7 @@ var _ = Describe("resources", func() {
 
 			err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			Expect(err).To(BeForbiddenError())
 		})
 	})
 

--- a/plugin/pkg/global/deletionconfirmation/admission_test.go
+++ b/plugin/pkg/global/deletionconfirmation/admission_test.go
@@ -24,9 +24,10 @@ import (
 	"github.com/gardener/gardener/pkg/operation/common"
 	. "github.com/gardener/gardener/plugin/pkg/global/deletionconfirmation"
 
+	. "github.com/gardener/gardener/test/gomega"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
@@ -107,8 +108,7 @@ var _ = Describe("deleteconfirmation", func() {
 
 					err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
-					Expect(err).To(HaveOccurred())
-					Expect(apierrors.IsForbidden(err)).To(BeTrue())
+					Expect(err).To(BeForbiddenError())
 				})
 
 				It("should reject for false annotation value", func() {
@@ -121,8 +121,7 @@ var _ = Describe("deleteconfirmation", func() {
 
 					err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
-					Expect(err).To(HaveOccurred())
-					Expect(apierrors.IsForbidden(err)).To(BeTrue())
+					Expect(err).To(BeForbiddenError())
 				})
 
 				It("should succeed for true annotation value (cache lookup)", func() {
@@ -172,8 +171,7 @@ var _ = Describe("deleteconfirmation", func() {
 
 					err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
-					Expect(err).To(HaveOccurred())
-					Expect(apierrors.IsForbidden(err)).To(BeTrue())
+					Expect(err).To(BeForbiddenError())
 				})
 			})
 
@@ -233,8 +231,7 @@ var _ = Describe("deleteconfirmation", func() {
 
 					err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
-					Expect(err).To(HaveOccurred())
-					Expect(apierrors.IsForbidden(err)).To(BeTrue())
+					Expect(err).To(BeForbiddenError())
 				})
 
 				It("should reject for false annotation value", func() {
@@ -247,8 +244,7 @@ var _ = Describe("deleteconfirmation", func() {
 
 					err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
-					Expect(err).To(HaveOccurred())
-					Expect(apierrors.IsForbidden(err)).To(BeTrue())
+					Expect(err).To(BeForbiddenError())
 				})
 
 				It("should succeed for true annotation value (cache lookup)", func() {

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/common"
 	. "github.com/gardener/gardener/plugin/pkg/shoot/validator"
+	. "github.com/gardener/gardener/test/gomega"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -311,8 +311,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("update should fail because shoot is not in garden namespace and seed is protected", func() {
@@ -325,8 +324,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("create should pass because shoot is in garden namespace and seed is protected", func() {
@@ -407,8 +405,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsBadRequest(err)).To(BeTrue())
+				Expect(err).To(BeBadRequestError())
 				Expect(err.Error()).To(ContainSubstring("consecutive hyphens"))
 			})
 
@@ -423,8 +420,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 				Expect(err.Error()).To(ContainSubstring("already marked for deletion"))
 			})
 
@@ -445,8 +441,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsBadRequest(err)).To(BeTrue())
+				Expect(err).To(BeBadRequestError())
 				Expect(err.Error()).To(ContainSubstring("name must not exceed"))
 			})
 
@@ -659,8 +654,7 @@ var _ = Describe("validator", func() {
 
 			err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsBadRequest(err)).To(BeTrue())
+			Expect(err).To(BeBadRequestError())
 		})
 
 		It("should reject because the referenced seed was not found", func() {
@@ -670,8 +664,7 @@ var _ = Describe("validator", func() {
 
 			err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsBadRequest(err)).To(BeTrue())
+			Expect(err).To(BeBadRequestError())
 		})
 
 		It("should reject because the referenced project was not found", func() {
@@ -681,8 +674,7 @@ var _ = Describe("validator", func() {
 
 			err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsBadRequest(err)).To(BeTrue())
+			Expect(err).To(BeBadRequestError())
 		})
 
 		It("should reject because the cloud provider in shoot and profile differ", func() {
@@ -696,8 +688,7 @@ var _ = Describe("validator", func() {
 
 			err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsBadRequest(err)).To(BeTrue())
+			Expect(err).To(BeBadRequestError())
 		})
 
 		Context("tests for infrastructure update", func() {
@@ -771,8 +762,7 @@ var _ = Describe("validator", func() {
 				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 				Expect(err.Error()).To(ContainSubstring("Unsupported value: \"europe-a\": supported values: \"asia-a\""))
 			})
 
@@ -783,8 +773,7 @@ var _ = Describe("validator", func() {
 				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 				Expect(err.Error()).To(ContainSubstring("Unsupported value: \"europe-a\": supported values: \"zone-1\", \"zone-2\""))
 			})
 		})
@@ -833,8 +822,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should reject because the shoot pod and the seed pod networks intersect", func() {
@@ -847,8 +835,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should reject because the shoot service and the seed service networks intersect", func() {
@@ -861,8 +848,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should reject because the specified domain is already used by another shoot", func() {
@@ -878,8 +864,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should reject because the specified domain is a subdomain of a domain already used by another shoot", func() {
@@ -898,8 +883,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should reject because the specified domain is a subdomain of a domain already used by another shoot (case one)", func() {
@@ -918,8 +902,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should reject because the specified domain is a subdomain of a domain already used by another shoot (case two)", func() {
@@ -937,8 +920,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should allow because the specified domain is not a subdomain of a domain already used by another shoot", func() {
@@ -970,8 +952,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should default a major.minor kubernetes version to latest patch version", func() {
@@ -1022,8 +1003,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should be able to explicitly pick preview versions", func() {
@@ -1054,8 +1034,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should reject due to an invalid machine image", func() {
@@ -1071,8 +1050,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should reject due to a machine image with expiration date in the past", func() {
@@ -1108,8 +1086,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should use latest machine image as old shoot does not specify one", func() {
@@ -1332,8 +1309,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should reject due to an invalid machine type", func() {
@@ -1352,8 +1328,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should reject due to an invalid volume type", func() {
@@ -1376,8 +1351,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should reject due to an invalid zone", func() {
@@ -1390,8 +1364,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should reject due to an invalid zone update", func() {
@@ -1406,8 +1379,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsForbidden(err)).To(BeTrue())
+				Expect(err).To(BeForbiddenError())
 			})
 
 			It("should allow update when zone has removed from CloudProfile", func() {

--- a/plugin/pkg/shootstate/validator/admission_test.go
+++ b/plugin/pkg/shootstate/validator/admission_test.go
@@ -23,8 +23,10 @@ import (
 	"github.com/gardener/gardener/pkg/client/core/clientset/internalversion/fake"
 	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 
+	. "github.com/gardener/gardener/test/gomega"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -83,8 +85,7 @@ var _ = Describe("Validate ShootState deletion", func() {
 
 		err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
-		Expect(err).To(HaveOccurred())
-		Expect(apierrors.IsForbidden(err)).To(BeTrue())
+		Expect(err).To(BeForbiddenError())
 	})
 
 	It("should return an error which is not Forbidden if retrieving the shoot fails with an error different from NotFound", func() {
@@ -96,7 +97,7 @@ var _ = Describe("Validate ShootState deletion", func() {
 
 		err := admissionHandler.Validate(context.TODO(), attrs, nil)
 		Expect(err).To(HaveOccurred())
-		Expect(apierrors.IsForbidden(err)).To(BeFalse())
+		Expect(err).ToNot(BeForbiddenError())
 	})
 
 	It("should allow ShootState deletion because shoot object does not exist", func() {
@@ -145,8 +146,7 @@ var _ = Describe("Validate ShootState deletion", func() {
 
 			err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsForbidden(err)).To(BeTrue())
+			Expect(err).To(BeForbiddenError())
 		})
 	})
 

--- a/test/gomega/deep_derivative.go
+++ b/test/gomega/deep_derivative.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gomega
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/format"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+const (
+	deepDerivativeMatcherNilError = `refusing to compare <nil> to <nil>.
+Be explicit and use BeNil() instead.
+This is to avoid mistakes where both sides of an assertion are erroneously uninitialized`
+)
+
+type deepDerivativeMatcher struct {
+	expected interface{}
+}
+
+func (m *deepDerivativeMatcher) Match(actual interface{}) (success bool, err error) {
+	if actual == nil && m.expected == nil {
+		return false, fmt.Errorf(deepDerivativeMatcherNilError)
+	}
+
+	return equality.Semantic.DeepDerivative(m.expected, actual), nil
+}
+
+func (m *deepDerivativeMatcher) FailureMessage(actual interface{}) (message string) {
+	actualString, actualOK := actual.(string)
+	expectedString, expectedOK := m.expected.(string)
+
+	if actualOK && expectedOK {
+		return format.MessageWithDiff(actualString, "to deep derivative equal", expectedString)
+	}
+
+	return format.Message(actual, "to deep derivative equal", m.expected)
+}
+
+func (m *deepDerivativeMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to deep derivative equal", m.expected)
+}

--- a/test/gomega/deep_derivative_test.go
+++ b/test/gomega/deep_derivative_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gomega_test
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/gardener/gardener/test/gomega"
+)
+
+var _ = Describe("DeepDerivativeEqual", func() {
+	var (
+		actual, expected *corev1.Pod
+	)
+
+	BeforeEach(func() {
+		actual = &corev1.Pod{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Pod",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		}
+		expected = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		}
+	})
+
+	It("should be true when expected has less info", func() {
+		Expect(actual).To(DeepDerivativeEqual(expected))
+	})
+
+	It("should be false when objects differ", func() {
+		expected.Name = "baz"
+		Expect(actual).ToNot(DeepDerivativeEqual(expected))
+	})
+
+	It("should throw error when both are nil", func() {
+		success, err := DeepDerivativeEqual(nil).Match(nil)
+
+		Expect(success).Should(BeFalse())
+		Expect(err).Should(HaveOccurred())
+	})
+})

--- a/test/gomega/gomega_suite_test.go
+++ b/test/gomega/gomega_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package framework
+package gomega_test
 
 import (
-	"github.com/onsi/gomega"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-// ExpectNoError checks if an error has occurred
-func ExpectNoError(actual interface{}, extra ...interface{}) {
-	gomega.ExpectWithOffset(1, actual, extra...).ToNot(gomega.HaveOccurred())
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gardener Gomega Matchers")
 }

--- a/test/gomega/kubernetes_errors.go
+++ b/test/gomega/kubernetes_errors.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gomega
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/format"
+)
+
+type kubernetesErrors struct {
+	checkFunc func(error) bool
+	message   string
+}
+
+func (k *kubernetesErrors) Match(actual interface{}) (success bool, err error) {
+	// is purely nil?
+	if actual == nil {
+		return false, nil
+	}
+
+	actualErr, actualOk := actual.(error)
+	if !actualOk {
+		return false, fmt.Errorf("expected an error-type.  got:\n%s", format.Object(actual, 1))
+	}
+
+	return k.checkFunc(actualErr), nil
+}
+
+func (k *kubernetesErrors) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, fmt.Sprintf("to be %s error", k.message))
+}
+func (k *kubernetesErrors) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, fmt.Sprintf("to not be %s error", k.message))
+}

--- a/test/gomega/kubernetes_errors_test.go
+++ b/test/gomega/kubernetes_errors_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gomega_test
+
+import (
+	"fmt"
+
+	. "github.com/gardener/gardener/test/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var _ = Describe("BeNotFoundError", func() {
+	It("should be true when error is not found", func() {
+		err := apierrors.NewNotFound(schema.GroupResource{Group: "baz", Resource: "bar"}, "foo")
+		Expect(err).To(BeNotFoundError())
+	})
+
+	It("should be false when error is not k8s not found error", func() {
+		err := apierrors.NewGone("opsie")
+		Expect(err).ToNot(BeNotFoundError())
+	})
+
+	It("should be false when error is random error", func() {
+		err := fmt.Errorf("not k8s error")
+		Expect(err).ToNot(BeNotFoundError())
+	})
+
+	It("should be false when error is nil", func() {
+		Expect(nil).ToNot(BeNotFoundError())
+	})
+
+	It("should throw error when actual is not error", func() {
+		success, err := BeNotFoundError().Match("not an error")
+
+		Expect(success).Should(BeFalse())
+		Expect(err).Should(HaveOccurred())
+	})
+})
+
+var _ = Describe("BeForbiddenError", func() {
+	It("should be true when error is fobidden", func() {
+		err := apierrors.NewForbidden(schema.GroupResource{Group: "baz", Resource: "bar"}, "foo", fmt.Errorf("got err"))
+		Expect(err).To(BeForbiddenError())
+	})
+
+	It("should be false when error is not k8s forbidden", func() {
+		err := apierrors.NewGone("opsie")
+		Expect(err).ToNot(BeForbiddenError())
+	})
+
+	It("should be false when error is random error", func() {
+		err := fmt.Errorf("not k8s error")
+		Expect(err).ToNot(BeForbiddenError())
+	})
+
+	It("should be false when error is nil", func() {
+		Expect(nil).ToNot(BeForbiddenError())
+	})
+
+	It("should throw error when actual is not error", func() {
+		success, err := BeForbiddenError().Match("not an error")
+
+		Expect(success).Should(BeFalse())
+		Expect(err).Should(HaveOccurred())
+	})
+})
+
+var _ = Describe("BeBadRequestError", func() {
+	It("should be true when error is bad request", func() {
+		err := apierrors.NewBadRequest("some reason")
+		Expect(err).To(BeBadRequestError())
+	})
+
+	It("should be false when error is not k8s bad request", func() {
+		err := apierrors.NewGone("opsie")
+		Expect(err).ToNot(BeBadRequestError())
+	})
+
+	It("should be false when error is random error", func() {
+		err := fmt.Errorf("not k8s error")
+		Expect(err).ToNot(BeBadRequestError())
+	})
+
+	It("should be false when error is nil", func() {
+		Expect(nil).ToNot(BeBadRequestError())
+	})
+
+	It("should throw error when actual is not error", func() {
+		success, err := BeBadRequestError().Match("not an error")
+
+		Expect(success).Should(BeFalse())
+		Expect(err).Should(HaveOccurred())
+	})
+})

--- a/test/gomega/matchers.go
+++ b/test/gomega/matchers.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gomega
+
+import (
+	"github.com/onsi/gomega/types"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// DeepDerivativeEqual is similar to DeepEqual except that unset fields in actual are
+// ignored (not compared). This allows us to focus on the fields that matter to
+// the semantic comparison.
+func DeepDerivativeEqual(expected interface{}) types.GomegaMatcher {
+	return &deepDerivativeMatcher{
+		expected: expected,
+	}
+}
+
+// BeNotFoundError checks if error is NotFound.
+func BeNotFoundError() types.GomegaMatcher {
+	return &kubernetesErrors{
+		checkFunc: apierrors.IsNotFound,
+		message:   "NotFound",
+	}
+}
+
+// BeForbiddenError checks if error is Forbidden.
+func BeForbiddenError() types.GomegaMatcher {
+	return &kubernetesErrors{
+		checkFunc: apierrors.IsForbidden,
+		message:   "Forbidden",
+	}
+}
+
+// BeBadRequestError checks if error is BadRequest.
+func BeBadRequestError() types.GomegaMatcher {
+	return &kubernetesErrors{
+		checkFunc: apierrors.IsBadRequest,
+		message:   "BadRequest",
+	}
+}


### PR DESCRIPTION


**What this PR does / why we need it**:

New matchers for K8S errors are added:

- `Expect(err).To(BeNotFoundError())`
- `Expect(err).To(BeForbiddenError())`
- `Expect(err).To(BeBadRequestError())`

Makes testing easier as you are no longer required to do:

```go
Expect(err).To(HaveOccurred())
Expect(apierrors.IsNotFound(err)).To(BeTrue())
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
