### PR TITLE
Forbid SecurityContextDeny admission plugin for shoots

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -539,12 +539,17 @@ func validateKubernetes(kubernetes core.Kubernetes, fldPath *field.Path) field.E
 			}
 		}
 
+		forbiddenAdmissionPlugins := sets.NewString("SecurityContextDeny")
 		admissionPluginsPath := fldPath.Child("kubeAPIServer", "admissionPlugins")
 		for i, plugin := range kubeAPIServer.AdmissionPlugins {
 			idxPath := admissionPluginsPath.Index(i)
 
 			if len(plugin.Name) == 0 {
 				allErrs = append(allErrs, field.Required(idxPath.Child("name"), "must provide a name"))
+			}
+
+			if forbiddenAdmissionPlugins.Has(plugin.Name) {
+				allErrs = append(allErrs, field.Forbidden(idxPath.Child("name"), fmt.Sprintf("forbidden admission plugin was specified - do not use %+v", forbiddenAdmissionPlugins.UnsortedList())))
 			}
 		}
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1234,6 +1234,21 @@ var _ = Describe("Shoot Validation Tests", func() {
 					"Field": Equal("spec.kubernetes.kubeAPIServer.admissionPlugins[0].name"),
 				}))
 			})
+
+			It("should forbid specifying the SecurityContextDeny admission plugin", func() {
+				shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = []core.AdmissionPlugin{
+					{
+						Name: "SecurityContextDeny",
+					},
+				}
+
+				errorList := ValidateShoot(shoot)
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal("spec.kubernetes.kubeAPIServer.admissionPlugins[0].name"),
+				}))))
+			})
 		})
 
 		Context("KubeControllerManager validation < 1.12", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR forbids using the `SecurityContextDeny` admission plugin for shoots as it conflicts with the `PodSecurityPolicy` admission plugin which we enable by default.

**Which issue(s) this PR fixes**:
Fixes #2047

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
The `SecurityContextDeny` admission plugin is no longer allowed to be used for shoots as it conflicts with the `PodSecurityPolicy` admission plugin which is enabled by default.
```

<!-- Please select area, kind, and priority for this pull request. This helps the community categorizing it. -->
<!-- Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion. -->
<!-- If multiple identifiers make sense you can also state the commands multiple times, e.g. -->
<!--   /area control-plane -->
<!--   /area auto-scaling -->
<!--   ... -->
**How to categorize this PR?**
<!-- "/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management -->
<!-- "/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test -->
<!-- "/priority" identifiers: normal|critical|blocker -->
/area quality
/area robustness
/kind bug
/priority normal
