### PR TITLE
Rely only on deployed tunnel pod in care controller

### DIFF
--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -618,18 +618,13 @@ func (b *Botanist) checkSystemComponents(
 	if err := b.K8sShootClient.Client().List(ctx, podsList, client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{"type": "tunnel"}); err != nil {
 		return nil, err
 	}
-
 	if len(podsList.Items) == 0 {
 		c := checker.FailedCondition(condition, "NoTunnelDeployed", "no tunnels are currently deployed to perform health-check on")
 		return &c, nil
 	}
-	var (
-		konnectivityHealthCheck = b.Shoot.KonnectivityTunnelEnabled
-		tunnelName              = common.VPNTunnel
-		deployedTunnelName      = podsList.Items[0].Labels["app"]
-	)
 
-	if konnectivityHealthCheck && deployedTunnelName == common.KonnectivityTunnel {
+	tunnelName := common.VPNTunnel
+	if podsList.Items[0].Labels["app"] == common.KonnectivityTunnel {
 		tunnelName = common.KonnectivityTunnel
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug
/priority normal

**What this PR does / why we need it**:
Disabling the `KonnectivityTunnel` feature gate leads to this error message currently:

```
Tunnel connection has not been established (could not forward to vpn-shoot pod: port forward connection could not be established within five seconds)
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
