### PR TITLE
Improve Metrics-Server scraping

### DIFF
--- a/charts/shoot-core/components/charts/metrics-server/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/metrics-server/templates/deployment.yaml
@@ -53,6 +53,7 @@ spec:
         # The kube-apiserver and the kubelet use different CAs, however, the metrics-server assumes the CAs are the same.
         # We should remove this flag once it is possible to specify the CA of the kubelet.
         - --kubelet-insecure-tls
+        - --kubelet-preferred-address-types=[Hostname,InternalDNS,InternalIP,ExternalDNS,ExternalIP]
         - --tls-cert-file=/srv/metrics-server/tls/tls.crt
         - --tls-private-key-file=/srv/metrics-server/tls/tls.key
         - --v=2

--- a/test/framework/resources/templates/simple-load-deployment.yaml.tpl
+++ b/test/framework/resources/templates/simple-load-deployment.yaml.tpl
@@ -17,6 +17,8 @@ spec:
       - image: alpine:3.11
         name: load
         command: ["sh", "-c"]
+        {{ if .nodeName }}
         nodeName: {{ .nodeName }}
+        {{ end }}
         args:
         - while true; do echo "testing"; done;

--- a/test/integration/shoots/applications/metrics.go
+++ b/test/integration/shoots/applications/metrics.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+	Overview
+		- Tests that runtime metrics are available
+
+	AfterSuite
+		- Cleanup Workload in Shoot
+
+	Test: Create arbitrary deployment
+	Expected Output
+		- Metrics are available
+ **/
+
+package applications
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	"github.com/gardener/gardener/test/framework"
+
+	"github.com/gardener/gardener/test/framework/resources/templates"
+	"github.com/onsi/ginkgo"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	metricsTestTimeout = 10 * time.Minute
+)
+
+var _ = ginkgo.Describe("Shoot application metrics testing", func() {
+
+	f := framework.NewShootFramework(&framework.ShootConfig{
+		CreateTestNamespace: true,
+	})
+
+	var (
+		name = "metrics-test"
+	)
+
+	f.Beta().CIt("should read runtime metrics", func(ctx context.Context) {
+		templateParams := map[string]string{
+			"name":      name,
+			"namespace": f.Namespace,
+		}
+		err := f.RenderAndDeployTemplate(ctx, f.ShootClient, templates.SimpleLoadDeploymentName, templateParams)
+		framework.ExpectNoError(err)
+
+		err = f.WaitUntilDeploymentIsReady(ctx, name, f.Namespace, f.ShootClient)
+		framework.ExpectNoError(err)
+
+		pods := &corev1.PodList{}
+		err = f.ShootClient.Client().List(ctx, pods, client.InNamespace(f.Namespace), client.MatchingLabels{"app": "load"})
+		framework.ExpectNoError(err)
+
+		if len(pods.Items) == 0 {
+			ginkgo.Fail("at least one pod is needed")
+		}
+		podName := pods.Items[0].Name
+
+		ginkgo.By("Check runtime metrics")
+		framework.ExpectNoError(
+			retry.Until(ctx, 30*time.Second, func(ctx context.Context) (bool, error) {
+				podMetrics := &metricsv1beta1.PodMetrics{}
+				if err := f.ShootClient.Client().Get(ctx, kutil.Key(f.Namespace, podName), podMetrics); err != nil {
+					if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+						f.Logger.Infof("No metrics for pod %s/%s available yet: %v", f.Namespace, podName, err)
+						return retry.MinorError(err)
+					}
+					return retry.SevereError(err)
+				}
+
+				if len(podMetrics.Containers) == 0 {
+					return retry.MinorError(errors.New("no metrics recorded yet"))
+				}
+
+				for _, container := range podMetrics.Containers {
+					if container.Usage.Cpu() == nil {
+						return retry.MinorError(fmt.Errorf("no CPU metrics recorded yet for container %q", container.Name))
+					}
+					if container.Usage.Memory() == nil {
+						return retry.MinorError(fmt.Errorf("no Memory metrics recorded yet for container %q", container.Name))
+					}
+				}
+				return retry.Ok()
+			}),
+		)
+	}, metricsTestTimeout, framework.WithCAfterTest(func(ctx context.Context) {
+		ginkgo.By("cleanup metrics test deployment")
+		err := f.ShootClient.Client().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: f.Namespace}})
+		framework.ExpectNoError(client.IgnoreNotFound(err))
+	}, cleanupTimeout))
+
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area monitoring
/area robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR configures a list of preferable address types for the Metrics-Server. Please look at the linked issue for more information.

**Which issue(s) this PR fixes**:
Fixes #2455

**Special notes for your reviewer**:
@danielfoehrKn would be nice if you could double check the integration test since you have experience in this field.

/cc @jia-jerry

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Runtime metrics for Pods and Nodes are now also available in environments which don't support a domain name resolution for worker nodes.
```
