### PR TITLE
Set effective version when building images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ FROM golang:1.14.4 AS builder
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .
 
-RUN make install
+ARG EFFECTIVE_VERSION
+
+RUN EFFECTIVE_VERSION=$EFFECTIVE_VERSION make install
 
 ############# base
 FROM alpine:3.12.0 AS base

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	go.uber.org/zap v1.13.0
 	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	golang.org/x/tools v0.0.0-20200422205258-72e4a01eba43 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.0.1
 	google.golang.org/grpc v1.26.0

--- a/hack/get-build-ld-flags.sh
+++ b/hack/get-build-ld-flags.sh
@@ -16,8 +16,10 @@
 
 SOURCE_REPOSITORY="${1:-github.com/gardener/gardener}"
 VERSION_PATH="${2:-$(dirname $0)/../VERSION}"
+VERSION_VERSIONFILE="$(cat "$VERSION_PATH")"
+VERSION="${EFFECTIVE_VERSION:-$VERSION_VERSIONFILE}"
 
-echo "-X $SOURCE_REPOSITORY/pkg/version.gitVersion=$(cat "$VERSION_PATH")
+echo "-X $SOURCE_REPOSITORY/pkg/version.gitVersion=$VERSION
       -X $SOURCE_REPOSITORY/pkg/version.gitTreeState=$([ -z git status --porcelain 2>/dev/null ] && echo clean || echo dirty)
       -X $SOURCE_REPOSITORY/pkg/version.gitCommit=$(git rev-parse --verify HEAD)
       -X $SOURCE_REPOSITORY/pkg/version.buildDate=$(date '+%Y-%m-%dT%H:%M:%S%z' | sed 's/\([0-9][0-9]\)$/:\1/g')"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -536,6 +536,7 @@ golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 golang.org/x/text/width
 # golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+## explicit
 golang.org/x/time/rate
 # golang.org/x/tools v0.0.0-20200422205258-72e4a01eba43
 ## explicit


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR, docker images built by `make docker-images` are tagged and build with a version including the commit hash (exactly like the images built by the pipeline).
This allows developers to build prerelease images with a correct version inside to evaluate a new release. E.g. the gardenlet uses the `pkg/version.gitVersion` to report its own version and to the deploy the same gardenlet image version into shooted Seeds.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Docker images built by `make docker-images` are now tagged and build with the commit hash appended to the version.
```
