### PR TITLE
Make some Terraformer functions public

### DIFF
--- a/extensions/pkg/terraformer/config.go
+++ b/extensions/pkg/terraformer/config.go
@@ -182,7 +182,7 @@ func (t *terraformer) prepare(ctx context.Context) (int, error) {
 	}
 
 	// Clean up possible existing pod artifacts from previous runs
-	if err := t.ensureCleanedUp(ctx); err != nil {
+	if err := t.EnsureCleanedUp(ctx); err != nil {
 		return -1, err
 	}
 
@@ -241,8 +241,8 @@ func (t *terraformer) CleanupConfiguration(ctx context.Context) error {
 	return nil
 }
 
-// ensureCleanedUp deletes the Terraformer pods, and waits until everything has been cleaned up.
-func (t *terraformer) ensureCleanedUp(ctx context.Context) error {
+// EnsureCleanedUp deletes the Terraformer pods, and waits until everything has been cleaned up.
+func (t *terraformer) EnsureCleanedUp(ctx context.Context) error {
 	podList, err := t.listTerraformerPods(ctx)
 	if err != nil {
 		return err
@@ -251,7 +251,7 @@ func (t *terraformer) ensureCleanedUp(ctx context.Context) error {
 		return err
 	}
 
-	return t.waitForCleanEnvironment(ctx)
+	return t.WaitForCleanEnvironment(ctx)
 }
 
 // GenerateVariablesEnvironment takes a <secret> and a <keyValueMap> and builds an environment which

--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -102,6 +102,8 @@ type Terraformer interface {
 	GetStateOutputVariables(variables ...string) (map[string]string, error)
 	ConfigExists() (bool, error)
 	NumberOfResources(context.Context) (int, error)
+	EnsureCleanedUp(ctx context.Context) error
+	WaitForCleanEnvironment(ctx context.Context) error
 }
 
 // Initializer can initialize a Terraformer.

--- a/extensions/pkg/terraformer/waiter.go
+++ b/extensions/pkg/terraformer/waiter.go
@@ -25,9 +25,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-// waitForCleanEnvironment waits until no Terraform Pod(s) exist for the current instance
+// WaitForCleanEnvironment waits until no Terraform Pod(s) exist for the current instance
 // of the Terraformer.
-func (t *terraformer) waitForCleanEnvironment(ctx context.Context) error {
+func (t *terraformer) WaitForCleanEnvironment(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, t.deadlineCleaning)
 	defer cancel()
 

--- a/pkg/mock/gardener/extensions/terraformer/mocks.go
+++ b/pkg/mock/gardener/extensions/terraformer/mocks.go
@@ -96,6 +96,20 @@ func (mr *MockTerraformerMockRecorder) Destroy() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockTerraformer)(nil).Destroy))
 }
 
+// EnsureCleanedUp mocks base method
+func (m *MockTerraformer) EnsureCleanedUp(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureCleanedUp", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureCleanedUp indicates an expected call of EnsureCleanedUp
+func (mr *MockTerraformerMockRecorder) EnsureCleanedUp(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureCleanedUp", reflect.TypeOf((*MockTerraformer)(nil).EnsureCleanedUp), arg0)
+}
+
 // GetRawState mocks base method
 func (m *MockTerraformer) GetRawState(arg0 context.Context) (*terraformer.RawState, error) {
 	m.ctrl.T.Helper()
@@ -242,6 +256,20 @@ func (m *MockTerraformer) SetVariablesEnvironment(arg0 map[string]string) terraf
 func (mr *MockTerraformerMockRecorder) SetVariablesEnvironment(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVariablesEnvironment", reflect.TypeOf((*MockTerraformer)(nil).SetVariablesEnvironment), arg0)
+}
+
+// WaitForCleanEnvironment mocks base method
+func (m *MockTerraformer) WaitForCleanEnvironment(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForCleanEnvironment", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitForCleanEnvironment indicates an expected call of WaitForCleanEnvironment
+func (mr *MockTerraformerMockRecorder) WaitForCleanEnvironment(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForCleanEnvironment", reflect.TypeOf((*MockTerraformer)(nil).WaitForCleanEnvironment), arg0)
 }
 
 // MockInitializer is a mock of Initializer interface


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/area robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR makes `EnsureCleanedUp` and `WaitForCleanEnvironment` exported via the `Terraformer` interface.

**Which issue(s) this PR fixes**:
Prerequisite for https://github.com/gardener/gardener-extension-provider-aws/issues/121 and related provider extension issues.
Please see https://github.com/gardener/gardener-extension-provider-aws/pull/124 for the intended usage.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The `EnsureCleanedUp` and `WaitForCleanEnvironment` funcs are now exported via the `Terraformer` interface.
```
