### PR TITLE
Gardenlet certificate rotation

### DIFF
--- a/cmd/gardenlet/app/bootstrap.go
+++ b/cmd/gardenlet/app/bootstrap.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,124 +18,62 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/gardenlet/bootstrap"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	bootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	certificatesv1beta1client "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/keyutil"
-	componentbaseconfig "k8s.io/component-base/config"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+// bootstrapKubeconfig retrieves an already existing kubeconfig for the Garden cluster from the Seed or bootstraps a new one
 func bootstrapKubeconfig(
 	ctx context.Context,
 	logger *logrus.Logger,
-	gardenClientConnection *config.GardenClientConnection,
-	seedClientConnection componentbaseconfig.ClientConnectionConfiguration,
-	seedConfig *config.SeedConfig,
+	seedClient client.Client,
+	config *config.GardenletConfiguration,
 ) (
 	[]byte,
 	string,
 	string,
 	error,
 ) {
-	seedRESTCfg, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&seedClientConnection, nil)
-	if err != nil {
-		return nil, "", "", err
-	}
-	k8sSeedClient, err := kubernetes.NewWithConfig(kubernetes.WithRESTConfig(seedRESTCfg))
+	gardenKubeconfig, err := bootstraputil.GetKubeconfigFromSecret(ctx, seedClient, config.GardenClientConnection.KubeconfigSecret.Namespace, config.GardenClientConnection.KubeconfigSecret.Name)
 	if err != nil {
 		return nil, "", "", err
 	}
 
-	kubeconfigSecret := &corev1.Secret{}
-	if err := k8sSeedClient.DirectClient().Get(ctx, kutil.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), kubeconfigSecret); client.IgnoreNotFound(err) != nil {
-		return nil, "", "", err
-	}
-
-	if len(kubeconfigSecret.Data[kubernetes.KubeConfig]) > 0 {
+	if len(gardenKubeconfig) > 0 {
 		logger.Info("Found kubeconfig generated from bootstrap process. Using it")
-		return kubeconfigSecret.Data[kubernetes.KubeConfig], "", "", nil
+		return gardenKubeconfig, "", "", nil
 	}
 
-	// kubeconfig secret not found or empty - trigger bootstrap process
-	if gardenClientConnection.BootstrapKubeconfig == nil {
-		return nil, "", "", fmt.Errorf("cannot trigger kubeconfig bootstrap process because `.gardenClientConnection.bootstrapKubeconfig` is not set")
+	logger.Info("No kubeconfig from a previous bootstrap found. Starting bootstrap process.")
+
+	if config.GardenClientConnection.BootstrapKubeconfig == nil {
+		logger.Warn("Unable to perform kubeconfig bootstrapping. The gardenlet configuration `.gardenClientConnection.bootstrapKubeconfig` is not set")
+		return nil, "", "", nil
 	}
 
-	logger.Info("No kubeconfig for garden cluster found, but bootstrap kubeconfig was given.")
-
-	// check if we got a kubeconfig for bootstrapping
-	bootstrapKubeconfigSecret := &corev1.Secret{}
-	if err := k8sSeedClient.DirectClient().Get(ctx, kutil.Key(gardenClientConnection.BootstrapKubeconfig.Namespace, gardenClientConnection.BootstrapKubeconfig.Name), bootstrapKubeconfigSecret); err != nil {
-		return nil, "", "", err
-	}
-	if len(bootstrapKubeconfigSecret.Data[kubernetes.KubeConfig]) == 0 {
-		return nil, "", "", fmt.Errorf("bootstrap kubeconfig secret does not contain a kubeconfig")
-	}
-
-	// create certificate client with bootstrap kubeconfig in order to create CSR
-	bootstrapClientConfig, err := clientcmd.NewClientConfigFromBytes(bootstrapKubeconfigSecret.Data[kubernetes.KubeConfig])
-	if err != nil {
-		return nil, "", "", err
-	}
-	bootstrapConfig, err := bootstrapClientConfig.ClientConfig()
-	if err != nil {
-		return nil, "", "", err
-	}
-	bootstrapClient, err := certificatesv1beta1client.NewForConfig(bootstrapConfig)
-	if err != nil {
-		return nil, "", "", fmt.Errorf("unable to create certificates signing request client: %v", err)
-	}
-
-	logger.Info("Creating certificate signing request...")
-
-	// generate a new private key and create a CSR resource + wait until it got approved/signed
-	seedName := "<ambiguous>"
-	if seedConfig != nil {
-		seedName = seedConfig.Name
-	}
-	privateKeyData, err := keyutil.MakeEllipticPrivateKeyPEM()
-	if err != nil {
-		return nil, "", "", fmt.Errorf("error generating key: %v", err)
-	}
-	certData, csrName, err := bootstrap.RequestSeedCertificate(ctx, bootstrapClient.CertificateSigningRequests(), privateKeyData, seedName)
+	bootstrapKubeconfig, err := bootstraputil.GetKubeconfigFromSecret(ctx, seedClient, config.GardenClientConnection.BootstrapKubeconfig.Namespace, config.GardenClientConnection.BootstrapKubeconfig.Name)
 	if err != nil {
 		return nil, "", "", err
 	}
 
-	logger.Infof("Certificate signing request got approved! Creating kubeconfig and storing it in secret %s/%s", gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name)
+	if len(bootstrapKubeconfig) == 0 {
+		logger.Warnf("unable to perform kubeconfig bootstrap. Bootstrap secret %s/%s does not contain a kubeconfig", config.GardenClientConnection.BootstrapKubeconfig.Namespace, config.GardenClientConnection.BootstrapKubeconfig.Name)
+		return nil, "", "", nil
+	}
 
-	// marshal kubeconfig with just derived client certificate
-	kubeconfig, err := bootstrap.MarshalKubeconfigWithClientCertificate(bootstrapConfig, privateKeyData, certData)
+	bootstrapClient, bootstrapRestConfig, err := bootstrap.CreateBootstrapClientFromKubeconfig(bootstrapKubeconfig)
 	if err != nil {
-		return nil, "", "", err
+		return nil, "", "", fmt.Errorf("unable to create bootstrap client from bootstrap kubeconfig: %v", err)
 	}
 
-	// store kubeconfig in kubeconfig secret in seed cluster and delete bootstrap kubeconfig secret
-	kubeconfigSecret.ObjectMeta = metav1.ObjectMeta{
-		Name:      gardenClientConnection.KubeconfigSecret.Name,
-		Namespace: gardenClientConnection.KubeconfigSecret.Namespace,
-	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, k8sSeedClient.DirectClient(), kubeconfigSecret, func() error {
-		kubeconfigSecret.Data = map[string][]byte{kubernetes.KubeConfig: kubeconfig}
-		return nil
-	}); err != nil {
-		return nil, "", "", err
-	}
+	bootstrapTargetCluster := bootstraputil.GetTargetClusterName(config.SeedClientConnection)
+	seedName := bootstraputil.GetSeedName(config.SeedConfig)
 
-	logger.Infof("Deleting secret %s/%s holding bootstrap kubeconfig", gardenClientConnection.BootstrapKubeconfig.Namespace, gardenClientConnection.BootstrapKubeconfig.Name)
+	logger.Info("Using provided bootstrap kubeconfig to request signed certificate.")
 
-	if err := k8sSeedClient.DirectClient().Delete(ctx, bootstrapKubeconfigSecret); client.IgnoreNotFound(err) != nil {
-		return nil, "", "", err
-	}
-
-	return kubeconfig, csrName, seedName, nil
+	return bootstrap.RequestBootstrapKubeconfig(ctx, logger, seedClient, bootstrapClient, bootstrapRestConfig, config.GardenClientConnection, seedName, bootstrapTargetCluster)
 }

--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -135,18 +135,9 @@ func RESTConfigFromClientConnectionConfiguration(cfg *componentbaseconfig.Client
 			return nil, err
 		}
 	} else {
-		clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
+		restConfig, err = RESTConfigFromKubeconfig(kubeconfig)
 		if err != nil {
-			return nil, err
-		}
-
-		if err := validateClientConfig(clientConfig); err != nil {
-			return nil, err
-		}
-
-		restConfig, err = clientConfig.ClientConfig()
-		if err != nil {
-			return nil, err
+			return restConfig, err
 		}
 	}
 
@@ -157,6 +148,24 @@ func RESTConfigFromClientConnectionConfiguration(cfg *componentbaseconfig.Client
 		restConfig.ContentType = cfg.ContentType
 	}
 
