### PR TITLE
Exit shoot flow when observing extension error

### DIFF
--- a/pkg/operation/common/extensions.go
+++ b/pkg/operation/common/extensions.go
@@ -68,7 +68,7 @@ func WaitUntilObjectReadyWithHealthFunction(
 	ctx context.Context,
 	c client.Client,
 	logger *logrus.Entry,
-	healthFunc func(obj runtime.Object) error,
+	healthFunc func(obj runtime.Object) (bool, error),
 	newObjFunc func() runtime.Object,
 	kind string,
 	namespace string,
@@ -85,10 +85,9 @@ func WaitUntilObjectReadyWithHealthFunction(
 			return retry.SevereError(err)
 		}
 
-		if err := healthFunc(obj); err != nil {
+		if retry, err := healthFunc(obj); err != nil {
 			logger.WithError(err).Errorf("%s did not get ready yet", extensionKey(kind, namespace, name))
-			lastObservedError = err
-			return retry.MinorError(err)
+			return retry, err
 		}
 
 		if postReadyFunc != nil {

--- a/pkg/utils/kubernetes/health/health_test.go
+++ b/pkg/utils/kubernetes/health/health_test.go
@@ -225,8 +225,10 @@ var _ = Describe("health", func() {
 
 	Context("CheckExtensionObject", func() {
 		DescribeTable("extension objects",
-			func(obj extensionsv1alpha1.Object, match types.GomegaMatcher) {
-				Expect(health.CheckExtensionObject(obj)).To(match)
+			func(obj extensionsv1alpha1.Object, match1, match2 types.GomegaMatcher) {
+				val1, val2 := health.CheckExtensionObject(obj)
+				Expect(val1).To(match1)
+				Expect(val2).To(match2)
 			},
 			Entry("healthy",
 				&extensionsv1alpha1.Infrastructure{
@@ -238,7 +240,7 @@ var _ = Describe("health", func() {
 						},
 					},
 				},
-				Succeed()),
+				BeTrue(), Succeed()),
 			Entry("generation outdated",
 				&extensionsv1alpha1.Infrastructure{
 					ObjectMeta: metav1.ObjectMeta{
@@ -252,7 +254,7 @@ var _ = Describe("health", func() {
 						},
 					},
 				},
-				HaveOccurred()),
+				BeFalse(), HaveOccurred()),
 			Entry("gardener operation ongoing",
 				&extensionsv1alpha1.Infrastructure{
 					ObjectMeta: metav1.ObjectMeta{
@@ -268,7 +270,7 @@ var _ = Describe("health", func() {
 						},
 					},
 				},
-				HaveOccurred()),
+				BeFalse(), HaveOccurred()),
 			Entry("last error non-nil",
 				&extensionsv1alpha1.Infrastructure{
 					Status: extensionsv1alpha1.InfrastructureStatus{
@@ -282,10 +284,10 @@ var _ = Describe("health", func() {
 						},
 					},
 				},
-				HaveOccurred()),
+				BeTrue(), HaveOccurred()),
 			Entry("no last operation",
 				&extensionsv1alpha1.Infrastructure{},
-				HaveOccurred()),
+				BeFalse(), HaveOccurred()),
 			Entry("last operation not succeeded",
 				&extensionsv1alpha1.Infrastructure{
 					Status: extensionsv1alpha1.InfrastructureStatus{
@@ -296,7 +298,7 @@ var _ = Describe("health", func() {
 						},
 					},
 				},
-				HaveOccurred()),
+				BeFalse(), HaveOccurred()),
 		)
 	})
 })

--- a/test/framework/dump.go
+++ b/test/framework/dump.go
@@ -198,7 +198,7 @@ func (f *GardenerFramework) dumpGardenerExtensionsInNamespace(ctx context.Contex
 
 // dumpGardenerExtensions prints all gardener extension crds in the shoot namespace
 func (f *GardenerFramework) dumpGardenerExtension(extension v1alpha1.Object) {
-	if err := health.CheckExtensionObject(extension); err != nil {
+	if _, err := health.CheckExtensionObject(extension); err != nil {
 		f.Logger.Printf("%s of type %s is %s - Error: %s", extension.GetName(), extension.GetExtensionSpec().GetExtensionType(), unhealthy, err.Error())
 	} else {
 		f.Logger.Printf("%s of type %s is %s", extension.GetName(), extension.GetExtensionSpec().GetExtensionType(), healthy)


### PR DESCRIPTION
This PR makes Gardener to exit the shoot reconciliation flow as soon as a step notices an error in one of resources reconciled in the seed cluster (e.g. infrastructure, etcd). Now, errors are reported quicker and not only after certain timeout has been exceeded.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The error reporting for shoot clusters has been improved. Configuration problems or similar issues which occur during shoot reconciliation are now instantly visible in the shoot resource.
```

<!-- Please select area, kind, and priority for this pull request. This helps the community categorizing it. -->
<!-- Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion. -->
<!-- If multiple identifiers make sense you can also state the commands multiple times, e.g. -->
<!--   /area control-plane -->
<!--   /area auto-scaling -->
<!--   ... -->
**How to categorize this PR?**
<!-- "/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management -->
<!-- "/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test -->
<!-- "/priority" identifiers: normal|critical|blocker -->
/area usability
/kind enhancement
/priority normal
