### PR TITLE
Make Terraform output compatible to any type

### DIFF
--- a/extensions/pkg/terraformer/state.go
+++ b/extensions/pkg/terraformer/state.go
@@ -80,7 +80,7 @@ func (t *terraformer) GetStateOutputVariables(variables ...string) (map[string]s
 
 	for _, variable := range variables {
 		if outputVariable, ok := outputVariables[variable]; ok {
-			output[variable] = outputVariable.Value.(string)
+			output[variable] = fmt.Sprint(outputVariable.Value)
 			foundVariables.Insert(variable)
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR changes the Terraformer state handling, so that it can deal with output formats other than strings. Before the output was casted to a string which does not work if the Terraform state has the type "Number" in the `outputs` block.

```
        "countUpdateDomains": {
          "value": 5,
          "type": "number"
        },
```


**Special notes for your reviewer**:
This is a prerequisite for https://github.com/gardener/gardener-extension-provider-azure/issues/109.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
The Terraformer can now deal with output types other than String in the Terraform state.
```
