### PR TITLE
Reduce the amount federated seed workers

### DIFF
--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -28,7 +28,7 @@ controllers:
     concurrentSyncs: 20
     syncPeriod: 30s
   controllerInstallationRequired:
-    concurrentSyncs: 20
+    concurrentSyncs: 1
   shoot:
     concurrentSyncs: 20
     syncPeriod: 1h
@@ -53,7 +53,7 @@ controllers:
     - type: EveryNodeReady
       duration: 5m
   shootStateSync:
-    concurrentSyncs: 5
+    concurrentSyncs: 1
     syncPeriod: 30s
   seed:
     concurrentSyncs: 5

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -223,7 +223,9 @@ func SetDefaults_ControllerInstallationCareControllerConfiguration(obj *Controll
 // SetDefaults_ControllerInstallationRequiredControllerConfiguration sets defaults for the ControllerInstallationRequired controller.
 func SetDefaults_ControllerInstallationRequiredControllerConfiguration(obj *ControllerInstallationRequiredControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
+		// The controller actually starts one controller per extension resource per Seed.
+		// For one seed that is already 1 * 10 extension resources = 10 workers.
+		v := 1
 		obj.ConcurrentSyncs = &v
 	}
 }
@@ -290,7 +292,9 @@ func SetDefaults_ShootCareControllerConfiguration(obj *ShootCareControllerConfig
 // SetDefaults_ShootStateSyncControllerConfiguration sets defaults for the shoot state controller.
 func SetDefaults_ShootStateSyncControllerConfiguration(obj *ShootStateSyncControllerConfiguration) {
 	if obj.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
+		// The controller actually starts one controller per extension resource per Seed.
+		// For one seed that is already 1 * 10 extension resources = 10 workers.
+		v := 1
 		obj.ConcurrentSyncs = &v
 	}
 

--- a/pkg/gardenlet/controller/federatedseed/extensions/extensions.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/extensions.go
@@ -103,11 +103,11 @@ func (s *Controller) Run(ctx context.Context, controllerInstallationWorkers, sho
 		}
 	}()
 
-	for i := 0; i <= controllerInstallationWorkers; i++ {
+	for i := 0; i < controllerInstallationWorkers; i++ {
 		s.createControllerInstallationWorkers(ctx, s.controllerInstallationControl)
 	}
 
-	for i := 0; i <= shootStateWorkers; i++ {
+	for i := 0; i < shootStateWorkers; i++ {
 		s.createShootStateWorkers(ctx, s.shootStateControl)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The current default settings for the ShootState controller and the ControllerInstallationRequired Controller in the federated seed controller lead to ca. 280 workers being created.
By reducing the default settings and fixing a bug during worker creation, the amount of workers created is reduced to the amount of extensions watched per Seed - around 20 per Seed.

Also do not update the ShootState if the Extension State is null. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Adjust default concurrent-sync settings for the Gardenlet controllers `ShootState` and `ControllerInstallationRequired`  causing too many goroutines to be created. Also fixed a bug during worker creation to further reduce the amount of workers being created. 
```
