### PR TITLE
Reconcile and delete Shoot resource references

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -87,6 +87,7 @@
   * Generic (non-essential) extensions
     * [`Extension` resource](extensions/extension.md)
 * [Extending project roles](extensions/project-roles.md)
+* [Referenced resources](extensions/referenced-resources.md)
 
 ## Testing
 

--- a/docs/extensions/referenced-resources.md
+++ b/docs/extensions/referenced-resources.md
@@ -1,0 +1,46 @@
+# Referenced Resources
+
+The Shoot resource can include a list of resources (usually secrets) that can be referenced by name in extension `providerConfig` and other Shoot sections, for example:
+
+```yaml
+kind: Shoot
+apiVersion: core.gardener.cloud/v1beta1
+metadata:
+  name: crazy-botany
+  namespace: garden-dev
+  ...
+spec:
+  ...
+  extensions:
+  - type: foobar
+    providerConfig:
+      apiVersion: foobar.extensions.gardener.cloud/v1alpha1
+      kind: FooBarConfig
+      foo: bar
+      secretRef: foobar-secret
+  resources:
+  - name: foobar-secret
+    resourceRef:
+      apiVersion: v1
+      kind: Secret
+      name: my-foobar-secret
+```
+
+Gardener expects to find these referenced resources in the project namespace (e.g. `garden-dev`) and will copy them to the Shoot namespace in the Seed cluster when reconciling a Shoot, adding a prefix to their names to avoid naming collisions with Gardener's own resources. 
+
+Extension controllers can resolve the references to these resources by accessing the Shoot via the `Cluster` resource. To properly read a referenced resources, extension controllers should use the utility function `GetObjectByReference` from the `extensions/pkg/controller` package, for example:
+
+```go
+    ...
+    ref = &autoscalingv1.CrossVersionObjectReference{
+        APIVersion: "v1",
+        Kind:       "Secret",
+        Name:       "foo",
+    }
+    secret := &corev1.Secret{}
+    if err := controller.GetObjectByReference(ctx, client, ref, "shoot--test--foo", secret); err != nil {
+        return err
+    }
+    // Use secret
+    ...
+```

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -219,6 +219,7 @@ spec:
   #   apiVersion: foobar.extensions.gardener.cloud/v1alpha1
   #   kind: FooBarConfig
   #   foo: bar
+  #   secretRef: foobar-secret # See the resources section below for the actual reference
   # disabled: true # only relevant for extensions that were marked as 'globally enabled' by Gardener administrators
   networking:
     type: calico
@@ -270,3 +271,10 @@ spec:
 # seedSelector:
 #   matchLabels:
 #     foo: bar
+# List resources referenced by providerConfig and other sections, if any
+# resources:
+# - name: foobar-secret
+#   resourceRef:
+#     apiVersion: v1
+#     kind: Secret
+#     name: my-foobar-secret

--- a/extensions/pkg/controller/managedresources.go
+++ b/extensions/pkg/controller/managedresources.go
@@ -16,18 +16,14 @@ package controller
 
 import (
 	"context"
-	"time"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/extensions/pkg/util"
-
-	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
-	"github.com/gardener/gardener-resource-manager/pkg/manager"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
-	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	managedresources "github.com/gardener/gardener/pkg/utils/managedresources"
 )
 
 // RenderChartAndCreateManagedResource renders a chart and creates a ManagedResource for the gardener-resource-manager
@@ -44,84 +40,5 @@ func RenderChartAndCreateManagedResource(ctx context.Context, namespace string, 
 		injectedLabels = map[string]string{ShootNoCleanupLabel: "true"}
 	}
 
