### PR TITLE
Fix panic on initializing Shoot clients

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -122,6 +122,16 @@ func shootClientInitializer(b *botanistpkg.Botanist) func() error {
 	)
 	return func() error {
 		once.Do(func() {
+			apiServerRunning, err2 := b.IsAPIServerRunning()
+			if err2 != nil {
+				err = err2
+				return
+			}
+			// Don't initialize clients for Shoots, that are currently hibernated or in the process of being created or deleted.
+			if !apiServerRunning {
+				return
+			}
+
 			err = b.InitializeShootClients()
 		})
 		return err

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -289,13 +289,15 @@ func (o *Operation) InitializeShootClients() error {
 		return nil
 	}
 
-	apiServerRunning, err := o.IsAPIServerRunning()
-	if err != nil {
-		return err
-	}
-	// Don't initialize clients for Shoots, that have are currently hibernated or in the process of being created or deleted.
-	if !apiServerRunning {
-		return nil
+	if o.Shoot.HibernationEnabled {
+		// Don't initialize clients for Shoots, that are currently hibernated and their API server is not running
+		apiServerRunning, err := o.IsAPIServerRunning()
+		if err != nil {
+			return err
+		}
+		if !apiServerRunning {
+			return nil
+		}
 	}
 
 	shootClient, err := o.ClientMap.GetClient(context.TODO(), keys.ForShoot(o.Shoot.Info))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority blocker

**What this PR does / why we need it**:
This PR fixes a regression/panic introduced by #2449.
Basically the motivation in the PR was to ensure, the shoot clients are not initialized when its API server is not running at the moment (mainly to avoid, that the care controller would create new clientsets when the shoot is hibernated or being deleted). However, if the API server is scaled down for whatever reason, when the gardenlet tries to initialize clients and the reconcile/delete flow, it should not skip initializing the clients as this will cause it to panic later on in the flow when trying to use the client.

**Which issue(s) this PR fixes**:
Fixes #2526

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
