### PR TITLE
[GEP-7] Remove DNSProviders in migration flow

### DIFF
--- a/pkg/apis/core/field_constants.go
+++ b/pkg/apis/core/field_constants.go
@@ -30,4 +30,8 @@ const (
 	// ShootSeedName is the field selector path for finding
 	// the Seed cluster of a core.gardener.cloud/{v1alpha1,v1beta1} Shoot.
 	ShootSeedName = "spec.seedName"
+	// ShootStatusSeedName is the field selector path for finding
+	// the Seed cluster of a core.gardener.cloud/{v1alpha1,v1beta1} Shoot
+	// referred in the status.
+	ShootStatusSeedName = "status.seedName"
 )

--- a/pkg/apis/core/v1alpha1/conversions.go
+++ b/pkg/apis/core/v1alpha1/conversions.go
@@ -28,7 +28,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Shoot"),
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "metadata.name", "metadata.namespace", core.ShootSeedName, core.ShootCloudProfileName:
+			case "metadata.name", "metadata.namespace", core.ShootSeedName, core.ShootCloudProfileName, core.ShootStatusSeedName:
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)

--- a/pkg/apis/core/v1beta1/conversions.go
+++ b/pkg/apis/core/v1beta1/conversions.go
@@ -56,7 +56,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 		SchemeGroupVersion.WithKind("Shoot"),
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "metadata.name", "metadata.namespace", core.ShootSeedName, core.ShootCloudProfileName:
+			case "metadata.name", "metadata.namespace", core.ShootSeedName, core.ShootCloudProfileName, core.ShootStatusSeedName:
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -953,3 +953,29 @@ func DeleteLastErrorByTaskID(lastErrors []gardencorev1beta1.LastError, taskID st
 	}
 	return out
 }
+
+// ShootItems provides helper functions with ShootLists
+type ShootItems gardencorev1beta1.ShootList
+
+// Union returns a set of Shoots that presents either in s or shootList
+func (s *ShootItems) Union(shootItems *ShootItems) []gardencorev1beta1.Shoot {
+	unionedShoots := make(map[string]gardencorev1beta1.Shoot)
+	for _, s := range s.Items {
+		unionedShoots[objectKey(s.Namespace, s.Name)] = s
+	}
+
+	for _, s := range shootItems.Items {
+		unionedShoots[objectKey(s.Namespace, s.Name)] = s
+	}
+
+	shoots := make([]gardencorev1beta1.Shoot, 0, len(unionedShoots))
+	for _, v := range unionedShoots {
+		shoots = append(shoots, v)
+	}
+
+	return shoots
+}
+
+func objectKey(namesapce, name string) string {
+	return fmt.Sprintf("%s/%s", namesapce, name)
+}

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -1354,4 +1354,111 @@ var _ = Describe("helper", func() {
 			),
 		)
 	})
+
+	Describe("ShootItems", func() {
+		Describe("#Union", func() {
+			It("tests if provided two sets of shoot slices will return ", func() {
+				shootList1 := gardencorev1beta1.ShootList{
+					Items: []gardencorev1beta1.Shoot{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "shoot1",
+								Namespace: "namespace1",
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "shoot2",
+								Namespace: "namespace1",
+							},
+						}, {
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "shoot3",
+								Namespace: "namespace2",
+							},
+						},
+					},
+				}
+
+				shootList2 := gardencorev1beta1.ShootList{
+					Items: []gardencorev1beta1.Shoot{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "shoot2",
+								Namespace: "namespace2",
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "shoot1",
+								Namespace: "namespace1",
+							},
+						}, {
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "shoot3",
+								Namespace: "namespace3",
+							},
+						},
+					},
+				}
+
+				s := ShootItems(shootList1)
+				s2 := ShootItems(shootList2)
+				shootSet := s.Union(&s2)
+
+				Expect(len(shootSet)).To(Equal(5))
+			})
+
+			It("should not fail if one of the lists is empty", func() {
+				shootList1 := gardencorev1beta1.ShootList{
+					Items: []gardencorev1beta1.Shoot{},
+				}
+
+				shootList2 := gardencorev1beta1.ShootList{
+					Items: []gardencorev1beta1.Shoot{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "shoot2",
+								Namespace: "namespace2",
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "shoot1",
+								Namespace: "namespace1",
+							},
+						}, {
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "shoot3",
+								Namespace: "namespace3",
+							},
+						},
+					},
+				}
+
+				s := ShootItems(shootList1)
+				s2 := ShootItems(shootList2)
+				shootSet := s.Union(&s2)
+				Expect(len(shootSet)).To(Equal(3))
+
+				shootSet2 := s2.Union(&s)
+				Expect(len(shootSet)).To(Equal(3))
+				Expect(shootSet).To(Equal(shootSet2))
+
+			})
+		})
+
+		It("should not fail if no items", func() {
+			shootList1 := gardencorev1beta1.ShootList{}
+
+			shootList2 := gardencorev1beta1.ShootList{}
+
+			s := ShootItems(shootList1)
+			s2 := ShootItems(shootList2)
+			shootSet := s.Union(&s2)
+			Expect(len(shootSet)).To(Equal(0))
+		})
+
+	})
+
 })

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
@@ -329,12 +329,10 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 				},
 			},
 		}
