### PR TITLE
Backport #2421

### DIFF
--- a/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
+++ b/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
@@ -14,6 +14,10 @@ metadata:
 spec:
   type: {{ required "type is required" .Values.type }}
   purpose: {{ required "purpose is required" .Values.purpose }}
+  {{- if .Values.cri }}
+  criConfig:
+    name: {{ .Values.cri.name }}
+  {{- end }}
   units:
   - name: cloud-config-downloader.service
     command: start

--- a/charts/seed-operatingsystemconfig/downloader/values.yaml
+++ b/charts/seed-operatingsystemconfig/downloader/values.yaml
@@ -2,3 +2,6 @@ type: coreos
 purpose: bootstrap
 secretName: cpu-worker-0
 server: api.shoot-cluster.example.com
+
+# cri:
+#   name: containerd

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -328,6 +328,7 @@ func (b *Botanist) deployOperatingSystemConfigsForWorker(ctx context.Context, ma
 		workerConfig["cri"] = map[string]interface{}{
 			"name": worker.CRI.Name,
 		}
+		downloaderConfig["cri"] = workerConfig["cri"]
 	}
 
 	originalConfig["worker"] = workerConfig


### PR DESCRIPTION
**How to categorize this PR?**

Backport #2421 to be able to run containerd based clusters

```improvement operator github.com/gardener/gardener #2421 @danielfoehrKn
Fixes a bug in the Gardener to include CRI information in the `OperatingSystemConfig` CRD.  Os-extensions depend on that information to generate CRI specific files and systemd.services. In an edge case that could also lead to the containerd.service to not be enabled.
```