### PR TITLE
Improve webhook hibernation validation

### DIFF
--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -25,6 +25,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	botanistconstants "github.com/gardener/gardener/pkg/operation/botanist/constants"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -136,7 +137,7 @@ func (b *Botanist) DeployManagedResources(ctx context.Context) error {
 			common.ShootNoCleanup: "true",
 		}
 		labels = map[string]string{
-			ManagedResourceLabelKeyOrigin: ManagedResourceLabelValueGardener,
+			botanistconstants.ManagedResourceLabelKeyOrigin: botanistconstants.ManagedResourceLabelValueGardener,
 		}
 		charts = map[string]managedResourceOptions{
 			"shoot-core":            {false, b.generateCoreAddonsChart},
@@ -188,7 +189,7 @@ func (b *Botanist) deployCloudConfigExecutionManagedResource(ctx context.Context
 			common.ShootNoCleanup: "true",
 		}
 		labels = map[string]string{
-			ManagedResourceLabelKeyOrigin: ManagedResourceLabelValueGardener,
+			botanistconstants.ManagedResourceLabelKeyOrigin: botanistconstants.ManagedResourceLabelValueGardener,
 		}
 		managedResourceName = "shoot-cloud-config-execution"
 		secretLabels        = map[string]string{

--- a/pkg/operation/botanist/constants/constants.go
+++ b/pkg/operation/botanist/constants/constants.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package constants
+
+const (
+	// ManagedResourceLabelKeyOrigin is a key for a label on a managed resource with the value 'origin'.
+	ManagedResourceLabelKeyOrigin = "origin"
+	// ManagedResourceLabelValueGardener is a value for a label on a managed resource with the value 'gardener'.
+	ManagedResourceLabelValueGardener = "gardener"
+)

--- a/pkg/operation/botanist/constraints_check.go
+++ b/pkg/operation/botanist/constraints_check.go
@@ -20,10 +20,9 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/operation/botanist/matchers"
 
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook"
 )
 
@@ -122,15 +121,13 @@ func IsProblematicWebhook(w webhook.WebhookAccessor) bool {
 		return false
 	}
 
-	for _, rule := range w.GetRules() {
-		apiGroups := sets.NewString(rule.APIGroups...)
-		resources := sets.NewString(rule.Resources...)
+	objSelector := w.GetObjectSelector()
+	nsSelector := w.GetNamespaceSelector()
 
-		if apiGroups.Has(corev1.GroupName) && resources.HasAny("pods", "nodes") {
-			for _, op := range rule.Operations {
-				if op == admissionregistrationv1beta1.Create || op == admissionregistrationv1beta1.Update || op == admissionregistrationv1beta1.OperationAll {
-					return true
-				}
+	for _, rule := range w.GetRules() {
+		for _, matcher := range matchers.WebhookConstraintMatchers {
+			if matcher.Match(rule, objSelector, nsSelector) {
+				return true
 			}
 		}
 	}

--- a/pkg/operation/botanist/constraints_check_test.go
+++ b/pkg/operation/botanist/constraints_check_test.go
@@ -27,19 +27,13 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	coordinationv1beta1 "k8s.io/api/coordination/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	eventsv1beta1 "k8s.io/api/events/v1beta1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
 	networkingv1beta1 "k8s.io/api/networking/v1beta1"
-	nodev1alpha1 "k8s.io/api/node/v1alpha1"
-	nodev1beta1 "k8s.io/api/node/v1beta1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	rbacv1alpha1 "k8s.io/api/rbac/v1alpha1"
@@ -54,8 +48,6 @@ import (
 	"k8s.io/apiserver/pkg/admission/plugin/webhook"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
-	metricsv1alpha1 "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
-	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 )
 
 type webhookTestCase struct {
@@ -228,15 +220,10 @@ var _ = Describe("#IsProblematicWebhook", func() {
 		}
 	)
 
-	kubeSystemNamespaceTables(schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"})
-	kubeSystemNamespaceTables(schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1alpha1", Resource: "endpointslices"})
-	kubeSystemNamespaceTables(schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1beta1", Resource: "endpointslices"})
-
 	podsTestTables(corev1.SchemeGroupVersion.WithResource("pods"))
 	podsTestTables(corev1.SchemeGroupVersion.WithResource("pods/status"))
 	kubeSystemNamespaceTables(corev1.SchemeGroupVersion.WithResource("configmaps"))
 	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("endpoints"))
-	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("events"))
 	kubeSystemNamespaceTables(corev1.SchemeGroupVersion.WithResource("secrets"))
 	kubeSystemNamespaceTables(corev1.SchemeGroupVersion.WithResource("serviceaccounts"))
 	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("services"))
@@ -246,8 +233,6 @@ var _ = Describe("#IsProblematicWebhook", func() {
 	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("namespaces"))
 	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("namespaces/status"))
 	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("namespaces/finalize"))
-
-	withoutSelectorsTables(eventsv1beta1.SchemeGroupVersion.WithResource("events"))
 
 	kubeSystemNamespaceTables(appsv1.SchemeGroupVersion.WithResource("controllerrevisions"))
 	kubeSystemNamespaceTables(appsv1.SchemeGroupVersion.WithResource("daemonsets"))
@@ -293,25 +278,10 @@ var _ = Describe("#IsProblematicWebhook", func() {
 	withoutSelectorsTables(coordinationv1.SchemeGroupVersion.WithResource("leases"))
 	withoutSelectorsTables(coordinationv1beta1.SchemeGroupVersion.WithResource("leases"))
 
-	kubeSystemNamespaceTables(metricsv1alpha1.SchemeGroupVersion.WithResource("podmetrics"))
-	withoutSelectorsTables(metricsv1alpha1.SchemeGroupVersion.WithResource("nodemetrics"))
-
-	kubeSystemNamespaceTables(metricsv1beta1.SchemeGroupVersion.WithResource("podmetrics"))
-	withoutSelectorsTables(metricsv1beta1.SchemeGroupVersion.WithResource("nodemetrics"))
-
 	kubeSystemNamespaceTables(networkingv1.SchemeGroupVersion.WithResource("networkpolicies"))
 	kubeSystemNamespaceTables(networkingv1beta1.SchemeGroupVersion.WithResource("networkpolicies"))
 
 	withoutSelectorsTables(policyv1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies"))
-
-	kubeSystemNamespaceTables(autoscalingv1.SchemeGroupVersion.WithResource("horizontalpodautoscalers"))
-	kubeSystemNamespaceTables(autoscalingv1.SchemeGroupVersion.WithResource("horizontalpodautoscalers/status"))
-
-	kubeSystemNamespaceTables(autoscalingv2beta1.SchemeGroupVersion.WithResource("horizontalpodautoscalers"))
-	kubeSystemNamespaceTables(autoscalingv2beta1.SchemeGroupVersion.WithResource("horizontalpodautoscalers/status"))
-
-	kubeSystemNamespaceTables(autoscalingv2beta2.SchemeGroupVersion.WithResource("horizontalpodautoscalers"))
-	kubeSystemNamespaceTables(autoscalingv2beta2.SchemeGroupVersion.WithResource("horizontalpodautoscalers/status"))
 
 	withoutSelectorsTables(rbacv1.SchemeGroupVersion.WithResource("clusterroles"))
 	withoutSelectorsTables(rbacv1.SchemeGroupVersion.WithResource("clusterrolebindings"))
@@ -343,9 +313,6 @@ var _ = Describe("#IsProblematicWebhook", func() {
 	withoutSelectorsTables(certificatesv1beta1.SchemeGroupVersion.WithResource("certificatesigningrequests"))
 	withoutSelectorsTables(certificatesv1beta1.SchemeGroupVersion.WithResource("certificatesigningrequests/status"))
 	withoutSelectorsTables(certificatesv1beta1.SchemeGroupVersion.WithResource("certificatesigningrequests/approval"))
-
-	withoutSelectorsTables(nodev1beta1.SchemeGroupVersion.WithResource("runtimeclasses"))
-	withoutSelectorsTables(nodev1alpha1.SchemeGroupVersion.WithResource("runtimeclasses"))
 
 	withoutSelectorsTables(schedulingv1.SchemeGroupVersion.WithResource("priorityclasses"))
 	withoutSelectorsTables(schedulingv1alpha1.SchemeGroupVersion.WithResource("priorityclasses"))

--- a/pkg/operation/botanist/constraints_check_test.go
+++ b/pkg/operation/botanist/constraints_check_test.go
@@ -15,143 +15,349 @@
 package botanist_test
 
 import (
+	"fmt"
+
 	"github.com/gardener/gardener/pkg/operation/botanist"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	coordinationv1beta1 "k8s.io/api/coordination/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1beta1 "k8s.io/api/events/v1beta1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	nodev1alpha1 "k8s.io/api/node/v1alpha1"
+	nodev1beta1 "k8s.io/api/node/v1beta1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	rbacv1alpha1 "k8s.io/api/rbac/v1alpha1"
+	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	schedulingv1alpha1 "k8s.io/api/scheduling/v1alpha1"
+	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+	metricsv1alpha1 "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
+	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 )
 
-var _ = Describe("constraints checks", func() {
-	Context("HibernationPossible", func() {
-		type webhookTestCase struct {
-			failurePolicy *admissionregistrationv1beta1.FailurePolicyType
-			operationType admissionregistrationv1beta1.OperationType
-			groupResource schema.GroupResource
+type webhookTestCase struct {
+	failurePolicy     *admissionregistrationv1beta1.FailurePolicyType
+	operationType     *admissionregistrationv1beta1.OperationType
+	gvr               schema.GroupVersionResource
+	namespaceSelector *metav1.LabelSelector
+	objectSelector    *metav1.LabelSelector
+}
+
+func (w *webhookTestCase) build() webhook.WebhookAccessor {
+	wh := &admissionregistrationv1beta1.MutatingWebhook{
+		Name:          "foo-webhook",
+		FailurePolicy: w.failurePolicy,
+
+		NamespaceSelector: w.namespaceSelector,
+		ObjectSelector:    w.objectSelector,
+
+		Rules: []admissionregistrationv1beta1.RuleWithOperations{{
+			Rule: admissionregistrationv1beta1.Rule{
+				APIGroups:   []string{w.gvr.Group},
+				Resources:   []string{w.gvr.Resource},
+				APIVersions: []string{w.gvr.Version},
+			}},
+		},
+	}
+
+	opType := admissionregistrationv1beta1.OperationAll
+	if w.operationType != nil {
+		opType = *w.operationType
+	}
+
+	wh.Rules[0].Operations = []admissionregistrationv1beta1.OperationType{opType}
+
+	return webhook.NewMutatingWebhookAccessor("test-uid", "test-cfg", wh)
+}
+
+var _ = Describe("#IsProblematicWebhook", func() {
+	var (
+		failurePolicyIgnore = admissionregistrationv1beta1.Ignore
+		failurePolicyFail   = admissionregistrationv1beta1.Fail
+
+		operationCreate = admissionregistrationv1beta1.Create
+		operationUpdate = admissionregistrationv1beta1.Update
+		operationAll    = admissionregistrationv1beta1.OperationAll
+		operationDelete = admissionregistrationv1beta1.Delete
+
+		kubeSystemNamespaceProblematic = []TableEntry{
+			Entry("namespaceSelector matching no-cleanup", webhookTestCase{
+				namespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"}},
+			}),
+			Entry("namespaceSelector matching purpose", webhookTestCase{
+				namespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"}},
+			}),
+			Entry("namespaceSelector matching role", webhookTestCase{
+				namespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"role": "kube-system"}},
+			}),
+			Entry("namespaceSelector matching all gardener labels", webhookTestCase{
+				namespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"shoot.gardener.cloud/no-cleanup": "true",
+						"gardener.cloud/purpose":          "kube-system",
+						"role":                            "kube-system",
+					}},
+			}),
 		}
 
-		var (
-			failurePolicyIgnore = admissionregistrationv1beta1.Ignore
-			failurePolicyFail   = admissionregistrationv1beta1.Fail
+		kubeSystemNamespaceNotProblematic = []TableEntry{
+			Entry("not matching namespaceSelector", webhookTestCase{
+				namespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"foo": "bar"}},
+			}),
+		}
 
-			operationCreate = admissionregistrationv1beta1.Create
-			operationUpdate = admissionregistrationv1beta1.Update
-			operationAll    = admissionregistrationv1beta1.OperationAll
-			operationDelete = admissionregistrationv1beta1.Delete
+		commonTests = func(gvr schema.GroupVersionResource, problematic, notProblematic []TableEntry) {
+			DescribeTable(fmt.Sprintf("problematic webhook for %s", gvr.String()),
+				func(testCase webhookTestCase) {
+					testCase.gvr = gvr
+					Expect(botanist.IsProblematicWebhook(testCase.build())).To(BeTrue())
+				},
+				append([]TableEntry{
+					Entry("CREATE", webhookTestCase{
+						failurePolicy: &failurePolicyFail,
+						operationType: &operationCreate,
+					}),
+					Entry("CREATE with nil failure policy", webhookTestCase{operationType: &operationCreate}),
+					Entry("UPDATE", webhookTestCase{operationType: &operationUpdate}),
+					Entry("*", webhookTestCase{operationType: &operationAll}),
+				}, problematic...)...,
+			)
 
-			groupResourcePods  = corev1.Resource("pods")
-			groupResourceNodes = corev1.Resource("nodes")
-			groupResourceOther = corev1.Resource("other")
+			DescribeTable(fmt.Sprintf("not problematic webhook for %s", gvr.String()),
+				func(testCase webhookTestCase) {
+					testCase.gvr = gvr
+					Expect(botanist.IsProblematicWebhook(testCase.build())).To(BeFalse())
+				},
+				append([]TableEntry{
+					Entry("failurePolicy 'Ignore'", webhookTestCase{failurePolicy: &failurePolicyIgnore}),
+					Entry("operationType 'DELETE'", webhookTestCase{operationType: &operationDelete}),
+				}, notProblematic...)...,
+			)
+		}
 
-			problematicWebhookTestCase = webhookTestCase{
-				failurePolicy: &failurePolicyFail,
-				operationType: operationCreate,
-				groupResource: groupResourcePods,
-			}
-		)
+		podsTestTables = func(gvr schema.GroupVersionResource) {
+			commonTests(gvr, append(kubeSystemNamespaceProblematic,
+				Entry("objectSelector matching no-cleanup", webhookTestCase{
+					objectSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"}},
+				}),
+				Entry("objectSelector matching origin", webhookTestCase{
+					objectSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"origin": "gardener"}},
+				}),
+				Entry("objectSelector matching all gardener labels", webhookTestCase{
+					objectSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"shoot.gardener.cloud/no-cleanup": "true",
+							"origin":                          "gardener",
+						}},
+				}),
+				Entry("objectSelector and namespaceSelector matching all gardener labels", webhookTestCase{
+					objectSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"shoot.gardener.cloud/no-cleanup": "true",
+							"origin":                          "gardener",
+						}},
+					namespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"shoot.gardener.cloud/no-cleanup": "true",
+							"gardener.cloud/purpose":          "kube-system",
+							"role":                            "kube-system",
+						}},
+				}),
+			), append(kubeSystemNamespaceNotProblematic,
+				Entry("matching objectSelector, not matching namespaceSelector", webhookTestCase{
+					objectSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"origin":                          "gardener",
+							"shoot.gardener.cloud/no-cleanup": "true",
+						}},
+					namespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"foo": "bar"}},
+				}),
+				Entry("not matching objectSelector", webhookTestCase{
+					objectSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"foo": "bar"}},
+				}),
+				Entry("matching namespaceSelector, not matching objectSelector", webhookTestCase{
+					objectSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"foo": "bar"}},
+					namespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"shoot.gardener.cloud/no-cleanup": "true",
+							"gardener.cloud/purpose":          "kube-system",
+							"role":                            "kube-system",
+						}},
+				}),
+			))
+		}
 
