### PR TITLE
Мutate shoot control plane pods annotation so to be excluded from log processing.

### DIFF
--- a/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluentd-es/templates/fluent-bit-configmap.yaml
@@ -241,6 +241,7 @@ data:
         Labels              Off
         Annotations         Off
         tls.verify          Off
+        K8S-Logging.Exclude On
 
     [FILTER]
         Name record_modifier

--- a/charts/seed-bootstrap/templates/gardener-seed-admission-controller/mutatingwebhookconfiguration.yaml
+++ b/charts/seed-bootstrap/templates/gardener-seed-admission-controller/mutatingwebhookconfiguration.yaml
@@ -1,0 +1,37 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app: gardener
+    role: seed-admission-controller
+  name: gardener-seed-admission-controller
+webhooks:
+- name: pods.seed.admission.core.gardener.cloud
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+    scope: '*'
+  admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMrakNDQWVLZ0F3SUJBZ0lVVHAzWHZocldPVk04WkdlODZZb1hNVi9VSjdBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekFlRncweE9UQXlNamN4TlRNME1EQmFGdzB5TkRBeQpNall4TlRNME1EQmFNQlV4RXpBUkJnTlZCQU1UQ210MVltVnlibVYwWlhNd2dnRWlNQTBHQ1NxR1NJYjNEUUVCCkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDeWkwUUdPY3YyYlRmM044T0xOOTdSd3NnSDZRQXI4d1NwQU9ydHRCSmcKRm5mblUyVDFSSGd4bTdxZDE5MFdMOERDaHYwZFpmNzZkNmVTUTRacmpqeUFyVHp1ZmI0RHRQd2crVldxN1h2RgpCTnluKzJoZjRTeVNrd2Q2azdYTGhVVFJ4MDQ4SWJCeUM0ditGRXZtb0xBd3JjMGQwRzE0ZWM2c25EKzdqTzdlCmt5a1EvTmdBT0w3UDZrRHM5ejYrYk9mZ0YwbkdOK2JtZVdRcUplalIwdCtPeVFEQ3g1L0ZNdFVmRVZSNVFYODAKYWVlZmdwM0pGWmI2ZkF3OUtoTHRkUlYzRlAwdHo2aFMrZTRTZzBtd0FBT3FpalpzVjg3a1A1R1l6anRjZkExMgpsRFlsL25iMUd0VnZ2a1FENDlWblY3bURubDZtRzNMQ01OQ05INldsWk52M0FnTUJBQUdqUWpCQU1BNEdBMVVkCkR3RUIvd1FFQXdJQkJqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01CMEdBMVVkRGdRV0JCU0ZBM0x2Sk0yMWQ4cXMKWlZWQ2U2UnJUVDl3aVRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQW5zL0VKM3lLc2p0SVNvdGVRNzE0cjJVbQpCTVB5VVlUVGRSSEQ4TFpNZDNSeWt2c2FjRjJsMnk4OE56NndKY0F1b1VqMWg4YUJEUDVvWFZ0Tm1GVDlqeWJTClRYclJ2V2krYWVZZGI1NTZuRUE1L2E5NGUrY2IrQ2szcXkvMXhnUW9TNDU3QVpRT0Rpc0RaTkJZV2tBRnMyTGMKdWNwY0F0WEp0SXRoVm03RmpvQUhZY3NyWTA0eUFpWUVKTEQwMlRqVURYZzRpR09HTWtWSGRtaGF3QkRCRjNBagplc2ZjcUZ3amk2SnlBS0ZSQUNQb3d5a1FPTkZ3VVNvbTg5dVlFU1NDSkZ2TkNrOU1KbWpKMlB6RFV0NkN5cFI0CmVwRmRkMWZYTHd1d243ZnZQTW1KcUQzSHRMYWxYMUFabVBrK0JJOGV6ZkFpVmNWcW5USlFNWGxZUHBZZTlBPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    service:
+      name: gardener-seed-admission-controller
+      namespace: garden
+      path: /webhooks/mutate-pods
+  failurePolicy: Ignore
+  matchPolicy: Exact
+  namespaceSelector:
+    matchLabels:
+      gardener.cloud/role: shoot
+  objectSelector: {}
+  reinvocationPolicy: Never
+  sideEffects: None
+  timeoutSeconds: 10

