### PR TITLE
Improve local-garden setup for Mac users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ local-garden-up:
 	# After this step, you can start using the cluster at hack/local-garden/kubeconfigs/admin.conf
 	@./hack/local-development/local-garden/apply-rbac-garden-ns
 
-	# Now you can start using the cluster at with `export KUBECONFIG=hack/local-garden/kubeconfigs/default-admin.conf`
+	# Now you can start using the cluster at with `export KUBECONFIG=hack/local-development/local-garden/kubeconfigs/default-admin.conf`
 	# Then you need to run `make dev-setup` to setup config and certificates files for gardener's components and to register the gardener-apiserver.
 	# Finally, run `make start-apiserver,start-controller-manager,start-scheduler,start-gardenlet` to start the gardener components as usual.
 

--- a/hack/local-development/dev-setup-register-gardener
+++ b/hack/local-development/dev-setup-register-gardener
@@ -24,7 +24,10 @@ APISERVER_ENDPOINT_NAME="gardener-apiserver"
 APISERVER_SERVICE_PORT=443
 APISERVICE_PORT_STRING=""
 
-APISERVER_EXTERNALNAME=gardener.localhost
+APISERVER_EXTERNALNAME=docker.for.mac.localhost
+if [[ "$(uname -s)" != *"Darwin"* ]]; then
+  APISERVER_EXTERNALNAME=gardener.localhost
+fi
 
 CORE_V1ALPHA1_APISERVICE_NAME="v1alpha1.core.gardener.cloud"
 CORE_V1BETA1_APISERVICE_NAME="v1beta1.core.gardener.cloud"
@@ -37,7 +40,6 @@ if [[ $(k8s_env) == "$NODELESS" ]]; then
   APISERVER_SERVICE_PORT=8443
   APISERVICE_PORT_STRING="    port: $APISERVER_SERVICE_PORT"
 fi
-
 
 if kubectl get apiservice "$CORE_V1ALPHA1_APISERVICE_NAME" &> /dev/null; then
   kubectl delete apiservice $CORE_V1ALPHA1_APISERVICE_NAME --wait=false

--- a/hack/local-development/local-garden/README.md
+++ b/hack/local-development/local-garden/README.md
@@ -10,9 +10,8 @@ Local-Garden consists of the following main directories:
 - *Certificates:* This directory contains all the certificates/keys/configs required for this setup.
 - *Kubeconfigs:* Contains the necessary configuration required for creating the admin and the controller-manager kubeconfigs.
 
-The rest of the directory consists of scripts to run the nodeless cluster components `kube-api-server`, `kube-controller-manager`,
+The rest of the directory consists of scripts to run the node-less cluster components `kube-apiserver`, `kube-controller-manager`,
 `etcd`. As well as scripts required for the Gardener aggregated API-server `gardener-etcd` and `apply-proxy-rbac`.
-
 
 The below figure describes how these components interact with one another.
 ![](img/2020-01-23-10-03-21.png)

--- a/hack/local-development/local-garden/apply-rbac-garden-ns
+++ b/hack/local-development/local-garden/apply-rbac-garden-ns
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-KUBECONFIGPATH=$SCRIPTPATH/kubeconfigs/default-admin.conf
+KUBECONFIGPATH="$(dirname $0)/kubeconfigs/default-admin.conf"
 
 cat <<EOF | KUBECONFIG=$KUBECONFIGPATH kubectl apply -f -
 ---
@@ -19,7 +18,6 @@ metadata:
     gardener.cloud/role: admin
 rules:
 - apiGroups:
-  - garden.sapcloud.io
   - core.gardener.cloud
   - dashboard.gardener.cloud
   - settings.gardener.cloud

--- a/hack/local-development/local-garden/cleanup
+++ b/hack/local-development/local-garden/cleanup
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-LABEL=${1:-local-garden}
+LABEL="${1:-local-garden}"
 
 docker rm -f $(docker ps -f "label=$LABEL" -aq) 2&> /dev/null || true
-docker network rm $(docker network ls -qf "label=$LABEL")  2&> /dev/null || true
+docker network rm $(docker network ls -qf "label=$LABEL") 2&> /dev/null || true

--- a/hack/local-development/local-garden/run-gardener-etcd
+++ b/hack/local-development/local-garden/run-gardener-etcd
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-LABEL=${1:-local-garden}
+LABEL="${1:-local-garden}"
 
 IMAGE=quay.io/coreos/etcd:v3.3.10
 PORT=22380
