### PR TITLE
Nit: Fix the newObj, oldObj order

### DIFF
--- a/pkg/gardenlet/controller/federatedseed/extensions/extensions.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/extensions.go
@@ -193,6 +193,6 @@ func extensionPredicateFunc(f func(extensionsv1alpha1.Object, extensionsv1alpha1
 			newExtensionObj, ok1 = newObj.(extensionsv1alpha1.Object)
 			oldExtensionObj, ok2 = oldObj.(extensionsv1alpha1.Object)
 		)
-		return ok1 && ok2 && f(oldExtensionObj, newExtensionObj)
+		return ok1 && ok2 && f(newExtensionObj, oldExtensionObj)
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/priority normal

**What this PR does / why we need it**:
`extensionPredicateFunc` callers pass `func` which first accept `new`, `old`. `extensionPredicateFunc` itself calls `f` with `old`, `new`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
