### PR TITLE
Changed rate of 1m to 2m on all grafana dashboards

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-dashboard.json
@@ -816,7 +816,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_fs_reads_bytes_total{namespace=\"kube-system\", pod=~\"etcd-(${cluster:pipe}).*\"}[1m])) by(pod, container)",
+          "expr": "sum(rate(container_fs_reads_bytes_total{namespace=\"kube-system\", pod=~\"etcd-(${cluster:pipe}).*\"}[2m])) by(pod, container)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} / {{container}}",
@@ -826,7 +826,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Container Disk Read Operations (1m rate)",
+      "title": "Container Disk Read Operations (2m rate)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -900,7 +900,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_fs_writes_bytes_total{namespace=\"kube-system\", pod=~\"etcd-(${cluster:pipe}).*\"}[1m])) by(pod, container)",
+          "expr": "sum(rate(container_fs_writes_bytes_total{namespace=\"kube-system\", pod=~\"etcd-(${cluster:pipe}).*\"}[2m])) by(pod, container)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} / {{container}}",
@@ -910,7 +910,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Container Disk Write Operations (1m rate)",
+      "title": "Container Disk Write Operations (2m rate)",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
@@ -169,7 +169,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{container=~\"$container\",pod=~\"$pod\"}[1m]))",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{container=~\"$container\",pod=~\"$pod\"}[2m]))",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -283,7 +283,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"$pod\"}[2m])) by (pod)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Received",
@@ -291,7 +291,7 @@
           "step": 20
         },
         {
-          "expr": "- sum(rate(container_network_transmit_bytes_total{pod=~\"$pod\"}[1m])) by (pod)",
+          "expr": "- sum(rate(container_network_transmit_bytes_total{pod=~\"$pod\"}[2m])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Sent",

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/vpn-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/vpn-dashboard.json
@@ -170,7 +170,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sort_desc(sum by (pod) (rate (container_network_receive_bytes_total{pod=~\"vpn-shoot-.*\"}[1m]) ))",
+          "expr": "sort_desc(sum by (pod) (rate (container_network_receive_bytes_total{pod=~\"vpn-shoot-.*\"}[2m]) ))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Received",
@@ -178,7 +178,7 @@
           "step": 20
         },
         {
-          "expr": "-sort_desc(sum by (pod) (rate (container_network_transmit_bytes_total{pod=~\"vpn-shoot-.*\"}[1m]) ))",
+          "expr": "-sort_desc(sum by (pod) (rate (container_network_transmit_bytes_total{pod=~\"vpn-shoot-.*\"}[2m]) ))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Transmitted",
@@ -274,7 +274,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"vpn-shoot-.*\"}[1m]))",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"vpn-shoot-.*\"}[2m]))",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -518,7 +518,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_cpu_usage_seconds_total{pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}[1m])",
+          "expr": "rate(container_cpu_usage_seconds_total{pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}[2m])",
           "format": "time_series",
           "hide": false,
           "interval": "10s",

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
@@ -553,7 +553,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[1m])) by (node) + on (node) group_right sum(kube_node_labels{label_worker_garden_sapcloud_io_group=~\"$worker_group\"}) by (label_worker_garden_sapcloud_io_group, node) - 1",
+          "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[2m])) by (node) + on (node) group_right sum(kube_node_labels{label_worker_garden_sapcloud_io_group=~\"$worker_group\"}) by (label_worker_garden_sapcloud_io_group, node) - 1",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area monitoring
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Prometheus has a scrape interval of 1m and some dashboards did not reflect this yet. To make sure that data is displayed correctly all dashboards with a rate of 1m have been changed to 2m.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @tim-ebert 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Some grafana dashboards have been changed to use a rate of 2m instead of 1m.
```
