### PR TITLE
Nit: Specify sideEffects for validate-kubeconfig-secrets webhook

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/validatingwebhook-controller-manager.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/validatingwebhook-controller-manager.yaml
@@ -53,4 +53,5 @@ webhooks:
       path: /webhooks/validate-kubeconfig-secrets
     {{- end }}
     caBundle: {{ required ".Values.global.controller.config.server.https.tls.caBundle is required" (b64enc .Values.global.controller.config.server.https.tls.caBundle) }}
+  sideEffects: None
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Currently trying kubectl apply with `--dry-run=server` and a cloud provider secret:
```
$ k apply -f cloudprovider-secret.yaml --dry-run=server
Error from server (BadRequest): error when creating "cloudprovider-secret.yaml": admission webhook "validate-kubeconfig-secrets.gardener.cloud" does not support dry run
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Ref https://github.com/gardener/gardener-extension-provider-aws/pull/89

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
