### PR TITLE
[GEP-7] Adds shoot component interfaces for Migration and Restoration.

### DIFF
--- a/pkg/api/extensions/utils.go
+++ b/pkg/api/extensions/utils.go
@@ -25,7 +25,8 @@ func GetShootNamespacedCRsLists() []runtime.Object {
 		&extensionsv1alpha1.ControlPlaneList{},
 		&extensionsv1alpha1.ExtensionList{},
 		&extensionsv1alpha1.InfrastructureList{},
-		&extensionsv1alpha1.NetworkList{},
+		//The Network CR is now handled as a shoot component
+		//&extensionsv1alpha1.NetworkList{},
 		&extensionsv1alpha1.OperatingSystemConfigList{},
 		&extensionsv1alpha1.WorkerList{},
 		&extensionsv1alpha1.ContainerRuntimeList{},

--- a/pkg/operation/botanist/component/interfaces.go
+++ b/pkg/operation/botanist/component/interfaces.go
@@ -16,6 +16,8 @@ package component
 
 import (
 	"context"
+
+	"github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 )
 
 // Deployer is used to control the life-cycle of a component.
@@ -34,8 +36,27 @@ type Waiter interface {
 	WaitCleanup(ctx context.Context) error
 }
 
+// Migrator is used to control the control-plane migration operations of a component.
+type Migrator interface {
+	Restore(ctx context.Context, shootState *v1alpha1.ShootState) error
+	Migrate(ctx context.Context) error
+}
+
+// MigrateWaiter waits for the control-plane migration operations of a component to finish.
+type MigrateWaiter interface {
+	WaitMigrate(ctx context.Context) error
+}
+
 // DeployWaiter controls and waits for life-cycle operations of a component.
 type DeployWaiter interface {
 	Deployer
+	Waiter
+}
+
+// DeployMigrateWaiter controls and waits for the life-cycle and control-plane migration operations of a component.
+type DeployMigrateWaiter interface {
+	Deployer
+	Migrator
+	MigrateWaiter
 	Waiter
 }

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -541,7 +541,7 @@ func (b *Botanist) DeployControlPlane(ctx context.Context) error {
 	}
 
 	if restorePhase {
-		return b.restoreExtensionObject(ctx, b.K8sSeedClient.DirectClient(), cp, extensionsv1alpha1.ControlPlaneResource)
+		return b.restoreExtensionObject(ctx, cp, extensionsv1alpha1.ControlPlaneResource)
 	}
 
 	return nil
@@ -591,7 +591,7 @@ func (b *Botanist) DeployControlPlaneExposure(ctx context.Context) error {
 	}
 
 	if restorePhase {
-		return b.restoreExtensionObject(ctx, b.K8sSeedClient.DirectClient(), cp, extensionsv1alpha1.ControlPlaneResource)
+		return b.restoreExtensionObject(ctx, cp, extensionsv1alpha1.ControlPlaneResource)
 	}
 	return nil
 }

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -26,8 +26,8 @@ import (
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/secrets"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -63,7 +63,7 @@ func (b *Botanist) DeployInfrastructure(ctx context.Context) error {
 	}
 
 	if b.isRestorePhase() {
-		return b.restoreExtensionObject(ctx, b.K8sSeedClient.DirectClient(), &extensionsv1alpha1.Infrastructure{
+		return b.restoreExtensionObject(ctx, &extensionsv1alpha1.Infrastructure{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      b.Shoot.Info.Name,
 				Namespace: b.Shoot.SeedNamespace,

--- a/pkg/operation/botanist/migration_test.go
+++ b/pkg/operation/botanist/migration_test.go
@@ -16,14 +16,18 @@ package botanist_test
 
 import (
 	"context"
+	"time"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	extensionsclient "github.com/gardener/gardener/pkg/client/extensions/clientset/versioned/scheme"
 	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/botanist"
+	"github.com/gardener/gardener/pkg/operation/botanist/extensions/network"
 	"github.com/gardener/gardener/pkg/operation/shoot"
+	"github.com/sirupsen/logrus"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -59,9 +63,18 @@ var _ = Describe("control plane migration", func() {
 	Describe("#AnnotateExtensionCRDsForMigration()", func() {
 		It("should annotate all extension objects", func() {
 			var (
+				log   = logrus.NewEntry(logger.NewNopLogger())
 				ctx   = context.TODO()
 				shoot = &shoot.Shoot{
 					SeedNamespace: testSeedNamespace,
+					Components: &shoot.Components{
+						Extensions: &shoot.Extensions{
+							Network: network.New(log, fakeClient, &network.Values{
+								Namespace: "test-network",
+								Name:      testSeedNamespace,
+							}, time.Second, 2*time.Second, 3*time.Second),
+						},
+					},
 				}
 			)
 

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -171,7 +171,7 @@ func (b *Botanist) DeployWorker(ctx context.Context) error {
 	}
 
 	if restorePhase {
-		return b.restoreExtensionObject(ctx, b.K8sSeedClient.DirectClient(), worker, extensionsv1alpha1.WorkerResource)
+		return b.restoreExtensionObject(ctx, worker, extensionsv1alpha1.WorkerResource)
 	}
 
 	return nil

--- a/pkg/operation/common/extensions_test.go
+++ b/pkg/operation/common/extensions_test.go
@@ -1,0 +1,570 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/logger"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
+	"github.com/gardener/gardener/pkg/operation/common"
+	. "github.com/gardener/gardener/pkg/operation/common"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/test"
+
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/types"
+)
+
+var _ = Describe("extensions", func() {
+	var (
+		ctx     context.Context
+		log     *logrus.Entry
+		ctrl    *gomock.Controller
+		mockNow *mocktime.MockNow
+		now     time.Time
+
+		c client.Client
+
+		defaultInterval  time.Duration
+		defaultTimeout   time.Duration
+		defaultThreshold time.Duration
+
+		namespace string
+		name      string
+
+		expected *extensionsv1alpha1.Worker
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		log = logrus.NewEntry(logger.NewNopLogger())
+		ctrl = gomock.NewController(GinkgoT())
+		mockNow = mocktime.NewMockNow(ctrl)
+
+		s := runtime.NewScheme()
+		Expect(extensionsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())
+		c = fake.NewFakeClientWithScheme(s)
+
+		defaultInterval = 1 * time.Second
+		defaultTimeout = 1 * time.Second
+		defaultThreshold = 1 * time.Second
+
+		namespace = "test-namespace"
+		name = "test-name"
+
+		expected = &extensionsv1alpha1.Worker{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       extensionsv1alpha1.WorkerResource,
+				APIVersion: extensionsv1alpha1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#WaitUntilExtensionCRReady", func() {
+		It("should return error if extension CR does not exist", func() {
+			err := WaitUntilExtensionCRReady(
+				ctx, c, log,
+				func() runtime.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
+				namespace, name,
+				defaultInterval, defaultTimeout, defaultTimeout, nil,
+			)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return error if extension CR is not ready", func() {
+			expected.Status.LastError = &gardencorev1beta1.LastError{
+				Description: "Some error",
+			}
+
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
+			err := WaitUntilExtensionCRReady(
+				ctx, c, log,
+				func() runtime.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
+				namespace, name,
+				defaultInterval, defaultThreshold, defaultTimeout, nil,
+			)
+			Expect(err).To(HaveOccurred(), "worker readiness error")
+		})
+
+		It("should return success if extension CR is ready", func() {
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+			}
+
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
+			err := WaitUntilExtensionCRReady(
+				ctx, c, log,
+				func() runtime.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
+				namespace, name,
+				defaultInterval, defaultThreshold, defaultTimeout, nil,
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should call postReadyFunc if extension CR is ready", func() {
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+			}
+
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
+
+			val := 0
+			err := WaitUntilExtensionCRReady(
+				ctx, c, log,
+				func() runtime.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
+				namespace, name,
+				defaultInterval, defaultThreshold, defaultTimeout, func(runtime.Object) error {
+					val++
+					return nil
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(Equal(1))
+		})
+	})
+
+	Describe("#WaitUntilObjectReadyWithHealthFunction", func() {
+		It("should return error if object does not exist error", func() {
+			err := WaitUntilObjectReadyWithHealthFunction(
+				ctx, c, log,
+				func(obj runtime.Object) error {
+					return nil
+				},
+				func() runtime.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
+				namespace, name,
+				defaultInterval, defaultThreshold, defaultTimeout,
+				nil,
+			)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return error if ready func returns error", func() {
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
+			err := WaitUntilObjectReadyWithHealthFunction(
+				ctx, c, log,
+				func(obj runtime.Object) error {
+					return errors.New("error")
+				},
+				func() runtime.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
+				namespace, name,
+				defaultInterval, defaultThreshold, defaultTimeout,
+				nil,
+			)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return success if health func does not return error", func() {
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
+			err := WaitUntilObjectReadyWithHealthFunction(
+				ctx, c, log,
+				func(obj runtime.Object) error {
+					return nil
+				},
+				func() runtime.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
+				namespace, name,
+				defaultInterval, defaultThreshold, defaultTimeout,
+				nil,
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should pass correct object to health func", func() {
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
+			err := WaitUntilObjectReadyWithHealthFunction(
+				ctx, c, log,
+				func(obj runtime.Object) error {
+					Expect(obj).To(Equal(expected))
+					return nil
+				},
+				func() runtime.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
+				namespace, name,
+				defaultInterval, defaultThreshold, defaultTimeout,
+				nil,
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should call post ready func if health func does not return error", func() {
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+			}
+
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
+
+			val := 0
+			err := WaitUntilObjectReadyWithHealthFunction(
+				ctx, c, log,
+				func(obj runtime.Object) error {
+					return nil
+				},
+				func() runtime.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
+				namespace, name,
+				defaultInterval, defaultThreshold, defaultTimeout, func(runtime.Object) error {
+					val++
+					return nil
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(Equal(1))
+		})
+	})
+
+	Describe("#DeleteExtensionCR", func() {
+		It("should not return error if extension CR does not exist", func() {
+			Expect(DeleteExtensionCR(ctx, c, func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, namespace, name)).To(Succeed())
+		})
+
+		It("should not return error if deleted successfully", func() {
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
+			Expect(DeleteExtensionCR(ctx, c, func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, namespace, name)).To(Succeed())
+		})
+
+		It("should delete extension CR", func() {
+			defer test.WithVars(
+				&common.TimeNow, mockNow.Do,
+			)()
+
+			expected.Annotations = map[string]string{
+				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+			}
+
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			mc := mockclient.NewMockClient(ctrl)
+			// check if the extension CR exists
+			mc.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{})).SetArg(2, *expected).Return(nil)
+			// add deletion confirmation and Timestamp annotation
+			mc.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{})).Return(nil)
+			mc.EXPECT().Delete(ctx, expected).Times(1).Return(fmt.Errorf("some random error"))
+
+			Expect(DeleteExtensionCR(ctx, mc, func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, namespace, name)).To(HaveOccurred())
+		})
+	})
+
+	Describe("#DeleteExtensionCRs", func() {
+		It("should delete all extension CRs", func() {
+			deletionTimestamp := metav1.Now()
+			expected.ObjectMeta.DeletionTimestamp = &deletionTimestamp
+
+			expected2 := expected.DeepCopy()
+			expected2.Name = "worker2"
+			list := &extensionsv1alpha1.WorkerList{
+				Items: []extensionsv1alpha1.Worker{*expected, *expected2},
+			}
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
+			Expect(c.Create(ctx, expected2)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
+
+			err := DeleteExtensionCRs(
+				ctx,
+				c,
+				list,
+				func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} },
+				namespace,
+				func(obj extensionsv1alpha1.Object) bool { return true },
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("#WaitUntilExtensionCRsDeleted", func() {
+		It("should return error if atleast one extension CR is not deleted", func() {
+			list := &extensionsv1alpha1.WorkerList{}
+
+			deletionTimestamp := metav1.Now()
+			expected.ObjectMeta.DeletionTimestamp = &deletionTimestamp
+
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
+
+			err := WaitUntilExtensionCRsDeleted(
+				ctx,
+				c,
+				log,
+				list,
+				func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
+				namespace, defaultInterval, defaultTimeout,
+				func(object extensionsv1alpha1.Object) bool { return true })
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return success if all extensions CRs are deleted", func() {
+			list := &extensionsv1alpha1.WorkerList{}
+			err := WaitUntilExtensionCRsDeleted(
+				ctx,
+				c,
+				log,
+				list,
+				func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
+				namespace, defaultInterval, defaultTimeout,
+				func(object extensionsv1alpha1.Object) bool { return true })
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+	})
+
+	Describe("#WaitUntilExtensionCRDeleted", func() {
+		It("should return error if extension CR is not deleted", func() {
+			deletionTimestamp := metav1.Now()
+			expected.ObjectMeta.DeletionTimestamp = &deletionTimestamp
+
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
+			err := WaitUntilExtensionCRDeleted(ctx, c, log,
+				func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
+				namespace, name,
+				defaultInterval, defaultTimeout)
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return success if extensions CRs gets deleted", func() {
+			err := WaitUntilExtensionCRDeleted(ctx, c, log,
+				func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
+				namespace, name,
+				defaultInterval, defaultTimeout)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("restoring extension CR state", func() {
+		var (
+			expectedState *runtime.RawExtension
+			shootState    *gardencorev1alpha1.ShootState
+		)
+
+		BeforeEach(func() {
+			expectedState = &runtime.RawExtension{Raw: []byte(`{"data":"value"}`)}
+
+			shootState = &gardencorev1alpha1.ShootState{
+				Spec: gardencorev1alpha1.ShootStateSpec{
+					Extensions: []gardencorev1alpha1.ExtensionResourceState{
+						{
+							Name:  &name,
+							Kind:  extensionsv1alpha1.WorkerResource,
+							State: expectedState,
+						},
+					},
+				},
+			}
+		})
+
+		Describe("#RestoreExtensionWithDeployFunction", func() {
+			It("should restore the extension CR state with the provided deploy fuction and annotate it for restoration", func() {
+				defer test.WithVars(
+					&common.TimeNow, mockNow.Do,
+				)()
+				mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+				err := RestoreExtensionWithDeployFunction(
+					ctx,
+					shootState,
+					c,
+					extensionsv1alpha1.WorkerResource,
+					namespace,
+					func(ctx context.Context, operationAnnotation string) (extensionsv1alpha1.Object, error) {
+						Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
+						return expected, nil
+					},
+				)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(expected.Annotations).To(Equal(map[string]string{
+					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationRestore,
+					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				}))
+				Expect(expected.Status.State).To(Equal(expectedState))
+			})
+
+			It("should only annotate the resource with restore operation annotation if a corresponding state does not exist in the ShootState", func() {
+				defer test.WithVars(
+					&common.TimeNow, mockNow.Do,
+				)()
+				mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+				expected.Name = "worker2"
+				err := RestoreExtensionWithDeployFunction(
+					ctx,
+					shootState,
+					c,
+					extensionsv1alpha1.WorkerResource,
+					namespace,
+					func(ctx context.Context, operationAnnotation string) (extensionsv1alpha1.Object, error) {
+						Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
+						return expected, nil
+					},
+				)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(expected.Annotations).To(Equal(map[string]string{
+					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationRestore,
+					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				}))
+				Expect(expected.Status.State).To(BeNil())
+			})
+		})
+
+		Describe("#RestoreExtensionObjectState", func() {
+			It("should return error if the extension CR does not exist", func() {
+				err := RestoreExtensionObjectState(
+					ctx,
+					c,
+					shootState,
+					namespace,
+					expected,
+					extensionsv1alpha1.WorkerResource,
+				)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should update the state if the extension CR exists", func() {
+				defer test.WithVars(
+					&common.TimeNow, mockNow.Do,
+				)()
+				mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+				Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
+				err := RestoreExtensionObjectState(
+					ctx,
+					c,
+					shootState,
+					namespace,
+					expected,
+					extensionsv1alpha1.WorkerResource,
+				)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(expected.Status.State).To(Equal(expectedState))
+			})
+		})
+	})
+
+	Describe("#MigrateExtensionCR", func() {
+		It("should not return error if extension CR does not exist", func() {
+			Expect(MigrateExtensionCR(ctx, c, func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, namespace, name)).To(Succeed())
+		})
+
+		It("should properly annotate extension CR for migration", func() {
+			defer test.WithVars(
+				&common.TimeNow, mockNow.Do,
+			)()
+
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			expectedWithAnnotations := expected.DeepCopy()
+			expectedWithAnnotations.Annotations = map[string]string{
+				v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationMigrate,
+				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+			}
+
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{})).SetArg(2, *expected).Return(nil)
+			mc.EXPECT().Patch(ctx, expectedWithAnnotations, gomock.AssignableToTypeOf(client.MergeFrom(expected))).Return(nil)
+
+			err := MigrateExtensionCR(ctx, mc, func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, namespace, name)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("#WaitUntilExtensionCRMigrated", func() {
+		It("should not return error if resource does not exist", func() {
+			err := WaitUntilExtensionCRMigrated(
+				ctx,
+				c,
+				func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} },
+				namespace, name,
+				defaultInterval, defaultTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		DescribeTable("should return error if migration times out",
+			func(lastOperation *gardencorev1beta1.LastOperation, match func() GomegaMatcher) {
+				expected.Status.LastOperation = lastOperation
+				Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
+				err := WaitUntilExtensionCRMigrated(
+					ctx,
+					c,
+					func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} },
+					namespace, name,
+					defaultInterval, defaultTimeout,
+				)
+				Expect(err).To(match())
+			},
+			Entry("last operation is not Migrate", &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+				Type:  gardencorev1beta1.LastOperationTypeReconcile,
+			}, HaveOccurred),
+			Entry("last operation is Migrate but not successful", &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateProcessing,
+				Type:  gardencorev1beta1.LastOperationTypeMigrate,
+			}, HaveOccurred),
+			Entry("last operation is Migrate and successful", &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+				Type:  gardencorev1beta1.LastOperationTypeMigrate,
+			}, Succeed),
+		)
+	})
+
+	Describe("#AnnotateExtensionObjectWithOperation", func() {
+		It("should return error if object does not exist", func() {
+			Expect(AnnotateExtensionObjectWithOperation(ctx, c, expected, v1beta1constants.GardenerOperationMigrate)).NotTo(Succeed())
+		})
+
+		It("should annotate extension object with operation", func() {
+			defer test.WithVars(
+				&common.TimeNow, mockNow.Do,
+			)()
+
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			expectedWithAnnotations := expected.DeepCopy()
+			expectedWithAnnotations.Annotations = map[string]string{
+				v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationMigrate,
+				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+			}
+
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Patch(ctx, expectedWithAnnotations, gomock.AssignableToTypeOf(client.MergeFrom(expected))).Return(nil)
+
+			err := AnnotateExtensionObjectWithOperation(ctx, mc, expected, v1beta1constants.GardenerOperationMigrate)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -94,7 +94,7 @@ type ControlPlane struct {
 type Extensions struct {
 	DNS            *DNS
 	Infrastructure Infrastructure
-	Network        component.DeployWaiter
+	Network        component.DeployMigrateWaiter
 }
 
 // DNS contains references to internal and external DNSProvider and DNSEntry deployers.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR adds interfaces which can be used by shoot components (namely for extension resources) if they need to be Migrated and then Restored during control plane migration.
The PR also implements these interfaces for the Network Component and fixes an issue which prevented the network resource from having its `Restore` annotation applied due to always running into conflict when update is called.

**Which issue(s) this PR fixes**:
Part of #1631 

**Special notes for your reviewer**:
In the future we should do this for all botanist shoot components responsible for extension resources.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Adds Migrator/Restorer interfaces to the botanist shoot components
```
