### PR TITLE
Increases generic worker actuator reliability

### DIFF
--- a/extensions/pkg/controller/worker/helper/helper.go
+++ b/extensions/pkg/controller/worker/helper/helper.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper
+
+import (
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+)
+
+const (
+	nameLabel = "name"
+	// MachineSetKind is the kind of the owner reference of a machine set
+	MachineSetKind = "MachineSet"
+	// MachineDeploymentKind is the kind of the owner reference of a machine deployment
+	MachineDeploymentKind = "MachineDeployment"
+)
+
+// BuildOwnerToMachinesMap builds a map from a slice of machinev1alpha1.Machine, that maps the owner reference
+// to a slice of machines with the same owner reference
+func BuildOwnerToMachinesMap(machines []machinev1alpha1.Machine) map[string][]machinev1alpha1.Machine {
+	ownerToMachines := make(map[string][]machinev1alpha1.Machine)
+	for index, machine := range machines {
+		if len(machine.OwnerReferences) > 0 {
+			for _, reference := range machine.OwnerReferences {
+				if reference.Kind == MachineSetKind {
+					ownerToMachines[reference.Name] = append(ownerToMachines[reference.Name], machines[index])
+				}
+			}
+		} else if len(machine.Labels) > 0 {
+			if machineDeploymentName, ok := machine.Labels[nameLabel]; ok {
+				ownerToMachines[machineDeploymentName] = append(ownerToMachines[machineDeploymentName], machines[index])
+			}
+		}
+	}
+	return ownerToMachines
+}
+
+// BuildOwnerToMachineSetsMap builds a map from a slice of machinev1alpha1.MachineSet, that maps the owner reference
+// to a slice of MachineSets with the same owner reference
+func BuildOwnerToMachineSetsMap(machineSets []machinev1alpha1.MachineSet) map[string][]machinev1alpha1.MachineSet {
+	ownerToMachineSets := make(map[string][]machinev1alpha1.MachineSet)
+	for index, machineSet := range machineSets {
+		if len(machineSet.OwnerReferences) > 0 {
+			for _, reference := range machineSet.OwnerReferences {
+				if reference.Kind == MachineDeploymentKind {
+					ownerToMachineSets[reference.Name] = append(ownerToMachineSets[reference.Name], machineSets[index])
+				}
+			}
+		} else if len(machineSet.Labels) > 0 {
+			if machineDeploymentName, ok := machineSet.Labels[nameLabel]; ok {
+				ownerToMachineSets[machineDeploymentName] = append(ownerToMachineSets[machineDeploymentName], machineSets[index])
+			}
+		}
+	}
+	return ownerToMachineSets
+}
+
+// GetMachineSetWithMachineClass checks if for the given <machineDeploymentName>, there exists a machine set in the <ownerReferenceToMachineSet> with the machine class <machineClassName>
+// returns the machine set or nil
+func GetMachineSetWithMachineClass(machineDeploymentName, machineClassName string, ownerReferenceToMachineSet map[string][]machinev1alpha1.MachineSet) *machinev1alpha1.MachineSet {
+	machineSets := ownerReferenceToMachineSet[machineDeploymentName]
+	for _, machineSet := range machineSets {
+		if machineSet.Spec.Template.Spec.Class.Name == machineClassName {
+			return &machineSet
+		}
+	}
+	return nil
+}

