### PR TITLE
Fix apierrors.IsAlreadyExists check in CreateState

### DIFF
--- a/extensions/pkg/terraformer/state.go
+++ b/extensions/pkg/terraformer/state.go
@@ -169,11 +169,9 @@ func (f StateConfigMapInitializerFunc) Initialize(ctx context.Context, c client.
 	return f(ctx, c, namespace, name)
 }
 
-// CreateState create terraform state config map and use empty state
-// It does not create or update state ConfigMap if alredy exists
+// CreateState create terraform state config map and use empty state.
+// It does not create or update state ConfigMap if already exists.
 func CreateState(ctx context.Context, c client.Client, namespace, name string) error {
-	var err error
-
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
 		Data: map[string]string{
@@ -181,17 +179,17 @@ func CreateState(ctx context.Context, c client.Client, namespace, name string) e
 		},
 	}
 
-	if err = c.Create(ctx, configMap); err != nil && !apierrors.IsAlreadyExists(err) {
-		return nil
+	if err := c.Create(ctx, configMap); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
 	}
 
-	return err
+	return nil
 }
 
 // Initialize implements StateConfigMapInitializer
 func (cus CreateOrUpdateState) Initialize(ctx context.Context, c client.Client, namespace, name string) error {
 	if cus.State == nil {
-		return fmt.Errorf("missing state when creating or updating terraform state comfigMap %s/%s", namespace, name)
+		return fmt.Errorf("missing state when creating or updating terraform state ConfigMap %s/%s", namespace, name)
 	}
 	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I hit Infrastructure reconciliation failing with the following error. No clear steps to reproduce however. 
```
$ k -n extension-provider-aws-ms2t2 logs gardener-extension-provider-aws-69769ccf47-f88k8 | grep "Could not create the Terraform ConfigMaps/Secrets"
time="2020-05-04T19:26:32Z" level=error msg="Could not create the Terraform ConfigMaps/Secrets: configmaps \"foo.infra.tf-state\" already exists"
time="2020-05-04T19:26:32Z" level=error msg="Could not create the Terraform ConfigMaps/Secrets: configmaps \"foo.infra.tf-state\" already exists"
time="2020-05-04T19:27:02Z" level=error msg="Could not create the Terraform ConfigMaps/Secrets: configmaps \"foo.infra.tf-state\" already exists"
time="2020-05-04T19:27:32Z" level=error msg="Could not create the Terraform ConfigMaps/Secrets: configmaps \"foo.infra.tf-state\" already exists"
time="2020-05-04T19:28:02Z" level=error msg="Could not create the Terraform ConfigMaps/Secrets: configmaps \"foo.infra.tf-state\" already exists"
time="2020-05-04T19:28:33Z" level=error msg="Could not create the Terraform ConfigMaps/Secrets: configmaps \"foo.infra.tf-state\" already exists"
```

The apierrors.IsAlreadyExists in CreateState seems to be wrong one. We rather want to ignore the error when it is AlreadyExists.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
