### PR TITLE
Add CRI information to OSC type=provision

### DIFF
--- a/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
+++ b/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
@@ -15,6 +15,10 @@ metadata:
 spec:
   type: {{ required "type is required" .Values.type }}
   purpose: {{ required "purpose is required" .Values.purpose }}
+  {{- if .Values.cri }}
+  criConfig:
+    name: {{ .Values.cri.name }}
+  {{- end }}
   units:
   - name: cloud-config-downloader.service
     command: start

--- a/charts/seed-operatingsystemconfig/downloader/values.yaml
+++ b/charts/seed-operatingsystemconfig/downloader/values.yaml
@@ -3,3 +3,6 @@ purpose: bootstrap
 secretName: cpu-worker-0
 server: api.shoot-cluster.example.com
 annotationCurrentTimestamp: 2020-05-06T10:18:01Z
+
+# cri:
+#   name: containerd

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -330,6 +330,7 @@ func (b *Botanist) deployOperatingSystemConfigsForWorker(ctx context.Context, ma
 		workerConfig["cri"] = map[string]interface{}{
 			"name": worker.CRI.Name,
 		}
+		downloaderConfig["cri"] = workerConfig["cri"]
 	}
 
 	originalConfig["worker"] = workerConfig


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area os
/kind bug
/priority normal

**What this PR does / why we need it**:

Adds missing CRI information to the downloader `OperatingSystemConfig` CRD  (type=provision).

This is required as os-extensions depend on that information to [add containerd specific files and services](https://github.com/gardener/gardener-extension-os-gardenlinux/pull/5).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixes a bug in the Gardener to include CRI information in the `OperatingSystemConfig` CRD.  Os-extensions depend on that information to generate CRI specific files and systemd.services. In an edge case that could also lead to the containerd.service to not be enabled.
```
