### PR TITLE
Upgrade grafana to 7.0.3 and update dashboards

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -99,7 +99,7 @@ images:
 - name: grafana
   sourceRepository: github.com/grafana/grafana
   repository: grafana/grafana
-  tag: "6.3.2"
+  tag: "7.0.3"
 - name: blackbox-exporter
   sourceRepository: github.com/prometheus/blackbox_exporter
   repository: quay.io/prometheus/blackbox-exporter

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-apiserver.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-apiserver.rules.test.yaml
@@ -18,9 +18,9 @@ tests:
   - series: 'process_max_fds{job="kube-apiserver", instance="instance"}'
     values: '100+0x60'
   # KubeApiServerLatency
-  - series: 'apiserver_request_latencies_bucket{verb="POST", le="5000000"}'
+  - series: 'apiserver_request_duration_seconds_bucket{verb="POST", le="5000000"}'
     values: '100+0x60'
-  - series: 'apiserver_request_latencies_bucket{verb="POST", le="+Inf"}'
+  - series: 'apiserver_request_duration_seconds_bucket{verb="POST", le="+Inf"}'
     values: '100+0x60'
   # KubeApiServerTooManyAuditlogFailures
   - series: 'apiserver_audit_error_total{plugin="webhook", job="kube-apiserver"}'

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-apiserver.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-apiserver.rules.yaml
@@ -26,7 +26,7 @@ groups:
   # Some verbs excluded because they are expected to be long-lasting:
   # WATCHLIST is long-poll, CONNECT is `kubectl exec`.
   - alert: KubeApiServerLatency
-    expr: histogram_quantile(0.99, sum without (instance,resource) (apiserver_request_latencies_bucket{subresource!="log",verb!~"CONNECT|WATCHLIST|WATCH|PROXY proxy"})) / 1e6 > 3.0
+    expr: histogram_quantile(0.99, sum without (instance,resource) (apiserver_request_duration_seconds_bucket{subresource!="log",verb!~"CONNECT|WATCHLIST|WATCH|PROXY proxy"})) > 3.0
     for: 30m
     labels:
       service: kube-apiserver
@@ -38,15 +38,15 @@ groups:
       summary: Kubernetes API server latency is high
   ### API latency ###
   - record: apiserver_latency_seconds:quantile
-    expr: histogram_quantile(0.99, rate(apiserver_request_latencies_bucket[5m])) / 1e+06
+    expr: histogram_quantile(0.99, rate(apiserver_request_duration_seconds_bucket[5m]))
     labels:
       quantile: "0.99"
   - record: apiserver_latency:quantile
-    expr: histogram_quantile(0.9, rate(apiserver_request_latencies_bucket[5m])) / 1e+06
+    expr: histogram_quantile(0.9, rate(apiserver_request_duration_seconds_bucket[5m]))
     labels:
       quantile: "0.9"
   - record: apiserver_latency_seconds:quantile
-    expr: histogram_quantile(0.5, rate(apiserver_request_latencies_bucket[5m])) / 1e+06
+    expr: histogram_quantile(0.5, rate(apiserver_request_duration_seconds_bucket[5m]))
     labels:
       quantile: "0.5"
   - alert: KubeApiServerTooManyOpenFileDescriptors

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -73,7 +73,7 @@ allowedMetrics:
   - apiserver_registered_watchers
   - apiserver_request_count
   - apiserver_request_total
