### PR TITLE
Add common funcs to the extensions library

### DIFF
--- a/extensions/pkg/util/index/index.go
+++ b/extensions/pkg/util/index/index.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// SecretRefNamespaceField is the field name for the index function that extracts the corresponding field from SecretBinding.
+const SecretRefNamespaceField string = "secretRef.namespace"
+
+// SecretRefNamespaceIndexerFunc extracts the secretRef.namespace field of a SecretBinding.
+func SecretRefNamespaceIndexerFunc(rawObj runtime.Object) []string {
+	secretBinding, ok := rawObj.(*gardencorev1beta1.SecretBinding)
+	if !ok {
+		return []string{}
+	}
+	return []string{secretBinding.SecretRef.Namespace}
+}
+
+// SecretBindingNameField is the field name for the index function that extracts the corresponding field from Shoot.
+const SecretBindingNameField string = "spec.secretBindingName"
+
+// SecretBindingNameIndexerFunc extracts the spec.secretBindingName field of a Shoot.
+func SecretBindingNameIndexerFunc(rawObj runtime.Object) []string {
+	shoot, ok := rawObj.(*gardencorev1beta1.Shoot)
+	if !ok {
+		return []string{}
+	}
+	return []string{shoot.Spec.SecretBindingName}
+}

--- a/extensions/pkg/util/index/index_test.go
+++ b/extensions/pkg/util/index/index_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index_test
+
+import (
+	"testing"
+
+	"github.com/gardener/gardener/extensions/pkg/util/index"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestIndex(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Index suite")
+}
+
+var _ = Describe("Index", func() {
+
+	Context("#SecretRefNamespaceIndexerFunc", func() {
+		It("should return empty slice for non SecretBinding", func() {
+			actual := index.SecretRefNamespaceIndexerFunc(&corev1.Secret{})
+			Expect(actual).To(Equal([]string{}))
+		})
+
+		It("should return secretRef.namespace for SecretBinding", func() {
+			secretBinding := &gardencorev1beta1.SecretBinding{
+				SecretRef: corev1.SecretReference{
+					Namespace: "garden-dev",
+				},
+			}
+
+			actual := index.SecretRefNamespaceIndexerFunc(secretBinding)
+			Expect(actual).To(Equal([]string{"garden-dev"}))
+		})
+	})
+
+	Context("#SecretBindingNameIndexerFunc", func() {
+		It("should return empty slice for non Shoot", func() {
+			actual := index.SecretBindingNameIndexerFunc(&corev1.Pod{})
+			Expect(actual).To(Equal([]string{}))
+		})
+
+		It("should return spec.secretBindingName for Shoot", func() {
+			shoot := &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					SecretBindingName: "foo",
+				},
+			}
+
+			actual := index.SecretBindingNameIndexerFunc(shoot)
+			Expect(actual).To(Equal([]string{"foo"}))
+		})
+	})
+})

--- a/extensions/pkg/util/secret/secret.go
+++ b/extensions/pkg/util/secret/secret.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secret
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/extensions/pkg/util/index"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IsSecretInUseByShoot checks whether the given secret is in use by Shoot with the given provider type.
+func IsSecretInUseByShoot(ctx context.Context, c client.Client, secret *corev1.Secret, providerType string) (bool, error) {
+	// TODO: controller-runtime cached client does not support non-exact field matches.
+	// Once this limitation is removed, we can add client.MatchingFields by secretRef.name and secretRef.namespace.
+	secretBindings := &gardencorev1beta1.SecretBindingList{}
+	if err := c.List(ctx, secretBindings,
+		client.MatchingFields{index.SecretRefNamespaceField: secret.Namespace}); err != nil {
+		return false, err
+	}
+
+	for _, secretBinding := range secretBindings.Items {
+		// Filter out the the SecretBindings that do not reference the given secret
+		if secretBinding.SecretRef.Name != secret.Name {
+			continue
+		}
+
+		shoots := &gardencorev1beta1.ShootList{}
+		if err := c.List(ctx, shoots,
+			client.InNamespace(secretBinding.Namespace),
+			client.MatchingFields{index.SecretBindingNameField: secretBinding.Name}); err != nil {
+			return false, err
+		}
+
+		for _, shoot := range shoots.Items {
+			if shoot.Spec.Provider.Type == providerType {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}

--- a/extensions/pkg/util/secret/secret_test.go
+++ b/extensions/pkg/util/secret/secret_test.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secret_test
+
+import (
+	"context"
+	"testing"
+
+	secretutil "github.com/gardener/gardener/extensions/pkg/util/secret"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSecretUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Secret utils suite")
+}
+
+var _ = Describe("Secret", func() {
+
+	Context("#IsSecretInUseByShoot", func() {
+		const namespace = "namespace"
+
+		var (
+			scheme *runtime.Scheme
+
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: namespace,
+				},
+			}
+			secretBinding = &gardencorev1beta1.SecretBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secretbinding",
+					Namespace: namespace,
+				},
+				SecretRef: corev1.SecretReference{
+					Name:      secret.Name,
+					Namespace: secret.Namespace,
+				},
+			}
+			shoot = &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "shoot",
+					Namespace: namespace,
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					Provider: gardencorev1beta1.Provider{
+						Type: "gcp",
+					},
+					SecretBindingName: secretBinding.Name,
+				},
+			}
+		)
+
+		BeforeEach(func() {
+			scheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).NotTo(HaveOccurred())
+			Expect(gardencorev1beta1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		})
+
+		It("should return false when the Secret is not used", func() {
+			client := fake.NewFakeClientWithScheme(
+				scheme,
+				secret,
+				secretBinding,
+			)
+
+			isUsed, err := secretutil.IsSecretInUseByShoot(context.TODO(), client, secret, "gcp")
+			Expect(isUsed).To(BeFalse())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return false when the Secret is in use but the provider does not match", func() {
+			client := fake.NewFakeClientWithScheme(
+				scheme,
+				secret,
+				secretBinding,
+				shoot,
+			)
+
+			isUsed, err := secretutil.IsSecretInUseByShoot(context.TODO(), client, secret, "other")
+			Expect(isUsed).To(BeFalse())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return true when the Secret is in use by Shoot with the given provider", func() {
+			client := fake.NewFakeClientWithScheme(
+				scheme,
+				secret,
+				secretBinding,
+				shoot,
+			)
+
+			isUsed, err := secretutil.IsSecretInUseByShoot(context.TODO(), client, secret, "gcp")
+			Expect(isUsed).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return true when the Secret is in use by Shoot from another namespace", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret",
+					Namespace: "another-namespace",
+				},
+			}
+			secretBinding := &gardencorev1beta1.SecretBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secretbinding",
+					Namespace: namespace,
+				},
+				SecretRef: corev1.SecretReference{
+					Name:      secret.Name,
+					Namespace: secret.Namespace,
+				},
+			}
+
+			client := fake.NewFakeClientWithScheme(
+				scheme,
+				secret,
+				secretBinding,
+				shoot,
+			)
+
+			isUsed, err := secretutil.IsSecretInUseByShoot(context.TODO(), client, secret, "gcp")
+			Expect(isUsed).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind task
/priority normal

**What this PR does / why we need it**:
This PR adds common funcs to the extensions library. Initially these funcs are part of https://github.com/gardener/gardener-extension-provider-gcp/pull/112 and this PR moves them to the extensions library to make possible also usage from validators for other providers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
