### PR TITLE
Fix HVPA CRD deletion after GASC introduction

### DIFF
--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -285,36 +285,37 @@ func DeleteHvpa(k8sClient kubernetes.Interface, namespace string) error {
 		LabelSelector: fmt.Sprintf("%s=%s", v1beta1constants.GardenRole, GardenRoleHvpa),
 	}
 
-	// Delete all Crds with label "gardener.cloud/role=hvpa"
-	if err := k8sClient.APIExtension().ApiextensionsV1beta1().CustomResourceDefinitions().DeleteCollection(
-		&metav1.DeleteOptions{}, listOptions); err != nil && !apierrors.IsNotFound(err) {
+	// Delete all CRDs with label "gardener.cloud/role=hvpa"
+	// Workaround: Due to https://github.com/gardener/gardener/issues/2257, we first list the HVPA CRDs and then remove
+	// them one by one.
+	crdList, err := k8sClient.APIExtension().ApiextensionsV1beta1().CustomResourceDefinitions().List(listOptions)
+	if err != nil {
 		return err
+	}
+	for _, crd := range crdList.Items {
+		if err := k8sClient.APIExtension().ApiextensionsV1beta1().CustomResourceDefinitions().Delete(crd.Name, &metav1.DeleteOptions{}); client.IgnoreNotFound(err) != nil {
+			return err
+		}
 	}
 
 	// Delete all Deployments with label "gardener.cloud/role=hvpa"
 	deletePropagation := metav1.DeletePropagationForeground
-	if err := k8sClient.Kubernetes().AppsV1().Deployments(namespace).DeleteCollection(
-		&metav1.DeleteOptions{
-			PropagationPolicy: &deletePropagation,
-		}, listOptions); err != nil && !apierrors.IsNotFound(err) {
+	if err := k8sClient.Kubernetes().AppsV1().Deployments(namespace).DeleteCollection(&metav1.DeleteOptions{PropagationPolicy: &deletePropagation}, listOptions); client.IgnoreNotFound(err) != nil {
 		return err
 	}
 
 	// Delete all ClusterRoles with label "gardener.cloud/role=hvpa"
-	if err := k8sClient.Kubernetes().RbacV1().ClusterRoles().DeleteCollection(
-		&metav1.DeleteOptions{}, listOptions); err != nil && !apierrors.IsNotFound(err) {
+	if err := k8sClient.Kubernetes().RbacV1().ClusterRoles().DeleteCollection(&metav1.DeleteOptions{}, listOptions); client.IgnoreNotFound(err) != nil {
 		return err
 	}
 
 	// Delete all ClusterRoleBindings with label "gardener.cloud/role=hvpa"
-	if err := k8sClient.Kubernetes().RbacV1().ClusterRoleBindings().DeleteCollection(
-		&metav1.DeleteOptions{}, listOptions); err != nil && !apierrors.IsNotFound(err) {
+	if err := k8sClient.Kubernetes().RbacV1().ClusterRoleBindings().DeleteCollection(&metav1.DeleteOptions{}, listOptions); client.IgnoreNotFound(err) != nil {
 		return err
 	}
 
 	// Delete all ServiceAccounts with label "gardener.cloud/role=hvpa"
-	if err := k8sClient.Kubernetes().CoreV1().ServiceAccounts(namespace).DeleteCollection(
-		&metav1.DeleteOptions{}, listOptions); err != nil && !apierrors.IsNotFound(err) {
+	if err := k8sClient.Kubernetes().CoreV1().ServiceAccounts(namespace).DeleteCollection(&metav1.DeleteOptions{}, listOptions); client.IgnoreNotFound(err) != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
After the introduction of the Gardener Seed Admission Controller some CRDs in the seed clusters  are protected from unconfirmed deletion. As there seems to be a bug in Kubernetes wrt label selectors and `DELETE COLLECTION` webhooks (https://github.com/gardener/gardener/issues/2257#issuecomment-621255204, at least for older versions) we workaround this problem by first listing and then deleting the CRDs one by one.

**Which issue(s) this PR fixes**:
Fixes #2257

**Special notes for your reviewer**:
Needs to be cherry-picked to `release-v1.3` and `release-v1.4` branches after mege.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug that was preventing the Gardenlet from bootstrapping seed clusters if the `HVPA` feature gate is disabled was fixed.
```

<!-- Please select area, kind, and priority for this pull request. This helps the community categorizing it. -->
<!-- Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion. -->
<!-- If multiple identifiers make sense you can also state the commands multiple times, e.g. -->
<!--   /area control-plane -->
<!--   /area auto-scaling -->
<!--   ... -->
**How to categorize this PR?**
<!-- "/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management -->
<!-- "/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test -->
<!-- "/priority" identifiers: normal|critical|blocker -->
/area open-source
/area usability
/kind bug
/priority normal
