### PR TITLE
Fix retry cycle time for shoots

### DIFF
--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -76,7 +76,7 @@ global:
         shoot:
           concurrentSyncs: 20
           syncPeriod: 1h
-          retryDuration: 24h
+          retryDuration: 12h
           respectSyncPeriodOverwrite: false
           reconcileInMaintenanceOnly: false
         shootCare:

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -32,7 +32,7 @@ controllers:
   shoot:
     concurrentSyncs: 20
     syncPeriod: 1h
-    retryDuration: 24h
+    retryDuration: 12h
 #    `respectSyncPeriodOverwrite` specifies whether Shoot owners can
 #    mark their Shoots ignored (no reconciliation) or change their sync period.
 #    respectSyncPeriodOverwrite: true

--- a/pkg/controllermanager/controller/shoot/shoot_hibernation_types.go
+++ b/pkg/controllermanager/controller/shoot/shoot_hibernation_types.go
@@ -102,7 +102,10 @@ func (h *hibernationJob) Run() {
 			if shoot.Spec.Hibernation == nil || !equality.Semantic.DeepEqual(h.target.Spec.Hibernation.Schedules, shoot.Spec.Hibernation.Schedules) {
 				return nil, fmt.Errorf("shoot %s/%s hibernation schedule changed mid-air", shoot.Namespace, shoot.Name)
 			}
-			shoot.Spec.Hibernation.Enabled = &h.enabled
+			if shoot.Status.LastOperation == nil || shoot.Status.LastOperation.State != gardencorev1beta1.LastOperationStateFailed {
+				shoot.Spec.Hibernation.Enabled = &h.enabled
+			}
+
 			return shoot, nil
 		})
 	if err != nil {

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -269,7 +269,7 @@ func SetDefaults_ShootControllerConfiguration(obj *ShootControllerConfiguration)
 	}
 
 	if obj.RetryDuration == nil {
-		v := metav1.Duration{Duration: 24 * time.Hour}
+		v := metav1.Duration{Duration: 12 * time.Hour}
 		obj.RetryDuration = &v
 	}
 }

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -509,8 +509,7 @@ func (c *Controller) updateShootStatusDeleteStart(o *operation.Operation) error 
 			if status.RetryCycleStartTime == nil ||
 				(status.LastOperation != nil && status.LastOperation.Type != gardencorev1beta1.LastOperationTypeDelete) ||
 				o.Shoot.Info.Generation != o.Shoot.Info.Status.ObservedGeneration ||
-				o.Shoot.Info.Status.Gardener.Version == version.Get().GitVersion ||
-				(o.Shoot.Info.Status.LastOperation != nil && o.Shoot.Info.Status.LastOperation.State == gardencorev1beta1.LastOperationStateFailed) {
+				o.Shoot.Info.Status.Gardener.Version != version.Get().GitVersion {
 
 				shoot.Status.RetryCycleStartTime = &now
 			}

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -432,8 +432,7 @@ func (c *Controller) updateShootStatusReconcileStart(o *operation.Operation, ope
 
 	if o.Shoot.Info.Status.RetryCycleStartTime == nil ||
 		o.Shoot.Info.Generation != o.Shoot.Info.Status.ObservedGeneration ||
-		o.Shoot.Info.Status.Gardener.Version == version.Get().GitVersion ||
-		(o.Shoot.Info.Status.LastOperation != nil && o.Shoot.Info.Status.LastOperation.State == gardencorev1beta1.LastOperationStateFailed) {
+		o.Shoot.Info.Status.Gardener.Version != version.Get().GitVersion {
 
 		now := metav1.NewTime(time.Now().UTC())
 		retryCycleStartTime = &now

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -318,6 +318,9 @@ const (
 	// possible.
 	ShootOperationMaintain = "maintain"
 
+	// FailedShootNeedsRetryOperation is a constant for an annotation on a Shoot in a failed state indicating that a retry operation should be triggered during the next maintenance time window.
+	FailedShootNeedsRetryOperation = "maintenance.shoot.gardener.cloud/needs-retry-operation"
+
 	// ShootOperationRotateKubeconfigCredentials is a constant for an annotation on a Shoot indicating that the credentials contained in the
 	// kubeconfig that is handed out to the user shall be rotated.
 	ShootOperationRotateKubeconfigCredentials = "rotate-kubeconfig-credentials"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue which reset the `.status.retryCycleStartTime` in several cases too often and thus prevented erroneous shoot clusters from transitioning to a `Failed` state.

The feature `confineSpecUpdateRollout` (https://github.com/gardener/gardener/pull/2233) for shoots in a failed state is now respected as well. Normally a `.spec` update resets the failed status and with `confineSpecUpdateRollout` this should only happen in the maintenance time window.

Additionally, @rfranzke and I suggest to decrease the default value for the Gardenlet setting `retryDuration` from 24h to 12h with the assumption that shoots failing for ~12h most often need an intervention by the shoot owner, i.e. it isn't reasonable to retry for another 12h w/o any spec update.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue has been fixed with prevented failed shoots from being excluded from reconciliation after the [retryDuration](https://github.com/gardener/gardener/blob/a46946fdce6bf75e0ce18272e7762f5765cced39/example/20-componentconfig-gardenlet.yaml#L33) is exceeded.
```
```noteworthy operator
The default value for [retryDuration](https://github.com/gardener/gardener/blob/a46946fdce6bf75e0ce18272e7762f5765cced39/example/20-componentconfig-gardenlet.yaml#L33) has been changed from 24h to 12h. Hence, Gardenlet tries to reconcile shoots with erroneous operations for 12 hours (by default). After this period of time only the `retry` operation, a `.spec` change, or a rollout of a new Gardenlet version re-triggers a reconciliation.
```