--- a/charts/seed-bootstrap/templates/gardener-seed-admission-controller/rbac.yaml
+++ b/charts/seed-bootstrap/templates/gardener-seed-admission-controller/rbac.yaml
@@ -26,6 +26,7 @@ rules:
   - networks
   - operatingsystemconfigs
   - workers
+  - clusters
   verbs:
   - get
   - list

--- a/pkg/seedadmission/pods.go
+++ b/pkg/seedadmission/pods.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seedadmission
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardenlogger "github.com/gardener/gardener/pkg/logger"
+
+	"github.com/sirupsen/logrus"
+	"gomodules.xyz/jsonpatch/v2"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// MutatePod mutates pod if mutation conditions are met
+func MutatePod(ctx context.Context, c client.Client, logger *logrus.Logger, request *admissionv1beta1.AdmissionRequest) ([]jsonpatch.JsonPatchOperation, error) {
+	// Ignore all resources other than our expected ones
+	switch request.Resource {
+	case
+		metav1.GroupVersionResource{Group: corev1.SchemeGroupVersion.Group, Version: corev1.SchemeGroupVersion.Version, Resource: "pods"}:
+	default:
+		return nil, nil
+	}
+
+	obj, err := getRequestObject(ctx, c, request)
+	if err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+
+	entryLogger := gardenlogger.
+		NewFieldLogger(logger, "resource", fmt.Sprintf("%s/%s/%s", request.Kind.Group, request.Kind.Version, request.Kind.Kind)).
+		WithField("operation", request.Operation).
+		WithField("namespace", request.Namespace)
+
+	entryLogger.Info("Handling request")
+	patch, err := mutateShootControlPlanePodAnnotations(ctx, c, entryLogger, obj, request.Namespace)
+	if err != nil {
+		logger.Errorf("Error mutating pod %s/%s: %v", request.Name, request.Namespace, err)
+		return nil, err
+	}
+
+	return patch, nil
+}
+
+// mutateShootControlPlanePodAnnotations checks if the object mutation is allowed and return the needed patches .
+func mutateShootControlPlanePodAnnotations(ctx context.Context, c client.Client, logger *logrus.Entry, pod runtime.Object, namespace string) ([]jsonpatch.JsonPatchOperation, error) {
+	var patch []jsonpatch.JsonPatchOperation
+	// determine whether to perform mutation
+	isMutationRequired, err := mutationRequired(ctx, c, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	acc, err := meta.Accessor(pod)
+	if err != nil {
+		return nil, err
+	}
+
+	if !isMutationRequired {
+		logger.Debugf("Skipping mutation for %s/%s due to policy check", acc.GetNamespace(), acc.GetName())
+		return nil, nil
+	}
+
+	originalAnnotations := acc.GetAnnotations()
+	annotationsToAdd := map[string]string{
+		"fluentbit.io/exclude": "true",
+	}
+
+	for key, value := range annotationsToAdd {
+		if originalAnnotations == nil || originalAnnotations[key] == "" {
+			patch = append(patch, jsonpatch.JsonPatchOperation{
+				Operation: "add",
+				Path:      "/metadata/annotations",
+				Value: map[string]string{
+					key: value,
+				},
+			})
+		} else {
+			patch = append(patch, jsonpatch.JsonPatchOperation{
+				Operation: "replace",
+				Path:      "/metadata/annotations/" + strings.ReplaceAll(key, "/", "~1"),
+				Value:     value,
+			})
+		}
+	}
+	return patch, nil
+}
+
+func mutationRequired(ctx context.Context, c client.Client, namespace string) (bool, error) {
+	cluster, err := extensionscontroller.GetCluster(ctx, c, namespace)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if cluster.Shoot == nil {
+		return false, nil
+	}
+
+	if cluster.Shoot.Spec.Hibernation != nil && cluster.Shoot.Spec.Hibernation.Enabled != nil && *cluster.Shoot.Spec.Hibernation.Enabled {
+		return true, nil
+	}
+
+	if cluster.Shoot.Spec.Purpose != nil && *cluster.Shoot.Spec.Purpose == gardencorev1beta1.ShootPurposeTesting {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/pkg/seedadmission/pods_test.go
+++ b/pkg/seedadmission/pods_test.go
@@ -1,0 +1,405 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seedadmission_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	gardenlogger "github.com/gardener/gardener/pkg/logger"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	. "github.com/gardener/gardener/pkg/seedadmission"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"gomodules.xyz/jsonpatch/v2"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type DescribeTableArgs struct {
+	ExpectedPatche *jsonpatch.JsonPatchOperation
+	Annotations    map[string]string
+	Cluster        *extensionsv1alpha1.Cluster
+	Object         *runtime.Object
+}
+
+var _ = Describe("Pods", func() {
+	Describe("#MutatePod", func() {
+		var (
+			ctx     = context.Background()
+			logger  = gardenlogger.NewNopLogger()
+			request *admissionv1beta1.AdmissionRequest
+
+			ctrl *gomock.Controller
+			c    *mockclient.MockClient
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			c = mockclient.NewMockClient(ctrl)
+
+			request = &admissionv1beta1.AdmissionRequest{}
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		var (
+			resource    = metav1.GroupVersionResource{Group: corev1.SchemeGroupVersion.Group, Version: corev1.SchemeGroupVersion.Version, Resource: "pods"}
+			fooResource = metav1.GroupVersionResource{Group: "foo", Version: "bar", Resource: "baz"}
+			key         = "fluentbit.io/exclude"
+		)
+
+		testingPurpuse := core.ShootPurpose("testing")
+		developmentPurpuse := core.ShootPurpose("development")
+		notHibernation := core.Hibernation{Enabled: pointer.BoolPtr(false)}
+		notHibernatedTestingShoot := &core.Shoot{
+			Spec: core.ShootSpec{
+				Purpose:     &testingPurpuse,
+				Hibernation: &notHibernation,
+			},
+		}
+		notHibernatedTestingShootRaw, _ := json.Marshal(notHibernatedTestingShoot)
+		testingCluster := &extensionsv1alpha1.Cluster{
+			Spec: extensionsv1alpha1.ClusterSpec{
+				Shoot: runtime.RawExtension{Raw: notHibernatedTestingShootRaw},
+			},
+		}
+		developmentNotHibernatedShoot := &core.Shoot{
+			Spec: core.ShootSpec{
+				Purpose:     &developmentPurpuse,
+				Hibernation: &notHibernation,
+			},
+		}
+		developmentNotHibernatedShootRaw, _ := json.Marshal(developmentNotHibernatedShoot)
+		developmentNotHibernatedCluster := &extensionsv1alpha1.Cluster{
+			Spec: extensionsv1alpha1.ClusterSpec{
+				Shoot: runtime.RawExtension{Raw: developmentNotHibernatedShootRaw},
+			},
+		}
+		annotationFluentBitExludeTrue := map[string]string{
+			"fluentbit.io/exclude": "true",
+		}
+		espectedPatcheAddFluentBitExludeTrue := &jsonpatch.JsonPatchOperation{
+			Operation: "add",
+			Path:      "/metadata/annotations",
+			Value: map[string]string{
+				key: "true",
+			},
+		}
+		espectedPatcheReplaceFluentBitExludeTrue := &jsonpatch.JsonPatchOperation{
+			Operation: "replace",
+			Path:      "/metadata/annotations/" + strings.ReplaceAll(key, "/", "~1"),
+			Value:     "true",
+		}
+
+		It("should ignore types other than Pods", func() {
+			request.Resource = fooResource
+			patchs, err := MutatePod(ctx, c, logger, request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(patchs).To(BeNil())
+		})
+
+		Context("old object is set", func() {
+			var obj *unstructured.Unstructured
+			var objJSON []byte
+			var cluster *extensionsv1alpha1.Cluster
+
+			BeforeEach(func() {
+				obj = &unstructured.Unstructured{}
+				objJSON = getObjectJSONWithLabelsAnnotations(obj, resource, nil, nil)
+				request.OldObject = runtime.RawExtension{Raw: objJSON}
+				request.Kind = metav1.GroupVersionKind{Kind: "Pod"}
+				request.Resource = resource
+				request.Name = "machine-controller-manager"
+				request.Namespace = "shoot--dev--test"
+				cluster = &extensionsv1alpha1.Cluster{}
+			})
+
+			It("should return an error because the old object cannot be decoded", func() {
+				request.OldObject = runtime.RawExtension{Raw: []byte("foo")}
+
+				_, err := MutatePod(ctx, c, logger, request)
+				Expect(err).To(HaveOccurred(), resourceToId(resource))
+				Expect(err.Error()).To(ContainSubstring("invalid character"), resourceToId(resource))
+			})
+
+			It("should return no error because the GET cluster call returned 'not found'", func() {
+				c.EXPECT().Get(ctx, kutil.Key(request.Namespace), cluster).Return(apierrors.NewNotFound(core.Resource("cluster"), request.Namespace))
+
+				patchs, err := MutatePod(ctx, c, logger, request)
+				Expect(err).ToNot(HaveOccurred(), resourceToId(resource))
+				Expect(patchs).To(BeNil())
+			})
+
+			It("should return error because the GET cluster call returned an error", func() {
+				fakeErr := errors.New("fake get cluster error")
+				c.EXPECT().Get(ctx, kutil.Key(request.Namespace), cluster).Return(fakeErr)
+
+				_, err := MutatePod(ctx, c, logger, request)
+				Expect(err).To(HaveOccurred(), resourceToId(resource))
+				Expect(err.Error()).To(ContainSubstring("fake get cluster error"), resourceToId(resource))
+			})
+
+			DescribeTable("It should work properly",
+				func(args DescribeTableArgs) {
+					if args.Annotations != nil {
+						objJSON = getObjectJSONWithLabelsAnnotations(obj, resource, nil, args.Annotations)
+						request.OldObject = runtime.RawExtension{Raw: objJSON}
+					}
+
+					c.EXPECT().Get(ctx, kutil.Key(request.Namespace), cluster).DoAndReturn(populateClusterFunc(args.Cluster))
+
+					patches, err := MutatePod(ctx, c, logger, request)
+					Expect(err).ToNot(HaveOccurred(), resourceToId(resource))
+
+					if args.ExpectedPatche != nil {
+						Expect(patches).To(ConsistOf(*args.ExpectedPatche))
+					} else {
+						Expect(patches).To(BeNil())
+					}
+				},
+				Entry("It should add annotation to object", DescribeTableArgs{
+					ExpectedPatche: espectedPatcheAddFluentBitExludeTrue,
+					Annotations:    nil,
+					Cluster:        testingCluster,
+				}),
+				Entry("It should replace annotation to object", DescribeTableArgs{
+					ExpectedPatche: espectedPatcheReplaceFluentBitExludeTrue,
+					Annotations:    annotationFluentBitExludeTrue,
+					Cluster:        testingCluster,
+				}),
+				Entry("It should not add annotation to object", DescribeTableArgs{
+					ExpectedPatche: nil,
+					Annotations:    nil,
+					Cluster:        developmentNotHibernatedCluster,
+				}),
+				Entry("It should not replace annotation to object", DescribeTableArgs{
+					ExpectedPatche: nil,
+					Annotations:    annotationFluentBitExludeTrue,
+					Cluster:        developmentNotHibernatedCluster,
+				}),
+			)
+		})
+
+		Context("new object is set", func() {
+			var obj *unstructured.Unstructured
+			var objJSON []byte
+			var cluster *extensionsv1alpha1.Cluster
+			BeforeEach(func() {
+				obj = &unstructured.Unstructured{}
+				objJSON = getObjectJSONWithLabelsAnnotations(obj, resource, nil, nil)
+				request.Object = runtime.RawExtension{Raw: objJSON}
+				request.Kind = metav1.GroupVersionKind{Kind: "Pod"}
+				request.Resource = resource
+				request.Name = "machine-controller-manager"
+				request.Namespace = "shoot--dev--test"
+				cluster = &extensionsv1alpha1.Cluster{}
+			})
+
+			It("should return an error because the new object cannot be decoded", func() {
+				request.Object = runtime.RawExtension{Raw: []byte("foo")}
+
+				_, err := MutatePod(ctx, c, logger, request)
+				Expect(err).To(HaveOccurred(), resourceToId(resource))
+				Expect(err.Error()).To(ContainSubstring("invalid character"), resourceToId(resource))
+			})
+
+			It("should return no error because the GET cluster call returned 'not found'", func() {
+				c.EXPECT().Get(ctx, kutil.Key(request.Namespace), cluster).Return(apierrors.NewNotFound(core.Resource("cluster"), request.Namespace))
+
+				patchs, err := MutatePod(ctx, c, logger, request)
+				Expect(err).ToNot(HaveOccurred(), resourceToId(resource))
+				Expect(patchs).To(BeNil())
+			})
+
+			It("should return error because the GET cluster call returned an error", func() {
+				fakeErr := errors.New("fake get cluster error")
+
+				c.EXPECT().Get(ctx, kutil.Key(request.Namespace), cluster).Return(fakeErr)
+
+				_, err := MutatePod(ctx, c, logger, request)
+				Expect(err).To(HaveOccurred(), resourceToId(resource))
+				Expect(err.Error()).To(ContainSubstring("fake get cluster error"), resourceToId(resource))
+			})
+
+			DescribeTable("It should work properly",
+				func(args DescribeTableArgs) {
+					if args.Annotations != nil {
+						objJSON = getObjectJSONWithLabelsAnnotations(obj, resource, nil, args.Annotations)
+						request.OldObject = runtime.RawExtension{Raw: objJSON}
+					}
+
+					c.EXPECT().Get(ctx, kutil.Key(request.Namespace), cluster).DoAndReturn(populateClusterFunc(args.Cluster))
+
+					patches, err := MutatePod(ctx, c, logger, request)
+					Expect(err).ToNot(HaveOccurred(), resourceToId(resource))
+
+					if args.ExpectedPatche != nil {
+						Expect(patches).To(ConsistOf(*args.ExpectedPatche))
+					} else {
+						Expect(patches).To(BeNil())
+					}
+				},
+				Entry("It should add annotation to object", DescribeTableArgs{
+					ExpectedPatche: espectedPatcheAddFluentBitExludeTrue,
+					Annotations:    nil,
+					Cluster:        testingCluster,
+				}),
+				Entry("It should replace annotation to object", DescribeTableArgs{
+					ExpectedPatche: espectedPatcheReplaceFluentBitExludeTrue,
+					Annotations:    annotationFluentBitExludeTrue,
+					Cluster:        testingCluster,
+				}),
+				Entry("It should not add annotation to object", DescribeTableArgs{
+					ExpectedPatche: nil,
+					Annotations:    nil,
+					Cluster:        developmentNotHibernatedCluster,
+				}),
+				Entry("It should not replace annotation to object", DescribeTableArgs{
+					ExpectedPatche: nil,
+					Annotations:    annotationFluentBitExludeTrue,
+					Cluster:        developmentNotHibernatedCluster,
+				}),
+			)
+		})
+
+		Context("object must be looked up", func() {
+			var obj *unstructured.Unstructured
+			var cluster *extensionsv1alpha1.Cluster
+
+			BeforeEach(func() {
+				obj = &unstructured.Unstructured{}
+				request.Resource = resource
+				request.Name = "machine-controller-manager"
+				request.Namespace = "shoot--dev--test"
+				prepareRequestAndObjectWithResource(request, obj, resource)
+				cluster = &extensionsv1alpha1.Cluster{}
+			})
+
+			It("should return an error because the GET call failed", func() {
+				fakeErr := errors.New("fake")
+
+				c.EXPECT().Get(ctx, gomock.AssignableToTypeOf(client.ObjectKey{}), gomock.AssignableToTypeOf(&unstructured.Unstructured{})).Return(fakeErr)
+
+				_, err := MutatePod(ctx, c, logger, request)
+				Expect(err).To(HaveOccurred(), resourceToId(resource))
+				Expect(err).To(Equal(err))
+			})
+
+			It("should return no error because the GET call returned 'not found'", func() {
+				c.EXPECT().Get(ctx, gomock.AssignableToTypeOf(client.ObjectKey{}), gomock.AssignableToTypeOf(&unstructured.Unstructured{})).Return(apierrors.NewNotFound(core.Resource(resource.Resource), "name"))
+
+				patchs, err := MutatePod(ctx, c, logger, request)
+				Expect(err).ToNot(HaveOccurred(), resourceToId(resource))
+				Expect(patchs).To(BeNil())
+			})
+
+			It("should return no error because the GET cluster call returned 'not found'", func() {
+				gomock.InOrder(
+					c.EXPECT().Get(ctx, kutil.Key(request.Namespace, request.Name), obj),
+					c.EXPECT().Get(ctx, kutil.Key(request.Namespace), cluster).Return(apierrors.NewNotFound(core.Resource("cluster"), request.Namespace)),
+				)
+
+				patchs, err := MutatePod(ctx, c, logger, request)
+				Expect(err).ToNot(HaveOccurred(), resourceToId(resource))
+				Expect(patchs).To(BeNil())
+			})
+
+			It("should return error because the GET cluster call returned an error", func() {
+				fakeErr := errors.New("fake get cluster error")
+
+				gomock.InOrder(
+					c.EXPECT().Get(ctx, kutil.Key(request.Namespace, request.Name), obj),
+					c.EXPECT().Get(ctx, kutil.Key(request.Namespace), cluster).Return(fakeErr),
+				)
+
+				_, err := MutatePod(ctx, c, logger, request)
+				Expect(err).To(HaveOccurred(), resourceToId(resource))
+				Expect(err.Error()).To(ContainSubstring("fake get cluster error"), resourceToId(resource))
+			})
+
+			DescribeTable("It should work properly",
+				func(args DescribeTableArgs) {
+
+					gomock.InOrder(
+						c.EXPECT().Get(ctx, kutil.Key(request.Namespace, request.Name), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, o runtime.Object) error {
+							prepareObjectWithLabelsAnnotations(o, resource, nil, args.Annotations)
+							return nil
+						}),
+						c.EXPECT().Get(ctx, kutil.Key(request.Namespace), cluster).DoAndReturn(populateClusterFunc(args.Cluster)),
+					)
+
+					patches, err := MutatePod(ctx, c, logger, request)
+					Expect(err).ToNot(HaveOccurred(), resourceToId(resource))
+
+					if args.ExpectedPatche != nil {
+						Expect(patches).To(ConsistOf(*args.ExpectedPatche))
+					} else {
+						Expect(patches).To(BeNil())
+					}
+				},
+				Entry("It should add annotation to object", DescribeTableArgs{
+					ExpectedPatche: espectedPatcheAddFluentBitExludeTrue,
+					Annotations:    nil,
+					Cluster:        testingCluster,
+				}),
+				Entry("It should replace annotation to object", DescribeTableArgs{
+					ExpectedPatche: espectedPatcheReplaceFluentBitExludeTrue,
+					Annotations:    annotationFluentBitExludeTrue,
+					Cluster:        testingCluster,
+				}),
+				Entry("It should not add annotation to object", DescribeTableArgs{
+					ExpectedPatche: nil,
+					Annotations:    nil,
+					Cluster:        developmentNotHibernatedCluster,
+				}),
+				Entry("It should not replace annotation to object", DescribeTableArgs{
+					ExpectedPatche: nil,
+					Annotations:    annotationFluentBitExludeTrue,
+					Cluster:        developmentNotHibernatedCluster,
+				}),
+			)
+
+		})
+	})
+})
+
+func populateClusterFunc(cluster *extensionsv1alpha1.Cluster) func(_ context.Context, _ client.ObjectKey, o runtime.Object) error {
+	return func(_ context.Context, _ client.ObjectKey, o runtime.Object) error {
+		cl, ok := o.(*extensionsv1alpha1.Cluster)
+		if !ok {
+			return fmt.Errorf("Error casting runtime object to cluster")
+		}
+		cluster.DeepCopyInto(cl)
+		return nil
+	}
+}

--- a/pkg/seedadmission/utils.go
+++ b/pkg/seedadmission/utils.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seedadmission
+
+import (
+	"context"
+	"encoding/json"
+
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func getRequestObject(ctx context.Context, c client.Client, request *admissionv1beta1.AdmissionRequest) (runtime.Object, error) {
+	// Older Kubernetes versions don't provide the object neither in OldObject nor in the Object field. In this case
+	// we have to look it up ourselves.
+	var (
+		obj runtime.Object
+		err error
+	)
+
+	switch {
+	case request.OldObject.Raw != nil:
+		o := &unstructured.Unstructured{}
+		err = json.Unmarshal(request.OldObject.Raw, o)
+		obj = o
+
+	case request.Object.Raw != nil:
+		o := &unstructured.Unstructured{}
+		err = json.Unmarshal(request.Object.Raw, o)
+		obj = o
+
+	case request.Name == "":
+		o := &unstructured.UnstructuredList{}
+		o.SetAPIVersion(request.Kind.Group + "/" + request.Kind.Version)
+		o.SetKind(request.Kind.Kind + "List")
+		err = c.List(ctx, o, client.InNamespace(request.Namespace))
+		obj = o
+
+	default:
+		o := &unstructured.Unstructured{}
+		o.SetAPIVersion(request.Kind.Group + "/" + request.Kind.Version)
+		o.SetKind(request.Kind.Kind)
+		err = c.Get(ctx, kutil.Key(request.Namespace, request.Name), o)
+		obj = o
+	}
+
+	return obj, err
+}

--- a/pkg/seedadmission/utils_test.go
+++ b/pkg/seedadmission/utils_test.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seedadmission
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Utils", func() {
+	var (
+		ctx     = context.Background()
+		request *admissionv1beta1.AdmissionRequest
+
+		ctrl *gomock.Controller
+		c    *mockclient.MockClient
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		c = mockclient.NewMockClient(ctrl)
+
+		request = &admissionv1beta1.AdmissionRequest{}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#getRequestObject", func() {
+
+		resource := metav1.GroupVersionResource{Group: corev1.SchemeGroupVersion.Group, Version: corev1.SchemeGroupVersion.Version, Resource: "pods"}
+
+		Context("Old object is set", func() {
+			var obj *unstructured.Unstructured
+
+			BeforeEach(func() {
+				obj = &unstructured.Unstructured{}
+				obj.SetAPIVersion(fmt.Sprintf("%s/%s", resource.Group, resource.Version))
+				obj.SetKind(resource.Resource)
+			})
+
+			It("should return an error because the old object cannot be decoded", func() {
+				request.OldObject = runtime.RawExtension{Raw: []byte("foo")}
+
+				_, err := getRequestObject(ctx, c, request)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid character"))
+			})
+
+			It("should return the old object", func() {
+				objJSON, err := json.Marshal(obj)
+				Expect(err).ToNot(HaveOccurred())
+
+				request.OldObject = runtime.RawExtension{Raw: objJSON}
+
+				result, err := getRequestObject(ctx, c, request)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result.GetObjectKind().GroupVersionKind().Kind).To(Equal(resource.Resource))
+			})
+		})
+
+		Context("New object is set", func() {
+			var obj *unstructured.Unstructured
+
+			BeforeEach(func() {
+				obj = &unstructured.Unstructured{}
+				obj.SetAPIVersion(fmt.Sprintf("%s/%s", resource.Group, resource.Version))
+				obj.SetKind(resource.Resource)
+			})
+
+			It("should return an error because the new object cannot be decoded", func() {
+				request.Object = runtime.RawExtension{Raw: []byte("foo")}
+
+				_, err := getRequestObject(ctx, c, request)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid character"))
+			})
+
+			It("should return the new object", func() {
+				objJSON, err := json.Marshal(obj)
+				Expect(err).ToNot(HaveOccurred())
+
+				request.Object = runtime.RawExtension{Raw: objJSON}
+
+				result, err := getRequestObject(ctx, c, request)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result.GetObjectKind().GroupVersionKind().Kind).To(Equal(resource.Resource))
+			})
+		})
+
+		Context("object must be looked up", func() {
+			var obj *unstructured.Unstructured
+
+			BeforeEach(func() {
+				obj = &unstructured.Unstructured{}
+				request.Resource = resource
+				request.Name = "machine-controller-manager"
+				request.Namespace = "shoot--dev--test"
+				request.Kind.Group = resource.Group
+				request.Kind.Version = resource.Version
+				obj.SetAPIVersion(request.Kind.Group + "/" + request.Kind.Version)
+				obj.SetKind(request.Kind.Kind)
+			})
+
+			It("should return an error because the GET call failed", func() {
+				fakeErr := errors.New("fake")
+
+				c.EXPECT().Get(ctx, gomock.AssignableToTypeOf(client.ObjectKey{}), gomock.AssignableToTypeOf(&unstructured.Unstructured{})).Return(fakeErr)
+
+				_, err := getRequestObject(ctx, c, request)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(err))
+			})
+
+			It("Shoul return the looked up resource", func() {
+				c.EXPECT().Get(ctx, kutil.Key(request.Namespace, request.Name), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, o runtime.Object) error {
+					ob, ok := o.(*unstructured.Unstructured)
+					if !ok {
+						return fmt.Errorf("Error casting %v to Unstructured object", o)
+					}
+					ob.SetAPIVersion(fmt.Sprintf("%s/%s", resource.Group, resource.Version))
+					ob.SetKind(resource.Resource)
+					return nil
+				})
+				result, err := getRequestObject(ctx, c, request)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result.GetObjectKind().GroupVersionKind().Kind).To(Equal(resource.Resource))
+			})
+		})
+
+		Context("object list must be looked up", func() {
+			var obj *unstructured.UnstructuredList
+
+			BeforeEach(func() {
+				obj = &unstructured.UnstructuredList{}
+				request.Resource = resource
+				request.Namespace = "shoot--dev--test"
+				request.Kind.Group = resource.Group
+				request.Kind.Version = resource.Version
+				obj.SetAPIVersion(request.Kind.Group + "/" + request.Kind.Version)
+				obj.SetKind(request.Kind.Kind + "List")
+			})
+
+			It("should return an error because the GET call failed", func() {
+				fakeErr := errors.New("fake")
+
+				c.EXPECT().List(ctx, obj, client.InNamespace(request.Namespace)).Return(fakeErr)
+
+				_, err := getRequestObject(ctx, c, request)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(err))
+			})
+
+			It("Shoul return the looked up resource", func() {
+				c.EXPECT().List(ctx, obj, client.InNamespace(request.Namespace)).DoAndReturn(func(_ context.Context, o runtime.Object, _ ...client.ListOption) error {
+					ob, ok := o.(*unstructured.UnstructuredList)
+					if !ok {
+						return fmt.Errorf("Error casting %v to UnstructuredList object", o)
+					}
+					ob.SetAPIVersion(request.Kind.Group + "/" + request.Kind.Version)
+					ob.SetKind(request.Kind.Kind + "List")
+					return nil
+				})
+				result, err := getRequestObject(ctx, c, request)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result.GetObjectKind().GroupVersionKind().Kind).To(Equal("List"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR when a shoot is for testing purpose or it has been set to hibernate the Gardener-Seed-Admission-Controller will annotate the shoot's pod with `fluentbit.io/exclude=true` which will exclude the pod's logs from the fluent-bit log processor.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Exclude logs from testing purpose or hibernated shoots
```
