### PR TITLE
Update Cluster extension resource when Shoot is updated

### DIFF
--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -134,13 +134,12 @@ func (b *Botanist) WaitUntilInfrastructureReady(ctx context.Context) error {
 
 			if infrastructure.Status.NodesCIDR != nil {
 				shootCopy := b.Shoot.Info.DeepCopy()
-				if _, err := controllerutil.CreateOrUpdate(ctx, b.K8sGardenClient.Client(), shootCopy, func() error {
+				if err := b.UpdateShootAndCluster(ctx, shootCopy, func() error {
 					shootCopy.Spec.Networking.Nodes = infrastructure.Status.NodesCIDR
 					return nil
 				}); err != nil {
 					return err
 				}
-				b.Shoot.Info = shootCopy
 			}
 			return nil
 		},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Some parts of the shoot reconciliation flow are updating the `Shoot` resource in the garden cluster. Unfortunately, the `Cluster` resource in the seed cluster was not updated with these changes. Hence, it was having an outdated state until the shoot reconciliation started again from beginning.

This PR improves this situation by introducing a helper function that updates both the `Shoot` and the `Cluster`. This way subsequent steps get to the up-to-date version of the `Shoot` resource.

**Special notes for your reviewer**:
/cc @majst01 @Gerrit91 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
