### PR TITLE
Configurable Gardenlet Stale health check verification

### DIFF
--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -40,7 +40,7 @@ controllers:
   shootCare:
     concurrentSyncs: 5
     syncPeriod: 30s
-    staleExtensionHealthCheckThreshold: 5m
+#    staleExtensionHealthCheckThreshold: 5m
     conditionThresholds:
     - type: APIServerAvailable
       duration: 1m

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -198,6 +198,8 @@ type ShootCareControllerConfiguration struct {
 	// StaleExtensionHealthCheckThreshold configures the threshold when Gardener considers a Health check report of an
 	// Extension CRD as outdated.
 	// The StaleExtensionHealthCheckThreshold should have some leeway in case a Gardener extension is temporarily unavailable.
+	// If not set, Gardener does not verify for outdated health check reports. This is for backwards-compatibility reasons
+	// and will become default in a future version.
 	StaleExtensionHealthCheckThreshold *metav1.Duration
 	// ConditionThresholds defines the condition threshold per condition type.
 	ConditionThresholds []ConditionThreshold

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -274,11 +274,6 @@ func SetDefaults_ShootCareControllerConfiguration(obj *ShootCareControllerConfig
 		v := metav1.Duration{Duration: time.Minute}
 		obj.SyncPeriod = &v
 	}
-
-	if obj.StaleExtensionHealthCheckThreshold == nil {
-		v := metav1.Duration{Duration: 5 * time.Minute}
-		obj.StaleExtensionHealthCheckThreshold = &v
-	}
 }
 
 // SetDefaults_ShootStateSyncControllerConfiguration sets defaults for the shoot state controller.

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -248,7 +248,8 @@ type ShootCareControllerConfiguration struct {
 	// StaleExtensionHealthCheckThreshold configures the threshold when Gardener considers a Health check report of an
 	// Extension CRD as outdated.
 	// The StaleExtensionHealthCheckThreshold should have some leeway in case a Gardener extension is temporarily unavailable.
-	// Defaults to 5 minutes.
+	// If not set, Gardener does not verify for outdated health check reports. This is for backwards-compatibility reasons
+	// and will become default in a future version.
 	// +optional
 	StaleExtensionHealthCheckThreshold *metav1.Duration `json:"staleExtensionHealthCheckThreshold,omitempty"`
 	// ConditionThresholds defines the condition threshold per condition type.


### PR DESCRIPTION
Gardenlet does not check for stale extension health check reports per default.

**What this PR does / why we need it**:

The Gardenlet introduced checks for stale extension reports with PR #2215 .
However the Gardener extensions are using the health check libraries that can produce outdated-health check reports. This should be fixed with this [PR](https://github.com/gardener/gardener/pull/2249).
To not couple the Gardener version with the extension versions, for now the Gardener does NOT check for outdated health checks per default. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
For backwards-compatibility reasons, the gardenlet does not  check for stale extension reports per default. To enable, the field controllers.shootCare.staleExtensionHealthCheckThreshold  in the Gardenlet configuration file (https://github.com/gardener/gardener/blob/master/example/20-componentconfig-gardenlet.yaml)can be set.
```
