### PR TITLE
Support etcd scale down enhancement

### DIFF
--- a/charts/seed-bootstrap/charts/etcd-druid/templates/druid-clusterrole.yaml
+++ b/charts/seed-bootstrap/charts/etcd-druid/templates/druid-clusterrole.yaml
@@ -30,6 +30,7 @@ rules:
   resources:
   - services
   - configmaps
+  - persistentvolumeclaims
   verbs:
   - get
   - list

--- a/charts/seed-bootstrap/charts/etcd-druid/templates/etcd-crd.yaml
+++ b/charts/seed-bootstrap/charts/etcd-druid/templates/etcd-crd.yaml
@@ -343,6 +343,13 @@ spec:
               description: VolumeClaimTemplate defines the volume claim template to
                 be created
               type: string
+            volumeRetentionPolicy:
+              description: VolumeRetentionPolicy defines the policy for retaining
+                volumes on etcd scale-down and deletion
+              enum:
+              - Delete
+              - Retain
+              type: string
           required:
           - backup
           - etcd

--- a/charts/seed-controlplane/charts/etcd/templates/etcd.yaml
+++ b/charts/seed-controlplane/charts/etcd/templates/etcd.yaml
@@ -80,3 +80,6 @@ spec:
 {{- else }}
   volumeClaimTemplate: etcd-{{ .Values.role }}
 {{- end }}
+{{- if .Values.volumeRetentionPolicy }}
+  volumeRetentionPolicy: {{ .Values.volumeRetentionPolicy }}
+{{- end }}


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area cost
/area storage
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR enhances etcd crd and druid role to support https://github.com/gardener/etcd-druid/pull/59, which allows druid to take full snapshot of etcd data and delete the etcd data volume on etcd scale down during shoot hibernation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR must go in before next druid release (which will contain https://github.com/gardener/etcd-druid/pull/59)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Add `volumeRetentionPolicy` field to etcd crd which will be respected by etcd-druid on etcd scale down and etcd deletion. Default policy is `Delete`.
```
