### PR TITLE
Add global cleanuphandler and possible after test options to the testsuite testcases

### DIFF
--- a/test/framework/cleanup.go
+++ b/test/framework/cleanup.go
@@ -1,0 +1,60 @@
+// Copied from https://github.com/kubernetes/kubernetes/blob/de66c643c479f420b1902f8897636ea41ac2b3c3/test/e2e/framework/cleanup.go
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import "sync"
+
+// CleanupActionHandle is an integer pointer type for handling cleanup action
+type CleanupActionHandle *int
+
+var cleanupActionsLock sync.Mutex
+var cleanupActions = map[CleanupActionHandle]func(){}
+
+// AddCleanupAction installs a function that will be called in the event of the
+// whole test being terminated.  This allows arbitrary pieces of the overall
+// test to hook into SynchronizedAfterSuite().
+func AddCleanupAction(fn func()) CleanupActionHandle {
+	p := CleanupActionHandle(new(int))
+	cleanupActionsLock.Lock()
+	defer cleanupActionsLock.Unlock()
+	cleanupActions[p] = fn
+	return p
+}
+
+// RemoveCleanupAction removes a function that was installed by
+// AddCleanupAction.
+func RemoveCleanupAction(p CleanupActionHandle) {
+	cleanupActionsLock.Lock()
+	defer cleanupActionsLock.Unlock()
+	delete(cleanupActions, p)
+}
+
+// RunCleanupActions runs all functions installed by AddCleanupAction.  It does
+// not remove them (see RemoveCleanupAction) but it does run unlocked, so they
+// may remove themselves.
+func RunCleanupActions() {
+	list := []func(){}
+	func() {
+		cleanupActionsLock.Lock()
+		defer cleanupActionsLock.Unlock()
+		for _, fn := range cleanupActions {
+			list = append(list, fn)
+		}
+	}()
+	// Run unlocked.
+	for _, fn := range list {
+		fn()
+	}
+}

