### PR TITLE
Fix duplicate Extension CRD reconcile in extension library

### DIFF
--- a/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
+++ b/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     gardener.cloud/operation: reconcile
+    gardener.cloud/timestamp: {{ required "annotationCurrentTimestamp is required" .Values.annotationCurrentTimestamp }}
 spec:
   type: {{ required "type is required" .Values.type }}
   purpose: {{ required "purpose is required" .Values.purpose }}

--- a/charts/seed-operatingsystemconfig/downloader/values.yaml
+++ b/charts/seed-operatingsystemconfig/downloader/values.yaml
@@ -2,3 +2,4 @@ type: coreos
 purpose: bootstrap
 secretName: cpu-worker-0
 server: api.shoot-cluster.example.com
+annotationCurrentTimestamp: 2020-05-06T10:18:01Z

--- a/charts/seed-operatingsystemconfig/original/templates/osc.yaml
+++ b/charts/seed-operatingsystemconfig/original/templates/osc.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     gardener.cloud/operation: reconcile
+    gardener.cloud/timestamp: {{ required ".osc.annotationCurrentTimestamp is required" .Values.osc.annotationCurrentTimestamp }}
 spec:
   type: {{ required ".osc.type is required" .Values.osc.type }}
   purpose: {{ required ".osc.purpose is required" .Values.osc.purpose }}

--- a/charts/seed-operatingsystemconfig/original/values.yaml
+++ b/charts/seed-operatingsystemconfig/original/values.yaml
@@ -1,6 +1,7 @@
 osc:
   type: coreos
   purpose: bootstrap
+  annotationCurrentTimestamp: 2020-05-06T10:18:01Z
   reloadConfigFilePath: /var/lib/...
   secretName: cpu-worker-0
   sshKey: "ssh-rsa"

--- a/extensions/pkg/controller/backupbucket/controller.go
+++ b/extensions/pkg/controller/backupbucket/controller.go
@@ -47,6 +47,10 @@ type AddArgs struct {
 	Predicates []predicate.Predicate
 	// Type is the type of the resource considered for reconciliation.
 	Type string
+	// IgnoreOperationAnnotation specifies whether to ignore the operation annotation or not.
+	// If the annotation is not ignored, the extension controller will only reconcile
+	// with a present operation annotation typically set during a reconcile (e.g in the maintenance time) by the Gardenlet
+	IgnoreOperationAnnotation bool
 }
 
 // DefaultPredicates returns the default predicates for a controlplane reconciler.
