### PR TITLE
Add restore and migrate to Network and ContainerRuntime Actuator

### DIFF
--- a/extensions/pkg/controller/containerruntime/actuator.go
+++ b/extensions/pkg/controller/containerruntime/actuator.go
@@ -28,4 +28,8 @@ type Actuator interface {
 	Reconcile(context.Context, *extensionsv1alpha1.ContainerRuntime, *extensioncontroller.Cluster) error
 	// Delete the ContainerRuntime resource.
 	Delete(context.Context, *extensionsv1alpha1.ContainerRuntime, *extensioncontroller.Cluster) error
+	// Restore the ContainerRuntime resource.
+	Restore(context.Context, *extensionsv1alpha1.ContainerRuntime, *extensioncontroller.Cluster) error
+	// Migrate the ContainerRuntime resource.
+	Migrate(context.Context, *extensionsv1alpha1.ContainerRuntime, *extensioncontroller.Cluster) error
 }

--- a/extensions/pkg/controller/containerruntime/controller.go
+++ b/extensions/pkg/controller/containerruntime/controller.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	// FinalizerPrefix is the prefix name of the finalizer written by this controller.
+	// FinalizerName is the prefix name of the finalizer written by this controller.
 	FinalizerName = "extensions.gardener.cloud/containerruntime"
 	// ControllerName is the name of the controller.
 	ControllerName = "containerruntime_controller"

--- a/extensions/pkg/controller/containerruntime/reconciler.go
+++ b/extensions/pkg/controller/containerruntime/reconciler.go
@@ -17,13 +17,14 @@ package containerruntime
 import (
 	"context"
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/util"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
@@ -43,8 +44,12 @@ import (
 const (
 	// EventContainerRuntimeReconciliation an event reason to describe container runtime reconciliation.
 	EventContainerRuntimeReconciliation string = "ContainerRuntimeReconciliation"
-	// EventRuntimeDeletion an event reason to describe container runtime deletion.
+	// EventContainerRuntimeDeletion an event reason to describe container runtime deletion.
 	EventContainerRuntimeDeletion string = "ContainerRuntimeDeletion"
+	// EventContainerRuntimeRestoration an event reason to describe container runtime restoration.
+	EventContainerRuntimeRestoration string = "ContainerRuntimeRestoration"
+	// EventContainerRuntimeMigration an event reason to describe container runtime migration.
+	EventContainerRuntimeMigration string = "ContainerRuntimeMigration"
 )
 
 // reconciler reconciles ContainerRuntime resources of Gardener's
@@ -103,39 +108,67 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
-	if cr.DeletionTimestamp != nil {
-		return r.delete(r.ctx, cr, cluster)
-	}
+	operationType := gardencorev1beta1helper.ComputeOperationType(cr.ObjectMeta, cr.Status.LastOperation)
 
-	return r.reconcile(r.ctx, cr, cluster)
+	switch {
+	case extensionscontroller.IsMigrated(cr):
+		return reconcile.Result{}, nil
+	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
+		return r.migrate(r.ctx, cr, cluster)
+	case cr.DeletionTimestamp != nil:
+		return r.delete(r.ctx, cr, cluster)
+	case cr.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRestore:
+		return r.restore(r.ctx, cr, cluster, operationType)
+	default:
+		return r.reconcile(r.ctx, cr, cluster, operationType)
+	}
 }
 
-func (r *reconciler) reconcile(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
+func (r *reconciler) reconcile(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, cluster *extensionscontroller.Cluster, operationType gardencorev1beta1.LastOperationType) (reconcile.Result, error) {
 	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, cr); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	operationType := gardencorev1beta1helper.ComputeOperationType(cr.ObjectMeta, cr.Status.LastOperation)
-	if err := r.updateStatusProcessing(ctx, cr, operationType, "Reconciling the container runtime"); err != nil {
+	if err := r.updateStatusProcessing(ctx, cr, operationType, EventContainerRuntimeReconciliation, "Reconciling the container runtime"); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	r.logger.Info("Starting the reconciliation of container runtime", "containerruntime", cr.Name)
-	r.recorder.Event(cr, corev1.EventTypeNormal, EventContainerRuntimeReconciliation, "Reconciling the container runtime")
 	if err := r.actuator.Reconcile(ctx, cr, cluster); err != nil {
-		msg := "Error reconciling container runtime"
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), cr, operationType, msg))
-		r.logger.Error(err, msg, "containerruntime", cr.Name)
+		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), cr, operationType, EventContainerRuntimeReconciliation, "Error reconciling container runtime"))
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	msg := "Successfully reconciled container runtime"
-	r.logger.Info(msg, "containerruntime", cr.Name)
-	r.recorder.Event(cr, corev1.EventTypeNormal, EventContainerRuntimeReconciliation, msg)
-	if err := r.updateStatusSuccess(ctx, cr, operationType, msg); err != nil {
+	if err := r.updateStatusSuccess(ctx, cr, operationType, EventContainerRuntimeReconciliation, "Successfully reconciled container runtime"); err != nil {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) restore(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, cluster *extensionscontroller.Cluster, operationType gardencorev1beta1.LastOperationType) (reconcile.Result, error) {
+	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, cr); err != nil {
 		return reconcile.Result{}, err
 	}
 
+	if err := r.updateStatusProcessing(ctx, cr, operationType, EventContainerRuntimeRestoration, "Restoring the container runtime"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.actuator.Restore(ctx, cr, cluster); err != nil {
+		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), cr, operationType, EventContainerRuntimeRestoration, "Error restoring container runtime"))
+		return extensionscontroller.ReconcileErr(err)
+	}
+
+	if err := r.updateStatusSuccess(ctx, cr, operationType, EventContainerRuntimeRestoration, "Successfully restored container runtime"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// remove operation annotation 'restore'
+	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, cr, v1beta1constants.GardenerOperation); err != nil {
+		msg := "Error removing annotation from Network"
+		r.recorder.Eventf(cr, corev1.EventTypeWarning, EventContainerRuntimeRestoration, "%s: %+v", msg, err)
+		r.logger.Error(err, msg, "network", cr.Name)
+		return reconcile.Result{}, err
+	}
 	return reconcile.Result{}, nil
 }
 
