### PR TITLE
Additional guestbook test wait step and increased timeout

### DIFF
--- a/test/integration/framework/garden_operation.go
+++ b/test/integration/framework/garden_operation.go
@@ -362,8 +362,8 @@ func (o *GardenerTestOperation) WaitUntilDeploymentsWithLabelsIsReady(ctx contex
 	})
 }
 
-// WaitUntilGuestbookAppIsAvailable waits until the guestbook app is available and ready to serve requests
-func (o *GardenerTestOperation) WaitUntilGuestbookAppIsAvailable(ctx context.Context, guestbookAppUrls []string) error {
+// WaitUntilGuestbookURLsRespondOK waits until the guestbook app is available and ready to serve requests
+func (o *GardenerTestOperation) WaitUntilGuestbookURLsRespondOK(ctx context.Context, guestbookAppUrls []string) error {
 	return retry.UntilTimeout(ctx, defaultPollInterval, 5*time.Minute, func(ctx context.Context) (done bool, err error) {
 		for _, guestbookAppURL := range guestbookAppUrls {
 			response, err := o.HTTPGet(ctx, guestbookAppURL)

--- a/test/integration/shoots/operations/operations.go
+++ b/test/integration/shoots/operations/operations.go
@@ -75,7 +75,8 @@ var _ = ginkgo.Describe("Shoot operation testing", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("test guestbook")
-		guestBookTest.WaitUntilPrerequisitesAreReady(ctx)
+		guestBookTest.WaitUntilRedisIsReady(ctx)
+		guestBookTest.WaitUntilGuestbookDeploymentIsReady(ctx)
 		guestBookTest.Test(ctx)
 
 	}, hibernationTestTimeout)


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes the guestbook test a bit more robust by:
- adding an additional wait step to wait for the guestbook app deployment to become `READY` (which can take some mins on i.e. azure), previously the test wouldn't wait for this but jump directly into a 5 min timeout.
- increases the timeout from `5` to `10` mins for waiting on the ingress to serve `HTTP 200`

We noticed in the past an increased error rate on azure clusters with regards to the guestbook test not being ready in 5 mins. One reason observed was long durations of image pulling.
