### PR TITLE
Remove hostPort usage for konnectivity-tunnel pods

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -279,10 +279,8 @@ spec:
         ports:
           - name: agentport
             containerPort: {{ .Values.konnectivityTunnel.agentPort }}
-            hostPort: {{ .Values.konnectivityTunnel.agentPort }}
           - name: adminport
             containerPort: {{ .Values.konnectivityTunnel.adminPort }}
-            hostPort: {{ .Values.konnectivityTunnel.adminPort }}
         volumeMounts:
           - name: konnectivity-server-certs
             mountPath: /certs/konnectivity-server


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area networking
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR removes the usage of hostPorts on the konnectivity tunnel pods. This results in blocked deployment when scheduled on the same node. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
A bug which blocked APIserver deployments on the same node (due to hostPort usage) is now fixed. 
```
