### PR TITLE
Make scheduler feature gates configurable

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/configmap-componentconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/configmap-componentconfig.yaml
@@ -51,4 +51,8 @@ data:
         candidateDeterminationStrategy: {{ required ".Values.global.scheduler.config.schedulers.shoot.candidateDeterminationStrategy is required" .Values.global.scheduler.config.schedulers.shoot.candidateDeterminationStrategy }}
       {{- end }}
     {{- end }}
+    {{- if .Values.global.scheduler.config.featureGates }}
+    featureGates:
+      {{- toYaml .Values.global.scheduler.config.featureGates | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -297,7 +297,7 @@ global:
 #         retrySyncPeriod: 15s
 #         concurrentSyncs: 5
 #         candidateDeterminationStrategy: SameRegion # either {SameRegion,MinimalDistance}
-
+      featureGates: {}
   internalDomain:
     provider: aws-route53 # depends on the DNS extension of your choice
     domain: example.com


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR makes the scheduler feature gates configurable in the `gardener/controlplane` chart.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
It is now possible to configure the enabled `FeatureGates` for the `gardener-scheduler` via the respective values in the `gardener/controlplane` chart.
```
