### PR TITLE
Add network policy documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@
     * [Gardener Seed Admission Controller](concepts/seed-admission-controller.md)
     * [Gardenlet](concepts/gardenlet.md)
 * [Backup Restore](concepts/backup-restore.md)
+* [Network Policies](concepts/network_policies.md)
 
 ## Usage
 
@@ -32,6 +33,7 @@
 * [`ManagedIstio` feature](usage/istio.md)
 * [Trusted TLS certificate for shoot control planes](usage/trusted-tls-for-control-planes.md)
 * [API Server Network Proxy Reverse Tunneling](usage/reverse-tunnel.md)
+* [Network Policies in the Shoot Cluster](usage/shoot_network_policies.md)
 
 ## Proposals
 
@@ -56,7 +58,7 @@
 * [Adding New Cloud Providers](development/new-cloud-provider.md)
 * [Extending the Monitoring Stack](development/monitoring-stack.md)
 * [How to create log parser for container into fluent-bit](development/log_parsers.md)
-* [Feature Gates in Gardener](development/feature_gates.md)
+* [Network Policies in the Seed Cluster](development/seed_network_policies.md)
 
 ## Extensions
 
@@ -103,6 +105,7 @@
 * [Deploying the Gardener and a Seed into an AKS cluster](deployment/aks.md)
 * [Overwrite image vector](deployment/image_vector.md)
 * [Migration from Gardener `v0` to `v1`](deployment/migration_v0_to_v1.md)
+* [Feature Gates in Gardener](deployment/feature_gates.md)
 
 ## Monitoring
 

