### PR TITLE
use legacy iptables for kube-proxy ~1.16.11

### DIFF
--- a/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -21,6 +21,7 @@ spec:
         checksum/secret-kube-proxy: {{ include (print $.Template.BasePath "/kube-proxy-secret.yaml") . | sha256sum }}
         checksum/configmap-componentconfig: {{ include (print $.Template.BasePath "/componentconfig.yaml") . | sha256sum }}
         checksum/configmap-kube-proxy-cleanup-script: {{ include (print $.Template.BasePath "/kube-proxy-cleanup-script.yaml") . | sha256sum }}
+        checksum/configmap-kube-proxy-start-script: {{ include (print $.Template.BasePath "/kube-proxy-start-script.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
@@ -88,18 +89,9 @@ spec:
         image: {{ index .Values.images "kube-proxy" }}
         imagePullPolicy: IfNotPresent
         command:
-        {{- if semverCompare "< 1.17" .Values.kubernetesVersion }}
-        - /hyperkube
-        {{- if semverCompare "< 1.15" .Values.kubernetesVersion }}
-        - proxy
-        {{- else }}
-        - kube-proxy
-        {{- end }}
-        {{- else }}
-        - /usr/local/bin/kube-proxy
-        {{- end }}
-        - --config=/var/lib/kube-proxy-config/config.yaml
-        - --v=2
+        - sh
+        - -c
+        - /script/start/start.sh
         securityContext:
           privileged: true
         resources:
@@ -112,6 +104,8 @@ spec:
           hostPort: {{ .Values.ports.metrics }}
           name: metrics
         volumeMounts:
+        - name: kube-proxy-start-script
+          mountPath: /script/start
         - name: kubeconfig
           mountPath: /var/lib/kube-proxy
         - name: kube-proxy-config
@@ -142,6 +136,10 @@ spec:
       - name: kube-proxy-cleanup-script
         configMap:
           name: kube-proxy-cleanup-script
+          defaultMode: 0777
+      - name: kube-proxy-start-script
+        configMap:
+          name: kube-proxy-start-script
           defaultMode: 0777
       - name: kube-proxy-dir
         hostPath:

--- a/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-start-script.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-start-script.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-proxy-start-script
+  namespace: kube-system
+  labels:
+    app: kubernetes
+    gardener.cloud/role: system-component
+    origin: gardener
+    role: proxy
+data:
+  start.sh: |
+    #!/bin/sh -e
+    {{ if (semverCompare "~1.16.11" .Values.kubernetesVersion) }}
+    update-alternatives --set iptables /usr/sbin/iptables-legacy
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+    update-alternatives --set ebtables /usr/sbin/ebtables-legacy
+    {{ end }}
+    {{ if semverCompare "< 1.17" .Values.kubernetesVersion }}
+    /hyperkube \
+    {{- if semverCompare "< 1.15" .Values.kubernetesVersion }}
+    proxy \
+    {{- else }}
+    kube-proxy \
+    {{- end }}
+    {{- else }}
+    /usr/local/bin/kube-proxy \
+    {{- end }}
+    --config=/var/lib/kube-proxy-config/config.yaml \
+    --v=2


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area networking
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area networking
/kind enhancement
/priority normal

**What this PR does / why we need it**:
use legacy iptables for kube-proxy ~1.16.11

**Which issue(s) this PR fixes**:
Mitigates https://github.com/kubernetes/kubernetes/issues/92275

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`kube-proxy` for k8s versions ~1.16.11 now explicitly use the legacy iptables.
```
