### PR TITLE
Move `ReferencedResourcesPrefix` constant to v1beta1constants pkg

### DIFF
--- a/extensions/pkg/controller/utils.go
+++ b/extensions/pkg/controller/utils.go
@@ -22,13 +22,13 @@ import (
 
 	controllererror "github.com/gardener/gardener/extensions/pkg/controller/error"
 	"github.com/gardener/gardener/extensions/pkg/util"
-	"github.com/gardener/gardener/pkg/operation/botanist"
-
-	resourcemanagerv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/api/extensions"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	resourcemanagerv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -350,5 +350,5 @@ func IsMigrated(obj runtime.Object) bool {
 // GetObjectByReference gets an object by the given reference, in the given namespace.
 // If the object kind doesn't match the given reference kind this will result in an error.
 func GetObjectByReference(ctx context.Context, c client.Client, ref *autoscalingv1.CrossVersionObjectReference, namespace string, obj runtime.Object) error {
-	return c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: botanist.ReferencedResourcesPrefix + ref.Name}, obj)
+	return c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: v1beta1constants.ReferencedResourcesPrefix + ref.Name}, obj)
 }

--- a/extensions/pkg/controller/utils_test.go
+++ b/extensions/pkg/controller/utils_test.go
@@ -19,12 +19,12 @@ import (
 	"fmt"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
-	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	"github.com/gardener/gardener/pkg/operation/botanist"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -284,7 +284,7 @@ var _ = Describe("Utils", func() {
 			namespace = "shoot--test--foo"
 			refSecret = &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      botanist.ReferencedResourcesPrefix + "foo",
+					Name:      v1beta1constants.ReferencedResourcesPrefix + "foo",
 					Namespace: namespace,
 				},
 				Data: map[string][]byte{
@@ -295,7 +295,7 @@ var _ = Describe("Utils", func() {
 
 		It("should call client.Get and return the result", func() {
 			secret := &corev1.Secret{}
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: botanist.ReferencedResourcesPrefix + ref.Name}, secret).DoAndReturn(
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: v1beta1constants.ReferencedResourcesPrefix + ref.Name}, secret).DoAndReturn(
 				func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret) error {
 					refSecret.DeepCopyInto(secret)
 					return nil

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -281,4 +281,8 @@ const (
 	LabelWorkerPool = "worker.gardener.cloud/pool"
 	// LabelWorkerPool is a deprecated constant for a label that indicates the worker pool the node belongs to
 	LabelWorkerPoolDeprecated = "worker.garden.sapcloud.io/group"
+
+	// ReferencedResourcesPrefix is the prefix used when copying referenced resources to the Shoot namespace in the Seed,
+	// to avoid naming collisions with resources managed by Gardener.
+	ReferencedResourcesPrefix = "ref-"
 )

--- a/pkg/operation/botanist/resources.go
+++ b/pkg/operation/botanist/resources.go
@@ -29,9 +29,6 @@ import (
 const (
 	// ManagedResourceName is the name of the managed resource used to deploy referenced resources to the Seed cluster.
 	ManagedResourceName = "referenced-resources"
-	// ReferencedResourcesPrefix is the prefix used when copying referenced resources to the Shoot namespace in the Seed,
-	// to avoid naming collisions with resources managed by Gardener.
-	ReferencedResourcesPrefix = "ref-"
 )
 
 // DeployReferencedResources reads all referenced resources from the Garden cluster and writes a managed resource to the Seed cluster.
@@ -51,7 +48,7 @@ func (b *Botanist) DeployReferencedResources(ctx context.Context) error {
 		// Create an unstructured object and append it to the slice
 		unstructuredObj := &unstructured.Unstructured{Object: obj}
 		unstructuredObj.SetNamespace(b.Shoot.SeedNamespace)
-		unstructuredObj.SetName(ReferencedResourcesPrefix + unstructuredObj.GetName())
+		unstructuredObj.SetName(v1beta1constants.ReferencedResourcesPrefix + unstructuredObj.GetName())
 		unstructuredObjs = append(unstructuredObjs, unstructuredObj)
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area dev-productivity
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Move `ReferencedResourcesPrefix` constant to `v1beta1constants` pkg to avoid a dependency from `extensions/pkg` to `pkg/operation/botanist` which carries a long tail of other dependent packages with it (introduced with #2360).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
