### PR TITLE
Default machine image without version to latest non-preview version

### DIFF
--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -151,9 +151,9 @@ func validateKubernetesSettings(kubernetes core.KubernetesSettings, fldPath *fie
 	if len(kubernetes.Versions) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("versions"), "must provide at least one Kubernetes version"))
 	}
-	latestKubernetesVersion, err := helper.DetermineLatestExpirableVersion(kubernetes.Versions)
+	latestKubernetesVersion, err := helper.DetermineLatestExpirableVersion(kubernetes.Versions, false)
 	if err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath, latestKubernetesVersion, "failed to determine latest kubernetes version from cloud profile"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("versions"), latestKubernetesVersion.Version, "failed to determine the latest kubernetes version from the cloud profile"))
 	}
 	if latestKubernetesVersion.ExpirationDate != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("versions[]").Child("expirationDate"), latestKubernetesVersion.ExpirationDate, fmt.Sprintf("expiration date of latest kubernetes version ('%s') must not be set", latestKubernetesVersion.Version)))
@@ -249,7 +249,7 @@ func validateMachineImages(machineImages []core.MachineImage, fldPath *field.Pat
 
 	latestMachineImages, err := helper.DetermineLatestMachineImageVersions(machineImages)
 	if err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath, latestMachineImages, "failed to determine latest machine images from cloud profile"))
+		allErrs = append(allErrs, field.Invalid(fldPath, latestMachineImages, err.Error()))
 	}
 
 	for imageName, latestImage := range latestMachineImages {

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -95,6 +95,9 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 					"Type":  Equal(field.ErrorTypeRequired),
 					"Field": Equal("spec.kubernetes.versions"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.kubernetes.versions"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
 					"Field": Equal("spec.machineImages"),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
@@ -211,6 +214,9 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 
 					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.kubernetes.versions"),
+					})), PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
 						"Field": Equal("spec.kubernetes.versions"),
 					}))))
 				})
@@ -347,6 +353,9 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.machineImages[0].versions"),
+					})), PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.machineImages"),
 					}))))
 				})
 

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -697,7 +697,7 @@ func validateZone(constraints []core.Region, region, zone string) (bool, []strin
 	return false, validValues
 }
 
-// getDefaultMachineImage determines the latest machine image version from the first machine image in the CloudProfile and considers that as the default image
+// getDefaultMachineImage determines the latest non-preview machine image version from the first machine image in the CloudProfile and considers that as the default image
 func getDefaultMachineImage(machineImages []core.MachineImage, imageName string) (*core.ShootMachineImage, error) {
 	if len(machineImages) == 0 {
 		return nil, errors.New("the cloud profile does not contain any machine image - cannot create shoot cluster")
@@ -719,7 +719,7 @@ func getDefaultMachineImage(machineImages []core.MachineImage, imageName string)
 		defaultImage = &machineImages[0]
 	}
 
-	latestMachineImageVersion, err := helper.DetermineLatestMachineImageVersion(*defaultImage)
+	latestMachineImageVersion, err := helper.DetermineLatestExpirableVersion(defaultImage.Versions, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine latest machine image from cloud profile: %s", err.Error())
 	}

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1124,15 +1124,21 @@ var _ = Describe("validator", func() {
 				Expect(err).To(BeForbiddenError())
 			})
 
-			It("should use latest machine image as old shoot does not specify one", func() {
+			It("should use latest non-preview machine image as old shoot does not specify one", func() {
 				imageName := "some-image"
 				version1 := "1.1.1"
 				version2 := "2.2.2"
+				version3 := "2.2.3"
+				classificationPreview := core.ClassificationPreview
 
 				cloudProfile.Spec.MachineImages = []core.MachineImage{
 					{
 						Name: imageName,
 						Versions: []core.ExpirableVersion{
+							{
+								Version:        version3,
+								Classification: &classificationPreview,
+							},
 							{
 								Version: version2,
 							},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operations
/kind bug
/priority normal

**What this PR does / why we need it**:

Properly default machine image without version to latest non-preview version.
Otherwise, Shoots that are created without a machine image or without a machine image version will get defaulted to a preview versions. 
Preview versions should always be opt-in, as they are not deemed "stable" by the Gardener Operator.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixes a bug that could lead to defaulting a  machine image of a Shoot to a preview version.
```
