### PR TITLE
Guestbook test is now compatible with shoots having allowPrivilegedContainers=false

### DIFF
--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -125,8 +125,6 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 	shoot := t.framework.Shoot
 	if !shoot.Spec.Addons.NginxIngress.Enabled {
 		ginkgo.Fail("The test requires .spec.addons.nginxIngress.enabled to be true")
-	} else if shoot.Spec.Kubernetes.AllowPrivilegedContainers == nil || !*shoot.Spec.Kubernetes.AllowPrivilegedContainers {
-		ginkgo.Fail("The test requires .spec.kubernetes.allowPrivilegedContainers to be true")
 	}
 
 	ginkgo.By("Applying redis chart")
@@ -134,6 +132,12 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 	chartOverrides := map[string]interface{}{
 		"cluster": map[string]interface{}{
 			"enabled": false,
+		},
+		"podSecurityPolicy": map[string]interface{}{
+			"create": true,
+		},
+		"rbac": map[string]interface{}{
+			"create": true,
 		},
 	}
 	if shoot.Spec.Provider.Type == "alicloud" {

--- a/test/framework/resources/templates/guestbook-app.yaml.tpl
+++ b/test/framework/resources/templates/guestbook-app.yaml.tpl
@@ -19,6 +19,8 @@ spec:
         name: guestbook
         ports:
         - containerPort: 8080
+        securityContext:
+          runAsUser: 1001
         env:
         - name: REDIS_SERVICE_NAME
           value: redis-master


### PR DESCRIPTION
**How to categorize this PR?**
/area testing
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Up to now the guestbook tests always required a shoot with `spec.kubernetes.allowPrivilegedContainers: true`, hence they couldn't be used to test clusters without that privilege.
This PR makes the respective deployments (redis and guestbook) compatible with shoots using 
`spec.kubernetes.allowPrivilegedContainers: false` so that the same tests can be used to test both flavors.
