### PR TITLE
Add `TolerateErrorFunc` to Applier and ManifestApplier

### DIFF
--- a/pkg/client/kubernetes/chartapplier.go
+++ b/pkg/client/kubernetes/chartapplier.go
@@ -104,7 +104,15 @@ func (c *chartApplier) Delete(ctx context.Context, chartPath, namespace, name st
 		manifestReader = NewNamespaceSettingReader(manifestReader, namespace)
 	}
 
-	return c.DeleteManifest(ctx, manifestReader)
+	deleteManifestOpts := []DeleteManifestOption{}
+
+	for _, tf := range deleteOpts.TolerateErrorFuncs {
+		if tf != nil {
+			deleteManifestOpts = append(deleteManifestOpts, tf)
+		}
+	}
+
+	return c.DeleteManifest(ctx, manifestReader, deleteManifestOpts...)
 }
 
 func (c *chartApplier) manifestReader(chartPath, namespace, name string, values interface{}) (UnstructuredReader, error) {

--- a/pkg/client/kubernetes/chartoptions.go
+++ b/pkg/client/kubernetes/chartoptions.go
@@ -14,7 +14,9 @@
 
 package kubernetes
 
-import "k8s.io/apimachinery/pkg/runtime/schema"
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
 
 // ApplyOption is some configuration that modifies options for a apply request.
 type ApplyOption interface {
@@ -98,4 +100,26 @@ type DeleteOptions struct {
 	// Forces the namespace for chart objects when applying the chart, this is because sometimes native chart
 	// objects do not come with a Release.Namespace option and leave the namespace field empty
 	ForceNamespace bool
+
+	// TolerateErrorFuncs are functions for which errors are tolerated.
+	TolerateErrorFuncs []TolerateErrorFunc
+}
+
+// TolerateErrorFunc is a function for which err is tolerated.
+type TolerateErrorFunc func(err error) bool
+
+func (t TolerateErrorFunc) MutateDeleteOptions(opts *DeleteOptions) {
+	if opts.TolerateErrorFuncs == nil {
+		opts.TolerateErrorFuncs = []TolerateErrorFunc{}
+	}
+
+	opts.TolerateErrorFuncs = append(opts.TolerateErrorFuncs, t)
+}
+
+func (t TolerateErrorFunc) MutateDeleteManifestOptions(opts *DeleteManifestOptions) {
+	if opts.TolerateErrorFuncs == nil {
+		opts.TolerateErrorFuncs = []TolerateErrorFunc{}
+	}
+
+	opts.TolerateErrorFuncs = append(opts.TolerateErrorFuncs, t)
 }

--- a/pkg/client/kubernetes/manifestoptions.go
+++ b/pkg/client/kubernetes/manifestoptions.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+// DeleteManifestOption is some configuration that modifies options for a delete request.
+type DeleteManifestOption interface {
+	// MutateDeleteOptions applies this configuration to the given delete options.
+	MutateDeleteManifestOptions(opts *DeleteManifestOptions)
+}
+
+// DeleteOptions contains options for delete requests
+type DeleteManifestOptions struct {
+	// TolerateErrorFuncs are functions for which errors are tolerated.
+	TolerateErrorFuncs []TolerateErrorFunc
+}

--- a/pkg/client/kubernetes/manifestoptions_test.go
+++ b/pkg/client/kubernetes/manifestoptions_test.go
@@ -16,77 +16,27 @@ package kubernetes_test
 
 import (
 	. "github.com/gardener/gardener/pkg/client/kubernetes"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("chart options", func() {
+var _ = Describe("chart manifest options", func() {
 	var (
-		aopts *ApplyOptions
-		dopts *DeleteOptions
+		dopts *DeleteManifestOptions
 	)
 
 	BeforeEach(func() {
-		aopts = &ApplyOptions{}
-		dopts = &DeleteOptions{}
-	})
-
-	Describe("Values", func() {
-		var vals ValueOption
-
-		BeforeEach(func() {
-			vals = Values("foo")
-		})
-
-		It("sets ApplyOptions", func() {
-			vals.MutateApplyOptions(aopts)
-
-			Expect(aopts.Values).To(Equal("foo"))
-		})
-
-		It("sets DeleteOptions", func() {
-			vals.MutateDeleteOptions(dopts)
-
-			Expect(dopts.Values).To(Equal("foo"))
-		})
-	})
-
-	It("MergeFuncs sets ApplyOptions", func() {
-		funcs := MergeFuncs{
-			schema.GroupKind{}: func(n, o *unstructured.Unstructured) {
-				n.SetName("baz")
-			},
-		}
-		funcs.MutateApplyOptions(aopts)
-
-		Expect(aopts.MergeFuncs).To(Equal(funcs))
-	})
-
-	Context("ForceNamespace", func() {
-		It("sets ApplyOptions", func() {
-			ForceNamespace.MutateApplyOptions(aopts)
-
-			Expect(aopts.ForceNamespace).To(BeTrue())
-		})
-
-		It("sets DeleteOptions", func() {
-			ForceNamespace.MutateDeleteOptions(dopts)
-
-			Expect(dopts.ForceNamespace).To(BeTrue())
-		})
+		dopts = &DeleteManifestOptions{}
 	})
 
 	Context("TolerateErrorFunc", func() {
 		It("sets DeleteOptions", func() {
 			var tTrue TolerateErrorFunc = func(_ error) bool { return true }
-			tTrue.MutateDeleteOptions(dopts)
+			tTrue.MutateDeleteManifestOptions(dopts)
 
 			Expect(dopts.TolerateErrorFuncs).To(HaveLen(1))
 			Expect(dopts.TolerateErrorFuncs[0](nil)).To(BeTrue())
-
 		})
 	})
 })

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -103,7 +103,7 @@ type MergeFunc func(newObj, oldObj *unstructured.Unstructured)
 // Kubernetes objects.
 type Applier interface {
 	ApplyManifest(ctx context.Context, unstructured UnstructuredReader, options MergeFuncs) error
-	DeleteManifest(ctx context.Context, unstructured UnstructuredReader) error
+	DeleteManifest(ctx context.Context, unstructured UnstructuredReader, opts ...DeleteManifestOption) error
 }
 
 // Interface is used to wrap the interactions with a Kubernetes cluster

--- a/pkg/mock/gardener/client/kubernetes/mocks_applier.go
+++ b/pkg/mock/gardener/client/kubernetes/mocks_applier.go
@@ -49,15 +49,20 @@ func (mr *MockApplierMockRecorder) ApplyManifest(arg0, arg1, arg2 interface{}) *
 }
 
 // DeleteManifest mocks base method
-func (m *MockApplier) DeleteManifest(arg0 context.Context, arg1 kubernetes.UnstructuredReader) error {
+func (m *MockApplier) DeleteManifest(arg0 context.Context, arg1 kubernetes.UnstructuredReader, arg2 ...kubernetes.DeleteManifestOption) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteManifest", arg0, arg1)
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteManifest", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteManifest indicates an expected call of DeleteManifest
-func (mr *MockApplierMockRecorder) DeleteManifest(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockApplierMockRecorder) DeleteManifest(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteManifest", reflect.TypeOf((*MockApplier)(nil).DeleteManifest), arg0, arg1)
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteManifest", reflect.TypeOf((*MockApplier)(nil).DeleteManifest), varargs...)
 }

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -1240,7 +1240,6 @@ func (b *Botanist) DefaultKubeAPIServersNI() component.DeployWaiter {
 		b.Shoot.SeedNamespace,
 		b.K8sSeedClient.ChartApplier(),
 		b.ChartsRootPath,
-		b.K8sSeedClient.Client(),
 	))
 }
 
@@ -1266,7 +1265,6 @@ func (b *Botanist) setAPIServerServiceClusterIP(clusterIP string) {
 		b.Shoot.SeedNamespace,
 		b.K8sSeedClient.ChartApplier(),
 		b.ChartsRootPath,
-		b.K8sSeedClient.Client(),
 	)
 
 }

--- a/pkg/operation/botanist/controlplane/kube_apiserver_sni.go
+++ b/pkg/operation/botanist/controlplane/kube_apiserver_sni.go
@@ -21,11 +21,8 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // kubeAPIServiceValues configure the kube-apiserver service SNI.
@@ -45,7 +42,6 @@ func NewKubeAPIServerSNI(
 	namespace string,
 	applier kubernetes.ChartApplier,
 	chartsRootPath string,
-	client crclient.Client,
 
 ) component.DeployWaiter {
 	if values == nil {
@@ -55,7 +51,6 @@ func NewKubeAPIServerSNI(
 	return &kubeAPIServerSNI{
 		ChartApplier: applier,
 		chartPath:    filepath.Join(chartsRootPath, "seed-controlplane", "charts", "kube-apiserver-sni"),
-		client:       client,
 		values:       values,
 		namespace:    namespace,
 	}
@@ -66,7 +61,6 @@ type kubeAPIServerSNI struct {
 	namespace string
 	kubernetes.ChartApplier
 	chartPath string
-	client    crclient.Client
 }
 
 func (k *kubeAPIServerSNI) Deploy(ctx context.Context) error {
@@ -80,58 +74,14 @@ func (k *kubeAPIServerSNI) Deploy(ctx context.Context) error {
 }
 
 func (k *kubeAPIServerSNI) Destroy(ctx context.Context) error {
-	objs := []*unstructured.Unstructured{
-		{
-			Object: map[string]interface{}{
-				"apiVersion": "networking.istio.io/v1beta1",
-				"kind":       "DestinationRule",
-				"metadata": map[string]interface{}{
-					"name":      k.values.Name,
-					"namespace": k.namespace,
-				},
-			},
-		},
-		{
-			Object: map[string]interface{}{
-				"apiVersion": "networking.istio.io/v1beta1",
-				"kind":       "Gateway",
-				"metadata": map[string]interface{}{
-					"name":      k.values.Name,
-					"namespace": k.namespace,
-				},
-			},
-		},
-		{
-			Object: map[string]interface{}{
-				"apiVersion": "networking.istio.io/v1beta1",
-				"kind":       "VirtualService",
-				"metadata": map[string]interface{}{
-					"name":      k.values.Name,
-					"namespace": k.namespace,
-				},
-			},
-		},
-		{
-			Object: map[string]interface{}{
-				"apiVersion": "networking.istio.io/v1alpha3",
-				"kind":       "EnvoyFilter",
-				"metadata": map[string]interface{}{
-					"name":      k.namespace,
-					"namespace": k.values.IstioIngressNamespace,
-				},
-			},
-		},
-	}
-
-	for _, obj := range objs {
-		if err := k.client.Delete(ctx, obj); err != nil {
-			if !apierrors.IsNotFound(err) && !meta.IsNoMatchError(err) {
-				return err
-			}
-		}
-	}
-
-	return nil
+	return k.Delete(
+		ctx,
+		k.chartPath,
+		k.namespace,
+		k.values.Name,
+		kubernetes.Values(k.values),
+		kubernetes.TolerateErrorFunc(meta.IsNoMatchError),
+	)
 }
 
 func (k *kubeAPIServerSNI) Wait(ctx context.Context) error        { return nil }

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -631,7 +631,7 @@ func BootstrapCluster(k8sSeedClient kubernetes.Interface, seed *Seed, secrets ma
 		}
 	}
 
-	proxy := istio.NewProxyProtocolGateway(common.IstioIngressGatewayNamespace, chartApplier, k8sSeedClient.Client(), "charts")
+	proxy := istio.NewProxyProtocolGateway(common.IstioIngressGatewayNamespace, chartApplier, "charts")
 
 	if gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI) {
 		if err := proxy.Deploy(context.TODO()); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement
/priority normal

**What this PR does / why we need it**:

Useful when attempting to delete custom resources with CRDs already removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

General fix for https://github.com/gardener/gardener/pull/2494

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
ChartApplier's `Delete` and ManifestReader's `DeleteManifest` now support passing `TolerateErrorFunc` option which can be used to tolerate certain errors - e.g. using `TolerateNoMatchError` can be useful in situations where a deleting a custom resource, but its CRD is already removed.
```
