### PR TITLE
Don't delete tunnel secrets on deletion

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -1365,7 +1365,7 @@ func (b *Botanist) setAPIServerServiceClusterIP(clusterIP string) {
 			},
 			Name:                     v1beta1constants.DeploymentNameKubeAPIServer,
 			IstioIngressNamespace:    common.IstioIngressGatewayNamespace,
-			EnableKonnectivityTunnel: gardenletfeatures.FeatureGate.Enabled(features.KonnectivityTunnel),
+			EnableKonnectivityTunnel: b.Shoot.KonnectivityTunnelEnabled,
 		},
 		b.Shoot.SeedNamespace,
 		b.K8sSeedClient.ChartApplier(),

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -90,13 +90,15 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 		}
 	}
 
-	if b.Shoot.KonnectivityTunnelEnabled {
-		if err := b.cleanupTunnelSecrets(ctx, &gardenerResourceDataList, "vpn-seed", "vpn-seed-tlsauth", "vpn-shoot"); err != nil {
-			return err
-		}
-	} else {
-		if err := b.cleanupTunnelSecrets(ctx, &gardenerResourceDataList, common.KonnectivityServerKubeconfig, common.KonnectivityServerCertName); err != nil {
-			return err
+	if b.Shoot.Info.DeletionTimestamp != nil {
+		if b.Shoot.KonnectivityTunnelEnabled {
+			if err := b.cleanupTunnelSecrets(ctx, &gardenerResourceDataList, "vpn-seed", "vpn-seed-tlsauth", "vpn-shoot"); err != nil {
+				return err
+			}
+		} else {
+			if err := b.cleanupTunnelSecrets(ctx, &gardenerResourceDataList, common.KonnectivityServerKubeconfig, common.KonnectivityServerCertName); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/priority normal

**What this PR does / why we need it**:
If the `KonnectivityTunnel` was enabled while a Shoot was hibernated, it can't be deleted without being reconciled first.

**Which issue(s) this PR fixes**:
Fixes #2458 

**Special notes for your reviewer**:
/invite @zanetworker 
@rfranzke and I decided to not redeploy the API server on deletion, as we are not sure about all the consequences and rather just not delete the vpn secrets on deletion, so the API server can get ready again.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue has been fixed, which caused the deletion of hibernated Shoots to be blocked if the `KonnectivityTunnel` has been enabled while the Shoot was hibernated.
```