+	return restConfig, nil
+}
+
+// RESTConfigFromKubeconfig returns a rest.Config from the bytes of a kubeconfig
+func RESTConfigFromKubeconfig(kubeconfig []byte) (*rest.Config, error) {
+	clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateClientConfig(clientConfig); err != nil {
+		return nil, err
+	}
+
+	restConfig, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
 	return restConfig, nil
 }
 

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -52,7 +52,7 @@ type GardenletConfiguration struct {
 	// "github.com/gardener/gardener/pkg/gardenlet/features/features.go".
 	// Default: nil
 	FeatureGates map[string]bool
-	// SeedConfig contains configuration for the seed cluster. May not be set if seed selector is set.
+	// SeedConfig contains configuration for the seed cluster. Must not be set if seed selector is set.
 	// In this case the gardenlet creates the `Seed` object itself based on the provided config.
 	SeedConfig *SeedConfig
 	// SeedSelector contains an optional list of labels on `Seed` resources that shall be managed by

--- a/pkg/gardenlet/bootstrap/bootstrap.go
+++ b/pkg/gardenlet/bootstrap/bootstrap.go
@@ -1,39 +1,32 @@
-/*
-Copyright 2016 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-This file was copied and modified from the kubernetes/kubernetes project
-https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/certificate/bootstrap/bootstrap.go
-
-Modifications Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved.
-*/
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package bootstrap
 
 import (
 	"context"
-	"crypto"
-	"crypto/sha512"
-	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/base64"
 	"fmt"
+	"net"
 	"strings"
-	"time"
 
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	"github.com/gardener/gardener/pkg/gardenlet/bootstrap/certificate"
+	bootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
+	"github.com/sirupsen/logrus"
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -43,160 +36,61 @@ import (
 	certificatesv1beta1client "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	certutil "k8s.io/client-go/util/cert"
-	"k8s.io/client-go/util/certificate/csr"
-	"k8s.io/client-go/util/keyutil"
 	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// RequestSeedCertificate will create a certificate signing request for a seed
-// (Organization and CommonName for the CSR will be set as expected for seed
-// certificates) and send it to API server, then it will watch the object's
-// status, once approved by API server, it will return the API server's issued
-// certificate (pem-encoded). If there is any errors, or the watch timeouts, it
-// will return an error. This is intended for use on seeds (gardenlet).
-func RequestSeedCertificate(ctx context.Context, certificateClient certificatesv1beta1client.CertificateSigningRequestInterface, privateKeyData []byte, seedName string) (certData []byte, csrName string, err error) {
-	return RequestCertificate(ctx, certificateClient, privateKeyData, "gardener.cloud:system:seed:"+string(seedName), []string{"gardener.cloud:system:seeds"})
+// CreateBootstrapClientFromKubeconfig creates a CertificatesV1beta1Client client from a given kubeconfig
+func CreateBootstrapClientFromKubeconfig(kubeconfig []byte) (*certificatesv1beta1client.CertificatesV1beta1Client, *rest.Config, error) {
+	bootstrapClientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bootstrapConfig, err := bootstrapClientConfig.ClientConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+	bootstrapClient, err := certificatesv1beta1client.NewForConfig(bootstrapConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	return bootstrapClient, bootstrapConfig, nil
 }
 
-// RequestCertificate will create a certificate signing request for a given
-// organization and common name for the CSR will be set as expected for seed
-// certificates) and send it to API server, then it will watch the object's
-// status, once approved by API server, it will return the API server's issued
-// certificate (pem-encoded). If there is any errors, or the watch timeouts, it
-// will return an error.
-func RequestCertificate(ctx context.Context, certificateClient certificatesv1beta1client.CertificateSigningRequestInterface, privateKeyData []byte, commonName string, organization []string) (certData []byte, csrName string, err error) {
-	subject := &pkix.Name{
-		Organization: organization,
-		CommonName:   commonName,
+// RequestBootstrapKubeconfig creates a kubeconfig with a signed certificate using the given bootstrap client
+// returns the kubeconfig []byte representation, the CSR name, the seed name or an error
+func RequestBootstrapKubeconfig(ctx context.Context, logger logrus.FieldLogger, seedClient client.Client, bootstrapClient certificatesv1beta1client.CertificatesV1beta1Interface, bootstrapConfig *rest.Config, gardenClientConnection *config.GardenClientConnection, seedName, bootstrapTargetCluster string) ([]byte, string, string, error) {
+	certificateSubject := &pkix.Name{
+		Organization: []string{"gardener.cloud:system:seeds"},
+		CommonName:   "gardener.cloud:system:seed:" + seedName,
 	}
 
-	privateKey, err := keyutil.ParsePrivateKeyPEM(privateKeyData)
+	certData, privateKeyData, csrName, err := certificate.RequestCertificate(ctx, logger, bootstrapClient, certificateSubject, []string{}, []net.IP{})
 	if err != nil {
-		return nil, "", fmt.Errorf("invalid private key for certificate request: %v", err)
+		return nil, "", "", fmt.Errorf("unable to bootstrap the kubeconfig for the Garden cluster: %v", err)
 	}
-	csrData, err := certutil.MakeCSR(privateKey, subject, nil, nil)
+
+	logger.Infof("Storing kubeconfig with bootstrapped certificate into secret (%s/%s) on target cluster '%s'", gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name, bootstrapTargetCluster)
+
+	kubeconfig, err := bootstraputil.UpdateGardenKubeconfigSecret(ctx, bootstrapConfig, certData, privateKeyData, seedClient, gardenClientConnection)
 	if err != nil {
-		return nil, "", fmt.Errorf("unable to generate certificate request: %v", err)
+		return nil, "", "", fmt.Errorf("unable to update secret (%s/%s) with bootstrapped kubeconfig: %v", gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name, err)
 	}
 
-	usages := []certificatesv1beta1.KeyUsage{
-		certificatesv1beta1.UsageDigitalSignature,
-		certificatesv1beta1.UsageKeyEncipherment,
-		certificatesv1beta1.UsageClientAuth,
+	logger.Infof("Deleting secret (%s/%s) containing the bootstrap kubeconfig from target cluster '%s')", gardenClientConnection.BootstrapKubeconfig.Namespace, gardenClientConnection.BootstrapKubeconfig.Name, bootstrapTargetCluster)
+
+	bootstrapSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gardenClientConnection.BootstrapKubeconfig.Name,
+			Namespace: gardenClientConnection.BootstrapKubeconfig.Namespace,
+		},
 	}
 
-	// The Signer interface contains the Public() method to get the public key.
-	signer, ok := privateKey.(crypto.Signer)
-	if !ok {
-		return nil, "", fmt.Errorf("private key does not implement crypto.Signer")
+	if err := seedClient.Delete(ctx, bootstrapSecret); client.IgnoreNotFound(err) != nil {
+		return nil, "", "", err
 	}
-
-	name, err := digestedName(signer.Public(), subject, usages)
-	if err != nil {
-		return nil, "", err
-	}
-
-	req, err := csr.RequestCertificate(certificateClient, csrData, name, usages, privateKey)
-	if err != nil {
-		return nil, "", err
-	}
-
-	childCtx, cancel := context.WithTimeout(ctx, 3600*time.Second)
-	defer cancel()
-
-	certData, err = csr.WaitForCertificate(childCtx, certificateClient, req)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return certData, req.Name, nil
-}
-
-// This digest should include all the relevant pieces of the CSR we care about.
-// We can't directly hash the serialized CSR because of random padding that we
-// regenerate every loop and we include usages which are not contained in the
-// CSR. This needs to be kept up to date as we add new fields to the node
-// certificates and with ensureCompatible.
-func digestedName(publicKey interface{}, subject *pkix.Name, usages []certificatesv1beta1.KeyUsage) (string, error) {
-	hash := sha512.New512_256()
-
-	// Here we make sure two different inputs can't write the same stream
-	// to the hash. This delimiter is not in the base64.URLEncoding
-	// alphabet so there is no way to have spill over collisions. Without
-	// it 'CN:foo,ORG:bar' hashes to the same value as 'CN:foob,ORG:ar'
-	const delimiter = '|'
-	encode := base64.RawURLEncoding.EncodeToString
-
-	write := func(data []byte) {
-		_, _ = hash.Write([]byte(encode(data)))
-		_, _ = hash.Write([]byte{delimiter})
-	}
-
-	publicKeyData, err := x509.MarshalPKIXPublicKey(publicKey)
-	if err != nil {
-		return "", err
-	}
-	write(publicKeyData)
-
-	write([]byte(subject.CommonName))
-	for _, v := range subject.Organization {
-		write([]byte(v))
-	}
-	for _, v := range usages {
-		write([]byte(v))
-	}
-
-	return fmt.Sprintf("seed-csr-%s", encode(hash.Sum(nil))), nil
-}
-
-// MarshalKubeconfigWithClientCertificate marshals the kubeconfig derived from the bootstrapping process.
-func MarshalKubeconfigWithClientCertificate(config *rest.Config, privateKeyData, certDat []byte) ([]byte, error) {
-	return kubeconfigWithAuthInfo(config, &clientcmdapi.AuthInfo{
-		ClientCertificateData: certDat,
-		ClientKeyData:         privateKeyData,
-	})
-}
-
-// MarshalKubeconfigWithToken marshals the kubeconfig derived with the given bootstrap token.
-func MarshalKubeconfigWithToken(config *rest.Config, token string) ([]byte, error) {
-	return kubeconfigWithAuthInfo(config, &clientcmdapi.AuthInfo{
-		Token: token,
-	})
-}
-
-func kubeconfigWithAuthInfo(config *rest.Config, authInfo *clientcmdapi.AuthInfo) ([]byte, error) {
-	// Get the CA data from the bootstrap client config.
-	caFile, caData := config.CAFile, []byte{}
-	if len(caFile) == 0 {
-		caData = config.CAData
-	}
-
-	return clientcmd.Write(clientcmdapi.Config{
-		Clusters: map[string]*clientcmdapi.Cluster{"gardenlet": {
-			Server:                   config.Host,
-			InsecureSkipTLSVerify:    config.Insecure,
-			CertificateAuthority:     caFile,
-			CertificateAuthorityData: caData,
-		}},
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{"gardenlet": authInfo},
-		Contexts: map[string]*clientcmdapi.Context{"gardenlet": {
-			Cluster:  "gardenlet",
-			AuthInfo: "gardenlet",
-		}},
-		CurrentContext: "gardenlet",
-	})
-}
-
-// GardenerSeedBootstrapper is a constant for the gardener seed bootstrapper name.
-const GardenerSeedBootstrapper = "gardener.cloud:system:seed-bootstrapper"
-
-// BuildBootstrapperName concatenates the gardener seed bootstrapper group with the given name,
-// separated by a colon.
-func BuildBootstrapperName(name string) string {
-	return fmt.Sprintf("%s:%s", GardenerSeedBootstrapper, name)
+	return kubeconfig, csrName, seedName, nil
 }
 
 // DeleteBootstrapAuth checks which authentication mechanism was used to request a certificate
@@ -236,7 +130,7 @@ func DeleteBootstrapAuth(ctx context.Context, c client.Client, csrName, seedName
 			},
 			&rbacv1.ClusterRoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: BuildBootstrapperName(seedName),
+					Name: bootstraputil.BuildBootstrapperName(seedName),
 				},
 			},
 		)

--- a/pkg/gardenlet/bootstrap/bootstrap_test.go
+++ b/pkg/gardenlet/bootstrap/bootstrap_test.go
@@ -16,10 +16,13 @@ package bootstrap_test
 
 import (
 	"context"
-	"fmt"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	. "github.com/gardener/gardener/pkg/gardenlet/bootstrap"
+	bootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
+	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
@@ -31,39 +34,143 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("Bootstrap", func() {
-	Describe("BuildBootstrapperName", func() {
-		It("should return the correct name", func() {
-			name := "foo"
-			result := BuildBootstrapperName(name)
-			Expect(result).To(Equal(fmt.Sprintf("%s:%s", GardenerSeedBootstrapper, name)))
+	var (
+		ctrl       *gomock.Controller
+		c          *mockclient.MockClient
+		ctx        = context.TODO()
+		testLogger = logger.NewNopLogger()
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		c = mockclient.NewMockClient(ctrl)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#RequestBootstrapKubeconfig", func() {
+		var (
+			seedName = "test"
+
+			seedClient            client.Client
+			bootstrapClientConfig *rest.Config
+
+			gardenClientConnection *config.GardenClientConnection
+
+			approvedCSR = certificatesv1beta1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "watched-csr",
+				},
+				Status: certificatesv1beta1.CertificateSigningRequestStatus{
+					Conditions: []certificatesv1beta1.CertificateSigningRequestCondition{
+						{
+							Type: certificatesv1beta1.CertificateApproved,
+						},
+					},
+					Certificate: []byte("my-cert"),
+				},
+			}
+
+			deniedCSR = certificatesv1beta1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "watched-csr",
+				},
+				Status: certificatesv1beta1.CertificateSigningRequestStatus{
+					Conditions: []certificatesv1beta1.CertificateSigningRequestCondition{
+						{
+							Type: certificatesv1beta1.CertificateDenied,
+						},
+					},
+				},
+			}
+		)
+
+		BeforeEach(func() {
+			secretReference := corev1.SecretReference{
+				Name:      "gardenlet-kubeconfig",
+				Namespace: "garden",
+			}
+
+			bootstrapSecretReference := corev1.SecretReference{
+				Name:      "bootstrap-kubeconfig",
+				Namespace: "garden",
+			}
+
+			// gardenClientConnection with required bootstrap secret kubeconfig secret
+			// in a non-test environment we would use two different secrets
+			gardenClientConnection = &config.GardenClientConnection{
+				BootstrapKubeconfig: &bootstrapSecretReference,
+				KubeconfigSecret:    &secretReference,
+			}
+
+			// create mock seed client
+			s := runtime.NewScheme()
+			Expect(corev1.AddToScheme(s)).ToNot(HaveOccurred())
+			seedClient = fakeclient.NewFakeClientWithScheme(s)
+
+			// rest config for the bootstrap client
+			bootstrapClientConfig = &rest.Config{Host: "testhost", TLSClientConfig: rest.TLSClientConfig{
+				Insecure: false,
+				CAFile:   "filepath",
+			}}
+
+		})
+
+		It("should not return an error", func() {
+			bootstrapClient := fake.NewSimpleClientset(&approvedCSR).CertificatesV1beta1()
+
+			c.EXPECT().Get(ctx, kutil.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{}))
+
+			c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
+				secret, ok := obj.(*corev1.Secret)
+				Expect(ok).To(BeTrue())
+				Expect(secret.Name).To(Equal(gardenClientConnection.KubeconfigSecret.Name))
+				Expect(secret.Namespace).To(Equal(gardenClientConnection.KubeconfigSecret.Namespace))
+				Expect(secret.Data).ToNot(BeNil())
+				Expect(secret.Data[kubernetes.KubeConfig]).ToNot(BeEmpty())
+				return nil
+			})
+			c.EXPECT().Delete(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gardenClientConnection.BootstrapKubeconfig.Name,
+					Namespace: gardenClientConnection.BootstrapKubeconfig.Namespace,
+				},
+			})
+
+			kubeconfig, csrName, seedName, err := RequestBootstrapKubeconfig(ctx, testLogger, c, bootstrapClient, bootstrapClientConfig, gardenClientConnection, seedName, "my-cluster")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(kubeconfig).ToNot(BeEmpty())
+			Expect(len(csrName)).ToNot(Equal(0))
+			Expect(len(seedName)).ToNot(Equal(0))
+		})
+
+		It("should return an error - the CSR got denied", func() {
+			bootstrapClient := fake.NewSimpleClientset(&deniedCSR).CertificatesV1beta1()
+
+			_, _, _, err := RequestBootstrapKubeconfig(ctx, testLogger, seedClient, bootstrapClient, bootstrapClientConfig, gardenClientConnection, seedName, "my-cluster")
+			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	Describe("#DeleteBootstrapAuth", func() {
 		var (
-			ctrl *gomock.Controller
-			c    *mockclient.MockClient
-
-			ctx     = context.TODO()
 			csrName = "csr-name"
 			csrKey  = kutil.Key(csrName)
 		)
-
-		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-			c = mockclient.NewMockClient(ctrl)
-		})
-
-		AfterEach(func() {
-			ctrl.Finish()
-		})
 
 		It("should return an error because the CSR was not found", func() {
 			c.EXPECT().
@@ -112,7 +219,7 @@ var _ = Describe("Bootstrap", func() {
 				serviceAccountUserName  = serviceaccount.MakeUsername(serviceAccountNamespace, serviceAccountName)
 				serviceAccount          = &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: serviceAccountNamespace, Name: serviceAccountName}}
 
-				clusterRoleBinding = &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: BuildBootstrapperName(seedName)}}
+				clusterRoleBinding = &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: bootstraputil.BuildBootstrapperName(seedName)}}
 			)
 
 			gomock.InOrder(

--- a/pkg/gardenlet/bootstrap/certificate/certificate.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509/pkix"
+	"fmt"
+	"net"
+	"time"
+
+	bootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
+
+	"github.com/sirupsen/logrus"
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	certificatesv1beta1client "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/certificate/csr"
+	"k8s.io/client-go/util/keyutil"
+)
+
+// RequestCertificate will create a certificate signing request for the Gardenlet
+// and send it to API server, then it will watch the object's
+// status, once approved by the gardener-controller-manager, it will return the kube-controller-manager's issued
+// certificate (pem-encoded). If there is any errors, or the watch timeouts, it
+// will return an error.
+func RequestCertificate(ctx context.Context, logger logrus.FieldLogger, certClient certificatesv1beta1client.CertificatesV1beta1Interface, certificateSubject *pkix.Name, dnsSANs []string, ipSANs []net.IP) ([]byte, []byte, string, error) {
+	if certificateSubject == nil || len(certificateSubject.CommonName) == 0 {
+		return nil, nil, "", fmt.Errorf("unable to request certificate. The Common Name (CN) of the of the certificate Subject has to be set")
+	}
+
+	privateKeyData, err := keyutil.MakeEllipticPrivateKeyPEM()
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("error generating client certificate private key: %v", err)
+	}
+
+	certData, csrName, err := requestCertificate(ctx, logger, certClient.CertificateSigningRequests(), privateKeyData, certificateSubject, dnsSANs, ipSANs)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	return certData, privateKeyData, csrName, nil
+}
+
+// requestCertificate will create a certificate signing request for the Gardenlet
+// and send it to API server, then it will watch the object's
+// status, once approved by the gardener-controller-manager, it will return the kube-controller-manager's issued
+// certificate (pem-encoded). If there is any errors, or the watch timeouts, it
+// will return an error.
+func requestCertificate(ctx context.Context, logger logrus.FieldLogger, certificateClient certificatesv1beta1client.CertificateSigningRequestInterface, privateKeyData []byte, certificateSubject *pkix.Name, dnsSANs []string, ipSANs []net.IP) (certData []byte, csrName string, err error) {
+	privateKey, err := keyutil.ParsePrivateKeyPEM(privateKeyData)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid private key for certificate request: %v", err)
+	}
+	csrData, err := certutil.MakeCSR(privateKey, certificateSubject, dnsSANs, ipSANs)
+	if err != nil {
+		return nil, "", fmt.Errorf("unable to generate certificate request: %v", err)
+	}
+
+	usages := []certificatesv1beta1.KeyUsage{
+		certificatesv1beta1.UsageDigitalSignature,
+		certificatesv1beta1.UsageKeyEncipherment,
+		certificatesv1beta1.UsageClientAuth,
+	}
+
+	// The Signer interface contains the Public() method to get the public key.
+	signer, ok := privateKey.(crypto.Signer)
+	if !ok {
+		return nil, "", fmt.Errorf("private key does not implement crypto.Signer")
+	}
+
+	name, err := bootstraputil.DigestedName(signer.Public(), certificateSubject, usages)
+	if err != nil {
+		return nil, "", err
+	}
+
+	logger.Info("Creating certificate signing request...")
+
+	req, err := csr.RequestCertificate(certificateClient, csrData, name, usages, privateKey)
+	if err != nil {
+		return nil, "", err
+	}
+
+	childCtx, cancel := context.WithTimeout(ctx, 15*time.Minute)
+	defer cancel()
+
+	logger.Infof("Waiting for certificate signing request %q to be approved and contain the client certificate ...", req.Name)
+
+	certData, err = csr.WaitForCertificate(childCtx, certificateClient, req)
+	if err != nil {
+		return nil, "", err
+	}
+
+	logger.Infof("Certificate signing request got approved. Retrieved client certificate!")
+
+	return certData, req.Name, nil
+}

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
@@ -1,0 +1,256 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"net"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
+	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	bootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
+	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/utils/retry"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var (
+	// certificateWaitTimeout controls the amount of time we wait for the certificate
+	// approval in one iteration.
+	certificateWaitTimeout = 15 * time.Minute
+
+	// EventGardenletCertificateRotationFailed is an event reason to describe a failed Gardenlet certificate rotation.
+	EventGardenletCertificateRotationFailed = "GardenletCertificateRotationFailed"
+)
+
+// Manager can be used to schedule the certificate rotation for the Gardenlet's Garden cluster client certificate
+type Manager struct {
+	logger                 logrus.FieldLogger
+	clientMap              clientmap.ClientMap
+	seedClient             client.Client
+	gardenClientConnection *config.GardenClientConnection
+	targetClusterName      string
+	seedName               string
+	seedSelector           *metav1.LabelSelector
+}
+
+// NewCertificateRotation creates a certificate manager that can be used to rotate gardenlet's client certificate for the Garden cluster
+func NewCertificateManager(clientMap clientmap.ClientMap, seedClient client.Client, config *config.GardenletConfiguration) *Manager {
+	seedName := bootstraputil.GetSeedName(config.SeedConfig)
+	gardenletTargetClusterName := bootstraputil.GetTargetClusterName(config.SeedClientConnection)
+
+	return &Manager{
+		logger:                 logger.NewFieldLogger(logger.Logger, "certificate-rotation", fmt.Sprintf("seed: %s, target cluster: %s", seedName, gardenletTargetClusterName)),
+		clientMap:              clientMap,
+		seedClient:             seedClient,
+		gardenClientConnection: config.GardenClientConnection,
+		seedName:               seedName,
+		targetClusterName:      gardenletTargetClusterName,
+		seedSelector:           config.SeedSelector,
+	}
+}
+
+// ScheduleCertificateRotation waits until the currently used Garden cluster client certificate approaches expiration.
+// Then requests a new certificate and stores the kubeconfig in a secret (`gardenClientConnection.kubeconfigSecret`) on the Seed.
+// the argument is a context.Cancel function to cancel the context of the Gardenlet used for graceful termination after a successful certificate rotation.
+// When the new gardenlet pod is started, it uses the rotated certificate stored in the secret in the Seed cluster
+func (cr *Manager) ScheduleCertificateRotation(ctx context.Context, gardenletCancel context.CancelFunc, recorder record.EventRecorder) {
+	go wait.Until(func() {
+		certificateSubject, dnsSANs, ipSANs, certificateExpirationTime, err := waitForCertificateRotation(ctx, cr.logger, cr.seedClient, cr.gardenClientConnection, time.Now)
+		if err != nil {
+			cr.logger.Errorf("waiting for the certificate rotation failed: %v", err)
+			return
+		}
+
+		err = retry.Until(ctx, certificateWaitTimeout, func(ctx context.Context) (bool, error) {
+			ctxWithTimeout, cancel := context.WithTimeout(ctx, certificateWaitTimeout)
+			defer cancel()
+
+			err := rotateCertificate(ctxWithTimeout, cr.logger, cr.clientMap, cr.seedClient, cr.gardenClientConnection, certificateSubject, dnsSANs, ipSANs)
+			if err != nil {
+				cr.logger.Errorf("certificate rotation failed: %v", err)
+				return retry.MinorError(err)
+			}
+			return retry.Ok()
+		})
+		if err != nil {
+			msg := fmt.Sprintf("Failed to rotate the kubeconfig for the Garden API Server. Certificate expires in %s (%s): %v", certificateExpirationTime.UTC().Sub(time.Now().UTC()).Round(time.Second).String(), certificateExpirationTime.Round(time.Second).String(), err)
+			cr.logger.Error(msg)
+			seeds, err := cr.getTargetedSeeds(ctx)
+			if err != nil {
+				cr.logger.Warnf("failed to record event on seeds announcing the failed certificate rotation: %v", err)
+				return
+			}
+			for _, seed := range seeds {
+				recorder.Event(&seed, corev1.EventTypeWarning, EventGardenletCertificateRotationFailed, msg)
+			}
+			return
+		}
+
+		cr.logger.Info("Terminating Gardenlet after successful certificate rotation.")
+		gardenletCancel()
+	}, time.Second, ctx.Done())
+}
+
+// waitForCertificateRotation determines and waits for the certificate rotation deadline.
+// Reschedules the certificate rotation in case the underlying certificate expiration date has changed in the meanwhile.
+func waitForCertificateRotation(ctx context.Context, logger logrus.FieldLogger, seedClient client.Client, gardenClientConnection *config.GardenClientConnection, now func() time.Time) (*pkix.Name, []string, []net.IP, *time.Time, error) {
+	cert, err := getCurrentCertificate(ctx, logger, seedClient, gardenClientConnection)
+	if err != nil {
+		return nil, []string{}, []net.IP{}, nil, err
+	}
+	deadline := nextRotationDeadline(*cert)
+	logger.Infof("Certificate expiration is at %v, rotation deadline is at %v", cert.Leaf.NotAfter, deadline)
+
+	if sleepInterval := deadline.Sub(now()); sleepInterval > 0 {
+		logger.Infof("Waiting for next certificate rotation in %d days (%s)", int(sleepInterval.Hours()/24), sleepInterval.Round(time.Second).String())
+		// block until certificate rotation or until context is cancelled
+		select {
+		case <-ctx.Done():
+			return nil, []string{}, []net.IP{}, nil, ctx.Err()
+		case <-time.After(sleepInterval):
+		}
+	}
+
+	logger.Infof("Starting the certificate rotation")
+
+	// check the validity of the certificate again. It might have changed
+	currentCert, err := getCurrentCertificate(ctx, logger, seedClient, gardenClientConnection)
+	if err != nil {
+		return nil, []string{}, []net.IP{}, nil, err
+	}
+
+	if currentCert.Leaf.NotAfter != cert.Leaf.NotAfter {
+		return nil, []string{}, []net.IP{}, nil, fmt.Errorf("the certificates expiration date has been changed. Rescheduling certificate rotation")
+	}
+	return &currentCert.Leaf.Subject, currentCert.Leaf.DNSNames, currentCert.Leaf.IPAddresses, &currentCert.Leaf.NotAfter, nil
+}
+
+func getCurrentCertificate(ctx context.Context, logger logrus.FieldLogger, seedClient client.Client, gardenClientConnection *config.GardenClientConnection) (*tls.Certificate, error) {
+	secretName := gardenClientConnection.KubeconfigSecret.Name
+	secretNamespace := gardenClientConnection.KubeconfigSecret.Namespace
+
+	gardenKubeconfig, err := bootstraputil.GetKubeconfigFromSecret(ctx, seedClient, gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(gardenKubeconfig) == 0 {
+		logger.Infof("secret (%s/%s) on the target cluster does not contain a kubeconfig. Falling back to `gardenClientConnection.Kubeconfig`. The secret's `.data` field should contain a key `kubeconfig` that is mapped to a byte representation of the garden kubeconfig", secretNamespace, secretName)
+		// check if there is a locally provided kubeconfig via Gardenlet configuration `gardenClientConnection.Kubeconfig`
+		if len(gardenClientConnection.Kubeconfig) == 0 {
+			return nil, fmt.Errorf("the secret (%s/%s) on the target cluster does not contain a kubeconfig and there is no fallback kubeconfig specified in `gardenClientConnection.Kubeconfig`. The secret's `.data` field should contain a key `kubeconfig` that is mapped to a byte representation of the garden kubeconfig. Possibly there was an external change to the secret specified in `gardenClientConnection.KubeconfigSecret`. If this error continues, stop the gardenlet, and either configure it with a fallback kubeconfig in `gardenClientConnection.Kubeconfig`, or provide `gardenClientConnection.KubeconfigBootstrap` to bootstrap a new certificate", secretNamespace, secretName)
+		}
+	}
+
+	// get a rest config from either the `gardenClientConnection.KubeconfigSecret` or from the fallback kubeconfig specified in `gardenClientConnection.Kubeconfig`
+	restConfig, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&gardenClientConnection.ClientConnectionConfiguration, gardenKubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := tls.X509KeyPair(restConfig.CertData, restConfig.KeyData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse X509 certificate from kubeconfig in secret %s/%s on the target cluster: %v", secretNamespace, secretName, err)
+	}
+
+	if len(cert.Certificate) < 1 {
+		return nil, fmt.Errorf("the X509 certificate from kubeconfig in secret %s/%s on the target cluster is invalid. No cert/key data found", secretNamespace, secretName)
+	}
+
+	certs, err := x509.ParseCertificates(cert.Certificate[0])
+	if err != nil {
+		return nil, fmt.Errorf("the X509 certificate from kubeconfig in secret %s/%s on the target cluster cannot be parsed: %v", secretNamespace, secretName, err)
+	}
+
+	if len(certs) < 1 {
+		return nil, fmt.Errorf("the X509 certificate from kubeconfig in secret %s/%s on the target cluster is invalid", secretNamespace, secretName)
+	}
+
+	cert.Leaf = certs[0]
+	return &cert, nil
+}
+
+// rotateCertificate uses an already existing garden client (already bootstrapped) to request a new client certificate
+// after successful retrieval of the client certificate, updates the secret in the seed with the rotated kubeconfig
+func rotateCertificate(ctx context.Context, logger logrus.FieldLogger, clientMap clientmap.ClientMap, seedClient client.Client, gardenClientConnection *config.GardenClientConnection, certificateSubject *pkix.Name, dnsSANs []string, ipSANs []net.IP) error {
+	// client to communicate with the Garden API server to create the CSR
+	gardenClient, err := clientMap.GetClient(ctx, keys.ForGarden())
+	if err != nil {
+		return err
+	}
+	gardenCertClient := gardenClient.Kubernetes().CertificatesV1beta1()
+
+	// request new client certificate
+	certData, privateKeyData, _, err := RequestCertificate(ctx, logger, gardenCertClient, certificateSubject, dnsSANs, ipSANs)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Updating secret (%s/%s) in the target cluster with rotated certificate", gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name)
+
+	_, err = bootstraputil.UpdateGardenKubeconfigSecret(ctx, gardenClient.RESTConfig(), certData, privateKeyData, seedClient, gardenClientConnection)
+	if err != nil {
+		return fmt.Errorf("unable to update secret (%s/%s) on the target cluster during certificate rotation: %v", gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name, err)
+	}
+
+	return nil
+}
+
+// getTargetedSeeds returns the Seeds that this Gardenlet is reconciling
+func getTargetedSeeds(ctx context.Context, gardenClient client.Client, seedSelector *metav1.LabelSelector, seedName string) ([]gardencorev1beta1.Seed, error) {
+	if seedSelector != nil {
+		seedLabelSelector, err := metav1.LabelSelectorAsSelector(seedSelector)
+		if err != nil {
+			return nil, err
+		}
+
+		seeds := &gardencorev1beta1.SeedList{}
+		err = gardenClient.List(ctx, seeds, client.MatchingLabelsSelector{Selector: seedLabelSelector})
+		if err != nil {
+			return nil, err
+		}
+		return seeds.Items, nil
+	}
+
+	seed := &gardencorev1beta1.Seed{}
+	if err := gardenClient.Get(ctx, client.ObjectKey{Name: seedName}, seed); err != nil {
+		return nil, err
+	}
+	return []gardencorev1beta1.Seed{*seed}, nil
+}
+
+func (cr *Manager) getTargetedSeeds(ctx context.Context) ([]gardencorev1beta1.Seed, error) {
+	gardenClient, err := cr.clientMap.GetClient(ctx, keys.ForGarden())
+	if err != nil {
+		return nil, err
+	}
+	return getTargetedSeeds(ctx, gardenClient.Client(), cr.seedSelector, cr.seedName)
+}

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
@@ -1,0 +1,414 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"context"
+	"crypto/x509/pkix"
+	"fmt"
+	"net"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakeclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
+	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	"github.com/gardener/gardener/pkg/logger"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	mock "github.com/gardener/gardener/pkg/mock/gardener/client/kubernetes"
+	"github.com/gardener/gardener/pkg/utils"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/secrets"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Certificates", func() {
+	var (
+		log logrus.FieldLogger = logger.NewNopLogger()
+		ctx                    = context.TODO()
+
+		ctrl                *gomock.Controller
+		mockGardenInterface *mock.MockInterface
+		mockSeedInterface   *mock.MockInterface
+
+		mockGardenClient *mockclient.MockClient
+		mockSeedClient   *mockclient.MockClient
+
+		seedName = "test"
+		seed     = &gardencorev1beta1.Seed{
+			ObjectMeta: metav1.ObjectMeta{Name: seedName},
+		}
+
+		gardenClientConnection = &config.GardenClientConnection{
+			KubeconfigSecret: &corev1.SecretReference{
+				Name:      "gardenlet-kubeconfig",
+				Namespace: "garden",
+			},
+		}
+
+		approvedCSR = certificatesv1beta1.CertificateSigningRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "watched-csr",
+			},
+			Status: certificatesv1beta1.CertificateSigningRequestStatus{
+				Conditions: []certificatesv1beta1.CertificateSigningRequestCondition{
+					{
+						Type: certificatesv1beta1.CertificateApproved,
+					},
+				},
+				Certificate: []byte("my-cert"),
+			},
+		}
+
+		deniedCSR = certificatesv1beta1.CertificateSigningRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "watched-csr",
+			},
+			Status: certificatesv1beta1.CertificateSigningRequestStatus{
+				Conditions: []certificatesv1beta1.CertificateSigningRequestCondition{
+					{
+						Type: certificatesv1beta1.CertificateDenied,
+					},
+				},
+			},
+		}
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockSeedInterface = mock.NewMockInterface(ctrl)
+		mockSeedClient = mockclient.NewMockClient(ctrl)
+		// mockSeedInterface.EXPECT().Client().Return(mockSeedClient).AnyTimes()
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#rotateCertificate", func() {
+		var certificateSubject = pkix.Name{
+			CommonName: x509CommonName,
+		}
+
+		BeforeEach(func() {
+			mockGardenInterface = mock.NewMockInterface(ctrl)
+			mockGardenClient = mockclient.NewMockClient(ctrl)
+			mockGardenInterface.EXPECT().Client().Return(mockGardenClient).AnyTimes()
+
+		})
+
+		It("should not return an error", func() {
+			// simple Kubernetes client that returns an approved CSR when requested (with watch support)
+			// no mock Kubernetes client available that could be easily used
+			kubeClient := fake.NewSimpleClientset(&approvedCSR)
+			mockGardenInterface.EXPECT().Kubernetes().Return(kubeClient)
+
+			// mock gardenClient.RESTConfig()
+			certClientConfig := &rest.Config{Host: "testhost", TLSClientConfig: rest.TLSClientConfig{
+				Insecure: false,
+				CAFile:   "filepath",
+			}}
+			mockGardenInterface.EXPECT().RESTConfig().Return(certClientConfig)
+
+			// mock update of secret in seed with the rotated kubeconfig
+			mockSeedClient.EXPECT().Get(ctx, kutil.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{}))
+			mockSeedClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
+				secret, ok := obj.(*corev1.Secret)
+				Expect(ok).To(BeTrue())
+				Expect(secret.Name).To(Equal(gardenClientConnection.KubeconfigSecret.Name))
+				Expect(secret.Namespace).To(Equal(gardenClientConnection.KubeconfigSecret.Namespace))
+				Expect(secret.Data).ToNot(BeEmpty())
+				return nil
+			})
+
+			fakeClientMap := fakeclientmap.NewClientMap().
+				AddClient(keys.ForGarden(), mockGardenInterface)
+
+			err := rotateCertificate(context.TODO(), log, fakeClientMap, mockSeedClient, gardenClientConnection, &certificateSubject, []string{}, []net.IP{})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return an error - CSR is denied", func() {
+			kubeClient := fake.NewSimpleClientset(&deniedCSR)
+			mockGardenInterface.EXPECT().Kubernetes().Return(kubeClient)
+			fakeClientMap := fakeclientmap.NewClientMap().
+				AddClient(keys.ForGarden(), mockGardenInterface).
+				AddClient(keys.ForSeed(seed), mockSeedInterface)
+
+			err := rotateCertificate(context.TODO(), log, fakeClientMap, mockSeedClient, gardenClientConnection, &certificateSubject, []string{}, []net.IP{})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return an error - the CN of the x509 cert to be rotated is not set", func() {
+			kubeClient := fake.NewSimpleClientset(&deniedCSR)
+			mockGardenInterface.EXPECT().Kubernetes().Return(kubeClient)
+			fakeClientMap := fakeclientmap.NewClientMap().
+				AddClient(keys.ForGarden(), mockGardenInterface).
+				AddClient(keys.ForSeed(seed), mockSeedInterface)
+
+			err := rotateCertificate(context.TODO(), log, fakeClientMap, mockSeedClient, gardenClientConnection, nil, x509DnsNames, x509IpAddresses)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("Tests that require a generated kubeconfig with a client certificate", func() {
+		var (
+			gardenKubeconfigWithValidClientCert   string
+			gardenKubeconfigWithInValidClientCert string
+			baseKubeconfig                        = `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:2443
+  name: gardenlet
+contexts:
+- context:
+    cluster: gardenlet
+    user: gardenlet
+  name: gardenlet
+current-context: gardenlet
+kind: Config
+preferences: {}
+users:
+- name: gardenlet
+  user:
+    client-certificate-data: %s
+    client-key-data: %s
+`
+		)
+
+		Describe("#getCurrentCertificate", func() {
+			BeforeEach(func() {
+				// generate kubeconfigs
+				validity := 20 * time.Second
+				cert := generateCertificate(validity)
+				gardenKubeconfigWithValidClientCert = fmt.Sprintf(baseKubeconfig, utils.EncodeBase64(cert.CertificatePEM), utils.EncodeBase64(cert.PrivateKeyPEM))
+				gardenKubeconfigWithInValidClientCert = fmt.Sprintf(baseKubeconfig, "bm90LXZhbGlk", utils.EncodeBase64(cert.PrivateKeyPEM))
+			})
+
+			It("should not return an error", func() {
+				// mock existing secret with garden kubeconfig
+				mockSeedClient.EXPECT().Get(ctx, kutil.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret) error {
+					secret.ObjectMeta = metav1.ObjectMeta{
+						Name:      gardenClientConnection.KubeconfigSecret.Name,
+						Namespace: gardenClientConnection.KubeconfigSecret.Namespace,
+					}
+					secret.Data = map[string][]byte{kubernetes.KubeConfig: []byte(gardenKubeconfigWithValidClientCert)}
+					return nil
+				})
+
+				cert, err := getCurrentCertificate(context.TODO(), log, mockSeedClient, gardenClientConnection)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cert).ToNot(BeNil())
+			})
+
+			It("should return an error - kubeconfig secret does not exist", func() {
+				secretGroupResource := schema.GroupResource{Resource: "Secrets"}
+				secretNotFoundErr := apierrors.NewNotFound(secretGroupResource, gardenClientConnection.KubeconfigSecret.Name)
+				mockSeedClient.EXPECT().Get(ctx, kutil.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(secretNotFoundErr)
+
+				_, err := getCurrentCertificate(context.TODO(), log, mockSeedClient, gardenClientConnection)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should return an error - secret does not contain a kubeconfig", func() {
+				// mock existing secret with missing garden kubeconfig
+				mockSeedClient.EXPECT().Get(ctx, kutil.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret) error {
+					secret.ObjectMeta = metav1.ObjectMeta{
+						Name:      gardenClientConnection.KubeconfigSecret.Name,
+						Namespace: gardenClientConnection.KubeconfigSecret.Namespace,
+					}
+					secret.Data = nil
+					return nil
+				})
+
+				_, err := getCurrentCertificate(context.TODO(), log, mockSeedClient, gardenClientConnection)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should return an error - kubeconfig client cert is invalid", func() {
+				// mock existing secret with garden kubeconfig that has an invalid client cert
+				mockSeedClient.EXPECT().Get(ctx, kutil.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret) error {
+					secret.ObjectMeta = metav1.ObjectMeta{
+						Name:      gardenClientConnection.KubeconfigSecret.Name,
+						Namespace: gardenClientConnection.KubeconfigSecret.Namespace,
+					}
+					secret.Data = map[string][]byte{kubernetes.KubeConfig: []byte(gardenKubeconfigWithInValidClientCert)}
+					return nil
+				})
+
+				_, err := getCurrentCertificate(context.TODO(), log, mockSeedClient, gardenClientConnection)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("#getTargetedSeeds", func() {
+			It("should return a single Seed", func() {
+				mockSeedClient.EXPECT().Get(ctx, kutil.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, seed *gardencorev1beta1.Seed) error {
+					seed.ObjectMeta = metav1.ObjectMeta{
+						Name: seedName,
+					}
+					return nil
+				})
+
+				seeds, err := getTargetedSeeds(context.TODO(), mockSeedClient, nil, seedName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(seeds).To(HaveLen(1))
+				Expect(seeds[0]).To(Equal(gardencorev1beta1.Seed{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: seedName,
+					},
+				}))
+			})
+
+			It("should return all Seed matched by seedSelector", func() {
+				items := []gardencorev1beta1.Seed{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "seed-one",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "seed-two",
+						},
+					},
+				}
+
+				seedSelector := &metav1.LabelSelector{MatchLabels: map[string]string{
+					"seed-kind": "promiscuous",
+				}}
+
+				seedLabelSelector, err := metav1.LabelSelectorAsSelector(seedSelector)
+				Expect(err).To(BeNil())
+				mockSeedClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SeedList{}), client.MatchingLabelsSelector{Selector: seedLabelSelector}).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SeedList, _ ...client.ListOption) error {
+					*list = gardencorev1beta1.SeedList{Items: items}
+					return nil
+				})
+
+				seeds, err := getTargetedSeeds(context.TODO(), mockSeedClient, seedSelector, seedName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(seeds).To(HaveLen(2))
+				Expect(seeds).To(Equal(items))
+			})
+		})
+
+		Describe("#waitForCertificateRotation", func() {
+			var (
+				ctx            = context.TODO()
+				testKubeconfig string
+			)
+
+			BeforeEach(func() {
+				// generate kubeconfigs
+				validity := 1 * time.Second
+				cert := generateCertificate(validity)
+				testKubeconfig = fmt.Sprintf(baseKubeconfig, utils.EncodeBase64(cert.CertificatePEM), utils.EncodeBase64(cert.PrivateKeyPEM))
+
+				// mock first secret retrieval
+				mockSeedClient.EXPECT().Get(ctx, kutil.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret) error {
+					secret.ObjectMeta = metav1.ObjectMeta{
+						Name:      gardenClientConnection.KubeconfigSecret.Name,
+						Namespace: gardenClientConnection.KubeconfigSecret.Namespace,
+					}
+					secret.Data = map[string][]byte{kubernetes.KubeConfig: []byte(testKubeconfig)}
+					return nil
+				})
+
+				mockSeedInterface.EXPECT().DirectClient().Return(mockSeedClient).AnyTimes()
+			})
+
+			It("should not return an error", func() {
+				// mock second secret retrieval - check the validity of the certificate again
+				// in this case the secret has not changed
+				mockSeedClient.EXPECT().Get(ctx, kutil.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret) error {
+					secret.ObjectMeta = metav1.ObjectMeta{
+						Name:      gardenClientConnection.KubeconfigSecret.Name,
+						Namespace: gardenClientConnection.KubeconfigSecret.Namespace,
+					}
+					secret.Data = map[string][]byte{kubernetes.KubeConfig: []byte(testKubeconfig)}
+					return nil
+				})
+
+				subject, dnsSANs, ipSANs, _, err := waitForCertificateRotation(context.TODO(), log, mockSeedClient, gardenClientConnection, time.Now)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(subject).ToNot(BeNil())
+				Expect(subject.CommonName).To(Equal(x509CommonName))
+				Expect(subject.Organization).To(Equal(x509Organization))
+				Expect(dnsSANs).To(Equal(x509DnsNames))
+				Expect(ipSANs).To(Equal(x509IpAddresses))
+			})
+
+			It("should return an error - simulate changing the certificate while waiting for the certificate rotation deadline", func() {
+				// generate new valid kubeconfig with different certificate validity
+				validity := 1 * time.Hour
+				cert := generateCertificate(validity)
+				updated := fmt.Sprintf(baseKubeconfig, utils.EncodeBase64(cert.CertificatePEM), utils.EncodeBase64(cert.PrivateKeyPEM))
+
+				// mock second secret retrieval - check the validity of the certificate again
+				// the secret has been updated!
+				mockSeedClient.EXPECT().Get(ctx, kutil.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret) error {
+					secret.ObjectMeta = metav1.ObjectMeta{
+						Name:      gardenClientConnection.KubeconfigSecret.Name,
+						Namespace: gardenClientConnection.KubeconfigSecret.Namespace,
+					}
+					secret.Data = map[string][]byte{kubernetes.KubeConfig: []byte(updated)}
+					return nil
+				})
+
+				_, _, _, _, err := waitForCertificateRotation(context.TODO(), log, mockSeedClient, gardenClientConnection, time.Now)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+})
+
+const x509CommonName = "gardener.cloud:system:seed:test"
+
+var (
+	x509Organization = []string{"gardener.cloud:system:seeds"}
+	x509DnsNames     = []string{"my.alternative.apiserver.domain"}
+	x509IpAddresses  = []net.IP{net.ParseIP("100.64.0.10").To4()}
+)
+
+func generateCertificate(validity time.Duration) secrets.Certificate {
+	caCertConfig := &secrets.CertificateSecretConfig{
+		Name:         "test",
+		CommonName:   x509CommonName,
+		Organization: x509Organization,
+		DNSNames:     x509DnsNames,
+		IPAddresses:  x509IpAddresses,
+		CertType:     secrets.ClientCert,
+		Validity:     &validity,
+	}
+	cert, err := caCertConfig.GenerateCertificate()
+	Expect(err).ToNot(HaveOccurred())
+	return *cert
+}

