### PR TITLE
Fix RESTMapper defaulting

### DIFF
--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -278,7 +278,7 @@ func new(conf *config) (Interface, error) {
 		return nil, err
 	}
 
-	c, err := NewDirectClient(conf.restConfig, conf.clientOptions)
+	c, err := newDirectClient(conf.restConfig, conf.clientOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -343,12 +343,14 @@ func setConfigDefaults(conf *config) error {
 }
 
 func setClientOptionsDefaults(config *rest.Config, options *client.Options) error {
-	// default the client's REST mapper to a dynamic REST mapper (automatically rediscovers resources on NoMatchErrors)
-	mapper, err := apiutil.NewDynamicRESTMapper(config, apiutil.WithLazyDiscovery)
-	if err != nil {
-		return fmt.Errorf("failed to create new DynamicRESTMapper: %w", err)
+	if options.Mapper == nil {
+		// default the client's REST mapper to a dynamic REST mapper (automatically rediscovers resources on NoMatchErrors)
+		mapper, err := apiutil.NewDynamicRESTMapper(config, apiutil.WithLazyDiscovery)
+		if err != nil {
+			return fmt.Errorf("failed to create new DynamicRESTMapper: %w", err)
+		}
+		options.Mapper = mapper
 	}
-	options.Mapper = mapper
 
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Follow-up to #2417: remove double defaulting of `client.Options.Mapper` which was introduced while resolving merge conflicts.

**Which issue(s) this PR fixes**:
Part of #2414 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
