### PR TITLE
Tweak values for hvpa's LimitsRequestsGapScaleParams

### DIFF
--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -92,11 +92,11 @@ global:
             percentage: 80
       limitsRequestsGapScaleParams:
         cpu:
-          value: "3"
-          percentage: 80
+          value: "1"
+          percentage: 40
         memory:
-          value: "5G"
-          percentage: 80
+          value: "1G"
+          percentage: 40
 
     audit:
  #    dynamicConfiguration: false                             Enables dynamic audit configuration. This feature also requires the DynamicAuditing feature flag

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -231,7 +231,7 @@ images:
 - name: hvpa-controller
   sourceRepository: github.com/gardener/hvpa-controller
   repository: eu.gcr.io/gardener-project/gardener/hvpa-controller
-  tag: "v0.2.5"
+  tag: "v0.3.0"
 
 # Istio
 - name: istio-proxy

--- a/charts/seed-controlplane/charts/etcd/values.yaml
+++ b/charts/seed-controlplane/charts/etcd/values.yaml
@@ -75,8 +75,8 @@ hvpa:
         percentage: 80
   limitsRequestsGapScaleParams:
     cpu:
-      value: "3"
-      percentage: 80
+      value: "1"
+      percentage: 40
     memory:
-      value: "5G"
-      percentage: 80
+      value: "1G"
+      percentage: 40

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -145,11 +145,11 @@ scaleDownStabilization:
 
 limitsRequestsGapScaleParams:
   cpu:
-    value: "3"
-    percentage: 80
+    value: "1"
+    percentage: 40
   memory:
-    value: "5G"
-    percentage: 80
+    value: "1G"
+    percentage: 40
 
 sni:
   enabled: false


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/area auto-scaling
/priority normal
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

**What this PR does / why we need it**:
Tweak values for hvpa's LimitsRequestsGapScaleParams according to latest hvpa version

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @amshuman-kr 
Refer: https://github.com/gardener/hvpa-controller/pull/72

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Adapts values for hvpa's LimitsRequestsGapScaleParams to latest hvpa-controller version
```

``` improvement operator github.com/gardener/hvpa-controller #73 @ggaurav10
Minor bug fix: Use vpa scale policies correctly
```

``` improvement operator github.com/gardener/hvpa-controller #72 @ggaurav10
Change handling of LimitsRequestsGapScaleParams: Use `max` of value and percentage gaps, instead of `min`
```

``` improvement operator github.com/gardener/hvpa-controller #68 @ggaurav10
Now HVPA doesn't take VPA recommendations into account if VPA condition has `ConfigUnsupported`, `ConfigDeprecated` or `LowConfidence` set to `true`
```

``` improvement operator github.com/gardener/hvpa-controller #64 @ggaurav10
Removing "Temporary/fast fix to enable scale down even if vpaWeight == 0" as we have better ways to optimise cost now
```

``` improvement operator github.com/gardener/hvpa-controller #61 @amshuman-kr
Ignore `minChange` configuration while overriding scale up stabilisation. This ensures that full VPA recommendations are applied in case the target pods are OOMKilled or restarted due to livenessProbe failure, no matter what.
```

``` improvement operator github.com/gardener/hvpa-controller #57 @ggaurav10
Consider HPA to be limited if we have seen oomkill or liveness probe fails already. This change makes HVPA controller scale the app vertically more actively, ignoring the HPA's status condition type `ScalingLimited`.
```

``` improvement operator github.com/gardener/hvpa-controller #56 @ggaurav10
Consider HPA scale out to be limited in case, overrideScaleUpStabilization is set in the status and hpa weight is 0 so that full VPA recommendation is immediately applied.
```

``` improvement operator github.com/gardener/hvpa-controller #54 @ggaurav10
Add ci master build status and go report card badges
```