@@ -150,25 +183,16 @@ func (r *reconciler) delete(ctx context.Context, cr *extensionsv1alpha1.Containe
 		return reconcile.Result{}, nil
 	}
 
-	operationType := gardencorev1beta1helper.ComputeOperationType(cr.ObjectMeta, cr.Status.LastOperation)
-	if err := r.updateStatusProcessing(ctx, cr, operationType, "Deleting the container runtime"); err != nil {
+	if err := r.updateStatusProcessing(ctx, cr, gardencorev1beta1.LastOperationTypeDelete, EventContainerRuntimeDeletion, "Deleting the container runtime"); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	r.logger.Info("Starting the deletion of container runtime", "containerruntime", cr.Name)
-	r.recorder.Event(cr, corev1.EventTypeNormal, EventContainerRuntimeDeletion, "Deleting the container runtime")
 	if err := r.actuator.Delete(r.ctx, cr, cluster); err != nil {
-		msg := "Error deleting container runtime"
-		r.recorder.Eventf(cr, corev1.EventTypeWarning, EventContainerRuntimeReconciliation, "%s: %+v", msg, err)
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), cr, operationType, msg))
-		r.logger.Error(err, msg, "containerruntime", cr.Name)
+		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), cr, gardencorev1beta1.LastOperationTypeDelete, EventContainerRuntimeDeletion, "Error deleting container runtime"))
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	msg := "Successfully deleted container runtime"
-	r.logger.Info(msg, "containerruntime", cr.Name)
-	r.recorder.Event(cr, corev1.EventTypeNormal, EventContainerRuntimeDeletion, msg)
-	if err := r.updateStatusSuccess(ctx, cr, operationType, msg); err != nil {
+	if err := r.updateStatusSuccess(ctx, cr, gardencorev1beta1.LastOperationTypeDelete, EventContainerRuntimeDeletion, "Successfully deleted container runtime"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -181,14 +205,49 @@ func (r *reconciler) delete(ctx context.Context, cr *extensionsv1alpha1.Containe
 	return reconcile.Result{}, nil
 }
 
-func (r *reconciler) updateStatusProcessing(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+func (r *reconciler) migrate(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
+	if err := r.updateStatusProcessing(ctx, cr, gardencorev1beta1.LastOperationTypeMigrate, EventContainerRuntimeMigration, "Migrating the container runtime"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.actuator.Migrate(r.ctx, cr, cluster); err != nil {
+		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), cr, gardencorev1beta1.LastOperationTypeMigrate, EventContainerRuntimeMigration, "Error migrating container runtime"))
+		return extensionscontroller.ReconcileErr(err)
+	}
+
+	if err := r.updateStatusSuccess(ctx, cr, gardencorev1beta1.LastOperationTypeMigrate, EventContainerRuntimeMigration, "Successfully migrated container runtime"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	r.logger.Info("Removing all finalizers.", "containerruntime", cr.Name)
+	if err := extensionscontroller.DeleteAllFinalizers(ctx, r.client, cr); err != nil {
+		r.logger.Error(err, "Error removing finalizers from the container runtime resource", "containerruntime", cr.Name)
+		return reconcile.Result{}, err
+	}
+
+	// remove operation annotation 'migrate'
+	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, cr, v1beta1constants.GardenerOperation); err != nil {
+		msg := "Error removing annotation from ContainerRuntime"
+		r.recorder.Eventf(cr, corev1.EventTypeWarning, EventContainerRuntimeMigration, "%s: %+v", msg, err)
+		r.logger.Error(err, msg, "containerruntime", cr.Name)
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) updateStatusProcessing(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, lastOperationType gardencorev1beta1.LastOperationType, eventReason, description string) error {
+	r.logger.Info(description, "containerruntime", cr.Name)
+	r.recorder.Event(cr, corev1.EventTypeNormal, eventReason, description)
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, cr, func() error {
 		cr.Status.LastOperation = extensionscontroller.LastOperation(lastOperationType, gardencorev1beta1.LastOperationStateProcessing, 1, description)
 		return nil
 	})
 }
 
-func (r *reconciler) updateStatusError(ctx context.Context, err error, cr *extensionsv1alpha1.ContainerRuntime, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+func (r *reconciler) updateStatusError(ctx context.Context, err error, cr *extensionsv1alpha1.ContainerRuntime, lastOperationType gardencorev1beta1.LastOperationType, eventReason, description string) error {
+	r.logger.Error(err, description, "containerruntime", cr.Name)
+	r.recorder.Eventf(cr, corev1.EventTypeWarning, eventReason, "%s: %+v", description, err)
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, cr, func() error {
 		cr.Status.ObservedGeneration = cr.Generation
 		cr.Status.LastOperation, cr.Status.LastError = extensionscontroller.ReconcileError(lastOperationType, gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, err)), 50, gardencorev1beta1helper.ExtractErrorCodes(err)...)
@@ -196,7 +255,9 @@ func (r *reconciler) updateStatusError(ctx context.Context, err error, cr *exten
 	})
 }
 