--- a/pkg/gardenlet/bootstrap/certificate/certificate_suite_test.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCertificates(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gardenlet Certificate Suite")
+}

--- a/pkg/gardenlet/bootstrap/certificate/certificate_util.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_util.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+The utility functions in this file were copied from the kubernetes/client-go project
+https://github.com/kubernetes/client-go/blob/master/util/certificate/certificate_manager.go
+
+Modifications Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+*/
+
+package certificate
+
+import (
+	"crypto/tls"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// nextRotationDeadline returns a value for the threshold at which the
+// current certificate should be rotated, 80%+/-10% of the expiration of the
+// certificate.
+func nextRotationDeadline(certificate tls.Certificate) time.Time {
+	notAfter := certificate.Leaf.NotAfter
+	totalDuration := float64(notAfter.Sub(certificate.Leaf.NotBefore))
+	return certificate.Leaf.NotBefore.Add(jitteryDuration(totalDuration))
+}
+
+// jitteryDuration uses some jitter to set the rotation threshold so each gardenlet
+// will rotate at approximately 70-90% of the total lifetime of the
+// certificate.  With jitter, if a number of gardenlets are added to a garden cluster at
+// approximately the same time, they won't all
+// try to rotate certificates at the same time for the rest of the lifetime
+var jitteryDuration = func(totalDuration float64) time.Duration {
+	return wait.Jitter(time.Duration(totalDuration), 0.2) - time.Duration(totalDuration*0.3)
+}

--- a/pkg/gardenlet/bootstrap/util/bootstrap_util_suite_test.go
+++ b/pkg/gardenlet/bootstrap/util/bootstrap_util_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBootstrapUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gardenlet Bootstrap Utils Suite")
+}

