### PR TITLE
Fix bug deleting stale extension roles for other projects

### DIFF
--- a/charts/garden-project/charts/project-rbac/templates/clusterrole-project-extensions.yaml
+++ b/charts/garden-project/charts/project-rbac/templates/clusterrole-project-extensions.yaml
@@ -6,6 +6,7 @@ metadata:
   name: gardener.cloud:extension:project:{{ $.Values.project.name }}:{{ $extension.name }}
   labels:
     gardener.cloud/role: extension-project-role
+    project.gardener.cloud/name: {{ $.Values.project.name }}
   ownerReferences:
   - apiVersion: core.gardener.cloud/v1beta1
     kind: Project

--- a/charts/garden-project/charts/project-rbac/templates/rolebinding-project-extensions.yaml
+++ b/charts/garden-project/charts/project-rbac/templates/rolebinding-project-extensions.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     gardener.cloud/role: extension-project-role
+    project.gardener.cloud/name: {{ $.Values.project.name }}
   ownerReferences:
   - apiVersion: core.gardener.cloud/v1beta1
     kind: Project

--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -264,6 +264,7 @@ func deleteStaleExtensionRoles(ctx context.Context, c client.Client, nonStaleExt
 			client.InNamespace(namespace),
 			client.MatchingLabels{
 				v1beta1constants.GardenRole: v1beta1constants.LabelExtensionProjectRole,
+				common.ProjectName:          projectName,
 			},
 		); err != nil {
 			return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area usability
/kind bug
/priority critical

**What this PR does / why we need it**:
This PR fixes a bug that causes that the GCM incorrectly deletes extension `ClusterRole`s of other projects when reconciling a `Project` that doesn't have a member with the same extension role.

Step for reproduction:

1. Create two projects `dev` and `dev1`.
1. Add a member with an extension role to the `dev` project:
```yaml
spec:
  members:
  - apiGroup: rbac.authorization.k8s.io
    kind: User
    name: john.doe@example.com
    role: admin
    roles:
    - owner
    - extension:barbaz
```
3. Now change the `dev1` project and add a member without this extension role:
```yaml
spec:
  members:
  - apiGroup: rbac.authorization.k8s.io
    kind: User
    name: test
    role: owner
    roles:
    - admin
```
4. See the `clusterrole.rbac.authorization.k8s.io/gardener.cloud:extension:project:dev:barbaz` being deleted.

**Special notes for your reviewer**:
Thanks @petersutter for reporting.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
A bug has been fixed that caused the gardener-controller-manager to incorrectly delete extension `ClusterRole`s of other projects when reconciling a `Project` that doesn't have a member with the same extension role.
```