### PR TITLE
expand extension actuator interface with migrate and restore

### DIFF
--- a/extensions/pkg/controller/extension/actuator.go
+++ b/extensions/pkg/controller/extension/actuator.go
@@ -26,4 +26,8 @@ type Actuator interface {
 	Reconcile(ctx context.Context, ex *extensionsv1alpha1.Extension) error
 	// Delete the Extension resource.
 	Delete(ctx context.Context, ex *extensionsv1alpha1.Extension) error
+	// Restore the Extension resource.
+	Restore(ctx context.Context, ex *extensionsv1alpha1.Extension) error
+	// Migrate the Extension resource.
+	Migrate(ctx context.Context, ex *extensionsv1alpha1.Extension) error
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we extend the Extensions actuator interface with Migrate and Restore functionality.
 
**Which issue(s) this PR fixes**:
Part of [# 1631](https://github.com/gardener/gardener/issues/1631) 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Extend the Extensions actuator interface with Migrate and Restore
```