--- a/pkg/gardenlet/bootstrap/util/util.go
+++ b/pkg/gardenlet/bootstrap/util/util.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"crypto/sha512"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// GetKubeconfigFromSecret tries to retrieve the kubeconfig bytes using the given client
+// returns the kubeconfig or nil if it cannot be found
+func GetKubeconfigFromSecret(ctx context.Context, seedClient client.Client, namespace, name string) ([]byte, error) {
+	kubeconfigSecret := &corev1.Secret{}
+	if err := seedClient.Get(ctx, kutil.Key(namespace, name), kubeconfigSecret); client.IgnoreNotFound(err) != nil {
+		return nil, err
+	}
+
+	return kubeconfigSecret.Data[kubernetes.KubeConfig], nil
+}
+
+// UpdateGardenKubeconfigSecret updates the secret in the seed cluster that holds the kubeconfig of the Garden cluster.
+func UpdateGardenKubeconfigSecret(ctx context.Context, certClientConfig *rest.Config, certData, privateKeyData []byte, seedClient client.Client, gardenClientConnection *config.GardenClientConnection) ([]byte, error) {
+	kubeconfig, err := MarshalKubeconfigWithClientCertificate(certClientConfig, privateKeyData, certData)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeconfigSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gardenClientConnection.KubeconfigSecret.Name,
+			Namespace: gardenClientConnection.KubeconfigSecret.Namespace,
+		},
+	}
+
+	if _, err := controllerutil.CreateOrUpdate(ctx, seedClient, kubeconfigSecret, func() error {
+		kubeconfigSecret.Data = map[string][]byte{kubernetes.KubeConfig: kubeconfig}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return kubeconfig, nil
+}
+
+// MarshalKubeconfigWithClientCertificate marshals the kubeconfig derived from the bootstrapping process.
+func MarshalKubeconfigWithClientCertificate(config *rest.Config, privateKeyData, certDat []byte) ([]byte, error) {
+	return kubeconfigWithAuthInfo(config, &clientcmdapi.AuthInfo{
+		ClientCertificateData: certDat,
+		ClientKeyData:         privateKeyData,
+	})
+}
+
+// MarshalKubeconfigWithToken marshals the kubeconfig derived with the given bootstrap token.
+func MarshalKubeconfigWithToken(config *rest.Config, token string) ([]byte, error) {
+	return kubeconfigWithAuthInfo(config, &clientcmdapi.AuthInfo{
+		Token: token,
+	})
+}
+
+// DigestedName is a digest that should include all the relevant pieces of the CSR we care about.
+// We can't directly hash the serialized CSR because of random padding that we
+// regenerate every loop and we include usages which are not contained in the
+// CSR. This needs to be kept up to date as we add new fields to the node
+// certificates and with ensureCompatible.
+func DigestedName(publicKey interface{}, subject *pkix.Name, usages []certificatesv1beta1.KeyUsage) (string, error) {
+	hash := sha512.New512_256()
+
+	// Here we make sure two different inputs can't write the same stream
+	// to the hash. This delimiter is not in the base64.URLEncoding
+	// alphabet so there is no way to have spill over collisions. Without
+	// it 'CN:foo,ORG:bar' hashes to the same value as 'CN:foob,ORG:ar'
+	const delimiter = '|'
+	encode := base64.RawURLEncoding.EncodeToString
+
+	write := func(data []byte) {
+		_, _ = hash.Write([]byte(encode(data)))
+		_, _ = hash.Write([]byte{delimiter})
+	}
+
+	publicKeyData, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		return "", err
+	}
+	write(publicKeyData)
+
+	write([]byte(subject.CommonName))
+	for _, v := range subject.Organization {
+		write([]byte(v))
+	}
+	for _, v := range usages {
+		write([]byte(v))
+	}
+
+	return fmt.Sprintf("seed-csr-%s", encode(hash.Sum(nil))), nil
+}
+
+func kubeconfigWithAuthInfo(config *rest.Config, authInfo *clientcmdapi.AuthInfo) ([]byte, error) {
+	// Get the CA data from the bootstrap client config.
+	caFile, caData := config.CAFile, []byte{}
+	if len(caFile) == 0 {
+		caData = config.CAData
+	}
+
+	return clientcmd.Write(clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{"gardenlet": {
+			Server:                   config.Host,
+			InsecureSkipTLSVerify:    config.Insecure,
+			CertificateAuthority:     caFile,
+			CertificateAuthorityData: caData,
+		}},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{"gardenlet": authInfo},
+		Contexts: map[string]*clientcmdapi.Context{"gardenlet": {
+			Cluster:  "gardenlet",
+			AuthInfo: "gardenlet",
+		}},
+		CurrentContext: "gardenlet",
+	})
+}
+
+// GardenerSeedBootstrapper is a constant for the gardener seed bootstrapper name.
+const GardenerSeedBootstrapper = "gardener.cloud:system:seed-bootstrapper"
+
+// BuildBootstrapperName concatenates the gardener seed bootstrapper group with the given name,
+// separated by a colon.
+func BuildBootstrapperName(name string) string {
+	return fmt.Sprintf("%s:%s", GardenerSeedBootstrapper, name)
+}
+
+// DefaultSeedName is the default seed name in case the gardenlet config.SeedConfig is not set
+const DefaultSeedName = "<ambiguous>"
+
+// GetSeedName returns the seed name from the SeedConfig or the default Seed name
+func GetSeedName(seedConfig *config.SeedConfig) string {
+	if seedConfig != nil {
+		return seedConfig.Name
+	}
+	return DefaultSeedName
+}
+
+const (
+	// DedicatedSeedKubeconfig is a constant for the target cluster name when the gardenlet is using a dedicated seed kubeconfig
+	DedicatedSeedKubeconfig = "configured in .SeedClientConnection.Kubeconfig"
+	// InCluster is a constant for the target cluster name  when the gardenlet is running in a Kubernetes cluster
+	// and is using the mounted service account token of that cluster
+	InCluster = "in cluster"
+)
+
+// GetTargetClusterName returns the target cluster of the gardenlet based on the SeedClientConnection.
+// This is either the cluster configured by .SeedClientConnection.Kubeconfig, or when running in Kubernetes,
+// the local cluster it is deployed to (by using a mounted service account token)
+func GetTargetClusterName(config *config.SeedClientConnection) string {
+	if config != nil && len(config.Kubeconfig) != 0 {
+		return DedicatedSeedKubeconfig
+	}
+	return InCluster
+}

