### PR TITLE
Update konnectivity tunnel to v0.0.10

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -77,7 +77,7 @@ images:
 - name: konnectivity-server
   sourceRepository: github.com/kubernetes-sigs/apiserver-network-proxy
   repository: eu.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-server
-  tag: "v0.0.8"
+  tag: "v0.0.10"
 
 # Monitoring
 - name: alertmanager
@@ -127,7 +127,7 @@ images:
 - name: konnectivity-agent
   sourceRepository: github.com/kubernetes-sigs/apiserver-network-proxy
   repository: eu.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent
-  tag: "v0.0.8"
+  tag: "v0.0.10"
 - name: coredns
   sourceRepository: github.com/coredns/coredns
   repository: coredns/coredns


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area networking
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area networking
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR updates the konnectivity-tunnel to v0.0.10, additionally missing logic to handle correct deletion of seed konnectivity-tunnel secrets is added in this PR. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Konnectivity tunnel is now updated to v0.0.10. 
```
