### PR TITLE
Add flag 'allowPrivilegedContainers' to the Shoot creation framework

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -32,6 +32,7 @@ spec:
     -networking-services=$NETWORKING_SERVICES
     -networking-nodes=$NETWORKING_NODES
     -start-hibernated=$START_HIBERNATED
+    -allow-privileged-containers=$ALLOW_PRIVILEGED_CONTAINERS
 #    -machine-image-name=$MACHINE_IMAGE
 #    -machine-image-version=$MACHINE_IMAGE_VERSION
 #    -machine-type=$MACHINE_TYPE

--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/retry"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -218,6 +219,11 @@ func setShootGeneralSettings(shoot *gardencorev1beta1.Shoot, cfg *ShootCreationC
 			shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{}
 		}
 		shoot.Spec.Hibernation.Enabled = &cfg.startHibernated
+	}
+
+	// allow privileged containers defaults to true
+	if cfg.allowPrivilegedContainers != nil {
+		shoot.Spec.Kubernetes.AllowPrivilegedContainers = cfg.allowPrivilegedContainers
 	}
 
 	if clearExtensions {

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -33,31 +33,33 @@ var shootCreationCfg *ShootCreationConfig
 type ShootCreationConfig struct {
 	GardenerConfig *GardenerConfig
 
-	shootKubeconfigPath          string
-	seedKubeconfigPath           string
-	testShootName                string
-	testShootPrefix              string
-	shootMachineImageName        string
-	shootMachineType             string
-	shootMachineImageVersion     string
-	cloudProfile                 string
-	seedName                     string
-	shootRegion                  string
-	secretBinding                string
-	shootProviderType            string
-	shootK8sVersion              string
-	externalDomain               string
-	workerZone                   string
-	networkingPods               string
-	networkingServices           string
-	networkingNodes              string
-	startHibernatedFlag          string
-	startHibernated              bool
-	infrastructureProviderConfig string
-	controlPlaneProviderConfig   string
-	networkingProviderConfig     string
-	workersConfig                string
-	shootYamlPath                string
+	shootKubeconfigPath           string
+	seedKubeconfigPath            string
+	testShootName                 string
+	testShootPrefix               string
+	shootMachineImageName         string
+	shootMachineType              string
+	shootMachineImageVersion      string
+	cloudProfile                  string
+	seedName                      string
+	shootRegion                   string
+	secretBinding                 string
+	shootProviderType             string
+	shootK8sVersion               string
+	externalDomain                string
+	workerZone                    string
+	networkingPods                string
+	networkingServices            string
+	networkingNodes               string
+	startHibernatedFlag           string
+	startHibernated               bool
+	allowPrivilegedContainersFlag string
+	allowPrivilegedContainers     *bool
+	infrastructureProviderConfig  string
+	controlPlaneProviderConfig    string
+	networkingProviderConfig      string
+	workersConfig                 string
+	shootYamlPath                 string
 }
 
 // ShootCreationFramework represents the shoot test framework that includes
@@ -131,6 +133,14 @@ func validateShootCreationConfig(cfg *ShootCreationConfig) {
 			ginkgo.Fail("startHibernated is not a boolean value")
 		}
 		cfg.startHibernated = parsedBool
+	}
+
+	if StringSet(cfg.allowPrivilegedContainersFlag) {
+		parsedBool, err := strconv.ParseBool(cfg.allowPrivilegedContainersFlag)
+		if err != nil {
+			ginkgo.Fail("allowPrivilegedContainers is not a boolean value")
+		}
+		cfg.allowPrivilegedContainers = &parsedBool
 	}
 
 	if !StringSet(cfg.infrastructureProviderConfig) {
@@ -252,6 +262,14 @@ func mergeShootCreationConfig(base, overwrite *ShootCreationConfig) *ShootCreati
 		base.startHibernated = overwrite.startHibernated
 	}
 
+	if StringSet(overwrite.allowPrivilegedContainersFlag) {
+		base.allowPrivilegedContainersFlag = overwrite.allowPrivilegedContainersFlag
+	}
+
+	if overwrite.allowPrivilegedContainers != nil {
+		base.allowPrivilegedContainers = overwrite.allowPrivilegedContainers
+	}
+
 	if StringSet(overwrite.infrastructureProviderConfig) {
 		base.infrastructureProviderConfig = overwrite.infrastructureProviderConfig
 	}
@@ -300,6 +318,8 @@ func RegisterShootCreationFrameworkFlags() *ShootCreationConfig {
 	flag.StringVar(&newCfg.networkingServices, "networking-services", "", "the spec.networking.services to use for this shoot. Optional.")
 	flag.StringVar(&newCfg.networkingNodes, "networking-nodes", "", "the spec.networking.nodes to use for this shoot. Optional.")
 	flag.StringVar(&newCfg.startHibernatedFlag, "start-hibernated", "", "the spec.hibernation.enabled to use for this shoot. Optional.")
+	flag.StringVar(&newCfg.allowPrivilegedContainersFlag, "allow-privileged-containers", "", "the spec.kubernetes.allowPrivilegedContainers to use for this shoot. Optional, defaults to true.")
+
 	newCfg.startHibernated = false
 
 	// ProviderConfigs flags


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area testing
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Add flag 'allowPrivilegedContainers' to the Shoot creation framework.
This is needed to test Shoot creation having .Spec.Kubernetes.allowPrivilegedContainers = false. (defaults to true).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
