### PR TITLE
VPA 0.8.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -204,16 +204,16 @@ images:
 # VPA
 - name: vpa-admission-controller
   sourceRepository: github.com/kubernetes/autoscaler
-  repository: k8s.gcr.io/vpa-admission-controller
-  tag: "0.6.3"
+  repository: eu.gcr.io/k8s-artifacts-prod/autoscaling/vpa-admission-controller
+  tag: "0.8.0"
 - name: vpa-recommender
   sourceRepository: github.com/kubernetes/autoscaler
-  repository: k8s.gcr.io/vpa-recommender
-  tag: "0.6.3"
+  repository: eu.gcr.io/k8s-artifacts-prod/autoscaling/vpa-recommender
+  tag: "0.8.0"
 - name: vpa-updater
   sourceRepository: github.com/kubernetes/autoscaler
-  repository: k8s.gcr.io/vpa-updater
-  tag: "0.6.3"
+  repository: eu.gcr.io/k8s-artifacts-prod/autoscaling/vpa-updater
+  tag: "0.8.0"
 - name: vpa-exporter
   sourceRepository: github.com/gardener/vpa-exporter
   repository: eu.gcr.io/gardener-project/gardener/vpa-exporter

--- a/charts/seed-bootstrap/charts/vpa/templates/updater-deployment.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/updater-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         args:
         - --min-replicas=1
         - --eviction-tolerance=1
-        - --evict-after-oom-treshold=48h
+        - --evict-after-oom-threshold=48h
         - --v=2
         - --stderrthreshold=info
         resources:

--- a/charts/seed-bootstrap/charts/vpa/templates/vpa-crd.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/vpa-crd.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -12,32 +13,56 @@ spec:
     singular: verticalpodautoscaler
     kind: VerticalPodAutoscaler
     shortNames:
-    - vpa
+      - vpa
   version: v1beta1
   versions:
   - name: v1beta1
-    served: true
+    served: false
     storage: false
   - name: v1beta2
     served: true
     storage: true
+  - name: v1
+    served: true
+    storage: false
   validation:
     # openAPIV3Schema is the schema for validating custom objects.
     openAPIV3Schema:
+      type: object
       properties:
         spec:
+          type: object
           required: []
           properties:
             targetRef:
               type: object
             updatePolicy:
+              type: object
               properties:
                 updateMode:
                   type: string
             resourcePolicy:
+              type: object
               properties:
                 containerPolicies:
                   type: array
+                  items:
+                    type: object
+                    properties:
+                      containerName:
+                        type: string
+                      mode:
+                        type: string
+                        enum: ["Auto", "Off"]
+                      minAllowed:
+                        type: object
+                      maxAllowed:
+                        type: object
+                      controlledResources:
+                        type: array
+                        items:
+                          type: string
+                          enum: ["cpu", "memory"]
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -53,12 +78,15 @@ spec:
     singular: verticalpodautoscalercheckpoint
     kind: VerticalPodAutoscalerCheckpoint
     shortNames:
-    - vpacheckpoint
+      - vpacheckpoint
   version: v1beta1
   versions:
   - name: v1beta1
-    served: true
+    served: false
     storage: false
   - name: v1beta2
     served: true
     storage: true
+  - name: v1
+    served: true
+    storage: false

--- a/charts/seed-bootstrap/charts/vpa/templates/vpa-rbac.yaml
+++ b/charts/seed-bootstrap/charts/vpa/templates/vpa-rbac.yaml
@@ -58,6 +58,14 @@ rules:
   - list
   - watch
   - patch
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
@@ -104,8 +112,8 @@ metadata:
 {{ toYaml .Values.labels | indent 4 }}
 rules:
 - apiGroups:
-  - "extensions"
   - "apps"
+  - "extensions"
   resources:
   - replicasets
   verbs:
@@ -172,6 +180,13 @@ metadata:
   labels:
 {{ toYaml .Values.labels | indent 4 }}
 rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*/scale'
+  verbs:
+  - get
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -292,6 +307,16 @@ rules:
   resources:
   - verticalpodautoscalers
   verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - create
+  - update
   - get
   - list
   - watch


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area auto-scaling
/area scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Upgrades VPA to 0.8.0

**Which issue(s) this PR fixes**:
Fixes #1942

**Special notes for your reviewer**:
The repository for the VPA images has [changed](https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-0.8.0). I've selected the `eu` repository but there are others available.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Upgrade VPA to 0.8.0
```
