### PR TITLE
[GEP-7] Enhance migration, fix BackupEntry annotation bug

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -33,8 +33,8 @@ import (
 )
 
 // Restore uses the Worker's spec to figure out the wanted MachineDeployments. Then it parses the Worker's state.
-// If there is a record in the state  corresponding to a wanted deployment then the Restore function
-// deploys that MachineDeployemnt with all related MachineSet and Machines.
+// If there is a record in the state corresponding to a wanted deployment then the Restore function
+// deploys that MachineDeployment with all related MachineSet and Machines.
 func (a *genericActuator) Restore(ctx context.Context, worker *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster) error {
 	workerDelegate, err := a.delegateFactory.WorkerDelegate(ctx, worker, cluster)
 	if err != nil {
@@ -157,9 +157,13 @@ func (a *genericActuator) waitUntilStatusIsUpdates(ctx context.Context, obj runt
 }
 
 func removeWantedDeploymentWithoutState(wantedMachineDeployments workercontroller.MachineDeployments) workercontroller.MachineDeployments {
-	var reducedMachineDeployments workercontroller.MachineDeployments
+	if wantedMachineDeployments == nil {
+		return nil
+	}
+
+	reducedMachineDeployments := make(workercontroller.MachineDeployments, 0)
 	for _, wantedMachineDeployment := range wantedMachineDeployments {
-		if wantedMachineDeployment.State != nil || len(wantedMachineDeployment.State.MachineSets) < 1 {
+		if wantedMachineDeployment.State != nil && len(wantedMachineDeployment.State.MachineSets) < 1 {
 			reducedMachineDeployments = append(reducedMachineDeployments, wantedMachineDeployment)
 		}
 	}

--- a/pkg/api/extensions/accessor.go
+++ b/pkg/api/extensions/accessor.go
@@ -181,7 +181,7 @@ func (u unstructuredStatusAccessor) GetState() *runtime.RawExtension {
 }
 
 // SetState implements Status.
-func (u unstructuredStatusAccessor) SetState(state *runtime.RawExtension) {
+func (u unstructuredStatusAccessor) SetState(state runtime.RawExtension) {
 	unstrc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&state)
 	if err != nil {
 		return

--- a/pkg/api/extensions/accessor.go
+++ b/pkg/api/extensions/accessor.go
@@ -180,6 +180,18 @@ func (u unstructuredStatusAccessor) GetState() *runtime.RawExtension {
 	return raw
 }
 
+// SetState implements Status.
+func (u unstructuredStatusAccessor) SetState(state *runtime.RawExtension) {
+	unstrc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&state)
+	if err != nil {
+		return
+	}
+
+	if err := unstructured.SetNestedField(u.UnstructuredContent(), unstrc, "status", "state"); err != nil {
+		return
+	}
+}
+
 // GetConditions implements Status.
 func (u unstructuredStatusAccessor) GetConditions() []gardencorev1beta1.Condition {
 	val, ok, err := unstructured.NestedFieldNoCopy(u.UnstructuredContent(), "status", "conditions")
@@ -232,4 +244,20 @@ func (u unstructuredStatusAccessor) GetResources() []gardencorev1beta1.NamedReso
 		resources = append(resources, *resource)
 	}
 	return resources
+}
+
+// SetResources implements Status.
+func (u unstructuredStatusAccessor) SetResources(namedResourceReference []gardencorev1beta1.NamedResourceReference) {
+	var interfaceSlice = make([]interface{}, len(namedResourceReference))
+	for i, d := range namedResourceReference {
+		unstrc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&d)
+		if err != nil {
+			return
+		}
+		interfaceSlice[i] = unstrc
+	}
+	err := unstructured.SetNestedSlice(u.UnstructuredContent(), interfaceSlice, "status", "resources")
+	if err != nil {
+		return
+	}
 }

--- a/pkg/api/extensions/accessor_test.go
+++ b/pkg/api/extensions/accessor_test.go
@@ -184,6 +184,15 @@ var _ = Describe("Accessor", func() {
 				})
 			})
 
+			Describe("#SetState", func() {
+				It("should set the extensions state", func() {
+					state := &runtime.RawExtension{Raw: []byte("{\"raw\":\"ext\"}")}
+					acc := mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{})
+					acc.SetState(state)
+					Expect(acc.GetState()).To(Equal(state))
+				})
+			})
+
 			Describe("#GetResources", func() {
 				It("should get the resources", func() {
 					var (
@@ -221,6 +230,26 @@ var _ = Describe("Accessor", func() {
 					acc.SetConditions(conditions)
 					getConditions := acc.GetConditions()
 					Expect(getConditions).To(Equal(conditions))
+				})
+			})
+
+			Describe("#SetNamedResourceReferences", func() {
+				It("should set the named resource references", func() {
+					var (
+						acc                    = mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{})
+						namedResourceReference = []gardencorev1beta1.NamedResourceReference{
+							{
+								Name: "test_name",
+								ResourceRef: autoscalingv1.CrossVersionObjectReference{
+									Kind:       "Secret",
+									Name:       "test_name",
+									APIVersion: "v1",
+								},
+							},
+						}
+					)
+					acc.SetResources(namedResourceReference)
+					Expect(acc.GetResources()).To(Equal(namedResourceReference))
 				})
 			})
 		})