--- a/pkg/gardenlet/bootstrap/util/util_test.go
+++ b/pkg/gardenlet/bootstrap/util/util_test.go
@@ -1,0 +1,292 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509/pkix"
+	"fmt"
+	"strings"
+
+	baseconfig "k8s.io/component-base/config"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	. "github.com/gardener/gardener/pkg/gardenlet/bootstrap"
+	bootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/keyutil"
+	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Util", func() {
+
+	Describe("#DigestedName", func() {
+		It("digest should start with `seed-csr-`", func() {
+			privateKeyData, err := keyutil.MakeEllipticPrivateKeyPEM()
+			Expect(err).ToNot(HaveOccurred())
+
+			privateKey, err := keyutil.ParsePrivateKeyPEM(privateKeyData)
+			Expect(err).ToNot(HaveOccurred())
+
+			signer, ok := privateKey.(crypto.Signer)
+			Expect(ok).To(BeTrue())
+
+			organization := "test-org"
+			subject := &pkix.Name{
+				Organization: []string{organization},
+				CommonName:   "test-cn",
+			}
+			digest, err := bootstraputil.DigestedName(signer.Public(), subject, []certificatesv1beta1.KeyUsage{certificatesv1beta1.UsageDigitalSignature})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(strings.HasPrefix(digest, "seed-csr-")).To(BeTrue())
+		})
+
+		It("should return an error because the public key cannot be marshalled", func() {
+			_, err := bootstraputil.DigestedName([]byte("test"), nil, []certificatesv1beta1.KeyUsage{certificatesv1beta1.UsageDigitalSignature})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("Util Tests requiring a mock client", func() {
+		var (
+			ctrl *gomock.Controller
+			c    *mockclient.MockClient
+			ctx  = context.TODO()
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			c = mockclient.NewMockClient(ctrl)
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		Describe("#GetKubeconfigFromSecret", func() {
+			var (
+				secretName      = "secret"
+				secretNamespace = "garden"
+				secretReference = corev1.SecretReference{
+					Name:      secretName,
+					Namespace: secretNamespace,
+				}
+			)
+
+			It("should not return an error because the secret does not exist", func() {
+				c.EXPECT().
+					Get(ctx, kutil.Key(secretReference.Namespace, secretReference.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).
+					Return(apierrors.NewNotFound(schema.GroupResource{Resource: "Secret"}, secretReference.Name))
+
+				kubeconfig, err := bootstraputil.GetKubeconfigFromSecret(ctx, c, secretNamespace, secretName)
+
+				Expect(kubeconfig).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should not return an error", func() {
+				kubeconfigContent := []byte("testing")
+
+				c.EXPECT().
+					Get(ctx, kutil.Key(secretReference.Namespace, secretReference.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).
+					DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret) error {
+						secret.Name = secretReference.Name
+						secret.Namespace = secretReference.Namespace
+						secret.Data = map[string][]byte{
+							kubernetes.KubeConfig: kubeconfigContent,
+						}
+						return nil
+					})
+
+				kubeconfig, err := bootstraputil.GetKubeconfigFromSecret(ctx, c, secretNamespace, secretName)
+
+				Expect(kubeconfig).To(Equal(kubeconfigContent))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Describe("#UpdateGardenKubeconfigSecret", func() {
+			It("should create the kubeconfig secret", func() {
+				secretReference := corev1.SecretReference{
+					Name:      "secret",
+					Namespace: "garden",
+				}
+
+				c.EXPECT().
+					Get(ctx, kutil.Key(secretReference.Namespace, secretReference.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).
+					Return(apierrors.NewNotFound(schema.GroupResource{Resource: "Secret"}, secretReference.Name))
+
+				certClientConfig := &rest.Config{Host: "testhost", TLSClientConfig: rest.TLSClientConfig{
+					Insecure: false,
+					CAFile:   "filepath",
+				}}
+
+				expectedKubeconfig, err := bootstraputil.MarshalKubeconfigWithClientCertificate(certClientConfig, nil, nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				expectedSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secretReference.Name,
+						Namespace: secretReference.Namespace,
+					},
+					Data: map[string][]byte{kubernetes.KubeConfig: expectedKubeconfig},
+				}
+				c.EXPECT().Create(ctx, expectedSecret).
+					Return(nil)
+
+				gardenClientConnection := &config.GardenClientConnection{
+					KubeconfigSecret: &secretReference,
+				}
+
+				kubeconfig, err := bootstraputil.UpdateGardenKubeconfigSecret(ctx, certClientConfig, nil, nil, c, gardenClientConnection)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(kubeconfig).To(Equal(expectedKubeconfig))
+			})
+		})
+
+		Describe("#DeleteBootstrapAuth", func() {
+			var (
+				csrName = "csr-name"
+				csrKey  = kutil.Key(csrName)
+			)
+
+			It("should return an error because the CSR was not found", func() {
+				c.EXPECT().
+					Get(ctx, csrKey, gomock.AssignableToTypeOf(&certificatesv1beta1.CertificateSigningRequest{})).
+					Return(apierrors.NewNotFound(schema.GroupResource{Resource: "CertificateSigningRequests"}, csrName))
+
+				Expect(DeleteBootstrapAuth(ctx, c, csrName, "")).NotTo(Succeed())
+			})
+
+			It("should delete nothing because the username in the CSR does not match a known pattern", func() {
+				c.EXPECT().
+					Get(ctx, csrKey, gomock.AssignableToTypeOf(&certificatesv1beta1.CertificateSigningRequest{})).
+					Return(nil)
+
+				Expect(DeleteBootstrapAuth(ctx, c, csrName, "")).To(Succeed())
+			})
+
+			It("should delete the bootstrap token secret", func() {
+				var (
+					bootstrapTokenID         = "12345"
+					bootstrapTokenSecretName = "bootstrap-token-" + bootstrapTokenID
+					bootstrapTokenUserName   = bootstraptokenapi.BootstrapUserPrefix + bootstrapTokenID
+					bootstrapTokenSecret     = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceSystem, Name: bootstrapTokenSecretName}}
+				)
+
+				gomock.InOrder(
+					c.EXPECT().
+						Get(ctx, csrKey, gomock.AssignableToTypeOf(&certificatesv1beta1.CertificateSigningRequest{})).
+						DoAndReturn(func(_ context.Context, _ client.ObjectKey, csr *certificatesv1beta1.CertificateSigningRequest) error {
+							csr.Spec.Username = bootstrapTokenUserName
+							return nil
+						}),
+
+					c.EXPECT().
+						Delete(ctx, bootstrapTokenSecret),
+				)
+
+				Expect(DeleteBootstrapAuth(ctx, c, csrName, "")).To(Succeed())
+			})
+
+			It("should delete the service account and cluster role binding", func() {
+				var (
+					seedName                = "foo"
+					serviceAccountName      = "foo"
+					serviceAccountNamespace = v1beta1constants.GardenNamespace
+					serviceAccountUserName  = serviceaccount.MakeUsername(serviceAccountNamespace, serviceAccountName)
+					serviceAccount          = &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: serviceAccountNamespace, Name: serviceAccountName}}
+
+					clusterRoleBinding = &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: bootstraputil.BuildBootstrapperName(seedName)}}
+				)
+
+				gomock.InOrder(
+					c.EXPECT().
+						Get(ctx, csrKey, gomock.AssignableToTypeOf(&certificatesv1beta1.CertificateSigningRequest{})).
+						DoAndReturn(func(_ context.Context, _ client.ObjectKey, csr *certificatesv1beta1.CertificateSigningRequest) error {
+							csr.Spec.Username = serviceAccountUserName
+							return nil
+						}),
+
+					c.EXPECT().
+						Delete(ctx, serviceAccount),
+
+					c.EXPECT().
+						Delete(ctx, clusterRoleBinding),
+				)
+
+				Expect(DeleteBootstrapAuth(ctx, c, csrName, seedName)).To(Succeed())
+			})
+		})
+	})
+
+	Describe("BuildBootstrapperName", func() {
+		It("should return the correct name", func() {
+			name := "foo"
+			result := bootstraputil.BuildBootstrapperName(name)
+			Expect(result).To(Equal(fmt.Sprintf("%s:%s", bootstraputil.GardenerSeedBootstrapper, name)))
+		})
+	})
+
+	Describe("GetSeedName", func() {
+		It("should return the configured name", func() {
+			name := "test-name"
+			result := bootstraputil.GetSeedName(&config.SeedConfig{Seed: gardencorev1beta1.Seed{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+			}})
+			Expect(result).To(Equal("test-name"))
+		})
+
+		It("should return the default name", func() {
+			result := bootstraputil.GetSeedName(nil)
+			Expect(result).To(Equal(bootstraputil.DefaultSeedName))
+		})
+	})
+
+	Describe("GetTargetClusterName", func() {
+		It("should return DedicatedSeedKubeconfig", func() {
+			result := bootstraputil.GetTargetClusterName(&config.SeedClientConnection{
+				ClientConnectionConfiguration: baseconfig.ClientConnectionConfiguration{
+					Kubeconfig: "/var/xxx/",
+				},
+			})
+			Expect(result).To(Equal(bootstraputil.DedicatedSeedKubeconfig))
+		})
+
+		It("should return InCluster", func() {
+			result := bootstraputil.GetTargetClusterName(nil)
+			Expect(result).To(Equal(bootstraputil.InCluster))
+		})
+	})
+})

--- a/pkg/gardenlet/controller/shoot/seed_registration_control.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control.go
@@ -33,7 +33,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	configv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
-	"github.com/gardener/gardener/pkg/gardenlet/bootstrap"
+	bootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
@@ -487,14 +487,14 @@ func deployGardenlet(ctx context.Context, gardenClient, seedClient, shootedSeedC
 
 			clusterRoleBinding := &rbacv1.ClusterRoleBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: bootstrap.BuildBootstrapperName(shoot.Name),
+					Name: bootstraputil.BuildBootstrapperName(shoot.Name),
 				},
 			}
 			if _, err := controllerutil.CreateOrUpdate(ctx, gardenClient.Client(), clusterRoleBinding, func() error {
 				clusterRoleBinding.RoleRef = rbacv1.RoleRef{
 					APIGroup: "rbac.authorization.k8s.io",
 					Kind:     "ClusterRole",
-					Name:     bootstrap.GardenerSeedBootstrapper,
+					Name:     bootstraputil.GardenerSeedBootstrapper,
 				}
 				clusterRoleBinding.Subjects = []rbacv1.Subject{
 					{
@@ -508,7 +508,7 @@ func deployGardenlet(ctx context.Context, gardenClient, seedClient, shootedSeedC
 				return err
 			}
 
-			bootstrapKubeconfig, err = bootstrap.MarshalKubeconfigWithToken(&restConfig, string(saSecret.Data[corev1.ServiceAccountTokenKey]))
+			bootstrapKubeconfig, err = bootstraputil.MarshalKubeconfigWithToken(&restConfig, string(saSecret.Data[corev1.ServiceAccountTokenKey]))
 			if err != nil {
 				return err
 			}
@@ -545,7 +545,7 @@ func deployGardenlet(ctx context.Context, gardenClient, seedClient, shootedSeedC
 				}
 			}
 
-			bootstrapKubeconfig, err = bootstrap.MarshalKubeconfigWithToken(&restConfig, kutil.BootstrapTokenFrom(bootstrapTokenSecret.Data))
+			bootstrapKubeconfig, err = bootstraputil.MarshalKubeconfigWithToken(&restConfig, kutil.BootstrapTokenFrom(bootstrapTokenSecret.Data))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Introduces Certificate Rotation for the Gardenlet. 
Currently the client certificate generated during the initial bootstrap is only valid for 1 year. 
The certificate needs to be renewed before it expires to avoid disruption.

**Which issue(s) this PR fixes**:
Fixes #1721

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Introduces Certificate Rotation for the Gardenlet. 
```
