### PR TITLE
Remove fixed CIDRs of integration test shoots (and rely on defaulting)

### DIFF
--- a/test/framework/resources/templates/default-shoot.yaml
+++ b/test/framework/resources/templates/default-shoot.yaml
@@ -10,9 +10,7 @@ spec:
   dns: {}
   networking:
     type: calico
-    pods: 100.96.0.0/11
     nodes: 10.250.0.0/16
-    services: 100.64.0.0/13
   maintenance:
     timeWindow:
       begin: 220000+0100


### PR DESCRIPTION
**How to categorize this PR?**
/area testing
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Removes the fixed CIDRs for pods and services so that tests can rely/reuse a seed's default CIDRs. This will help to e.g. use different CIDRs for alicloud vs. other cloudproviders without having to configure special CIDRs for a TestRun's dimension.