### PR TITLE
Allow K8s pod to exclude their logs from the fluent-bit log processor

### DIFF
--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
@@ -241,6 +241,7 @@ data:
         Labels              Off
         Annotations         Off
         tls.verify          Off
+        K8S-Logging.Exclude On
 
     [FILTER]
         Name record_modifier

--- a/charts/seed-monitoring/charts/alertmanager/values.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/values.yaml
@@ -11,3 +11,4 @@ ingress:
 
 emailConfigs: []
 replicas: 1
+podAnnotations: {}

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-seed/templates/deployment.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-seed/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
+      annotations:
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
       labels:
         garden.sapcloud.io/role: monitoring
         component: kube-state-metrics

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-seed/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-seed/values.yaml
@@ -1,3 +1,4 @@
 images:
   kube-state-metrics: image-repository:image-tag
 replicas: 1
+podAnnotations: {}

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/kube-state-metrics.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/kube-state-metrics.yaml
@@ -52,6 +52,10 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
+      annotations:
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
       labels:
         garden.sapcloud.io/role: monitoring
         component: kube-state-metrics

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/values.yaml
@@ -1,3 +1,4 @@
 images:
   kube-state-metrics: image-repository:image-tag
 replicas: 1
+podAnnotations: {}

--- a/charts/seed-monitoring/charts/core/values.yaml
+++ b/charts/seed-monitoring/charts/core/values.yaml
@@ -14,10 +14,12 @@ prometheus:
     vpn-seed: image-repository:image-tag
 kube-state-metrics-seed:
   replicas: 1
+  podAnnotations: {}
   images:
     kube-state-metrics: image-repository:image-tag
 kube-state-metrics-shoot:
   replicas: 1
+  podAnnotations: {}
   images:
     kube-state-metrics: image-repository:image-tag
 global:

--- a/charts/seed-monitoring/charts/grafana/values.yaml
+++ b/charts/seed-monitoring/charts/grafana/values.yaml
@@ -9,6 +9,7 @@ ingress:
   # admin : admin base64 encoded
   basicAuthSecret: YWRtaW46JGFwcjEkSWRSaVM5c3MkR3U1MHMxaGUwL2Z6Tzh2elE4S1BEMQ==
 replicas: 1
+podAnnotations: {}
 ports:
   prometheus: 9090
   grafana: 3000

--- a/charts/seed-monitoring/values.yaml
+++ b/charts/seed-monitoring/values.yaml
@@ -14,15 +14,20 @@ prometheus:
     vpn-seed: image-repository:image-tag
 grafana:
   replicas: 1
+  podAnnotations: {}
   images:
     grafana: image-repository:image-tag
     busybox: image-repository:image-tag
+alertmanager:
+  podAnnotations: {}
 kube-state-metrics-seed:
   replicas: 1
+  podAnnotations: {}
   images:
     kube-state-metrics: image-repository:image-tag
 kube-state-metrics-shoot:
   replicas: 1
+  podAnnotations: {}
   images:
     kube-state-metrics: image-repository:image-tag
 global:

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -147,6 +148,7 @@ func (b *Botanist) DeployClusterAutoscaler(ctx context.Context) error {
 	defaultValues := map[string]interface{}{
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-cluster-autoscaler": b.CheckSums[v1beta1constants.DeploymentNameClusterAutoscaler],
+			"fluentbit.io/exclude":               strconv.FormatBool(b.isLoggingStackSkipped()),
 		},
 		"namespace": map[string]interface{}{
 			"uid": b.SeedNamespaceObject.UID,
@@ -479,6 +481,7 @@ func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
 	defaultValues := map[string]interface{}{
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-" + name: b.CheckSums[name],
+			"fluentbit.io/exclude":    strconv.FormatBool(b.isLoggingStackSkipped()),
 		},
 		"replicas": b.Shoot.GetReplicas(1),
 	}
@@ -711,6 +714,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 				"checksum/secret-service-account-key":    b.CheckSums["service-account-key"],
 				"checksum/secret-etcd-ca":                b.CheckSums[v1beta1constants.SecretNameCAETCD],
 				"checksum/secret-etcd-client-tls":        b.CheckSums["etcd-client-tls"],
+				"fluentbit.io/exclude":                   strconv.FormatBool(b.isLoggingStackSkipped()),
 			},
 			"hvpa": map[string]interface{}{
 				"enabled": hvpaEnabled,
@@ -1000,6 +1004,7 @@ func (b *Botanist) DeployKubeControllerManager(ctx context.Context) error {
 			"checksum/secret-kube-controller-manager":        b.CheckSums[v1beta1constants.DeploymentNameKubeControllerManager],
 			"checksum/secret-kube-controller-manager-server": b.CheckSums[common.KubeControllerManagerServerName],
 			"checksum/secret-service-account-key":            b.CheckSums["service-account-key"],
+			"fluentbit.io/exclude":                           strconv.FormatBool(b.isLoggingStackSkipped()),
 		},
 		"podLabels": map[string]interface{}{
 			v1beta1constants.LabelPodMaintenanceRestart: "true",
@@ -1045,6 +1050,7 @@ func (b *Botanist) DeployKubeScheduler(ctx context.Context) error {
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-kube-scheduler":        b.CheckSums[v1beta1constants.DeploymentNameKubeScheduler],
 			"checksum/secret-kube-scheduler-server": b.CheckSums[common.KubeSchedulerServerName],
+			"fluentbit.io/exclude":                  strconv.FormatBool(b.isLoggingStackSkipped()),
 		},
 	}
 
@@ -1087,6 +1093,7 @@ func (b *Botanist) DeployETCD(ctx context.Context) error {
 			"checksum/secret-etcd-ca":          b.CheckSums[v1beta1constants.SecretNameCAETCD],
 			"checksum/secret-etcd-server-cert": b.CheckSums[common.EtcdServerTLS],
 			"checksum/secret-etcd-client-tls":  b.CheckSums[common.EtcdClientTLS],
+			"fluentbit.io/exclude":             strconv.FormatBool(b.isLoggingStackSkipped()),
 		},
 		"storageCapacity": b.Seed.GetValidVolumeSize("10Gi"),
 	}

