### PR TITLE
Do not pardon False ConditionStatus for recently created Shoots

### DIFF
--- a/pkg/operation/botanist/constraints_check.go
+++ b/pkg/operation/botanist/constraints_check.go
@@ -34,7 +34,8 @@ func shootHibernatedConstraint(condition gardencorev1beta1.Condition) gardencore
 // ConstraintsChecks conducts the constraints checks on all the given constraints.
 func (b *Botanist) ConstraintsChecks(ctx context.Context, initializeShootClients func() error, hibernation gardencorev1beta1.Condition) gardencorev1beta1.Condition {
 	hibernationPossible := b.constraintsChecks(ctx, initializeShootClients, hibernation)
-	return b.pardonCondition(hibernationPossible)
+	lastOp := b.Shoot.Info.Status.LastOperation
+	return PardonCondition(lastOp, hibernationPossible)
 }
 
 func (b *Botanist) constraintsChecks(ctx context.Context, initializeShootClients func() error, hibernationConstraint gardencorev1beta1.Condition) gardencorev1beta1.Condition {


### PR DESCRIPTION
**What this PR does / why we need it**:
Do not pardon False ConditionStatus for recently created Shoots.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/2295

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue preventing gardenlet to properly reflect the Shoot condition as false for newly created Shoots is now fixed.
```