--- a/docs/concepts/network_policies.md
+++ b/docs/concepts/network_policies.md
@@ -1,0 +1,18 @@
+# Network Policies in Gardener
+
+As `Seed` clusters can host the [Kubernetes control planes](https://kubernetes.io/docs/concepts/#kubernetes-control-plane) of many `Shoot` clusters, it is necessary to isolate the control planes from each other for security reasons.
+Besides deploying each control plane in its own namespace, Gardener creates [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) to also isolate the networks. 
+Essentially, network policies make sure that pods can only talk to other pods over the network they are supposed to.
+As such, network policies are an important part of Gardener's tenant isolation.
+
+Gardener deploys network policies into
+ - each namespace hosting the Kubernetes control plane of the Shoot cluster.
+ - the namespace dedicated to Gardener seed-wide global controllers. This namespace is often called `garden` and contains e.g. the [Gardenlet](https://github.com/gardener/gardener/blob/15cae57db802cbe460ff4cb3f80c26b2fc15e26f/docs/concepts/gardenlet.md).
+ - the `kube-system` namespace in the Shoot.
+ 
+The aforementioned namespaces in the Seed contain a `deny-all` network policy that [denies all ingress and egress traffic](https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-and-all-egress-traffic).
+This [secure by default](https://en.wikipedia.org/wiki/Secure_by_default) setting requires pods to whitelist network traffic.
+This is done by pods having [labels matching to the selectors of the network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/#networkpolicy-resource) deployed by Gardener.
+
+More details on the deployed network policies can be found in the [development](https://github.com/gardener/gardener/tree/master/docs/development/seed_network_policies.md) and [usage](https://github.com/gardener/gardener/tree/master/docs/development/shoot_network_policies.md) sections.
+ 

--- a/docs/development/seed_network_policies.md
+++ b/docs/development/seed_network_policies.md
@@ -1,0 +1,130 @@
+# Network Policies in the Seed Cluster
+
+This document describes the [Kubernetes network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) deployed by Gardener into the Seed cluster.
+For network policies deployed into the Shoot `kube-system` namespace, please see the [usage section](https://github.com/gardener/gardener/tree/master/docs/development/shoot_network_policies.md).
+
+Network policies deployed by Gardener have names and annotations describing their purpose, so this document does only highlight a subset of the policies in detail.
+
+## Network policies in the Shoot namespace in the Seed
+
+The network policies in the Shoot namespace in the Seed can roughly be grouped into policies required for the control plane components and for logging & monitoring.   
+
+The network policy `deny-all` plays a special role. This policy [denies all ingress and egress traffic](https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-and-all-egress-traffic) from each pod in the Shoot namespace.
+So per default, a pod running in the control plane cannot talk to any other pod in the whole Seed cluster.
+This means the pod needs to have labels matching to appropriate network policies allowing it to talk to exactly the components required to execute its desired functionality.
+[This has also implications for Gardener extensions](#implications-for-gardener-extensions) that need to deploy additional components into the `Shoot's` control plane.
+
+### Network Policies for Control Plane Components
+
+This section highlights a selection of network policies that exist in the Shoot namespace in the Seed cluster.
+In general, the control plane components serve different purposes and thus need access to different pods and network ranges.
+
+In contrast to other network policies, the policy `allow-to-shoot-networks` is tailored to the individual Shoot cluster, 
+because it is based on the network configuration in the Shoot manifest.
+It allows pods with the label `networking.gardener.cloud/to-shoot-networks=allowed` to access pods in the Shoot pod, 
+service and node CIDR range. This is used by the Shoot API Server and the prometheus pods to communicate over VPN/proxy with pods in the Shoot cluster.
+
+The policy `allow-to-blocked-cidrs` allows pods with the label `networking.gardener.cloud/to-blocked-cidrs=allowed` to access IPs that are explicitly blocked for all control planes in a Seed cluster (configurable via `spec.networks.blockCIDRS`). 
+This is used for instance to block the cloud provider's metadata service.
+
+Another network policy to be highlighted is `allow-to-seed-apiserver`.
+Some components need access to the Seed API Server. This can be allowed by labeling the pod with `networking.gardener.cloud/to-seed-apiserver=allowed`.
+This policy allows exactly the IPs of the `kube-apiserver` of the Seed.
+While all other policies have a static set of permissions (do not change during the lifecycle of the Shoot), the policy `allow-to-seed-apiserver` is reconciled to reflect the endpoints in the `default` namespace.
+This is required because endpoint IPs are not necessarily stable (think of scaling the Seed API Server pods or hibernating the Seed cluster (acting as a shooted Seed) in a local development environment).
+
+Furthermore, the following network policies exist in the Shoot namespace.
+These policies are the same for every Shoot control plane.
+
+```
+NAME                              POD-SELECTOR      
+# Pods that need to access the Shoot API server. Used by all Kubernetes control plane components.
+allow-to-shoot-apiserver          networking.gardener.cloud/to-shoot-apiserver=allowed 
+
+# allows access to kube-dns/core-dns pods for DNS queries                       
+allow-to-dns                      networking.gardener.cloud/to-dns=allowed
+
+# allows access to private IP address ranges 
+allow-to-private-networks         networking.gardener.cloud/to-private-networks=allowed  
+
+# allows access to all but private IP address ranges 
+allow-to-public-networks          networking.gardener.cloud/to-public-networks=allowed                     
+
+# allows Ingress to etcd pods from the Shoot's Kubernetes API Server
+allow-etcd                        app=etcd-statefulset,garden.sapcloud.io/role=controlplane   
+
+# used by the Shoot API server to allows ingress from pods labeled
+# with'networking.gardener.cloud/to-shoot-apiserver=allowed', from Prometheus, and allows Egress to etcd pods
+allow-kube-apiserver              app=kubernetes,garden.sapcloud.io/role=controlplane,role=apiserver       
+```
+
+
+### Network policies for Logging & Monitoring 
+
+[Gardener provides out-of-the-box logging and monitoring](https://github.com/gardener/gardener/blob/master/docs/extensions/logging-and-monitoring.md) for the Shoot control plane via a stack based on prometheus, elasticsearch, kibana and grafana.
+
+Gardener currently introduces a logging stack based on [Loki](https://github.com/grafana/loki). So this section is subject to change. 
+Please checkout [the Community Meeting for more information](https://www.youtube.com/watch?v=345b8xCcB-U&t=1166s).
+
+These are the logging and monitoring related network policies:
+```
+NAME                              POD-SELECTOR                                                             
+allow-elasticsearch               app=elasticsearch-logging,garden.sapcloud.io/role=logging,role=logging   
+allow-from-prometheus             networking.gardener.cloud/from-prometheus=allowed                        
+allow-grafana                     component=grafana,garden.sapcloud.io/role=monitoring                     
+allow-kibana                      app=kibana-logging,garden.sapcloud.io/role=logging,role=logging 
+allow-prometheus                  app=prometheus,garden.sapcloud.io/role=monitoring,role=monitoring        
+allow-to-aggregate-prometheus     networking.gardener.cloud/to-aggregate-prometheus=allowed 
+allow-to-elasticsearch            networking.gardener.cloud/to-elasticsearch=allowed  
+allow-elasticsearch               app=elasticsearch-logging,garden.sapcloud.io/role=logging,role=logging   
+```
+
+Let's take for instance a look at the network policy `from-prometheus`.
+As part of the shoot reconciliation flow, Gardener deploys a shoot-specific Prometheus into the shoot namespace. 
+Each pod that should be scraped for metrics must be labeled with `networking.gardener.cloud/from-prometheus=allowed` to allow incoming network requests by the prometheus pod.
+Most components of the Shoot cluster's control plane expose metrics and are therefore labeled appropriately. 
+
+### Implications for Gardener Extensions
+Gardener extensions sometimes need to deploy additional components into the Shoot namespace in the Seed hosting the control plane. 
+For example the Gardener extension [provider-aws](https://github.com/gardener/gardener-extension-provider-aws) deploys the `MachineControllerManager` into the Shoot namespace, that is ultimately responsible to create the VMs with the cloud provider AWS.
+
+Every Shoot namespace in the Seed contains the network policy `deny-all`.
+This requires a pod deployed by a Gardener extension to have labels from network policies, that exist in the Shoot namespace, that allow the required network ranges. 
+
+Additionally, extensions could also deploy their own network policies. This is used e.g by the Gardener extension [provider-aws](https://github.com/gardener/gardener-extension-provider-aws) 
+to serve [Admission Webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) for the Shoot API server that need to be reachable from within the Shoot namespace.
+
+The pod can use an arbitrary combination of network policies.
+
+## Network policies in the `garden` namespace
+
+The network policies in the `garden` namespace are, with a few exceptions (e.g Kubernetes control plane specific policies), the same as in the Shoot namespaces.
+For your reference, these are all the deployed network policies.
+```
+NAME                              POD-SELECTOR  
+allow-elasticsearch               app=elasticsearch-logging,garden.sapcloud.io/role=logging,role=logging   
+allow-fluentbit                   app=fluent-bit,garden.sapcloud.io/role=logging,role=logging              
+allow-fluentd                     app=fluentd-es,garden.sapcloud.io/role=logging,role=logging              
+allow-from-aggregate-prometheus   networking.gardener.cloud/from-aggregate-prometheus=allowed              
+allow-kibana                      app=kibana-logging,garden.sapcloud.io/role=logging,role=logging          
+allow-to-aggregate-prometheus     networking.gardener.cloud/to-aggregate-prometheus=allowed                
+allow-to-all-shoot-apiservers     networking.gardener.cloud/to-all-shoot-apiservers=allowed                
+allow-to-blocked-cidrs            networking.gardener.cloud/to-blocked-cidrs=allowed                       
+allow-to-dns                      networking.gardener.cloud/to-dns=allowed                                 
+allow-to-elasticsearch            networking.gardener.cloud/to-elasticsearch=allowed                       
+allow-to-private-networks         networking.gardener.cloud/to-private-networks=allowed                    
+allow-to-public-networks          networking.gardener.cloud/to-public-networks=allowed                     
+allow-to-seed-apiserver           networking.gardener.cloud/to-seed-apiserver=allowed                      
+deny-all                          networking.gardener.cloud/to-all=disallowed                              
+```
+
+This section describes the network policies that are unique to the `garden` namespace.
+
+The network policy `allow-to-all-shoot-apiservers` allows pods to access every `Shoot` API server in the `Seed`.
+This is for instance used by the [dependency watchdog](https://github.com/gardener/dependency-watchdog) to regularly check 
+the health of all the Shoot API servers.
+
+[Gardener deploys a central Prometheus instance](https://github.com/gardener/gardener/blob/master/docs/extensions/logging-and-monitoring.md#monitoring) in the `garden` namespace that fetches metrics and data from all seed cluster nodes and all seed cluster pods.
+The network policies `allow-to-aggregate-prometheus` and `allow-from-aggregate-prometheus` allow traffic from and to this prometheus instance.
+
+Worth mentioning is, that the network policy `allow-to-shoot-networks` does not exist in the `garden` namespace. This is to forbid Gardener system components to talk to workload deployed in the Shoot VPC.

--- a/docs/extensions/controlplane.md
+++ b/docs/extensions/controlplane.md
@@ -56,6 +56,12 @@ The second one contains the output of the [`Infrastructure` resource](infrastruc
 In order to support a new control plane provider you need to write a controller that watches all `ControlPlane`s with `.spec.type=<my-provider-name>`.
 You can take a look at the below referenced example implementation for the Alicloud provider.
 
+The control plane controller as part of the `ControlPlane` reconciliation, often deploys resources (e.g. pods/deployments) into the Shoot namespace in the `Seed` as part of its `ControlPlane` reconciliation loop.
+Because the namespace contains [network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) that per default [deny all ingress and egress traffic](https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-and-all-egress-traffic), 
+the pods may need to have proper labels matching to the selectors of the network policies in order to allow the required network traffic. 
+Otherwise, they won't be allowed to talk to certain other components (e.g., the kube-apiserver of the shoot).
+Please [see this document](https://github.com/gardener/gardener/tree/master/docs/development/seed_network_policies.md) for more information.
+
 ## Non-provider specific information required for infrastructure creation
 
 Most providers might require further information that is not provider specific but already part of the shoot resource.

--- a/docs/usage/shoot_network_policies.md
+++ b/docs/usage/shoot_network_policies.md
@@ -1,0 +1,26 @@
+## Network policies in the Shoot Cluster
+
+In addition to deploying network policies [into the Seed](https://github.com/gardener/gardener/tree/master/docs/development/network_policies.md),
+Gardener deploys network policies into the `kube-system` namespace of the Shoot.
+These network policies are used by Shoot system components (that are not part of the control plane).
+Other namespaces in the Shoot do not contain network policies deployed by Gardener. 
+
+As best practice, every pod deployed into the `kube-system` namespace should use appropriate network policies in order to only allow **required** network traffic.
+Therefore, pods should have labels matching to the selectors of the available network policies.
+
+Gardener deploys the following network policies:
+```
+NAME                                       POD-SELECTOR                                   
+gardener.cloud--allow-from-seed            networking.gardener.cloud/from-seed=allowed            
+gardener.cloud--allow-to-apiserver         networking.gardener.cloud/to-apiserver=allowed         
+gardener.cloud--allow-to-dns               networking.gardener.cloud/to-dns=allowed               
+gardener.cloud--allow-to-from-nginx        app=nginx-ingress                                      
+gardener.cloud--allow-to-kubelet           networking.gardener.cloud/to-kubelet=allowed           
+gardener.cloud--allow-to-public-networks   networking.gardener.cloud/to-public-networks=allowed
+```
+
+Additionally, there can be network policies deployed by Gardener extensions such as [extension-calico](https://github.com/gardener/gardener-extension-networking-calico).
+```
+NAME                                       POD-SELECTOR  
+gardener.cloud--allow-from-calico-node     k8s-app=calico-typha                                   
+```


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area documentation
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Add documentation for the network policies that Gardener deploys into the Seed's  `gardener` &`shoot-namespaces` and into the `kube-system` namespace in the Shoot.
**Which issue(s) this PR fixes**:
Fixes # 1580

**Special notes for your reviewer**:

We should not introduce such features without proper documentation. 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
