### PR TITLE
Fix slow network test

### DIFF
--- a/pkg/operation/botanist/extensions/network/network_test.go
+++ b/pkg/operation/botanist/extensions/network/network_test.go
@@ -60,7 +60,7 @@ var _ = Describe("#Network", func() {
 		ctx              context.Context
 		c                client.Client
 		expected         *extensionsv1alpha1.Network
-		vals             *network.Values
+		values           *network.Values
 		log              *logrus.Entry
 		defaultDepWaiter component.DeployWaiter
 
@@ -93,7 +93,7 @@ var _ = Describe("#Network", func() {
 			Mask: net.CIDRMask(networkServiceMask, 32),
 		}
 
-		vals = &network.Values{
+		values = &network.Values{
 			Name:                                    "test-deploy",
 			Namespace:                               networkNs,
 			IsInRestorePhaseOfControlPlaneMigration: false,
@@ -122,7 +122,7 @@ var _ = Describe("#Network", func() {
 			},
 		}
 
-		defaultDepWaiter = network.New(log, c, vals)
+		defaultDepWaiter = network.New(log, c, values, time.Second, 2*time.Second, 3*time.Second)
 	})
 
 	AfterEach(func() {
@@ -148,7 +148,7 @@ var _ = Describe("#Network", func() {
 		},
 			Entry("with no modification", func() {}),
 			Entry("during restore phase", func() {
-				vals.IsInRestorePhaseOfControlPlaneMigration = true
+				values.IsInRestorePhaseOfControlPlaneMigration = true
 				expected.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationWaitForState
 			}),
 		)
@@ -224,7 +224,7 @@ var _ = Describe("#Network", func() {
 			defaultDepWaiter = network.New(log, mc, &network.Values{
 				Namespace: networkNs,
 				Name:      networkName,
-			})
+			}, time.Second, 2*time.Second, 3*time.Second)
 
 			err := defaultDepWaiter.Destroy(ctx)
 			Expect(err).To(HaveOccurred())

--- a/pkg/operation/botanist/network.go
+++ b/pkg/operation/botanist/network.go
@@ -39,6 +39,9 @@ func (b *Botanist) DefaultNetwork(seedClient client.Client) component.DeployWait
 			PodCIDR:                                 b.Shoot.Networks.Pods,
 			ServiceCIDR:                             b.Shoot.Networks.Services,
 		},
+		network.DefaultInterval,
+		network.DefaultSevereThreshold,
+		network.DefaultTimeout,
 	)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Fixes
```
[1593086406] Botanist Extensions Network Suite - 9/9 specs ••
------------------------------
• [SLOW TEST:180.003 seconds]
#Network #Wait should return error when it's not found
/Users/root/go/src/github.com/gardener/gardener/pkg/operation/botanist/extensions/network/network_test.go:158
------------------------------
• [SLOW TEST:30.028 seconds]
#Network #Wait should return error when it's not ready
/Users/root/go/src/github.com/gardener/gardener/pkg/operation/botanist/extensions/network/network_test.go:162
------------------------------
••••• SUCCESS! 3m30.033703257s PASS
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
