### PR TITLE
Add general GEP info

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,8 @@ If multiple identifiers make sense you can also state the commands multiple time
 "/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
 "/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
 "/priority" identifiers: normal|critical|blocker
+
+For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
 -->
 /area TODO
 /kind TODO

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,8 @@
 
 ## Proposals
 
+* [GEP: Gardener Enhancement Proposal Description](proposals/README.md)
+* [GEP: Template](proposals/00-template.md)
 * [GEP-1: Gardener extensibility and extraction of cloud-specific/OS-specific knowledge](proposals/01-extensibility.md)
 * [GEP-2: `BackupInfrastructure` CRD and Controller Redesign](proposals/02-backupinfra.md)
 * [GEP-3: Network extensibility](proposals/03-networking-extensibility.md)

--- a/docs/proposals/00-template.md
+++ b/docs/proposals/00-template.md
@@ -1,0 +1,20 @@
+# Headline of GEP
+
+## Table of Contents
+
+- [Headline of GEP](#headline-of-gep)
+  - [Table of Contents](#table-of-contents)
+  - [Summary](#summary)
+  - [Motivation](#motivation)
+    - [Goals](#goals)
+    - [Non-Goals](#non-goals)
+  - [Proposal](#proposal)
+
+## Summary
+
+## Motivation
+
+### Goals
+### Non-Goals
+
+## Proposal

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,38 @@
+# Gardener Enhancement Proposal (GEP)
+
+Changes to the Gardener code base are often incorporated directly via pull requests which either themselves contain a description about the motivation and scope of a change or a linked GitHub issue does.
+
+If a perspective feature has a bigger extent, requires the involvement of several parties or more discussion is needed before the actual implementation can be started, you may consider filing a pull request with a Gardener Enhancement Proposal (GEP) first.
+
+GEPs are a measure to propose a change or to add a feature to Gardener, help you to describe the change(s) conceptionally, and to list the steps that are necessary to reach this goal. It helps the Gardener maintainers as well as the community to understand the motivation and scope around your proposed change(s) and encourages their contribution to discussions and future pull requests. If you are familiar with the Kubernetes community, GEPs are analogue to Kubernetes Enhancement Proposals ([KEPs]( https://github.com/kubernetes/enhancements/tree/master/keps)).
+
+## Reasons for a GEP
+
+You may consider filing a GEP for the following reasons:
+-	A Gardener architectural change is intended / necessary
+-	Major changes to the Gardener code base
+-	A phased implementation approach is expected because of the widespread scope of the change
+-	Your proposed changes may be controversial
+
+We encourage you to take a look at already merged [GEPs]( https://github.com/gardener/gardener/tree/master/docs/proposals) since they give you a sense of what a typical GEP comprises.
+
+## Before creating a GEP
+
+It is recommended to discuss and outline the motivation of your prospective GEP as a draft with the community before you take the investment of creating the actual GEP. This early briefing supports the understanding for the broad community and leads to a fast feedback for your proposal from the respective experts in the community.
+An appropriate format for this may be the regular [Gardener community meeting](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md#weekly-meeting).
+
+## How to file a GEP
+
+GEPs should be created as Markdown `.md` files and are submitted through a GitHub pull request to their current home in [docs/proposals](https://github.com/gardener/gardener/tree/master/docs/proposals). Please use the provided [template](./00-template.md) or follow the structure of existing [GEPs]( https://github.com/gardener/gardener/tree/master/docs/proposals) which makes reviewing easier and faster. Additionally, please link the new GEP in our documentation [index](../README.md#Proposals).
+
+If not already done, please present your GEP in the [regular community meeting](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md#weekly-meeting) to brief the community about your proposal (we strive for personal communication :) ). Also consider that this may be an important step to raise awareness and understanding for everyone involved.
+
+## GEP Process
+
+1. Pre-discussions about GEP (if necessary)
+2. GEP is filed through GitHub PR
+3. Presentation in Gardener community meeting (if possible)
+4. Review of GEP from maintainers/community
+5. GEP is merged if accepted
+6. Implementation of GEP
+7. Consider keeping GEP up-to-date in case implementation differs essentially


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area documentation
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR adds a description and a template for creating Gardener Enhancement Proposals (GEPs).

The description isn't meant to be an exhaustive list of process steps but rather a best practice that I've been observing. I also think that we shouldn't make it a too strict process since we haven't been flooded by GEPs yet.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
General information about Gardener Enhancement Proposals (GEPs) have been added. Please consult this [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) for more information.
```
