### PR TITLE
Adapt workaround for broken ShootNotFailed predicate

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -141,13 +141,14 @@ func (c *Controller) syncClusterResourceToSeed(ctx context.Context, shoot *garde
 	}
 
 	// TODO: Workaround for the issue that was fixed with https://github.com/gardener/gardener/pull/2265. It adds a
-	//       fake "last operation" in case it is not set yet. This prevents the ShootNotFailed predicate in the
-	//       extensions library from reacting false negatively. This fake status is only internally and will not be
-	//       reported in the Shoot object in the garden cluster.
+	//       fake "observed generation" and a fake "last operation" and in case it is not set yet. This prevents the
+	//       ShootNotFailed predicate in the extensions library from reacting false negatively. This fake status is only
+	//       internally and will not be reported in the Shoot object in the garden cluster.
 	//       This code can be removed in a future version after giving extension controllers enough time to revendor
 	//       Gardener's extensions library.
-	if shoot.Status.LastOperation == nil {
-		shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{
+	shootObj.Status.ObservedGeneration = shootObj.Generation
+	if shootObj.Status.LastOperation == nil {
+		shootObj.Status.LastOperation = &gardencorev1beta1.LastOperation{
 			Type:  gardencorev1beta1.LastOperationTypeCreate,
 			State: gardencorev1beta1.LastOperationStateSucceeded,
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
The `ShootNotFailed` predicate was broken and got fixed with #2265. However, to give extension controllers enough time to revendor we have added a temporary workaround in #2217. It was faking the last operation for newly created shoots. However, @ialidzhikov reported in https://github.com/gardener/gardener/pull/2217#issuecomment-623637931 that it does not work properly.
This PR adapts the workaround to allow extensio controllers to properly react for newly created shoots (where the `status` of the `Shoot` is not yet fully set up).

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
