### PR TITLE
Add node anti-affinities and PDBs for CoreDNS

### DIFF
--- a/charts/shoot-core/components/charts/coredns/templates/coredns-deployment.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-deployment.yaml
@@ -26,6 +26,18 @@ spec:
         k8s-app: kube-dns
       # we won't be using the checksum of the configmap since coredns provides the "reload" plugins that does the reload if config changes.
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                    - key: k8s-app
+                      operator: In
+                      values:
+                        - kube-dns
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true

--- a/charts/shoot-core/components/charts/coredns/templates/coredns-poddisruptionbudget.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-poddisruptionbudget.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: coredns
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: kube-dns
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns


### PR DESCRIPTION
**How to categorize this PR?**
/area networking 
/kind enhancement

**What this PR does / why we need it**:
Currently there is a possibility that CoreDNS pods would reside on the same node. This can be problematic during machine OS upgrades. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
CoreDNS pods are now protected by a PDB during machine upgrades and should reside on different nodes for HA.
```
