### PR TITLE
Nit: Clean up double imports

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-apiserver.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-apiserver.rules.test.yaml
@@ -96,5 +96,5 @@ tests:
         job: kube-apiserver
         visibility: operator
       exp_annotations:
-        description: 'The API servers cumulative failure rate in logging audit events is 0.03%. This may be caused by an unavailable/unreachable audisink(s) and/or improper API server audit configuration.'
+        description: 'The API servers cumulative failure rate in logging audit events is 0.03%. This may be caused by an unavailable/unreachable AuditSink(s) and/or improper API server audit configuration.'
         summary: 'The API server has too many failed attempts to log audit events'

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-apiserver.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-apiserver.rules.yaml
@@ -81,7 +81,7 @@ groups:
       job: kube-apiserver
       visibility: operator
     annotations:
-        description: 'The API servers cumulative failure rate in logging audit events is {{ printf "%0.2f" $value }}%. This may be caused by an unavailable/unreachable audisink(s) and/or improper API server audit configuration.'
+        description: 'The API servers cumulative failure rate in logging audit events is {{ printf "%0.2f" $value }}%. This may be caused by an unavailable/unreachable AuditSink(s) and/or improper API server audit configuration.'
         summary: 'The API server has too many failed attempts to log audit events'
 
   - record: shoot:kube_apiserver:sum_by_pod

--- a/docs/monitoring/operator_alerts.md
+++ b/docs/monitoring/operator_alerts.md
@@ -5,7 +5,7 @@
 |CoreDNSDown|critical|shoot|`CoreDNS could not be found. Cluster DNS resolution will not work.`|
 |ApiServerNotReachable|blocker|seed|`API server not reachable via external endpoint: {{ $labels.instance }}.`|
 |KubeApiserverDown|blocker|seed|`All API server replicas are down/unreachable, or all API server could not be found.`|
-|KubeApiServerTooManyAuditlogFailures|critical|seed|`The API servers cumulative failure rate in logging audit events is {{ printf "%0.2f" $value }}%. This may be caused by an unavailable/unreachable audisink(s) and/or improper API server audit configuration.`|
+|KubeApiServerTooManyAuditlogFailures|critical|seed|`The API servers cumulative failure rate in logging audit events is {{ printf "%0.2f" $value }}%. This may be caused by an unavailable/unreachable AuditSink(s) and/or improper API server audit configuration.`|
 |KubeControllerManagerDown|critical|seed|`Deployments and replication controllers are not making progress.`|
 |KubeEtcdMainDown|blocker|seed|`Etcd3 cluster main is unavailable or cannot be scraped. As long as etcd3 main is down the cluster is unreachable.`|
 |KubeEtcdEventsDown|critical|seed|`Etcd3 cluster events is unavailable or cannot be scraped. Cluster events cannot be collected.`|

