### PR TITLE
Retain replicas for istio deployments managed by HPA

### DIFF
--- a/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/charts/istio/istio-ingress/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 spec:
+  revisionHistoryLimit: 0
   selector:
     matchLabels:
 {{ .Values.labels | toYaml | indent 6 }}

--- a/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/charts/istio/istio-istiod/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 spec:
+  revisionHistoryLimit: 0
   strategy:
     rollingUpdate:
       maxSurge: 100%

--- a/charts/istio/istio-istiod/templates/service.yaml
+++ b/charts/istio/istio-istiod/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 spec:
+  type: ClusterIP
   ports:
   - name: https-sds # mTLS with k8s-signed cert
     port: 15012

--- a/pkg/client/kubernetes/applier.go
+++ b/pkg/client/kubernetes/applier.go
@@ -127,95 +127,104 @@ func (a *defaultApplier) deleteObject(ctx context.Context, desired *unstructured
 }
 
 // DefaultMergeFuncs contains options for common k8s objects, e.g. Service, ServiceAccount.
-var DefaultMergeFuncs = MergeFuncs{
-	corev1.SchemeGroupVersion.WithKind("Service").GroupKind(): func(newObj, oldObj *unstructured.Unstructured) {
-		newSvcType, found, _ := unstructured.NestedString(newObj.Object, "spec", "type")
-		if !found {
-			newSvcType = string(corev1.ServiceTypeClusterIP)
-			_ = unstructured.SetNestedField(newObj.Object, newSvcType, "spec", "type")
-		}
-
-		oldSvcType, found, _ := unstructured.NestedString(oldObj.Object, "spec", "type")
-		if !found {
-			oldSvcType = string(corev1.ServiceTypeClusterIP)
-
-		}
-
-		switch newSvcType {
-		case string(corev1.ServiceTypeLoadBalancer), string(corev1.ServiceTypeNodePort):
-			oldPorts, found, _ := unstructured.NestedSlice(oldObj.Object, "spec", "ports")
+var (
+	DefaultMergeFuncs = MergeFuncs{
+		corev1.SchemeGroupVersion.WithKind("Service").GroupKind(): func(newObj, oldObj *unstructured.Unstructured) {
+			newSvcType, found, _ := unstructured.NestedString(newObj.Object, "spec", "type")
 			if !found {
-				// no old ports probably means that the service was of type External name before.
-				break
+				newSvcType = string(corev1.ServiceTypeClusterIP)
+				_ = unstructured.SetNestedField(newObj.Object, newSvcType, "spec", "type")
 			}
 
-			newPorts, found, _ := unstructured.NestedSlice(newObj.Object, "spec", "ports")
+			oldSvcType, found, _ := unstructured.NestedString(oldObj.Object, "spec", "type")
 			if !found {
-				// no new ports is safe to ignore
-				break
+				oldSvcType = string(corev1.ServiceTypeClusterIP)
 			}
 
-			ports := make([]interface{}, 0, len(newPorts))
-			for _, newPort := range newPorts {
-				np := newPort.(map[string]interface{})
-				npName, _, _ := unstructured.NestedString(np, "name")
-				npPort, _ := nestedFloat64OrInt64(np, "port")
-				nodePort, ok := nestedFloat64OrInt64(np, "nodePort")
-
-				for _, oldPortObj := range oldPorts {
-					op := oldPortObj.(map[string]interface{})
-					opName, _, _ := unstructured.NestedString(op, "name")
-					opPort, _ := nestedFloat64OrInt64(op, "port")
-
-					if (opName == npName || opPort == npPort) && (!ok || nodePort == 0) {
-						np["nodePort"] = op["nodePort"]
-					}
+			switch newSvcType {
+			case string(corev1.ServiceTypeLoadBalancer), string(corev1.ServiceTypeNodePort):
+				oldPorts, found, _ := unstructured.NestedSlice(oldObj.Object, "spec", "ports")
+				if !found {
+					// no old ports probably means that the service was of type External name before.
+					break
 				}
 
-				ports = append(ports, np)
+				newPorts, found, _ := unstructured.NestedSlice(newObj.Object, "spec", "ports")
+				if !found {
+					// no new ports is safe to ignore
+					break
+				}
+
+				ports := make([]interface{}, 0, len(newPorts))
+				for _, newPort := range newPorts {
+					np := newPort.(map[string]interface{})
+					npName, _, _ := unstructured.NestedString(np, "name")
+					npPort, _ := nestedFloat64OrInt64(np, "port")
+					nodePort, ok := nestedFloat64OrInt64(np, "nodePort")
+
+					for _, oldPortObj := range oldPorts {
+						op := oldPortObj.(map[string]interface{})
+						opName, _, _ := unstructured.NestedString(op, "name")
+						opPort, _ := nestedFloat64OrInt64(op, "port")
+
+						if (opName == npName || opPort == npPort) && (!ok || nodePort == 0) {
+							np["nodePort"] = op["nodePort"]
+						}
+					}
+
+					ports = append(ports, np)
+				}
+
+				_ = unstructured.SetNestedSlice(newObj.Object, ports, "spec", "ports")
+
+			case string(corev1.ServiceTypeExternalName):
+				// there is no ClusterIP in this case
+				return
 			}
 
-			_ = unstructured.SetNestedSlice(newObj.Object, ports, "spec", "ports")
+			// ClusterIP is immutable unless that old service is of type ExternalName
+			if oldSvcType != string(corev1.ServiceTypeExternalName) {
+				newClusterIP, _, _ := unstructured.NestedString(newObj.Object, "spec", "clusterIP")
+				if newClusterIP != corev1.ClusterIPNone || newSvcType != string(corev1.ServiceTypeClusterIP) {
+					oldClusterIP, _, _ := unstructured.NestedString(oldObj.Object, "spec", "clusterIP")
+					_ = unstructured.SetNestedField(newObj.Object, oldClusterIP, "spec", "clusterIP")
+				}
+			}
 
-		case string(corev1.ServiceTypeExternalName):
-			// there is no ClusterIP in this case
+			newETP, _, _ := unstructured.NestedString(newObj.Object, "spec", "externalTrafficPolicy")
+			oldETP, _, _ := unstructured.NestedString(oldObj.Object, "spec", "externalTrafficPolicy")
+
+			if oldSvcType == string(corev1.ServiceTypeLoadBalancer) &&
+				newSvcType == string(corev1.ServiceTypeLoadBalancer) &&
+				newETP == string(corev1.ServiceExternalTrafficPolicyTypeLocal) &&
+				oldETP == string(corev1.ServiceExternalTrafficPolicyTypeLocal) {
+				newHealthCheckPort, _ := nestedFloat64OrInt64(newObj.Object, "spec", "healthCheckNodePort")
+				if newHealthCheckPort == 0 {
+					oldHealthCheckPort, _ := nestedFloat64OrInt64(oldObj.Object, "spec", "healthCheckNodePort")
+					_ = unstructured.SetNestedField(newObj.Object, oldHealthCheckPort, "spec", "healthCheckNodePort")
+				}
+			}
+
+		},
+		corev1.SchemeGroupVersion.WithKind("ServiceAccount").GroupKind(): func(newObj, oldObj *unstructured.Unstructured) {
+			// We do not want to overwrite a ServiceAccount's `.secrets[]` list or `.imagePullSecrets[]`.
+			newObj.Object["secrets"] = oldObj.Object["secrets"]
+			newObj.Object["imagePullSecrets"] = oldObj.Object["imagePullSecrets"]
+		},
+		{Group: "autoscaling.k8s.io", Kind: "VerticalPodAutoscaler"}: func(newObj, oldObj *unstructured.Unstructured) {
+			// Never override the status of VPA resources
+			newObj.Object["status"] = oldObj.Object["status"]
+		},
+	}
+
+	DeploymentKeepReplicasMergeFunc = MergeFunc(func(newObj, oldObj *unstructured.Unstructured) {
+		oldReplicas, ok := nestedFloat64OrInt64(oldObj.Object, "spec", "replicas")
+		if !ok {
 			return
 		}
-
-		// ClusterIP is immutable unless that old service is of type ExternalName
-		if oldSvcType != string(corev1.ServiceTypeExternalName) {
-			newClusterIP, _, _ := unstructured.NestedString(newObj.Object, "spec", "clusterIP")
-			if newClusterIP != corev1.ClusterIPNone || newSvcType != string(corev1.ServiceTypeClusterIP) {
-				oldClusterIP, _, _ := unstructured.NestedString(oldObj.Object, "spec", "clusterIP")
-				_ = unstructured.SetNestedField(newObj.Object, oldClusterIP, "spec", "clusterIP")
-			}
-		}
-
-		newETP, _, _ := unstructured.NestedString(newObj.Object, "spec", "externalTrafficPolicy")
-		oldETP, _, _ := unstructured.NestedString(oldObj.Object, "spec", "externalTrafficPolicy")
-
-		if oldSvcType == string(corev1.ServiceTypeLoadBalancer) &&
-			newSvcType == string(corev1.ServiceTypeLoadBalancer) &&
-			newETP == string(corev1.ServiceExternalTrafficPolicyTypeLocal) &&
-			oldETP == string(corev1.ServiceExternalTrafficPolicyTypeLocal) {
-			newHealthCheckPort, _ := nestedFloat64OrInt64(newObj.Object, "spec", "healthCheckNodePort")
-			if newHealthCheckPort == 0 {
-				oldHealthCheckPort, _ := nestedFloat64OrInt64(oldObj.Object, "spec", "healthCheckNodePort")
-				_ = unstructured.SetNestedField(newObj.Object, oldHealthCheckPort, "spec", "healthCheckNodePort")
-			}
-		}
-
-	},
-	corev1.SchemeGroupVersion.WithKind("ServiceAccount").GroupKind(): func(newObj, oldObj *unstructured.Unstructured) {
-		// We do not want to overwrite a ServiceAccount's `.secrets[]` list or `.imagePullSecrets[]`.
-		newObj.Object["secrets"] = oldObj.Object["secrets"]
-		newObj.Object["imagePullSecrets"] = oldObj.Object["imagePullSecrets"]
-	},
-	{Group: "autoscaling.k8s.io", Kind: "VerticalPodAutoscaler"}: func(newObj, oldObj *unstructured.Unstructured) {
-		// Never override the status of VPA resources
-		newObj.Object["status"] = oldObj.Object["status"]
-	},
-}
+		_ = unstructured.SetNestedField(newObj.Object, oldReplicas, "spec", "replicas")
+	})
+)
 
 func nestedFloat64OrInt64(obj map[string]interface{}, fields ...string) (int64, bool) {
 	val, found, err := unstructured.NestedFieldNoCopy(obj, fields...)

--- a/pkg/operation/seed/istio/ingress_gateway.go
+++ b/pkg/operation/seed/istio/ingress_gateway.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -82,7 +83,10 @@ func (i *ingress) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return i.Apply(ctx, i.chartPath, i.namespace, istioReleaseName, kubernetes.Values(i.values))
+	applierOptions := kubernetes.CopyApplierOptions(kubernetes.DefaultMergeFuncs)
+	applierOptions[appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind()] = kubernetes.DeploymentKeepReplicasMergeFunc
+
+	return i.Apply(ctx, i.chartPath, i.namespace, istioReleaseName, kubernetes.Values(i.values), applierOptions)
 }
 
 func (i *ingress) Destroy(ctx context.Context) error {

--- a/pkg/operation/seed/istio/istiod.go
+++ b/pkg/operation/seed/istio/istiod.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -74,7 +75,10 @@ func (i *istiod) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return i.Apply(ctx, i.chartPath, i.namespace, istioReleaseName, kubernetes.Values(i.values))
+	applierOptions := kubernetes.CopyApplierOptions(kubernetes.DefaultMergeFuncs)
+	applierOptions[appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind()] = kubernetes.DeploymentKeepReplicasMergeFunc
+
+	return i.Apply(ctx, i.chartPath, i.namespace, istioReleaseName, kubernetes.Values(i.values), applierOptions)
 }
 
 func (i *istiod) Destroy(ctx context.Context) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area usability
/kind bug
/priority normal

**What this PR does / why we need it**:
The istio deployments are managed by HPA and the applier is overriding the `.spec.replicas` to `nil` for each invocation.
This PR fixes the behaviour by retaining the `.spec.replicas` value of the existing deployment. For new deployments the HPA will take care of scaling it up.

**Special notes for your reviewer**:
* Ref https://github.com/gardener/gardener/pull/2406#issuecomment-647355316
* @tim-ebert will leverage the GRM as part of his work in #1825
* With @tim-ebert we also discussed that it would make sense to harmonize the applier of g/g and g/grm, but this is more work and could be put to the quality backlog

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug has been fixed that prevented the HPA for istio to work as expected when the `ManagedIstio` feature gate was enabled.
```
