### PR TITLE
Add kernel version to metric shoot:node_operating_system:sum

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-state-metrics.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-state-metrics.rules.yaml
@@ -46,4 +46,4 @@ groups:
     expr: sum(kube_node_labels) by (label_beta_kubernetes_io_instance_type)
 
   - record: shoot:node_operating_system:sum
-    expr: sum(kube_node_info) by (os_image)
+    expr: sum(kube_node_info) by (os_image, kernel_version)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area monitoring
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Adds the kernel version to the metric `shoot:node_operating_system:sum`. This metric is federated and is useful for auditing purposes and seeing what OS versions are running on the landscape.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Adds the kernel version to the metric `shoot:node_operating_system:sum`
```
