### PR TITLE
Fix retaining existing pod annotations in GSAC

### DIFF
--- a/pkg/seedadmission/pods.go
+++ b/pkg/seedadmission/pods.go
@@ -88,23 +88,22 @@ func mutateShootControlPlanePodAnnotations(ctx context.Context, c client.Client,
 		"fluentbit.io/exclude": "true",
 	}
 
-	for key, value := range annotationsToAdd {
-		if originalAnnotations == nil || originalAnnotations[key] == "" {
-			patch = append(patch, jsonpatch.JsonPatchOperation{
-				Operation: "add",
-				Path:      "/metadata/annotations",
-				Value: map[string]string{
-					key: value,
-				},
-			})
-		} else {
+	if originalAnnotations != nil {
+		for key, value := range annotationsToAdd {
 			patch = append(patch, jsonpatch.JsonPatchOperation{
 				Operation: "replace",
 				Path:      "/metadata/annotations/" + strings.ReplaceAll(key, "/", "~1"),
 				Value:     value,
 			})
 		}
+		return patch, nil
 	}
+
+	patch = append(patch, jsonpatch.JsonPatchOperation{
+		Operation: "add",
+		Path:      "/metadata/annotations",
+		Value:     annotationsToAdd,
+	})
 	return patch, nil
 }
 

--- a/pkg/seedadmission/pods_test.go
+++ b/pkg/seedadmission/pods_test.go
@@ -44,10 +44,10 @@ import (
 )
 
 type DescribeTableArgs struct {
-	ExpectedPatche *jsonpatch.JsonPatchOperation
-	Annotations    map[string]string
-	Cluster        *extensionsv1alpha1.Cluster
-	Object         *runtime.Object
+	ExpectedPatch *jsonpatch.JsonPatchOperation
+	Annotations   map[string]string
+	Cluster       *extensionsv1alpha1.Cluster
+	Object        *runtime.Object
 }
 
 var _ = Describe("Pods", func() {
@@ -181,31 +181,31 @@ var _ = Describe("Pods", func() {
 					patches, err := MutatePod(ctx, c, logger, request)
 					Expect(err).ToNot(HaveOccurred(), resourceToId(resource))
 
-					if args.ExpectedPatche != nil {
-						Expect(patches).To(ConsistOf(*args.ExpectedPatche))
+					if args.ExpectedPatch != nil {
+						Expect(patches).To(ConsistOf(*args.ExpectedPatch))
 					} else {
 						Expect(patches).To(BeNil())
 					}
 				},
 				Entry("It should add annotation to object", DescribeTableArgs{
-					ExpectedPatche: espectedPatcheAddFluentBitExludeTrue,
-					Annotations:    nil,
-					Cluster:        testingCluster,
+					ExpectedPatch: espectedPatcheAddFluentBitExludeTrue,
+					Annotations:   nil,
+					Cluster:       testingCluster,
 				}),
 				Entry("It should replace annotation to object", DescribeTableArgs{
-					ExpectedPatche: espectedPatcheReplaceFluentBitExludeTrue,
-					Annotations:    annotationFluentBitExludeTrue,
-					Cluster:        testingCluster,
+					ExpectedPatch: espectedPatcheReplaceFluentBitExludeTrue,
+					Annotations:   annotationFluentBitExludeTrue,
+					Cluster:       testingCluster,
 				}),
 				Entry("It should not add annotation to object", DescribeTableArgs{
-					ExpectedPatche: nil,
-					Annotations:    nil,
-					Cluster:        developmentNotHibernatedCluster,
+					ExpectedPatch: nil,
+					Annotations:   nil,
+					Cluster:       developmentNotHibernatedCluster,
 				}),
 				Entry("It should not replace annotation to object", DescribeTableArgs{
-					ExpectedPatche: nil,
-					Annotations:    annotationFluentBitExludeTrue,
-					Cluster:        developmentNotHibernatedCluster,
+					ExpectedPatch: nil,
+					Annotations:   annotationFluentBitExludeTrue,
+					Cluster:       developmentNotHibernatedCluster,
 				}),
 			)
 		})
@@ -263,31 +263,31 @@ var _ = Describe("Pods", func() {
 					patches, err := MutatePod(ctx, c, logger, request)
 					Expect(err).ToNot(HaveOccurred(), resourceToId(resource))
 
-					if args.ExpectedPatche != nil {
-						Expect(patches).To(ConsistOf(*args.ExpectedPatche))
+					if args.ExpectedPatch != nil {
+						Expect(patches).To(ConsistOf(*args.ExpectedPatch))
 					} else {
 						Expect(patches).To(BeNil())
 					}
 				},
 				Entry("It should add annotation to object", DescribeTableArgs{
-					ExpectedPatche: espectedPatcheAddFluentBitExludeTrue,
-					Annotations:    nil,
-					Cluster:        testingCluster,
+					ExpectedPatch: espectedPatcheAddFluentBitExludeTrue,
+					Annotations:   nil,
+					Cluster:       testingCluster,
 				}),
 				Entry("It should replace annotation to object", DescribeTableArgs{
-					ExpectedPatche: espectedPatcheReplaceFluentBitExludeTrue,
-					Annotations:    annotationFluentBitExludeTrue,
-					Cluster:        testingCluster,
+					ExpectedPatch: espectedPatcheReplaceFluentBitExludeTrue,
+					Annotations:   annotationFluentBitExludeTrue,
+					Cluster:       testingCluster,
 				}),
 				Entry("It should not add annotation to object", DescribeTableArgs{
-					ExpectedPatche: nil,
-					Annotations:    nil,
-					Cluster:        developmentNotHibernatedCluster,
+					ExpectedPatch: nil,
+					Annotations:   nil,
+					Cluster:       developmentNotHibernatedCluster,
 				}),
 				Entry("It should not replace annotation to object", DescribeTableArgs{
-					ExpectedPatche: nil,
-					Annotations:    annotationFluentBitExludeTrue,
-					Cluster:        developmentNotHibernatedCluster,
+					ExpectedPatch: nil,
+					Annotations:   annotationFluentBitExludeTrue,
+					Cluster:       developmentNotHibernatedCluster,
 				}),
 			)
 		})
@@ -361,31 +361,36 @@ var _ = Describe("Pods", func() {
 					patches, err := MutatePod(ctx, c, logger, request)
 					Expect(err).ToNot(HaveOccurred(), resourceToId(resource))
 
-					if args.ExpectedPatche != nil {
-						Expect(patches).To(ConsistOf(*args.ExpectedPatche))
+					if args.ExpectedPatch != nil {
+						Expect(patches).To(ConsistOf(*args.ExpectedPatch))
 					} else {
 						Expect(patches).To(BeNil())
 					}
 				},
 				Entry("It should add annotation to object", DescribeTableArgs{
-					ExpectedPatche: espectedPatcheAddFluentBitExludeTrue,
-					Annotations:    nil,
-					Cluster:        testingCluster,
+					ExpectedPatch: espectedPatcheAddFluentBitExludeTrue,
+					Annotations:   nil,
+					Cluster:       testingCluster,
 				}),
 				Entry("It should replace annotation to object", DescribeTableArgs{
-					ExpectedPatche: espectedPatcheReplaceFluentBitExludeTrue,
-					Annotations:    annotationFluentBitExludeTrue,
-					Cluster:        testingCluster,
+					ExpectedPatch: espectedPatcheReplaceFluentBitExludeTrue,
+					Annotations:   annotationFluentBitExludeTrue,
+					Cluster:       testingCluster,
+				}),
+				Entry("It should replace annotation to object w/o Fluent Bit excluder", DescribeTableArgs{
+					ExpectedPatch: espectedPatcheReplaceFluentBitExludeTrue,
+					Annotations:   map[string]string{"foo": "bar"},
+					Cluster:       testingCluster,
 				}),
 				Entry("It should not add annotation to object", DescribeTableArgs{
-					ExpectedPatche: nil,
-					Annotations:    nil,
-					Cluster:        developmentNotHibernatedCluster,
+					ExpectedPatch: nil,
+					Annotations:   nil,
+					Cluster:       developmentNotHibernatedCluster,
 				}),
 				Entry("It should not replace annotation to object", DescribeTableArgs{
-					ExpectedPatche: nil,
-					Annotations:    annotationFluentBitExludeTrue,
-					Cluster:        developmentNotHibernatedCluster,
+					ExpectedPatch: nil,
+					Annotations:   annotationFluentBitExludeTrue,
+					Cluster:       developmentNotHibernatedCluster,
 				}),
 			)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area control-plane
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR fixes the patch calculation for pods belonging to a **test shoot** in the GSAC. These pods are supposed to be annotated with `"fluentbit.io/exclude": "true"` (see #2320). However, the previously calculated patch caused any existing annotations of a Pod to be dropped if an update (create) request didn't already contain the `"fluentbit.io/exclude"` annotation.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issues has been resolved which caused missing annotations for control plane pods of test shoots (`.spec.purpose: testing`).
```
