### PR TITLE
Remove tolerations from control-plane components.

### DIFF
--- a/charts/seed-controlplane/charts/gardener-resource-manager/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/templates/deployment.yaml
@@ -27,9 +27,6 @@ spec:
         networking.gardener.cloud/to-seed-apiserver: allowed
         networking.gardener.cloud/to-shoot-apiserver: allowed
     spec:
-      tolerations:
-      - effect: NoExecute
-        operator: Exists
       serviceAccountName: gardener-resource-manager
       containers:
       - name: gardener-resource-manager

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -67,9 +67,6 @@ spec:
                     values:
                     - apiserver
       priorityClassName: gardener-shoot-controlplane
-      tolerations:
-      - effect: NoExecute
-        operator: Exists
       {{- if not .Values.konnectivityTunnel.enabled }}
       initContainers:
       - name: set-iptable-rules

--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -31,9 +31,6 @@ spec:
 {{ toYaml .Values.podLabels | indent 8 }}
 {{- end }}
     spec:
-      tolerations:
-      - effect: NoExecute
-        operator: Exists
       containers:
       - name: kube-controller-manager
         image: {{ index .Values.images "kube-controller-manager" }}

--- a/charts/seed-controlplane/charts/kube-scheduler/templates/kube-scheduler.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/templates/kube-scheduler.yaml
@@ -48,9 +48,6 @@ spec:
         networking.gardener.cloud/to-shoot-apiserver: allowed
         networking.gardener.cloud/from-prometheus: allowed
     spec:
-      tolerations:
-      - effect: NoExecute
-        operator: Exists
       containers:
       - name: kube-scheduler
         image: {{ index .Values.images "kube-scheduler" }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Removed the generic tolerations for all taints from control-plane component deployments. This is required for dedicated worker pool nodes to host only ETCD pods if [gardener/kupid](https://github.com/gardener/kupid) extension is deployed in the seed clusters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I have only removed the taints from the control-plane component deployments. I have left untouched similar tolerations in the shoot-core components.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Removed the generic tolerations for all taints from control-plane component deployments. This is required for dedicated worker pool nodes to host only ETCD pods if [gardener/kupid](https://github.com/gardener/kupid) extension is deployed in the seed clusters.
```
