### PR TITLE
Refresh clients on secret update

### DIFF
--- a/pkg/client/kubernetes/clientmap/builder/seed_builder.go
+++ b/pkg/client/kubernetes/clientmap/builder/seed_builder.go
@@ -56,7 +56,7 @@ func (b *SeedClientMapBuilder) WithGardenClientMap(clientMap clientmap.ClientMap
 	return b
 }
 
-// WithGardenClientMap sets the ClientSet that should be used as the Garden client.
+// WithGardenClientSet sets the ClientSet that should be used as the Garden client.
 func (b *SeedClientMapBuilder) WithGardenClientSet(clientSet kubernetes.Interface) *SeedClientMapBuilder {
 	b.gardenClientFunc = func(ctx context.Context) (kubernetes.Interface, error) {
 		return clientSet, nil

--- a/pkg/client/kubernetes/clientmap/internal/garden_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/garden_clientmap.go
@@ -46,11 +46,16 @@ type GardenClientSetFactory struct {
 	RESTConfig *rest.Config
 }
 
+// CalculateClientSetHash returns "" as the garden client config cannot change during runtime
+func (f *GardenClientSetFactory) CalculateClientSetHash(context.Context, clientmap.ClientSetKey) (string, error) {
+	return "", nil
+}
+
 // NewClientSet creates a new ClientSet to the garden cluster.
 func (f *GardenClientSetFactory) NewClientSet(_ context.Context, k clientmap.ClientSetKey) (kubernetes.Interface, error) {
 	_, ok := k.(GardenClientSetKey)
 	if !ok {
-		return nil, fmt.Errorf("call to GetClient with unsupported ClientSetKey: expected %T got %T", GardenClientSetKey{}, k)
+		return nil, fmt.Errorf("unsupported ClientSetKey: expected %T got %T", GardenClientSetKey{}, k)
 	}
 
 	return NewClientSetWithConfig(

--- a/pkg/client/kubernetes/clientmap/internal/plant_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/plant_clientmap.go
@@ -19,11 +19,13 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
+	"github.com/gardener/gardener/pkg/utils"
 )
 
 // plantClientMap is a ClientMap for requesting and storing clients for Plant clusters.
@@ -45,32 +47,61 @@ type PlantClientSetFactory struct {
 	GetGardenClient func(ctx context.Context) (kubernetes.Interface, error)
 }
 
+// CalculateClientSetHash calculates a SHA256 hash of the kubeconfig in the plant secret.
+func (f *PlantClientSetFactory) CalculateClientSetHash(ctx context.Context, k clientmap.ClientSetKey) (string, error) {
+	key, ok := k.(PlantClientSetKey)
+	if !ok {
+		return "", fmt.Errorf("unsupported ClientSetKey: expected %T got %T", PlantClientSetKey{}, k)
+	}
+
+	secretRef, gardenClient, err := f.getPlantSecretRef(ctx, key)
+	if err != nil {
+		return "", err
+	}
+
+	kubeconfigSecret := &corev1.Secret{}
+	if err := gardenClient.Client().Get(ctx, client.ObjectKey{Namespace: key.Namespace, Name: secretRef.Name}, kubeconfigSecret); err != nil {
+		return "", err
+	}
+
+	return utils.ComputeSHA256Hex(kubeconfigSecret.Data[kubernetes.KubeConfig]), nil
+}
+
 // NewClientSet creates a new ClientSet for a Plant cluster.
 func (f *PlantClientSetFactory) NewClientSet(ctx context.Context, k clientmap.ClientSetKey) (kubernetes.Interface, error) {
 	key, ok := k.(PlantClientSetKey)
 	if !ok {
-		return nil, fmt.Errorf("call to GetClient with unsupported ClientSetKey: expected %T got %T", PlantClientSetKey{}, k)
+		return nil, fmt.Errorf("unsupported ClientSetKey: expected %T got %T", PlantClientSetKey{}, k)
 	}
 
-	gardenClient, err := f.GetGardenClient(ctx)
+	secretRef, gardenClient, err := f.getPlantSecretRef(ctx, key)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get garden client: %w", err)
+		return nil, err
 	}
 
-	plant := &gardencorev1beta1.Plant{}
-	if err := gardenClient.Client().Get(ctx, client.ObjectKey{Namespace: key.Namespace, Name: key.Name}, plant); err != nil {
-		return nil, fmt.Errorf("failed to get Plant object %q: %w", key.Key(), err)
-	}
-
-	if plant.Spec.SecretRef.Name == "" {
-		return nil, fmt.Errorf("plant %q does not have a secretRef", key.Key())
-	}
-
-	return NewClientFromSecret(ctx, gardenClient.Client(), key.Namespace, plant.Spec.SecretRef.Name,
+	return NewClientFromSecret(ctx, gardenClient.Client(), key.Namespace, secretRef.Name,
 		kubernetes.WithClientOptions(client.Options{
 			Scheme: kubernetes.PlantScheme,
 		}),
 	)
+}
+
+func (f *PlantClientSetFactory) getPlantSecretRef(ctx context.Context, key PlantClientSetKey) (*corev1.LocalObjectReference, kubernetes.Interface, error) {
+	gardenClient, err := f.GetGardenClient(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get garden client: %w", err)
+	}
+
+	plant := &gardencorev1beta1.Plant{}
+	if err := gardenClient.Client().Get(ctx, client.ObjectKey{Namespace: key.Namespace, Name: key.Name}, plant); err != nil {
+		return nil, nil, fmt.Errorf("failed to get Plant object %q: %w", key.Key(), err)
+	}
+
+	if plant.Spec.SecretRef.Name == "" {
+		return nil, nil, fmt.Errorf("plant %q does not have a secretRef", key.Key())
+	}
+
+	return &plant.Spec.SecretRef, gardenClient, nil
 }
 
 // PlantClientSetKey is a ClientSetKey for a Plant cluster.

--- a/pkg/client/kubernetes/clientmap/internal/seed_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/seed_clientmap.go
@@ -19,12 +19,14 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	baseconfig "k8s.io/component-base/config"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
+	"github.com/gardener/gardener/pkg/utils"
 )
 
 // seedClientMap is a ClientMap for requesting and storing clients for Seed clusters.
@@ -51,11 +53,36 @@ type SeedClientSetFactory struct {
 	ClientConnectionConfig baseconfig.ClientConnectionConfiguration
 }
 
+// CalculateClientSetHash returns "" if the gardenlet uses in-cluster communication. Otherwise, it calculates a SHA256
+// hash of the kubeconfig in the seed secret.
+func (f *SeedClientSetFactory) CalculateClientSetHash(ctx context.Context, k clientmap.ClientSetKey) (string, error) {
+	key, ok := k.(SeedClientSetKey)
+	if !ok {
+		return "", fmt.Errorf("unsupported ClientSetKey: expected %T got %T", SeedClientSetKey(""), k)
+	}
+
+	if f.InCluster {
+		return "", nil
+	}
+
+	secretRef, gardenClient, err := f.getSeedSecretRef(ctx, key)
+	if err != nil {
+		return "", err
+	}
+
+	kubeconfigSecret := &corev1.Secret{}
+	if err := gardenClient.Client().Get(ctx, client.ObjectKey{Namespace: secretRef.Namespace, Name: secretRef.Name}, kubeconfigSecret); err != nil {
+		return "", err
+	}
+
+	return utils.ComputeSHA256Hex(kubeconfigSecret.Data[kubernetes.KubeConfig]), nil
+}
+
 // NewClientSet creates a new ClientSet for a Seed cluster.
 func (f *SeedClientSetFactory) NewClientSet(ctx context.Context, k clientmap.ClientSetKey) (kubernetes.Interface, error) {
 	key, ok := k.(SeedClientSetKey)
 	if !ok {
-		return nil, fmt.Errorf("call to GetClient with unsupported ClientSetKey: expected %T got %T", SeedClientSetKey(""), k)
+		return nil, fmt.Errorf("unsupported ClientSetKey: expected %T got %T", SeedClientSetKey(""), k)
 	}
 
 	if f.InCluster {
@@ -71,26 +98,35 @@ func (f *SeedClientSetFactory) NewClientSet(ctx context.Context, k clientmap.Cli
 		)
 	}
 
-	gardenClient, err := f.GetGardenClient(ctx)
+	secretRef, gardenClient, err := f.getSeedSecretRef(ctx, key)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get garden client: %w", err)
+		return nil, err
 	}
 
-	seed := &gardencorev1beta1.Seed{}
-	if err := gardenClient.Client().Get(ctx, client.ObjectKey{Name: key.Key()}, seed); err != nil {
-		return nil, fmt.Errorf("failed to get Seed object %q: %w", key.Key(), err)
-	}
-
-	if seed.Spec.SecretRef == nil {
-		return nil, fmt.Errorf("seed %q does not have a secretRef", key.Key())
-	}
-
-	return NewClientFromSecret(ctx, gardenClient.Client(), seed.Spec.SecretRef.Namespace, seed.Spec.SecretRef.Name,
+	return NewClientFromSecret(ctx, gardenClient.Client(), secretRef.Namespace, secretRef.Name,
 		kubernetes.WithClientConnectionOptions(f.ClientConnectionConfig),
 		kubernetes.WithClientOptions(client.Options{
 			Scheme: kubernetes.SeedScheme,
 		}),
 	)
+}
+
+func (f *SeedClientSetFactory) getSeedSecretRef(ctx context.Context, key SeedClientSetKey) (*corev1.SecretReference, kubernetes.Interface, error) {
+	gardenClient, err := f.GetGardenClient(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get garden client: %w", err)
+	}
+
+	seed := &gardencorev1beta1.Seed{}
+	if err := gardenClient.Client().Get(ctx, client.ObjectKey{Name: key.Key()}, seed); err != nil {
+		return nil, nil, fmt.Errorf("failed to get Seed object %q: %w", key.Key(), err)
+	}
+
+	if seed.Spec.SecretRef == nil {
+		return nil, nil, fmt.Errorf("seed %q does not have a secretRef", key.Key())
+	}
+
+	return seed.Spec.SecretRef, gardenClient, nil
 }
 
 // SeedClientSetKey is a ClientSetKey for a Seed cluster.

--- a/pkg/client/kubernetes/clientmap/internal/seed_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/internal/seed_clientmap_test.go
@@ -178,6 +178,10 @@ var _ = Describe("SeedClientMap", func() {
 				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
 					seed.DeepCopyInto(obj.(*gardencorev1beta1.Seed))
 					return nil
+				}).Times(2)
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: seed.Spec.SecretRef.Namespace, Name: seed.Spec.SecretRef.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					return nil
 				})
 			internal.NewClientFromSecret = func(ctx context.Context, c client.Client, namespace, secretName string, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
 				Expect(c).To(BeIdenticalTo(fakeGardenClient.Client()))
@@ -189,6 +193,60 @@ var _ = Describe("SeedClientMap", func() {
 			cs, err := cm.GetClient(ctx, key)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cs).To(BeIdenticalTo(fakeCS))
+		})
+	})
+
+	Context("#CalculateClientSetHash", func() {
+		It("should fail if ClientSetKey type is unsupported", func() {
+			key = fakeKey{}
+			hash, err := factory.CalculateClientSetHash(ctx, key)
+			Expect(hash).To(BeEmpty())
+			Expect(err).To(MatchError(ContainSubstring("unsupported ClientSetKey")))
+		})
+
+		It("should fail if getSeedSecretRef fails", func() {
+			fakeErr := fmt.Errorf("fake")
+			factory.GetGardenClient = func(ctx context.Context) (kubernetes.Interface, error) {
+				return nil, fakeErr
+			}
+
+			hash, err := factory.CalculateClientSetHash(ctx, key)
+			Expect(hash).To(BeEmpty())
+			Expect(err).To(MatchError(ContainSubstring("failed to get garden client: fake")))
+		})
+
+		It("should fail if Get Seed Secret fails", func() {
+			fakeErr := fmt.Errorf("fake")
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					seed.DeepCopyInto(obj.(*gardencorev1beta1.Seed))
+					return nil
+				})
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: seed.Spec.SecretRef.Namespace, Name: seed.Spec.SecretRef.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					return fakeErr
+				})
+
+			hash, err := factory.CalculateClientSetHash(ctx, key)
+			Expect(hash).To(BeEmpty())
+			Expect(err).To(MatchError("fake"))
+		})
+
+		It("should correctly calculate hash", func() {
+			c.EXPECT().Get(ctx, client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					seed.DeepCopyInto(obj.(*gardencorev1beta1.Seed))
+					return nil
+				})
+			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: seed.Spec.SecretRef.Namespace, Name: seed.Spec.SecretRef.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					(&corev1.Secret{}).DeepCopyInto(obj.(*corev1.Secret))
+					return nil
+				})
+
+			hash, err := factory.CalculateClientSetHash(ctx, key)
+			Expect(hash).To(Equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/pkg/client/kubernetes/clientmap/types.go
+++ b/pkg/client/kubernetes/clientmap/types.go
@@ -53,4 +53,7 @@ type ClientSetKey interface {
 type ClientSetFactory interface {
 	// NewClientSet constructs a new ClientSet for the given key.
 	NewClientSet(ctx context.Context, key ClientSetKey) (kubernetes.Interface, error)
+	// CalculateClientSetHash calculates a hash for the configuration that is used to construct a ClientSet
+	// (e.g. kubeconfig secret) to detect if it has changed mid-air and the ClientSet should be refreshed.
+	CalculateClientSetHash(ctx context.Context, key ClientSetKey) (string, error)
 }

--- a/pkg/mock/gardener/client/kubernetes/clientmap/mock_factory.go
+++ b/pkg/mock/gardener/client/kubernetes/clientmap/mock_factory.go
@@ -35,6 +35,21 @@ func (m *MockClientSetFactory) EXPECT() *MockClientSetFactoryMockRecorder {
 	return m.recorder
 }
 
+// CalculateClientSetHash mocks base method
+func (m *MockClientSetFactory) CalculateClientSetHash(arg0 context.Context, arg1 clientmap.ClientSetKey) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CalculateClientSetHash", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CalculateClientSetHash indicates an expected call of CalculateClientSetHash
+func (mr *MockClientSetFactoryMockRecorder) CalculateClientSetHash(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalculateClientSetHash", reflect.TypeOf((*MockClientSetFactory)(nil).CalculateClientSetHash), arg0, arg1)
+}
+
 // NewClientSet mocks base method
 func (m *MockClientSetFactory) NewClientSet(arg0 context.Context, arg1 clientmap.ClientSetKey) (kubernetes.Interface, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...


"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/priority blocker

**What this PR does / why we need it**:
With this PR the ClientMaps check if the config used for constructing a ClientSet has changed since creation (e.g. kubeconfig secret was updated). If that's the case, the ClientSet is refreshed (invalidated and recreated).
This PR also fixes limiting the refresh checks directly after a ClientSet has been created.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
