### PR TITLE
Use DirectClient when removing finalizers

### DIFF
--- a/pkg/controllermanager/controller/cloudprofile/cloudprofile_control.go
+++ b/pkg/controllermanager/controller/cloudprofile/cloudprofile_control.go
@@ -136,7 +136,7 @@ func (c *defaultControl) ReconcileCloudProfile(obj *gardencorev1beta1.CloudProfi
 		if len(associatedShoots) == 0 {
 			cloudProfileLogger.Infof("No Shoots are referencing the CloudProfile. Deletion accepted.")
 
-			if err := controllerutils.RemoveGardenerFinalizer(ctx, gardenClient.Client(), cloudProfile); client.IgnoreNotFound(err) != nil {
+			if err := controllerutils.RemoveGardenerFinalizer(ctx, gardenClient.DirectClient(), cloudProfile); client.IgnoreNotFound(err) != nil {
 				logger.Logger.Errorf("could not remove finalizer from CloudProfile: %s", err.Error())
 				return err
 			}

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_control.go
@@ -126,7 +126,7 @@ func (c *defaultControllerRegistrationControl) Reconcile(obj *gardencorev1beta1.
 			}
 		}
 
-		return controllerutils.RemoveFinalizer(ctx, gardenClient.Client(), controllerRegistration, FinalizerName)
+		return controllerutils.RemoveFinalizer(ctx, gardenClient.DirectClient(), controllerRegistration, FinalizerName)
 	}
 
 	return controllerutils.EnsureFinalizer(ctx, gardenClient.Client(), controllerRegistration, FinalizerName)

--- a/pkg/controllermanager/controller/controllerregistration/seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed_control.go
@@ -114,7 +114,7 @@ func (c *defaultSeedControl) Reconcile(obj *gardencorev1beta1.Seed) error {
 			}
 		}
 
-		return controllerutils.RemoveFinalizer(ctx, gardenClient.Client(), seed, FinalizerName)
+		return controllerutils.RemoveFinalizer(ctx, gardenClient.DirectClient(), seed, FinalizerName)
 	}
 
 	return controllerutils.EnsureFinalizer(ctx, gardenClient.Client(), seed, FinalizerName)

--- a/pkg/controllermanager/controller/plant/plant_control.go
+++ b/pkg/controllermanager/controller/plant/plant_control.go
@@ -249,11 +249,11 @@ func (c *defaultPlantControl) delete(ctx context.Context, plant *gardencorev1bet
 		return fmt.Errorf("failed to get plant secret '%s/%s': %w", plant.Namespace, plant.Spec.SecretRef.Name, err)
 	}
 