-		DescribeTable("#IsProblematicWebhook",
-			func(testCase webhookTestCase, expected bool) {
-				var (
-					w = admissionregistrationv1beta1.MutatingWebhook{
-						Name:          "foo-webhook",
-						FailurePolicy: testCase.failurePolicy,
-						Rules: []admissionregistrationv1beta1.RuleWithOperations{
-							{
-								Operations: []admissionregistrationv1beta1.OperationType{testCase.operationType},
-								Rule: admissionregistrationv1beta1.Rule{
-									APIGroups: []string{testCase.groupResource.Group},
-									Resources: []string{testCase.groupResource.Resource},
-								},
-							},
-						},
-					}
-					accessor = webhook.NewMutatingWebhookAccessor("test-uid", "test-cfg", &w)
-				)
+		kubeSystemNamespaceTables = func(gvr schema.GroupVersionResource) {
+			commonTests(gvr, kubeSystemNamespaceProblematic, kubeSystemNamespaceNotProblematic)
+		}
 
-				isProblematic := botanist.IsProblematicWebhook(accessor)
-				Expect(isProblematic).To(Equal(expected))
-			},
-			Entry("Problematic Webhook for CREATE pods",
-				problematicWebhookTestCase,
-				true,
-			),
-			Entry("Problematic Webhook with failurePolicy nil for CREATE pods",
-				webhookTestCase{
-					failurePolicy: nil,
-					operationType: problematicWebhookTestCase.operationType,
-					groupResource: problematicWebhookTestCase.groupResource,
-				},
-				true,
-			),
-			Entry("Problematic Webhook for UPDATE pods",
-				webhookTestCase{
-					failurePolicy: problematicWebhookTestCase.failurePolicy,
-					operationType: operationUpdate,
-					groupResource: problematicWebhookTestCase.groupResource,
-				},
-				true,
-			),
-			Entry("Problematic Webhook for * pods",
-				webhookTestCase{
-					failurePolicy: problematicWebhookTestCase.failurePolicy,
-					operationType: operationAll,
-					groupResource: problematicWebhookTestCase.groupResource,
-				},
-				true,
-			),
-			Entry("Problematic Webhook for CREATE nodes",
-				webhookTestCase{
-					failurePolicy: problematicWebhookTestCase.failurePolicy,
-					operationType: problematicWebhookTestCase.operationType,
-					groupResource: groupResourceNodes,
-				},
-				true,
-			),
-			Entry("Problematic Webhook for UPDATE nodes",
-				webhookTestCase{
-					failurePolicy: problematicWebhookTestCase.failurePolicy,
-					operationType: operationUpdate,
-					groupResource: groupResourceNodes,
-				},
-				true,
-			),
-			Entry("Problematic Webhook for * nodes",
-				webhookTestCase{
-					failurePolicy: problematicWebhookTestCase.failurePolicy,
-					operationType: operationAll,
-					groupResource: groupResourceNodes,
-				},
-				true,
-			),
-			Entry("Unproblematic Webhook because of failurePolicy 'Ignore'",
-				webhookTestCase{
-					failurePolicy: &failurePolicyIgnore,
-					operationType: problematicWebhookTestCase.operationType,
-					groupResource: problematicWebhookTestCase.groupResource,
-				},
-				false,
-			),
-			Entry("Unproblematic Webhook because of operationType 'DELETE'",
-				webhookTestCase{
-					failurePolicy: problematicWebhookTestCase.failurePolicy,
-					operationType: operationDelete,
-					groupResource: problematicWebhookTestCase.groupResource,
-				},
-				false,
-			),
-			Entry("Unproblematic Webhook because of resource 'other'",
-				webhookTestCase{
-					failurePolicy: problematicWebhookTestCase.failurePolicy,
-					operationType: problematicWebhookTestCase.operationType,
-					groupResource: groupResourceOther,
-				},
-				false,
-			),
-		)
+		withoutSelectorsTables = func(gvr schema.GroupVersionResource) {
+			commonTests(gvr, []TableEntry{}, []TableEntry{})
+		}
+	)
+
+	kubeSystemNamespaceTables(schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"})
+	kubeSystemNamespaceTables(schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1alpha1", Resource: "endpointslices"})
+	kubeSystemNamespaceTables(schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1beta1", Resource: "endpointslices"})
+
+	podsTestTables(corev1.SchemeGroupVersion.WithResource("pods"))
+	podsTestTables(corev1.SchemeGroupVersion.WithResource("pods/status"))
+	kubeSystemNamespaceTables(corev1.SchemeGroupVersion.WithResource("configmaps"))
+	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("endpoints"))
+	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("events"))
+	kubeSystemNamespaceTables(corev1.SchemeGroupVersion.WithResource("secrets"))
+	kubeSystemNamespaceTables(corev1.SchemeGroupVersion.WithResource("serviceaccounts"))
+	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("services"))
+	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("services/status"))
+	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("nodes"))
+	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("nodes/status"))
+	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("namespaces"))
+	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("namespaces/status"))
+	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("namespaces/finalize"))
+
+	withoutSelectorsTables(eventsv1beta1.SchemeGroupVersion.WithResource("events"))
+
+	kubeSystemNamespaceTables(appsv1.SchemeGroupVersion.WithResource("controllerrevisions"))
+	kubeSystemNamespaceTables(appsv1.SchemeGroupVersion.WithResource("daemonsets"))
+	kubeSystemNamespaceTables(appsv1.SchemeGroupVersion.WithResource("daemonsets/status"))
+	kubeSystemNamespaceTables(appsv1.SchemeGroupVersion.WithResource("deployments"))
+	kubeSystemNamespaceTables(appsv1.SchemeGroupVersion.WithResource("deployments/scale"))
+	kubeSystemNamespaceTables(appsv1.SchemeGroupVersion.WithResource("replicasets"))
+	kubeSystemNamespaceTables(appsv1.SchemeGroupVersion.WithResource("replicasets/status"))
+	kubeSystemNamespaceTables(appsv1.SchemeGroupVersion.WithResource("replicasets/scale"))
+
+	//don't remove this version if deprecated / removed
+	kubeSystemNamespaceTables(appsv1beta1.SchemeGroupVersion.WithResource("controllerrevisions"))
+	kubeSystemNamespaceTables(appsv1beta1.SchemeGroupVersion.WithResource("daemonsets"))
+	kubeSystemNamespaceTables(appsv1beta1.SchemeGroupVersion.WithResource("daemonsets/status"))
+	kubeSystemNamespaceTables(appsv1beta1.SchemeGroupVersion.WithResource("deployments"))
+	kubeSystemNamespaceTables(appsv1beta1.SchemeGroupVersion.WithResource("deployments/scale"))
+	kubeSystemNamespaceTables(appsv1beta1.SchemeGroupVersion.WithResource("replicasets"))
+	kubeSystemNamespaceTables(appsv1beta1.SchemeGroupVersion.WithResource("replicasets/status"))
+	kubeSystemNamespaceTables(appsv1beta1.SchemeGroupVersion.WithResource("replicasets/scale"))
+
+	//don't remove this version if deprecated / removed
+	kubeSystemNamespaceTables(appsv1beta2.SchemeGroupVersion.WithResource("controllerrevisions"))
+	kubeSystemNamespaceTables(appsv1beta2.SchemeGroupVersion.WithResource("daemonsets"))
+	kubeSystemNamespaceTables(appsv1beta2.SchemeGroupVersion.WithResource("daemonsets/status"))
+	kubeSystemNamespaceTables(appsv1beta2.SchemeGroupVersion.WithResource("deployments"))
+	kubeSystemNamespaceTables(appsv1beta2.SchemeGroupVersion.WithResource("deployments/scale"))
+	kubeSystemNamespaceTables(appsv1beta2.SchemeGroupVersion.WithResource("replicasets"))
+	kubeSystemNamespaceTables(appsv1beta2.SchemeGroupVersion.WithResource("replicasets/status"))
+	kubeSystemNamespaceTables(appsv1beta2.SchemeGroupVersion.WithResource("replicasets/scale"))
+
+	//don't remove this version if deprecated / removed
+	kubeSystemNamespaceTables(extensionsv1beta1.SchemeGroupVersion.WithResource("controllerrevisions"))
+	kubeSystemNamespaceTables(extensionsv1beta1.SchemeGroupVersion.WithResource("daemonsets"))
+	kubeSystemNamespaceTables(extensionsv1beta1.SchemeGroupVersion.WithResource("daemonsets/status"))
+	kubeSystemNamespaceTables(extensionsv1beta1.SchemeGroupVersion.WithResource("deployments"))
+	kubeSystemNamespaceTables(extensionsv1beta1.SchemeGroupVersion.WithResource("deployments/scale"))
+	kubeSystemNamespaceTables(extensionsv1beta1.SchemeGroupVersion.WithResource("replicasets"))
+	kubeSystemNamespaceTables(extensionsv1beta1.SchemeGroupVersion.WithResource("replicasets/status"))
+	kubeSystemNamespaceTables(extensionsv1beta1.SchemeGroupVersion.WithResource("replicasets/scale"))
+	kubeSystemNamespaceTables(extensionsv1beta1.SchemeGroupVersion.WithResource("networkpolicies"))
+	withoutSelectorsTables(extensionsv1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies"))
+
+	withoutSelectorsTables(coordinationv1.SchemeGroupVersion.WithResource("leases"))
+	withoutSelectorsTables(coordinationv1beta1.SchemeGroupVersion.WithResource("leases"))
+
+	kubeSystemNamespaceTables(metricsv1alpha1.SchemeGroupVersion.WithResource("podmetrics"))
+	withoutSelectorsTables(metricsv1alpha1.SchemeGroupVersion.WithResource("nodemetrics"))
+
+	kubeSystemNamespaceTables(metricsv1beta1.SchemeGroupVersion.WithResource("podmetrics"))
+	withoutSelectorsTables(metricsv1beta1.SchemeGroupVersion.WithResource("nodemetrics"))
+
+	kubeSystemNamespaceTables(networkingv1.SchemeGroupVersion.WithResource("networkpolicies"))
+	kubeSystemNamespaceTables(networkingv1beta1.SchemeGroupVersion.WithResource("networkpolicies"))
+
+	withoutSelectorsTables(policyv1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies"))
+
+	kubeSystemNamespaceTables(autoscalingv1.SchemeGroupVersion.WithResource("horizontalpodautoscalers"))
+	kubeSystemNamespaceTables(autoscalingv1.SchemeGroupVersion.WithResource("horizontalpodautoscalers/status"))
+
+	kubeSystemNamespaceTables(autoscalingv2beta1.SchemeGroupVersion.WithResource("horizontalpodautoscalers"))
+	kubeSystemNamespaceTables(autoscalingv2beta1.SchemeGroupVersion.WithResource("horizontalpodautoscalers/status"))
+
+	kubeSystemNamespaceTables(autoscalingv2beta2.SchemeGroupVersion.WithResource("horizontalpodautoscalers"))
+	kubeSystemNamespaceTables(autoscalingv2beta2.SchemeGroupVersion.WithResource("horizontalpodautoscalers/status"))
+
+	withoutSelectorsTables(rbacv1.SchemeGroupVersion.WithResource("clusterroles"))
+	withoutSelectorsTables(rbacv1.SchemeGroupVersion.WithResource("clusterrolebindings"))
+	kubeSystemNamespaceTables(rbacv1.SchemeGroupVersion.WithResource("roles"))
+	kubeSystemNamespaceTables(rbacv1.SchemeGroupVersion.WithResource("rolebindings"))
+
+	withoutSelectorsTables(rbacv1alpha1.SchemeGroupVersion.WithResource("clusterroles"))
+	withoutSelectorsTables(rbacv1alpha1.SchemeGroupVersion.WithResource("clusterrolebindings"))
+	kubeSystemNamespaceTables(rbacv1alpha1.SchemeGroupVersion.WithResource("roles"))
+	kubeSystemNamespaceTables(rbacv1alpha1.SchemeGroupVersion.WithResource("rolebindings"))
+
+	withoutSelectorsTables(rbacv1beta1.SchemeGroupVersion.WithResource("clusterroles"))
+	withoutSelectorsTables(rbacv1beta1.SchemeGroupVersion.WithResource("clusterrolebindings"))
+	kubeSystemNamespaceTables(rbacv1beta1.SchemeGroupVersion.WithResource("roles"))
+	kubeSystemNamespaceTables(rbacv1beta1.SchemeGroupVersion.WithResource("rolebindings"))
+
+	withoutSelectorsTables(apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions"))
+	withoutSelectorsTables(apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions/status"))
+
+	withoutSelectorsTables(apiextensionsv1beta1.SchemeGroupVersion.WithResource("customresourcedefinitions"))
+	withoutSelectorsTables(apiextensionsv1beta1.SchemeGroupVersion.WithResource("customresourcedefinitions/status"))
+
+	withoutSelectorsTables(apiregistrationv1.SchemeGroupVersion.WithResource("apiservices"))
+	withoutSelectorsTables(apiregistrationv1.SchemeGroupVersion.WithResource("apiservices/status"))
+
+	withoutSelectorsTables(apiregistrationv1beta1.SchemeGroupVersion.WithResource("apiservices"))
+	withoutSelectorsTables(apiregistrationv1beta1.SchemeGroupVersion.WithResource("apiservices/status"))
+
+	withoutSelectorsTables(certificatesv1beta1.SchemeGroupVersion.WithResource("certificatesigningrequests"))
+	withoutSelectorsTables(certificatesv1beta1.SchemeGroupVersion.WithResource("certificatesigningrequests/status"))
+	withoutSelectorsTables(certificatesv1beta1.SchemeGroupVersion.WithResource("certificatesigningrequests/approval"))
+
+	withoutSelectorsTables(nodev1beta1.SchemeGroupVersion.WithResource("runtimeclasses"))
+	withoutSelectorsTables(nodev1alpha1.SchemeGroupVersion.WithResource("runtimeclasses"))
+
+	withoutSelectorsTables(schedulingv1.SchemeGroupVersion.WithResource("priorityclasses"))
+	withoutSelectorsTables(schedulingv1alpha1.SchemeGroupVersion.WithResource("priorityclasses"))
+	withoutSelectorsTables(schedulingv1beta1.SchemeGroupVersion.WithResource("priorityclasses"))
+
+	It("should not block another resource", func() {
+		wh := webhookTestCase{
+			failurePolicy: &failurePolicyFail,
+			gvr:           schema.GroupVersionResource{Group: "foo", Resource: "bar", Version: "baz"},
+			operationType: &operationCreate,
+		}
+
+		Expect(botanist.IsProblematicWebhook(wh.build())).To(BeFalse())
 	})
 })

--- a/pkg/operation/botanist/matchers/matcher.go
+++ b/pkg/operation/botanist/matchers/matcher.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matchers
+
+import (
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	botanistconstants "github.com/gardener/gardener/pkg/operation/botanist/constants"
+	"github.com/gardener/gardener/pkg/operation/common"
+
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	coordinationv1beta1 "k8s.io/api/coordination/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	eventsv1beta1 "k8s.io/api/events/v1beta1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	nodev1alpha1 "k8s.io/api/node/v1alpha1"
+	nodev1beta1 "k8s.io/api/node/v1beta1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	rbacv1alpha1 "k8s.io/api/rbac/v1alpha1"
+	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	schedulingv1alpha1 "k8s.io/api/scheduling/v1alpha1"
+	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	apiregistrationv1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+	metricsv1alpha1 "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
+	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+)
+
+var (
+	kubeSystemLabels = labels.Set{
+		common.ShootNoCleanup:            "true",
+		v1beta1constants.LabelRole:       metav1.NamespaceSystem,
+		v1beta1constants.GardenerPurpose: metav1.NamespaceSystem,
+	}
+	podsLabels = labels.Set{
+		common.ShootNoCleanup:                           "true",
+		botanistconstants.ManagedResourceLabelKeyOrigin: botanistconstants.ManagedResourceLabelValueGardener,
+	}
+	// WebhookConstraintMatchers contains a list of all api resources which can break
+	// the waking up of a cluster.
+	WebhookConstraintMatchers = []WebhookConstraintMatcher{
+		{GVR: schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1alpha1", Resource: "endpointslices"}, NamespaceLabels: kubeSystemLabels},
+		{GVR: schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1beta1", Resource: "endpointslices"}, NamespaceLabels: kubeSystemLabels},
+		// v1 is still not available, but the APi will be promoted soon
+		{GVR: schema.GroupVersionResource{Group: "discovery.k8s.io", Version: "v1", Resource: "endpointslices"}, NamespaceLabels: kubeSystemLabels},
+
+		{GVR: corev1.SchemeGroupVersion.WithResource("pods"), NamespaceLabels: kubeSystemLabels, ObjectLabels: podsLabels},
+		{GVR: corev1.SchemeGroupVersion.WithResource("pods"), NamespaceLabels: kubeSystemLabels, ObjectLabels: podsLabels, Subresource: "status"},
+		{GVR: corev1.SchemeGroupVersion.WithResource("configmaps"), NamespaceLabels: kubeSystemLabels},
+		{GVR: corev1.SchemeGroupVersion.WithResource("endpoints")},
+		{GVR: corev1.SchemeGroupVersion.WithResource("events")},
+		{GVR: corev1.SchemeGroupVersion.WithResource("secrets"), NamespaceLabels: kubeSystemLabels},
+		{GVR: corev1.SchemeGroupVersion.WithResource("serviceaccounts"), NamespaceLabels: kubeSystemLabels},
+		{GVR: corev1.SchemeGroupVersion.WithResource("services")},
+		{GVR: corev1.SchemeGroupVersion.WithResource("services"), Subresource: "status"},
+		{GVR: corev1.SchemeGroupVersion.WithResource("nodes"), ClusterScoped: true},
+		{GVR: corev1.SchemeGroupVersion.WithResource("nodes"), ClusterScoped: true, Subresource: "status"},
+		{GVR: corev1.SchemeGroupVersion.WithResource("namespaces"), ClusterScoped: true},
+		{GVR: corev1.SchemeGroupVersion.WithResource("namespaces"), ClusterScoped: true, Subresource: "status"},
+		{GVR: corev1.SchemeGroupVersion.WithResource("namespaces"), ClusterScoped: true, Subresource: "finalize"},
+
+		{GVR: eventsv1beta1.SchemeGroupVersion.WithResource("events")},
+
+		{GVR: appsv1.SchemeGroupVersion.WithResource("controllerrevisions"), NamespaceLabels: kubeSystemLabels},
+		{GVR: appsv1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels},
+		{GVR: appsv1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
+		{GVR: appsv1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemLabels},
+		{GVR: appsv1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemLabels, Subresource: "scale"},
+		{GVR: appsv1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels},
+		{GVR: appsv1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
+		{GVR: appsv1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels, Subresource: "scale"},
+
+		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("controllerrevisions"), NamespaceLabels: kubeSystemLabels},
+		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels},
+		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
+		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemLabels},
+		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemLabels, Subresource: "scale"},
+		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels},
+		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
+		{GVR: appsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels, Subresource: "scale"},
+
+		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("controllerrevisions"), NamespaceLabels: kubeSystemLabels},
+		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels},
+		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
+		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemLabels},
+		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemLabels, Subresource: "scale"},
+		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels},
+		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
+		{GVR: appsv1beta2.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels, Subresource: "scale"},
+
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("controllerrevisions"), NamespaceLabels: kubeSystemLabels},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemLabels},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("deployments"), NamespaceLabels: kubeSystemLabels, Subresource: "scale"},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("replicasets"), NamespaceLabels: kubeSystemLabels, Subresource: "scale"},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("networkpolicies"), NamespaceLabels: kubeSystemLabels},
+		{GVR: extensionsv1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies"), ClusterScoped: true},
+
+		{GVR: coordinationv1.SchemeGroupVersion.WithResource("leases")},
+		{GVR: coordinationv1beta1.SchemeGroupVersion.WithResource("leases")},
+
+		{GVR: metricsv1alpha1.SchemeGroupVersion.WithResource("podmetrics"), NamespaceLabels: kubeSystemLabels},
+		{GVR: metricsv1alpha1.SchemeGroupVersion.WithResource("nodemetrics"), NamespaceLabels: kubeSystemLabels},
+
+		{GVR: metricsv1beta1.SchemeGroupVersion.WithResource("podmetrics"), NamespaceLabels: kubeSystemLabels},
+		{GVR: metricsv1beta1.SchemeGroupVersion.WithResource("nodemetrics"), NamespaceLabels: kubeSystemLabels},
+
+		{GVR: networkingv1.SchemeGroupVersion.WithResource("networkpolicies"), NamespaceLabels: kubeSystemLabels},
+		{GVR: networkingv1beta1.SchemeGroupVersion.WithResource("networkpolicies"), NamespaceLabels: kubeSystemLabels},
+
+		{GVR: policyv1beta1.SchemeGroupVersion.WithResource("podsecuritypolicies"), ClusterScoped: true},
+
+		{GVR: autoscalingv1.SchemeGroupVersion.WithResource("horizontalpodautoscalers"), NamespaceLabels: kubeSystemLabels},
+		{GVR: autoscalingv1.SchemeGroupVersion.WithResource("horizontalpodautoscalers"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
+
+		{GVR: autoscalingv2beta1.SchemeGroupVersion.WithResource("horizontalpodautoscalers"), NamespaceLabels: kubeSystemLabels},
+		{GVR: autoscalingv2beta1.SchemeGroupVersion.WithResource("horizontalpodautoscalers"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
+
+		{GVR: autoscalingv2beta2.SchemeGroupVersion.WithResource("horizontalpodautoscalers"), NamespaceLabels: kubeSystemLabels},
+		{GVR: autoscalingv2beta2.SchemeGroupVersion.WithResource("horizontalpodautoscalers"), NamespaceLabels: kubeSystemLabels, Subresource: "status"},
+
+		{GVR: rbacv1.SchemeGroupVersion.WithResource("clusterroles"), ClusterScoped: true},
+		{GVR: rbacv1.SchemeGroupVersion.WithResource("clusterrolebindings"), ClusterScoped: true},
+		{GVR: rbacv1.SchemeGroupVersion.WithResource("roles"), NamespaceLabels: kubeSystemLabels},
+		{GVR: rbacv1.SchemeGroupVersion.WithResource("rolebindings"), NamespaceLabels: kubeSystemLabels},
+
+		{GVR: rbacv1alpha1.SchemeGroupVersion.WithResource("clusterroles"), ClusterScoped: true},
+		{GVR: rbacv1alpha1.SchemeGroupVersion.WithResource("clusterrolebindings"), ClusterScoped: true},
+		{GVR: rbacv1alpha1.SchemeGroupVersion.WithResource("roles"), NamespaceLabels: kubeSystemLabels},
+		{GVR: rbacv1alpha1.SchemeGroupVersion.WithResource("rolebindings"), NamespaceLabels: kubeSystemLabels},
+
+		{GVR: rbacv1beta1.SchemeGroupVersion.WithResource("clusterroles"), ClusterScoped: true},
+		{GVR: rbacv1beta1.SchemeGroupVersion.WithResource("clusterrolebindings"), ClusterScoped: true},
+		{GVR: rbacv1beta1.SchemeGroupVersion.WithResource("roles"), NamespaceLabels: kubeSystemLabels},
+		{GVR: rbacv1beta1.SchemeGroupVersion.WithResource("rolebindings"), NamespaceLabels: kubeSystemLabels},
+
+		{GVR: apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions"), ClusterScoped: true},
+		{GVR: apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions"), ClusterScoped: true, Subresource: "status"},
+
+		{GVR: apiextensionsv1beta1.SchemeGroupVersion.WithResource("customresourcedefinitions"), ClusterScoped: true},
+		{GVR: apiextensionsv1beta1.SchemeGroupVersion.WithResource("customresourcedefinitions"), ClusterScoped: true, Subresource: "status"},
+
+		{GVR: apiregistrationv1.SchemeGroupVersion.WithResource("apiservices"), ClusterScoped: true},
+		{GVR: apiregistrationv1.SchemeGroupVersion.WithResource("apiservices"), ClusterScoped: true, Subresource: "status"},
+
+		{GVR: apiregistrationv1beta1.SchemeGroupVersion.WithResource("apiservices"), ClusterScoped: true},
+		{GVR: apiregistrationv1beta1.SchemeGroupVersion.WithResource("apiservices"), ClusterScoped: true, Subresource: "status"},
+
+		{GVR: certificatesv1beta1.SchemeGroupVersion.WithResource("certificatesigningrequests"), ClusterScoped: true},
+		{GVR: certificatesv1beta1.SchemeGroupVersion.WithResource("certificatesigningrequests"), ClusterScoped: true, Subresource: "status"},
+		{GVR: certificatesv1beta1.SchemeGroupVersion.WithResource("certificatesigningrequests"), ClusterScoped: true, Subresource: "approval"},
+
+		{GVR: nodev1alpha1.SchemeGroupVersion.WithResource("runtimeclasses"), ClusterScoped: true},
+		{GVR: nodev1beta1.SchemeGroupVersion.WithResource("runtimeclasses"), ClusterScoped: true},
+
+		{GVR: schedulingv1.SchemeGroupVersion.WithResource("priorityclasses"), ClusterScoped: true},
+		{GVR: schedulingv1alpha1.SchemeGroupVersion.WithResource("priorityclasses"), ClusterScoped: true},
+		{GVR: schedulingv1beta1.SchemeGroupVersion.WithResource("priorityclasses"), ClusterScoped: true},
+	}
+)
+
+// selectors in webhooks are defaulted to matchAll selector.
+func defaultEmptySelector(ls *metav1.LabelSelector) (labels.Selector, error) {
+	if ls == nil {
+		ls = &metav1.LabelSelector{}
+	}
+
+	return metav1.LabelSelectorAsSelector(ls)
+}
+
+// WebhookConstraintMatcher contains an api resource matcher.
+type WebhookConstraintMatcher struct {
+	GVR             schema.GroupVersionResource
+	Subresource     string
+	ClusterScoped   bool
+	ObjectLabels    labels.Labels
+	NamespaceLabels labels.Labels
+}
+
+// Match rule with objLabelSelector and namespaceLabelSelector if
+// the resource is not namespaced.
+func (w *WebhookConstraintMatcher) Match(
+	r admissionregistrationv1beta1.RuleWithOperations,
+	objLabelSelector *metav1.LabelSelector,
+	namespaceLabelSelector *metav1.LabelSelector,
+) bool {
+	var (
+		objLabels = w.ObjectLabels
+		nsLabels  = w.NamespaceLabels
+	)
+
+	if objLabels == nil {
+		objLabels = labels.Set{}
+	}
+
+	if nsLabels == nil {
+		nsLabels = labels.Set{}
+	}
+
+	nsSelector, err := defaultEmptySelector(namespaceLabelSelector)
+	if err != nil {
+		// this should really not happen
+		return true
+	}
+
+	objSelector, err := defaultEmptySelector(objLabelSelector)
+	if err != nil {
+		// this should really not happen
+		return true
+	}
+
+	matchObj := objSelector.Empty() || objSelector.Matches(objLabels)
+	matchNS := nsSelector.Empty() || nsSelector.Matches(nsLabels)
+
+	rm := ruleMatcher{rule: r, gvr: w.GVR, subresource: w.Subresource}
+	if !w.ClusterScoped {
+		rm.namespace = "dummy"
+	}
+
+	return matchObj && (w.ClusterScoped || matchNS) && rm.Matches()
+}

--- a/pkg/operation/botanist/matchers/rule_matcher.go
+++ b/pkg/operation/botanist/matchers/rule_matcher.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// this file is copy of https://github.com/kubernetes/kubernetes/blob/f247e75980061d7cf83c63c0fb1f12c7060c599f/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/rules/rules.go
+// with some modifications for the webhook matching use-case.
+package matchers
+
+import (
+	"strings"
+
+	"k8s.io/api/admissionregistration/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ruleMatcher determines if the Attr matches the Rule.
+type ruleMatcher struct {
+	rule        v1beta1.RuleWithOperations
+	gvr         schema.GroupVersionResource
+	namespace   string
+	subresource string
+}
+
+// Matches returns if the resource matches the Rule.
+func (r *ruleMatcher) Matches() bool {
+	return r.scope() &&
+		r.operation() &&
+		r.group() &&
+		r.version() &&
+		r.resource()
+}
+
+func exactOrWildcard(items []string, requested string) bool {
+	for _, item := range items {
+		if item == "*" {
+			return true
+		}
+
+		if item == requested {
+			return true
+		}
+	}
+
+	return false
+}
+
+var namespaceResource = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+
+func (r *ruleMatcher) scope() bool {
+	if r.rule.Scope == nil || *r.rule.Scope == v1beta1.AllScopes {
+		return true
+	}
+
+	switch *r.rule.Scope {
+	case v1beta1.NamespacedScope:
+		// first make sure that we are not requesting a namespace object (namespace objects are cluster-scoped)
+		return r.gvr != namespaceResource && r.namespace != metav1.NamespaceNone
+	case v1beta1.ClusterScope:
+		// also return true if the request is for a namespace object (namespace objects are cluster-scoped)
+		return r.gvr == namespaceResource || r.namespace == metav1.NamespaceNone
+	default:
+		return false
+	}
+}
+
+func (r *ruleMatcher) group() bool {
+	return exactOrWildcard(r.rule.APIGroups, r.gvr.Group)
+}
+
+func (r *ruleMatcher) version() bool {
+	return exactOrWildcard(r.rule.APIVersions, r.gvr.Version)
+}
+
+func (r *ruleMatcher) operation() bool {
+	for _, op := range r.rule.Operations {
+		switch op {
+		case v1beta1.OperationAll, v1beta1.Create, v1beta1.Update:
+			return true
+		}
+	}
+
+	return false
+}
+
+func splitResource(resSub string) (res, sub string) {
+	parts := strings.SplitN(resSub, "/", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+
+	return parts[0], ""
+}
+
+func (r *ruleMatcher) resource() bool {
+	opRes, opSub := r.gvr.Resource, r.subresource
+
+	for _, res := range r.rule.Resources {
+		res, sub := splitResource(res)
+		resMatch := res == "*" || res == opRes
+		subMatch := sub == "*" || sub == opSub
+
+		if resMatch && subMatch {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -19,17 +19,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gardener/gardener/pkg/operation/botanist/constants"
 	"github.com/gardener/gardener/pkg/utils/retry"
 
 	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	// ManagedResourceLabelKeyOrigin is a key for a label on a managed resource with the value 'origin'.
-	ManagedResourceLabelKeyOrigin = "origin"
-	// ManagedResourceLabelValueGardener is a value for a label on a managed resource with the value 'gardener'.
-	ManagedResourceLabelValueGardener = "gardener"
 )
 
 // DeleteManagedResources deletes all managed resources from the Shoot namespace in the Seed.
@@ -38,7 +32,7 @@ func (b *Botanist) DeleteManagedResources(ctx context.Context) error {
 		ctx,
 		&resourcesv1alpha1.ManagedResource{},
 		client.InNamespace(b.Shoot.SeedNamespace),
-		client.MatchingLabels{ManagedResourceLabelKeyOrigin: ManagedResourceLabelValueGardener},
+		client.MatchingLabels{constants.ManagedResourceLabelKeyOrigin: constants.ManagedResourceLabelValueGardener},
 	)
 }
 
@@ -49,7 +43,7 @@ func (b *Botanist) WaitUntilManagedResourcesDeleted(ctx context.Context) error {
 		if err := b.K8sSeedClient.Client().List(ctx,
 			managedResources,
 			client.InNamespace(b.Shoot.SeedNamespace),
-			client.MatchingLabels{ManagedResourceLabelKeyOrigin: ManagedResourceLabelValueGardener}); err != nil {
+			client.MatchingLabels{constants.ManagedResourceLabelKeyOrigin: constants.ManagedResourceLabelValueGardener}); err != nil {
 			return retry.SevereError(err)
 		}
 

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -32,7 +32,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -510,8 +509,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(apierrors.IsBadRequest(err)).To(BeTrue())
+				Expect(err).To(BeBadRequestError())
 				Expect(err.Error()).To(ContainSubstring("name must not exceed"))
 			})
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

Improve hibernation webhook check filter

Webhooks with `failurePolicy: Fail` stop hibernation if they select any of the following resources:

- `apiservices`
- `apiservices/status`
- `certificatesigningrequests`
- `certificatesigningrequests/approval`
- `certificatesigningrequests/status`
- `clusterrolebindings`
- `clusterroles`
- `configmaps` (only for `kube-system` namespace)
- `controllerrevisions` (only for `kube-system` namespace)
- `customresourcedefinitions`
- `customresourcedefinitions/status`
- `daemonsets` (only for `kube-system` namespace)
- `daemonsets/status` (only for `kube-system` namespace)
- `deployments` (only for `kube-system` namespace)
- `deployments/scale` (only for `kube-system` namespace)
- `endpoints`
- `leases`
- `namespaces`
- `namespaces/finalize`
- `namespaces/status`
- `networkpolicies` (only for `kube-system` namespace)
- `nodes`
- `nodes/status`
- `pods` (only for `kube-system` namespace and `shoot.gardener.cloud/no-cleanup=true,orgin=gardener` labels)
- `pods/status` (only for `kube-system` namespace and `shoot.gardener.cloud/no-cleanup=true,orgin=gardener` labels)
- `podsecuritypolicies`
- `priorityclasses`
- `replicasets` (only for `kube-system` namespace)
- `replicasets/scale` (only for `kube-system` namespace)
- `replicasets/status` (only for `kube-system` namespace)
- `rolebindings` (only for `kube-system` namespace)
- `roles` (only for `kube-system` namespace)
- `secrets` (only for `kube-system` namespace)
- `serviceaccounts` (only for `kube-system` namespace)
- `services`
- `services/status`

**Which issue(s) this PR fixes**:
Fixes #1751

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Hibernation blocking due to Mutating/Validating webhooks is now improved and enforced for hooks with `failurePolicy: Fail` and operation `CREATE`, `UPDATE` or `*` for the following resources:

- `apiservices`
- `apiservices/status`
- `certificatesigningrequests`
- `certificatesigningrequests/approval`
- `certificatesigningrequests/status`
- `clusterrolebindings`
- `clusterroles`
- `configmaps` (only for `kube-system` namespace)
- `controllerrevisions` (only for `kube-system` namespace)
- `customresourcedefinitions`
- `customresourcedefinitions/status`
- `daemonsets` (only for `kube-system` namespace)
- `daemonsets/status` (only for `kube-system` namespace)
- `deployments` (only for `kube-system` namespace)
- `deployments/scale` (only for `kube-system` namespace)
- `endpoints`
- `leases`
- `namespaces`
- `namespaces/finalize`
- `namespaces/status`
- `networkpolicies` (only for `kube-system` namespace)
- `nodes`
- `nodes/status`
- `pods` (only for `kube-system` namespace and `shoot.gardener.cloud/no-cleanup=true,orgin=gardener` labels)
- `pods/status` (only for `kube-system` namespace and `shoot.gardener.cloud/no-cleanup=true,orgin=gardener` labels)
- `podsecuritypolicies`
- `priorityclasses`
- `replicasets` (only for `kube-system` namespace)
- `replicasets/scale` (only for `kube-system` namespace)
- `replicasets/status` (only for `kube-system` namespace)
- `rolebindings` (only for `kube-system` namespace)
- `roles` (only for `kube-system` namespace)
- `secrets` (only for `kube-system` namespace)
- `serviceaccounts` (only for `kube-system` namespace)
- `services`
- `services/status`
```
