### PR TITLE
Add fake Golang package to allow vendoring .github/ISSUE_TEMPLATE directory, move categorization to the top

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -5,6 +5,23 @@ labels: kind/bug
 
 ---
 
+**How to categorize this issue?**
+<!--
+Please select area, kind, and priority for this issue. This helps the community categorizing it.
+Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
+If multiple identifiers make sense you can also state the commands multiple times, e.g.
+  /area control-plane
+  /area auto-scaling
+  ...
+
+"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
+"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
+"/priority" identifiers: normal|critical|blocker
+-->
+/area TODO
+/kind bug
+/priority normal
+
 **What happened**:
 
 **What you expected to happen**:
@@ -19,17 +36,3 @@ labels: kind/bug
 - Kubernetes version (use `kubectl version`):
 - Cloud provider or hardware configuration:
 - Others:
-
-<!-- Please select area, kind, and priority for this issue. This helps the community categorizing it. -->
-<!-- Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion. -->
-<!-- If multiple identifiers make sense you can also state the commands multiple times, e.g. -->
-<!--   /area control-plane -->
-<!--   /area auto-scaling -->
-<!--   ... -->
-**How to categorize this issue?**
-<!-- "/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management -->
-<!-- "/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test -->
-<!-- "/priority" identifiers: normal|critical|blocker -->
-/area TODO
-/kind bug
-/priority normal

--- a/.github/ISSUE_TEMPLATE/doc.go
+++ b/.github/ISSUE_TEMPLATE/doc.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This package imports GitHub related templates - it is to force `go mod` to see them as dependencies.
+package issue_template

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -5,20 +5,23 @@ labels: kind/enhancement
 
 ---
 
-**What would you like to be added**:
-
-**Why is this needed**:
-
-<!-- Please select area, kind, and priority for this issue. This helps the community categorizing it. -->
-<!-- Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion. -->
-<!-- If multiple identifiers make sense you can also state the commands multiple times, e.g. -->
-<!--   /area control-plane -->
-<!--   /area auto-scaling -->
-<!--   ... -->
 **How to categorize this issue?**
-<!-- "/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management -->
-<!-- "/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test -->
-<!-- "/priority" identifiers: normal|critical|blocker -->
+<!--
+Please select area, kind, and priority for this issue. This helps the community categorizing it.
+Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
+If multiple identifiers make sense you can also state the commands multiple times, e.g.
+  /area control-plane
+  /area auto-scaling
+  ...
+
+"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
+"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
+"/priority" identifiers: normal|critical|blocker
+-->
 /area TODO
 /kind enhancement
 /priority normal
+
+**What would you like to be added**:
+
+**Why is this needed**:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,20 @@
+**How to categorize this PR?**
+<!--
+Please select area, kind, and priority for this pull request. This helps the community categorizing it.
+Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
+If multiple identifiers make sense you can also state the commands multiple times, e.g.
+  /area control-plane
+  /area auto-scaling
+  ...
+
+"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
+"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
+"/priority" identifiers: normal|critical|blocker
+-->
+/area TODO
+/kind TODO
+/priority normal
+
 **What this PR does / why we need it**:
 
 **Which issue(s) this PR fixes**:
@@ -6,7 +23,8 @@ Fixes #
 **Special notes for your reviewer**:
 
 **Release note**:
-<!--  Write your release note:
+<!--
+Write your release note:
 1. Enter your release note in the below block.
 2. If no release note is required, just write "NONE" within the block.
 
@@ -18,17 +36,3 @@ Possible values:
 ```improvement operator
 
 ```
-
-<!-- Please select area, kind, and priority for this pull request. This helps the community categorizing it. -->
-<!-- Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion. -->
-<!-- If multiple identifiers make sense you can also state the commands multiple times, e.g. -->
-<!--   /area control-plane -->
-<!--   /area auto-scaling -->
-<!--   ... -->
-**How to categorize this PR?**
-<!-- "/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management -->
-<!-- "/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test -->
-<!-- "/priority" identifiers: normal|critical|blocker -->
-/area TODO
-/kind TODO
-/priority normal


### PR DESCRIPTION
**What this PR does / why we need it**:
Add fake Golang package to allow vendoring the `.github/ISSUE_TEMPLATE` directory (left-over after #2328).
Also, it moves the categorization at the top so that it cannot be overlooked accidentally.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```

<!-- Please select area, kind, and priority for this pull request. This helps the community categorizing it. -->
<!-- Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion. -->
<!-- If multiple identifiers make sense you can also state the commands multiple times, e.g. -->
<!--   /area control-plane -->
<!--   /area auto-scaling -->
<!--   ... -->
**How to categorize this PR?**
<!-- "/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management -->
<!-- "/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test -->
<!-- "/priority" identifiers: normal|critical|blocker -->
/area dev-productivity
/area open-source
/kind enhancement
/priority normal
