### PR TITLE
Remove etcd and etcd-backup-restore images

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -31,14 +31,6 @@ images:
   tag: "0.4.0"
 
 # Seed controlplane
-- name: etcd
-  sourceRepository: github.com/etcd-io/etcd
-  repository: quay.io/coreos/etcd
-  tag: v3.3.17
-- name: etcd-backup-restore
-  sourceRepository: github.com/gardener/etcd-backup-restore
-  repository: eu.gcr.io/gardener-project/gardener/etcdbrctl
-  tag: "v0.9.0"
 - name: hyperkube # used for kubectl + kubelet binaries on the worker nodes
   sourceRepository: github.com/kubernetes/kubernetes
   repository: k8s.gcr.io/hyperkube

--- a/charts/seed-controlplane/charts/etcd/templates/etcd.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd.yaml
@@ -33,7 +33,6 @@ spec:
     networking.gardener.cloud/to-public-networks: allowed
     networking.gardener.cloud/to-private-networks: allowed
   etcd:
-    image: {{ index .Values.images "etcd" }}
 {{- if .Values.etcd.resources }}
     resources:
 {{ toYaml .Values.etcd.resources | indent 6 }}
@@ -53,7 +52,6 @@ spec:
     metrics: {{ .Values.etcd.metrics }}
     defragmentationSchedule: {{ .Values.etcd.defragmentSchedule }}
   backup:
-    image: {{ index .Values.images "etcd-backup-restore" }}
     port: {{ .Values.sidecar.port }}
 {{- if .Values.sidecar.resources }}
     resources:

--- a/charts/seed-controlplane/charts/etcd/values.yaml
+++ b/charts/seed-controlplane/charts/etcd/values.yaml
@@ -4,10 +4,6 @@ labels: {}
 annotations: {}
 podAnnotations: {}
 
-images:
-  etcd: image-repository:image-tag
-  etcd-backup-restore: image-repository:image-tag
-
 etcd:
   resources:
     requests:

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -1066,11 +1066,10 @@ func (b *Botanist) DeployKubeScheduler(ctx context.Context) error {
 func (b *Botanist) DeployETCD(ctx context.Context) error {
 	hvpaEnabled := gardenletfeatures.FeatureGate.Enabled(features.HVPA)
 	if b.ShootedSeed != nil {
-		// Override for shooted seeds
 		hvpaEnabled = gardenletfeatures.FeatureGate.Enabled(features.HVPAForShootedSeed)
 	}
 
-	defaultValues := map[string]interface{}{
+	values := map[string]interface{}{
 		"annotations": map[string]string{
 			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
 		},
@@ -1080,15 +1079,6 @@ func (b *Botanist) DeployETCD(ctx context.Context) error {
 			"checksum/secret-etcd-client-tls":  b.CheckSums[common.EtcdClientTLS],
 		},
 		"storageCapacity": b.Seed.GetValidVolumeSize("10Gi"),
-	}
-
-	values, err := b.InjectSeedShootImages(
-		defaultValues,
-		common.ETCDImageName,
-		common.ETCDBackupRestoreImageName,
-	)
-	if err != nil {
-		return err
 	}
 
 	for _, role := range []string{common.EtcdRoleMain, common.EtcdRoleEvents} {

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -443,12 +443,6 @@ const (
 	// KubeStateMetricsImageName is the name of the KubeStateMetrics image.
 	KubeStateMetricsImageName = "kube-state-metrics"
 
-	// ETCDImageName is the name of the ETCD image.
-	ETCDImageName = "etcd"
-
-	// ETCDBackupRestoreImageName is the name of the ETCD backup-restore image.
-	ETCDBackupRestoreImageName = "etcd-backup-restore"
-
 	// EtcdDruidImageName is the name of Etcd Druid image
 	EtcdDruidImageName = "etcd-druid"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
After the introduction of `etcd-druid` we decided that it does not make sense to let Gardener control the versions of the `etcd` and `etcd-backup-restore` images as their manifests/configuration are controlled by `etcd-druid`. It is necessary for a successful deployment that the version works well with the manifests/configuration.
Consequently, `etcd-druid` was meanwhile made capable of controlling these versions using the image vector concept (see gardener/etcd-druid#23 and gardener/etcd-druid#24).
Gardener already supports overwriting the image vector for components it deploys, see #2036 and https://github.com/gardener/gardener/blob/master/docs/deployment/image_vector.md#image-vectors-for-dependent-components.
This PR now removes the `etcd` and `etcd-backup-restore` images from Gardener so that `etcd-druid` can take over.

**Special notes for your reviewer**:
/cc @shreyas-s-rao @swapnilgm @georgekuruvillak - once this PR is merged you need to release a new version of etcd-druid when you want Gardener to use a newer/different version of etcd or etcd-backup-restore. There won't be PRs such as #2260 anymore to this repository. Instead, they should be opened to the [gardener/etcd-druid](https://github.com/gardener/etcd-druid) repository. I opened gardener/etcd-druid#50 to track this.

ℹ️Softly depends on #2263

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Gardener's image vector does no longer contain `etcd` and `etcd-backup-restore`. If you want to overwrite these versions you must do it via the `etcd-druid`. Please consult [this document](https://github.com/gardener/gardener/blob/master/docs/deployment/image_vector.md#image-vectors-for-dependent-components) for more information.
```
