### PR TITLE
Adapt client usage in integration tests

### DIFF
--- a/docs/testing/integration_tests.md
+++ b/docs/testing/integration_tests.md
@@ -234,8 +234,8 @@ Create Shoot test is meant to test shoot creation.
 **Example Run**
 
 ```console
-go test -mod=vendor -timeout=0 -ginkgo.v -ginkgo.progress \
-  ./test/system/shoot_creation \
+go test -mod=vendor -timeout=0 ./test/system/shoot_creation \
+  --v -ginkgo.v -ginkgo.progress \
   -kubecfg=$HOME/.kube/config \
   -shoot-name=$SHOOT_NAME \
   -cloud-profile=$CLOUDPROFILE \
@@ -278,8 +278,8 @@ If there is no available newer version this test is a noop.
 **Example Run**
 
 ```console
-go test -mod=vendor -timeout=0 -ginkgo.v -ginkgo.progress \
-  ./test/system/shoot_update \
+go test -mod=vendor -timeout=0 ./test/system/shoot_update \
+  --v -ginkgo.v -ginkgo.progress \
   -kubecfg=$HOME/.kube/config \
   -shoot-name=$SHOOT_NAME \
   -project-namespace=$PROJECT_NAMESPACE \
@@ -293,8 +293,8 @@ The Gardener Full Reconcile test is meant to test if all shoots of a gardener in
 **Example Run**
 
 ```console
-go test -mod=vendor -timeout=0 -ginkgo.v -ginkgo.progress \
-  ./test/system/complete_reconcile \
+go test -mod=vendor -timeout=0 ./test/system/complete_reconcile \
+  --v -ginkgo.v -ginkgo.progress \
   -kubecfg=$HOME/.kube/config \
   -project-namespace=$PROJECT_NAMESPACE \
   -gardenerVersion=$GARDENER_VERSION # needed to validate the last acted gardener version of a shoot

--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -231,7 +231,7 @@ func (t *GuestBookTest) Cleanup(ctx context.Context) {
 	// Clean up shoot
 	ginkgo.By("Cleaning up guestbook app resources")
 	deleteResource := func(ctx context.Context, resource runtime.Object) error {
-		err := t.framework.ShootClient.Client().Delete(ctx, resource)
+		err := t.framework.ShootClient.DirectClient().Delete(ctx, resource)
 		if apierrors.IsNotFound(err) {
 			return nil
 		}

--- a/test/framework/dump.go
+++ b/test/framework/dump.go
@@ -41,7 +41,7 @@ const (
 // DumpDefaultResourcesInAllNamespaces dumps all default k8s resources of a namespace
 func (f *CommonFramework) DumpDefaultResourcesInAllNamespaces(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface) error {
 	namespaces := &corev1.NamespaceList{}
-	if err := k8sClient.Client().List(ctx, namespaces); err != nil {
+	if err := k8sClient.DirectClient().List(ctx, namespaces); err != nil {
 		return err
 	}
 
@@ -121,7 +121,7 @@ func (f *GardenerFramework) dumpGardenerExtensionsInNamespace(ctx context.Contex
 
 	f.Logger.Infof("%s [EXTENSIONS] [INFRASTRUCTURE]", ctxIdentifier)
 	infrastructures := &v1alpha1.InfrastructureList{}
-	err := k8sClient.Client().List(ctx, infrastructures, client.InNamespace(namespace))
+	err := k8sClient.DirectClient().List(ctx, infrastructures, client.InNamespace(namespace))
 	result = multierror.Append(result, err)
 	if err != nil {
 		for _, infra := range infrastructures.Items {
@@ -132,7 +132,7 @@ func (f *GardenerFramework) dumpGardenerExtensionsInNamespace(ctx context.Contex
 
 	f.Logger.Infof("%s [EXTENSIONS] [CONTROLPLANE]", ctxIdentifier)
 	controlplanes := &v1alpha1.ControlPlaneList{}
-	err = k8sClient.Client().List(ctx, controlplanes, client.InNamespace(namespace))
+	err = k8sClient.DirectClient().List(ctx, controlplanes, client.InNamespace(namespace))
 	if err != nil {
 		for _, cp := range controlplanes.Items {
 			f.dumpGardenerExtension(&cp)
@@ -142,7 +142,7 @@ func (f *GardenerFramework) dumpGardenerExtensionsInNamespace(ctx context.Contex
 
 	f.Logger.Infof("%s [EXTENSIONS] [OS]", ctxIdentifier)
 	operatingSystems := &v1alpha1.OperatingSystemConfigList{}
-	err = k8sClient.Client().List(ctx, operatingSystems, client.InNamespace(namespace))
+	err = k8sClient.DirectClient().List(ctx, operatingSystems, client.InNamespace(namespace))
 	result = multierror.Append(result, err)
 	if err == nil {
 		for _, os := range operatingSystems.Items {
@@ -153,7 +153,7 @@ func (f *GardenerFramework) dumpGardenerExtensionsInNamespace(ctx context.Contex
 
 	f.Logger.Infof("%s [EXTENSIONS] [WORKER]", ctxIdentifier)
 	workers := &v1alpha1.WorkerList{}
-	err = k8sClient.Client().List(ctx, workers, client.InNamespace(namespace))
+	err = k8sClient.DirectClient().List(ctx, workers, client.InNamespace(namespace))
 	result = multierror.Append(result, err)
 	if err == nil {
 		for _, worker := range workers.Items {
@@ -164,7 +164,7 @@ func (f *GardenerFramework) dumpGardenerExtensionsInNamespace(ctx context.Contex
 
 	f.Logger.Infof("%s [EXTENSIONS] [BACKUPBUCKET]", ctxIdentifier)
 	backupBuckets := &v1alpha1.BackupBucketList{}
-	err = k8sClient.Client().List(ctx, backupBuckets, client.InNamespace(namespace))
+	err = k8sClient.DirectClient().List(ctx, backupBuckets, client.InNamespace(namespace))
 	result = multierror.Append(result, err)
 	if err == nil {
 		for _, bucket := range backupBuckets.Items {
@@ -175,7 +175,7 @@ func (f *GardenerFramework) dumpGardenerExtensionsInNamespace(ctx context.Contex
 
 	f.Logger.Infof("%s [EXTENSIONS] [BACKUPENTRY]", ctxIdentifier)
 	backupEntries := &v1alpha1.BackupEntryList{}
-	err = k8sClient.Client().List(ctx, backupEntries, client.InNamespace(namespace))
+	err = k8sClient.DirectClient().List(ctx, backupEntries, client.InNamespace(namespace))
 	result = multierror.Append(result, err)
 	if err == nil {
 		for _, entry := range backupEntries.Items {
@@ -186,7 +186,7 @@ func (f *GardenerFramework) dumpGardenerExtensionsInNamespace(ctx context.Contex
 
 	f.Logger.Infof("%s [EXTENSIONS] [NETWORK]", ctxIdentifier)
 	networks := &v1alpha1.NetworkList{}
-	err = k8sClient.Client().List(ctx, networks, client.InNamespace(namespace))
+	err = k8sClient.DirectClient().List(ctx, networks, client.InNamespace(namespace))
 	result = multierror.Append(result, err)
 	if err == nil {
 		for _, network := range networks.Items {
@@ -214,7 +214,7 @@ func (f *GardenerFramework) dumpGardenerExtension(extension v1alpha1.Object) {
 func (f *CommonFramework) DumpLogsForPodsWithLabelsInNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string, opts ...client.ListOption) error {
 	pods := &corev1.PodList{}
 	opts = append(opts, client.InNamespace(namespace))
-	if err := k8sClient.Client().List(ctx, pods, opts...); err != nil {
+	if err := k8sClient.DirectClient().List(ctx, pods, opts...); err != nil {
 		return err
 	}
 
@@ -246,7 +246,7 @@ func (f *CommonFramework) DumpLogsForPodInNamespace(ctx context.Context, ctxIden
 func (f *CommonFramework) dumpDeploymentInfoForNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string) error {
 	f.Logger.Infof("%s [NAMESPACE %s] [DEPLOYMENTS]", ctxIdentifier, namespace)
 	deployments := &appsv1.DeploymentList{}
-	if err := k8sClient.Client().List(ctx, deployments, client.InNamespace(namespace)); err != nil {
+	if err := k8sClient.DirectClient().List(ctx, deployments, client.InNamespace(namespace)); err != nil {
 		return err
 	}
 	for _, deployment := range deployments.Items {
@@ -264,7 +264,7 @@ func (f *CommonFramework) dumpDeploymentInfoForNamespace(ctx context.Context, ct
 func (f *CommonFramework) dumpStatefulSetInfoForNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string) error {
 	f.Logger.Infof("%s [NAMESPACE %s] [STATEFULSETS]", ctxIdentifier, namespace)
 	statefulSets := &appsv1.StatefulSetList{}
-	if err := k8sClient.Client().List(ctx, statefulSets, client.InNamespace(namespace)); err != nil {
+	if err := k8sClient.DirectClient().List(ctx, statefulSets, client.InNamespace(namespace)); err != nil {
 		return err
 	}
 	for _, statefulSet := range statefulSets.Items {
@@ -282,7 +282,7 @@ func (f *CommonFramework) dumpStatefulSetInfoForNamespace(ctx context.Context, c
 func (f *CommonFramework) dumpDaemonSetInfoForNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string) error {
 	f.Logger.Infof("%s [NAMESPACE %s] [DAEMONSETS]", ctxIdentifier, namespace)
 	daemonSets := &appsv1.DaemonSetList{}
-	if err := k8sClient.Client().List(ctx, daemonSets, client.InNamespace(namespace)); err != nil {
+	if err := k8sClient.DirectClient().List(ctx, daemonSets, client.InNamespace(namespace)); err != nil {
 		return err
 	}
 	for _, ds := range daemonSets.Items {
@@ -300,7 +300,7 @@ func (f *CommonFramework) dumpDaemonSetInfoForNamespace(ctx context.Context, ctx
 func (f *CommonFramework) dumpServiceInfoForNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string) error {
 	f.Logger.Infof("%s [NAMESPACE %s] [SERVICES]", ctxIdentifier, namespace)
 	services := &corev1.ServiceList{}
-	if err := k8sClient.Client().List(ctx, services, client.InNamespace(namespace)); err != nil {
+	if err := k8sClient.DirectClient().List(ctx, services, client.InNamespace(namespace)); err != nil {
 		return err
 	}
 	for _, service := range services.Items {
@@ -314,7 +314,7 @@ func (f *CommonFramework) dumpServiceInfoForNamespace(ctx context.Context, ctxId
 func (f *CommonFramework) dumpNodes(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface) error {
 	f.Logger.Infof("%s [NODES]", ctxIdentifier)
 	nodes := &corev1.NodeList{}
-	if err := k8sClient.Client().List(ctx, nodes); err != nil {
+	if err := k8sClient.DirectClient().List(ctx, nodes); err != nil {
 		return err
 	}
 	for _, node := range nodes.Items {
@@ -326,7 +326,7 @@ func (f *CommonFramework) dumpNodes(ctx context.Context, ctxIdentifier string, k
 		f.Logger.Printf("Node %s has a capacity of %s cpu, %s memory", node.Name, node.Status.Capacity.Cpu().String(), node.Status.Capacity.Memory().String())
 
 		nodeMetric := &metricsv1beta1.NodeMetrics{}
-		if err := k8sClient.Client().Get(ctx, client.ObjectKey{Name: node.Name}, nodeMetric); err != nil {
+		if err := k8sClient.DirectClient().Get(ctx, client.ObjectKey{Name: node.Name}, nodeMetric); err != nil {
 			f.Logger.Errorf("unable to receive metrics for node %s: %s", node.Name, err.Error())
 			continue
 		}
@@ -340,7 +340,7 @@ func (f *CommonFramework) dumpNodes(ctx context.Context, ctxIdentifier string, k
 func (f *CommonFramework) dumpPodInfoForNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string) error {
 	f.Logger.Infof("%s [NAMESPACE %s] [PODS]", ctxIdentifier, namespace)
 	pods := &corev1.PodList{}
-	if err := k8sClient.Client().List(ctx, pods, client.InNamespace(namespace)); err != nil {
+	if err := k8sClient.DirectClient().List(ctx, pods, client.InNamespace(namespace)); err != nil {
 		return err
 	}
 	for _, pod := range pods.Items {
@@ -353,7 +353,7 @@ func (f *CommonFramework) dumpPodInfoForNamespace(ctx context.Context, ctxIdenti
 // dumpEventsInNamespace prints all events of a namespace
 func (f *CommonFramework) dumpEventsInAllNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, filters ...EventFilterFunc) error {
 	namespaces := &corev1.NamespaceList{}
-	if err := k8sClient.Client().List(ctx, namespaces); err != nil {
+	if err := k8sClient.DirectClient().List(ctx, namespaces); err != nil {
 		return err
 	}
 
@@ -371,7 +371,7 @@ func (f *CommonFramework) dumpEventsInAllNamespace(ctx context.Context, ctxIdent
 func (f *CommonFramework) dumpEventsInNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string, filters ...EventFilterFunc) error {
 	f.Logger.Infof("%s [NAMESPACE %s] [EVENTS]", ctxIdentifier, namespace)
 	events := &corev1.EventList{}
-	if err := k8sClient.Client().List(ctx, events, client.InNamespace(namespace)); err != nil {
+	if err := k8sClient.DirectClient().List(ctx, events, client.InNamespace(namespace)); err != nil {
 		return err
 	}
 

--- a/test/framework/plant_utils.go
+++ b/test/framework/plant_utils.go
@@ -34,7 +34,7 @@ func (f *GardenerFramework) CreatePlantSecret(ctx context.Context, namespace str
 	plantSecret.Data = make(map[string][]byte)
 	plantSecret.Data["kubeconfig"] = kubeConfigContent
 
-	err := f.GardenClient.Client().Create(ctx, plantSecret)
+	err := f.GardenClient.DirectClient().Create(ctx, plantSecret)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (f *GardenerFramework) CreatePlantSecret(ctx context.Context, namespace str
 
 // CreatePlant Creates a plant from a plant Object
 func (f *GardenerFramework) CreatePlant(ctx context.Context, plant *gardencorev1beta1.Plant) error {
-	err := f.GardenClient.Client().Create(ctx, plant)
+	err := f.GardenClient.DirectClient().Create(ctx, plant)
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func (f *GardenerFramework) CreatePlant(ctx context.Context, plant *gardencorev1
 
 // DeletePlant deletes the test plant
 func (f *GardenerFramework) DeletePlant(ctx context.Context, plant *gardencorev1beta1.Plant) error {
-	err := f.GardenClient.Client().Delete(ctx, plant)
+	err := f.GardenClient.DirectClient().Delete(ctx, plant)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func (f *GardenerFramework) DeletePlant(ctx context.Context, plant *gardencorev1
 func (f *GardenerFramework) WaitForPlantToBeCreated(ctx context.Context, plant *gardencorev1beta1.Plant) error {
 	return retry.Until(ctx, 2*time.Second, func(ctx context.Context) (done bool, err error) {
 		newPlant := &gardencorev1beta1.Plant{}
-		err = f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: plant.GetNamespace(), Name: plant.GetName()}, newPlant)
+		err = f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: plant.GetNamespace(), Name: plant.GetName()}, newPlant)
 		if err != nil {
 			return retry.SevereError(err)
 		}
@@ -93,7 +93,7 @@ func (f *GardenerFramework) WaitForPlantToBeCreated(ctx context.Context, plant *
 func (f *GardenerFramework) WaitForPlantToBeReconciledSuccessfully(ctx context.Context, plant *gardencorev1beta1.Plant) error {
 	return retry.Until(ctx, 2*time.Second, func(ctx context.Context) (done bool, err error) {
 		newPlant := &gardencorev1beta1.Plant{}
-		err = f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: plant.GetNamespace(), Name: plant.GetName()}, newPlant)
+		err = f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: plant.GetNamespace(), Name: plant.GetName()}, newPlant)
 		if err != nil {
 			return retry.SevereError(err)
 		}
@@ -112,7 +112,7 @@ func (f *GardenerFramework) WaitForPlantToBeReconciledSuccessfully(ctx context.C
 func (f *GardenerFramework) WaitForPlantToBeDeleted(ctx context.Context, plant *gardencorev1beta1.Plant) error {
 	return retry.Until(ctx, 2*time.Second, func(ctx context.Context) (done bool, err error) {
 		newPlant := &gardencorev1beta1.Plant{}
-		err = f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: plant.GetNamespace(), Name: plant.GetName()}, newPlant)
+		err = f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: plant.GetNamespace(), Name: plant.GetName()}, newPlant)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return retry.Ok()
@@ -131,7 +131,7 @@ func (f *GardenerFramework) WaitForPlantToBeDeleted(ctx context.Context, plant *
 func (f *GardenerFramework) WaitForPlantToBeReconciledWithUnknownStatus(ctx context.Context, plant *gardencorev1beta1.Plant) error {
 	return retry.Until(ctx, 2*time.Second, func(ctx context.Context) (done bool, err error) {
 		newPlant := &gardencorev1beta1.Plant{}
-		err = f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: plant.GetNamespace(), Name: plant.GetName()}, newPlant)
+		err = f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: plant.GetNamespace(), Name: plant.GetName()}, newPlant)
 		if err != nil {
 			return retry.SevereError(err)
 		}

--- a/test/framework/rootpod_executor.go
+++ b/test/framework/rootpod_executor.go
@@ -95,7 +95,7 @@ func (e *rootPodExecutor) Execute(ctx context.Context, command string) ([]byte, 
 
 // deploy deploys a root pod on the specified node and waits until it is running
 func (e *rootPodExecutor) deploy(ctx context.Context) error {
-	rootPod, err := DeployRootPod(ctx, e.client.Client(), e.namespace, e.nodeName)
+	rootPod, err := DeployRootPod(ctx, e.client.DirectClient(), e.namespace, e.nodeName)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func (e *rootPodExecutor) checkPodRunning(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if err := e.client.Client().Get(ctx, key, pod); err != nil {
+	if err := e.client.DirectClient().Get(ctx, key, pod); err != nil {
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}

--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -130,7 +130,7 @@ func (f *ShootFramework) DumpState(ctx context.Context) {
 		// dump seed status if seed is available
 		if f.Shoot.Spec.SeedName != nil {
 			seed := &gardencorev1beta1.Seed{}
-			if err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Name: *f.Shoot.Spec.SeedName}, seed); err != nil {
+			if err := f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Name: *f.Shoot.Spec.SeedName}, seed); err != nil {
 				f.Logger.Errorf("unable to get seed %s: %s", *f.Shoot.Spec.SeedName, err.Error())
 				return
 			}

--- a/test/integration/gardener/scheduler/scheduler_test.go
+++ b/test/integration/gardener/scheduler/scheduler_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Scheduler testing", func() {
 		framework.ExpectNoError(err)
 
 		schedulerConfigurationConfigMap := &corev1.ConfigMap{}
-		err = hostClusterClient.Client().Get(ctx, client.ObjectKey{Namespace: schedulerconfigv1alpha1.SchedulerDefaultConfigurationConfigMapNamespace, Name: schedulerconfigv1alpha1.SchedulerDefaultConfigurationConfigMapName}, schedulerConfigurationConfigMap)
+		err = hostClusterClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: schedulerconfigv1alpha1.SchedulerDefaultConfigurationConfigMapNamespace, Name: schedulerconfigv1alpha1.SchedulerDefaultConfigurationConfigMapName}, schedulerConfigurationConfigMap)
 		framework.ExpectNoError(err)
 
 		schedulerConfiguration, err = framework.ParseSchedulerConfiguration(schedulerConfigurationConfigMap)
@@ -137,7 +137,7 @@ var _ = Describe("Scheduler testing", func() {
 
 		if testMachineryRun != nil && *testMachineryRun {
 			f.Logger.Info("Running in test Machinery")
-			replicas, err := framework.ScaleGardenerControllerManager(setupContextTimeout, f.GardenClient.Client(), pointer.Int32Ptr(0))
+			replicas, err := framework.ScaleGardenerControllerManager(setupContextTimeout, f.GardenClient.DirectClient(), pointer.Int32Ptr(0))
 			Expect(err).To(BeNil())
 			gardenerSchedulerReplicaCount = replicas
 			f.Logger.Info("Environment for test-machinery run is prepared")
@@ -153,7 +153,7 @@ var _ = Describe("Scheduler testing", func() {
 		}
 		if testMachineryRun != nil && *testMachineryRun {
 			// Scale up ControllerManager again to restore state before this test.
-			_, err := framework.ScaleGardenerControllerManager(restoreCtxTimeout, f.GardenClient.Client(), gardenerSchedulerReplicaCount)
+			_, err := framework.ScaleGardenerControllerManager(restoreCtxTimeout, f.GardenClient.DirectClient(), gardenerSchedulerReplicaCount)
 			framework.ExpectNoError(err)
 			f.Logger.Infof("Environment is restored")
 		}
@@ -218,7 +218,7 @@ var _ = Describe("Scheduler testing", func() {
 
 		// retrieve valid shoot
 		alreadyScheduledShoot := &gardencorev1beta1.Shoot{}
-		err = f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: f.Shoot.Namespace, Name: f.Shoot.Name}, alreadyScheduledShoot)
+		err = f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: f.Shoot.Namespace, Name: f.Shoot.Name}, alreadyScheduledShoot)
 		framework.ExpectNoError(err)
 
 		err = f.ScheduleShoot(ctx, alreadyScheduledShoot, invalidSeed)
@@ -226,7 +226,7 @@ var _ = Describe("Scheduler testing", func() {
 
 		// double check that invalid seed is not set
 		currentShoot := &gardencorev1beta1.Shoot{}
-		err = f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: f.Shoot.Namespace, Name: f.Shoot.Name}, currentShoot)
+		err = f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: f.Shoot.Namespace, Name: f.Shoot.Name}, currentShoot)
 		framework.ExpectNoError(err)
 		Expect(*currentShoot.Spec.SeedName).NotTo(Equal(invalidSeed.Name))
 

--- a/test/integration/gardener/security/rbac.go
+++ b/test/integration/gardener/security/rbac.go
@@ -76,15 +76,15 @@ var _ = ginkgo.Describe("RBAC testing", func() {
 			},
 		}
 
-		err := f.GardenClient.Client().Create(ctx, serviceAccount)
+		err := f.GardenClient.DirectClient().Create(ctx, serviceAccount)
 		framework.ExpectNoError(err)
 		defer func() {
-			framework.ExpectNoError(f.GardenClient.Client().Delete(ctx, serviceAccount))
+			framework.ExpectNoError(f.GardenClient.DirectClient().Delete(ctx, serviceAccount))
 		}()
 
 		err = retry.UntilTimeout(ctx, 10*time.Second, serviceAccountPermissionTimeout, func(ctx context.Context) (bool, error) {
 			newServiceAccount := &corev1.ServiceAccount{}
-			if err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: serviceAccount.Namespace, Name: serviceAccount.Name}, newServiceAccount); err != nil {
+			if err := f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: serviceAccount.Namespace, Name: serviceAccount.Name}, newServiceAccount); err != nil {
 				return retry.MinorError(err)
 			}
 			serviceAccount = newServiceAccount
@@ -99,7 +99,7 @@ var _ = ginkgo.Describe("RBAC testing", func() {
 		framework.ExpectNoError(err)
 
 		shoots := &gardencorev1beta1.ShootList{}
-		err = saClient.Client().List(ctx, shoots, client.InNamespace(v1beta1constants.GardenNamespace))
+		err = saClient.DirectClient().List(ctx, shoots, client.InNamespace(v1beta1constants.GardenNamespace))
 		g.Expect(err).To(g.HaveOccurred())
 		g.Expect(errors.IsForbidden(err)).To(g.BeTrue())
 	}, serviceAccountPermissionTimeout)

--- a/test/integration/plants/plant.go
+++ b/test/integration/plants/plant.go
@@ -60,7 +60,7 @@ const (
 )
 
 func cleanPlant(ctx context.Context, f *framework.ShootFramework, plant *gardencorev1beta1.Plant, secret *corev1.Secret) error {
-	if err := f.GardenClient.Client().Delete(ctx, secret); err != nil {
+	if err := f.GardenClient.DirectClient().Delete(ctx, secret); err != nil {
 		return err
 	}
 	return f.DeletePlant(ctx, plant)

--- a/test/integration/shoots/applications/metrics.go
+++ b/test/integration/shoots/applications/metrics.go
@@ -73,7 +73,7 @@ var _ = ginkgo.Describe("Shoot application metrics testing", func() {
 		framework.ExpectNoError(err)
 
 		pods := &corev1.PodList{}
-		err = f.ShootClient.Client().List(ctx, pods, client.InNamespace(f.Namespace), client.MatchingLabels{"app": "load"})
+		err = f.ShootClient.DirectClient().List(ctx, pods, client.InNamespace(f.Namespace), client.MatchingLabels{"app": "load"})
 		framework.ExpectNoError(err)
 
 		if len(pods.Items) == 0 {
@@ -85,7 +85,7 @@ var _ = ginkgo.Describe("Shoot application metrics testing", func() {
 		framework.ExpectNoError(
 			retry.Until(ctx, 30*time.Second, func(ctx context.Context) (bool, error) {
 				podMetrics := &metricsv1beta1.PodMetrics{}
-				if err := f.ShootClient.Client().Get(ctx, kutil.Key(f.Namespace, podName), podMetrics); err != nil {
+				if err := f.ShootClient.DirectClient().Get(ctx, kutil.Key(f.Namespace, podName), podMetrics); err != nil {
 					if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 						f.Logger.Infof("No metrics for pod %s/%s available yet: %v", f.Namespace, podName, err)
 						return retry.MinorError(err)
@@ -110,7 +110,7 @@ var _ = ginkgo.Describe("Shoot application metrics testing", func() {
 		)
 	}, metricsTestTimeout, framework.WithCAfterTest(func(ctx context.Context) {
 		ginkgo.By("cleanup metrics test deployment")
-		err := f.ShootClient.Client().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: f.Namespace}})
+		err := f.ShootClient.DirectClient().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: f.Namespace}})
 		framework.ExpectNoError(client.IgnoreNotFound(err))
 	}, cleanupTimeout))
 

--- a/test/integration/shoots/applications/networking.go
+++ b/test/integration/shoots/applications/networking.go
@@ -69,11 +69,11 @@ var _ = ginkgo.Describe("Shoot network testing", func() {
 		err := f.RenderAndDeployTemplate(ctx, f.ShootClient, templates.NginxDaemonSetName, templateParams)
 		framework.ExpectNoError(err)
 
-		err = f.WaitUntilDaemonSetIsRunning(ctx, f.ShootClient.Client(), name, f.Namespace)
+		err = f.WaitUntilDaemonSetIsRunning(ctx, f.ShootClient.DirectClient(), name, f.Namespace)
 		framework.ExpectNoError(err)
 
 		pods := &corev1.PodList{}
-		err = f.ShootClient.Client().List(ctx, pods, client.InNamespace(f.Namespace), client.MatchingLabels{"app": "net-nginx"})
+		err = f.ShootClient.DirectClient().List(ctx, pods, client.InNamespace(f.Namespace), client.MatchingLabels{"app": "net-nginx"})
 		framework.ExpectNoError(err)
 
 		podExecutor := framework.NewPodExecutor(f.ShootClient)
@@ -100,7 +100,7 @@ var _ = ginkgo.Describe("Shoot network testing", func() {
 		framework.ExpectNoError(err)
 	}, networkTestTimeout, framework.WithCAfterTest(func(ctx context.Context) {
 		ginkgo.By("cleanup network test daemonset")
-		err := f.ShootClient.Client().Delete(ctx, &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: f.Namespace}})
+		err := f.ShootClient.DirectClient().Delete(ctx, &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: f.Namespace}})
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
 				framework.ExpectNoError(err)

--- a/test/integration/shoots/care/shoot_care.go
+++ b/test/integration/shoots/care/shoot_care.go
@@ -55,7 +55,7 @@ var _ = ginkgo.Describe("Shoot Care testing", func() {
 		gomega.Expect(cond.Status).To(gomega.Equal(gardencorev1beta1.ConditionTrue))
 
 		zero := int32(0)
-		origReplicas, err = framework.ScaleDeployment(timeout, f.SeedClient.Client(), &zero, gardencorev1beta1constants.DeploymentNameKubeAPIServer, f.ShootSeedNamespace())
+		origReplicas, err = framework.ScaleDeployment(timeout, f.SeedClient.DirectClient(), &zero, gardencorev1beta1constants.DeploymentNameKubeAPIServer, f.ShootSeedNamespace())
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		// wait for unhealthy condition
@@ -64,7 +64,7 @@ var _ = ginkgo.Describe("Shoot Care testing", func() {
 	}, timeout, framework.WithCAfterTest(func(ctx context.Context) {
 		if origReplicas != nil {
 			f.Logger.Infof("Test cleanup: Scale API Server to '%d' replicas again", *origReplicas)
-			origReplicas, err = framework.ScaleDeployment(timeout, f.SeedClient.Client(), origReplicas, gardencorev1beta1constants.DeploymentNameKubeAPIServer, f.ShootSeedNamespace())
+			origReplicas, err = framework.ScaleDeployment(timeout, f.SeedClient.DirectClient(), origReplicas, gardencorev1beta1constants.DeploymentNameKubeAPIServer, f.ShootSeedNamespace())
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// wait for healthy condition

--- a/test/integration/shoots/logging/utils.go
+++ b/test/integration/shoots/logging/utils.go
@@ -30,12 +30,12 @@ import (
 // If not, probably the logging feature gate is not enabled.
 func hasRequiredResources(ctx context.Context, k8sSeedClient kubernetes.Interface) (bool, error) {
 	fluentBit := &appsv1.DaemonSet{}
-	if err := k8sSeedClient.Client().Get(ctx, client.ObjectKey{Namespace: garden, Name: fluentBitName}, fluentBit); err != nil {
+	if err := k8sSeedClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: garden, Name: fluentBitName}, fluentBit); err != nil {
 		return false, err
 	}
 
 	fluentd := &appsv1.StatefulSet{}
-	if err := k8sSeedClient.Client().Get(ctx, client.ObjectKey{Namespace: garden, Name: fluentdName}, fluentd); err != nil {
+	if err := k8sSeedClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: garden, Name: fluentdName}, fluentd); err != nil {
 		return false, err
 	}
 

--- a/test/integration/shoots/maintenance/maintenance.go
+++ b/test/integration/shoots/maintenance/maintenance.go
@@ -124,7 +124,7 @@ var _ = ginkgo.Describe("Shoot Maintenance testing", func() {
 			f.Logger.Info("Running in test Machinery")
 			// setup the integration test environment by manipulation the Gardener Components (namespace garden) in the garden cluster
 			// scale down the gardener-scheduler to 0 replicas
-			replicas, err := framework.ScaleGardenerScheduler(setupContextTimeout, f.GardenClient.Client(), pointer.Int32Ptr(0))
+			replicas, err := framework.ScaleGardenerScheduler(setupContextTimeout, f.GardenClient.DirectClient(), pointer.Int32Ptr(0))
 			gardenerSchedulerReplicaCount = replicas
 			gomega.Expect(err).To(gomega.BeNil())
 			f.Logger.Info("Environment for test-machinery run is prepared")
@@ -174,12 +174,12 @@ var _ = ginkgo.Describe("Shoot Maintenance testing", func() {
 	framework.CAfterSuite(func(ctx context.Context) {
 		framework.CommonAfterSuite()
 		if cloudProfileCleanupNeeded {
-			err := CleanupCloudProfile(ctx, f.GardenClient.Client(), testShootCloudProfile.Name, testMachineImage, []gardencorev1beta1.ExpirableVersion{testKubernetesVersionLowPatchLowMinor, testKubernetesVersionHighestPatchLowMinor, testKubernetesVersionLowPatchConsecutiveMinor, testKubernetesVersionHighestPatchConsecutiveMinor})
+			err := CleanupCloudProfile(ctx, f.GardenClient.DirectClient(), testShootCloudProfile.Name, testMachineImage, []gardencorev1beta1.ExpirableVersion{testKubernetesVersionLowPatchLowMinor, testKubernetesVersionHighestPatchLowMinor, testKubernetesVersionLowPatchConsecutiveMinor, testKubernetesVersionHighestPatchConsecutiveMinor})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			f.Logger.Infof("Cleaned Cloud Profile '%s'", testShootCloudProfile.Name)
 		}
 		if testMachineryRun != nil && *testMachineryRun {
-			_, err := framework.ScaleGardenerScheduler(restoreCtxTimeout, f.GardenClient.Client(), gardenerSchedulerReplicaCount)
+			_, err := framework.ScaleGardenerScheduler(restoreCtxTimeout, f.GardenClient.DirectClient(), gardenerSchedulerReplicaCount)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			f.Logger.Infof("Environment is restored")
 		}
@@ -210,53 +210,53 @@ var _ = ginkgo.Describe("Shoot Maintenance testing", func() {
 
 	ginkgo.Describe("Machine image maintenance tests", func() {
 		f.Beta().Serial().CIt("Do not update Shoot machine image in maintenance time: AutoUpdate.MachineImageVersion == false && expirationDate does not apply", func(ctx context.Context) {
-			err = StartShootMaintenance(ctx, f.GardenClient.Client(), f.Shoot)
+			err = StartShootMaintenance(ctx, f.GardenClient.DirectClient(), f.Shoot)
 			gomega.Expect(err).To(gomega.BeNil())
-			err = WaitForExpectedMachineImageMaintenance(ctx, f.Logger, f.GardenClient.Client(), f.Shoot, testMachineImage, false, time.Now().Add(time.Second*10))
+			err = WaitForExpectedMachineImageMaintenance(ctx, f.Logger, f.GardenClient.DirectClient(), f.Shoot, testMachineImage, false, time.Now().Add(time.Second*10))
 			gomega.Expect(err).To(gomega.BeNil())
 		}, waitForCreateDeleteTimeout)
 
 		f.Beta().Serial().CIt("Shoot machine image must be updated in maintenance time: AutoUpdate.MachineImageVersion == true && expirationDate does not apply", func(ctx context.Context) {
 			// set test specific shoot settings
 			f.Shoot.Spec.Maintenance.AutoUpdate.MachineImageVersion = true
-			err = TryUpdateShootForMachineImageMaintenance(ctx, f.GardenClient.Client(), f.Shoot)
+			err = TryUpdateShootForMachineImageMaintenance(ctx, f.GardenClient.DirectClient(), f.Shoot)
 			gomega.Expect(err).To(gomega.BeNil())
 
-			err = StartShootMaintenance(ctx, f.GardenClient.Client(), f.Shoot)
+			err = StartShootMaintenance(ctx, f.GardenClient.DirectClient(), f.Shoot)
 			gomega.Expect(err).To(gomega.BeNil())
 
-			err = WaitForExpectedMachineImageMaintenance(ctx, f.Logger, f.GardenClient.Client(), f.Shoot, highestShootMachineImage, true, time.Now().Add(time.Second*20))
+			err = WaitForExpectedMachineImageMaintenance(ctx, f.Logger, f.GardenClient.DirectClient(), f.Shoot, highestShootMachineImage, true, time.Now().Add(time.Second*20))
 			gomega.Expect(err).To(gomega.BeNil())
 		}, waitForCreateDeleteTimeout)
 
 		f.Beta().Serial().CIt("Shoot machine image must be updated in maintenance time: AutoUpdate.MachineImageVersion == false && expirationDate applies", func(ctx context.Context) {
 			defer func() {
 				// make sure to remove expiration date from cloud profile after test
-				err = TryUpdateCloudProfileForMachineImageMaintenance(ctx, f.GardenClient.Client(), f.Shoot, testMachineImage, nil, &deprecatedClassification)
+				err = TryUpdateCloudProfileForMachineImageMaintenance(ctx, f.GardenClient.DirectClient(), f.Shoot, testMachineImage, nil, &deprecatedClassification)
 				gomega.Expect(err).To(gomega.BeNil())
 				f.Logger.Infof("Cleaned expiration date on machine image from Cloud Profile '%s'", testShootCloudProfile.Name)
 			}()
 			// expire the Shoot's machine image
-			err = TryUpdateCloudProfileForMachineImageMaintenance(ctx, f.GardenClient.Client(), f.Shoot, testMachineImage, &expirationDateInThePast, &deprecatedClassification)
+			err = TryUpdateCloudProfileForMachineImageMaintenance(ctx, f.GardenClient.DirectClient(), f.Shoot, testMachineImage, &expirationDateInThePast, &deprecatedClassification)
 			gomega.Expect(err).To(gomega.BeNil())
 
 			// give controller caches time to sync
 			time.Sleep(10 * time.Second)
 
-			err = StartShootMaintenance(ctx, f.GardenClient.Client(), f.Shoot)
+			err = StartShootMaintenance(ctx, f.GardenClient.DirectClient(), f.Shoot)
 			gomega.Expect(err).To(gomega.BeNil())
 
-			err = WaitForExpectedMachineImageMaintenance(ctx, f.Logger, f.GardenClient.Client(), f.Shoot, highestShootMachineImage, true, time.Now().Add(time.Minute*1))
+			err = WaitForExpectedMachineImageMaintenance(ctx, f.Logger, f.GardenClient.DirectClient(), f.Shoot, highestShootMachineImage, true, time.Now().Add(time.Minute*1))
 			gomega.Expect(err).To(gomega.BeNil())
 		}, waitForCreateDeleteTimeout)
 	})
 
 	ginkgo.Describe("Kubernetes version maintenance tests", func() {
 		f.Beta().Serial().CIt("Kubernetes version should not be updated: auto update not enabled", func(ctx context.Context) {
-			err = StartShootMaintenance(ctx, f.GardenClient.Client(), f.Shoot)
+			err = StartShootMaintenance(ctx, f.GardenClient.DirectClient(), f.Shoot)
 			gomega.Expect(err).To(gomega.BeNil())
 
-			err = WaitForExpectedKubernetesVersionMaintenance(ctx, f.Logger, f.GardenClient.Client(), f.Shoot, testKubernetesVersionLowPatchLowMinor.Version, false, time.Now().Add(time.Second*10))
+			err = WaitForExpectedKubernetesVersionMaintenance(ctx, f.Logger, f.GardenClient.DirectClient(), f.Shoot, testKubernetesVersionLowPatchLowMinor.Version, false, time.Now().Add(time.Second*10))
 			gomega.Expect(err).To(gomega.BeNil())
 
 		}, waitForCreateDeleteTimeout)
@@ -264,63 +264,63 @@ var _ = ginkgo.Describe("Shoot Maintenance testing", func() {
 		f.Beta().Serial().CIt("Kubernetes version should be updated: auto update enabled", func(ctx context.Context) {
 			// set test specific shoot settings
 			f.Shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion = true
-			err = TryUpdateShootForKubernetesMaintenance(ctx, f.GardenClient.Client(), f.Shoot)
+			err = TryUpdateShootForKubernetesMaintenance(ctx, f.GardenClient.DirectClient(), f.Shoot)
 			gomega.Expect(err).To(gomega.BeNil())
 
-			err = StartShootMaintenance(ctx, f.GardenClient.Client(), f.Shoot)
+			err = StartShootMaintenance(ctx, f.GardenClient.DirectClient(), f.Shoot)
 			gomega.Expect(err).To(gomega.BeNil())
 
-			err = WaitForExpectedKubernetesVersionMaintenance(ctx, f.Logger, f.GardenClient.Client(), f.Shoot, testKubernetesVersionHighestPatchLowMinor.Version, true, time.Now().Add(time.Second*20))
+			err = WaitForExpectedKubernetesVersionMaintenance(ctx, f.Logger, f.GardenClient.DirectClient(), f.Shoot, testKubernetesVersionHighestPatchLowMinor.Version, true, time.Now().Add(time.Second*20))
 			gomega.Expect(err).To(gomega.BeNil())
 		}, waitForCreateDeleteTimeout)
 
 		f.Beta().Serial().CIt("Kubernetes version should be updated: force update patch version", func(ctx context.Context) {
 			defer func() {
 				// make sure to remove expiration date from cloud profile after test
-				err = TryUpdateCloudProfileForKubernetesVersionMaintenance(ctx, f.GardenClient.Client(), f.Shoot, testKubernetesVersionLowPatchLowMinor.Version, nil, &deprecatedClassification)
+				err = TryUpdateCloudProfileForKubernetesVersionMaintenance(ctx, f.GardenClient.DirectClient(), f.Shoot, testKubernetesVersionLowPatchLowMinor.Version, nil, &deprecatedClassification)
 				gomega.Expect(err).To(gomega.BeNil())
 				f.Logger.Infof("Cleaned expiration date on kubernetes version from Cloud Profile '%s'", testShootCloudProfile.Name)
 			}()
 
 			// expire the Shoot's Kubernetes version
-			err = TryUpdateCloudProfileForKubernetesVersionMaintenance(ctx, f.GardenClient.Client(), f.Shoot, testKubernetesVersionLowPatchLowMinor.Version, &expirationDateInThePast, &deprecatedClassification)
+			err = TryUpdateCloudProfileForKubernetesVersionMaintenance(ctx, f.GardenClient.DirectClient(), f.Shoot, testKubernetesVersionLowPatchLowMinor.Version, &expirationDateInThePast, &deprecatedClassification)
 			gomega.Expect(err).To(gomega.BeNil())
 
 			// give controller caches time to sync
 			time.Sleep(10 * time.Second)
 
-			err = StartShootMaintenance(ctx, f.GardenClient.Client(), f.Shoot)
+			err = StartShootMaintenance(ctx, f.GardenClient.DirectClient(), f.Shoot)
 			gomega.Expect(err).To(gomega.BeNil())
 
-			err = WaitForExpectedKubernetesVersionMaintenance(ctx, f.Logger, f.GardenClient.Client(), f.Shoot, testKubernetesVersionHighestPatchLowMinor.Version, true, time.Now().Add(time.Second*20))
+			err = WaitForExpectedKubernetesVersionMaintenance(ctx, f.Logger, f.GardenClient.DirectClient(), f.Shoot, testKubernetesVersionHighestPatchLowMinor.Version, true, time.Now().Add(time.Second*20))
 			gomega.Expect(err).To(gomega.BeNil())
 		}, waitForCreateDeleteTimeout)
 
 		f.Beta().Serial().CIt("Kubernetes version should be updated: force update minor version", func(ctx context.Context) {
 			defer func() {
 				// make sure to remove expiration date from cloud profile after test
-				err = TryUpdateCloudProfileForKubernetesVersionMaintenance(ctx, f.GardenClient.Client(), f.Shoot, testKubernetesVersionHighestPatchLowMinor.Version, &expirationDateInThePast, &deprecatedClassification)
+				err = TryUpdateCloudProfileForKubernetesVersionMaintenance(ctx, f.GardenClient.DirectClient(), f.Shoot, testKubernetesVersionHighestPatchLowMinor.Version, &expirationDateInThePast, &deprecatedClassification)
 				gomega.Expect(err).To(gomega.BeNil())
 				f.Logger.Infof("Cleaned expiration date on kubernetes version from Cloud Profile '%s'", testShootCloudProfile.Name)
 			}()
 
 			// set the shoots Kubernetes version to be the highest patch version of the minor version
 			f.Shoot.Spec.Kubernetes.Version = testKubernetesVersionHighestPatchLowMinor.Version
-			err = TryUpdateShootForKubernetesMaintenance(ctx, f.GardenClient.Client(), f.Shoot)
+			err = TryUpdateShootForKubernetesMaintenance(ctx, f.GardenClient.DirectClient(), f.Shoot)
 			gomega.Expect(err).To(gomega.BeNil())
 
 			// let Shoot's Kubernetes version expire
-			err = TryUpdateCloudProfileForKubernetesVersionMaintenance(ctx, f.GardenClient.Client(), f.Shoot, testKubernetesVersionHighestPatchLowMinor.Version, &expirationDateInThePast, &deprecatedClassification)
+			err = TryUpdateCloudProfileForKubernetesVersionMaintenance(ctx, f.GardenClient.DirectClient(), f.Shoot, testKubernetesVersionHighestPatchLowMinor.Version, &expirationDateInThePast, &deprecatedClassification)
 			gomega.Expect(err).To(gomega.BeNil())
 
 			// give controller caches time to sync
 			time.Sleep(10 * time.Second)
 
-			err = StartShootMaintenance(ctx, f.GardenClient.Client(), f.Shoot)
+			err = StartShootMaintenance(ctx, f.GardenClient.DirectClient(), f.Shoot)
 			gomega.Expect(err).To(gomega.BeNil())
 
 			// expect shoot to have updated to latest patch version of next minor version
-			err = WaitForExpectedKubernetesVersionMaintenance(ctx, f.Logger, f.GardenClient.Client(), f.Shoot, testKubernetesVersionHighestPatchConsecutiveMinor.Version, true, time.Now().Add(time.Second*20))
+			err = WaitForExpectedKubernetesVersionMaintenance(ctx, f.Logger, f.GardenClient.DirectClient(), f.Shoot, testKubernetesVersionHighestPatchConsecutiveMinor.Version, true, time.Now().Add(time.Second*20))
 			gomega.Expect(err).To(gomega.BeNil())
 		}, waitForCreateDeleteTimeout)
 	})
@@ -341,6 +341,6 @@ func prepareCloudProfile(ctx context.Context, profile gardencorev1beta1.CloudPro
 
 	// add  test kubernetes versions (one low patch version, one high patch version)
 	profile.Spec.Kubernetes.Versions = append(profile.Spec.Kubernetes.Versions, testKubernetesVersionLowPatchLowMinor, testKubernetesVersionHighestPatchLowMinor, testKubernetesVersionLowPatchConsecutiveMinor, testKubernetesVersionHighestPatchConsecutiveMinor)
-	err = f.GardenClient.Client().Update(ctx, &profile)
+	err = f.GardenClient.DirectClient().Update(ctx, &profile)
 	gomega.Expect(err).To(gomega.BeNil())
 }

--- a/test/integration/shoots/operatingsystem/os.go
+++ b/test/integration/shoots/operatingsystem/os.go
@@ -53,7 +53,7 @@ var _ = ginkgo.Describe("Operating system testing", func() {
 
 			// choose random node
 			nodes := &corev1.NodeList{}
-			err := f.ShootClient.Client().List(ctx, nodes)
+			err := f.ShootClient.DirectClient().List(ctx, nodes)
 			framework.ExpectNoError(err)
 
 			if len(nodes.Items) == 0 {

--- a/test/integration/shoots/operations/clusterautoscaler.go
+++ b/test/integration/shoots/operations/clusterautoscaler.go
@@ -133,7 +133,7 @@ var _ = ginkgo.Describe("Shoot clusterautoscaler testing", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("scaling up reserve-capacity deployment")
-		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.Client(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, origMinWorkers+1)
+		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.DirectClient(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, origMinWorkers+1)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("one node should be added to the worker pool")
@@ -145,7 +145,7 @@ var _ = ginkgo.Describe("Shoot clusterautoscaler testing", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("scaling down reserve-capacity deployment")
-		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.Client(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, origMinWorkers)
+		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.DirectClient(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, origMinWorkers)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("one node should be removed from the worker pool")
@@ -252,7 +252,7 @@ var _ = ginkgo.Describe("Shoot clusterautoscaler testing", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("scaling up reserve-capacity deployment")
-		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.Client(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, 1)
+		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.DirectClient(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, 1)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("one node should be added to the worker pool")
@@ -264,7 +264,7 @@ var _ = ginkgo.Describe("Shoot clusterautoscaler testing", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("scaling down reserve-capacity deployment")
-		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.Client(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, 0)
+		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.DirectClient(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, 0)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("worker pool should be scaled-down to 0")

--- a/test/system/complete_reconcile/gardener_reconcile_test.go
+++ b/test/system/complete_reconcile/gardener_reconcile_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Shoot reconciliation testing", func() {
 
 		err := retry.UntilTimeout(ctx, 30*time.Second, ReconcileShootsTimeout, func(ctx context.Context) (bool, error) {
 			shoots := &gardencorev1beta1.ShootList{}
-			err := f.GardenClient.Client().List(ctx, shoots)
+			err := f.GardenClient.DirectClient().List(ctx, shoots)
 			if err != nil {
 				f.Logger.Debug(err.Error())
 				return retry.MinorError(err)

--- a/test/system/shoot_deletion/delete_test.go
+++ b/test/system/shoot_deletion/delete_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Shoot deletion testing", func() {
 		validateFlags()
 
 		shoot := &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Namespace: f.ProjectNamespace, Name: *shootName}}
-		if err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: f.ProjectNamespace, Name: *shootName}, shoot); err != nil {
+		if err := f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: f.ProjectNamespace, Name: *shootName}, shoot); err != nil {
 			if apierrors.IsNotFound(err) {
 				Skip("shoot is already deleted")
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area testing
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR adapts the usage of kubernetes clients in the integration test framework and all integration tests to the changes made in #2449.
Basically it just replaces all occurences of `kubernetes.Interface.Client()` with `kubernetes.Interface.DirectClient()`. This way, the integration tests explicitly do not rely on cached clients and always use direct clients when talking to clusters. This is done because the effort of implementing a clean and proper way of using cached clients in our integration tests seems to be huge and also not worth it, as we wouldn't profit too much from cached clients there.

/invite @gardener/test-infra-maintainers 

**Which issue(s) this PR fixes**:
Part of #2414

**Special notes for your reviewer**:
✅ Depends on #2449, will rebase and drop the commits from #2449 once it is merged.
Please select the last commit to review the changes of this PR.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