-func (r *reconciler) updateStatusSuccess(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+func (r *reconciler) updateStatusSuccess(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, lastOperationType gardencorev1beta1.LastOperationType, eventReason, description string) error {
+	r.logger.Info(description, "containerruntime", cr.Name)
+	r.recorder.Event(cr, corev1.EventTypeNormal, eventReason, description)
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, cr, func() error {
 		cr.Status.ObservedGeneration = cr.Generation
 		cr.Status.LastOperation, cr.Status.LastError = extensionscontroller.ReconcileSucceeded(lastOperationType, description)

--- a/extensions/pkg/controller/controlplane/reconciler.go
+++ b/extensions/pkg/controller/controlplane/reconciler.go
@@ -158,7 +158,7 @@ func (r *reconciler) restore(ctx context.Context, cp *extensionsv1alpha1.Control
 		return reconcile.Result{}, err
 	}
 
-	r.logger.Info("Starting the reconciliation of controlplane", "controlplane", cp.Name)
+	r.logger.Info("Starting the restoration of controlplane", "controlplane", cp.Name)
 	r.recorder.Event(cp, corev1.EventTypeNormal, EventControlPlaneRestoration, "Restoring the controlplane")
 	requeue, err := r.actuator.Restore(ctx, cp, cluster)
 	if err != nil {

--- a/extensions/pkg/controller/network/actuator.go
+++ b/extensions/pkg/controller/network/actuator.go
@@ -28,4 +28,8 @@ type Actuator interface {
 	Reconcile(context.Context, *extensionsv1alpha1.Network, *extensioncontroller.Cluster) error
 	// Delete deletes the Network resource.
 	Delete(context.Context, *extensionsv1alpha1.Network, *extensioncontroller.Cluster) error
+	// Reconcile restores the Network resource.
+	Restore(context.Context, *extensionsv1alpha1.Network, *extensioncontroller.Cluster) error
+	// Migrate migrates the Network resource.
+	Migrate(context.Context, *extensionsv1alpha1.Network, *extensioncontroller.Cluster) error
 }

--- a/extensions/pkg/controller/network/reconciler.go
+++ b/extensions/pkg/controller/network/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/util"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
@@ -42,6 +43,10 @@ const (
 	EventNetworkReconciliation string = "NetworkReconciliation"
 	// EventNetworkDeletion an event reason to describe network deletion.
 	EventNetworkDeletion string = "NetworkDeletion"
+	// EventNetworkRestoration an event reason to describe network restoration.
+	EventNetworkRestoration string = "NetworkRestoration"
+	// EventNetworkMigartion an event reason to describe network migration.
+	EventNetworkMigartion string = "NetworkMigration"
 )
 
 type reconciler struct {
@@ -94,36 +99,66 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
-	if network.DeletionTimestamp != nil {
-		return r.delete(r.ctx, network, cluster)
-	}
+	operationType := gardencorev1beta1helper.ComputeOperationType(network.ObjectMeta, network.Status.LastOperation)
 
-	return r.reconcile(r.ctx, network, cluster)
+	switch {
+	case extensionscontroller.IsMigrated(network):
+		return reconcile.Result{}, nil
+	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
+		return r.migrate(r.ctx, network, cluster)
+	case network.DeletionTimestamp != nil:
+		return r.delete(r.ctx, network, cluster)
+	case network.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRestore:
+		return r.restore(r.ctx, network, cluster, operationType)
+	default:
+		return r.reconcile(r.ctx, network, cluster, operationType)
+	}
 }
 
-func (r *reconciler) reconcile(ctx context.Context, network *extensionsv1alpha1.Network, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
+func (r *reconciler) reconcile(ctx context.Context, network *extensionsv1alpha1.Network, cluster *extensionscontroller.Cluster, operationType gardencorev1beta1.LastOperationType) (reconcile.Result, error) {
 	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, network); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	operationType := gardencorev1beta1helper.ComputeOperationType(network.ObjectMeta, network.Status.LastOperation)
-	if err := r.updateStatusProcessing(ctx, network, operationType, "Reconciling the network"); err != nil {
+	if err := r.updateStatusProcessing(ctx, network, operationType, EventNetworkReconciliation, "Reconciling the network"); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	r.logger.Info("Starting the reconciliation of network", "network", network.Name)
-	r.recorder.Event(network, corev1.EventTypeNormal, EventNetworkReconciliation, "Reconciling the network")
 	if err := r.actuator.Reconcile(ctx, network, cluster); err != nil {
-		msg := "Error reconciling network"
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), network, operationType, msg))
-		r.logger.Error(err, msg, "network", network.Name)
+		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), network, operationType, EventNetworkReconciliation, "Error reconciling network"))
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	msg := "Successfully reconciled network"
-	r.logger.Info(msg, "network", network.Name)
-	r.recorder.Event(network, corev1.EventTypeNormal, EventNetworkReconciliation, msg)
-	if err := r.updateStatusSuccess(ctx, network, operationType, msg); err != nil {
+	if err := r.updateStatusSuccess(ctx, network, operationType, EventNetworkReconciliation, "Successfully reconciled network"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) restore(ctx context.Context, network *extensionsv1alpha1.Network, cluster *extensionscontroller.Cluster, operationType gardencorev1beta1.LastOperationType) (reconcile.Result, error) {
+	if err := extensionscontroller.EnsureFinalizer(ctx, r.client, FinalizerName, network); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.updateStatusProcessing(ctx, network, operationType, EventNetworkRestoration, "Restoring the network"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.actuator.Restore(ctx, network, cluster); err != nil {
+		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), network, operationType, EventNetworkRestoration, "Error restoring network"))
+		return extensionscontroller.ReconcileErr(err)
+	}
+
+	if err := r.updateStatusSuccess(ctx, network, operationType, EventNetworkRestoration, "Successfully restored network"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// remove operation annotation 'restore'
+	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, network, v1beta1constants.GardenerOperation); err != nil {
+		msg := "Error removing annotation from Network"
+		r.recorder.Eventf(network, corev1.EventTypeWarning, EventNetworkRestoration, "%s: %+v", msg, err)
+		r.logger.Error(err, msg, "network", network.Name)
 		return reconcile.Result{}, err
 	}
 
@@ -141,25 +176,18 @@ func (r *reconciler) delete(ctx context.Context, network *extensionsv1alpha1.Net
 		return reconcile.Result{}, nil
 	}
 
-	operationType := gardencorev1beta1helper.ComputeOperationType(network.ObjectMeta, network.Status.LastOperation)
-	if err := r.updateStatusProcessing(ctx, network, operationType, "Deleting the network"); err != nil {
+	if err := r.updateStatusProcessing(ctx, network, gardencorev1beta1.LastOperationTypeDelete, EventNetworkDeletion, "Deleting the network"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	r.logger.Info("Starting the deletion of network", "network", network.Name)
 	r.recorder.Event(network, corev1.EventTypeNormal, EventNetworkDeletion, "Deleting the network")
 	if err := r.actuator.Delete(r.ctx, network, cluster); err != nil {
-		msg := "Error deleting network"
-		r.recorder.Eventf(network, corev1.EventTypeWarning, EventNetworkDeletion, "%s: %+v", msg, err)
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), network, operationType, msg))
-		r.logger.Error(err, msg, "network", network.Name)
+		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), network, gardencorev1beta1.LastOperationTypeDelete, EventNetworkDeletion, "Error deleting network"))
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	msg := "Successfully deleted network"
-	r.logger.Info(msg, "network", network.Name)
-	r.recorder.Event(network, corev1.EventTypeNormal, EventNetworkDeletion, msg)
-	if err := r.updateStatusSuccess(ctx, network, operationType, msg); err != nil {
+	if err := r.updateStatusSuccess(ctx, network, gardencorev1beta1.LastOperationTypeDelete, EventNetworkDeletion, "Successfully deleted network"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -172,14 +200,48 @@ func (r *reconciler) delete(ctx context.Context, network *extensionsv1alpha1.Net
 	return reconcile.Result{}, nil
 }
 
-func (r *reconciler) updateStatusProcessing(ctx context.Context, network *extensionsv1alpha1.Network, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+func (r *reconciler) migrate(ctx context.Context, network *extensionsv1alpha1.Network, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
+	if err := r.updateStatusProcessing(ctx, network, gardencorev1beta1.LastOperationTypeMigrate, EventNetworkMigartion, "Migrating the network"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.actuator.Migrate(r.ctx, network, cluster); err != nil {
+		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), network, gardencorev1beta1.LastOperationTypeMigrate, EventNetworkMigartion, "Error migrating network"))
+		return extensionscontroller.ReconcileErr(err)
+	}
+
+	if err := r.updateStatusSuccess(ctx, network, gardencorev1beta1.LastOperationTypeMigrate, EventNetworkMigartion, "Successfully migrated network"); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	r.logger.Info("Removing all finalizers.", "network", network.Name)
+	if err := extensionscontroller.DeleteAllFinalizers(ctx, r.client, network); err != nil {
+		r.logger.Error(err, "Error removing finalizers from the Network resource", "network", network.Name)
+		return reconcile.Result{}, err
+	}
+
+	// remove operation annotation 'migrate'
+	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, network, v1beta1constants.GardenerOperation); err != nil {
+		msg := "Error removing annotation from Network"
+		r.recorder.Eventf(network, corev1.EventTypeWarning, EventNetworkRestoration, "%s: %+v", msg, err)
+		r.logger.Error(err, msg, "network", network.Name)
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) updateStatusProcessing(ctx context.Context, network *extensionsv1alpha1.Network, lastOperationType gardencorev1beta1.LastOperationType, eventReason, description string) error {
+	r.logger.Info(description, "network", network.Name)
+	r.recorder.Event(network, corev1.EventTypeNormal, eventReason, description)
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, network, func() error {
 		network.Status.LastOperation = extensionscontroller.LastOperation(lastOperationType, gardencorev1beta1.LastOperationStateProcessing, 1, description)
 		return nil
 	})
 }
 