--- a/pkg/api/extensions/accessor_test.go
+++ b/pkg/api/extensions/accessor_test.go
@@ -186,10 +186,11 @@ var _ = Describe("Accessor", func() {
 
 			Describe("#SetState", func() {
 				It("should set the extensions state", func() {
-					state := &runtime.RawExtension{Raw: []byte("{\"raw\":\"ext\"}")}
+					state := runtime.RawExtension{Raw: []byte("{\"raw\":\"ext\"}")}
 					acc := mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{})
 					acc.SetState(state)
-					Expect(acc.GetState()).To(Equal(state))
+					actualState := acc.GetState()
+					Expect(*actualState).To(Equal(state))
 				})
 			})
 

--- a/pkg/api/extensions/utils.go
+++ b/pkg/api/extensions/utils.go
@@ -19,10 +19,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// GetShootCRsLists returns an empty CR list struct, for each CR used for Shoot managment
-func GetShootCRsLists() []runtime.Object {
+// GetShootNamespacedCRsLists returns an empty CR list struct, for each CR used for Shoot managment
+func GetShootNamespacedCRsLists() []runtime.Object {
 	return []runtime.Object{
-		&extensionsv1alpha1.BackupEntryList{},
 		&extensionsv1alpha1.ControlPlaneList{},
 		&extensionsv1alpha1.ExtensionList{},
 		&extensionsv1alpha1.InfrastructureList{},

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -39,8 +39,13 @@ type Status interface {
 	GetLastError() *gardencorev1beta1.LastError
 	// GetState retrieves the State of the extension
 	GetState() *runtime.RawExtension
-	// GetResources retrieves the list of named resource references referred to in the state by their names.
+	// SetState sets the State of the extension
+	SetState(state *runtime.RawExtension)
+	// GetResources retrieves the list of named resource references referred to in the State by their names.
 	GetResources() []gardencorev1beta1.NamedResourceReference
+	// SetResources sets a list of named resource references in the Status, that are referred by
+	// their names in the State.
+	SetResources(namedResourceReferences []gardencorev1beta1.NamedResourceReference)
 }
 
 // Spec is the spec section of an Object.

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -40,7 +40,7 @@ type Status interface {
 	// GetState retrieves the State of the extension
 	GetState() *runtime.RawExtension
 	// SetState sets the State of the extension
-	SetState(state *runtime.RawExtension)
+	SetState(state runtime.RawExtension)
 	// GetResources retrieves the list of named resource references referred to in the State by their names.
 	GetResources() []gardencorev1beta1.NamedResourceReference
 	// SetResources sets a list of named resource references in the Status, that are referred by

--- a/pkg/apis/extensions/v1alpha1/types_defaults.go
+++ b/pkg/apis/extensions/v1alpha1/types_defaults.go
@@ -103,7 +103,17 @@ func (d *DefaultStatus) GetState() *runtime.RawExtension {
 	return d.State
 }
 
+// SetState implements Status.
+func (d *DefaultStatus) SetState(state *runtime.RawExtension) {
+	d.State = state
+}
+
 // GetResources implements Status.
 func (d *DefaultStatus) GetResources() []gardencorev1beta1.NamedResourceReference {
 	return d.Resources
+}
+
+// SetResources implements Status.
+func (d *DefaultStatus) SetResources(namedResourceReference []gardencorev1beta1.NamedResourceReference) {
+	d.Resources = namedResourceReference
 }

--- a/pkg/apis/extensions/v1alpha1/types_defaults.go
+++ b/pkg/apis/extensions/v1alpha1/types_defaults.go
@@ -104,8 +104,8 @@ func (d *DefaultStatus) GetState() *runtime.RawExtension {
 }
 
 // SetState implements Status.
-func (d *DefaultStatus) SetState(state *runtime.RawExtension) {
-	d.State = state
+func (d *DefaultStatus) SetState(state runtime.RawExtension) {
+	d.State = &state
 }
 
 // GetResources implements Status.

--- a/pkg/gardenlet/controller/federatedseed/extensions/shootstate_control.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/shootstate_control.go
@@ -140,7 +140,9 @@ func shouldSkipExtensionObjectSync(extensionObject extensionsv1alpha1.Object) bo
 	annotations := extensionObject.GetAnnotations()
 	if annotations != nil {
 		operationAnnotation := annotations[v1beta1constants.GardenerOperation]
-		return operationAnnotation == v1beta1constants.GardenerOperationWaitForState
+		return operationAnnotation == v1beta1constants.GardenerOperationWaitForState ||
+			operationAnnotation == v1beta1constants.GardenerOperationRestore ||
+			operationAnnotation == v1beta1constants.GardenerOperationMigrate
 	}
 	return false
 }

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -70,11 +70,6 @@ func (c *Controller) reconcileShootCareKey(key string) error {
 		return fmt.Errorf("shoot %s has not yet been scheduled on a Seed", key)
 	}
 
-	// if shoot is not yet created or being migrated
-	if shoot.Spec.SeedName != shoot.Status.SeedName {
-		return fmt.Errorf("shoot %s is being not yet created or being migrated", key)
-	}
-
 	// if shoot is no longer managed by this gardenlet (e.g., due to migration to another seed) then don't requeue
 	if seedName := confighelper.SeedNameFromSeedConfig(c.config.SeedConfig); (len(seedName) > 0 && *shoot.Spec.SeedName != seedName) || (len(seedName) == 0 && !controllerutils.SeedLabelsMatch(c.seedLister, *shoot.Spec.SeedName, c.config.SeedSelector)) {
 		return nil

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -70,6 +70,11 @@ func (c *Controller) reconcileShootCareKey(key string) error {
 		return fmt.Errorf("shoot %s has not yet been scheduled on a Seed", key)
 	}
 
+	// if shoot is not yet created or being migrated
+	if shoot.Spec.SeedName != shoot.Status.SeedName {
+		return fmt.Errorf("shoot %s is being not yet created or being migrated", key)
+	}
+
 	// if shoot is no longer managed by this gardenlet (e.g., due to migration to another seed) then don't requeue
 	if seedName := confighelper.SeedNameFromSeedConfig(c.config.SeedConfig); (len(seedName) > 0 && *shoot.Spec.SeedName != seedName) || (len(seedName) == 0 && !controllerutils.SeedLabelsMatch(c.seedLister, *shoot.Spec.SeedName, c.config.SeedSelector)) {
 		return nil

--- a/pkg/gardenlet/controller/shoot/shoot_control_prepare_migration.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_prepare_migration.go
@@ -202,7 +202,7 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 		})
 		waitUntilAPIServerDeleted = g.Add(flow.Task{
 			Name:         "Waits until kube-apiserver doesn't exist",
-			Fn:           flow.TaskFn(botanist.WaitUntilKubeAPIServerScaledDown),
+			Fn:           flow.TaskFn(botanist.WaitUntilKubeAPIServerIsDeleted),
 			Dependencies: flow.NewTaskIDs(prepareKubeAPIServerForMigration),
 		})
 		annotateExtensionCRsForMigration = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot_control_prepare_migration.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_prepare_migration.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation"
@@ -33,6 +34,7 @@ import (
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
 
 	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,11 +80,12 @@ func (c *Controller) prepareShootForMigration(logger *logrus.Entry, shoot *garde
 
 func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation) *gardencorev1beta1helper.WrappedLastErrors {
 	var (
-		namespace       = &corev1.Namespace{}
-		botanist        *botanistpkg.Botanist
-		err             error
-		dnsEnabled      = !o.Shoot.DisableDNS
-		tasksWithErrors []string
+		namespace                    = &corev1.Namespace{}
+		botanist                     *botanistpkg.Botanist
+		err                          error
+		dnsEnabled                   = !o.Shoot.DisableDNS
+		tasksWithErrors              []string
+		kubeAPIServerDeploymentFound = true
 	)
 
 	for _, lastError := range o.Shoot.Info.Status.LastErrors {
@@ -108,6 +111,19 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 				return retryutils.Ok()
 			})
 		}),
+		utilerrors.ToExecute("Retrieve kube-apiserver deployment in the shoot namespace in the seed cluster", func() error {
+			deploymentKubeAPIServer := &appsv1.Deployment{}
+			if err := botanist.K8sSeedClient.Client().Get(context.TODO(), kutil.Key(o.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), deploymentKubeAPIServer); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return err
+				}
+				kubeAPIServerDeploymentFound = false
+			}
+			if deploymentKubeAPIServer.DeletionTimestamp != nil {
+				kubeAPIServerDeploymentFound = false
+			}
+			return nil
+		}),
 		utilerrors.ToExecute("Retrieve the Shoot namespace in the Seed cluster", func() error {
 			if err := botanist.K8sSeedClient.Client().Get(context.TODO(), client.ObjectKey{Name: o.Shoot.SeedNamespace}, namespace); err != nil {
 				if apierrors.IsNotFound(err) {
@@ -128,6 +144,8 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 
 	var (
 		nonTerminatingNamespace = namespace.Status.Phase != corev1.NamespaceTerminating
+		cleanupShootResources   = nonTerminatingNamespace && kubeAPIServerDeploymentFound
+		wakeupRequired          = (o.Shoot.Info.Status.IsHibernated || (!o.Shoot.Info.Status.IsHibernated && o.Shoot.HibernationEnabled)) && cleanupShootResources
 		defaultTimeout          = 10 * time.Minute
 		defaultInterval         = 5 * time.Second
 
@@ -152,14 +170,19 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 			Fn:           flow.TaskFn(botanist.WaitUntilEtcdReady).DoIf(nonTerminatingNamespace),
 			Dependencies: flow.NewTaskIDs(deployETCD, scaleETCDToOne),
 		})
+		wakeUpKubeAPIServer = g.Add(flow.Task{
+			Name:         "Scales Kubernetes API Server up and waits until ready",
+			Fn:           flow.TaskFn(botanist.WakeUpKubeAPIServer).DoIf(wakeupRequired),
+			Dependencies: flow.NewTaskIDs(deployETCD, scaleETCDToOne),
+		})
 		ensureResourceManagerScaledUp = g.Add(flow.Task{
 			Name:         "Ensure that the gardener resource manager is scaled to 1",
-			Fn:           flow.TaskFn(botanist.ScaleGardenerResourceManagerToOne).DoIf(nonTerminatingNamespace),
-			Dependencies: flow.NewTaskIDs(),
+			Fn:           flow.TaskFn(botanist.ScaleGardenerResourceManagerToOne).DoIf(cleanupShootResources),
+			Dependencies: flow.NewTaskIDs(wakeUpKubeAPIServer),
 		})
 		keepManagedResourcesObjectsInShoot = g.Add(flow.Task{
 			Name:         "Keep Managed Resources objects in the Shoot",
-			Fn:           flow.TaskFn(botanist.KeepManagedResourcesObjects),
+			Fn:           flow.TaskFn(botanist.KeepManagedResourcesObjects).DoIf(cleanupShootResources),
 			Dependencies: flow.NewTaskIDs(ensureResourceManagerScaledUp),
 		})
 		deleteAllManagedResourcesFromShootNamespace = g.Add(flow.Task{
@@ -172,55 +195,60 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 			Fn:           flow.TaskFn(botanist.WaitUntilAllManagedResourcesDeleted).Timeout(10 * time.Minute),
 			Dependencies: flow.NewTaskIDs(deleteAllManagedResourcesFromShootNamespace),
 		})
-		prepareControlPlaneDeploymentsForMigration = g.Add(flow.Task{
-			Name:         "Prepare Control Plane Deployments in Shoot's namespace for migration, by scaling to zero and deleting the respective hvpa",
-			Fn:           flow.TaskFn(botanist.PrepareControlPlaneDeploymentsForMigration).SkipIf(o.Shoot.HibernationEnabled),
+		prepareKubeAPIServerForMigration = g.Add(flow.Task{
+			Name:         "Prepare kube-apiserver in Shoot's namespace for migration, by deleting it and its respective hvpa",
+			Fn:           flow.TaskFn(botanist.PrepareKubeAPIServerForMigration).SkipIf(o.Shoot.HibernationEnabled || !kubeAPIServerDeploymentFound),
 			Dependencies: flow.NewTaskIDs(waitForManagedResourcesDeletion, waitUntilEtcdReady),
+		})
+		waitUntilAPIServerDeleted = g.Add(flow.Task{
+			Name:         "Waits until kube-apiserver doesn't exist",
+			Fn:           flow.TaskFn(botanist.WaitUntilKubeAPIServerScaledDown),
+			Dependencies: flow.NewTaskIDs(prepareKubeAPIServerForMigration),
 		})
 		annotateExtensionCRsForMigration = g.Add(flow.Task{
 			Name:         "Annotate Extensions CRs with operation - migration",
 			Fn:           botanist.AnnotateExtensionCRsForMigration,
-			Dependencies: flow.NewTaskIDs(prepareControlPlaneDeploymentsForMigration),
+			Dependencies: flow.NewTaskIDs(waitUntilAPIServerDeleted),
 		})
 		waitForExtensionCRsOperationMigrateToSucceed = g.Add(flow.Task{
 			Name:         "Waits until all extension CRs are with lastOperation Status Migrate = Succeeded",
 			Fn:           botanist.WaitForExtensionsOperationMigrateToSucceed,
 			Dependencies: flow.NewTaskIDs(annotateExtensionCRsForMigration),
 		})
+		annotateBackupEntryInSeedForMigration = g.Add(flow.Task{
+			Name:         "Annotate BackupEntry in Seed with operation - migration",
+			Fn:           botanist.AnnotateBackupEntryInSeedForMigration,
+			Dependencies: flow.NewTaskIDs(waitUntilAPIServerDeleted),
+		})
+		waitForBackupEntryOperationMigrateToSucceed = g.Add(flow.Task{
+			Name:         "Waits until BackupEntry in Seed has lastOperation Status Migrate = Succeeded",
+			Fn:           botanist.WaitForBackupEntryOperationMigrateToSucceed,
+			Dependencies: flow.NewTaskIDs(annotateBackupEntryInSeedForMigration),
+		})
 		deleteAllExtensionCRs = g.Add(flow.Task{
 			Name:         "Deletes all extension CRs from the Shoot namespace",
 			Fn:           botanist.DeleteAllExtensionCRs,
 			Dependencies: flow.NewTaskIDs(waitForExtensionCRsOperationMigrateToSucceed),
 		})
-		waitUntilAPIServerScaledDown = g.Add(flow.Task{
-			Name:         "Wait for Kubernetes API Server to be scaled to zero",
-			Fn:           flow.TaskFn(botanist.WaitUntilKubeAPIServerScaledDown).SkipIf(o.Shoot.HibernationEnabled || !nonTerminatingNamespace),
-			Dependencies: flow.NewTaskIDs(prepareControlPlaneDeploymentsForMigration),
-		})
-		_ = g.Add(flow.Task{
-			Name:         "Wait for gardener-resource-manager to be scaled to zero",
-			Fn:           flow.TaskFn(botanist.WaitUntilGardenerResourceManagerScalesDown).SkipIf(o.Shoot.HibernationEnabled || !nonTerminatingNamespace),
-			Dependencies: flow.NewTaskIDs(prepareControlPlaneDeploymentsForMigration),
-		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying ingress DNS record",
 			Fn:           flow.TaskFn(component.OpWaiter(botanist.Shoot.Components.DNS.NginxEntry).Destroy).DoIf(dnsEnabled),
-			Dependencies: flow.NewTaskIDs(waitUntilAPIServerScaledDown),
+			Dependencies: flow.NewTaskIDs(waitUntilAPIServerDeleted),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying external domain DNS record",
 			Fn:           flow.TaskFn(component.OpWaiter(botanist.Shoot.Components.DNS.ExternalEntry).Destroy).DoIf(dnsEnabled),
-			Dependencies: flow.NewTaskIDs(waitUntilAPIServerScaledDown),
+			Dependencies: flow.NewTaskIDs(waitUntilAPIServerDeleted),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying internal domain DNS record",
 			Fn:           flow.TaskFn(component.OpWaiter(botanist.Shoot.Components.DNS.InternalEntry).Destroy).DoIf(dnsEnabled),
-			Dependencies: flow.NewTaskIDs(waitUntilAPIServerScaledDown),
+			Dependencies: flow.NewTaskIDs(waitUntilAPIServerDeleted),
 		})
 		createETCDSnapshot = g.Add(flow.Task{
 			Name:         "Create ETCD Snapshot",
 			Fn:           flow.TaskFn(botanist.CreateETCDSnapshot).DoIf(nonTerminatingNamespace),
-			Dependencies: flow.NewTaskIDs(waitUntilAPIServerScaledDown),
+			Dependencies: flow.NewTaskIDs(waitUntilAPIServerDeleted),
 		})
 		scaleETCDToZero = g.Add(flow.Task{
 			Name:         "Scale ETCD to zero",
@@ -230,7 +258,7 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 		deleteNamespace = g.Add(flow.Task{
 			Name:         "Deleting shoot namespace in Seed",
 			Fn:           flow.TaskFn(botanist.DeleteNamespace).Retry(defaultInterval),
-			Dependencies: flow.NewTaskIDs(deleteAllExtensionCRs, waitForManagedResourcesDeletion, scaleETCDToZero),
+			Dependencies: flow.NewTaskIDs(deleteAllExtensionCRs, waitForBackupEntryOperationMigrateToSucceed, waitForManagedResourcesDeletion, scaleETCDToZero),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until shoot namespace in Seed has been deleted",

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -346,7 +346,7 @@ func (b *Botanist) ScaleGardenerResourceManagerToOne(ctx context.Context) error 
 	return kubernetes.ScaleDeployment(ctx, b.K8sSeedClient.Client(), kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameGardenerResourceManager), 1)
 }
 
-// PrepareKubeAPIServerForMigration deletes the kube-apiserverand deletes its hvpa
+// PrepareKubeAPIServerForMigration deletes the kube-apiserver and deletes its hvpa
 func (b *Botanist) PrepareKubeAPIServerForMigration(ctx context.Context) error {
 	if err := b.K8sSeedClient.Client().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: b.Shoot.SeedNamespace}}); client.IgnoreNotFound(err) != nil && !meta.IsNoMatchError(err) {
 		return err

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -424,7 +424,7 @@ func (b *Botanist) DeployControlPlane(ctx context.Context) error {
 	}
 
 	if restorePhase {
-		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), cp, &cp.ObjectMeta, &cp.Status.DefaultStatus, extensionsv1alpha1.ControlPlaneResource, cp.Name, cp.Spec.DefaultSpec.GetExtensionPurpose())
+		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), cp, extensionsv1alpha1.ControlPlaneResource)
 	}
 
 	return nil
@@ -474,7 +474,7 @@ func (b *Botanist) DeployControlPlaneExposure(ctx context.Context) error {
 	}
 
 	if restorePhase {
-		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), cp, &cp.ObjectMeta, &cp.Status.DefaultStatus, extensionsv1alpha1.ControlPlaneResource, cp.Name, cp.Spec.DefaultSpec.GetExtensionPurpose())
+		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), cp, extensionsv1alpha1.ControlPlaneResource)
 	}
 	return nil
 }