@@ -75,18 +79,20 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 func Add(mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
 	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	return add(mgr, args.ControllerOptions, predicates)
+	return add(mgr, args, predicates)
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, options controller.Options, predicates []predicate.Predicate) error {
-	ctrl, err := controller.New(ControllerName, mgr, options)
+func add(mgr manager.Manager, args AddArgs, predicates []predicate.Predicate) error {
+	ctrl, err := controller.New(ControllerName, mgr, args.ControllerOptions)
 	if err != nil {
 		return err
 	}
 
-	if err := ctrl.Watch(&source.Kind{Type: &corev1.Secret{}}, &extensionshandler.EnqueueRequestsFromMapFunc{ToRequests: extensionshandler.SimpleMapper(SecretToBackupBucketMapper(predicates), extensionshandler.UpdateWithNew)}); err != nil {
-		return err
+	if args.IgnoreOperationAnnotation {
+		if err := ctrl.Watch(&source.Kind{Type: &corev1.Secret{}}, &extensionshandler.EnqueueRequestsFromMapFunc{ToRequests: extensionshandler.SimpleMapper(SecretToBackupBucketMapper(predicates), extensionshandler.UpdateWithNew)}); err != nil {
+			return err
+		}
 	}
 
 	return ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.BackupBucket{}}, &handler.EnqueueRequestForObject{}, predicates...)

--- a/extensions/pkg/controller/backupentry/controller.go
+++ b/extensions/pkg/controller/backupentry/controller.go
@@ -47,6 +47,10 @@ type AddArgs struct {
 	Predicates []predicate.Predicate
 	// Type is the type of the resource considered for reconciliation.
 	Type string
+	// IgnoreOperationAnnotation specifies whether to ignore the operation annotation or not.
+	// If the annotation is not ignored, the extension controller will only reconcile
+	// with a present operation annotation typically set during a reconcile (e.g in the maintenance time) by the Gardenlet
+	IgnoreOperationAnnotation bool
 }
 
 // DefaultPredicates returns the default predicates for a controlplane reconciler.
@@ -75,30 +79,32 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 func Add(mgr manager.Manager, args AddArgs) error {
 	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
 	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
-	return add(mgr, args.ControllerOptions, predicates)
+	return add(mgr, args, predicates)
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, options controller.Options, predicates []predicate.Predicate) error {
-	ctrl, err := controller.New(ControllerName, mgr, options)
+func add(mgr manager.Manager, args AddArgs, predicates []predicate.Predicate) error {
+	ctrl, err := controller.New(ControllerName, mgr, args.ControllerOptions)
 	if err != nil {
 		return err
 	}
 
-	if err := ctrl.Watch(
-		&source.Kind{Type: &corev1.Namespace{}},
-		&extensionshandler.EnqueueRequestsFromMapFunc{
-			ToRequests: extensionshandler.SimpleMapper(NamespaceToBackupEntryMapper(mgr.GetClient(), predicates), extensionshandler.UpdateWithNew),
-		}); err != nil {
-		return err
-	}
+	if args.IgnoreOperationAnnotation {
+		if err := ctrl.Watch(
+			&source.Kind{Type: &corev1.Namespace{}},
+			&extensionshandler.EnqueueRequestsFromMapFunc{
+				ToRequests: extensionshandler.SimpleMapper(NamespaceToBackupEntryMapper(mgr.GetClient(), predicates), extensionshandler.UpdateWithNew),
+			}); err != nil {
+			return err
+		}
 
-	if err := ctrl.Watch(
-		&source.Kind{Type: &corev1.Secret{}},
-		&extensionshandler.EnqueueRequestsFromMapFunc{
-			ToRequests: extensionshandler.SimpleMapper(SecretToBackupEntryMapper(mgr.GetClient(), predicates), extensionshandler.UpdateWithNew),
-		}); err != nil {
-		return err
+		if err := ctrl.Watch(
+			&source.Kind{Type: &corev1.Secret{}},
+			&extensionshandler.EnqueueRequestsFromMapFunc{
+				ToRequests: extensionshandler.SimpleMapper(SecretToBackupEntryMapper(mgr.GetClient(), predicates), extensionshandler.UpdateWithNew),
+			}); err != nil {
+			return err
+		}
 	}
 
 	return ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.BackupEntry{}}, &handler.EnqueueRequestForObject{}, predicates...)

--- a/extensions/pkg/controller/extension/reconciler.go
+++ b/extensions/pkg/controller/extension/reconciler.go
@@ -64,6 +64,10 @@ type AddArgs struct {
 	Resync time.Duration
 	// Type is the type of the resource considered for reconciliation.
 	Type string
+	// IgnoreOperationAnnotation specifies whether to ignore the operation annotation or not.
+	// If the annotation is not ignored, the extension controller will only reconcile
+	// with a present operation annotation typically set during a reconcile (e.g in the maintenance time) by the Gardenlet
+	IgnoreOperationAnnotation bool
 }
 
 // Add adds an Extension controller to the given manager using the given AddArgs.
@@ -101,13 +105,15 @@ func add(mgr manager.Manager, args AddArgs) error {
 
 	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
 
-	if err := ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.Extension{}}, &handler.EnqueueRequestForObject{}, predicates...); err != nil {
-		return err
+	if args.IgnoreOperationAnnotation {
+		if err := ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.Cluster{}}, &extensionshandler.EnqueueRequestsFromMapFunc{
+			ToRequests: extensionshandler.SimpleMapper(ClusterToExtensionMapper(predicates...), extensionshandler.UpdateWithNew),
+		}); err != nil {
+			return err
+		}
 	}
 