-func (r *reconciler) updateStatusError(ctx context.Context, err error, network *extensionsv1alpha1.Network, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+func (r *reconciler) updateStatusError(ctx context.Context, err error, network *extensionsv1alpha1.Network, lastOperationType gardencorev1beta1.LastOperationType, eventReason, description string) error {
+	r.recorder.Eventf(network, corev1.EventTypeWarning, eventReason, "%s: %+v", description, err)
+	r.logger.Error(err, description, "network", network.Name)
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, network, func() error {
 		network.Status.ObservedGeneration = network.Generation
 		network.Status.LastOperation, network.Status.LastError = extensionscontroller.ReconcileError(lastOperationType, gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, err)), 50, gardencorev1beta1helper.ExtractErrorCodes(err)...)
@@ -187,7 +249,9 @@ func (r *reconciler) updateStatusError(ctx context.Context, err error, network *
 	})
 }
 
-func (r *reconciler) updateStatusSuccess(ctx context.Context, network *extensionsv1alpha1.Network, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+func (r *reconciler) updateStatusSuccess(ctx context.Context, network *extensionsv1alpha1.Network, lastOperationType gardencorev1beta1.LastOperationType, eventReason, description string) error {
+	r.logger.Info(description, "network", network.Name)
+	r.recorder.Event(network, corev1.EventTypeNormal, eventReason, description)
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, network, func() error {
 		network.Status.ObservedGeneration = network.Generation
 		network.Status.LastOperation, network.Status.LastError = extensionscontroller.ReconcileSucceeded(lastOperationType, description)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds restore and migrate operations to Network and ContainerRuntime actuators
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action developer
Extension controllers for `Network` and `ContainerRuntime` CRDs have to implement the Restore and Migrate operations.
```
