### PR TITLE
Fix shoot maintenance defaulting

### DIFF
--- a/pkg/apis/core/v1alpha1/defaults.go
+++ b/pkg/apis/core/v1alpha1/defaults.go
@@ -205,14 +205,14 @@ func SetDefaults_Shoot(obj *Shoot) {
 	if obj.Spec.Kubernetes.Kubelet.FailSwapOn == nil {
 		obj.Spec.Kubernetes.Kubelet.FailSwapOn = &trueVar
 	}
+
+	if obj.Spec.Maintenance == nil {
+		obj.Spec.Maintenance = &Maintenance{}
+	}
 }
 
 // SetDefaults_Maintenance sets default values for Maintenance objects.
 func SetDefaults_Maintenance(obj *Maintenance) {
-	if obj == nil {
-		obj = &Maintenance{}
-	}
-
 	if obj.AutoUpdate == nil {
 		obj.AutoUpdate = &MaintenanceAutoUpdate{
 			KubernetesVersion:   true,

--- a/pkg/apis/core/v1alpha1/defaults_test.go
+++ b/pkg/apis/core/v1alpha1/defaults_test.go
@@ -307,5 +307,35 @@ var _ = Describe("Defaults", func() {
 
 			Expect(obj.Spec.Kubernetes.Kubelet.FailSwapOn).To(PointTo(BeFalse()))
 		})
+
+		It("should set the maintenance field", func() {
+			obj.Spec.Maintenance = nil
+
+			SetDefaults_Shoot(obj)
+
+			Expect(obj.Spec.Maintenance).To(Equal(&Maintenance{}))
+		})
+	})
+
+	Describe("#SetDefaults_Maintenance", func() {
+		var obj *Maintenance
+
+		BeforeEach(func() {
+			obj = &Maintenance{}
+		})
+
+		It("should correctly default the maintenance", func() {
+			obj.AutoUpdate = nil
+			obj.TimeWindow = nil
+
+			SetDefaults_Maintenance(obj)
+
+			Expect(obj.AutoUpdate).NotTo(BeNil())
+			Expect(obj.AutoUpdate.KubernetesVersion).To(BeTrue())
+			Expect(obj.AutoUpdate.MachineImageVersion).To(BeTrue())
+			Expect(obj.TimeWindow).NotTo(BeNil())
+			Expect(obj.TimeWindow.Begin).To(HaveSuffix("0000+0000"))
+			Expect(obj.TimeWindow.End).To(HaveSuffix("0000+0000"))
+		})
 	})
 })

--- a/pkg/apis/core/v1beta1/defaults.go
+++ b/pkg/apis/core/v1beta1/defaults.go
@@ -205,14 +205,14 @@ func SetDefaults_Shoot(obj *Shoot) {
 	if obj.Spec.Kubernetes.Kubelet.FailSwapOn == nil {
 		obj.Spec.Kubernetes.Kubelet.FailSwapOn = &trueVar
 	}
+
+	if obj.Spec.Maintenance == nil {
+		obj.Spec.Maintenance = &Maintenance{}
+	}
 }
 
 // SetDefaults_Maintenance sets default values for Maintenance objects.
 func SetDefaults_Maintenance(obj *Maintenance) {
-	if obj == nil {
-		obj = &Maintenance{}
-	}
-
 	if obj.AutoUpdate == nil {
 		obj.AutoUpdate = &MaintenanceAutoUpdate{
 			KubernetesVersion:   true,

--- a/pkg/apis/core/v1beta1/defaults_test.go
+++ b/pkg/apis/core/v1beta1/defaults_test.go
@@ -307,5 +307,35 @@ var _ = Describe("Defaults", func() {
 
 			Expect(obj.Spec.Kubernetes.Kubelet.FailSwapOn).To(PointTo(BeFalse()))
 		})
+
+		It("should set the maintenance field", func() {
+			obj.Spec.Maintenance = nil
+
+			SetDefaults_Shoot(obj)
+
+			Expect(obj.Spec.Maintenance).To(Equal(&Maintenance{}))
+		})
+	})
+
+	Describe("#SetDefaults_Maintenance", func() {
+		var obj *Maintenance
+
+		BeforeEach(func() {
+			obj = &Maintenance{}
+		})
+
+		It("should correctly default the maintenance", func() {
+			obj.AutoUpdate = nil
+			obj.TimeWindow = nil
+
+			SetDefaults_Maintenance(obj)
+
+			Expect(obj.AutoUpdate).NotTo(BeNil())
+			Expect(obj.AutoUpdate.KubernetesVersion).To(BeTrue())
+			Expect(obj.AutoUpdate.MachineImageVersion).To(BeTrue())
+			Expect(obj.TimeWindow).NotTo(BeNil())
+			Expect(obj.TimeWindow.Begin).To(HaveSuffix("0000+0000"))
+			Expect(obj.TimeWindow.End).To(HaveSuffix("0000+0000"))
+		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area usability
/kind bug
/priority normal

**What this PR does / why we need it**:
Creating a shoot with `.spec.maintenance=nil` was rejected with the following error message:

```
The Shoot "foo" is invalid: spec.maintenance: Required value: maintenance information is required
```

However, it was supposed to be defaulted. This PR fixes this behaviour and correctly defaults the maintenance section if it's not provided by the end-user:

```yaml
spec:
  maintenance:
    autoUpdate:
      kubernetesVersion: true
      machineImageVersion: true
    timeWindow:
      begin: 080000+0000
      end: 090000+0000
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The `.spec.maintenance` settings are now correctly defaulted when a `Shoot` is being created without any such configuration.
```
