### PR TITLE
Include Prometheus tests in verify-extended rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,18 +162,23 @@ format:
 .PHONY: test
 test:
 	@./hack/test.sh -r ./cmd/... ./extensions/... ./pkg/... ./plugin/...
-	@./hack/test-prometheus.sh
+	$(MAKE) test-prometheus
 
 .PHONY: test-cov
 test-cov:
 	@./hack/test-cover.sh -r ./cmd/... ./extensions/... ./pkg/... ./plugin/...
+	$(MAKE) test-prometheus
 
-.PHONY: test-clean
-test-clean:
+.PHONY: test-cov-clean
+test-cov-clean:
 	@./hack/test-cover-clean.sh
+
+.PHONY: test-prometheus
+test-prometheus:
+	@./hack/test-prometheus.sh
 
 .PHONY: verify
 verify: check format test
 
 .PHONY: verify-extended
-verify-extended: install-requirements check-generate check format test-cov test-clean
+verify-extended: install-requirements check-generate check format test-cov test-cov-clean test-prometheus

--- a/docs/development/testing_and_dependencies.md
+++ b/docs/development/testing_and_dependencies.md
@@ -12,7 +12,7 @@ There is an additional command for analyzing the code coverage of the tests. Gin
 ```bash
 make test-cov
 open gardener.coverage.html
-make test-clean
+make test-cov-clean
 ```
 
 ## Dependency Management


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area dev-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:
The Prometheus tests weren't executed as part of the `verify-extended` rule which caused #2439. Let's better include them to detect issues before they get merged.

**Which issue(s) this PR fixes**:
Ref #2439 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
