### PR TITLE
Fix kubelet bootstrapping race condition

### DIFF
--- a/charts/shoot-cloud-config/templates/scripts/_cloud-config-script.sh
+++ b/charts/shoot-cloud-config/templates/scripts/_cloud-config-script.sh
@@ -61,7 +61,7 @@ if [ ! -f "$PATH_CLOUDCONFIG_OLD" ]; then
   touch "$PATH_CLOUDCONFIG_OLD"
 fi
 
-if [[ ! -f "$DIR_KUBELET/kubeconfig-real" ]]; then
+if [[ ! -f "$DIR_KUBELET/kubeconfig-real" ]] || [[ ! -f "$DIR_KUBELET/pki/kubelet-client-current.pem" ]]; then
   cat <<EOF > "$DIR_KUBELET/kubeconfig-bootstrap"
 ---
 apiVersion: v1


### PR DESCRIPTION
**What this PR does / why we need it**:
We are sometimes observing that randomly individual nodes cannot join. After investigating a particular case I saw that the kubelet bootstrapping was not yet completed but the bootstrap kubeconfig was already deleted from `/var/lib/kubelet`:

```
root@ip-10-250-29-137:~# cd /var/lib/kubelet
root@ip-10-250-29-137:/var/lib/kubelet# ls -al
total 56
drwxr-xr-x 11 root root 4096 May 11 12:25 .
drwxr-xr-x 23 root root 4096 May 11 12:24 ..
-rw-r--r--  1 root root 1038 May 11 12:24 ca.crt
drwxr-xr-x  2 root root 4096 May 11 12:24 config
-rw-------  1 root root   62 May 11 12:24 cpu_manager_state
drwxr-xr-x  2 root root 4096 May 11 12:24 device-plugins
-rw-------  1 root root 1917 May 11 12:24 kubeconfig-real
drwxr-xr-x  2 root root 4096 May 11 12:24 pki
drwx------  2 root root 4096 May 11 12:24 plugin-containers
drwxr-x---  2 root root 4096 May 11 12:24 plugins
drwxr-x---  2 root root 4096 May 11 12:24 plugins_registry
drwxr-x---  2 root root 4096 May 11 12:24 pod-resources
drwxr-x---  2 root root 4096 May 11 12:24 pods
drwxr-xr-x  2 root root 4096 May 11 12:24 volumeplugins

root@ip-10-250-29-137:/var/lib/kubelet# ls -al pki
total 16
drwxr-xr-x  2 root root 4096 May 11 12:24 .
drwxr-xr-x 11 root root 4096 May 11 12:25 ..
-rw-r--r--  1 root root 2420 May 11 12:24 kubelet.crt
-rw-------  1 root root 1675 May 11 12:24 kubelet.key
```

While the kubelet has successfully generated the server certificate (`/var/lib/kubelet/pki/kubelet.{crt,key}`) and the "real" kubeconfig (`/var/lib/kubelet/kubeconfig-real`) it has not yet generated a client certificate. The `kubeconfig-real` looks as follows:

```yaml
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: <ca-cert>
    server: https://api-server.example.com
  name: default-cluster
contexts:
- context:
    cluster: default-cluster
    namespace: default
    user: default-auth
  name: default-context
current-context: default-context
kind: Config
preferences: {}
users:
- name: default-auth
  user:
    client-certificate: /var/lib/kubelet/pki/kubelet-client-current.pem
    client-key: /var/lib/kubelet/pki/kubelet-client-current.pem
```

The `cloud-config-downloader` has removed the `/var/lib/kubelet/kubeconfig-bootstrap` too early which doesn't allow the kubelet to finish its bootstrapping process anymore.

Usually, when the kubelet has successfully stored its client certificate on the node, the `/var/lib/kubelet/pki` directory looks as follows:

```
root@ip-10-250-29-137:/var/lib/kubelet# ls -al pki
total 20
drwxr-xr-x  2 root root 4096 May 11 12:43 .
drwxr-xr-x 11 root root 4096 May 11 12:44 ..
-rw-------  1 root root 1167 May 11 12:43 kubelet-client-2020-05-11-12-43-39.pem
lrwxrwxrwx  1 root root   59 May 11 12:43 kubelet-client-current.pem -> /var/lib/kubelet/pki/kubelet-client-2020-05-11-12-43-39.pem
-rw-r--r--  1 root root 2420 May 11 12:43 kubelet.crt
-rw-------  1 root root 1675 May 11 12:43 kubelet.key
```

With this PR, the `cloud-config-downloader` now waits for the `/var/lib/kubelet/pki/kubelet-client-current.pem` file to exist before it removes the bootstrap kubeconfig from the file system.

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The bootstrapping of new shoot worker nodes has been made more reliable.
```
