### PR TITLE
Fix PSP for kube-proxy

### DIFF
--- a/charts/shoot-core/components/charts/kube-proxy/templates/psp/kube-proxy-psp.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/psp/kube-proxy-psp.yaml
@@ -16,6 +16,7 @@ spec:
   - pathPrefix: /usr/share/ca-certificates
   - pathPrefix: /var/run/dbus/system_bus_socket
   - pathPrefix: /lib/modules
+  - pathPrefix: /var/lib/kube-proxy
   runAsUser:
     rule: 'RunAsAny'
   seLinux:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area networking
/kind bug
/priority normal

**What this PR does / why we need it**:
#2238 introduce a bug, that the `kube-proxy` could not start up properly for newly created cluster with `.spec.kubernetes.allowPrivilegedContainers=false`.
This PR fixes this issue.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
A bug has been fixed, which caused the `kube-proxy` to fail starting up for clusters with `.spec.kubernetes.allowPrivilegedContainers=false`.
```