--- a/pkg/operation/botanist/extension.go
+++ b/pkg/operation/botanist/extension.go
@@ -69,7 +69,7 @@ func (b *Botanist) DeployExtensionResources(ctx context.Context) error {
 			})
 
 			if restorePhase {
-				return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), &toApply, &toApply.ObjectMeta, &toApply.Status.DefaultStatus, extensionsv1alpha1.ExtensionResource, toApply.Name, toApply.GetExtensionSpec().GetExtensionPurpose())
+				return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), &toApply, extensionsv1alpha1.ExtensionResource)
 			}
 
 			return err

--- a/pkg/operation/botanist/extension.go
+++ b/pkg/operation/botanist/extension.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/flow"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -152,12 +153,18 @@ func (b *Botanist) WaitUntilExtensionResourcesDeleted(ctx context.Context) error
 func (b *Botanist) WaitForExtensionsOperationMigrateToSucceed(ctx context.Context) error {
 	fns, err := b.applyFuncToAllExtensionCRs(ctx, func(obj runtime.Object) error {
 		return retry.UntilTimeout(ctx, 5*time.Second, 300*time.Second, func(ctx context.Context) (done bool, err error) {
-			acc, err := extensions.Accessor(obj)
+			objDeepCopy := obj.DeepCopyObject()
+			extensionObj, err := extensions.Accessor(objDeepCopy)
 			if err != nil {
 				return retry.SevereError(err)
 			}
 
-			if extensionObjStatus := acc.GetExtensionStatus(); extensionObjStatus != nil {
+			// fetch last object
+			if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(extensionObj.GetNamespace(), extensionObj.GetName()), extensionObj); err != nil {
+				return retry.SevereError(err)
+			}
+
+			if extensionObjStatus := extensionObj.GetExtensionStatus(); extensionObjStatus != nil {
 				if lastOperation := extensionObjStatus.GetLastOperation(); lastOperation != nil {
 					if lastOperation.Type == gardencorev1beta1.LastOperationTypeMigrate && lastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
 						return retry.Ok()
@@ -166,10 +173,10 @@ func (b *Botanist) WaitForExtensionsOperationMigrateToSucceed(ctx context.Contex
 			}
 
 			var exetnsionType string
-			if extensionSpec := acc.GetExtensionSpec(); extensionSpec != nil {
+			if extensionSpec := extensionObj.GetExtensionSpec(); extensionSpec != nil {
 				exetnsionType = extensionSpec.GetExtensionType()
 			}
-			return retry.MinorError(fmt.Errorf("extension CR %s with type %s lastOperation was not Migrate=Succeeded", acc.GetName(), exetnsionType))
+			return retry.MinorError(fmt.Errorf("lastOperation for extension CR %s with name %s and type %s is not Migrate=Succeeded", extensionObj.GetObjectKind().GroupVersionKind().Kind, extensionObj.GetName(), exetnsionType))
 		})
 	})
 	if err != nil {

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -91,7 +91,7 @@ func (b *Botanist) DeployInfrastructure(ctx context.Context) error {
 	}
 
 	if restorePhase {
-		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), infrastructure, &infrastructure.ObjectMeta, &infrastructure.Status.DefaultStatus, extensionsv1alpha1.InfrastructureResource, infrastructure.Name, nil)
+		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), infrastructure, extensionsv1alpha1.InfrastructureResource)
 	}
 
 	return nil

--- a/pkg/operation/botanist/network.go
+++ b/pkg/operation/botanist/network.go
@@ -72,7 +72,7 @@ func (b *Botanist) DeployNetwork(ctx context.Context) error {
 	}
 
 	if restorePhase {
-		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), network, &network.ObjectMeta, &network.Status.DefaultStatus, extensionsv1alpha1.NetworkResource, network.Name, network.GetExtensionSpec().GetExtensionPurpose())
+		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), network, extensionsv1alpha1.NetworkResource)
 	}
 
 	return nil

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -127,8 +127,8 @@ func (b *Botanist) WaitUntilEtcdReady(ctx context.Context) error {
 	})
 }
 