--- a/extensions/pkg/controller/worker/helper/helper_test.go
+++ b/extensions/pkg/controller/worker/helper/helper_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper
+
+import (
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Helper Tests", func() {
+	machineSetName := "machine-set-1"
+	machineDeploymentName := "machine-deployment-1"
+	var (
+		machineSetReference = machinev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: MachineSetKind,
+						Name: machineSetName,
+					},
+				},
+			},
+		}
+
+		machineDeploymentReference = machinev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: MachineDeploymentKind,
+						Name: machineDeploymentName,
+					},
+				},
+			},
+		}
+
+		machineLabelReference = machinev1alpha1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					nameLabel: machineDeploymentName,
+				},
+			},
+		}
+	)
+
+	DescribeTable("#BuildOwnerToMachinesMap", func(machines []machinev1alpha1.Machine, expected map[string][]machinev1alpha1.Machine) {
+		result := BuildOwnerToMachinesMap(machines)
+		Expect(result).To(Equal(expected))
+	},
+		Entry("should map using reference kind = `MachineSet`", []machinev1alpha1.Machine{machineSetReference, machineLabelReference}, map[string][]machinev1alpha1.Machine{
+			machineSetName: {machineSetReference}, machineDeploymentName: {machineLabelReference},
+		}),
+
+		Entry("should map using label with key `name`", []machinev1alpha1.Machine{machineLabelReference}, map[string][]machinev1alpha1.Machine{
+			machineDeploymentName: {machineLabelReference},
+		}),
+
+		Entry("should not consider machines with machine deployment reference", []machinev1alpha1.Machine{machineSetReference, machineDeploymentReference, machineLabelReference}, map[string][]machinev1alpha1.Machine{
+			machineSetName: {machineSetReference}, machineDeploymentName: {machineLabelReference},
+		}),
+	)
+
+	var (
+		machineSetWithOwnerReference = machinev1alpha1.MachineSet{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: MachineDeploymentKind,
+						Name: machineDeploymentName,
+					},
+				},
+			},
+		}
+
+		machineSetWithWrongOwnerReference = machinev1alpha1.MachineSet{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: MachineSetKind,
+						Name: machineDeploymentName,
+					},
+				},
+			},
+		}
+
+		machineSetWithLabelReference = machinev1alpha1.MachineSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					nameLabel: machineDeploymentName,
+				},
+			},
+		}
+	)
+
+	DescribeTable("#BuildOwnerToMachineSetsMap", func(machines []machinev1alpha1.MachineSet, expected map[string][]machinev1alpha1.MachineSet) {
+		result := BuildOwnerToMachineSetsMap(machines)
+		Expect(result).To(Equal(expected))
+	},
+		Entry("should map using reference kind = `MachineDeployment", []machinev1alpha1.MachineSet{machineSetWithOwnerReference}, map[string][]machinev1alpha1.MachineSet{
+			machineDeploymentName: {machineSetWithOwnerReference},
+		}),
+
+		Entry("should map using label with key `name`", []machinev1alpha1.MachineSet{machineSetWithLabelReference}, map[string][]machinev1alpha1.MachineSet{
+			machineDeploymentName: {machineSetWithLabelReference},
+		}),
+
+		Entry("should not consider machines with machine set reference", []machinev1alpha1.MachineSet{machineSetWithOwnerReference, machineSetWithLabelReference, machineSetWithWrongOwnerReference}, map[string][]machinev1alpha1.MachineSet{
+			machineDeploymentName: {machineSetWithOwnerReference, machineSetWithLabelReference},
+		}),
+	)
+
+	var (
+		machineClassName   = "test-machine-class"
+		expectedMachineSet = machinev1alpha1.MachineSet{Spec: machinev1alpha1.MachineSetSpec{
+			Template: machinev1alpha1.MachineTemplateSpec{
+				Spec: machinev1alpha1.MachineSpec{
+					Class: machinev1alpha1.ClassSpec{
+						Name: machineClassName,
+					},
+				},
+			},
+		}}
+
+		ownerReferenceToMachineSet = map[string][]machinev1alpha1.MachineSet{
+			machineDeploymentName: {expectedMachineSet}}
+	)
+
+	DescribeTable("#GetMachineSetWithMachineClass", func(machineDeploymentName, machineClassName string, ownerReferenceToMachineSet map[string][]machinev1alpha1.MachineSet, expected *machinev1alpha1.MachineSet) {
+		result := GetMachineSetWithMachineClass(machineDeploymentName, machineClassName, ownerReferenceToMachineSet)
+		Expect(result).To(Equal(expected))
+	},
+		Entry("should find expected machine set", machineDeploymentName, machineClassName, ownerReferenceToMachineSet, &expectedMachineSet),
+
+		Entry("should not find machine set - unknown machine deployment name", "unknown-machine-deployment", machineClassName, ownerReferenceToMachineSet, nil),
+
+		Entry("should not find machine set - unknown machine class", machineDeploymentName, "unknown-machine-class", ownerReferenceToMachineSet, nil),
+	)
+})

--- a/extensions/pkg/controller/worker/helper/worker_helper_suite_test.go
+++ b/extensions/pkg/controller/worker/helper/worker_helper_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestWorkerHelper(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Extensions Controller Worker Helper Test Suite")
+}

