### PR TITLE
Fix transportation of machine image providerConfig to OSC

### DIFF
--- a/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
+++ b/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
@@ -15,6 +15,10 @@ metadata:
 spec:
   type: {{ required "type is required" .Values.type }}
   purpose: {{ required "purpose is required" .Values.purpose }}
+  {{- if .Values.providerConfig }}
+  providerConfig:
+{{ .Values.providerConfig | indent 4 }}
+  {{- end }}
   {{- if .Values.cri }}
   criConfig:
     name: {{ .Values.cri.name }}

--- a/charts/seed-operatingsystemconfig/downloader/values.yaml
+++ b/charts/seed-operatingsystemconfig/downloader/values.yaml
@@ -3,6 +3,8 @@ purpose: bootstrap
 secretName: cpu-worker-0
 server: api.shoot-cluster.example.com
 annotationCurrentTimestamp: 2020-05-06T10:18:01Z
+#providerConfig:
+#  some-provider-specific-config
 
 # cri:
 #   name: containerd

--- a/charts/seed-operatingsystemconfig/original/values.yaml
+++ b/charts/seed-operatingsystemconfig/original/values.yaml
@@ -9,6 +9,8 @@ osc:
     containerRuntimesBinaryPath: /var/bin/containerruntimes
     names:
       containerd: containerd
+# providerConfig:
+#   some-provider-specific-config
 
 # caBundle: |
 #   root certificates

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -32,7 +32,6 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -151,37 +150,32 @@ func (b *Botanist) generateOriginalConfig() (map[string]interface{}, error) {
 func (b *Botanist) deployOperatingSystemConfigsForWorker(ctx context.Context, machineTypes []gardencorev1beta1.MachineType, machineImage *gardencorev1beta1.ShootMachineImage, downloaderConfig, originalConfig map[string]interface{}, worker gardencorev1beta1.Worker) (*shoot.OperatingSystemConfigs, error) {
 	secretName := b.Shoot.ComputeCloudConfigSecretName(worker.Name)
 
-	downloaderConfig["secretName"] = secretName
-
-	var customization = map[string]interface{}{}
-	if machineImage.ProviderConfig != nil {
-		err := yaml.Unmarshal(machineImage.ProviderConfig.Raw, &customization)
-		if err != nil {
-			return nil, err
+	var (
+		criNamesConfig = map[string]interface{}{
+			"containerd": extensionsv1alpha1.CRINameContainerD,
 		}
+		criConfig = map[string]interface{}{
+			"containerRuntimesBinaryPath": extensionsv1alpha1.ContainerDRuntimeContainersBinFolder,
+			"names":                       criNamesConfig,
+		}
+		osc = map[string]interface{}{
+			"type":                       machineImage.Name,
+			"purpose":                    extensionsv1alpha1.OperatingSystemConfigPurposeReconcile,
+			"reloadConfigFilePath":       common.CloudConfigFilePath,
+			"secretName":                 secretName,
+			"sshKey":                     string(b.Secrets[v1beta1constants.SecretNameSSHKeyPair].Data[secrets.DataKeySSHAuthorizedKeys]),
+			"cri":                        criConfig,
+			"annotationCurrentTimestamp": time.Now().UTC().String(),
+		}
+	)
+
+	if machineImage.ProviderConfig != nil && machineImage.ProviderConfig.Raw != nil {
+		downloaderConfig["providerConfig"] = string(machineImage.ProviderConfig.Raw)
+		osc["providerConfig"] = string(machineImage.ProviderConfig.Raw)
 	}
 
-	sshKey := b.Secrets[v1beta1constants.SecretNameSSHKeyPair].Data[secrets.DataKeySSHAuthorizedKeys]
-
-	criNamesConfig := map[string]interface{}{
-		"containerd": extensionsv1alpha1.CRINameContainerD,
-	}
-
-	criConfig := map[string]interface{}{
-		"containerRuntimesBinaryPath": extensionsv1alpha1.ContainerDRuntimeContainersBinFolder,
-		"names":                       criNamesConfig,
-	}
-
-	originalConfig["osc"] = map[string]interface{}{
-		"type":                       machineImage.Name,
-		"purpose":                    extensionsv1alpha1.OperatingSystemConfigPurposeReconcile,
-		"reloadConfigFilePath":       common.CloudConfigFilePath,
-		"secretName":                 secretName,
-		"customization":              customization,
-		"sshKey":                     string(sshKey),
-		"cri":                        criConfig,
-		"annotationCurrentTimestamp": time.Now().UTC().String(),
-	}
+	downloaderConfig["secretName"] = secretName
+	originalConfig["osc"] = osc
 
 	if data := worker.CABundle; data != nil {
 		if existingCABundle, ok := originalConfig["caBundle"]; ok {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area os
/kind bug
/priority normal

**What this PR does / why we need it**:
With #1261 the machine image specific provider config was introduced, however, it never worked because it wasn't correctly transported to the `OperatingSystemConfig` resource. This PR fixes the bug.

**Which issue(s) this PR fixes**:
Ref #2354 

**Special notes for your reviewer**:
Thanks @vpnachev for spotting!
/assign @vpnachev 
/invite @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
A bug has been fixed that prevented the correct transportation of the machine image specific configuration in `.spec.provider.workers[].machine.image.providerConfig` to the respective extension controller.
```