--- a/test/framework/commonframework.go
+++ b/test/framework/commonframework.go
@@ -92,6 +92,10 @@ func (f *CommonFramework) BeforeEach() {
 
 // CommonAfterSuite performs necessary common steps after all tests of a suite a run
 func CommonAfterSuite() {
+
+	// run all registered cleanup functions
+	RunCleanupActions()
+
 	resourcesDir, err := filepath.Abs(filepath.Join("..", "..", "framework", "resources"))
 	ExpectNoError(err)
 	err = os.RemoveAll(filepath.Join(resourcesDir, "charts"))

--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -110,7 +110,7 @@ func (f *ShootFramework) DumpState(ctx context.Context) {
 		}
 	}
 
-	//dump controlplane in the shoot namespace
+	// dump controlplane in the shoot namespace
 	if f.Seed != nil && f.SeedClient != nil {
 		if err := f.dumpControlplaneInSeed(ctx, f.Seed, f.ShootSeedNamespace()); err != nil {
 			f.Logger.Errorf("unable to dump controlplane of %s in seed %s: %v", f.Shoot.Name, f.Seed.Name, err)

--- a/test/framework/test_description.go
+++ b/test/framework/test_description.go
@@ -70,23 +70,43 @@ func (t TestDescription) newLabel(label string) TestDescription {
 }
 
 // It defines a ginkgo It block and enhances the test description with the provided labels
-func (t TestDescription) It(text string, body func()) {
-	ginkgo.It(fmt.Sprintf("%s %s", t.String(), text), body)
+func (t TestDescription) It(text string, body func(), opts ...TestOption) {
+	testOptions := &TestOptions{}
+	testOptions.ApplyOptions(opts)
+
+	testOptions.Complete(func() {
+		ginkgo.It(fmt.Sprintf("%s %s", t.String(), text), body)
+	})
 }
 
 // FIt defines a ginkgo FIt block and enhances the test description with the provided labels
-func (t TestDescription) FIt(text string, body func()) {
-	ginkgo.FIt(fmt.Sprintf("%s %s", t.String(), text), body)
+func (t TestDescription) FIt(text string, body func(), opts ...TestOption) {
+	testOptions := &TestOptions{}
+	testOptions.ApplyOptions(opts)
+
+	testOptions.Complete(func() {
+		ginkgo.FIt(fmt.Sprintf("%s %s", t.String(), text), body)
+	})
 }
 
 // CIt defines a contextified ginkgo It block and enhances the test description with the provided labels
-func (t TestDescription) CIt(text string, body func(context.Context), timeout time.Duration) {
-	CIt(fmt.Sprintf("%s %s", t.String(), text), body, timeout)
+func (t TestDescription) CIt(text string, body func(context.Context), timeout time.Duration, opts ...TestOption) {
+	testOptions := &TestOptions{}
+	testOptions.ApplyOptions(opts)
+
+	testOptions.Complete(func() {
+		CIt(fmt.Sprintf("%s %s", t.String(), text), body, timeout)
+	})
 }
 
 // FCIt defines a contextified ginkgo FIt block and enhances the test description with the provided labels
-func (t TestDescription) FCIt(text string, body func(context.Context), timeout time.Duration) {
-	FCIt(fmt.Sprintf("%s %s", t.String(), text), body, timeout)
+func (t TestDescription) FCIt(text string, body func(context.Context), timeout time.Duration, opts ...TestOption) {
+	testOptions := &TestOptions{}
+	testOptions.ApplyOptions(opts)
+
+	testOptions.Complete(func() {
+		FCIt(fmt.Sprintf("%s %s", t.String(), text), body, timeout)
+	})
 }
 
 // String returns the test description labels

--- a/test/framework/test_options.go
+++ b/test/framework/test_options.go
@@ -1,0 +1,125 @@
+// Copyright 2020 Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/ginkgo"
+)
+
+// TestOptions contains options to add additional functionality
+// or cleanup handlers to a testcase.
+type TestOptions struct {
+	// afterTests holds a list of all registered AfterTest functions
+	// that are executed when the test has finished.
+	AfterTests afterTests
+
+	// CAfterTests holds a list of all registered contextified AfterTest functions
+	// that are executed when the test has finished.
+	CAfterTests []cAfterTestOption
+}
+
+// ApplyOptions applies the given test options on these options.
+func (o *TestOptions) ApplyOptions(opts []TestOption) *TestOptions {
+	for _, opt := range opts {
+		opt.ApplyToTestOptions(o)
+	}
+	return o
+}
+
+// Complete registers all test options that are configured.
+// it should be a function that configures a ginkgo test case
+// This should get called when all options are applied.
+func (o *TestOptions) Complete(it func()) {
+
+	if len(o.AfterTests) == 0 && len(o.CAfterTests) == 0 {
+		it()
+		return
+	}
+
+	// Create a new context so that the afterTests function only runs once after this one testcase.
+	// Otherwise the after tests would run after every test case in the outer context.
+	ginkgo.Context("", func() {
+		it()
+
+		for _, aftertest := range o.AfterTests {
+			// register afterTest to global aftersuite in case the test interrupts
+			var h CleanupActionHandle
+			ginkgo.BeforeEach(func() {
+				h = AddCleanupAction(aftertest)
+			})
+			ginkgo.AfterEach(func() {
+				RemoveCleanupAction(h)
+				aftertest()
+			})
+		}
+
+		for _, caftertest := range o.CAfterTests {
+			// register afterTest to global aftersuite in case the test interrupts
+			var h CleanupActionHandle
+			ginkgo.BeforeEach(func() {
+				h = AddCleanupAction(func() {
+					contextify(caftertest.Body, caftertest.Timeout)()
+				})
+			})
+			CAfterEach(func(ctx context.Context) {
+				RemoveCleanupAction(h)
+				caftertest.Body(ctx)
+			}, caftertest.Timeout)
+		}
+	})
+}
+
+// cAfterTestOption contains options for contextified after test function.
+type cAfterTestOption struct {
+	Body    func(ctx context.Context)
+	Timeout time.Duration
+}
+
+// ApplyToTestOptions adds contextified after test functions to test options
+func (at *cAfterTestOption) ApplyToTestOptions(opts *TestOptions) {
+	opts.CAfterTests = append(opts.CAfterTests, *at)
+}
+
+// TestOption is some configuration that modifies options for testcase.
+type TestOption interface {
+	// ApplyToTestOptions applies this configuration to the given test options.
+	ApplyToTestOptions(*TestOptions)
+}
+
+// afterTests are functions that should run when a test has finished
+type afterTests []func()
+
+// ApplyToTestOptions adds after test functions to test options
+func (at afterTests) ApplyToTestOptions(opts *TestOptions) {
+	opts.AfterTests = append(opts.AfterTests, at...)
+}
+
+// WithAfterTests adds functions to the current test that are called
+// when the test has finished
+func WithAfterTests(funcs ...func()) TestOption {
+	return afterTests(funcs)
+}
+
+// WithAfterTests adds contextified functions to the current test that are called
+// when the test has finished
+func WithCAfterTest(body func(ctx context.Context), timeout time.Duration) TestOption {
+	return &cAfterTestOption{
+		Body:    body,
+		Timeout: timeout,
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently most testcases implement their cleanup logic with `defer` functions which does not cleanup in every case and may leak resources.

Therefore, two new features are added to the testframework to be able to 
- set cleanup functions per test
- set global test cleanup for the `AfterSuite`

A *global cleanup* handler can be now easily added by registering the cleanup function with `framework.AddCleanupAction(fn func())`.
I can also be removed if not needed with`framework.RemoveCleanupAction(fn func())`
Explination: this global cleanup actions store is needed as there can only be one `ginkgo.AfterSuite` which means that we have to invoke all cleanup handlers there.

*cleanup functions* for a specific test can be defined by adding a cleanup option to the testdefinition `It()`. An example can be found below.

The `AfterTest` cleanup function is defined by creating a new context just for the test and register a `ginkgo.AfterEach`. 
As ginkgo's `AfterEach` is not invoked when the test is interrupt(see this issue onsi/ginkgo#222 ), the cleanup function is also registered as a global aftersuite cleanup.
This registered aftersuite cleanup is removed from the global again when it is executed as aftersuite cleanup so that the cleanup function does not run multiple times.

```go
f := framework.NewShootFramework(nil)
f.Serial().CIt("My test", func(ctx context.Context) {
  // my test goes here
  Expect(val).ToBe(somevalue)
}, 1 * time.Minute,
framework.WithCAfterTests(func(ctx context.Context) {
  // my cleanup code goes here
}, 30 * time.Seconds))
```


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/2272

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
It is now possible to add a global cleanup function for integration tests.
```
```improvement developer
It is now possible to add a dedicated `AfterTest` function to test cases to run a specific function when the test has finished.
```
