### PR TITLE
Fix kube-apiserver anti-affinity rule

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -47,17 +47,19 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - kubernetes
-              - key: role
-                operator: In
-                values:
-                - apiserver
-            topologyKey: kubernetes.io/hostname
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - kubernetes
+                  - key: role
+                    operator: In
+                    values:
+                    - apiserver
       priorityClassName: gardener-shoot-controlplane
       tolerations:
       - effect: NoExecute


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix kube-apiserver anti-affinity rule

**Which issue(s) this PR fixes**:
Fixes #2319

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
