### PR TITLE
Enable namespace release when deleting Projects

### DIFF
--- a/pkg/controllermanager/controller/project/project_control.go
+++ b/pkg/controllermanager/controller/project/project_control.go
@@ -173,14 +173,14 @@ func (c *defaultControl) ReconcileProject(obj *gardencorev1beta1.Project) (bool,
 	projectLogger.Infof("[PROJECT RECONCILE]")
 
 	if project.DeletionTimestamp != nil {
-		return c.delete(project, projectLogger)
+		return c.delete(context.TODO(), project)
 	}
 
 	if err := controllerutils.EnsureFinalizer(context.TODO(), c.k8sGardenClient.Client(), project, gardencorev1beta1.GardenerName); err != nil {
 		return false, fmt.Errorf("could not add finalizer to Project: %s", err.Error())
 	}
 
-	return false, c.reconcile(project, projectLogger)
+	return false, c.reconcile(context.TODO(), project)
 }
 
 func (c *defaultControl) updateProjectStatus(objectMeta metav1.ObjectMeta, transform func(project *gardencorev1beta1.Project) (*gardencorev1beta1.Project, error)) (*gardencorev1beta1.Project, error) {

--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -29,7 +29,6 @@ import (
 	kutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
 
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -42,9 +41,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (c *defaultControl) reconcile(project *gardencorev1beta1.Project, projectLogger logrus.FieldLogger) error {
+func (c *defaultControl) reconcile(ctx context.Context, project *gardencorev1beta1.Project) error {
 	var (
-		ctx        = context.TODO()
 		generation = project.Generation
 		err        error
 	)

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -283,6 +283,11 @@ const (
 	// Deprecated: Use `NamespaceProject` instead.
 	NamespaceProjectDeprecated = "namespace.garden.sapcloud.io/project"
 
+	// NamespaceKeepAfterProjectDeletion is a constant for an annotation on a `Namespace` resource that states that it
+	// should not be deleted if the corresponding `Project` gets deleted. Please note that all project related labels
+	// from the namespace will be removed when the project is being deleted.
+	NamespaceKeepAfterProjectDeletion = "namespace.gardener.cloud/keep-after-project-deletion"
+
 	// ShootAlphaScalingAPIServerClass is a constant for an annotation on the shoot stating the initial API server class.
 	// It influences the size of the initial resource requests/limits.
 	// Possible values are [small, medium, large, xlarge, 2xlarge].


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR enables the possibility to release a `Namespace` when deleting a `Project`, i.e., it is not being deleted. In order to achieve this the `Namespace` must be annotated with `namespace.gardener.cloud/keep-after-project-deletion=true`.

**Which issue(s) this PR fixes**:
Fixes #879

**Special notes for your reviewer**:
/cc @Diaphteiros 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
It is now possible to keep a `Namespace` in the system even when the related `Project` is deleted by annotating the `Namespace` with `namespace.gardener.cloud/keep-after-project-deletion=true`.
```
