### PR TITLE
Correctly evalute seed settings when registering shooted seed

### DIFF
--- a/pkg/gardenlet/controller/shoot/seed_registration_control.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control.go
@@ -322,13 +322,13 @@ func prepareSeedConfig(ctx context.Context, k8sGardenClient kubernetes.Interface
 		},
 		Settings: &gardencorev1beta1.SeedSettings{
 			ExcessCapacityReservation: &gardencorev1beta1.SeedSettingExcessCapacityReservation{
-				Enabled: shootedSeedConfig.DisableCapacityReservation == nil || *shootedSeedConfig.DisableCapacityReservation,
+				Enabled: shootedSeedConfig.DisableCapacityReservation == nil || !*shootedSeedConfig.DisableCapacityReservation,
 			},
 			Scheduling: &gardencorev1beta1.SeedSettingScheduling{
 				Visible: shootedSeedConfig.Visible == nil || *shootedSeedConfig.Visible,
 			},
 			ShootDNS: &gardencorev1beta1.SeedSettingShootDNS{
-				Enabled: shootedSeedConfig.DisableDNS == nil || *shootedSeedConfig.DisableDNS,
+				Enabled: shootedSeedConfig.DisableDNS == nil || !*shootedSeedConfig.DisableDNS,
 			},
 		},
 		Taints: taints,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
The seed settings for excess capacity reservation and shoot DNS were not correctly evaluated when registering shooted seeds. This PR addresses the problem.

**Special notes for your reviewer**:
A similar PR (#2375) was already merged.
cc @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