-	return CreateManagedResource(ctx, client, namespace, name, "", chartName, data, false, injectedLabels, forceOverwriteAnnotations)
-}
-
-func CreateManagedResourceFromUnstructured(ctx context.Context, client client.Client, namespace, name, class string, objs []*unstructured.Unstructured, keepObjects bool, injectedLabels map[string]string) error {
-	var data []byte
-	for _, obj := range objs {
-		bytes, err := obj.MarshalJSON()
-		if err != nil {
-			return errors.Wrapf(err, "marshal failed for '%s/%s' for secret '%s/%s'", obj.GetNamespace(), obj.GetName(), namespace, name)
-		}
-		data = append(data, []byte("\n---\n")...)
-		data = append(data, bytes...)
-	}
-	return CreateManagedResource(ctx, client, namespace, name, class, name, data, keepObjects, injectedLabels, false)
-}
-
-func CreateManagedResourceFromFileChart(ctx context.Context, client client.Client, namespace, name, class string, renderer chartrenderer.Interface, chartPath, chartName string, chartValues map[string]interface{}, injectedLabels map[string]string) error {
-	chart, err := renderer.Render(chartPath, chartName, namespace, chartValues)
-	if err != nil {
-		return err
-	}
-
-	return CreateManagedResource(ctx, client, namespace, name, class, chartName, chart.Manifest(), false, injectedLabels, false)
-}
-
-func CreateManagedResource(ctx context.Context, client client.Client, namespace, name, class, key string, data []byte, keepObjects bool, injectedLabels map[string]string, forceOverwriteAnnotations bool) error {
-	if key == "" {
-		key = name
-	}
-
-	// Create or update secret containing the rendered rbac manifests
-	if err := manager.NewSecret(client).
-		WithNamespacedName(namespace, name).
-		WithKeyValues(map[string][]byte{key: data}).
-		Reconcile(ctx); err != nil {
-		return errors.Wrapf(err, "could not create or update secret '%s/%s' of managed resources", namespace, name)
-	}
-
-	if err := manager.NewManagedResource(client).
-		WithNamespacedName(namespace, name).
-		WithClass(class).
-		WithInjectedLabels(injectedLabels).
-		KeepObjects(keepObjects).
-		WithSecretRef(name).
-		ForceOverwriteAnnotations(forceOverwriteAnnotations).
-		Reconcile(ctx); err != nil {
-		return errors.Wrapf(err, "could not create or update managed resource '%s/%s'", namespace, name)
-	}
-
-	return nil
-}
-
-// DeleteManagedResource deletes a managed resource and a secret with the given <name>.
-func DeleteManagedResource(ctx context.Context, client client.Client, namespace string, name string) error {
-	if err := manager.
-		NewManagedResource(client).
-		WithNamespacedName(namespace, name).
-		Delete(ctx); err != nil {
-		return errors.Wrapf(err, "could not delete managed resource '%s/%s'", namespace, name)
-	}
-
-	if err := manager.
-		NewSecret(client).
-		WithNamespacedName(namespace, name).
-		Delete(ctx); err != nil {
-		return errors.Wrapf(err, "could not delete secret '%s/%s' of managed resource", namespace, name)
-	}
-
-	return nil
-}
-
-// WaitUntilManagedResourceDeleted waits until the given managed resource is deleted.
-func WaitUntilManagedResourceDeleted(ctx context.Context, client client.Client, namespace, name string) error {
-	mr := &resourcesv1alpha1.ManagedResource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-	}
-	return WaitUntilResourceDeleted(ctx, client, mr, 2*time.Second)
+	return managedresources.CreateManagedResource(ctx, client, namespace, name, "", chartName, data, false, injectedLabels, forceOverwriteAnnotations)
 }

--- a/extensions/pkg/controller/utils.go
+++ b/extensions/pkg/controller/utils.go
@@ -22,12 +22,14 @@ import (
 
 	controllererror "github.com/gardener/gardener/extensions/pkg/controller/error"
 	"github.com/gardener/gardener/extensions/pkg/util"
+	"github.com/gardener/gardener/pkg/operation/botanist"
 
 	resourcemanagerv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/api/extensions"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -272,25 +274,6 @@ func exponentialBackoff(ctx context.Context, backoff wait.Backoff, condition wai
 	return wait.ErrWaitTimeout
 }
 