-  - apiserver_request_latencies_bucket
+  - apiserver_request_duration_seconds_bucket
   - etcd_object_counts
   - process_max_fds
   - process_open_fds

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-deployments-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-deployments-dashboard.json
@@ -5,8 +5,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 5,
-  "iteration": 1538572542659,
+  "iteration": 1591604023145,
   "links": [],
   "panels": [
     {
@@ -21,6 +20,12 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -103,6 +108,12 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -185,6 +196,12 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "Bps",
       "gauge": {
         "maxValue": 100,
@@ -268,6 +285,12 @@
       "decimals": null,
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -316,11 +339,13 @@
         "lineColor": "rgb(31, 120, 193)",
         "show": false
       },
-      "tableColumn": "",
+      "tableColumn": "{deployment=\"aws-lb-readvertiser\", job=\"kube-state-metrics\", namespace=\"kube-system\", type=\"seed\"}",
       "targets": [
         {
-          "expr": "max(kube_deployment_spec_replicas{deployment=\"$deployment_name\"}) without (instance, pod)",
+          "expr": "max(kube_deployment_spec_replicas{instance=\"kube-state-metrics\",deployment=\"$deployment_name\"}) without (instance, pod)",
+          "interval": "",
           "intervalFactor": 2,
+          "legendFormat": "",
           "metric": "kube_deployment_spec_replicas",
           "refId": "A",
           "step": 600
@@ -351,6 +376,12 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -399,11 +430,13 @@
         "lineColor": "rgb(31, 120, 193)",
         "show": false
       },
-      "tableColumn": "",
+      "tableColumn": "{deployment=\"aws-lb-readvertiser\", job=\"kube-state-metrics\", namespace=\"kube-system\", type=\"seed\"}",
       "targets": [
         {
-          "expr": "min(kube_deployment_status_replicas_available{deployment=\"$deployment_name\"}) without (instance, pod)",
+          "expr": "min(kube_deployment_status_replicas_available{instance=\"kube-state-metrics\",deployment=\"$deployment_name\"}) without (instance, pod)",
+          "interval": "",
           "intervalFactor": 2,
+          "legendFormat": "",
           "refId": "A",
           "step": 600
         }
@@ -433,6 +466,12 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -481,10 +520,11 @@
         "lineColor": "rgb(31, 120, 193)",
         "show": false
       },
-      "tableColumn": "",
+      "tableColumn": "{deployment=\"aws-lb-readvertiser\", job=\"kube-state-metrics\", namespace=\"kube-system\", type=\"seed\"}",
       "targets": [
         {
-          "expr": "max(kube_deployment_status_observed_generation{deployment=\"$deployment_name\"}) without (instance, pod)",
+          "expr": "max(kube_deployment_status_observed_generation{instance=\"kube-state-metrics\",deployment=\"$deployment_name\"}) without (instance, pod)",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "",
           "refId": "A",
@@ -516,6 +556,12 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -564,10 +610,11 @@
         "lineColor": "rgb(31, 120, 193)",
         "show": false
       },
-      "tableColumn": "",
+      "tableColumn": "{deployment=\"aws-lb-readvertiser\", job=\"kube-state-metrics\", namespace=\"kube-system\", type=\"seed\"}",
       "targets": [
         {
-          "expr": "max(kube_deployment_metadata_generation{deployment=\"$deployment_name\"}) without (instance, pod)",
+          "expr": "max(kube_deployment_metadata_generation{instance=\"kube-state-metrics\",deployment=\"$deployment_name\"}) without (instance, pod)",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "",
           "refId": "A",
@@ -595,7 +642,14 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "grid": {},
       "gridPos": {
         "h": 9,
@@ -603,6 +657,7 @@
         "x": 0,
         "y": 8
       },
+      "hiddenSeries": false,
       "id": 1,
       "legend": {
         "avg": false,
@@ -618,6 +673,9 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -665,6 +723,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Replicas",
       "tooltip": {
@@ -673,7 +732,6 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": false,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -708,6 +766,12 @@
     {
       "columns": [],
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 6,
@@ -727,12 +791,14 @@
       "styles": [
         {
           "alias": "Time",
+          "align": "auto",
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "pattern": "Time",
           "type": "hidden"
         },
         {
           "alias": "Pod",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -753,6 +819,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -781,11 +848,11 @@
       ],
       "title": "Drill down to to Pod Dashboard",
       "transform": "timeseries_to_rows",
-      "type": "table"
+      "type": "table-old"
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 16,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [
     "kubernetes",
@@ -825,15 +892,18 @@
           }
         ],
         "query": "seed,shoot",
+        "skipUrlSync": false,
         "type": "custom"
       },
       {
         "allValue": null,
         "current": {
-          "text": "grafana",
-          "value": "grafana"
+          "selected": false,
+          "text": "aws-lb-readvertiser",
+          "value": "aws-lb-readvertiser"
         },
         "datasource": "prometheus",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": "Deployment",
@@ -843,6 +913,7 @@
         "query": "label_values(kube_deployment_metadata_generation{type=~\"$type\"}, deployment)",
         "refresh": 2,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-statefulsets-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-statefulsets-dashboard.json
@@ -5,8 +5,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 9,
-  "iteration": 1542183663626,
+  "iteration": 1591602806091,
   "links": [],
   "panels": [
     {
@@ -21,6 +20,12 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -103,6 +108,12 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -185,6 +196,12 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "Bps",
       "gauge": {
         "maxValue": 100,
@@ -268,6 +285,12 @@
       "decimals": null,
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -316,12 +339,14 @@
         "lineColor": "rgb(31, 120, 193)",
         "show": false
       },
-      "tableColumn": "",
+      "tableColumn": "{job=\"kube-state-metrics\", namespace=\"kube-system\", statefulset=\"etcd-events\", type=\"seed\"}",
       "targets": [
         {
-          "expr": "max(kube_statefulset_replicas{statefulset=\"$statefulset_name\"}) without (instance, pod)",
+          "expr": "max(kube_statefulset_replicas{instance=\"kube-state-metrics\", statefulset=\"$statefulset_name\"}) without (instance, pod)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
+          "legendFormat": "",
           "metric": "kube_statefulset_replicas",
           "refId": "A",
           "step": 600
@@ -352,6 +377,12 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -400,11 +431,12 @@
         "lineColor": "rgb(31, 120, 193)",
         "show": false
       },
-      "tableColumn": "",
+      "tableColumn": "{job=\"kube-state-metrics\", namespace=\"kube-system\", statefulset=\"etcd-events\", type=\"seed\"}",
       "targets": [
         {
-          "expr": "min(kube_statefulset_status_replicas_ready{statefulset=\"$statefulset_name\"}) without (instance, pod)",
+          "expr": "min(kube_statefulset_status_replicas_ready{instance=\"kube-state-metrics\",statefulset=\"$statefulset_name\"}) without (instance, pod)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "",
           "refId": "A",
@@ -436,6 +468,12 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -484,10 +522,11 @@
         "lineColor": "rgb(31, 120, 193)",
         "show": false
       },
-      "tableColumn": "",
+      "tableColumn": "{job=\"kube-state-metrics\", namespace=\"kube-system\", statefulset=\"etcd-events\", type=\"seed\"}",
       "targets": [
         {
-          "expr": "max(kube_statefulset_status_observed_generation{statefulset=\"$statefulset_name\"}) without (instance, pod)",
+          "expr": "max(kube_statefulset_status_observed_generation{instance=\"kube-state-metrics\",statefulset=\"$statefulset_name\"}) without (instance, pod)",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "",
           "refId": "A",
@@ -519,6 +558,12 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -567,10 +612,11 @@
         "lineColor": "rgb(31, 120, 193)",
         "show": false
       },
-      "tableColumn": "",
+      "tableColumn": "{job=\"kube-state-metrics\", namespace=\"kube-system\", statefulset=\"etcd-events\", type=\"seed\"}",
       "targets": [
         {
-          "expr": "max(kube_statefulset_metadata_generation{statefulset=\"$statefulset_name\"}) without (instance, pod)",
+          "expr": "max(kube_statefulset_metadata_generation{instance=\"kube-state-metrics\",statefulset=\"$statefulset_name\"}) without (instance, pod)",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "",
           "refId": "A",
@@ -598,7 +644,14 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "grid": {},
       "gridPos": {
         "h": 9,
@@ -606,6 +659,7 @@
         "x": 0,
         "y": 8
       },
+      "hiddenSeries": false,
       "id": 1,
       "legend": {
         "avg": false,
@@ -621,6 +675,9 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -661,6 +718,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Replicas",
       "tooltip": {
@@ -669,7 +727,6 @@
         "sort": 0,
         "value_type": "cumulative"
       },
-      "transparent": false,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -704,6 +761,12 @@
     {
       "columns": [],
       "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 6,
@@ -723,12 +786,14 @@
       "styles": [
         {
           "alias": "Time",
+          "align": "auto",
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "pattern": "Time",
           "type": "hidden"
         },
         {
           "alias": "Pod",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -749,6 +814,7 @@
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -777,11 +843,11 @@
       ],
       "title": "Drill down to to Pod Dashboard",
       "transform": "timeseries_to_rows",
-      "type": "table"
+      "type": "table-old"
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 16,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [
     "kubernetes",
@@ -825,8 +891,13 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "etcd-events",
+          "value": "etcd-events"
+        },
         "datasource": "prometheus",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": "Statefulset",
@@ -852,7 +923,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "5s",
       "10s",
       "30s",
       "1m",

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-api-server-details.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-api-server-details.json
@@ -5,6 +5,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
+  "iteration": 1591607086411,
   "links": [],
   "panels": [
     {
@@ -16,6 +17,12 @@
       "description": "Shows the rate of all API server requests.",
       "editable": false,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "grid": {
@@ -28,6 +35,7 @@
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 6,
       "isNew": false,
       "legend": {
@@ -114,6 +122,12 @@
       "description": "Shows the request latency of each verb for the API server.",
       "editable": false,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "grid": {
@@ -126,6 +140,7 @@
         "x": 12,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 7,
       "isNew": false,
       "legend": {
@@ -213,6 +228,12 @@
       "description": "Shows the request rate per verb for the API server.",
       "editable": false,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "grid": {
@@ -225,6 +246,7 @@
         "x": 0,
         "y": 8
       },
+      "hiddenSeries": false,
       "id": 49,
       "isNew": false,
       "legend": {
@@ -312,6 +334,12 @@
       "dashes": false,
       "datasource": "prometheus",
       "description": "Shows the average rate of requests to the API server.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "gridPos": {
@@ -320,6 +348,7 @@
         "x": 12,
         "y": 8
       },
+      "hiddenSeries": false,
       "id": 51,
       "legend": {
         "avg": false,
@@ -375,6 +404,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:199",
           "decimals": null,
           "format": "short",
           "label": "requests/s",
@@ -382,6 +412,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:200",
           "format": "short",
           "logBase": 1,
           "show": true
@@ -401,6 +432,12 @@
       "description": "Shows the request rate per scope for the API server.",
       "editable": false,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "grid": {
@@ -413,6 +450,7 @@
         "x": 0,
         "y": 16
       },
+      "hiddenSeries": false,
       "id": 47,
       "isNew": false,
       "legend": {
@@ -501,6 +539,12 @@
       "description": "Shows the request rate per resource for the API server.",
       "editable": false,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "grid": {
@@ -513,6 +557,7 @@
         "x": 0,
         "y": 24
       },
+      "hiddenSeries": false,
       "id": 48,
       "isNew": false,
       "legend": {
@@ -601,6 +646,12 @@
       "description": "Shows the request rate per verb and resource for the API server.",
       "editable": false,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "grid": {
@@ -613,6 +664,7 @@
         "x": 0,
         "y": 32
       },
+      "hiddenSeries": false,
       "id": 45,
       "isNew": false,
       "legend": {
@@ -694,7 +746,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 19,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [
     "seed",
@@ -705,6 +757,8 @@
       {
         "allValue": "",
         "current": {
+          "selected": true,
+          "tags": [],
           "text": "All",
           "value": [
             "$__all"
@@ -778,13 +832,14 @@
           }
         ],
         "query": "DELETE,PUT,POST,DELETECOLLECTION,WATCH,GET,LIST,PATCH,CONNECT,UPDATE,CREATE",
+        "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
       },
       {
         "allValue": null,
         "current": {
-          "selected": "true",
+          "selected": false,
           "text": "5m",
           "value": "5m"
         },
@@ -796,11 +851,6 @@
         "options": [
           {
             "selected": false,
-            "text": "1m",
-            "value": "1m"
-          },
-          {
-            "selected": false,
             "text": "3m",
             "value": "3m"
           },
@@ -810,7 +860,8 @@
             "value": "5m"
           }
         ],
-        "query": "1m,3m,5m",
+        "query": "3m,5m",
+        "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
       }
@@ -822,7 +873,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "5s",
       "10s",
       "30s",
       "1m",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area monitoring
/kind enhancement
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Upgraded grafana to the newest version to prevent grafana [vulnerability](https://grafana.com/blog/2020/06/03/grafana-6.7.4-and-7.0.2-released-with-important-security-fix/). Some dashboards were also updated.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Upgrade grafana to `7.0.3`
```
