### PR TITLE
Remove default delete options when deleting extensions

### DIFF
--- a/pkg/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/operatingsystemconfig_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	mock "github.com/gardener/gardener/pkg/mock/gardener/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation"
@@ -77,11 +76,11 @@ var _ = Describe("operatingsystemconfig", func() {
 
 			k8sSeedRuntimeClient.EXPECT().Get(ctx, kutil.Key(oldOriginalOsc.Namespace, oldOriginalOsc.Name), &oldOriginalOsc)
 			k8sSeedRuntimeClient.EXPECT().Update(ctx, oldOriginalOscCopy)
-			k8sSeedRuntimeClient.EXPECT().Delete(ctx, oldOriginalOscCopy, kubernetes.DefaultDeleteOptions)
+			k8sSeedRuntimeClient.EXPECT().Delete(ctx, oldOriginalOscCopy)
 
 			k8sSeedRuntimeClient.EXPECT().Get(ctx, kutil.Key(oldDownloaderOsc.Namespace, oldDownloaderOsc.Name), &oldDownloaderOsc)
 			k8sSeedRuntimeClient.EXPECT().Update(ctx, oldDownloaderOscCopy)
-			k8sSeedRuntimeClient.EXPECT().Delete(ctx, oldDownloaderOscCopy, kubernetes.DefaultDeleteOptions)
+			k8sSeedRuntimeClient.EXPECT().Delete(ctx, oldDownloaderOscCopy)
 
 			op := &operation.Operation{
 				K8sSeedClient: k8sSeedClient,

--- a/pkg/operation/common/extensions.go
+++ b/pkg/operation/common/extensions.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gardener/gardener/pkg/api/extensions"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -117,6 +116,7 @@ func DeleteExtensionCR(
 	newObjFunc func() extensionsv1alpha1.Object,
 	namespace string,
 	name string,
+	deleteOpts ...client.DeleteOption,
 ) error {
 	obj := newObjFunc()
 	obj.SetNamespace(namespace)
@@ -126,7 +126,7 @@ func DeleteExtensionCR(
 		return err
 	}
 
-	return client.IgnoreNotFound(c.Delete(ctx, obj, kubernetes.DefaultDeleteOptions...))
+	return client.IgnoreNotFound(c.Delete(ctx, obj, deleteOpts...))
 }
 
 // DeleteExtensionCRs lists all extension resources and loops over them. It executes the given <predicateFunc> for each
@@ -138,6 +138,7 @@ func DeleteExtensionCRs(
 	newObjFunc func() extensionsv1alpha1.Object,
 	namespace string,
 	predicateFunc func(obj extensionsv1alpha1.Object) bool,
+	deleteOpts ...client.DeleteOption,
 ) error {
 	if err := c.List(ctx, listObj, client.InNamespace(namespace)); err != nil {
 		return err
@@ -156,7 +157,7 @@ func DeleteExtensionCRs(
 		}
 
 		fns = append(fns, func(ctx context.Context) error {
-			return DeleteExtensionCR(ctx, c, newObjFunc, o.GetNamespace(), o.GetName())
+			return DeleteExtensionCR(ctx, c, newObjFunc, o.GetNamespace(), o.GetName(), deleteOpts...)
 		})
 
 		return nil

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -26,11 +26,13 @@ import (
 	"github.com/gardener/gardener/pkg/operation/common"
 	. "github.com/gardener/gardener/plugin/pkg/shoot/validator"
 	. "github.com/gardener/gardener/test/gomega"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
**What this PR does / why we need it**:
With the refactoring of #2222 the default delete options were introduced when deleting extension resources. However, the delete options weren't provided before this PR (only for `OperatingSystemConfig` resources, but even here there was no specific rationale behind it).

The reason for removing it now again is that @ialidzhikov detected extension resources that were blocked with `foregroundDeletion` finalizer for seeds < 1.16. Basically, https://github.com/kubernetes/kubernetes/issues/77081 is hit which is only fixed in Kubernetes >= 1.16. Hence, let's restore the old behaviour for now.

Also, the PR fixes a linting problem in the `plugin/pkg/shoot/validator/admission_test.go` file introduced with #2254.

**Special notes for your reviewer**:
/cc @ialidzhikov, thanks for spotting

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