-		shootList = &gardencorev1beta1.ShootList{
-			Items: []gardencorev1beta1.Shoot{
-				*shoot1,
-				*shoot2,
-				*shoot3,
-			},
+		shootList = []gardencorev1beta1.Shoot{
+			*shoot1,
+			*shoot2,
+			*shoot3,
 		}
 
 		internalDomain = &gardenpkg.Domain{
@@ -614,6 +612,60 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 				extensionsv1alpha1.ControlPlaneResource+"/"+type6,
 				extensionsv1alpha1.InfrastructureResource+"/"+type6,
 				extensionsv1alpha1.WorkerResource+"/"+type6,
+
+				// globally enabled extensions
+				extensionsv1alpha1.ExtensionResource+"/"+type10,
+			)))
+		})
+
+		It("should correctly compute types for shoot that has the Seed`s name as status not spec", func() {
+			shootList := []gardencorev1beta1.Shoot{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "s4",
+					},
+					Spec: gardencorev1beta1.ShootSpec{
+						SeedName: pointer.StringPtr("anotherSeed"),
+						Provider: gardencorev1beta1.Provider{
+							Type: type2,
+							Workers: []gardencorev1beta1.Worker{
+								{
+									Machine: gardencorev1beta1.Machine{
+										Image: &gardencorev1beta1.ShootMachineImage{
+											Name: type5,
+										},
+									},
+								},
+							},
+						},
+						Networking: gardencorev1beta1.Networking{
+							Type: type3,
+						},
+						Extensions: []gardencorev1beta1.Extension{
+							{Type: type4},
+						},
+					},
+					Status: gardencorev1beta1.ShootStatus{
+						SeedName: &seedName,
+					},
+				},
+			}
+
+			kindTypes := computeKindTypesForShoots(ctx, nopLogger, nil, shootList, seedWithShootDNSDisabled, controllerRegistrationList, internalDomain, nil)
+
+			Expect(kindTypes).To(Equal(sets.NewString(
+				// seedWithShootDNSDisabled types
+				extensionsv1alpha1.BackupBucketResource+"/"+type8,
+				extensionsv1alpha1.BackupEntryResource+"/"+type8,
+				extensionsv1alpha1.ControlPlaneResource+"/"+type11,
+
+				// shoot4 types
+				extensionsv1alpha1.ControlPlaneResource+"/"+type2,
+				extensionsv1alpha1.InfrastructureResource+"/"+type2,
+				extensionsv1alpha1.WorkerResource+"/"+type2,
+				extensionsv1alpha1.OperatingSystemConfigResource+"/"+type5,
+				extensionsv1alpha1.NetworkResource+"/"+type3,
+				extensionsv1alpha1.ExtensionResource+"/"+type4,
 
 				// globally enabled extensions
 				extensionsv1alpha1.ExtensionResource+"/"+type10,

--- a/pkg/operation/botanist/migration.go
+++ b/pkg/operation/botanist/migration.go
@@ -155,7 +155,8 @@ func (b *Botanist) AnnotateBackupEntryInSeedForMigration(ctx context.Context) er
 		name        = common.GenerateBackupEntryName(b.Shoot.Info.Status.TechnicalID, b.Shoot.Info.Status.UID)
 		backupEntry = &extensionsv1alpha1.BackupEntry{}
 	)
-	if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(name), backupEntry); err != nil {
+
+	if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(name), backupEntry); client.IgnoreNotFound(err) != nil {
 		return err
 	}
 

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -186,8 +186,9 @@ func ToSelectableFields(shoot *core.Shoot) fields.Set {
 	// amount of allocations needed to create the fields.Set. If you add any
 	// field here or the number of object-meta related fields changes, this should
 	// be adjusted.
-	shootSpecificFieldsSet := make(fields.Set, 4)
+	shootSpecificFieldsSet := make(fields.Set, 5)
 	shootSpecificFieldsSet[core.ShootSeedName] = getSeedName(shoot)
+	shootSpecificFieldsSet[core.ShootStatusSeedName] = getStatusSeedName(shoot)
 	shootSpecificFieldsSet[core.ShootCloudProfileName] = shoot.Spec.CloudProfileName
 	return generic.AddObjectMetaFieldsSet(shootSpecificFieldsSet, &shoot.ObjectMeta, true)
 }
@@ -226,4 +227,11 @@ func getSeedName(shoot *core.Shoot) string {
 		return ""
 	}
 	return *shoot.Spec.SeedName
+}
+
+func getStatusSeedName(shoot *core.Shoot) string {
+	if shoot.Status.SeedName == nil {
+		return ""
+	}
+	return *shoot.Status.SeedName
 }

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -388,11 +388,13 @@ var _ = Describe("ToSelectableFields", func() {
 	It("should return correct fields", func() {
 		result := shootregistry.ToSelectableFields(newShoot("foo"))
 
-		Expect(result).To(HaveLen(4))
+		Expect(result).To(HaveLen(5))
 		Expect(result.Has(core.ShootSeedName)).To(BeTrue())
 		Expect(result.Get(core.ShootSeedName)).To(Equal("foo"))
 		Expect(result.Has(core.ShootCloudProfileName)).To(BeTrue())
 		Expect(result.Get(core.ShootCloudProfileName)).To(Equal("baz"))
+		Expect(result.Has(core.ShootStatusSeedName)).To(BeTrue())
+		Expect(result.Get(core.ShootStatusSeedName)).To(Equal("foo"))
 	})
 })
 
@@ -442,6 +444,9 @@ func newShoot(seedName string) *core.Shoot {
 		Spec: core.ShootSpec{
 			CloudProfileName: "baz",
 			SeedName:         &seedName,
+		},
+		Status: core.ShootStatus{
+			SeedName: &seedName,
 		},
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area control-plane-migration 
/kind enhancement 
/priority normal

**What this PR does / why we need it**:
Adds one more step to delete the DNSProviders explicitly during the migration process and
keeps the `ControllerInstallations` on the Seed if there is atleast one `Shoot` referring it in the shoot.spec.seedName or shoot.status.seedName. This in cases where you are migrating the last `Shoot` on the `Seed` to new `Seed`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
ControllerInstallations are not removed from the Seed if there is at least one Shoot referring it in the `spec.seedName` or `status.seedName`.
```
