### PR TITLE
Allow status label to be unhealthy for recently created Shoots

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_utils.go
+++ b/pkg/gardenlet/controller/shoot/shoot_utils.go
@@ -110,8 +110,9 @@ func ComputeStatus(lastOperation *gardencorev1beta1.LastOperation, lastErrors []
 		return StatusHealthy
 	}
 
-	// If shoot is created or deleted then the last error indicates the healthiness.
-	if lastOperation.Type == gardencorev1beta1.LastOperationTypeCreate || lastOperation.Type == gardencorev1beta1.LastOperationTypeDelete {
+	// If the Shoot is either in create (except successful create) or delete state then the last error indicates the healthiness.
+	if (lastOperation.Type == gardencorev1beta1.LastOperationTypeCreate && lastOperation.State != gardencorev1beta1.LastOperationStateSucceeded) ||
+		lastOperation.Type == gardencorev1beta1.LastOperationTypeDelete {
 		return BoolToStatus(len(lastErrors) == 0)
 	}
 

--- a/pkg/gardenlet/controller/shoot/shoot_utils_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot_utils_test.go
@@ -107,6 +107,8 @@ var _ = Describe("Shoot Utils", func() {
 				&gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateSucceeded}, nil, nil, shoot.StatusHealthy),
 			Entry("lastOperation.State is LastOperationStateSucceeded with unhealthy conditions",
 				&gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateSucceeded}, nil, []gardencorev1beta1.Condition{{Status: gardencorev1beta1.ConditionFalse}}, shoot.StatusUnhealthy),
+			Entry("lastOperation.Type is LastOperationTypeCreate and lastOperation.State is LastOperationStateSucceeded with unhealthy conditions",
+				&gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeCreate, State: gardencorev1beta1.LastOperationStateSucceeded}, nil, []gardencorev1beta1.Condition{{Status: gardencorev1beta1.ConditionFalse}}, shoot.StatusUnhealthy),
 		)
 
 		DescribeTable("#StatusLabelTransform",


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently ComputeStatus func can return StatusHealthy when actually there are unhealthy conditions when Shoot `.status.lastOperation.type=Create` and `.status.lastOperation.state=Succeeded`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**How to reproduce it (as minimally and precisely as possible)**:
1. Create Shoot.

2. Scale the kube-apiserver to 0 replicas to simulate condition fail.

```
$ k -n shoot--foo--bar scale deploy kube-apiserver --replicas=0
deployment.extensions/kube-apiserver scaled
```

3. Ensure that the `APIServerAvailable` condition will be False after threshold duration but the `shoot.gardener.cloud/status` label will still have the value `healthy`.
```yaml
apiVersion: core.gardener.cloud/v1beta1
kind: Shoot
metadata:
# ...
  labels:
    shoot.garden.sapcloud.io/status: healthy
    shoot.gardener.cloud/status: healthy
# ...
status:
  conditions:
    - type: APIServerAvailable
      status: False
      lastTransitionTime: '2020-05-06T21:03:32Z'
      lastUpdateTime: '2020-05-06T21:03:32Z'
      reason: APIServerDown
      message: Could not reach API server during client initialization.
# ...
  lastOperation:
    description: Shoot cluster state has been successfully reconciled.
    lastUpdateTime: '2020-05-06T20:21:38Z'
    progress: 100
    state: Succeeded
    type: Create
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue preventing gardenlet to reflect unhealthy Shoot conditions in the `shoot.gardener.cloud/status` label for newly created Shoots is now fixed.
```
