### PR TITLE
Increase limits for CoreDNS + blackbox-exporter

### DIFF
--- a/charts/shoot-core/components/charts/coredns/values.yaml
+++ b/charts/shoot-core/components/charts/coredns/values.yaml
@@ -19,7 +19,7 @@ deployment:
       imagePullPolicy: IfNotPresent
       resources:
         limits:
-          cpu: 100m
+          cpu: 250m
           memory: 100Mi
         requests:
           cpu: 50m
@@ -74,4 +74,4 @@ horizontalPodAutoScaler:
     maxReplicas: 5
     minReplicas: 2
     metrics:
-      targetAverageUtilization: 80
+      targetAverageUtilization: 70

--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/config.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/config.yaml
@@ -11,7 +11,7 @@ data:
     modules:
       http_kubernetes_service:
         prober: http
-        timeout: 5s
+        timeout: 10s
         http:
           headers:
             Accept: "*/*"

--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -44,10 +44,10 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           requests:
-            cpu: 5m
+            cpu: 10m
             memory: 5Mi
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 35Mi
         ports:
         - containerPort: 9115


### PR DESCRIPTION
**What this PR does / why we need it**:
We sometimes observe that the blackbox-exporter cannot properly report the API server availability as either itself gets CPU-throttled or CoreDNS gets CPU-throttled or its request times out (probably related to the CPU-throttling itself, but may also occur for shoots where the worker nodes are far away from the control plane).

This PR adapts the limits slightly and increases the timeout for the BBX. It should prevent false negative API reports from the BBX.

**Special notes for your reviewer**:
* /cc @vlerenc
* We are having a `HorizontalPodAutoscaler` for CoreDNS that scales between 2-5 replicas and for `80%` target CPU average utilization. However, this seems to not work too well, so we should revisit this again.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The CPU limits for the `coredns` and `blackbox-exporter` deployments in the shoot have been slightly increased to prevent false negative API server availability reports.
```