-// WaitUntilResourceDeleted deletes the given resource and then waits until it has been deleted. It respects the
-// given interval and timeout.
-func WaitUntilResourceDeleted(ctx context.Context, c client.Client, obj runtime.Object, interval time.Duration) error {
-	key, err := client.ObjectKeyFromObject(obj)
-	if err != nil {
-		return err
-	}
-
-	return wait.PollImmediateUntil(interval, func() (done bool, err error) {
-		if err := c.Get(ctx, key, obj); err != nil {
-			if apierrors.IsNotFound(err) {
-				return true, nil
-			}
-			return false, err
-		}
-		return false, nil
-	}, ctx.Done())
-}
-
 // WatchBuilder holds various functions which add watch controls to the passed Controller.
 type WatchBuilder []func(controller.Controller) error
 
@@ -362,4 +345,10 @@ func IsMigrated(obj runtime.Object) bool {
 	return lastOp != nil &&
 		lastOp.Type == gardencorev1beta1.LastOperationTypeMigrate &&
 		lastOp.State == gardencorev1beta1.LastOperationStateSucceeded
+}
+
+// GetObjectByReference gets an object by the given reference, in the given namespace.
+// If the object kind doesn't match the given reference kind this will result in an error.
+func GetObjectByReference(ctx context.Context, c client.Client, ref *autoscalingv1.CrossVersionObjectReference, namespace string, obj runtime.Object) error {
+	return c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: botanist.ReferencedResourcesPrefix + ref.Name}, obj)
 }

--- a/extensions/pkg/controller/utils_test.go
+++ b/extensions/pkg/controller/utils_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	"github.com/gardener/gardener/pkg/operation/botanist"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -27,6 +28,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -268,6 +270,38 @@ var _ = Describe("Utils", func() {
 				State: gardencorev1beta1.LastOperationStateSucceeded,
 			}
 			Expect(controller.IsMigrated(worker)).To(BeTrue())
+		})
+	})
+
+	Describe("#GetObjectByReference", func() {
+		var (
+			ctx = context.TODO()
+			ref = &autoscalingv1.CrossVersionObjectReference{
+				APIVersion: "v1",
+				Kind:       "Secret",
+				Name:       "foo",
+			}
+			namespace = "shoot--test--foo"
+			refSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      botanist.ReferencedResourcesPrefix + "foo",
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{
+					"foo": []byte("bar"),
+				},
+			}
+		)
+
+		It("should call client.Get and return the result", func() {
+			secret := &corev1.Secret{}
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: botanist.ReferencedResourcesPrefix + ref.Name}, secret).DoAndReturn(
+				func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret) error {
+					refSecret.DeepCopyInto(secret)
+					return nil
+				})
+			Expect(controller.GetObjectByReference(ctx, c, ref, namespace, secret)).To(Succeed())
+			Expect(secret).To(Equal(refSecret))
 		})
 	})
 })

--- a/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -22,13 +22,15 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/util"
+	managedresources "github.com/gardener/gardener/pkg/utils/managedresources"
 
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils/secrets"
 )
 
 // McmShootResourceName is the name of the managed resource that contains the Machine Controller Manager
