### PR TITLE
Nit: Use NewNopLogger in the tests

### DIFF
--- a/pkg/operation/botanist/addons_test.go
+++ b/pkg/operation/botanist/addons_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	cr "github.com/gardener/gardener/pkg/chartrenderer"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/botanist"
 	"github.com/gardener/gardener/pkg/operation/garden"
@@ -72,7 +73,7 @@ var _ = Describe("dns", func() {
 					},
 				},
 				Garden:         &garden.Garden{},
-				Logger:         logrus.NewEntry(logrus.New()),
+				Logger:         logrus.NewEntry(logger.NewNopLogger()),
 				ChartsRootPath: "../../../charts",
 			},
 		}

--- a/pkg/operation/botanist/controlplane/kube_apiserver_service_test.go
+++ b/pkg/operation/botanist/controlplane/kube_apiserver_service_test.go
@@ -19,6 +19,7 @@ import (
 
 	cr "github.com/gardener/gardener/pkg/chartrenderer"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	. "github.com/gardener/gardener/pkg/operation/botanist/controlplane"
 	"github.com/sirupsen/logrus"
@@ -48,7 +49,7 @@ var _ = Describe("#KubeAPIServerService", func() {
 		ctx                context.Context
 		c                  client.Client
 		expected           *corev1.Service
-		logger             *logrus.Entry
+		log                *logrus.Entry
 		defaultDepWaiter   component.DeployWaiter
 		ingressIP          string
 		clusterIP          string
@@ -61,9 +62,8 @@ var _ = Describe("#KubeAPIServerService", func() {
 	)
 
 	BeforeEach(func() {
-
 		ctx = context.TODO()
-		logger = logrus.NewEntry(logrus.New())
+		log = logrus.NewEntry(logger.NewNopLogger())
 
 		s := runtime.NewScheme()
 		Expect(corev1.AddToScheme(s)).NotTo(HaveOccurred())
@@ -123,7 +123,7 @@ var _ = Describe("#KubeAPIServerService", func() {
 				sniServiceObjKey,
 				ca,
 				chartsRoot(),
-				logger,
+				log,
 				c,
 				&fakeOps{},
 				clusterIPFunc,
@@ -139,7 +139,7 @@ var _ = Describe("#KubeAPIServerService", func() {
 				nil,
 				ca,
 				chartsRoot(),
-				logger,
+				log,
 				c,
 				&fakeOps{},
 				clusterIPFunc,

--- a/pkg/operation/botanist/dns_test.go
+++ b/pkg/operation/botanist/dns_test.go
@@ -22,6 +22,7 @@ import (
 	cr "github.com/gardener/gardener/pkg/chartrenderer"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
+	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/botanist"
 	"github.com/gardener/gardener/pkg/operation/garden"
@@ -69,7 +70,7 @@ var _ = Describe("dns", func() {
 					SeedNamespace: seedNS,
 				},
 				Garden:         &garden.Garden{},
-				Logger:         logrus.NewEntry(logrus.New()),
+				Logger:         logrus.NewEntry(logger.NewNopLogger()),
 				ChartsRootPath: "../../../charts",
 			},
 		}

--- a/pkg/operation/botanist/extensions/dns/dnsprovider_test.go
+++ b/pkg/operation/botanist/extensions/dns/dnsprovider_test.go
@@ -21,6 +21,7 @@ import (
 
 	cr "github.com/gardener/gardener/pkg/chartrenderer"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	. "github.com/gardener/gardener/pkg/operation/botanist/extensions/dns"
@@ -58,7 +59,7 @@ var _ = Describe("#DNSProvider", func() {
 		expectedSecret   *corev1.Secret
 		expectedDNS      *dnsv1alpha1.DNSProvider
 		vals             *ProviderValues
-		logger           *logrus.Entry
+		log              *logrus.Entry
 		defaultDepWaiter component.DeployWaiter
 	)
 
@@ -66,7 +67,7 @@ var _ = Describe("#DNSProvider", func() {
 		ctrl = gomock.NewController(GinkgoT())
 
 		ctx = context.TODO()
-		logger = logrus.NewEntry(logrus.New())
+		log = logrus.NewEntry(logger.NewNopLogger())
 
 		s := runtime.NewScheme()
 		Expect(corev1.AddToScheme(s)).NotTo(HaveOccurred())
@@ -129,7 +130,7 @@ var _ = Describe("#DNSProvider", func() {
 		ca = kubernetes.NewChartApplier(cr.NewWithServerVersion(&version.Info{}), kubernetes.NewApplier(c, meta.NewDefaultRESTMapper([]schema.GroupVersion{})))
 		Expect(ca).NotTo(BeNil(), "should return chart applier")
 
-		defaultDepWaiter = NewDNSProvider(vals, deployNS, ca, chartsRoot(), logger, c, &fakeOps{})
+		defaultDepWaiter = NewDNSProvider(vals, deployNS, ca, chartsRoot(), log, c, &fakeOps{})
 	})
 
 	AfterEach(func() {
@@ -212,7 +213,7 @@ var _ = Describe("#DNSProvider", func() {
 					Namespace: deployNS,
 				}}).Times(1).Return(fmt.Errorf("some random error"))
 
-			Expect(NewDNSProvider(vals, deployNS, ca, chartsRoot(), logger, mc, &fakeOps{}).Destroy(ctx)).To(HaveOccurred())
+			Expect(NewDNSProvider(vals, deployNS, ca, chartsRoot(), log, mc, &fakeOps{}).Destroy(ctx)).To(HaveOccurred())
 		})
 	})
 
@@ -239,7 +240,7 @@ var _ = Describe("#DNSProvider", func() {
 		})
 
 		It("should set a default waiter", func() {
-			wrt := NewDNSProvider(vals, deployNS, ca, chartsRoot(), logger, c, nil)
+			wrt := NewDNSProvider(vals, deployNS, ca, chartsRoot(), log, c, nil)
 			Expect(reflect.ValueOf(wrt).Elem().FieldByName("waiter").IsNil()).ToNot(BeTrue())
 		})
 	})

--- a/pkg/operation/botanist/extensions/network/network_test.go
+++ b/pkg/operation/botanist/extensions/network/network_test.go
@@ -23,6 +23,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
@@ -60,7 +61,7 @@ var _ = Describe("#Network", func() {
 		c                client.Client
 		expected         *extensionsv1alpha1.Network
 		vals             *network.Values
-		logger           *logrus.Entry
+		log              *logrus.Entry
 		defaultDepWaiter component.DeployWaiter
 
 		mockNow *mocktime.MockNow
@@ -76,7 +77,7 @@ var _ = Describe("#Network", func() {
 		mockNow = mocktime.NewMockNow(ctrl)
 
 		ctx = context.TODO()
-		logger = logrus.NewEntry(logrus.New())
+		log = logrus.NewEntry(logger.NewNopLogger())
 
 		s := runtime.NewScheme()
 		Expect(extensionsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())
@@ -121,7 +122,7 @@ var _ = Describe("#Network", func() {
 			},
 		}
 
-		defaultDepWaiter = network.New(logger, c, vals)
+		defaultDepWaiter = network.New(log, c, vals)
 	})
 
 	AfterEach(func() {
@@ -220,7 +221,7 @@ var _ = Describe("#Network", func() {
 
 			mc.EXPECT().Delete(ctx, &expected).Times(1).Return(fmt.Errorf("some random error"))
 
-			defaultDepWaiter = network.New(logger, mc, &network.Values{
+			defaultDepWaiter = network.New(log, mc, &network.Values{
 				Namespace: networkNs,
 				Name:      networkName,
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/priority normal

**What this PR does / why we need it**:
Use `NewNopLogger` in the tests to prevent log entries to appear on `make test`.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
