### PR TITLE
Enhance GitHub templates with label categorization

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -19,3 +19,17 @@ labels: kind/bug
 - Kubernetes version (use `kubectl version`):
 - Cloud provider or hardware configuration:
 - Others:
+
+<!-- Please select area, kind, and priority for this issue. This helps the community categorizing it. -->
+<!-- Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion. -->
+<!-- If multiple identifiers make sense you can also state the commands multiple times, e.g. -->
+<!--   /area control-plane -->
+<!--   /area auto-scaling -->
+<!--   ... -->
+**How to categorize this issue?**
+<!-- "/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management -->
+<!-- "/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test -->
+<!-- "/priority" identifiers: normal|critical|blocker -->
+/area TODO
+/kind bug
+/priority normal

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -8,3 +8,17 @@ labels: kind/enhancement
 **What would you like to be added**:
 
 **Why is this needed**:
+
+<!-- Please select area, kind, and priority for this issue. This helps the community categorizing it. -->
+<!-- Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion. -->
+<!-- If multiple identifiers make sense you can also state the commands multiple times, e.g. -->
+<!--   /area control-plane -->
+<!--   /area auto-scaling -->
+<!--   ... -->
+**How to categorize this issue?**
+<!-- "/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management -->
+<!-- "/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test -->
+<!-- "/priority" identifiers: normal|critical|blocker -->
+/area TODO
+/kind enhancement
+/priority normal

--- a/.github/doc.go
+++ b/.github/doc.go
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This package imports things required by build scripts, to force `go mod` to see them as dependencies
-package template
+// This package imports GitHub related templates - it is to force `go mod` to see them as dependencies.
+package github

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,3 +18,17 @@ Possible values:
 ```improvement operator
 
 ```
+
+<!-- Please select area, kind, and priority for this pull request. This helps the community categorizing it. -->
+<!-- Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion. -->
+<!-- If multiple identifiers make sense you can also state the commands multiple times, e.g. -->
+<!--   /area control-plane -->
+<!--   /area auto-scaling -->
+<!--   ... -->
+**How to categorize this PR?**
+<!-- "/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management -->
+<!-- "/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test -->
+<!-- "/priority" identifiers: normal|critical|blocker -->
+/area TODO
+/kind TODO
+/priority normal

--- a/extensions/hack/doc.go
+++ b/extensions/hack/doc.go
@@ -1,6 +1,4 @@
-// +build tools
-
-// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This package imports CI related scripts - it is to force `go mod` to see them as dependencies.
-package ci
+// This package imports things required by build scripts, to force `go mod` to see them as dependencies
+package tools

--- a/hack/.ci/doc.go
+++ b/hack/.ci/doc.go
@@ -1,6 +1,4 @@
-// +build tools
-
-// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This package imports things required by build scripts, to force `go mod` to see them as dependencies
-package tools
+// This package imports CI related scripts - it is to force `go mod` to see them as dependencies.
+package ci


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhance GitHub templates with label categorization

/area/open-source <!-- audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management -->
/component/gardener <!-- cicd|etcd-druid|gardener|hvpa -->
/kind/enhancement <!-- api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test -->
/priority/normal <!-- normal|critical|blocker -->
/platform/all <!-- all|aws-gov|aws|azure|bare-metal|gcp|gmp|openstack|vmware -->

/cc @vlerenc @ialidzhikov 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
