### PR TITLE
[rel-v1.6] fallback to the vpn-shoot pod if cluster is not reconciled

### DIFF
--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -607,9 +607,17 @@ func (b *Botanist) checkSystemComponents(
 	}
 
 	if len(podsList.Items) == 0 {
+		// If the cluster is still not reconciled by this version of Gardener, fall back and check explicitly for the vpn pod
+		if err := b.K8sShootClient.Client().List(ctx, podsList, client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{"app": common.VPNTunnel}); err != nil {
+			return nil, err
+		}
+	}
+
+	if len(podsList.Items) == 0 {
 		c := checker.FailedCondition(condition, "NoTunnelDeployed", "no tunnels are currently deployed to perform health-check on")
 		return &c, nil
 	}
+
 	var (
 		konnectivityHealthCheck = b.Shoot.KonnectivityTunnelEnabled
 		tunnelName              = common.VPNTunnel


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area networking
/area operations
/kind bug
/priority normal

**What this PR does / why we need it**:
Fallback to the vpn-shoot pod if cluster is not reconciled

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
With #2251 the vpn health check was made to rely on the label `type` on the tunnel pod, but this health checks is failing for cluster that are still not reconciled with gardener v1.6.x.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The health check for the tunnel pod is now falling back to the `vpn-shoot` pod if no pod labeled with `type=tunnel` is found.
```
