### PR TITLE
Skip infrastructure reconciliation for hibernated shoots

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -172,10 +172,11 @@ func (c *defaultMaintenanceControl) Maintain(shootObj *gardencorev1beta1.Shoot, 
 			return nil, fmt.Errorf("auto update section of Shoot %s/%s changed mid-air", s.Namespace, s.Name)
 		}
 
-		delete(s.Annotations, v1beta1constants.GardenerOperation)
-		controllerutils.AddTasks(s.Annotations, common.ShootTaskDeployInfrastructure)
 		s.Annotations[v1beta1constants.GardenerOperation] = common.ShootOperationReconcile
 
+		if !gardencorev1beta1helper.HibernationIsEnabled(s) {
+			controllerutils.AddTasks(s.Annotations, common.ShootTaskDeployInfrastructure)
+		}
 		if utils.IsTrue(c.config.EnableShootControlPlaneRestarter) {
 			controllerutils.AddTasks(s.Annotations, common.ShootTaskRestartControlPlanePods)
 		}

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -21,6 +21,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/common"
@@ -42,7 +43,8 @@ func (b *Botanist) DeployInfrastructure(ctx context.Context) error {
 	var (
 		lastOperation                       = b.Shoot.Info.Status.LastOperation
 		creationPhase                       = lastOperation != nil && lastOperation.Type == gardencorev1beta1.LastOperationTypeCreate
-		requestInfrastructureReconciliation = creationPhase || controllerutils.HasTask(b.Shoot.Info.Annotations, common.ShootTaskDeployInfrastructure)
+		shootIsWakingUp                     = !gardencorev1beta1helper.HibernationIsEnabled(b.Shoot.Info) && b.Shoot.Info.Status.IsHibernated
+		requestInfrastructureReconciliation = creationPhase || shootIsWakingUp || controllerutils.HasTask(b.Shoot.Info.Annotations, common.ShootTaskDeployInfrastructure)
 
 		infrastructure = &extensionsv1alpha1.Infrastructure{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:
The infrastructure reconciliation task will now only be added if the shoot is not hibernated. Also, the gardenlet will request infrastructure reconciliation when the shoot is waking up.

**Which issue(s) this PR fixes**:
Fixes #2253

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The infrastructure reconciliation for hibernated shoots is now skipped.
```
