### PR TITLE
Guestbook

### DIFF
--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -86,7 +86,7 @@ func (t *GuestBookTest) WaitUntilGuestbookDeploymentIsReady(ctx context.Context)
 // WaitUntilGuestbookURLsRespondOK waits until the deployed guestbook application can be reached via http
 func (t *GuestBookTest) WaitUntilGuestbookURLsRespondOK(ctx context.Context, guestbookAppUrls []string) error {
 	defaultPollInterval := time.Minute
-	return retry.UntilTimeout(ctx, defaultPollInterval, 10*time.Minute, func(ctx context.Context) (done bool, err error) {
+	return retry.UntilTimeout(ctx, defaultPollInterval, 20*time.Minute, func(ctx context.Context) (done bool, err error) {
 		for _, guestbookAppURL := range guestbookAppUrls {
 			response, err := framework.HTTPGet(ctx, guestbookAppURL)
 			if err != nil {
@@ -213,7 +213,7 @@ func (t *GuestBookTest) dump(ctx context.Context) {
 	}
 }
 
-// Cleanup cleans up all resources depoyed by the guestbook test
+// Cleanup cleans up all resources deployed by the guestbook test
 func (t *GuestBookTest) Cleanup(ctx context.Context) {
 	// First dump all resources if the test has failed
 	t.dump(ctx)

--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -32,6 +32,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -210,6 +211,11 @@ func (t *GuestBookTest) dump(ctx context.Context) {
 	err := t.framework.DumpDefaultResourcesInNamespace(ctx, identifier, t.framework.ShootClient, t.framework.Namespace)
 	if err != nil {
 		t.framework.Logger.Errorf("unable to dump guestbook resources in namespace %s: %s", t.framework.Namespace, err.Error())
+	}
+
+	labels := client.MatchingLabels{"app": "nginx-ingress", "component": "controller", "origin": "gardener"}
+	if err = t.framework.DumpLogsForPodsWithLabelsInNamespace(ctx, identifier, t.framework.ShootClient, "kube-system", labels); err != nil {
+		t.framework.Logger.Errorf("unable to dump nginx logs (from namespace %s and labels %v): %v", "kube-system", labels, err)
 	}
 }
 

--- a/test/integration/shoots/applications/shoot_app.go
+++ b/test/integration/shoots/applications/shoot_app.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	guestbookAppTimeout       = 30 * time.Minute
-	finalizationTimeout       = 5 * time.Minute
+	finalizationTimeout       = 10 * time.Minute
 	downloadKubeconfigTimeout = 600 * time.Second
 	dashboardAvailableTimeout = 60 * time.Minute
 )


### PR DESCRIPTION
**How to categorize this PR?**
/area testing
/kind test
/priority normal

**What this PR does / why we need it**:
Azure guestbook tests are flaky, see #2423
This PR increases the timeout to wait for the guestbook app to serve its URLs from `10min` to `20min` and the timeout to wait for the namespace to be deleted (at the end of the test) from `5min` to `10min`.
It adds additional dumping logic to dump the nginx ingress controller logs at the end of a failed test so that we have a better chance to analyze the cause of the flakes.

**Which issue(s) this PR fixes**:
Maybe improves #2423, at least helps to better understand its potential causes.