@@ -74,13 +76,13 @@ func (a *genericActuator) deployMachineControllerManager(ctx context.Context, wo
 func (a *genericActuator) deleteMachineControllerManager(ctx context.Context, workerObj *extensionsv1alpha1.Worker) error {
 	a.logger.Info("Deleting the machine-controller-manager", "worker", fmt.Sprintf("%s/%s", workerObj.Namespace, workerObj.Name))
 
-	if err := extensionscontroller.DeleteManagedResource(ctx, a.client, workerObj.Namespace, McmShootResourceName); err != nil {
+	if err := managedresources.DeleteManagedResource(ctx, a.client, workerObj.Namespace, McmShootResourceName); err != nil {
 		return errors.Wrapf(err, "could not delete managed resource containing mcm chart for worker '%s'", util.ObjectName(workerObj))
 	}
 
 	timeoutCtx3, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
-	if err := extensionscontroller.WaitUntilManagedResourceDeleted(timeoutCtx3, a.client, workerObj.Namespace, McmShootResourceName); err != nil {
+	if err := managedresources.WaitUntilManagedResourceDeleted(timeoutCtx3, a.client, workerObj.Namespace, McmShootResourceName); err != nil {
 		return errors.Wrapf(err, "error while waiting for managed resource containing mcm for '%s' to be deleted", util.ObjectName(workerObj))
 	}
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -477,9 +477,14 @@ func validateExtensions(extensions []core.Extension, fldPath *field.Path) field.
 
 func validateResources(resources []core.NamedResourceReference, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+	names := make(map[string]bool)
 	for i, resource := range resources {
 		if resource.Name == "" {
 			allErrs = append(allErrs, field.Required(fldPath.Index(i).Child("name"), "field must not be empty"))
+		} else if names[resource.Name] {
+			allErrs = append(allErrs, field.Duplicate(fldPath.Index(i).Child("name"), resource.Name))
+		} else {
+			names[resource.Name] = true
 		}
 		allErrs = append(allErrs, validateCrossVersionObjectReference(resource.ResourceRef, fldPath.Index(i).Child("resourceRef"))...)
 	}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -544,6 +544,27 @@ var _ = Describe("Shoot Validation Tests", func() {
 			))
 		})
 
+		It("should forbid resources with non-unique names", func() {
+			ref := core.NamedResourceReference{
+				Name: "test",
+				ResourceRef: autoscalingv1.CrossVersionObjectReference{
+					Kind:       "Secret",
+					Name:       "test-secret",
+					APIVersion: "v1",
+				},
+			}
+			shoot.Spec.Resources = append(shoot.Spec.Resources, ref, ref)
+
+			errorList := ValidateShoot(shoot)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeDuplicate),
+					"Field": Equal("spec.resources[1].name"),
+				})),
+			))
+		})
+
 		It("should allow resources w/ names and valid references", func() {
 			ref := core.NamedResourceReference{
 				Name: "test",

--- a/pkg/apiserver/admission/initializer/initializer.go
+++ b/pkg/apiserver/admission/initializer/initializer.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/client-go/dynamic"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 )
@@ -34,6 +35,7 @@ func New(
 	settingsInformers settingsinformer.SharedInformerFactory,
 	kubeInformers kubeinformers.SharedInformerFactory,
 	kubeClient kubernetes.Interface,
+	dynamicClient dynamic.Interface,
 	authz authorizer.Authorizer,
 ) admission.PluginInitializer {
 	return pluginInitializer{
@@ -46,6 +48,8 @@ func New(
 
 		kubeInformers: kubeInformers,
 		kubeClient:    kubeClient,
+
+		dynamicClient: dynamicClient,
 
 		authorizer: authz,
 	}
@@ -74,6 +78,10 @@ func (i pluginInitializer) Initialize(plugin admission.Interface) {
 	}
 	if wants, ok := plugin.(WantsKubeClientset); ok {
 		wants.SetKubeClientset(i.kubeClient)
+	}
+
+	if wants, ok := plugin.(WantsDynamicClient); ok {
+		wants.SetDynamicClient(i.dynamicClient)
 	}
 
 	if wants, ok := plugin.(WantsAuthorizer); ok {

--- a/pkg/apiserver/admission/initializer/types.go
+++ b/pkg/apiserver/admission/initializer/types.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/client-go/dynamic"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 )
@@ -62,6 +63,12 @@ type WantsKubeClientset interface {
 	admission.InitializationValidator
 }
 
+// WantsDynamicClient defines a function which sets a dynamic client for admission plugins that need it.
+type WantsDynamicClient interface {
+	SetDynamicClient(dynamic.Interface)
+	admission.InitializationValidator
+}
+
 // WantsAuthorizer defines a function which sets an authorizer for admission plugins that need it.
 type WantsAuthorizer interface {
 	SetAuthorizer(authorizer.Authorizer)
@@ -78,6 +85,8 @@ type pluginInitializer struct {
 
 	kubeInformers kubeinformers.SharedInformerFactory
 	kubeClient    kubernetes.Interface
+
+	dynamicClient dynamic.Interface
 
 	authorizer authorizer.Authorizer
 }

--- a/pkg/operation/botanist/resources.go
+++ b/pkg/operation/botanist/resources.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist
+
+import (
+	"context"
+	"fmt"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
+	managedresources "github.com/gardener/gardener/pkg/utils/managedresources"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// ManagedResourceName is the name of the managed resource used to deploy referenced resources to the Seed cluster.
+	ManagedResourceName = "referenced-resources"
+	// ReferencedResourcesPrefix is the prefix used when copying referenced resources to the Shoot namespace in the Seed,
+	// to avoid naming collisions with resources managed by Gardener.
+	ReferencedResourcesPrefix = "ref-"
+)
+
+// DeployReferencedResources reads all referenced resources from the Garden cluster and writes a managed resource to the Seed cluster.
+func (b *Botanist) DeployReferencedResources(ctx context.Context) error {
+	// Read referenced objects into a slice of unstructured objects
+	var unstructuredObjs []*unstructured.Unstructured
+	for _, resourceRef := range b.Shoot.ResourceRefs {
+		// Read the resource from the Garden cluster
+		obj, err := utils.GetObjectByRef(ctx, b.K8sGardenClient.Client(), &resourceRef, b.Shoot.Info.Namespace)
+		if err != nil {
+			return err
+		}
+		if obj == nil {
+			return fmt.Errorf("object not found %v", resourceRef)
+		}
+
+		// Create an unstructured object and append it to the slice
+		unstructuredObj := &unstructured.Unstructured{Object: obj}
+		unstructuredObj.SetNamespace(b.Shoot.SeedNamespace)
+		unstructuredObj.SetName(ReferencedResourcesPrefix + unstructuredObj.GetName())
+		unstructuredObjs = append(unstructuredObjs, unstructuredObj)
+	}
+
+	// Create managed resource from the slice of unstructured objects
+	return managedresources.CreateManagedResourceFromUnstructured(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, ManagedResourceName,
+		v1beta1constants.SeedResourceManagerClass, unstructuredObjs, false, nil)
+}
+
+// DestroyReferencedResources deletes the managed resource containing referenced resources from the Seed cluster.
+func (b *Botanist) DestroyReferencedResources(ctx context.Context) error {
+	return client.IgnoreNotFound(managedresources.DeleteManagedResource(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, ManagedResourceName))
+}

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -191,6 +192,8 @@ func (b *Builder) Build(ctx context.Context, c client.Client) (*Shoot, error) {
 		return nil, err
 	}
 	shoot.Networks = networks
+
+	shoot.ResourceRefs = getResourceRefs(shootObject)
 
 	return shoot, nil
 }
@@ -586,4 +589,13 @@ func ComputeRequiredExtensions(shoot *gardencorev1beta1.Shoot, seed *gardencorev
 	}
 
 	return requiredExtensions
+}
+
+// getResourceRefs returns resource references from the Shoot spec as map[string]autoscalingv1.CrossVersionObjectReference.
+func getResourceRefs(shoot *gardencorev1beta1.Shoot) map[string]autoscalingv1.CrossVersionObjectReference {
+	resourceRefs := make(map[string]autoscalingv1.CrossVersionObjectReference)
+	for _, r := range shoot.Spec.Resources {
+		resourceRefs[r.Name] = r.ResourceRef
+	}
+	return resourceRefs
 }

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/etcdencryption"
 	"github.com/gardener/gardener/pkg/operation/garden"
 
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -70,6 +71,8 @@ type Shoot struct {
 	MachineDeployments        []extensionsv1alpha1.MachineDeployment
 
 	ETCDEncryption *etcdencryption.EncryptionConfig
+
+	ResourceRefs map[string]autoscalingv1.CrossVersionObjectReference
 }
 
 // Components contains different components deployed

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener-resource-manager/pkg/manager"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+// CreateManagedResourceFromUnstructured creates a managed resource and its secret with the given name, class, and objects in the given namespace.
+func CreateManagedResourceFromUnstructured(ctx context.Context, client client.Client, namespace, name, class string, objs []*unstructured.Unstructured, keepObjects bool, injectedLabels map[string]string) error {
+	var data []byte
+	for _, obj := range objs {
+		bytes, err := obj.MarshalJSON()
+		if err != nil {
+			return errors.Wrapf(err, "marshal failed for '%s/%s' for secret '%s/%s'", obj.GetNamespace(), obj.GetName(), namespace, name)
+		}
+		data = append(data, []byte("\n---\n")...)
+		data = append(data, bytes...)
+	}
+	return CreateManagedResource(ctx, client, namespace, name, class, name, data, keepObjects, injectedLabels, false)
+}
+
+// CreateManagedResource creates a managed resource and its secret with the given name, class, key, and data in the given namespace.
+func CreateManagedResource(ctx context.Context, client client.Client, namespace, name, class, key string, data []byte, keepObjects bool, injectedLabels map[string]string, forceOverwriteAnnotations bool) error {
+	if key == "" {
+		key = name
+	}
+
+	// Create or update secret containing the rendered rbac manifests
+	if err := manager.NewSecret(client).
+		WithNamespacedName(namespace, name).
+		WithKeyValues(map[string][]byte{key: data}).
+		Reconcile(ctx); err != nil {
+		return errors.Wrapf(err, "could not create or update secret '%s/%s' of managed resources", namespace, name)
+	}
+
+	if err := manager.NewManagedResource(client).
+		WithNamespacedName(namespace, name).
+		WithClass(class).
+		WithInjectedLabels(injectedLabels).
+		KeepObjects(keepObjects).
+		WithSecretRef(name).
+		ForceOverwriteAnnotations(forceOverwriteAnnotations).
+		Reconcile(ctx); err != nil {
+		return errors.Wrapf(err, "could not create or update managed resource '%s/%s'", namespace, name)
+	}
+
+	return nil
+}
+
+// DeleteManagedResource deletes the managed resource and its secret with the given name in the given namespace.
+func DeleteManagedResource(ctx context.Context, client client.Client, namespace string, name string) error {
+	if err := manager.
+		NewManagedResource(client).
+		WithNamespacedName(namespace, name).
+		Delete(ctx); err != nil {
+		return errors.Wrapf(err, "could not delete managed resource '%s/%s'", namespace, name)
+	}
+
+	if err := manager.
+		NewSecret(client).
+		WithNamespacedName(namespace, name).
+		Delete(ctx); err != nil {
+		return errors.Wrapf(err, "could not delete secret '%s/%s' of managed resource", namespace, name)
+	}
+
+	return nil
+}
+
+// WaitUntilManagedResourceDeleted waits until the given managed resource is deleted.
+func WaitUntilManagedResourceDeleted(ctx context.Context, client client.Client, namespace, name string) error {
+	mr := &resourcesv1alpha1.ManagedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	return kutil.WaitUntilResourceDeleted(ctx, client, mr, 2*time.Second)
+}

--- a/vendor/k8s.io/client-go/dynamic/fake/simple.go
+++ b/vendor/k8s.io/client-go/dynamic/fake/simple.go
@@ -1,0 +1,370 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/testing"
+)
+
+func NewSimpleDynamicClient(scheme *runtime.Scheme, objects ...runtime.Object) *FakeDynamicClient {
+	// In order to use List with this client, you have to have the v1.List registered in your scheme. Neat thing though
+	// it does NOT have to be the *same* list
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "fake-dynamic-client-group", Version: "v1", Kind: "List"}, &unstructured.UnstructuredList{})
+
+	codecs := serializer.NewCodecFactory(scheme)
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &FakeDynamicClient{scheme: scheme}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
+// Clientset implements clientset.Interface. Meant to be embedded into a
+// struct to get a default implementation. This makes faking out just the method
+// you want to test easier.
+type FakeDynamicClient struct {
+	testing.Fake
+	scheme *runtime.Scheme
+}
+
+type dynamicResourceClient struct {
+	client    *FakeDynamicClient
+	namespace string
+	resource  schema.GroupVersionResource
+}
+
+var _ dynamic.Interface = &FakeDynamicClient{}
+
+func (c *FakeDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource}
+}
+
+func (c *dynamicResourceClient) Namespace(ns string) dynamic.ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+func (c *dynamicResourceClient) Create(obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateAction(c.resource, obj), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateSubresourceAction(c.resource, name, strings.Join(subresources, "/"), obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateAction(c.resource, c.namespace, obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateSubresourceAction(c.resource, name, strings.Join(subresources, "/"), c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Update(obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateAction(c.resource, obj), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceAction(c.resource, strings.Join(subresources, "/"), obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateAction(c.resource, c.namespace, obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceAction(c.resource, strings.Join(subresources, "/"), c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceAction(c.resource, "status", obj), obj)
+
+	case len(c.namespace) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceAction(c.resource, "status", c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Delete(name string, opts *metav1.DeleteOptions, subresources ...string) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteAction(c.resource, name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteSubresourceAction(c.resource, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteAction(c.resource, c.namespace, name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteSubresourceAction(c.resource, strings.Join(subresources, "/"), c.namespace, name), &metav1.Status{Status: "dynamic delete fail"})
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) DeleteCollection(opts *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		action := testing.NewRootDeleteCollectionAction(c.resource, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	case len(c.namespace) > 0:
+		action := testing.NewDeleteCollectionAction(c.resource, c.namespace, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) Get(name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetAction(c.resource, name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetSubresourceAction(c.resource, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetAction(c.resource, c.namespace, name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetSubresourceAction(c.resource, c.namespace, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic get fail"})
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	var obj runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewRootListAction(c.resource, schema.GroupVersionKind{Group: "fake-dynamic-client-group", Version: "v1", Kind: "" /*List is appended by the tracker automatically*/}, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	case len(c.namespace) > 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewListAction(c.resource, schema.GroupVersionKind{Group: "fake-dynamic-client-group", Version: "v1", Kind: "" /*List is appended by the tracker automatically*/}, c.namespace, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	}
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+
+	retUnstructured := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(obj, retUnstructured, nil); err != nil {
+		return nil, err
+	}
+	entireList, err := retUnstructured.ToList()
+	if err != nil {
+		return nil, err
+	}
+
+	list := &unstructured.UnstructuredList{}
+	list.SetResourceVersion(entireList.GetResourceVersion())
+	for i := range entireList.Items {
+		item := &entireList.Items[i]
+		metadata, err := meta.Accessor(item)
+		if err != nil {
+			return nil, err
+		}
+		if label.Matches(labels.Set(metadata.GetLabels())) {
+			list.Items = append(list.Items, *item)
+		}
+	}
+	return list, nil
+}
+
+func (c *dynamicResourceClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	switch {
+	case len(c.namespace) == 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewRootWatchAction(c.resource, opts))
+
+	case len(c.namespace) > 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewWatchAction(c.resource, c.namespace, opts))
+
+	}
+
+	panic("math broke")
+}
+
+// TODO: opts are currently ignored.
+func (c *dynamicResourceClient) Patch(name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchAction(c.resource, name, pt, data), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchSubresourceAction(c.resource, name, pt, data, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchAction(c.resource, c.namespace, name, pt, data), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchSubresourceAction(c.resource, c.namespace, name, pt, data, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -914,6 +914,7 @@ k8s.io/client-go/discovery/cached/disk
 k8s.io/client-go/discovery/cached/memory
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/dynamic
+k8s.io/client-go/dynamic/fake
 k8s.io/client-go/informers
 k8s.io/client-go/informers/admissionregistration
 k8s.io/client-go/informers/admissionregistration/v1


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane-migration
/kind task
/priority normal

**What this PR does / why we need it**:
Extends the Shoot API, as well as the corresponding reconciliation and deletion logic, to support references to resources (usually secrets) required by various Shoot components (DNS, extension provider configurations, etc.).

**Which issue(s) this PR fixes**:
Fixes #2321, see also #2327.

**Special notes for your reviewer**:
* Doesn't change `DNS` in Shoot as recommended in #2321, this could be added later in a separate PR.

**Release note**:
```improvement operator
References to resources (usually secrets) can now be added to the Shoot and referred to by name in various Shoot components, e.g. extension provider configurations. 
```
