### PR TITLE
Fix potential panic in federated seed controller

### DIFF
--- a/pkg/gardenlet/controller/federatedseed/extensions/extensions.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/extensions.go
@@ -154,11 +154,11 @@ func createEnqueueFunc(queue workqueue.RateLimitingInterface) func(extensionObje
 func createEnqueueOnUpdateFunc(queue workqueue.RateLimitingInterface, predicateFunc func(old, new extensionsv1alpha1.Object) bool) func(newExtensionObject, oldExtensionObject interface{}) {
 	return func(newObj, oldObj interface{}) {
 		var (
-			newExtensionObj = newObj.(extensionsv1alpha1.Object)
-			oldExtensionObj = oldObj.(extensionsv1alpha1.Object)
+			newExtensionObj, ok1 = newObj.(extensionsv1alpha1.Object)
+			oldExtensionObj, ok2 = oldObj.(extensionsv1alpha1.Object)
 		)
 
-		if !predicateFunc(oldExtensionObj, newExtensionObj) {
+		if ok1 && ok2 && !predicateFunc(oldExtensionObj, newExtensionObj) {
 			return
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Some watched objects don't implement the `extensionsv1alpha1.Object` interface. This might lead to panics as follows:

```yaml
E0511 15:57:22.148843    1684 runtime.go:78] Observed a panic: &runtime.TypeAssertionError{_interface:(*runtime._type)(nil), concrete:(*runtime._type)(0x27fc560), asserted:(*runtime._type)(0x27bc4a0), missingMethod:"GetExtensionSpec"} (interface conversion: *v1alpha1.DNSProvider is not v1alpha1.Object: missing method GetExtensionSpec)
goroutine 4403 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x2612140, 0xc001a10450)

/Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)

/Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x82
panic(0x2612140, 0xc001a10450)
      /usr/local/Cellar/go/1.14.2_1/libexec/src/runtime/panic.go:969 +0x166
github.com/gardener/gardener/pkg/gardenlet/controller/federatedseed/extensions.createEnqueueOnUpdateFunc.func1(0x27fc560, 0xc001704000, 0x27fc560, 0xc0003d61e0)

/Users/root/go/src/github.com/gardener/gardener/pkg/gardenlet/controller/federatedseed/extensions/extensions.go:157 +0x60
...
```

**Special notes for your reviewer**:
/cc @mvladev, thanks for spotting

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
