### PR TITLE
Nit: Update label for webhook namespaceSelector

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/validatingwebhook-controller-manager.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/validatingwebhook-controller-manager.yaml
@@ -17,7 +17,7 @@ webhooks:
   failurePolicy: Fail
   namespaceSelector:
     matchLabels:
-      garden.sapcloud.io/role: project
+      gardener.cloud/role: project
   clientConfig:
     {{- if .Values.global.deployment.virtualGarden.enabled }}
     url: https://gardener-controller-manager.garden/webhooks/validate-namespace-deletion
@@ -42,7 +42,7 @@ webhooks:
   failurePolicy: Fail
   namespaceSelector:
     matchLabels:
-      garden.sapcloud.io/role: project
+      gardener.cloud/role: project
   clientConfig:
     {{- if .Values.global.deployment.virtualGarden.enabled }}
     url: https://gardener-controller-manager.garden/webhooks/validate-kubeconfig-secrets

--- a/hack/local-development/dev-setup-register-gardener
+++ b/hack/local-development/dev-setup-register-gardener
@@ -220,6 +220,9 @@ webhooks:
     resources:
     - namespaces
   failurePolicy: Fail
+  namespaceSelector:
+    matchLabels:
+      gardener.cloud/role: project
   clientConfig:
     service:
       namespace: garden
@@ -241,7 +244,7 @@ $CONTROLLER_MANAGER_PORT_STRING
   failurePolicy: Fail
   namespaceSelector:
     matchLabels:
-      garden.sapcloud.io/role: project
+      gardener.cloud/role: project
   clientConfig:
     service:
       namespace: garden


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Update the project label to the equivalent of the new API group in the namespaceSelector of `gardener-controller-manager` validating webhook.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
