### PR TITLE
[release-v1.6] fixed a bug that leads to Shoots not receiving a minor version update when the AutoUpdate = true

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -286,14 +286,14 @@ func shouldKubernetesVersionBeUpdated(shoot *gardencorev1beta1.Shoot, profile *g
 		return true, &updateReason, true, nil
 	}
 
-	if shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion {
-		updateReason = "AutoUpdate of Kubernetes version configured"
-		return true, &updateReason, false, nil
-	}
-
 	if ExpirationDateExpired(version.ExpirationDate) {
 		updateReason = "Kubernetes version expired - force update required"
 		return true, &updateReason, true, nil
+	}
+
+	if shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion {
+		updateReason = "AutoUpdate of Kubernetes version configured"
+		return true, &updateReason, false, nil
 	}
 
 	return false, nil, false, nil

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_test.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_test.go
@@ -371,6 +371,18 @@ var _ = Describe("Shoot Maintenance", func() {
 			Expect(*version).To(Equal("1.1.2"))
 		})
 
+		It("should determine that the shoot kubernetes version must be maintained - ForceUpdate to latest qualifying patch version of next minor version", func() {
+			shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion = true
+			cloudProfile.Spec.Kubernetes.Versions[3].ExpirationDate = &expirationDateInThePast
+			shoot.Spec.Kubernetes = gardencorev1beta1.Kubernetes{Version: "1.0.2"}
+
+			version, _, err := MaintainKubernetesVersion(shoot, cloudProfile, shootLogger)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).NotTo(BeNil())
+			Expect(*version).To(Equal("1.1.2"))
+		})
+
 		// special case when all the patch versions of the consecutive minor versions are expired
 		It("should determine that the shoot kubernetes version must be maintained - ForceUpdate to latest qualifying patch version (is expired) of next minor version.", func() {
 			shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion = false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
cherry-pick #2490 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixed a bug that leads to Shoots not receiving a force minor version update when the Kubernetes AutoUpdate is enabled.
```