### PR TITLE
Restructure botanist deploy network CRD & add missing tests

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -301,12 +301,12 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation) *gardencorev1bet
 		})
 		destroyNetwork = g.Add(flow.Task{
 			Name:         "Destroying shoot network plugin",
-			Fn:           flow.TaskFn(botanist.DestroyNetwork).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.Network.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(cleanShootNamespaces),
 		})
 		waitUntilNetworkIsDestroyed = g.Add(flow.Task{
 			Name:         "Waiting until shoot network plugin has been destroyed",
-			Fn:           flow.TaskFn(botanist.WaitUntilNetworkIsDeleted),
+			Fn:           botanist.Shoot.Components.Network.WaitCleanup,
 			Dependencies: flow.NewTaskIDs(destroyNetwork),
 		})
 		destroyWorker = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -269,7 +269,7 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 		})
 		waitUntilNetworkIsReady = g.Add(flow.Task{
 			Name:         "Waiting until shoot network plugin has been reconciled",
-			Fn:           flow.TaskFn(botanist.WaitUntilNetworkIsReady),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.Network.Wait),
 			Dependencies: flow.NewTaskIDs(deployNetworking),
 		})
 		deployManagedResources = g.Add(flow.Task{

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -21,14 +21,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gardener/gardener-resource-manager/pkg/manager"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	botanistconstants "github.com/gardener/gardener/pkg/operation/botanist/constants"
-	"github.com/gardener/gardener/pkg/operation/botanist/dns"
+	"github.com/gardener/gardener/pkg/operation/botanist/extensions/dns"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -36,6 +35,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
+	"github.com/gardener/gardener-resource-manager/pkg/manager"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,7 +73,7 @@ func (b *Botanist) EnsureIngressDNSRecord(ctx context.Context) error {
 	return component.OpWaiter(b.Shoot.Components.DNS.NginxEntry).Deploy(ctx)
 }
 
-// DefaultNginxIngressDNSEntry returns a Deployer which removes existing nginx ingress DNSEtnry.
+// DefaultNginxIngressDNSEntry returns a Deployer which removes existing nginx ingress DNSEntry.
 func (b *Botanist) DefaultNginxIngressDNSEntry(seedClient client.Client) component.DeployWaiter {
 	return component.OpDestroy(dns.NewDNSEntry(
 		&dns.EntryValues{

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -84,6 +84,9 @@ func New(o *operation.Operation) (*Botanist, error) {
 
 	o.Shoot.Components.DNS.NginxEntry = b.DefaultNginxIngressDNSEntry(b.K8sSeedClient.Client())
 
+	// Extension CRD components
+	o.Shoot.Components.Network = b.DefaultNetwork(b.K8sSeedClient.Client())
+
 	return b, nil
 }
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
-	"github.com/gardener/gardener/pkg/operation/botanist/dns"
+	"github.com/gardener/gardener/pkg/operation/botanist/extensions/dns"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -20,13 +20,13 @@ import (
 	"strings"
 	"time"
 
-	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
-	"github.com/gardener/gardener/pkg/operation/botanist/dns"
+	"github.com/gardener/gardener/pkg/operation/botanist/extensions/dns"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/operation/botanist/extensions/dns/dns_suite_test.go
+++ b/pkg/operation/botanist/extensions/dns/dns_suite_test.go
@@ -21,14 +21,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gardener/gardener/pkg/utils/retry"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener/pkg/utils/retry"
 )
 
 func TestDns(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Dns Suite")
+	RunSpecs(t, "Botanist Extensions DNS Suite")
 }
 
 var _ retry.Ops = &fakeOps{}
@@ -55,6 +56,6 @@ func (o *fakeOps) UntilTimeout(ctx context.Context, interval, timeout time.Durat
 }
 
 func chartsRoot() string {
-	return filepath.Join("../", "../", "../", "../", "charts")
+	return filepath.Join("../", "../", "../", "../", "../", "charts")
 
 }

--- a/pkg/operation/botanist/extensions/dns/dnsentry.go
+++ b/pkg/operation/botanist/extensions/dns/dnsentry.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"

--- a/pkg/operation/botanist/extensions/dns/dnsentry_test.go
+++ b/pkg/operation/botanist/extensions/dns/dnsentry_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
-	. "github.com/gardener/gardener/pkg/operation/botanist/dns"
+	. "github.com/gardener/gardener/pkg/operation/botanist/extensions/dns"
 	. "github.com/gardener/gardener/test/gomega"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
@@ -158,7 +158,7 @@ var _ = Describe("#DNSEntry", func() {
 			Expect(defaultDepWaiter.Destroy(ctx)).ToNot(HaveOccurred())
 		})
 
-		It("should not return error when it's deleted successfully", func() {
+		It("should return error when it's not deleted successfully", func() {
 			mc := mockclient.NewMockClient(ctrl)
 			mc.EXPECT().Delete(ctx, &dnsv1alpha1.DNSEntry{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operation/botanist/extensions/dns/dnsprovider.go
+++ b/pkg/operation/botanist/extensions/dns/dnsprovider.go
@@ -21,15 +21,16 @@ import (
 	"time"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
-	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ProviderValues contains the values used to create a DNSProvider.

--- a/pkg/operation/botanist/extensions/dns/dnsprovider_test.go
+++ b/pkg/operation/botanist/extensions/dns/dnsprovider_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
-	. "github.com/gardener/gardener/pkg/operation/botanist/dns"
+	. "github.com/gardener/gardener/pkg/operation/botanist/extensions/dns"
 	. "github.com/gardener/gardener/test/gomega"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"

--- a/pkg/operation/botanist/extensions/network/network.go
+++ b/pkg/operation/botanist/extensions/network/network.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/operation/common"
+)
+
+const (
+	// NetworkDefaultTimeout is the default timeout and defines how long Gardener should wait
+	// for a successful reconciliation of a network resource.
+	NetworkDefaultTimeout = 3 * time.Minute
+	// DefaultInterval is the default interval for retry operations.
+	DefaultInterval = 5 * time.Second
+	// DefaultSevereThreshold  is the default threshold until an error reported by another component is treated as 'severe'.
+	DefaultSevereThreshold = 30 * time.Second
+)
+
+// TimeNow returns the current time. Exposed for testing.
+var TimeNow = time.Now
+
+// Values contains the values used to create a Network CRD
+type Values struct {
+	// Namespace is the namespace of the Shoot network in the Seed
+	Namespace string
+	// Name is the name of the Network extension. Commonly the Shoot's name.
+	Name string
+	// isInRestorePhaseOfControlPlaneMigration indicates if the Shoot is in the restore
+	// Phase of the ControlPlane migration
+	IsInRestorePhaseOfControlPlaneMigration bool
+	// Type is the type of Network plugin/extension (e.g calico)
+	Type string
+	// ProviderConfig contains the provider config for the Network extension.
+	ProviderConfig *runtime.RawExtension
+	// PodCIDR is the Shoot's pod CIDR in the Shoot VPC
+	PodCIDR *net.IPNet
+	// ServiceCIDR is the Shoot's service CIDR in the Shoot VPC
+	ServiceCIDR *net.IPNet
+}
+
+// New creates a new instance of DeployWaiter for a Network.
+func New(
+	logger *logrus.Entry,
+	client crclient.Client,
+	values *Values,
+) component.DeployWaiter {
+	return &network{
+		client: client,
+		logger: logger,
+		values: values,
+	}
+}
+
+type network struct {
+	values *Values
+	logger *logrus.Entry
+	client crclient.Client
+}
+
+// Deploy uses the seed client to create or update the Network custom resource in the Shoot namespace in the Seed
+func (d *network) Deploy(ctx context.Context) error {
+	var (
+		restorePhase = d.values.IsInRestorePhaseOfControlPlaneMigration
+		operation    = v1beta1constants.GardenerOperationReconcile
+		network      = &extensionsv1alpha1.Network{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      d.values.Name,
+				Namespace: d.values.Namespace,
+			},
+		}
+	)
+
+	if restorePhase {
+		operation = v1beta1constants.GardenerOperationWaitForState
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, d.client, network, func() error {
+		metav1.SetMetaDataAnnotation(&network.ObjectMeta, v1beta1constants.GardenerOperation, operation)
+		metav1.SetMetaDataAnnotation(&network.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+
+		network.Spec = extensionsv1alpha1.NetworkSpec{
+			DefaultSpec: extensionsv1alpha1.DefaultSpec{
+				Type:           d.values.Type,
+				ProviderConfig: d.values.ProviderConfig,
+			},
+			PodCIDR:     d.values.PodCIDR.String(),
+			ServiceCIDR: d.values.ServiceCIDR.String(),
+		}
+
+		return nil
+	})
+	return err
+}
+
+// Destroy deletes the Network CRD
+func (d *network) Destroy(ctx context.Context) error {
+	return common.DeleteExtensionCR(
+		ctx,
+		d.client,
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Network{} },
+		d.values.Namespace,
+		d.values.Name,
+	)
+}
+
+// Wait waits until the Network CRD is ready
+func (d *network) Wait(ctx context.Context) error {
+	return common.WaitUntilExtensionCRReady(
+		ctx,
+		d.client,
+		d.logger,
+		func() runtime.Object { return &extensionsv1alpha1.Network{} },
+		"Network",
+		d.values.Namespace,
+		d.values.Name,
+		DefaultInterval,
+		DefaultSevereThreshold,
+		NetworkDefaultTimeout,
+		nil,
+	)
+}
+
+// WaitCleanup waits until the Network CRD is deleted
+func (d *network) WaitCleanup(ctx context.Context) error {
+	return common.DeleteExtensionCR(
+		ctx,
+		d.client,
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Network{} },
+		d.values.Namespace,
+		d.values.Name,
+	)
+}
+
+// emptyNetwork returns an empty Network CRD used for deletion.
+func (d *network) emptyNetwork() *extensionsv1alpha1.Network {
+	return &extensionsv1alpha1.Network{ObjectMeta: metav1.ObjectMeta{Name: d.values.Name, Namespace: d.values.Namespace}}
+}

--- a/pkg/operation/botanist/extensions/network/network_suite_test.go
+++ b/pkg/operation/botanist/extensions/network/network_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestNetwork(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Botanist Extensions Network Suite")
+}

--- a/pkg/operation/botanist/extensions/network/network_test.go
+++ b/pkg/operation/botanist/extensions/network/network_test.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/operation/botanist/extensions/network"
+	"github.com/gardener/gardener/pkg/operation/common"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/test/gomega"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("#Network", func() {
+	const (
+		networkNs          = "test-namespace"
+		networkName        = "test-deploy"
+		networkType        = "calico"
+		networkPodIp       = "100.96.0.0"
+		networkPodMask     = 11
+		networkServiceIp   = "100.64.0.0"
+		networkServiceMask = 13
+	)
+	var (
+		ctrl *gomock.Controller
+
+		ctx              context.Context
+		c                client.Client
+		expected         *extensionsv1alpha1.Network
+		vals             *network.Values
+		logger           *logrus.Entry
+		defaultDepWaiter component.DeployWaiter
+
+		mockNow *mocktime.MockNow
+		now     time.Time
+
+		networkPodCIDR     = fmt.Sprintf("%s/%d", networkPodIp, networkPodMask)
+		networkServiceCIDR = fmt.Sprintf("%s/%d", networkServiceIp, networkServiceMask)
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+
+		mockNow = mocktime.NewMockNow(ctrl)
+
+		ctx = context.TODO()
+		logger = logrus.NewEntry(logrus.New())
+
+		s := runtime.NewScheme()
+		Expect(extensionsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())
+
+		c = fake.NewFakeClientWithScheme(s)
+
+		podCIDR := net.IPNet{
+			IP:   net.ParseIP(networkPodIp),
+			Mask: net.CIDRMask(networkPodMask, 32),
+		}
+		serviceCIDR := net.IPNet{
+			IP:   net.ParseIP(networkServiceIp),
+			Mask: net.CIDRMask(networkServiceMask, 32),
+		}
+
+		vals = &network.Values{
+			Name:                                    "test-deploy",
+			Namespace:                               networkNs,
+			IsInRestorePhaseOfControlPlaneMigration: false,
+			Type:                                    networkType,
+			ProviderConfig:                          nil,
+			PodCIDR:                                 &podCIDR,
+			ServiceCIDR:                             &serviceCIDR,
+		}
+
+		expected = &extensionsv1alpha1.Network{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      networkName,
+				Namespace: networkNs,
+				Annotations: map[string]string{
+					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				},
+			},
+			Spec: extensionsv1alpha1.NetworkSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type:           networkType,
+					ProviderConfig: nil,
+				},
+				PodCIDR:     networkPodCIDR,
+				ServiceCIDR: networkServiceCIDR,
+			},
+		}
+
+		defaultDepWaiter = network.New(logger, c, vals)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#Deploy", func() {
+		DescribeTable("correct Network is created", func(mutator func()) {
+			defer test.WithVars(
+				&network.TimeNow, mockNow.Do,
+			)()
+
+			mutator()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			Expect(defaultDepWaiter.Deploy(ctx)).ToNot(HaveOccurred())
+
+			actual := &extensionsv1alpha1.Network{}
+			err := c.Get(ctx, client.ObjectKey{Name: networkName, Namespace: networkNs}, actual)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(actual).To(DeepDerivativeEqual(expected))
+		},
+			Entry("with no modification", func() {}),
+			Entry("during restore phase", func() {
+				vals.IsInRestorePhaseOfControlPlaneMigration = true
+				expected.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationWaitForState
+			}),
+		)
+	})
+
+	Describe("#Wait", func() {
+		It("should return error when it's not found", func() {
+			Expect(defaultDepWaiter.Wait(ctx)).To(HaveOccurred())
+		})
+
+		It("should return error when it's not ready", func() {
+			expected.Status.LastError = &gardencorev1beta1.LastError{
+				Description: "Some error",
+			}
+
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating network succeeds")
+			Expect(defaultDepWaiter.Wait(ctx)).To(HaveOccurred(), "network indicates error")
+		})
+
+		It("should return no error when is ready", func() {
+			expected.Status.LastError = nil
+			// remove operation annotation
+			expected.ObjectMeta.Annotations = map[string]string{}
+			// set last operation
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+			}
+
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating network succeeds")
+			Expect(defaultDepWaiter.Wait(ctx)).ToNot(HaveOccurred(), "network is ready, should not return an error")
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should not return error when it's not found", func() {
+			Expect(defaultDepWaiter.Destroy(ctx)).ToNot(HaveOccurred())
+		})
+
+		It("should not return error when it's deleted successfully", func() {
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing network succeeds")
+
+			Expect(defaultDepWaiter.Destroy(ctx)).ToNot(HaveOccurred())
+		})
+
+		It("should return error when it's not deleted successfully", func() {
+			defer test.WithVars(
+				&common.TimeNow, mockNow.Do,
+			)()
+
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			expected := extensionsv1alpha1.Network{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      networkName,
+					Namespace: networkNs,
+					Annotations: map[string]string{
+						common.ConfirmationDeletion:        "true",
+						v1beta1constants.GardenerTimestamp: now.UTC().String(),
+					},
+				}}
+
+			mc := mockclient.NewMockClient(ctrl)
+			// check if the Network exist
+			mc.EXPECT().Get(ctx, kutil.Key(networkNs, networkName), gomock.AssignableToTypeOf(&extensionsv1alpha1.Network{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, n *extensionsv1alpha1.Network) error {
+				return nil
+			})
+
+			// add deletion confirmation and Timestamp annotation
+			mc.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Network{})).Return(nil)
+
+			mc.EXPECT().Delete(ctx, &expected).Times(1).Return(fmt.Errorf("some random error"))
+
+			defaultDepWaiter = network.New(logger, mc, &network.Values{
+				Namespace: networkNs,
+				Name:      networkName,
+			})
+
+			err := defaultDepWaiter.Destroy(ctx)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("#WaitCleanup", func() {
+		It("should not return error when it's already removed", func() {
+			Expect(defaultDepWaiter.WaitCleanup(ctx)).ToNot(HaveOccurred())
+		})
+	})
+})

--- a/pkg/operation/botanist/network.go
+++ b/pkg/operation/botanist/network.go
@@ -16,105 +16,46 @@ package botanist
 
 import (
 	"context"
-	"time"
 
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/operation/botanist/extensions/network"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// NetworkDefaultTimeout is the default timeout and defines how long Gardener should wait
-// for a successful reconciliation of a network resource.
-const NetworkDefaultTimeout = 3 * time.Minute
+// DefaultNetwork creates the default deployer for the Network custom resource.
+func (b *Botanist) DefaultNetwork(seedClient client.Client) component.DeployWaiter {
+	return network.New(
+		b.Logger,
+		seedClient,
+		&network.Values{
+			Namespace:                               b.Shoot.SeedNamespace,
+			Name:                                    b.Shoot.Info.Name,
+			IsInRestorePhaseOfControlPlaneMigration: b.isRestorePhase(),
+			Type:                                    b.Shoot.Info.Spec.Networking.Type,
+			ProviderConfig:                          b.Shoot.Info.Spec.Networking.ProviderConfig,
+			PodCIDR:                                 b.Shoot.Networks.Pods,
+			ServiceCIDR:                             b.Shoot.Networks.Services,
+		},
+	)
+}
 
-// DeployNetwork creates the `Network` extension resource in the shoot namespace in the seed
-// cluster. Gardener waits until an external controller did reconcile the cluster successfully.
+// DeployNetwork deploys the Network custom resource and triggers the restore operation in case
+// the Shoot is in the restore phase of the control plane migration
 func (b *Botanist) DeployNetwork(ctx context.Context) error {
-	var (
-		restorePhase = b.isRestorePhase()
-		operation    = v1beta1constants.GardenerOperationReconcile
-		network      = &extensionsv1alpha1.Network{
+	if err := b.Shoot.Components.Network.Deploy(ctx); err != nil {
+		return err
+	}
+
+	if b.isRestorePhase() {
+		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), &extensionsv1alpha1.Network{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      b.Shoot.Info.Name,
 				Namespace: b.Shoot.SeedNamespace,
 			},
-		}
-	)
-
-	if restorePhase {
-		operation = v1beta1constants.GardenerOperationWaitForState
+		}, extensionsv1alpha1.NetworkResource)
 	}
-
-	_, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), network, func() error {
-		metav1.SetMetaDataAnnotation(&network.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-		metav1.SetMetaDataAnnotation(&network.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
-
-		network.Spec = extensionsv1alpha1.NetworkSpec{
-			DefaultSpec: extensionsv1alpha1.DefaultSpec{
-				Type:           b.Shoot.Info.Spec.Networking.Type,
-				ProviderConfig: b.Shoot.Info.Spec.Networking.ProviderConfig,
-			},
-			PodCIDR:     b.Shoot.Networks.Pods.String(),
-			ServiceCIDR: b.Shoot.Networks.Services.String(),
-		}
-
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	if restorePhase {
-		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), network, extensionsv1alpha1.NetworkResource)
-	}
-
 	return nil
-}
-
-// DestroyNetwork deletes the `Network` extension resource in the shoot namespace in the seed cluster,
-// and it waits for a maximum of 10m until it is deleted.
-func (b *Botanist) DestroyNetwork(ctx context.Context) error {
-	return common.DeleteExtensionCR(
-		ctx,
-		b.K8sSeedClient.Client(),
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Network{} },
-		b.Shoot.SeedNamespace,
-		b.Shoot.Info.Name,
-	)
-}
-
-// WaitUntilNetworkIsReady waits until the network resource has been reconciled successfully.
-func (b *Botanist) WaitUntilNetworkIsReady(ctx context.Context) error {
-	return common.WaitUntilExtensionCRReady(
-		ctx,
-		b.K8sSeedClient.Client(),
-		b.Logger,
-		func() runtime.Object { return &extensionsv1alpha1.Network{} },
-		"Network",
-		b.Shoot.SeedNamespace,
-		b.Shoot.Info.Name,
-		DefaultInterval,
-		DefaultSevereThreshold,
-		NetworkDefaultTimeout,
-		nil,
-	)
-}
-
-// WaitUntilNetworkIsDeleted waits until the Network resource has been deleted.
-func (b *Botanist) WaitUntilNetworkIsDeleted(ctx context.Context) error {
-	return common.WaitUntilExtensionCRDeleted(
-		ctx,
-		b.K8sSeedClient.Client(),
-		b.Logger,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Network{} },
-		"Network",
-		b.Shoot.SeedNamespace,
-		b.Shoot.Info.Name,
-		DefaultInterval,
-		NetworkDefaultTimeout,
-	)
 }

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -77,7 +77,8 @@ type Shoot struct {
 
 // Components contains different components deployed
 type Components struct {
-	DNS *DNS
+	DNS     *DNS
+	Network component.DeployWaiter
 }
 
 // DNS contains references to internal and external DNSProvider and DNSEntry deployers.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/kind test
/priority normal

**What this PR does / why we need it**:

Restructuring the botanist Network CRD deployment  during the Shoot reconciliation to be a testable component.
Also introducing missing tests .

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
