### PR TITLE
Fix health check library predicate & LastTransitionTime

### DIFF
--- a/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/extensions/pkg/controller/healthcheck/reconciler.go
@@ -116,8 +116,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 	if controller.IsHibernated(cluster) {
 		for _, healthConditionType := range r.registeredExtension.healthConditionTypes {
-			healthCondition := gardencorev1beta1helper.GetOrInitCondition(r.registeredExtension.extension.GetExtensionStatus().GetConditions(), gardencorev1beta1.ConditionType(healthConditionType))
-			if err := r.updateExtensionConditionHibernated(r.ctx, r.registeredExtension.extension, extension, healthCondition); err != nil {
+			if err := r.updateExtensionConditionHibernated(r.ctx, healthConditionType, r.registeredExtension.extension, extension); err != nil {
 				return reconcile.Result{}, err
 			}
 		}
@@ -134,8 +133,7 @@ func (r *reconciler) performHealthCheck(ctx context.Context, request reconcile.R
 	if err != nil {
 		r.logger.Info("Failed to execute healthChecks. Updating each HealthCheckCondition for the extension resource to ConditionCheckError.", "kind", r.registeredExtension.groupVersionKind.Kind, "health condition types", r.registeredExtension.healthConditionTypes, "name", request.Name, "namespace", request.Namespace, "error", err.Error())
 		for _, healthConditionType := range r.registeredExtension.healthConditionTypes {
-			healthCondition := gardencorev1beta1helper.GetOrInitCondition(r.registeredExtension.extension.GetExtensionStatus().GetConditions(), gardencorev1beta1.ConditionType(healthConditionType))
-			if err := r.updateExtensionConditionFailedToExecute(ctx, r.registeredExtension.extension, extension, healthCondition, r.registeredExtension.groupVersionKind.Kind, err); err != nil {
+			if err := r.updateExtensionConditionFailedToExecute(ctx, healthConditionType, r.registeredExtension.extension, extension, r.registeredExtension.groupVersionKind.Kind, err); err != nil {
 				return r.resultWithRequeue(), err
 			}
 		}
@@ -143,11 +141,14 @@ func (r *reconciler) performHealthCheck(ctx context.Context, request reconcile.R
 	}
 
 	for _, healthCheckResult := range *healthCheckResults {
-		// get or init conditions on extension resource
-		healthCondition := gardencorev1beta1helper.GetOrInitCondition(r.registeredExtension.extension.GetExtensionStatus().GetConditions(), gardencorev1beta1.ConditionType(healthCheckResult.HealthConditionType))
+		conditionBuilder, err := gardencorev1beta1helper.NewConditionBuilder(gardencorev1beta1.ConditionType(healthCheckResult.HealthConditionType))
+		if err != nil {
+			return r.resultWithRequeue(), err
+		}
+
 		if !healthCheckResult.IsHealthy && healthCheckResult.FailedChecks > 0 {
 			r.logger.Info("Updating HealthCheckCondition for extension resource to ConditionCheckError.", "kind", r.registeredExtension.groupVersionKind.Kind, "health condition type", healthCheckResult.HealthConditionType, "name", request.Name, "namespace", request.Namespace)
-			if err := r.updateExtensionConditionToConditionCheckError(ctx, r.registeredExtension.extension, extension, healthCondition, r.registeredExtension.groupVersionKind.Kind, healthCheckResult); err != nil {
+			if err := r.updateExtensionConditionToConditionCheckError(ctx, conditionBuilder, healthCheckResult.HealthConditionType, r.registeredExtension.extension, extension, r.registeredExtension.groupVersionKind.Kind, healthCheckResult); err != nil {
 				return r.resultWithRequeue(), err
 			}
 			continue
@@ -155,53 +156,91 @@ func (r *reconciler) performHealthCheck(ctx context.Context, request reconcile.R
 
 		if !healthCheckResult.IsHealthy {
 			r.logger.Info("Health check for extension resource unsuccessful.", "kind", fmt.Sprintf("%s.%s.%s", r.registeredExtension.groupVersionKind.Kind, r.registeredExtension.groupVersionKind.Group, r.registeredExtension.groupVersionKind.Version), "name", request.Name, "namespace", request.Namespace, "failed", healthCheckResult.FailedChecks, "successful", healthCheckResult.SuccessfulChecks, "details", healthCheckResult.GetDetails())
-			if err := r.updateExtensionConditionToError(ctx, r.registeredExtension.extension, extension, healthCondition, healthCheckResult); err != nil {
+			if err := r.updateExtensionConditionToError(ctx, conditionBuilder, healthCheckResult.HealthConditionType, r.registeredExtension.extension, extension, healthCheckResult); err != nil {
 				return r.resultWithRequeue(), err
 			}
 			continue
 		}
 
 		r.logger.V(6).Info("Health check for extension resource successful.", "kind", r.registeredExtension.groupVersionKind.Kind, "health condition type", healthCheckResult.HealthConditionType, "name", request.Name, "namespace", request.Namespace)
-		if err := r.updateExtensionConditionToSuccessful(ctx, r.registeredExtension.extension, extension, healthCondition, healthCheckResult); err != nil {
+		if err := r.updateExtensionConditionToSuccessful(ctx, conditionBuilder, healthCheckResult.HealthConditionType, r.registeredExtension.extension, extension, healthCheckResult); err != nil {
 			return r.resultWithRequeue(), err
 		}
 	}
 	return r.resultWithRequeue(), nil
 }
 
-func (r *reconciler) updateExtensionConditionFailedToExecute(ctx context.Context, extensionResource extensionsv1alpha1.Object, extension runtime.Object, condition gardencorev1beta1.Condition, kind string, err error) error {
-	healthCondition := gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionUnknown, gardencorev1beta1.ConditionCheckError, fmt.Sprintf("failed to execute health checks for '%s': %v", kind, err.Error()))
-	return r.updateExtensionCondition(ctx, extension, condition, extensionResource, healthCondition)
+func (r *reconciler) updateExtensionConditionFailedToExecute(ctx context.Context, healthConditionType string, extensionResource extensionsv1alpha1.Object, extension runtime.Object, kind string, executionError error) error {
+	conditionBuilder, err := gardencorev1beta1helper.NewConditionBuilder(gardencorev1beta1.ConditionType(healthConditionType))
+	if err != nil {
+		return err
+	}
+
+	msg := fmt.Sprintf("failed to execute health checks for '%s': %v", kind, executionError.Error())
+	conditionBuilder.
+		WithStatus(gardencorev1beta1.ConditionUnknown).
+		WithReason(gardencorev1beta1.ConditionCheckError).
+		WithMessage(msg)
+	return r.updateExtensionCondition(ctx, conditionBuilder, healthConditionType, extension, extensionResource)
 }
 
-func (r *reconciler) updateExtensionConditionToConditionCheckError(ctx context.Context, extensionResource extensionsv1alpha1.Object, extension runtime.Object, condition gardencorev1beta1.Condition, kind string, healthCheckResult Result) error {
-	healthCondition := gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionUnknown, gardencorev1beta1.ConditionCheckError, fmt.Sprintf("failed to execute %d/%d health checks for '%s': %v", healthCheckResult.FailedChecks, healthCheckResult.SuccessfulChecks+healthCheckResult.UnsuccessfulChecks+healthCheckResult.FailedChecks, kind, healthCheckResult.GetDetails()))
-	return r.updateExtensionCondition(ctx, extension, condition, extensionResource, healthCondition)
+func (r *reconciler) updateExtensionConditionToConditionCheckError(ctx context.Context, conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, extensionResource extensionsv1alpha1.Object, extension runtime.Object, kind string, healthCheckResult Result) error {
+	msg := fmt.Sprintf("failed to execute %d/%d health checks for '%s': %v", healthCheckResult.FailedChecks, healthCheckResult.SuccessfulChecks+healthCheckResult.UnsuccessfulChecks+healthCheckResult.FailedChecks, kind, healthCheckResult.GetDetails())
+	conditionBuilder.
+		WithStatus(gardencorev1beta1.ConditionUnknown).
+		WithReason(gardencorev1beta1.ConditionCheckError).
+		WithMessage(msg)
+	return r.updateExtensionCondition(ctx, conditionBuilder, healthConditionType, extension, extensionResource)
 }
 
-func (r *reconciler) updateExtensionConditionToError(ctx context.Context, extensionResource extensionsv1alpha1.Object, extension runtime.Object, condition gardencorev1beta1.Condition, healthCheckResult Result) error {
-	detail := fmt.Sprintf("Health check for %d/%d component(s) unsuccessful. ", healthCheckResult.UnsuccessfulChecks, healthCheckResult.UnsuccessfulChecks+healthCheckResult.SuccessfulChecks)
-	healthCondition := gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionFalse, HealthCheckUnsuccessful, detail+healthCheckResult.GetDetails())
-	return r.updateExtensionCondition(ctx, extension, condition, extensionResource, healthCondition)
+func (r *reconciler) updateExtensionConditionToError(ctx context.Context, conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, extensionResource extensionsv1alpha1.Object, extension runtime.Object, healthCheckResult Result) error {
+	msg := fmt.Sprintf("Health check for %d/%d component(s) unsuccessful: %v", healthCheckResult.UnsuccessfulChecks, healthCheckResult.UnsuccessfulChecks+healthCheckResult.SuccessfulChecks, healthCheckResult.GetDetails())
+	conditionBuilder.
+		WithStatus(gardencorev1beta1.ConditionFalse).
+		WithReason(HealthCheckUnsuccessful).
+		WithMessage(msg)
+	return r.updateExtensionCondition(ctx, conditionBuilder, healthConditionType, extension, extensionResource)
 }
 
-func (r *reconciler) updateExtensionConditionToSuccessful(ctx context.Context, extensionResource extensionsv1alpha1.Object, extension runtime.Object, condition gardencorev1beta1.Condition, healthCheckResult Result) error {
-	healthCondition := gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionTrue, HealthCheckSuccessful, fmt.Sprintf("(%d/%d) Health checks successful", healthCheckResult.SuccessfulChecks, healthCheckResult.SuccessfulChecks))
-	return r.updateExtensionCondition(ctx, extension, condition, extensionResource, healthCondition)
+func (r *reconciler) updateExtensionConditionToSuccessful(ctx context.Context, conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, extensionResource extensionsv1alpha1.Object, extension runtime.Object, healthCheckResult Result) error {
+	msg := fmt.Sprintf("(%d/%d) Health checks successful", healthCheckResult.SuccessfulChecks, healthCheckResult.SuccessfulChecks)
+	conditionBuilder.
+		WithStatus(gardencorev1beta1.ConditionTrue).
+		WithReason(HealthCheckSuccessful).
+		WithMessage(msg)
+	return r.updateExtensionCondition(ctx, conditionBuilder, healthConditionType, extension, extensionResource)
 }
 
-func (r *reconciler) updateExtensionConditionHibernated(ctx context.Context, extensionResource extensionsv1alpha1.Object, extension runtime.Object, condition gardencorev1beta1.Condition) error {
-	healthCondition := gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionTrue, "HealthCheckSuccessful", "Shoot is hibernated")
-	return r.updateExtensionCondition(ctx, extension, condition, extensionResource, healthCondition)
+func (r *reconciler) updateExtensionConditionHibernated(ctx context.Context, healthConditionType string, extensionResource extensionsv1alpha1.Object, extension runtime.Object) error {
+	conditionBuilder, err := gardencorev1beta1helper.NewConditionBuilder(gardencorev1beta1.ConditionType(healthConditionType))
+	if err != nil {
+		return err
+	}
+	msg := "Shoot is hibernated"
+	conditionBuilder.
+		WithStatus(gardencorev1beta1.ConditionTrue).
+		WithReason(HealthCheckSuccessful).
+		WithMessage(msg)
+	return r.updateExtensionCondition(ctx, conditionBuilder, healthConditionType, extension, extensionResource)
 }
 
-func (r *reconciler) updateExtensionCondition(ctx context.Context, extension runtime.Object, condition gardencorev1beta1.Condition, extensionResource extensionsv1alpha1.Object, healthCondition gardencorev1beta1.Condition) error {
+func (r *reconciler) updateExtensionCondition(ctx context.Context, conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, extension runtime.Object, extensionResource extensionsv1alpha1.Object) error {
 	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, extension, func() error {
 		acc, err := extensions.Accessor(extension)
 		if err != nil {
-			return fmt.Errorf("error updating health check condition (type: %s, name: %s, ns %s) - failed to create an extensionsv1alpha1.Object from the extension object: %v", condition.Type, extensionResource.GetName(), extensionResource.GetNamespace(), err)
+			return fmt.Errorf("error updating health check condition (type: %s, name: %s, ns %s) - failed to create an extensionsv1alpha1.Object from the extension object: %v", healthConditionType, extensionResource.GetName(), extensionResource.GetNamespace(), err)
 		}
-		newConditions := gardencorev1beta1helper.MergeConditions(acc.GetExtensionStatus().GetConditions(), healthCondition)
+
+		if c := gardencorev1beta1helper.GetCondition(acc.GetExtensionStatus().GetConditions(), gardencorev1beta1.ConditionType(healthConditionType)); c != nil {
+			conditionBuilder.WithOldCondition(*c)
+		}
+
+		updatedCondition, _ := conditionBuilder.WithNowFunc(metav1.Now).Build()
+
+		// always update - the Gardenlet expects a recent health check
+		updatedCondition.LastUpdateTime = metav1.Now()
+
+		newConditions := gardencorev1beta1helper.MergeConditions(acc.GetExtensionStatus().GetConditions(), updatedCondition)
 		acc.GetExtensionStatus().SetConditions(newConditions)
 		return nil
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
There was a regression introduced with my [previous PR ](https://github.com/gardener/gardener/commit/e62d2960f04636e30a37c08901b61d7d32f50f63) not discover during testing.
This leads to too many reconciles when the Extension.status is updated. 

Also fixes the health check condition LastTransition time.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixed a bug in the health check library that leads to too many health checks being executed when the Extension.Status changes.
```
```improvement operator
Fixed the health check condition.lastTransitionTime in the health check library.
```