--- a/extensions/pkg/controller/csimigration/reconciler.go
+++ b/extensions/pkg/controller/csimigration/reconciler.go
@@ -30,7 +30,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -82,7 +81,7 @@ func (r *reconciler) InjectStopChannel(stopCh <-chan struct{}) error {
 func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	cluster := &extensionsv1alpha1.Cluster{}
 	if err := r.client.Get(r.ctx, request.NamespacedName, cluster); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err

--- a/extensions/pkg/controller/utils_test.go
+++ b/extensions/pkg/controller/utils_test.go
@@ -31,7 +31,6 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -112,8 +111,8 @@ var _ = Describe("Utils", func() {
 
 	Describe("#DeleteAllFinalizers", func() {
 		It("should delete all finalizers", func() {
-			creationTimestamp := v1.Now()
-			deletionTimestamp := v1.Now()
+			creationTimestamp := metav1.Now()
+			deletionTimestamp := metav1.Now()
 			labels := make(map[string]string)
 			labels["test-label-key"] = "test-label-value"
 			annotation := make(map[string]string)

--- a/extensions/pkg/predicate/predicate_test.go
+++ b/extensions/pkg/predicate/predicate_test.go
@@ -21,7 +21,6 @@ import (
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/util"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	mockcache "github.com/gardener/gardener/pkg/mock/controller-runtime/cache"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
@@ -65,9 +64,9 @@ var _ = Describe("Predicate", func() {
 
 		BeforeEach(func() {
 			extensionType = "extension-type"
-			object = &v1alpha1.Extension{
-				Spec: v1alpha1.ExtensionSpec{
-					DefaultSpec: v1alpha1.DefaultSpec{
+			object = &extensionsv1alpha1.Extension{
+				Spec: extensionsv1alpha1.ExtensionSpec{
+					DefaultSpec: extensionsv1alpha1.DefaultSpec{
 						Type: extensionType,
 					},
 				},

--- a/extensions/pkg/util/shoot_clients.go
+++ b/extensions/pkg/util/shoot_clients.go
@@ -19,7 +19,6 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/chartrenderer"
-	gardener "github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerkubernetes "github.com/gardener/gardener/pkg/client/kubernetes"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
@@ -37,7 +36,7 @@ type ShootClients interface {
 	Client() client.Client
 	Clientset() kubernetes.Interface
 	GardenerClientset() gardenerkubernetes.Interface
-	ChartApplier() gardener.ChartApplier
+	ChartApplier() gardenerkubernetes.ChartApplier
 	Version() *version.Info
 }
 
@@ -45,18 +44,18 @@ type shootClients struct {
 	c                 client.Client
 	clientset         kubernetes.Interface
 	gardenerClientset gardenerkubernetes.Interface
-	chartApplier      gardener.ChartApplier
+	chartApplier      gardenerkubernetes.ChartApplier
 	version           *version.Info
 }
 
 func (s *shootClients) Client() client.Client                           { return s.c }
 func (s *shootClients) Clientset() kubernetes.Interface                 { return s.clientset }
 func (s *shootClients) GardenerClientset() gardenerkubernetes.Interface { return s.gardenerClientset }
-func (s *shootClients) ChartApplier() gardener.ChartApplier             { return s.chartApplier }
+func (s *shootClients) ChartApplier() gardenerkubernetes.ChartApplier   { return s.chartApplier }
 func (s *shootClients) Version() *version.Info                          { return s.version }
 
 // NewShootClients creates a new shoot client interface based on the given clients.
-func NewShootClients(c client.Client, clientset kubernetes.Interface, gardenerClientset gardenerkubernetes.Interface, chartApplier gardener.ChartApplier, version *version.Info) ShootClients {
+func NewShootClients(c client.Client, clientset kubernetes.Interface, gardenerClientset gardenerkubernetes.Interface, chartApplier gardenerkubernetes.ChartApplier, version *version.Info) ShootClients {
 	return &shootClients{
 		c:                 c,
 		clientset:         clientset,

--- a/extensions/pkg/util/shoot_test.go
+++ b/extensions/pkg/util/shoot_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/gardener/gardener/extensions/pkg/util"
-	. "github.com/gardener/gardener/extensions/pkg/util"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -184,7 +183,7 @@ var _ = Describe("Shoot", func() {
 
 	Describe("#VersionMajorMinor", func() {
 		It("should return an error due to an invalid version format", func() {
-			v, err := VersionMajorMinor("invalid-semver")
+			v, err := util.VersionMajorMinor("invalid-semver")
 
 			Expect(v).To(BeEmpty())
 			Expect(err).To(HaveOccurred())
@@ -198,7 +197,7 @@ var _ = Describe("Shoot", func() {
 				expectedVersion = fmt.Sprintf("%d.%d", major, minor)
 			)
 
-			v, err := VersionMajorMinor(fmt.Sprintf("%s.88", expectedVersion))
+			v, err := util.VersionMajorMinor(fmt.Sprintf("%s.88", expectedVersion))
 
 			Expect(v).To(Equal(expectedVersion))
 			Expect(err).NotTo(HaveOccurred())
@@ -207,7 +206,7 @@ var _ = Describe("Shoot", func() {
 
 	Describe("#VersionInfo", func() {
 		It("should return an error due to an invalid version format", func() {
-			v, err := VersionInfo("invalid-semver")
+			v, err := util.VersionInfo("invalid-semver")
 
 			Expect(v).To(BeNil())
 			Expect(err).To(HaveOccurred())
@@ -222,7 +221,7 @@ var _ = Describe("Shoot", func() {
 				}
 			)
 
-			v, err := VersionInfo("14.123.42")
+			v, err := util.VersionInfo("14.123.42")
 
 			Expect(v).To(Equal(expectedVersionInfo))
 			Expect(err).NotTo(HaveOccurred())

--- a/extensions/pkg/webhook/handler_shootclient.go
+++ b/extensions/pkg/webhook/handler_shootclient.go
@@ -94,10 +94,10 @@ func (h *handlerShootClient) HandleWithRequest(ctx context.Context, req admissio
 		ip := ipPort[0]
 
 		podList := &corev1.PodList{}
-		if err := h.client.List(ctx, podList, client.MatchingLabels(map[string]string{
+		if err := h.client.List(ctx, podList, client.MatchingLabels{
 			v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
 			v1beta1constants.LabelRole: v1beta1constants.LabelAPIServer,
-		})); err != nil {
+		}); err != nil {
 			return errors.Wrapf(err, "error while listing all pods")
 		}
 

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
@@ -554,7 +553,7 @@ func getShoots(ctx context.Context, g gardencoreclientset.Interface, seed *garde
 		return nil, err
 	}
 
-	shootListAsItems := v1beta1helper.ShootItems(*shootList)
-	shootListAsItems2 := v1beta1helper.ShootItems(*shootList2)
+	shootListAsItems := gardencorev1beta1helper.ShootItems(*shootList)
+	shootListAsItems2 := gardencorev1beta1helper.ShootItems(*shootList2)
 	return shootListAsItems.Union(&shootListAsItems2), nil
 }

--- a/pkg/controllermanager/controller/seed/seed_lifecycle_control.go
+++ b/pkg/controllermanager/controller/seed/seed_lifecycle_control.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	gardencore "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
@@ -140,12 +139,12 @@ func (c *defaultControl) Reconcile(seedObj *gardencorev1beta1.Seed) (fastRequeue
 
 	seedLogger.Debugf("Setting status for seed %q to 'Unknown' as gardenlet stopped reporting seed status.", seed.Name)
 
-	bldr, err := helper.NewConditionBuilder(gardencorev1beta1.SeedGardenletReady)
+	bldr, err := gardencorev1beta1helper.NewConditionBuilder(gardencorev1beta1.SeedGardenletReady)
 	if err != nil {
 		return false, err
 	}
 
-	conditionGardenletReady := helper.GetCondition(seed.Status.Conditions, gardencorev1beta1.SeedGardenletReady)
+	conditionGardenletReady := gardencorev1beta1helper.GetCondition(seed.Status.Conditions, gardencorev1beta1.SeedGardenletReady)
 	if conditionGardenletReady != nil {
 		bldr.WithOldCondition(*conditionGardenletReady)
 	}
@@ -154,7 +153,7 @@ func (c *defaultControl) Reconcile(seedObj *gardencorev1beta1.Seed) (fastRequeue
 	bldr.WithReason("SeedStatusUnknown")
 	bldr.WithMessage("Gardenlet stopped posting seed status.")
 	if newCondition, update := bldr.WithNowFunc(metav1.Now).Build(); update {
-		seed.Status.Conditions = helper.MergeConditions(seed.Status.Conditions, newCondition)
+		seed.Status.Conditions = gardencorev1beta1helper.MergeConditions(seed.Status.Conditions, newCondition)
 		if err := gardenClient.Client().Status().Update(ctx, seed); err != nil {
 			return false, err
 		}

--- a/pkg/gardenlet/controller/lease/lease_test.go
+++ b/pkg/gardenlet/controller/lease/lease_test.go
@@ -24,7 +24,6 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -61,7 +60,7 @@ var _ = Describe("LeaseController", func() {
 			},
 		}
 
-		ownerRef = v1.OwnerReference{
+		ownerRef = metav1.OwnerReference{
 			APIVersion: "apiVersion", Name: holderName, Kind: "kind", UID: holderUID}
 	)
 
@@ -97,10 +96,10 @@ var _ = Describe("LeaseController", func() {
 
 			Expect(leaseController.Sync(holderName)).NotTo(HaveOccurred())
 
-			lease, err := k8sClientSet.CoordinationV1().Leases(testLeaseNamespace).Get(holderName, v1.GetOptions{})
+			lease, err := k8sClientSet.CoordinationV1().Leases(testLeaseNamespace).Get(holderName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(lease).ShouldNot(BeNil())
-			Expect(lease.Spec.RenewTime).To(BeEquivalentTo(&v1.MicroTime{Time: fakeNowFunc()}))
+			Expect(lease.Spec.RenewTime).To(BeEquivalentTo(&metav1.MicroTime{Time: fakeNowFunc()}))
 			Expect(lease.OwnerReferences).Should(BeEmpty())
 		})
 
@@ -108,10 +107,10 @@ var _ = Describe("LeaseController", func() {
 			leaseController := NewLeaseController(fakeNowFunc, fakeClientMap, 2, testLeaseNamespace)
 			Expect(leaseController.Sync(holderName, ownerRef)).NotTo(HaveOccurred())
 
-			lease, err := k8sClientSet.CoordinationV1().Leases(testLeaseNamespace).Get(holderName, v1.GetOptions{})
+			lease, err := k8sClientSet.CoordinationV1().Leases(testLeaseNamespace).Get(holderName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(lease).ShouldNot(BeNil())
-			Expect(lease.Spec.RenewTime).To(BeEquivalentTo(&v1.MicroTime{Time: fakeNowFunc()}))
+			Expect(lease.Spec.RenewTime).To(BeEquivalentTo(&metav1.MicroTime{Time: fakeNowFunc()}))
 			Expect(lease.OwnerReferences).Should(ContainElement(ownerRef))
 		})
 
@@ -136,20 +135,20 @@ var _ = Describe("LeaseController", func() {
 		})
 
 		It("should update lease time if the lease exists", func() {
-			fakeTime := &v1.MicroTime{Time: time.Date(2020, time.April, 1, 1, 1, 1, 1, time.Local)}
+			fakeTime := &metav1.MicroTime{Time: time.Date(2020, time.April, 1, 1, 1, 1, 1, time.Local)}
 			lease.Spec.RenewTime = fakeTime
 			Expect(k8sClientSet.Tracker().Add(lease)).NotTo(HaveOccurred())
 
 			leaseController := NewLeaseController(fakeNowFunc, fakeClientMap, 2, testLeaseNamespace)
 			Expect(leaseController.Sync(holderName)).NotTo(HaveOccurred())
 
-			actualLease, err := k8sClientSet.CoordinationV1().Leases(testLeaseNamespace).Get(holderName, v1.GetOptions{})
+			actualLease, err := k8sClientSet.CoordinationV1().Leases(testLeaseNamespace).Get(holderName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(actualLease.Spec.RenewTime).To(Equal(&v1.MicroTime{Time: fakeNowFunc()}))
+			Expect(actualLease.Spec.RenewTime).To(Equal(&metav1.MicroTime{Time: fakeNowFunc()}))
 		})
 
 		It("should return error, when updates lease time and the lease exists but fails", func() {
-			fakeTime := &v1.MicroTime{Time: time.Date(2020, time.April, 1, 1, 1, 1, 1, time.Local)}
+			fakeTime := &metav1.MicroTime{Time: time.Date(2020, time.April, 1, 1, 1, 1, 1, time.Local)}
 			lease.Spec.RenewTime = fakeTime
 			Expect(k8sClientSet.Tracker().Add(lease)).NotTo(HaveOccurred())
 			k8sClientSet.PrependReactor("update", "leases", func(action k8stesting.Action) (bool, runtime.Object, error) {
@@ -163,7 +162,7 @@ var _ = Describe("LeaseController", func() {
 		})
 
 		It("should retry to update lease if conflict is returned as error from the client", func() {
-			fakeTime := &v1.MicroTime{Time: time.Date(2020, time.April, 1, 1, 1, 1, 1, time.Local)}
+			fakeTime := &metav1.MicroTime{Time: time.Date(2020, time.April, 1, 1, 1, 1, 1, time.Local)}
 			lease.Spec.RenewTime = fakeTime
 			Expect(k8sClientSet.Tracker().Add(lease)).NotTo(HaveOccurred())
 			k8sClientSet.PrependReactor("update", "leases", func(action k8stesting.Action) (bool, runtime.Object, error) {

--- a/pkg/gardenlet/controller/shoot/controllerinstallation_control.go
+++ b/pkg/gardenlet/controller/shoot/controllerinstallation_control.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/common"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -134,7 +133,7 @@ func (c *defaultControllerInstallationControl) Reconcile(controllerInstallationO
 		resources[resource.Kind] = resource.Type
 	}
 
-	shootList, err := c.k8sGardenCoreInformers.Shoots().Lister().Shoots(metav1.NamespaceAll).List(labels.Everything())
+	shootList, err := c.k8sGardenCoreInformers.Shoots().Lister().Shoots(corev1.NamespaceAll).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -84,7 +84,7 @@ func New(o *operation.Operation) (*Botanist, error) {
 
 	o.Shoot.Components.DNS.NginxEntry = b.DefaultNginxIngressDNSEntry(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.ControlPlane.KubeAPIServerService = b.DefaultKubeAPIServerService()
-	o.Shoot.Components.ControlPlane.KubeAPIServerSNI = b.DefaultKubeAPIServersNI()
+	o.Shoot.Components.ControlPlane.KubeAPIServerSNI = b.DefaultKubeAPIServerSNI()
 
 	// Extension CRD components
 	o.Shoot.Components.Network = b.DefaultNetwork(b.K8sSeedClient.DirectClient())

--- a/pkg/operation/botanist/containerruntime.go
+++ b/pkg/operation/botanist/containerruntime.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/common"
@@ -62,7 +61,7 @@ func (b *Botanist) DeployContainerRuntimeResources(ctx context.Context) error {
 					toApply.Spec.Type = cr.Type
 					toApply.Spec.ProviderConfig = cr.ProviderConfig
 					toApply.Spec.WorkerPool.Name = workerName
-					toApply.Spec.WorkerPool.Selector.MatchLabels = map[string]string{gardencorev1beta1constants.LabelWorkerPool: workerName, gardencorev1beta1constants.LabelWorkerPoolDeprecated: workerName}
+					toApply.Spec.WorkerPool.Selector.MatchLabels = map[string]string{v1beta1constants.LabelWorkerPool: workerName, v1beta1constants.LabelWorkerPoolDeprecated: workerName}
 					return nil
 				})
 				return err

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -1330,13 +1330,13 @@ func (b *Botanist) DefaultKubeAPIServerService() component.DeployWaiter {
 	)
 }
 
-// DeployInternalDNS deploys the internal DNSProvider and DNSEntry.
+// DeployKubeAPIServerSNI deploys the kube-apiserver-sni chart.
 func (b *Botanist) DeployKubeAPIServerSNI(ctx context.Context) error {
 	return b.Shoot.Components.ControlPlane.KubeAPIServerSNI.Deploy(ctx)
 }
 
-// DefaultKubeAPIServersNI returns a deployer for kube-apiserver SNI.
-func (b *Botanist) DefaultKubeAPIServersNI() component.DeployWaiter {
+// DefaultKubeAPIServerSNI returns a deployer for kube-apiserver SNI.
+func (b *Botanist) DefaultKubeAPIServerSNI() component.DeployWaiter {
 	return component.OpDestroy(controlplane.NewKubeAPIServerSNI(
 		&controlplane.KubeAPIServerSNIValues{
 			Name:                  v1beta1constants.DeploymentNameKubeAPIServer,

--- a/pkg/operation/botanist/controlplane/kube_apiserver_service.go
+++ b/pkg/operation/botanist/controlplane/kube_apiserver_service.go
@@ -29,7 +29,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -51,7 +50,7 @@ func NewKubeAPIService(
 	applier kubernetes.ChartApplier,
 	chartsRootPath string,
 	logger *logrus.Entry,
-	client crclient.Client,
+	client client.Client,
 	waiter retry.Ops,
 	clusterIPFunc func(clusterIP string),
 	ingressFunc func(ingressIP string),
@@ -173,7 +172,7 @@ type kubeAPIService struct {
 	kubernetes.ChartApplier
 	chartPath     string
 	logger        *logrus.Entry
-	client        crclient.Client
+	client        client.Client
 	waiter        retry.Ops
 	clusterIPFunc func(clusterIP string)
 	ingressFunc   func(ingressIP string)

--- a/pkg/operation/botanist/extensions/dns/dnsentry.go
+++ b/pkg/operation/botanist/extensions/dns/dnsentry.go
@@ -31,7 +31,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // EntryValues contains the values used to create a DNSEntry
@@ -50,7 +49,7 @@ func NewDNSEntry(
 	applier kubernetes.ChartApplier,
 	chartsRootPath string,
 	logger *logrus.Entry,
-	client crclient.Client,
+	client client.Client,
 	waiter retry.Ops,
 
 ) component.DeployWaiter {
@@ -75,7 +74,7 @@ type dnsEntry struct {
 	kubernetes.ChartApplier
 	chartPath string
 	logger    *logrus.Entry
-	client    crclient.Client
+	client    client.Client
 	waiter    retry.Ops
 }
 
@@ -104,7 +103,7 @@ func (d *dnsEntry) Wait(ctx context.Context) error {
 		entry := &dnsv1alpha1.DNSEntry{}
 		if err := d.client.Get(
 			ctx,
-			crclient.ObjectKey{Name: d.values.Name, Namespace: d.shootNamespace},
+			client.ObjectKey{Name: d.values.Name, Namespace: d.shootNamespace},
 			entry,
 		); err != nil {
 			if apierrors.IsNotFound(err) {

--- a/pkg/operation/botanist/extensions/dns/dnsprovider.go
+++ b/pkg/operation/botanist/extensions/dns/dnsprovider.go
@@ -20,17 +20,16 @@ import (
 	"path/filepath"
 	"time"
 
-	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
+
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ProviderValues contains the values used to create a DNSProvider.
@@ -58,7 +57,7 @@ func NewDNSProvider(
 	applier kubernetes.ChartApplier,
 	chartsRootPath string,
 	logger *logrus.Entry,
-	client crclient.Client,
+	client client.Client,
 	waiter retry.Ops,
 ) component.DeployWaiter {
 	if waiter == nil {
@@ -82,7 +81,7 @@ type dnsProvider struct {
 	kubernetes.ChartApplier
 	chartPath string
 	logger    *logrus.Entry
-	client    crclient.Client
+	client    client.Client
 	waiter    retry.Ops
 }
 
@@ -109,7 +108,7 @@ func (d *dnsProvider) Wait(ctx context.Context) error {
 		provider := &dnsv1alpha1.DNSProvider{}
 		if err := d.client.Get(
 			ctx,
-			crclient.ObjectKey{Name: d.values.Name, Namespace: d.shootNamespace},
+			client.ObjectKey{Name: d.values.Name, Namespace: d.shootNamespace},
 			provider,
 		); err != nil {
 			return retry.SevereError(err)

--- a/pkg/operation/botanist/extensions/network/network.go
+++ b/pkg/operation/botanist/extensions/network/network.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -66,7 +66,7 @@ type Values struct {
 // New creates a new instance of DeployWaiter for a Network.
 func New(
 	logger *logrus.Entry,
-	client crclient.Client,
+	client client.Client,
 	values *Values,
 	waitInterval time.Duration,
 	waitSevereThreshold time.Duration,
@@ -85,7 +85,7 @@ func New(
 type network struct {
 	values              *Values
 	logger              *logrus.Entry
-	client              crclient.Client
+	client              client.Client
 	waitInterval        time.Duration
 	waitSevereThreshold time.Duration
 	waitTimeout         time.Duration

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -423,7 +423,7 @@ func DeleteLoggingStack(ctx context.Context, k8sClient client.Client, namespace 
 	for _, list := range lists {
 		if err := k8sClient.List(ctx, list,
 			client.InNamespace(namespace),
-			client.MatchingLabels(map[string]string{v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleLogging})); err != nil {
+			client.MatchingLabels{v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleLogging}); err != nil {
 			return err
 		}
 

--- a/pkg/operation/garden/garden_test.go
+++ b/pkg/operation/garden/garden_test.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/gardener/gardener/pkg/operation/common"
-	"github.com/gardener/gardener/pkg/operation/garden"
 	. "github.com/gardener/gardener/pkg/operation/garden"
 
 	. "github.com/onsi/ginkgo"
@@ -155,7 +154,7 @@ var _ = Describe("Garden", func() {
 	var (
 		defaultDomainProvider   = "default-domain-provider"
 		defaultDomainSecretData = map[string][]byte{"default": []byte("domain")}
-		defaultDomain           = &garden.Domain{
+		defaultDomain           = &Domain{
 			Domain:     "bar.com",
 			Provider:   defaultDomainProvider,
 			SecretData: defaultDomainSecretData,
@@ -163,12 +162,12 @@ var _ = Describe("Garden", func() {
 	)
 
 	DescribeTable("#DomainIsDefaultDomain",
-		func(domain string, defaultDomains []*garden.Domain, expected gomegatypes.GomegaMatcher) {
+		func(domain string, defaultDomains []*Domain, expected gomegatypes.GomegaMatcher) {
 			Expect(DomainIsDefaultDomain(domain, defaultDomains)).To(expected)
 		},
 
 		Entry("no default domain", "foo.bar.com", nil, BeNil()),
-		Entry("default domain", "foo.bar.com", []*garden.Domain{defaultDomain}, Equal(defaultDomain)),
-		Entry("no default domain but with same suffix", "foo.foobar.com", []*garden.Domain{defaultDomain}, BeNil()),
+		Entry("default domain", "foo.bar.com", []*Domain{defaultDomain}, Equal(defaultDomain)),
+		Entry("no default domain but with same suffix", "foo.foobar.com", []*Domain{defaultDomain}, BeNil()),
 	)
 })

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -35,7 +35,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/garden"
 	"github.com/gardener/gardener/pkg/operation/seed"
 	"github.com/gardener/gardener/pkg/operation/shoot"
-	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/chart"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -173,7 +172,7 @@ func (b *Builder) WithChartsRootPath(chartsRootPath string) *Builder {
 // WithShootFrom sets the shootFunc attribute at the Builder which will build a new Shoot object.
 func (b *Builder) WithShootFrom(k8sGardenCoreInformers gardencoreinformers.Interface, s *gardencorev1beta1.Shoot) *Builder {
 	b.shootFunc = func(ctx context.Context, c client.Client, gardenObj *garden.Garden, seedObj *seed.Seed) (*shoot.Shoot, error) {
-		return shootpkg.
+		return shoot.
 			NewBuilder().
 			WithShootObject(s).
 			WithCloudProfileObjectFromLister(k8sGardenCoreInformers.CloudProfiles().Lister()).

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -842,7 +842,7 @@ func GetWildcardCertificate(ctx context.Context, c client.Client) (*corev1.Secre
 		ctx,
 		wildcardCerts,
 		client.InNamespace(v1beta1constants.GardenNamespace),
-		client.MatchingLabels(map[string]string{v1beta1constants.GardenRole: common.ControlPlaneWildcardCert}),
+		client.MatchingLabels{v1beta1constants.GardenRole: common.ControlPlaneWildcardCert},
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/operation/seed/seed_test.go
+++ b/pkg/operation/seed/seed_test.go
@@ -53,7 +53,7 @@ var _ = Describe("seed", func() {
 
 	Describe("#GetWildcardCertificate", func() {
 		It("should return no wildcard certificate secret", func() {
-			runtimeClient.EXPECT().List(context.TODO(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels(map[string]string{v1beta1constants.GardenRole: common.ControlPlaneWildcardCert}))
+			runtimeClient.EXPECT().List(context.TODO(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels{v1beta1constants.GardenRole: common.ControlPlaneWildcardCert})
 
 			secret, err := GetWildcardCertificate(context.TODO(), runtimeClient)
 
@@ -67,7 +67,7 @@ var _ = Describe("seed", func() {
 					{},
 				},
 			}
-			runtimeClient.EXPECT().List(context.TODO(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels(map[string]string{v1beta1constants.GardenRole: common.ControlPlaneWildcardCert})).DoAndReturn(
+			runtimeClient.EXPECT().List(context.TODO(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels{v1beta1constants.GardenRole: common.ControlPlaneWildcardCert}).DoAndReturn(
 				func(_ context.Context, secrets *corev1.SecretList, _ client.ListOption, _ client.ListOption) error {
 					*secrets = *secretList
 					return nil
@@ -86,7 +86,7 @@ var _ = Describe("seed", func() {
 					{},
 				},
 			}
-			runtimeClient.EXPECT().List(context.TODO(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels(map[string]string{v1beta1constants.GardenRole: common.ControlPlaneWildcardCert})).DoAndReturn(
+			runtimeClient.EXPECT().List(context.TODO(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels{v1beta1constants.GardenRole: common.ControlPlaneWildcardCert}).DoAndReturn(
 				func(_ context.Context, secrets *corev1.SecretList, _ client.ListOption, _ client.ListOption) error {
 					*secrets = *secretList
 					return nil

--- a/pkg/utils/secrets/certificates_test.go
+++ b/pkg/utils/secrets/certificates_test.go
@@ -16,7 +16,6 @@ package secrets_test
 
 import (
 	"github.com/gardener/gardener/pkg/utils"
-	"github.com/gardener/gardener/pkg/utils/secrets"
 
 	. "github.com/gardener/gardener/pkg/utils/secrets"
 	. "github.com/onsi/ginkgo"
@@ -40,7 +39,7 @@ var _ = Describe("Certificate Secrets", func() {
 			certificateConfig = &CertificateSecretConfig{
 				Name:       "ca",
 				CommonName: "metrics-server",
-				CertType:   secrets.CACert,
+				CertType:   CACert,
 			}
 
 			var err error

--- a/pkg/utils/secrets/static_token.go
+++ b/pkg/utils/secrets/static_token.go
@@ -126,7 +126,7 @@ func (s *StaticTokenSecretConfig) LoadFromSecretData(secretData map[string][]byt
 	return NewStaticTokenInfoData(tokens), nil
 }
 
-// GenerateStaticToken computes a random token of length 64.
+// GenerateStaticToken computes a random token of length 128.
 func (s *StaticTokenSecretConfig) GenerateStaticToken() (*StaticToken, error) {
 	tokens := make([]Token, 0, len(s.Tokens))
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Clean up double imports.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
