### PR TITLE
Do not reconcile extensions of failed shoot clusters

### DIFF
--- a/extensions/pkg/controller/backupbucket/reconciler.go
+++ b/extensions/pkg/controller/backupbucket/reconciler.go
@@ -87,9 +87,20 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
+	shoot, err := extensionscontroller.GetShoot(r.ctx, r.client, request.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if extensionscontroller.IsShootFailed(shoot) {
+		r.logger.Info("Stop reconciling BackupBucket of failed Shoot.", "namespace", request.Namespace, "name", bb.Name)
+		return reconcile.Result{}, nil
+	}
+
 	if bb.DeletionTimestamp != nil {
 		return r.delete(r.ctx, bb)
 	}
+
 	return r.reconcile(r.ctx, bb)
 }
 

--- a/extensions/pkg/controller/backupentry/reconciler.go
+++ b/extensions/pkg/controller/backupentry/reconciler.go
@@ -92,6 +92,16 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
+	shoot, err := extensionscontroller.GetShoot(r.ctx, r.client, request.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if extensionscontroller.IsShootFailed(shoot) {
+		r.logger.Info("Stop reconciling BackupEntry of failed Shoot.", "namespace", request.Namespace, "name", be.Name)
+		return reconcile.Result{}, nil
+	}
+
 	operationType := gardencorev1beta1helper.ComputeOperationType(be.ObjectMeta, be.Status.LastOperation)
 
 	switch {

--- a/extensions/pkg/controller/cluster.go
+++ b/extensions/pkg/controller/cluster.go
@@ -132,6 +132,21 @@ func ShootFromCluster(decoder runtime.Decoder, cluster *extensionsv1alpha1.Clust
 	return shoot, nil
 }
 
+// GetShoot tries to read Gardener's Cluster extension resource in the given namespace and return the embedded Shoot resource.
+func GetShoot(ctx context.Context, c client.Client, namespace string) (*gardencorev1beta1.Shoot, error) {
+	cluster := &extensionsv1alpha1.Cluster{}
+	if err := c.Get(ctx, kutil.Key(namespace), cluster); err != nil {
+		return nil, err
+	}
+
+	decoder, err := NewGardenDecoder()
+	if err != nil {
+		return nil, err
+	}
+
+	return ShootFromCluster(decoder, cluster)
+}
+
 // NewGardenDecoder returns a new Garden API decoder.
 func NewGardenDecoder() (runtime.Decoder, error) {
 	return serializer.NewCodecFactory(gardenscheme).UniversalDecoder(), nil

--- a/extensions/pkg/controller/containerruntime/reconciler.go
+++ b/extensions/pkg/controller/containerruntime/reconciler.go
@@ -107,6 +107,10 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+	if extensionscontroller.IsFailed(cluster) {
+		r.logger.Info("Stop reconciling ContainerRuntime of failed Shoot.", "namespace", request.Namespace, "name", cr.Name)
+		return reconcile.Result{}, nil
+	}
 
 	operationType := gardencorev1beta1helper.ComputeOperationType(cr.ObjectMeta, cr.Status.LastOperation)
 

--- a/extensions/pkg/controller/controlplane/reconciler.go
+++ b/extensions/pkg/controller/controlplane/reconciler.go
@@ -101,6 +101,11 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
+	if extensionscontroller.IsFailed(cluster) {
+		r.logger.Info("Stop reconciling ControlPlane of failed Shoot.", "namespace", request.Namespace, "name", cp.Name)
+		return reconcile.Result{}, nil
+	}
+
 	operationType := gardencorev1beta1helper.ComputeOperationType(cp.ObjectMeta, cp.Status.LastOperation)
 
 	switch {

--- a/extensions/pkg/controller/infrastructure/reconciler.go
+++ b/extensions/pkg/controller/infrastructure/reconciler.go
@@ -99,6 +99,11 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
+	if extensionscontroller.IsFailed(cluster) {
+		r.logger.Info("Stop reconciling Infrastructure of failed Shoot.", "namespace", request.Namespace, "name", infrastructure.Name)
+		return reconcile.Result{}, nil
+	}
+
 	operationType := gardencorev1beta1helper.ComputeOperationType(infrastructure.ObjectMeta, infrastructure.Status.LastOperation)
 
 	switch {

--- a/extensions/pkg/controller/network/reconciler.go
+++ b/extensions/pkg/controller/network/reconciler.go
@@ -99,6 +99,11 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
+	if extensionscontroller.IsFailed(cluster) {
+		r.logger.Info("Stop reconciling Network of failed Shoot.", "namespace", request.Namespace, "name", network.Name)
+		return reconcile.Result{}, nil
+	}
+
 	operationType := gardencorev1beta1helper.ComputeOperationType(network.ObjectMeta, network.Status.LastOperation)
 
 	switch {

--- a/extensions/pkg/controller/operatingsystemconfig/reconciler.go
+++ b/extensions/pkg/controller/operatingsystemconfig/reconciler.go
@@ -96,6 +96,17 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		r.logger.Error(err, "Could not fetch OperatingSystemConfig")
 		return reconcile.Result{}, err
 	}
+
+	shoot, err := extensionscontroller.GetShoot(r.ctx, r.client, request.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if extensionscontroller.IsShootFailed(shoot) {
+		r.logger.Info("Stop reconciling OperatingSystemConfig of failed Shoot.", "namespace", request.Namespace, "name", osc.Name)
+		return reconcile.Result{}, nil
+	}
+
 	operationType := gardencorev1beta1helper.ComputeOperationType(osc.ObjectMeta, osc.Status.LastOperation)
 
 	switch {

--- a/extensions/pkg/controller/shoot.go
+++ b/extensions/pkg/controller/shoot.go
@@ -15,6 +15,7 @@
 package controller
 
 import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 )
 
@@ -57,6 +58,20 @@ func GetServiceNetwork(cluster *Cluster) string {
 // IsHibernated returns true if the shoot is hibernated, or false otherwise.
 func IsHibernated(cluster *Cluster) bool {
 	return cluster.Shoot.Spec.Hibernation != nil && cluster.Shoot.Spec.Hibernation.Enabled != nil && *cluster.Shoot.Spec.Hibernation.Enabled
+}
+
+// IsFailed returns true if the embedded shoot is failed, or false otherwise.
+func IsFailed(cluster *Cluster) bool {
+	return IsShootFailed(cluster.Shoot)
+}
+
+// IsShootFailed returns true if the shoot is failed, or false otherwise.
+func IsShootFailed(shoot *gardencorev1beta1.Shoot) bool {
+	if shoot == nil {
+		return false
+	}
+	lastOperation := shoot.Status.LastOperation
+	return lastOperation != nil && lastOperation.State == gardencorev1beta1.LastOperationStateFailed
 }
 
 // IsUnmanagedDNSProvider returns true if the shoot uses an unmanaged DNS provider.

--- a/extensions/pkg/controller/shoot_test.go
+++ b/extensions/pkg/controller/shoot_test.go
@@ -116,4 +116,37 @@ var _ = Describe("Shoot", func() {
 		Entry("hibernation is not enabled", nil, 3, 3),
 		Entry("hibernation is enabled", &gardencorev1beta1.Hibernation{Enabled: &trueVar}, 1, 0),
 	)
+
+	DescribeTable("#IsFailed",
+		func(lastOperation *gardencorev1beta1.LastOperation, expectedToBeFailed bool) {
+			cluster := &Cluster{
+				Shoot: &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{
+						LastOperation: lastOperation,
+					},
+				},
+			}
+
+			Expect(IsFailed(cluster)).To(Equal(expectedToBeFailed))
+		},
+
+		Entry("cluster is failed", &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateFailed}, true),
+		Entry("cluster is not failed", &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateError}, false),
+		Entry("cluster is not failed", nil, false),
+	)
+
+	DescribeTable("#IsShootFailed",
+		func(lastOperation *gardencorev1beta1.LastOperation, expectedToBeFailed bool) {
+			shoot := &gardencorev1beta1.Shoot{
+				Status: gardencorev1beta1.ShootStatus{
+					LastOperation: lastOperation,
+				},
+			}
+			Expect(IsShootFailed(shoot)).To(Equal(expectedToBeFailed))
+		},
+
+		Entry("cluster is failed", &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateFailed}, true),
+		Entry("cluster is not failed", &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateError}, false),
+		Entry("cluster is not failed", nil, false),
+	)
 })

--- a/extensions/pkg/controller/worker/reconciler.go
+++ b/extensions/pkg/controller/worker/reconciler.go
@@ -84,6 +84,11 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
+	if extensionscontroller.IsFailed(cluster) {
+		r.logger.Info("Stop reconciling Worker of failed Shoot.", "namespace", request.Namespace, "name", worker.Name)
+		return reconcile.Result{}, nil
+	}
+
 	operationType := gardencorev1beta1helper.ComputeOperationType(worker.ObjectMeta, worker.Status.LastOperation)
 
 	switch {

--- a/extensions/pkg/controller/worker/state_reconciler.go
+++ b/extensions/pkg/controller/worker/state_reconciler.go
@@ -115,7 +115,7 @@ func (r *stateReconciler) Reconcile(request reconcile.Request) (reconcile.Result
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	msg := "Successfully update worker state"
+	msg := "Successfully updated worker state"
 	r.logger.Info(msg, "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
 	r.recorder.Event(worker, corev1.EventTypeNormal, SuccessSynced, msg)
 

--- a/extensions/pkg/predicate/predicate.go
+++ b/extensions/pkg/predicate/predicate.go
@@ -76,8 +76,7 @@ func (s *shootNotFailedMapper) Map(e event.GenericEvent) bool {
 		return false
 	}
 
-	lastOperation := cluster.Shoot.Status.LastOperation
-	if lastOperation != nil && lastOperation.State == gardencorev1beta1.LastOperationStateFailed {
+	if extensionscontroller.IsFailed(cluster) {
 		return cluster.Shoot.Generation != cluster.Shoot.Status.ObservedGeneration
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Extensions CRDs for Shoots with lastOperation.Failed should not be reconciled.
Introduces a check (in addition to the controller-runtime predicate) that checks the Shoot inlined in the Cluster CRD for last.operation == failed. If a Shoot is failed, stops the reconcile. 

Also see [this issue](https://github.com/gardener/gardener/issues/2145).
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixes a bug in the extension library of all extension resources that lead to not stopping the reconciliation of extension resources when the Shoot is in 'failed' state (Shoot.Status.lastOperation.state = Failed). 
```
