### PR TITLE
Upgade dependency-watchdog to v0.5.0.

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -28,7 +28,7 @@ images:
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog
-  tag: "v0.4.1"
+  tag: "v0.5.0"
 
 # Seed controlplane
 - name: hyperkube # used for kubectl + kubelet binaries on the worker nodes

--- a/charts/seed-bootstrap/charts/dependency-watchdog/templates/endpoint-rbac.yaml
+++ b/charts/seed-bootstrap/charts/dependency-watchdog/templates/endpoint-rbac.yaml
@@ -65,7 +65,9 @@ rules:
   - ""
   resources:
   - endpoints
+  - events
   verbs:
   - get
   - create
   - update
+  - patch

--- a/charts/seed-bootstrap/charts/dependency-watchdog/templates/probe-deployment.yaml
+++ b/charts/seed-bootstrap/charts/dependency-watchdog/templates/probe-deployment.yaml
@@ -38,7 +38,13 @@ spec:
         - probe
         - --config-file=/etc/dependency-watchdog/config/dep-config.yaml
         - --deployed-namespace={{ .Release.Namespace }}
+        - --qps=20.0
+        - --burst=100
         - --v=4
+        ports:
+        - name: metrics
+          containerPort: 9643
+          protocol: TCP
         resources:
           requests:
             cpu: 200m

--- a/charts/seed-bootstrap/charts/dependency-watchdog/templates/probe-rbac.yaml
+++ b/charts/seed-bootstrap/charts/dependency-watchdog/templates/probe-rbac.yaml
@@ -38,6 +38,8 @@ rules:
   - deployments
   - deployments/scale
   verbs:
+  - list
+  - watch
   - get
   - update
 ---
@@ -65,7 +67,9 @@ rules:
   - ""
   resources:
   - endpoints
+  - events
   verbs:
   - get
   - create
   - update
+  - patch


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Upgade dependency-watchdog to v0.5.0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Fixes https://github.com/gardener/dependency-watchdog/issues/19.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
``` improvement operator github.com/gardener/dependency-watchdog #20 @amshuman-kr
Minimize throttling for happy path of probes (when targets do not need to be updated).
For example, load the current replicas via the local cache, add jitter to the probe intervals to spread out host apiserver call, make client-go QPS and Burst configurable via CLI flags and export load-related metrics.
```
