### PR TITLE
Fix deletion case for extension predicates

### DIFF
--- a/extensions/pkg/controller/backupbucket/controller.go
+++ b/extensions/pkg/controller/backupbucket/controller.go
@@ -67,10 +67,6 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 			extensionspredicate.LastOperationNotSuccessful(),
 			extensionspredicate.IsDeleting(),
 		),
-		extensionspredicate.Or(
-			extensionspredicate.HasOperationAnnotation(),
-			predicate.GenerationChangedPredicate{},
-		),
 	}
 }
 

--- a/extensions/pkg/controller/backupentry/controller.go
+++ b/extensions/pkg/controller/backupentry/controller.go
@@ -67,10 +67,6 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 			extensionspredicate.LastOperationNotSuccessful(),
 			extensionspredicate.IsDeleting(),
 		),
-		extensionspredicate.Or(
-			extensionspredicate.HasOperationAnnotation(),
-			predicate.GenerationChangedPredicate{},
-		),
 	}
 }
 

--- a/extensions/pkg/controller/containerruntime/controller.go
+++ b/extensions/pkg/controller/containerruntime/controller.go
@@ -77,10 +77,6 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 			extensionspredicate.IsDeleting(),
 		),
 		extensionspredicate.ShootNotFailed(),
-		extensionspredicate.Or(
-			extensionspredicate.HasOperationAnnotation(),
-			predicate.GenerationChangedPredicate{},
-		),
 	}
 }
 

--- a/extensions/pkg/controller/controlplane/controller.go
+++ b/extensions/pkg/controller/controlplane/controller.go
@@ -67,10 +67,6 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 			extensionspredicate.IsDeleting(),
 		),
 		extensionspredicate.ShootNotFailed(),
-		extensionspredicate.Or(
-			extensionspredicate.HasOperationAnnotation(),
-			predicate.GenerationChangedPredicate{},
-		),
 	}
 }
 

--- a/extensions/pkg/controller/extension/reconciler.go
+++ b/extensions/pkg/controller/extension/reconciler.go
@@ -91,10 +91,6 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 			extensionspredicate.IsDeleting(),
 		),
 		extensionspredicate.ShootNotFailed(),
-		extensionspredicate.Or(
-			extensionspredicate.HasOperationAnnotation(),
-			predicate.GenerationChangedPredicate{},
-		),
 	}
 }
 

--- a/extensions/pkg/controller/infrastructure/controller.go
+++ b/extensions/pkg/controller/infrastructure/controller.go
@@ -71,10 +71,6 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 			extensionspredicate.IsDeleting(),
 		),
 		extensionspredicate.ShootNotFailed(),
-		extensionspredicate.Or(
-			extensionspredicate.HasOperationAnnotation(),
-			predicate.GenerationChangedPredicate{},
-		),
 	}
 }
 

--- a/extensions/pkg/controller/network/controller.go
+++ b/extensions/pkg/controller/network/controller.go
@@ -67,10 +67,6 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 			extensionspredicate.IsDeleting(),
 		),
 		extensionspredicate.ShootNotFailed(),
-		extensionspredicate.Or(
-			extensionspredicate.HasOperationAnnotation(),
-			predicate.GenerationChangedPredicate{},
-		),
 	}
 }
 

--- a/extensions/pkg/controller/operatingsystemconfig/controller.go
+++ b/extensions/pkg/controller/operatingsystemconfig/controller.go
@@ -72,10 +72,6 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 			extensionspredicate.LastOperationNotSuccessful(),
 			extensionspredicate.IsDeleting(),
 		),
-		extensionspredicate.Or(
-			extensionspredicate.HasOperationAnnotation(),
-			predicate.GenerationChangedPredicate{},
-		),
 	}
 }
 

--- a/extensions/pkg/controller/worker/controller.go
+++ b/extensions/pkg/controller/worker/controller.go
@@ -71,10 +71,6 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 			extensionspredicate.IsDeleting(),
 		),
 		extensionspredicate.ShootNotFailed(),
-		extensionspredicate.Or(
-			extensionspredicate.HasOperationAnnotation(),
-			predicate.GenerationChangedPredicate{},
-		),
 	}
 }
 

--- a/extensions/pkg/predicate/predicate.go
+++ b/extensions/pkg/predicate/predicate.go
@@ -166,7 +166,7 @@ func HasOperationAnnotation() predicate.Predicate {
 	}), CreateTrigger, UpdateNewTrigger, GenericTrigger)
 }
 
-// LastOperationNotSuccessful is a predicate for unsuccessful last operations for creation events.
+// LastOperationNotSuccessful is a predicate for unsuccessful last operations **only** for creation events.
 func LastOperationNotSuccessful() predicate.Predicate {
 	operationNotSucceeded := func(obj runtime.Object) bool {
 		acc, err := extensions.Accessor(obj)
@@ -184,13 +184,13 @@ func LastOperationNotSuccessful() predicate.Predicate {
 			return operationNotSucceeded(event.Object)
 		},
 		UpdateFunc: func(event event.UpdateEvent) bool {
-			return operationNotSucceeded(event.ObjectNew)
+			return false
 		},
 		GenericFunc: func(event event.GenericEvent) bool {
-			return operationNotSucceeded(event.Object)
+			return false
 		},
 		DeleteFunc: func(event event.DeleteEvent) bool {
-			return operationNotSucceeded(event.Object)
+			return false
 		},
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR fixes the deletion of shoots or their extension resources in the seed once shoots were in a `Failed` state.

It also simplifies the predicates for extension controllers. I create a list of cases (operation annotation not ignored) in which a reconciliation is desired and ask the reviewers to double check them. Please note, that those cases only consider _events_ that are send to the queue and does not cover cases in which a controller enqueues elements directly.

**Desired reconciliation:**
1. Resource creation
2. Existing resource is annotated with `gardener.cloud/operation: reconcile`
3. Resource deletion
4. Reconcile loop is interrupted (e.g. through Pod deletion), so that the next controller instance is supposed to automatically reconcile the resource (`lastOperation.state` != `Succeeded` for create events).

**Undesired reconciliation:**
1. Resource (meta, spec, status) is updated w/o `gardener.cloud/operation: reconcile` annotation and is not in deletion.
2. Shoot has `lastOperation.state: Failed`.

**Which issue(s) this PR fixes**:
Fixes #2432

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue has been fixed which caused failed shoot clusters to not be deleted successfully after a retry had been triggered.
```