-	return ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.Cluster{}}, &extensionshandler.EnqueueRequestsFromMapFunc{
-		ToRequests: extensionshandler.SimpleMapper(ClusterToExtensionMapper(predicates...), extensionshandler.UpdateWithNew),
-	})
+	return ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.Extension{}}, &handler.EnqueueRequestForObject{}, predicates...)
 }
 
 // reconciler reconciles Extension resources of Gardener's

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -103,6 +103,9 @@ const (
 	// GardenerOperationReconcile is a constant for the value of the operation annotation describing a reconcile
 	// operation.
 	GardenerOperationReconcile = "reconcile"
+	// GardenerTimestamp is a constant for an annotation on a resource that describes the timestamp when a reconciliation has been requested.
+	// It is only used to guarantee an update event for watching clients in case the operation-annotation is already present.
+	GardenerTimestamp = "gardener.cloud/timestamp"
 	// GardenerOperationMigrate is a constant for the value of the operation annotation describing a migration
 	// operation.
 	GardenerOperationMigrate = "migrate"

--- a/pkg/controllermanager/controller/shoot/shoot_hibernation_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_hibernation_control.go
@@ -104,7 +104,7 @@ func ComputeHibernationSchedule(client gardencore.Interface, logger logrus.Field
 				}
 
 				cr.Schedule(start, NewHibernationJob(client, cronLogger, shoot, true))
-				cronLogger.Debugf("Next hibernation for spec %q will trigger at %v", *schedule.Start, start.Next(TimeNow()))
+				cronLogger.Debugf("Next hibernation for spec %q will trigger at %v", *schedule.Start, start.Next(TimeNow().UTC()))
 			}
 
 			if schedule.End != nil {
@@ -114,7 +114,7 @@ func ComputeHibernationSchedule(client gardencore.Interface, logger logrus.Field
 				}
 
 				cr.Schedule(end, NewHibernationJob(client, cronLogger, shoot, false))
-				cronLogger.Debugf("Next wakeup for spec %q will trigger at %v", *schedule.End, end.Next(TimeNow()))
+				cronLogger.Debugf("Next wakeup for spec %q will trigger at %v", *schedule.End, end.Next(TimeNow().UTC()))
 			}
 		}
 		schedule[locationID] = cr

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
@@ -167,6 +167,7 @@ func (a *actuator) deployBackupBucketExtension(ctx context.Context) error {
 
 	_, err = controllerutil.CreateOrUpdate(ctx, a.seedClient, extensionBackupBucket, func() error {
 		metav1.SetMetaDataAnnotation(&extensionBackupBucket.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+		metav1.SetMetaDataAnnotation(&extensionBackupBucket.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
 
 		extensionBackupBucket.Spec = extensionsv1alpha1.BackupBucketSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{

--- a/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
@@ -213,6 +213,7 @@ func (a *actuator) deployBackupEntryExtension(ctx context.Context) error {
 
 	_, err = controllerutil.CreateOrUpdate(ctx, a.seedClient, extensionBackupEntry, func() error {
 		metav1.SetMetaDataAnnotation(&extensionBackupEntry.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+		metav1.SetMetaDataAnnotation(&extensionBackupEntry.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
 
 		extensionBackupEntry.Spec = extensionsv1alpha1.BackupEntrySpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{

--- a/pkg/operation/botanist/containerruntime.go
+++ b/pkg/operation/botanist/containerruntime.go
@@ -17,6 +17,7 @@ package botanist
 import (
 	"context"
 	"fmt"
+	"time"
 
 	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -54,6 +55,8 @@ func (b *Botanist) DeployContainerRuntimeResources(ctx context.Context) error {
 			fns = append(fns, func(ctx context.Context) error {
 				_, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), &toApply, func() error {
 					metav1.SetMetaDataAnnotation(&toApply.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+					metav1.SetMetaDataAnnotation(&toApply.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
+
 					toApply.Spec.BinaryPath = extensionsv1alpha1.ContainerDRuntimeContainersBinFolder
 					toApply.Spec.Type = cr.Type
 					if cr.ProviderConfig != nil {

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -333,6 +333,8 @@ func (b *Botanist) DeployControlPlane(ctx context.Context) error {
 
 	_, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), cp, func() error {
 		metav1.SetMetaDataAnnotation(&cp.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+		metav1.SetMetaDataAnnotation(&cp.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
+
 		cp.Spec = extensionsv1alpha1.ControlPlaneSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
 				Type:           string(b.Shoot.Info.Spec.Provider.Type),
@@ -371,6 +373,8 @@ func (b *Botanist) DeployControlPlaneExposure(ctx context.Context) error {
 
 	_, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), cp, func() error {
 		metav1.SetMetaDataAnnotation(&cp.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+		metav1.SetMetaDataAnnotation(&cp.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
+
 		cp.Spec = extensionsv1alpha1.ControlPlaneSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
 				Type: b.Seed.Info.Spec.Provider.Type,
@@ -523,6 +527,8 @@ func (b *Botanist) DeployBackupEntryInGarden(ctx context.Context) error {
 
 	_, err := controllerutil.CreateOrUpdate(ctx, b.K8sGardenClient.Client(), backupEntry, func() error {
 		metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+		metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
+
 		finalizers := sets.NewString(backupEntry.GetFinalizers()...)
 		finalizers.Insert(gardencorev1beta1.GardenerName)
 		backupEntry.SetFinalizers(finalizers.UnsortedList())
@@ -1082,6 +1088,7 @@ func (b *Botanist) DeployETCD(ctx context.Context) error {
 	values := map[string]interface{}{
 		"annotations": map[string]string{
 			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+			v1beta1constants.GardenerTimestamp: time.Now().UTC().String(),
 		},
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-etcd-ca":          b.CheckSums[v1beta1constants.SecretNameCAETCD],

--- a/pkg/operation/botanist/extension.go
+++ b/pkg/operation/botanist/extension.go
@@ -16,6 +16,7 @@ package botanist
 
 import (
 	"context"
+	"time"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -48,6 +49,7 @@ func (b *Botanist) DeployExtensionResources(ctx context.Context) error {
 		fns = append(fns, func(ctx context.Context) error {
 			_, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), &toApply, func() error {
 				metav1.SetMetaDataAnnotation(&toApply.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+				metav1.SetMetaDataAnnotation(&toApply.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
 
 				toApply.Spec.Type = extensionType
 				toApply.Spec.ProviderConfig = providerConfig

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -64,6 +64,7 @@ func (b *Botanist) DeployInfrastructure(ctx context.Context) error {
 	_, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), infrastructure, func() error {
 		if requestInfrastructureReconciliation {
 			metav1.SetMetaDataAnnotation(&infrastructure.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+			metav1.SetMetaDataAnnotation(&infrastructure.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
 		}
 
 		infrastructure.Spec = extensionsv1alpha1.InfrastructureSpec{

--- a/pkg/operation/botanist/network.go
+++ b/pkg/operation/botanist/network.go
@@ -43,6 +43,8 @@ func (b *Botanist) DeployNetwork(ctx context.Context) error {
 
 	_, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), network, func() error {
 		metav1.SetMetaDataAnnotation(&network.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+		metav1.SetMetaDataAnnotation(&network.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
+
 		network.Spec = extensionsv1alpha1.NetworkSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
 				Type: string(b.Shoot.Info.Spec.Networking.Type),

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -119,9 +119,10 @@ func (b *Botanist) ComputeShootOperatingSystemConfig(ctx context.Context) error 
 
 func (b *Botanist) generateDownloaderConfig(machineImageName string) map[string]interface{} {
 	return map[string]interface{}{
-		"type":    machineImageName,
-		"purpose": extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
-		"server":  fmt.Sprintf("https://%s", b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true)),
+		"type":                       machineImageName,
+		"purpose":                    extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
+		"annotationCurrentTimestamp": time.Now().UTC().String(),
+		"server":                     fmt.Sprintf("https://%s", b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true)),
 	}
 }
 
@@ -172,13 +173,14 @@ func (b *Botanist) deployOperatingSystemConfigsForWorker(ctx context.Context, ma
 	}
 
 	originalConfig["osc"] = map[string]interface{}{
-		"type":                 machineImage.Name,
-		"purpose":              extensionsv1alpha1.OperatingSystemConfigPurposeReconcile,
-		"reloadConfigFilePath": common.CloudConfigFilePath,
-		"secretName":           secretName,
-		"customization":        customization,
-		"sshKey":               string(sshKey),
-		"cri":                  criConfig,
+		"type":                       machineImage.Name,
+		"purpose":                    extensionsv1alpha1.OperatingSystemConfigPurposeReconcile,
+		"reloadConfigFilePath":       common.CloudConfigFilePath,
+		"secretName":                 secretName,
+		"customization":              customization,
+		"sshKey":                     string(sshKey),
+		"cri":                        criConfig,
+		"annotationCurrentTimestamp": time.Now().UTC().String(),
 	}
 
 	if data := worker.CABundle; data != nil {

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -136,6 +136,7 @@ func (b *Botanist) DeployWorker(ctx context.Context) error {
 
 	_, err = controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), worker, func() error {
 		metav1.SetMetaDataAnnotation(&worker.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+		metav1.SetMetaDataAnnotation(&worker.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
 
 		worker.Spec = extensionsv1alpha1.WorkerSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -53,7 +53,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var json = jsoniter.ConfigFastest
+var (
+	json = jsoniter.ConfigFastest
+
+	// TimeNow returns the current time. Exposed for testing.
+	TimeNow = time.Now
+)
 
 // GetSecretKeysWithPrefix returns a list of keys of the given map <m> which are prefixed with <kind>.
 func GetSecretKeysWithPrefix(kind string, m map[string]*corev1.Secret) []string {
@@ -736,6 +741,7 @@ func ConfirmDeletion(ctx context.Context, c client.Client, obj runtime.Object) e
 			return err
 		}
 		kutil.SetMetaDataAnnotation(acc, ConfirmationDeletion, "true")
+		kutil.SetMetaDataAnnotation(acc, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 
 		if reflect.DeepEqual(existing, obj) {
 			return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Gardenlet sets the operation annotation ( gardener.cloud/operation: reconcile) on extension CRDs to trigger a reconcile (if the extension does not deliberately ignore the annotation). This is for the Gardenlet to be able to control the reconcile times -e.g only during maintenance time.

If the extension respects the operation-annotation, the extensions now only watch the Extension CRD and no auxiliary resources as it was previously the case. 
 
In turn the Gardenlet must make sure that the watching clients in the extension receive an update event when the extension should be reconciled. Though the Gardenlet already sets the operation annotation, clients could sometimes miss the update event, leading to no/ delayed reconciles. In the following reconcile, the Gardenlet requests another reonciliation, but the operation annotation is already present. No update event will be send to the extensions -> Extension is not being reconciled anymore. 

To circumvent that issue, the Gardenlet now sets an annotation on the Extension CRDs  in addition to the operation-annotation that guarantees an update event (contains timestamp).


**Which issue(s) this PR fixes**:
Fixes #2179

**Special notes for your reviewer**:
As the extension controller registration changes - there is a small code change required when revendoring Gardener in the Extensions.

I have split it in two commits with one containing the changes in the Gardenlet and the other the changes in the extensions.
The commits have a relationship to each other.  The extension controllers now only watch the Extension CRD, in turn the Gardenlet must add a new annotation to guarantee the update event.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The Gardenlet sets an additional annotation to Extension CRDs during reconciliation to guarantee an update event for the watching clients.
```
```improvement operator
Fixes a bug in the extension libraries that could lead to duplicate reconciliation of extension resources. When respecting the operation annotation set by the Gardenlet during reconciliation, extension controllers now only watch the Extension CRD.
```
