### PR TITLE
Fix panic during extension deletion

### DIFF
--- a/pkg/operation/common/extensions.go
+++ b/pkg/operation/common/extensions.go
@@ -256,8 +256,11 @@ func WaitUntilExtensionCRDeleted(
 			lastObservedError = gardencorev1beta1helper.NewErrorWithCodes(lastErr.Description, lastErr.Codes...)
 		}
 
-		logger.Infof("Waiting for %s %s/%s to be deleted...", kind, namespace, name)
-		return retry.MinorError(fmt.Errorf("%s is still present, last observed error: %s", extensionKey(kind, namespace, name), lastObservedError.Error()))
+		var message = fmt.Sprintf("%s is still present", extensionKey(kind, namespace, name))
+		if lastObservedError != nil {
+			message += fmt.Sprintf(", last observed error: %s", lastObservedError.Error())
+		}
+		return retry.MinorError(fmt.Errorf(message))
 	}); err != nil {
 		message := fmt.Sprintf("Failed to delete %s", extensionKey(kind, namespace, name))
 		if lastObservedError != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a panic during Extension CRD deletion. Please take a look at the referenced issue #2255.

**Which issue(s) this PR fixes**:
Fixes #2255

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
