### PR TITLE
Fix possible race condition when updating ShootState

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -207,12 +207,12 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 		generateEncryptionConfigurationMetaData = g.Add(flow.Task{
 			Name:         "Generating etcd encryption configuration",
 			Fn:           flow.TaskFn(botanist.GenerateEncryptionConfiguration).DoIf(enableEtcdEncryption),
-			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootStateExists),
+			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootStateExists, loadSecrets, generateSecrets),
 		})
 		persistETCDEncryptionConfiguration = g.Add(flow.Task{
 			Name:         "Persisting etcd encryption configuration in ShootState",
 			Fn:           flow.TaskFn(botanist.PersistEncryptionConfiguration).DoIf(enableEtcdEncryption),
-			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootStateExists, generateEncryptionConfigurationMetaData),
+			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootStateExists, generateEncryptionConfigurationMetaData, loadSecrets, generateSecrets),
 		})
 		// TODO: This can be removed in a future version once all etcd encryption configuration secrets have been cleaned up.
 		_ = g.Add(flow.Task{

--- a/pkg/operation/botanist/etcdencryption.go
+++ b/pkg/operation/botanist/etcdencryption.go
@@ -192,7 +192,7 @@ func (b *Botanist) updateShootLabelsForEtcdEncryption(ctx context.Context, label
 func (b *Botanist) persistEncryptionConfigInShootState(ctx context.Context) error {
 	shootState := &gardencorev1alpha1.ShootState{ObjectMeta: kutil.ObjectMeta(b.Shoot.Info.Namespace, b.Shoot.Info.Name)}
 	if _, err := controllerutil.CreateOrUpdate(ctx, b.K8sGardenClient.Client(), shootState, func() error {
-		gardenerResourceList := gardencorev1alpha1helper.GardenerResourceDataList(b.ShootState.Spec.Gardener)
+		gardenerResourceList := gardencorev1alpha1helper.GardenerResourceDataList(shootState.Spec.Gardener)
 		if err := infodata.UpsertInfoData(&gardenerResourceList, common.ETCDEncryptionConfigDataName, b.Shoot.ETCDEncryption); err != nil {
 			return err
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug
/priority critical

**What this PR does / why we need it**:
This PR makes the step which saves the etcd encryption configuration depend on the steps which load and generate the shoot secrets since all of these steps read and write to the `botanist.ShootState` field.
In the future we could make the etcd encryption config generation part of the shoot secrets generation steps and come up with a better way to synchronise steps which write/read from the `botanist.ShootState` field.

**Which issue(s) this PR fixes**:
Part of #1631

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixed possible race condition when updating the ShootState.
```
