### PR TITLE
Fix backupentry and backupbucket reconcile

### DIFF
--- a/extensions/pkg/controller/backupbucket/reconciler.go
+++ b/extensions/pkg/controller/backupbucket/reconciler.go
@@ -87,16 +87,6 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
-	shoot, err := extensionscontroller.GetShoot(r.ctx, r.client, request.Namespace)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-
-	if extensionscontroller.IsShootFailed(shoot) {
-		r.logger.Info("Stop reconciling BackupBucket of failed Shoot.", "namespace", request.Namespace, "name", bb.Name)
-		return reconcile.Result{}, nil
-	}
-
 	if bb.DeletionTimestamp != nil {
 		return r.delete(r.ctx, bb)
 	}

--- a/extensions/pkg/controller/backupentry/reconciler.go
+++ b/extensions/pkg/controller/backupentry/reconciler.go
@@ -92,13 +92,14 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 		return reconcile.Result{}, err
 	}
 
-	shoot, err := extensionscontroller.GetShoot(r.ctx, r.client, request.Namespace)
+	shootTechnicalID, _ := ExtractShootDetailsFromBackupEntryName(be.Name)
+	shoot, err := extensionscontroller.GetShoot(r.ctx, r.client, shootTechnicalID)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if extensionscontroller.IsShootFailed(shoot) {
-		r.logger.Info("Stop reconciling BackupEntry of failed Shoot.", "namespace", request.Namespace, "name", be.Name)
+		r.logger.Info("Stop reconciling BackupEntry of failed Shoot.", "namespace", shootTechnicalID, "name", be.Name)
 		return reconcile.Result{}, nil
 	}
 

--- a/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/extensions/pkg/controller/healthcheck/reconciler.go
@@ -239,7 +239,7 @@ func (r *reconciler) updateExtensionConditionToUnsuccessful(ctx context.Context,
 func (r *reconciler) updateExtensionConditionToSuccessful(ctx context.Context, conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, extension extensionsv1alpha1.Object, healthCheckResult Result) error {
 	conditionBuilder.
 		WithStatus(gardencorev1beta1.ConditionTrue).
-		WithReason(ReasonUnsuccessful).
+		WithReason(ReasonSuccessful).
 		WithMessage(fmt.Sprintf("(%d/%d) Health checks successful", healthCheckResult.SuccessfulChecks, healthCheckResult.SuccessfulChecks))
 	return r.updateExtensionCondition(ctx, conditionBuilder, healthConditionType, extension)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
Currently `BackupEntry` fails to reconcile with
```
{"level":"error","ts":"2020-05-22T14:26:08.224Z","logger":"controller-runtime.controller","msg":"Reconciler error","controller":"backupentry_controller","request":"/shoot--foo--bar--4d92aa1e-49a6-4dc5-b6c1-ccc7665c9bd8","error":"Cluster.extensions.gardener.cloud \"\" not found","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/go/src/github.com/gardener/gardener-extension-provider-openstack/vendor/github.com/go-logr/zapr/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/gardener/gardener-extension-provider-openstack/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:258\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/gardener/gardener-extension-provider-openstack/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/go/src/github.com/gardener/gardener-extension-provider-openstack/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/go/src/github.com/gardener/gardener-extension-provider-openstack/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/src/github.com/gardener/gardener-extension-provider-openstack/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/go/src/github.com/gardener/gardener-extension-provider-openstack/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```

BackupEntry and BackupBucket are not namespaced resources and `request.Namespace` is an empty string for them.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
