### PR TITLE
Fix cluster sync after retry operation

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -361,7 +361,7 @@ func (c *Controller) deleteShoot(logger *logrus.Entry, shoot *gardencorev1beta1.
 	// At this point the deletion is allowed, hence, check if the seed is up-to-date, then sync the Cluster resource
 	// initialize a new operation and, eventually, start the deletion flow.
 	if err := c.checkSeedAndSyncClusterResource(ctx, o.Shoot.Info, project, cloudProfile, seed); err != nil {
-		return c.updateShootStatusAndRequeueOnSyncError(shoot, err)
+		return c.updateShootStatusAndRequeueOnSyncError(o.Shoot.Info, err)
 	}
 
 	if flowErr := c.runDeleteShootFlow(o); flowErr != nil {
@@ -475,8 +475,8 @@ func (c *Controller) reconcileShoot(logger *logrus.Entry, shoot *gardencorev1bet
 
 	// At this point the reconciliation is allowed, hence, check if the seed is up-to-date, then sync the Cluster resource
 	// initialize a new operation and, eventually, start the reconciliation flow.
-	if err := c.checkSeedAndSyncClusterResource(ctx, shoot, project, cloudProfile, seed); err != nil {
-		return c.updateShootStatusAndRequeueOnSyncError(shoot, err)
+	if err := c.checkSeedAndSyncClusterResource(ctx, o.Shoot.Info, project, cloudProfile, seed); err != nil {
+		return c.updateShootStatusAndRequeueOnSyncError(o.Shoot.Info, err)
 	}
 
 	var dnsEnabled = !o.Shoot.DisableDNS


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR replicates the correct shoot status through the `cluster` resource to the seed after the shoot was triggered for a retry (`gardener.cloud/operation:retry`).

**Which issue(s) this PR fixes**:
Fixes #2452

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue has been fixed which prevented the `retry` operation for shoots from working reliably in case of a reconciliation.
```
