### PR TITLE
Don't panic on empty kubeconfig

### DIFF
--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -105,6 +105,10 @@ func NewClientFromSecret(ctx context.Context, c client.Client, namespace, secret
 // contain a field "kubeconfig" which will be used.
 func NewClientFromSecretObject(secret *corev1.Secret, fns ...ConfigFunc) (Interface, error) {
 	if kubeconfig, ok := secret.Data[KubeConfig]; ok {
+		if len(kubeconfig) == 0 {
+			return nil, errors.New("the secret's field 'kubeconfig' is empty")
+		}
+
 		return NewClientFromBytes(kubeconfig, fns...)
 	}
 	return nil, errors.New("the secret does not contain a field with name 'kubeconfig'")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
gcm panics if you reference a Secret with `data.kubeconfig=null` in a Plant. The same applies to the gardenlet for empty Seed kubeconfigs.
This PR fixes this issue.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixed a bug, that caused `gardener-controller-manager` and `gardenlet` to panic if the Kubeconfig referenced by a Plant or Seed is empty.
```
