### PR TITLE
Add utility function for cleaning up leaked worker `ClusterRole`s

### DIFF
--- a/extensions/pkg/controller/backupentry/reconciler.go
+++ b/extensions/pkg/controller/backupentry/reconciler.go
@@ -99,7 +99,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	if extensionscontroller.IsShootFailed(shoot) {
-		r.logger.Info("Stop reconciling BackupEntry of failed Shoot.", "namespace", shootTechnicalID, "name", be.Name)
+		r.logger.Info("Stop reconciling BackupEntry of failed Shoot.", "name", be.Name)
 		return reconcile.Result{}, nil
 	}
 

--- a/extensions/pkg/controller/worker/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_test.go
@@ -16,18 +16,25 @@ package genericactuator
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/go-multierror"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("Actuator", func() {
-	Describe("listMachineClassSecrets", func() {
+	Describe("#listMachineClassSecrets", func() {
 		const (
 			ns      = "test-ns"
 			purpose = "machineclass"
@@ -42,7 +49,7 @@ var _ = Describe("Actuator", func() {
 
 		BeforeEach(func() {
 			existing = &corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "new",
 					Namespace: ns,
 					Labels:    map[string]string{},
@@ -68,6 +75,7 @@ var _ = Describe("Actuator", func() {
 			allExisting = append(allExisting, existing)
 			allExpected = append(allExpected, expected)
 		})
+
 		It("only classes with old label exists", func() {
 			existing.Labels["garden.sapcloud.io/purpose"] = purpose
 			expected := *existing.DeepCopy()
@@ -75,6 +83,7 @@ var _ = Describe("Actuator", func() {
 			allExisting = append(allExisting, existing)
 			allExpected = append(allExpected, expected)
 		})
+
 		It("secret is labeled with both labels", func() {
 			existing.Labels["garden.sapcloud.io/purpose"] = purpose
 			existing.Labels["gardener.cloud/purpose"] = purpose
@@ -83,6 +92,7 @@ var _ = Describe("Actuator", func() {
 			allExisting = append(allExisting, existing)
 			allExpected = append(allExpected, expected)
 		})
+
 		It("one old and one new secret exists", func() {
 			oldExisting := existing.DeepCopy()
 			oldExisting.Name = "old-deprecated"
@@ -95,6 +105,144 @@ var _ = Describe("Actuator", func() {
 			allExisting = append(allExisting, existing, oldExisting)
 			allExpected = append(allExpected, expected, expectedOld)
 		})
+	})
 
+	Describe("#CleanupLeakedClusterRoles", func() {
+		var (
+			ctrl *gomock.Controller
+
+			ctx = context.TODO()
+			c   *mockclient.MockClient
+
+			providerName = "provider-foo"
+			fakeErr      = errors.New("fake")
+
+			namespace1              = "abcd"
+			namespace2              = "efgh"
+			namespace3              = "ijkl"
+			nonMatchingClusterRoles = []rbacv1.ClusterRole{
+				{ObjectMeta: metav1.ObjectMeta{Name: "doesnotmatch"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("extensions.gardener.cloud:provider-bar:%s:machine-controller-manager", namespace1)}},
+				{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("extensions.gardener.cloud:%s:%s", providerName, namespace1)}},
+				{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("extensions.gardener.cloud:%s:%s:bar", providerName, namespace1)}},
+				{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("extensions.gardener.cloud:%s:machine-controller-manager", providerName)}},
+			}
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			c = mockclient.NewMockClient(ctrl)
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("should return an error while listing the clusterroles", func() {
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleList{})).Return(fakeErr)
+
+			Expect(CleanupLeakedClusterRoles(ctx, c, providerName)).To(Equal(fakeErr))
+		})
+
+		It("should return an error while listing the namespaces", func() {
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleList{}))
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.NamespaceList{})).Return(fakeErr)
+
+			Expect(CleanupLeakedClusterRoles(ctx, c, providerName)).To(Equal(fakeErr))
+		})
+
+		It("should do nothing because clusterrole list is empty", func() {
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleList{}))
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.NamespaceList{}))
+
+			Expect(CleanupLeakedClusterRoles(ctx, c, providerName)).To(Succeed())
+		})
+
+		It("should do nothing because clusterrole list doesn't contain matches", func() {
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleList{})).DoAndReturn(func(_ context.Context, list *rbacv1.ClusterRoleList, _ ...client.ListOption) error {
+				*list = rbacv1.ClusterRoleList{Items: nonMatchingClusterRoles}
+				return nil
+			})
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.NamespaceList{}))
+
+			Expect(CleanupLeakedClusterRoles(ctx, c, providerName)).To(Succeed())
+		})
+
+		It("should do nothing because no orphaned clusterroles found", func() {
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleList{})).DoAndReturn(func(_ context.Context, list *rbacv1.ClusterRoleList, _ ...client.ListOption) error {
+				*list = rbacv1.ClusterRoleList{
+					Items: append(nonMatchingClusterRoles, rbacv1.ClusterRole{
+						ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("extensions.gardener.cloud:%s:%s:machine-controller-manager", providerName, namespace1)},
+					}),
+				}
+				return nil
+			})
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.NamespaceList{})).DoAndReturn(func(_ context.Context, list *corev1.NamespaceList, _ ...client.ListOption) error {
+				*list = corev1.NamespaceList{
+					Items: []corev1.Namespace{
+						{ObjectMeta: metav1.ObjectMeta{Name: namespace1}},
+					},
+				}
+				return nil
+			})
+
+			Expect(CleanupLeakedClusterRoles(ctx, c, providerName)).To(Succeed())
+		})
+
+		It("should delete the orphaned clusterroles", func() {
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleList{})).DoAndReturn(func(_ context.Context, list *rbacv1.ClusterRoleList, _ ...client.ListOption) error {
+				*list = rbacv1.ClusterRoleList{
+					Items: append(
+						nonMatchingClusterRoles,
+						rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("extensions.gardener.cloud:%s:%s:machine-controller-manager", providerName, namespace1)}},
+						rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("extensions.gardener.cloud:%s:%s:machine-controller-manager", providerName, namespace2)}},
+						rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("extensions.gardener.cloud:%s:%s:machine-controller-manager", providerName, namespace3)}},
+					),
+				}
+				return nil
+			})
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.NamespaceList{})).DoAndReturn(func(_ context.Context, list *corev1.NamespaceList, _ ...client.ListOption) error {
+				*list = corev1.NamespaceList{
+					Items: []corev1.Namespace{
+						{ObjectMeta: metav1.ObjectMeta{Name: namespace1}},
+					},
+				}
+				return nil
+			})
+			c.EXPECT().Delete(ctx, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("extensions.gardener.cloud:%s:%s:machine-controller-manager", providerName, namespace2)}})
+			c.EXPECT().Delete(ctx, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("extensions.gardener.cloud:%s:%s:machine-controller-manager", providerName, namespace3)}})
+
+			Expect(CleanupLeakedClusterRoles(ctx, c, providerName)).To(Succeed())
+		})
+
+		It("should return the error occurred during orphaned clusterrole deletion", func() {
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleList{})).DoAndReturn(func(_ context.Context, list *rbacv1.ClusterRoleList, _ ...client.ListOption) error {
+				*list = rbacv1.ClusterRoleList{
+					Items: append(
+						nonMatchingClusterRoles,
+						rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("extensions.gardener.cloud:%s:%s:machine-controller-manager", providerName, namespace1)}},
+						rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("extensions.gardener.cloud:%s:%s:machine-controller-manager", providerName, namespace2)}},
+						rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("extensions.gardener.cloud:%s:%s:machine-controller-manager", providerName, namespace3)}},
+					),
+				}
+				return nil
+			})
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.NamespaceList{})).DoAndReturn(func(_ context.Context, list *corev1.NamespaceList, _ ...client.ListOption) error {
+				*list = corev1.NamespaceList{
+					Items: []corev1.Namespace{
+						{ObjectMeta: metav1.ObjectMeta{Name: namespace1}},
+					},
+				}
+				return nil
+			})
+			c.EXPECT().Delete(ctx, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("extensions.gardener.cloud:%s:%s:machine-controller-manager", providerName, namespace2)}})
+			c.EXPECT().Delete(ctx, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("extensions.gardener.cloud:%s:%s:machine-controller-manager", providerName, namespace3)}}).Return(fakeErr)
+
+			err := CleanupLeakedClusterRoles(ctx, c, providerName)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(BeAssignableToTypeOf(&multierror.Error{}))
+			Expect(err.(*multierror.Error).Errors).To(Equal([]error{fakeErr}))
+		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/kind cleanup
/priority normal

**What this PR does / why we need it**:
In an early state of the `Worker` extension we had a bug that was leaking `ClusterRole`s for the machine-controller-manager. It was fixed with https://github.com/gardener-attic/gardener-extensions/pull/378 but the leaked resources weren't cleaned up yet.
This PR adds a utility function to the generic `Worker` actuator package that can be called by affected extension controllers. It cleans up those orphaned resources.

**Which issue(s) this PR fixes**:
Fixes #2144

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
A utility function for cleaning up orphaned `ClusterRole`s for the `machine-controller-manager` was added to the `extensions/pkg/controller/worker/genericactuator` package.
```