--- a/extensions/pkg/controller/worker/machines.go
+++ b/extensions/pkg/controller/worker/machines.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/util"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
+
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -79,6 +80,17 @@ func (m MachineDeployments) HasDeployment(name string) bool {
 		}
 	}
 	return false
+}
+
+// FindByName finds the deployment with the <name> from the <machineDeployments>
+// returns the machine deployment or nil
+func (m MachineDeployments) FindByName(name string) *MachineDeployment {
+	for _, deployment := range m {
+		if name == deployment.Name {
+			return &deployment
+		}
+	}
+	return nil
 }
 
 // HasClass checks whether the <className> is part of the <machineDeployments>

--- a/extensions/pkg/controller/worker/machines_test.go
+++ b/extensions/pkg/controller/worker/machines_test.go
@@ -17,9 +17,9 @@ package worker_test
 import (
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	. "github.com/gardener/gardener/extensions/pkg/controller/worker"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -40,6 +40,17 @@ var _ = Describe("Machines", func() {
 			Entry("empty list", MachineDeployments{}, "foo", false),
 			Entry("entry not found", MachineDeployments{{Name: "bar"}}, "foo", false),
 			Entry("entry exists", MachineDeployments{{Name: "bar"}}, "bar", true),
+		)
+
+		DescribeTable("#FindByName",
+			func(machineDeployments MachineDeployments, name string, expectedDeployment *MachineDeployment) {
+				Expect(machineDeployments.FindByName(name)).To(Equal(expectedDeployment))
+			},
+
+			Entry("list is nil", nil, "foo", nil),
+			Entry("empty list", MachineDeployments{}, "foo", nil),
+			Entry("entry not found", MachineDeployments{{Name: "bar"}}, "foo", nil),
+			Entry("entry exists", MachineDeployments{{Name: "bar"}}, "bar", &MachineDeployment{Name: "bar"}),
 		)
 
 		DescribeTable("#HasClass",

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -15,6 +15,8 @@
 package v1alpha1
 
 import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -189,3 +191,6 @@ type MachineDeployment struct {
 	// Maximum is the maximum number for this machine deployment.
 	Maximum int32 `json:"maximum"`
 }
+
+// WorkerRollingUpdate is a constant for a condition type indicating a rolling update for any worker pool of the Shoot.
+const WorkerRollingUpdate gardencorev1beta1.ConditionType = "RollingUpdate"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area usability
/kind enhancement
/area quality
/area robustness
/kind bug
/priority normal

**What this PR does / why we need it**:
Increases the reliability of the generic worker actuator to detect rolling updates and populates rolling updates  in a condition in the status of the Worker CRD.

This condition is set to `True` as long as there is a rolling update in progress
 - until all updated machines joined the cluster (`numUnavailable == 0`) 
 - until the old machine is deleted in the case of a rolling update with maxUnavailability = 0 (`numUpdated == numberOfAwakeMachines`) 

Adds checks to verify that the required machine sets have been created by the MCM. This should prevent stale cache issues.

**Restart stuck Machine controller manager**

Restarts the machine controller manager if it failed to create the proper machine sets after unsuccessfully waiting for the machine deployments to become ready.

**Bugfix**

Also fixes a stale cache bug that leads to not waiting for the rolling update to complete. The check if the rolling update is complete is sometimes done on an outdated machine deployment. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The topic of this PR is increasing the reliability of the generic worker actuator. 
Because the introduced features use shared coding and are thematically coherent, I propose having them in the same PR. If that is unfeasible, let me know.

Please note that the cluster autoscaler scale down behaviour has not changed (scaled down during creation and rolling updates).
In the future, the cluster autoscaler might not be required to be scaled down any more.
See [this issue](https://github.com/gardener/autoscaler/issues/48) and the corresponding issue on the [MCM](https://github.com/gardener/machine-controller-manager/issues/472)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
 Introduces a `RollingUpdate` condition in the generic worker actuator (condition.Type `RollingUpdate`) . Gardener provider extensions write this condition to the Worker CRD.
```
```improvement operator
The generic worker actuator more reliably waits for rolling updates to finish.  Waits until all updated machines joined the cluster and until old machines are deleted. Also  fixes a stale cache bug that leads to not waiting for the rolling update to complete.
```

```improvement operator
 The generic worker actuator detects and restarts 'stuck' machine controller manager pods.
```