--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -34,7 +34,7 @@ import (
 
 // DeploySeedLogging will install the Helm release "seed-bootstrap/charts/elastic-kibana-curator" in the Seed clusters.
 func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
-	if b.Shoot.GetPurpose() == gardencorev1beta1.ShootPurposeTesting || !gardenletfeatures.FeatureGate.Enabled(features.Logging) {
+	if b.isLoggingStackSkipped() {
 		return common.DeleteLoggingStack(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace)
 	}
 
@@ -172,4 +172,8 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 	}
 
 	return b.ChartApplierSeed.Apply(ctx, filepath.Join(common.ChartPath, "seed-bootstrap", "charts", "elastic-kibana-curator"), b.Shoot.SeedNamespace, fmt.Sprintf("%s-logging", b.Shoot.SeedNamespace), kubernetes.Values(elasticKibanaCurator))
+}
+
+func (b *Botanist) isLoggingStackSkipped() bool {
+	return b.Shoot.GetPurpose() == gardencorev1beta1.ShootPurposeTesting || !gardenletfeatures.FeatureGate.Enabled(features.Logging)
 }

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -113,6 +114,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 				"checksum/secret-prometheus":       b.CheckSums["prometheus"],
 				"checksum/secret-vpn-seed":         b.CheckSums["vpn-seed"],
 				"checksum/secret-vpn-seed-tlsauth": b.CheckSums["vpn-seed-tlsauth"],
+				"fluentbit.io/exclude":             strconv.FormatBool(b.isLoggingStackSkipped()),
 			},
 			"replicas":           b.Shoot.GetReplicas(1),
 			"apiserverServiceIP": b.Shoot.Networks.APIServer.String(),
@@ -151,9 +153,15 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 			},
 		}
 		kubeStateMetricsSeedConfig = map[string]interface{}{
+			"podAnnotations": map[string]interface{}{
+				"fluentbit.io/exclude": strconv.FormatBool(b.isLoggingStackSkipped()),
+			},
 			"replicas": b.Shoot.GetReplicas(1),
 		}
 		kubeStateMetricsShootConfig = map[string]interface{}{
+			"podAnnotations": map[string]interface{}{
+				"fluentbit.io/exclude": strconv.FormatBool(b.isLoggingStackSkipped()),
+			},
 			"replicas": b.Shoot.GetReplicas(1),
 		}
 	)
@@ -250,6 +258,9 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		}
 
 		alertManagerValues, err := b.InjectSeedShootImages(map[string]interface{}{
+			"podAnnotations": map[string]interface{}{
+				"fluentbit.io/exclude": strconv.FormatBool(b.isLoggingStackSkipped()),
+			},
 			"ingress": map[string]interface{}{
 				"basicAuthSecret": basicAuthUsers,
 				"hosts":           hosts,
@@ -368,6 +379,9 @@ func (b *Botanist) deployGrafanaCharts(ctx context.Context, role, dashboards, ba
 	}
 
 	values, err := b.InjectSeedShootImages(map[string]interface{}{
+		"podAnnotations": map[string]interface{}{
+			"fluentbit.io/exclude": strconv.FormatBool(b.isLoggingStackSkipped()),
+		},
 		"ingress": map[string]interface{}{
 			"basicAuthSecret": basicAuth,
 			"hosts":           hosts,


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR when the installation of the logging stack is skipped for a particular shoot, the pods in that shoot control plane are annotated so their logs to be excluded from processing.
Thus fluentd-es will be  partially unloaded.
This PR does not handle pods spawned by extensions controllers.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Allow K8s pod to exclude their logs from the fluent-bit log processor when logging is turned off for those pods
```