-// WaitUntilKubeAPIServerScaledDown waits until the kube-apiserver pod(s) are scaled to zero.
-func (b *Botanist) WaitUntilKubeAPIServerScaledDown(ctx context.Context) error {
+// WaitUntilKubeAPIServerIsDeleted waits until the kube-apiserver is deleted
+func (b *Botanist) WaitUntilKubeAPIServerIsDeleted(ctx context.Context) error {
 	return retry.UntilTimeout(ctx, 5*time.Second, 300*time.Second, func(ctx context.Context) (done bool, err error) {
 		deploy := &appsv1.Deployment{}
 		err = b.K8sSeedClient.Client().Get(ctx, kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), deploy)

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -165,7 +165,7 @@ func (b *Botanist) DeployWorker(ctx context.Context) error {
 	}
 
 	if restorePhase {
-		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), worker, &worker.ObjectMeta, &worker.Status.DefaultStatus, extensionsv1alpha1.WorkerResource, worker.Name, worker.GetExtensionSpec().GetExtensionPurpose())
+		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), worker, extensionsv1alpha1.WorkerResource)
 	}
 
 	return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area control-plane-migration
/kind enhancement
/kind bug
/priority normal

**What this PR does / why we need it**:
Enhances the migration flow by adding steps for: 
- Kubernetes API Server scale-up, in case of hibernated Shoot
- Annotating BackupEntry for migration (there was a bug that was annotating every BackupEntry with migrate in the Seed)

**Which issue(s) this PR fixes**:
Fixes partially #1631  
**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
