### PR TITLE
[GEP-7] Don`t use tryUpdate when restoring extensions

### DIFF
--- a/pkg/api/extensions/accessor.go
+++ b/pkg/api/extensions/accessor.go
@@ -181,8 +181,8 @@ func (u unstructuredStatusAccessor) GetState() *runtime.RawExtension {
 }
 
 // SetState implements Status.
-func (u unstructuredStatusAccessor) SetState(state runtime.RawExtension) {
-	unstrc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&state)
+func (u unstructuredStatusAccessor) SetState(state *runtime.RawExtension) {
+	unstrc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(state)
 	if err != nil {
 		return
 	}

--- a/pkg/api/extensions/accessor_test.go
+++ b/pkg/api/extensions/accessor_test.go
@@ -186,11 +186,11 @@ var _ = Describe("Accessor", func() {
 
 			Describe("#SetState", func() {
 				It("should set the extensions state", func() {
-					state := runtime.RawExtension{Raw: []byte("{\"raw\":\"ext\"}")}
+					state := &runtime.RawExtension{Raw: []byte("{\"raw\":\"ext\"}")}
 					acc := mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{})
 					acc.SetState(state)
 					actualState := acc.GetState()
-					Expect(*actualState).To(Equal(state))
+					Expect(actualState).To(Equal(state))
 				})
 			})
 

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -40,7 +40,7 @@ type Status interface {
 	// GetState retrieves the State of the extension
 	GetState() *runtime.RawExtension
 	// SetState sets the State of the extension
-	SetState(state runtime.RawExtension)
+	SetState(state *runtime.RawExtension)
 	// GetResources retrieves the list of named resource references referred to in the State by their names.
 	GetResources() []gardencorev1beta1.NamedResourceReference
 	// SetResources sets a list of named resource references in the Status, that are referred by

--- a/pkg/apis/extensions/v1alpha1/types_defaults.go
+++ b/pkg/apis/extensions/v1alpha1/types_defaults.go
@@ -104,8 +104,8 @@ func (d *DefaultStatus) GetState() *runtime.RawExtension {
 }
 
 // SetState implements Status.
-func (d *DefaultStatus) SetState(state runtime.RawExtension) {
-	d.State = &state
+func (d *DefaultStatus) SetState(state *runtime.RawExtension) {
+	d.State = state
 }
 
 // GetResources implements Status.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area control-plane-migration
/kind bug
/priority normal

**What this PR does / why we need it**:
Found a bug that was preventing `status.state` from update if a conflict occurs, when using `tryUpdate()` . For example:
For the first call of tryUpdateStatus we have the obj `worker.status.state=nil`.
And in tryUpdate we get the object from the server, transform it so `worker.status.state=something`, we check the object for changes before and after the transform and if it has changed we try to update. If a conflict occurs we fail, but our in memory object has `worker.status.state=something`.
So on the next iteration we get the object from API Server, which still has `worker.status.state=nil` in the server, but the object in memory is with `worker.status.state=something` (for some reason client.Get() merges it). On the next step we transform it which doesn't change anything and test if the transformed object is different from the one received from the server. They are now equal so we don't update and simply return.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I am not sure if a release note should be set for fixing bugs of feature that is not available yet.
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
