### PR TITLE
Fix typo in ManagedResourceCoreNamespaceName

### DIFF
--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -375,7 +375,7 @@ const (
 	ManagedResourceShootCoreName = "shoot-core"
 
 	// ManagedResourceCoreNamespaceName is the name of the core namespace managed resource.
-	ManagedResourceCoreNamespaceName = "shoot-core-namespace"
+	ManagedResourceCoreNamespaceName = "shoot-core-namespaces"
 
 	// ManagedResourceAddonsName is the name of the addons managed resource.
 	ManagedResourceAddonsName = "addons"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/kind bug
/priority normal

**What this PR does / why we need it**:
Fix typo in the `shoot-core-namespaces` managed resource name introduced with #2422 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
