### PR TITLE
Fix panic in GCM seed-lifecycle-control

### DIFF
--- a/pkg/controllermanager/controller/seed/seed_lifecycle_control.go
+++ b/pkg/controllermanager/controller/seed/seed_lifecycle_control.go
@@ -156,7 +156,7 @@ func (c *defaultControl) Reconcile(seedObj *gardencorev1beta1.Seed, key string) 
 	// and constraints for all the shoots that belong to this seed as `Unknown`. The reason is that the gardenlet didn't send a heartbeat
 	// anymore, hence, it most likely didn't check the shoot status. This means that the current shoot status might not reflect the truth
 	// anymore. We are indicating this by marking it as `Unknown`.
-	if !conditionGardenletReady.LastTransitionTime.UTC().Before(time.Now().UTC().Add(-c.config.Controllers.Seed.ShootMonitorPeriod.Duration)) {
+	if conditionGardenletReady != nil && !conditionGardenletReady.LastTransitionTime.UTC().Before(time.Now().UTC().Add(-c.config.Controllers.Seed.ShootMonitorPeriod.Duration)) {
 		return true, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a nil pointer in the Gardener Controller Manager seed-lifecycle-controller. 
If the condition "GardenletReady" currently does not exist yet on the Seed, the GCM currently panics.
This situation occurs if 
- the GCM is quicker in reconciling a new Seed than the Gardenlet 
- the Gardenlet for a Seed does not exist (yet)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Does not need a release note as the [commit that introduced the bug](https://github.com/gardener/gardener/commit/4ab754ce6f29c122e99e27aa9d3c0e6576f8ed12) is not released yet.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
```
