### PR TITLE
 Update the helm install script version

### DIFF
--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -20,7 +20,7 @@ echo "> Installing requirements"
 
 export GO111MODULE=on
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
-curl -s "https://raw.githubusercontent.com/helm/helm/v2.13.1/scripts/get" | bash -s -- --version 'v2.13.1'
+curl -s "https://raw.githubusercontent.com/helm/helm/v2.16.9/scripts/get" | bash -s -- --version 'v2.13.1'
 
 if [[ "$(uname -s)" == *"Darwin"* ]]; then
   cat <<EOM


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/priority normal

**What this PR does / why we need it**:
It looks like the v2.13.1 get script is broken and fails with:

```
Downloading https://kubernetes-helm.storage.googleapis.com/helm-og:image-linux-amd64.tar.gz
SHA sum of /tmp/helm-installer-9e9VWc/helm-og:image-linux-amd64.tar.gz does not match. Aborting.
Failed to install helm with the arguments provided: --version v2.13.1
Accepted cli arguments are:
	[--help|-h ] ->> prints this help
	[--version|-v <desired_version>] . When not defined it defaults to latest
	e.g. --version v2.4.0  or -v latest
	[--no-sudo]  ->> install without sudo
	For support, go to https://github.com/helm/helm.
make: *** [Makefile:139: install-requirements] Error 1
```

It seems that the tag computation is broken for some reason

```
++ cat /var/folders/p9/6dr9snnx6ws1dxkj4b66st6r0000gn/T/helm-installer-G3nyPR/helm-og:image-darwin-amd64.tar.gz.sha256
+ local 'expected_sum=<?xml version='\''1.0'\'' encoding='\''UTF-8'\''?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: kubernetes-helm/helm-og:image-darwin-amd64.tar.gz.sha256</Details></Error>'
+ '[' 6255bd212013e0898aba6ac0fda15e35d50bf430c9018401316f31ddde32e9d9 '!=' '<?xml version='\''1.0'\'' encoding='\''UTF-8'\''?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: kubernetes-helm/helm-og:image-darwin-amd64.tar.gz.sha256</Details></Error>' ']'
+ echo 'SHA sum of /var/folders/p9/6dr9snnx6ws1dxkj4b66st6r0000gn/T/helm-installer-G3nyPR/helm-og:image-darwin-amd64.tar.gz does not match. Aborting.'
SHA sum of /var/folders/p9/6dr9snnx6ws1dxkj4b66st6r0000gn/T/helm-installer-G3nyPR/helm-og:image-darwin-amd64.tar.gz does not match. Aborting.
```

This PR adapts to use the get script from the v2.16.9 branch.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
