### PR TITLE
Remove staleExtensionHealthCheckThreshold from gardenlet default values.yaml

### DIFF
--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -82,7 +82,6 @@ global:
         shootCare:
           concurrentSyncs: 5
           syncPeriod: 30s
-          staleExtensionHealthCheckThreshold: 5m
           conditionThresholds:
           - type: APIServerAvailable
             duration: 1m


### PR DESCRIPTION
**What this PR does / why we need it**:
As of #2266 the gardenlet check for stale extension healthchecks needs to be disabled by default for several releases to ensure backwards compatibility.
But currently `staleExtensionHealthCheckThreshold` is part of gardenlet default values.yaml - if you need to disable the check, you have to explicitly set the value to `null` in the values file passed to helm install or helm upgrade.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The check for stale extension healthchecks is now also disabled by default in gardenlet chart values.yaml.
```

<!-- Please select area, kind, and priority for this pull request. This helps the community categorizing it. -->
<!-- Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion. -->
<!-- If multiple identifiers make sense you can also state the commands multiple times, e.g. -->
<!--   /area control-plane -->
<!--   /area auto-scaling -->
<!--   ... -->
**How to categorize this PR?**
<!-- "/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management -->
<!-- "/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test -->
<!-- "/priority" identifiers: normal|critical|blocker -->
/area quality
/kind enhancement
/priority normal
