### PR TITLE
Adds some detail logging to test shoot creation/reconciliation loops

### DIFF
--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -305,10 +305,11 @@ func (f *GardenerFramework) WaitForShootToBeCreated(ctx context.Context, shoot *
 			return retry.MinorError(err)
 		}
 		*shoot = *newShoot
-		if ShootCreationCompleted(shoot) {
+		completed, msg := ShootCreationCompleted(shoot)
+		if completed {
 			return retry.Ok()
 		}
-		f.Logger.Infof("Waiting for shoot %s to be created", shoot.Name)
+		f.Logger.Infof("Shoot %s not yet created successfully (%s)", shoot.Name, msg)
 		if shoot.Status.LastOperation != nil {
 			f.Logger.Infof("%d%%: Shoot State: %s, Description: %s", shoot.Status.LastOperation.Progress, shoot.Status.LastOperation.State, shoot.Status.LastOperation.Description)
 		}
@@ -347,10 +348,11 @@ func (f *GardenerFramework) WaitForShootToBeReconciled(ctx context.Context, shoo
 			return retry.MinorError(err)
 		}
 		shoot = newShoot
-		if ShootCreationCompleted(shoot) {
+		completed, msg := ShootCreationCompleted(shoot)
+		if completed {
 			return retry.Ok()
 		}
-		f.Logger.Infof("Waiting for shoot %s to be reconciled", shoot.Name)
+		f.Logger.Infof("Shoot %s not yet reconciled successfully (%s)", shoot.Name, msg)
 		if newShoot.Status.LastOperation != nil {
 			f.Logger.Debugf("%d%%: Shoot State: %s, Description: %s", shoot.Status.LastOperation.Progress, shoot.Status.LastOperation.State, shoot.Status.LastOperation.Description)
 		}

--- a/test/system/complete_reconcile/gardener_reconcile_test.go
+++ b/test/system/complete_reconcile/gardener_reconcile_test.go
@@ -73,9 +73,12 @@ var _ = Describe("Shoot reconciliation testing", func() {
 					f.Logger.Debugf("last acted gardener version %s does not match current gardener version %s", shoot.Status.Gardener.Version, *gardenerVersion)
 					continue
 				}
-				if framework.ShootCreationCompleted(&shoot) {
+				if completed, msg := framework.ShootCreationCompleted(&shoot); completed {
 					reconciledShoots++
+				} else {
+					f.Logger.Debugf("Shoot %s not yet reconciled successfully (%s)", shoot.Name, msg)
 				}
+
 			}
 
 			if reconciledShoots != len(shoots.Items) {


### PR DESCRIPTION
**How to categorize this PR?**
/area testing
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Adds some details to logging in the integration tests of shoot creation and reconciliation so that the logs contain the reason why a shoot was not considered as successfully created or reconciled.

**Which issue(s) this PR fixes**:
Misleading and incomplete logging.