-	if err := controllerutils.RemoveFinalizer(ctx, gardenClient.Client(), secret, FinalizerName); err != nil {
+	if err := controllerutils.RemoveFinalizer(ctx, gardenClient.DirectClient(), secret, FinalizerName); err != nil {
 		return fmt.Errorf("failed to remove finalizer from plant secret '%s/%s': %w", plant.Namespace, plant.Spec.SecretRef.Name, err)
 	}
 
-	if err := controllerutils.RemoveFinalizer(ctx, gardenClient.Client(), plant, FinalizerName); err != nil {
+	if err := controllerutils.RemoveFinalizer(ctx, gardenClient.DirectClient(), plant, FinalizerName); err != nil {
 		return fmt.Errorf("failed to remove finalizer from plant: %w", err)
 	}
 

--- a/pkg/controllermanager/controller/project/project_control_delete.go
+++ b/pkg/controllermanager/controller/project/project_control_delete.go
@@ -52,7 +52,7 @@ func (c *defaultControl) delete(ctx context.Context, project *gardencorev1beta1.
 		}
 	}
 
-	return false, controllerutils.RemoveFinalizer(ctx, gardenClient.Client(), project, gardencorev1beta1.GardenerName)
+	return false, controllerutils.RemoveFinalizer(ctx, gardenClient.DirectClient(), project, gardencorev1beta1.GardenerName)
 }
 
 func (c *defaultControl) releaseNamespace(ctx context.Context, gardenClient kubernetes.Interface, project *gardencorev1beta1.Project, namespaceName string) (bool, error) {

--- a/pkg/controllermanager/controller/quota/quota_control.go
+++ b/pkg/controllermanager/controller/quota/quota_control.go
@@ -139,7 +139,7 @@ func (c *defaultControl) ReconcileQuota(obj *gardencorev1beta1.Quota) error {
 			quotaLogger.Info("No SecretBindings are referencing the Quota. Deletion accepted.")
 
 			// Remove finalizer from Quota
-			if err := controllerutils.RemoveGardenerFinalizer(ctx, gardenClient.Client(), quota); err != nil {
+			if err := controllerutils.RemoveGardenerFinalizer(ctx, gardenClient.DirectClient(), quota); err != nil {
 				return fmt.Errorf("failed removing finalizer from quota: %w", err)
 			}
 

--- a/pkg/controllermanager/controller/secretbinding/secretbinding_control.go
+++ b/pkg/controllermanager/controller/secretbinding/secretbinding_control.go
@@ -151,7 +151,7 @@ func (c *defaultControl) ReconcileSecretBinding(obj *gardencorev1beta1.SecretBin
 				// Remove finalizer from referenced secret
 				secret, err := c.secretLister.Secrets(secretBinding.SecretRef.Namespace).Get(secretBinding.SecretRef.Name)
 				if err == nil {
-					if err2 := controllerutils.RemoveFinalizer(ctx, gardenClient.Client(), secret.DeepCopy(), gardencorev1beta1.ExternalGardenerName); err2 != nil {
+					if err2 := controllerutils.RemoveFinalizer(ctx, gardenClient.DirectClient(), secret.DeepCopy(), gardencorev1beta1.ExternalGardenerName); err2 != nil {
 						secretBindingLogger.Error(err2.Error())
 						return err2
 					}
@@ -161,7 +161,7 @@ func (c *defaultControl) ReconcileSecretBinding(obj *gardencorev1beta1.SecretBin
 			}
 
 			// Remove finalizer from SecretBinding
-			if err := controllerutils.RemoveFinalizer(ctx, gardenClient.Client(), secretBinding, gardencorev1beta1.GardenerName); err != nil {
+			if err := controllerutils.RemoveFinalizer(ctx, gardenClient.DirectClient(), secretBinding, gardencorev1beta1.GardenerName); err != nil {
 				secretBindingLogger.Error(err.Error())
 				return err
 			}

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_control.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_control.go
@@ -347,7 +347,7 @@ func (c *defaultControllerInstallationControl) delete(controllerInstallation *ga
 	}
 	conditionInstalled = helper.UpdatedCondition(conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionSuccessful", "Deletion of old resources succeeded.")
 
-	return controllerutils.RemoveFinalizer(ctx, gardenClient.Client(), controllerInstallation.DeepCopy(), FinalizerName)
+	return controllerutils.RemoveFinalizer(ctx, gardenClient.DirectClient(), controllerInstallation.DeepCopy(), FinalizerName)
 }
 
 func updateConditions(gardenClient kubernetes.Interface, controllerInstallation *gardencorev1beta1.ControllerInstallation, conditions ...gardencorev1beta1.Condition) (*gardencorev1beta1.ControllerInstallation, error) {

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -220,14 +220,14 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 						Namespace: seed.Spec.SecretRef.Namespace,
 					},
 				}
-				if err := controllerutils.RemoveFinalizer(ctx, gardenClient.Client(), secret, gardencorev1beta1.ExternalGardenerName); err != nil {
+				if err := controllerutils.RemoveFinalizer(ctx, gardenClient.DirectClient(), secret, gardencorev1beta1.ExternalGardenerName); err != nil {
 					seedLogger.Error(err.Error())
 					return err
 				}
 			}
 
 			// Remove finalizer from Seed
-			if err := controllerutils.RemoveGardenerFinalizer(ctx, gardenClient.Client(), seed); err != nil {
+			if err := controllerutils.RemoveGardenerFinalizer(ctx, gardenClient.DirectClient(), seed); err != nil {
 				seedLogger.Error(err.Error())
 				return err
 			}

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -513,7 +513,7 @@ func (c *Controller) removeFinalizerFrom(ctx context.Context, gardenClient kuber
 	}
 
 	// Remove finalizer with retry on conflict
-	if err := controllerutils.RemoveGardenerFinalizer(ctx, gardenClient.Client(), newShoot); err != nil {
+	if err := controllerutils.RemoveGardenerFinalizer(ctx, gardenClient.DirectClient(), newShoot); err != nil {
 		return fmt.Errorf("could not remove finalizer from Shoot: %s", err.Error())
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
When removing finalizers, we might run into the same race condition like for other updates that happen concurrently, that the cache is not synced fast enough.
With this PR we always use the `DirectClient` for ensuring, that the finalizer is removed properly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
