### PR TITLE
More control for operating system config extension controllers

### DIFF
--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_reconcile.go
@@ -23,11 +23,10 @@ import (
 
 // Reconcile reconciles the update of a OperatingSystemConfig regenerating the os-specific format
 func (a *Actuator) Reconcile(ctx context.Context, config *extensionsv1alpha1.OperatingSystemConfig) ([]byte, *string, []string, error) {
-
 	cloudConfig, cmd, err := CloudConfigFromOperatingSystemConfig(ctx, a.client, config, a.generator)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("could not generate cloud config: %v", err)
 	}
 
-	return []byte(cloudConfig), cmd, OperatingSystemConfigUnitNames(config), nil
+	return cloudConfig, cmd, OperatingSystemConfigUnitNames(config), nil
 }

--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/generator/generator.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/generator/generator.go
@@ -47,6 +47,7 @@ type DropIn struct {
 
 // OperatingSystemConfig is the data required to create a cloud init script.
 type OperatingSystemConfig struct {
+	Object    *extensionsv1alpha1.OperatingSystemConfig
 	CRI       *extensionsv1alpha1.CRIConfig
 	Files     []*File
 	Units     []*Unit

--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/generator/test/README.md
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/generator/test/README.md
@@ -12,22 +12,22 @@ Each Generator implementation can use this function as shown bellow:
 ```go
 import (
 	"github.com/gobuffalo/packr"
-	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/os-common/generator/test"
+	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/generator/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
-         
+
 var _ Describe("My Generator Test", func(){
       var box packr.Box
 
       BeforeSuite(func() {
-     	box = packr.NewBox("/path/to/testfiles")
+            box = packr.NewBox("/path/to/testfiles")
       })
 
       Describe("Conformance Tests", test.DescribeTest(NewGenerator(),box))
 
       Describe("My other Tests", func(){
-       ...
+           ...
       })
- })
+})
 ```

--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/generator/test/template_generator.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/generator/test/template_generator.go
@@ -16,6 +16,7 @@ package test
 
 import (
 	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/generator"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
 	"github.com/gobuffalo/packr"
 	"github.com/onsi/ginkgo"
@@ -37,6 +38,7 @@ var DescribeTest = func(g generator.Generator, box packr.Box) func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			cloudInit, _, err := g.Generate(&generator.OperatingSystemConfig{
+				Object: &extensionsv1alpha1.OperatingSystemConfig{},
 				Files: []*generator.File{
 					{
 						Path:        "/foo",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area os
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR enhances the `oscommon` library for `OperatingSystemConfig` extension controllers to allow them providing additional values for the to-be-rendered template. These additional values can be computed out of the `OperatingSystemConfig` resource, for example, out of the `providerConfig`.

**Which issue(s) this PR fixes**:
Ref #2354
Ref https://github.com/gardener/gardener-extension-os-suse-jeos/issues/18

**Special notes for your reviewer**:
/assign @vpnachev @hardikdr
/invite @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
The `oscommon` library for `OperatingSystemConfig` extension controllers was enhanced to allow providing additional values for the to-be-rendered template. These additional values can be computed out of the `OperatingSystemConfig` resource, for example, out of the `providerConfig`.
```
