### PR TITLE
Fix premature controllerinstallation deletion

### DIFF
--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
@@ -436,6 +436,16 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 				Name: "cr6",
 			},
 		}
+		controllerRegistration7 = &gardencorev1beta1.ControllerRegistration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cr7",
+			},
+			Spec: gardencorev1beta1.ControllerRegistrationSpec{
+				Deployment: &gardencorev1beta1.ControllerDeployment{
+					Policy: &onDemandPolicy,
+				},
+			},
+		}
 		controllerRegistrationList = []*gardencorev1beta1.ControllerRegistration{
 			controllerRegistration1,
 			controllerRegistration2,
@@ -443,6 +453,7 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 			controllerRegistration4,
 			controllerRegistration5,
 			controllerRegistration6,
+			controllerRegistration7,
 		}
 		controllerRegistrations = map[string]controllerRegistration{
 			controllerRegistration1.Name: {obj: controllerRegistration1, deployAlways: false},
@@ -451,6 +462,7 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 			controllerRegistration4.Name: {obj: controllerRegistration4, deployAlways: true},
 			controllerRegistration5.Name: {obj: controllerRegistration5, deployAlways: true},
 			controllerRegistration6.Name: {obj: controllerRegistration6, deployAlways: false},
+			controllerRegistration7.Name: {obj: controllerRegistration7, deployAlways: false},
 		}
 
 		controllerInstallation1 = &gardencorev1beta1.ControllerInstallation{
@@ -504,6 +516,19 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 					Name: controllerRegistration4.Name,
 				},
 			},
+		}
+		controllerInstallation7 = &gardencorev1beta1.ControllerInstallation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "ci7",
+			},
+			Spec: gardencorev1beta1.ControllerInstallationSpec{
+				SeedRef: corev1.ObjectReference{
+					Name: seedName,
+				},
+				RegistrationRef: corev1.ObjectReference{
+					Name: controllerRegistration7.Name,
+				},
+			},
 			Status: gardencorev1beta1.ControllerInstallationStatus{
 				Conditions: []gardencorev1beta1.Condition{
 					{
@@ -519,6 +544,7 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 				*controllerInstallation2,
 				*controllerInstallation3,
 				*controllerInstallation4,
+				*controllerInstallation7,
 			},
 		}
 	)
@@ -688,9 +714,9 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 				extensionsv1alpha1.ControlPlaneResource+"/"+type3,
 			)
 
-			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerRegistrations, seedLabels)
+			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, seedLabels, seedName)
 
-			Expect(names).To(Equal(sets.NewString(controllerRegistration1.Name, controllerRegistration2.Name, controllerRegistration3.Name, controllerRegistration4.Name)))
+			Expect(names).To(Equal(sets.NewString(controllerRegistration1.Name, controllerRegistration2.Name, controllerRegistration3.Name, controllerRegistration4.Name, controllerRegistration7.Name)))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -699,7 +725,7 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 				extensionsv1alpha1.ExtensionResource + "/foo",
 			)
 
-			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerRegistrations, seedLabels)
+			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, seedLabels, seedName)
 
 			Expect(names).To(BeNil())
 			Expect(err).To(HaveOccurred())
@@ -715,6 +741,7 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 				controllerRegistration2.Name: controllerInstallation2.Name,
 				controllerRegistration3.Name: controllerInstallation3.Name,
 				controllerRegistration4.Name: controllerInstallation4.Name,
+				controllerRegistration7.Name: controllerInstallation7.Name,
 			}))
 		})
 

--- a/pkg/gardenlet/controller/federatedseed/networkpolicy/namespace_reconciler.go
+++ b/pkg/gardenlet/controller/federatedseed/networkpolicy/namespace_reconciler.go
@@ -65,7 +65,7 @@ func (r *namespaceReconciler) Reconcile(request reconcile.Request) (reconcile.Re
 		if client.IgnoreNotFound(err) != nil {
 			return reconcile.Result{}, err
 		}
-		r.log.Debugf("namespace %q is not found, not trying to reconcile", namespace.Name)
+		r.log.Debugf("namespace %q is not found, not trying to reconcile", request.Name)
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR fixes a bug which caused the GCM to delete on-demand `ControllerInstallations` prematurely. https://github.com/gardener/gardener/pull/2261 already fixed this issue but the code was accidentally removed by some changes later.

**Special notes for your reviewer**:
Co-authored-by: Rafael Franzke <rafael.franzke@sap.com>

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue has been fixed which caused Gardener to delete on-demand extensions prematurely. 
```
