### PR TITLE
Federate kube-apiserver network metrics

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/networking.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/networking.rules.yaml
@@ -1,0 +1,20 @@
+groups:
+- name: networking.rules
+  rules:
+  - record: shoot:container_network_transmit_bytes_total_apiserver:sum
+    expr: sum(rate(container_network_transmit_bytes_total{pod=~"kube-apiserver(.+)"}[10m]))
+
+  - record: shoot:container_network_receive_bytes_total_apiserver:sum
+    expr: sum(rate(container_network_receive_bytes_total{pod=~"kube-apiserver(.+)"}[10m]))
+
+  - record: shoot:container_network_transmit_bytes_total_vpn:sum
+    expr: sum(rate(container_network_transmit_bytes_total{pod=~"vpn-shoot(.+)"}[10m]))
+
+  - record: shoot:container_network_receive_bytes_total_vpn:sum
+    expr: sum(rate(container_network_receive_bytes_total{pod=~"vpn-shoot(.+)"}[10m]))
+
+  - record: shoot:container_network_transmit_bytes_total_konnectivity:sum
+    expr: sum(rate(container_network_transmit_bytes_total{pod=~"konnectivity-agent(.+)"}[10m]))
+
+  - record: shoot:container_network_receive_bytes_total_konnectivity:sum
+    expr: sum(rate(container_network_receive_bytes_total{pod=~"konnectivity-agent(.+)"}[10m]))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area monitoring
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Federates kube-apiserver network metrics. This is useful because it allows operators to see which shoots/projects produce the most network traffic. Currently this is only possible when viewing the prometheus/grafana of each shoot, but with the federated metrics it will be possible to look at the metrics in one place.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @zanetworker 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Added the metrics `shoot:container_network_transmit_bytes_total_apiserver:sum` and `shoot:container_network_receive_bytes_total_apiserver:sum` which will be useful in observing the network traffic for all shoots.
```