@@ -10,10 +10,8 @@ CLUSTERNAME=gardener-etcd
 # Change this value to the desired storage location
 ETCD_DATA_DIR="$PWD/dev/gardener-etcd/gardener"
 
-
 PORTS="-p $PORT:$PORT -p $ETCDPORT:$ETCDPORT"
 MOUNTS="-v $ETCD_DATA_DIR:/etcd-data"
-
 
 echo "Starting gardener-dev gardener-etcd cluster!"
 docker run -d --name g-etcd -l $LABEL --network gardener-dev --rm $PORTS $MOUNTS $IMAGE etcd --name $CLUSTERNAME \

--- a/hack/local-development/local-garden/run-kube-apiserver
+++ b/hack/local-development/local-garden/run-kube-apiserver
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
-
-IP_ROUTE=$(ip route get 1)
-IP_ADDRESS=$(echo ${IP_ROUTE#*src} | awk '{print $1}')
-
-DNS_NAME=gardener.localhost
-HOSTS_LINE=$DNS_NAME:$IP_ADDRESS
+IP_ROUTE=""
+IP_ADDRESS=""
+ADD_HOSTS=""
+if [[ "$(uname -s)" != *"Darwin"* ]]; then
+  IP_ROUTE=$(ip route get 1)
+  IP_ADDRESS=$(echo ${IP_ROUTE#*src} | awk '{print $1}')
+  ADD_HOSTS="--add-host gardener.localhost:$IP_ADDRESS"
+fi
 
 LABEL=${1:-local-garden}
 
@@ -17,7 +19,7 @@ ETCD_PORT=12379
 LISTEN_PORT="2443"
 
 echo "Starting gardener-dev kube-apiserver!"
-docker run -d --name kube-apiserver -l $LABEL --add-host $HOSTS_LINE --network gardener-dev --rm -p $LISTEN_PORT:$LISTEN_PORT $MOUNTS $IMAGE /usr/local/bin/kube-apiserver \
+docker run -d --name kube-apiserver -l $LABEL $ADD_HOSTS --network gardener-dev --rm -p $LISTEN_PORT:$LISTEN_PORT $MOUNTS $IMAGE /usr/local/bin/kube-apiserver \
   --etcd-servers="https://etcd:$ETCD_PORT" \
   --storage-media-type='application/json' \
   --authorization-mode="Node,RBAC" \

--- a/hack/local-development/local-garden/run-kube-controller-manager
+++ b/hack/local-development/local-garden/run-kube-controller-manager
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 
-LABEL=${1:-local-garden}
-
+LABEL="${1:-local-garden}"
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 IMAGE=k8s.gcr.io/kube-controller-manager:v1.17.3
 MOUNTS="-v $SCRIPTPATH/certificates/certs:/certs -v $SCRIPTPATH/certificates/keys:/keys -v $SCRIPTPATH/kubeconfigs/default-controller-manager.conf:/kubeconfig"
-
 
 echo "Starting gardener-dev kube-controller-manager!"
 docker run -d --name kube-controller-manager -l $LABEL --network gardener-dev --rm $MOUNTS $IMAGE /usr/local/bin/kube-controller-manager \

--- a/hack/local-development/local-garden/run-kube-etcd
+++ b/hack/local-development/local-garden/run-kube-etcd
@@ -5,17 +5,14 @@ LABEL=${1:-local-garden}
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
 IMAGE=quay.io/coreos/etcd:v3.3.10
-
 HTTPS_PEER_PORT=12380
 HTTP_PEER_PORT=12381
 HTTPS_ETCD_PORT=12379
 HTTP_ETCD_PORT=32739
-
 CLUSTERNAME=gardener-etcd
 
 # Change this value to the desired storage location
 ETCD_DATA_DIR="$PWD/dev/gardener-etcd/kubernetes"
-
 
 PORTS="-p $PORT:$PORT -p $ETCDPORT:$ETCDPORT"
 MOUNTS="-v $SCRIPTPATH/certificates/certs:/certs -v $SCRIPTPATH/certificates/keys:/keys -v $ETCD_DATA_DIR:/etcd-data"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area dev-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR mainly improves how the kube-apiserver running as Docker container talks to the gardener-apiserver running as process on the host.

**Special notes for your reviewer**:
/cc @timuthy @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
