### PR TITLE
Refactor infrastructure extension management with DeployWaiter concept

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -314,12 +314,12 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation) *gardencorev1bet
 		})
 		destroyNetwork = g.Add(flow.Task{
 			Name:         "Destroying shoot network plugin",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.Network.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.Network.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(cleanShootNamespaces),
 		})
 		waitUntilNetworkIsDestroyed = g.Add(flow.Task{
 			Name:         "Waiting until shoot network plugin has been destroyed",
-			Fn:           botanist.Shoot.Components.Network.WaitCleanup,
+			Fn:           botanist.Shoot.Components.Extensions.Network.WaitCleanup,
 			Dependencies: flow.NewTaskIDs(destroyNetwork),
 		})
 		destroyWorker = g.Add(flow.Task{
@@ -429,22 +429,22 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation) *gardencorev1bet
 
 		destroyNginxIngressDNSRecord = g.Add(flow.Task{
 			Name:         "Destroying ingress DNS record",
-			Fn:           flow.TaskFn(component.OpDestroyAndWait(botanist.Shoot.Components.DNS.NginxEntry).Destroy),
+			Fn:           flow.TaskFn(component.OpDestroyAndWait(botanist.Shoot.Components.Extensions.DNS.NginxEntry).Destroy),
 			Dependencies: flow.NewTaskIDs(syncPointCleaned),
 		})
 		destroyInfrastructure = g.Add(flow.Task{
 			Name:         "Destroying shoot infrastructure",
-			Fn:           flow.TaskFn(botanist.DestroyInfrastructure).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.Infrastructure.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(syncPointCleaned, waitUntilControlPlaneDeleted),
 		})
 		waitUntilInfrastructureDeleted = g.Add(flow.Task{
 			Name:         "Waiting until shoot infrastructure has been destroyed",
-			Fn:           botanist.WaitUntilInfrastructureDeleted,
+			Fn:           botanist.Shoot.Components.Extensions.Infrastructure.WaitCleanup,
 			Dependencies: flow.NewTaskIDs(destroyInfrastructure),
 		})
 		destroyExternalDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Destroying external DNS entry",
-			Fn:           flow.TaskFn(component.OpWaiter(botanist.Shoot.Components.DNS.ExternalEntry).Destroy),
+			Fn:           flow.TaskFn(component.OpWaiter(botanist.Shoot.Components.Extensions.DNS.ExternalEntry).Destroy),
 			Dependencies: flow.NewTaskIDs(syncPointCleaned),
 		})
 
@@ -460,7 +460,7 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation) *gardencorev1bet
 
 		destroyInternalDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Destroying internal DNS entry",
-			Fn:           flow.TaskFn(component.OpWaiter(botanist.Shoot.Components.DNS.InternalEntry).Destroy),
+			Fn:           flow.TaskFn(component.OpWaiter(botanist.Shoot.Components.Extensions.DNS.InternalEntry).Destroy),
 			Dependencies: flow.NewTaskIDs(syncPoint),
 		})
 		deleteDNSProviders = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -258,17 +258,17 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 		})
 		destroyIngressDNSEntries = g.Add(flow.Task{
 			Name:         "Destroying ingress DNS record",
-			Fn:           flow.TaskFn(component.OpWaiter(botanist.Shoot.Components.DNS.NginxEntry).Destroy),
+			Fn:           flow.TaskFn(component.OpWaiter(botanist.Shoot.Components.Extensions.DNS.NginxEntry).Destroy),
 			Dependencies: flow.NewTaskIDs(waitUntilAPIServerDeleted),
 		})
 		destroyExternalDNSEntries = g.Add(flow.Task{
 			Name:         "Destroying external domain DNS record",
-			Fn:           flow.TaskFn(component.OpWaiter(botanist.Shoot.Components.DNS.ExternalEntry).Destroy),
+			Fn:           flow.TaskFn(component.OpWaiter(botanist.Shoot.Components.Extensions.DNS.ExternalEntry).Destroy),
 			Dependencies: flow.NewTaskIDs(waitUntilAPIServerDeleted),
 		})
 		destroyInternalDNSEntries = g.Add(flow.Task{
 			Name:         "Destroying internal domain DNS record",
-			Fn:           flow.TaskFn(component.OpWaiter(botanist.Shoot.Components.DNS.InternalEntry).Destroy),
+			Fn:           flow.TaskFn(component.OpWaiter(botanist.Shoot.Components.Extensions.DNS.InternalEntry).Destroy),
 			Dependencies: flow.NewTaskIDs(waitUntilAPIServerDeleted),
 		})
 		destroyDNSProviders = g.Add(flow.Task{

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -70,7 +70,7 @@ func (b *Botanist) GenerateKubernetesDashboardConfig() (map[string]interface{}, 
 
 // EnsureIngressDNSRecord ensures the nginx DNSEntry and waits for completion.
 func (b *Botanist) EnsureIngressDNSRecord(ctx context.Context) error {
-	return component.OpWaiter(b.Shoot.Components.DNS.NginxEntry).Deploy(ctx)
+	return component.OpWaiter(b.Shoot.Components.Extensions.DNS.NginxEntry).Deploy(ctx)
 }
 
 // DefaultNginxIngressDNSEntry returns a Deployer which removes existing nginx ingress DNSEntry.
@@ -91,7 +91,7 @@ func (b *Botanist) DefaultNginxIngressDNSEntry(seedClient client.Client) compone
 // SetNginxIngressAddress sets the IP address of the API server's LoadBalancer.
 func (b *Botanist) SetNginxIngressAddress(address string, seedClient client.Client) {
 	if b.NeedsExternalDNS() && !b.Shoot.HibernationEnabled && b.Shoot.NginxIngressEnabled() {
-		b.Shoot.Components.DNS.NginxEntry = dns.NewDNSEntry(
+		b.Shoot.Components.Extensions.DNS.NginxEntry = dns.NewDNSEntry(
 			&dns.EntryValues{
 				Name:    DNSIngressName,
 				DNSName: b.Shoot.GetIngressFQDN("*"),

--- a/pkg/operation/botanist/addons_test.go
+++ b/pkg/operation/botanist/addons_test.go
@@ -70,7 +70,9 @@ var _ = Describe("dns", func() {
 					},
 					SeedNamespace: seedNS,
 					Components: &shoot.Components{
-						DNS: &shoot.DNS{},
+						Extensions: &shoot.Extensions{
+							DNS: &shoot.DNS{},
+						},
 					},
 				},
 				Garden:         &garden.Garden{},
@@ -116,7 +118,7 @@ var _ = Describe("dns", func() {
 
 			b.SetNginxIngressAddress("1.2.3.4", seedClient)
 
-			Expect(b.Shoot.Components.DNS.NginxEntry).To(BeNil())
+			Expect(b.Shoot.Components.Extensions.DNS.NginxEntry).To(BeNil())
 		})
 
 		It("does nothing when hibernated", func() {
@@ -128,7 +130,7 @@ var _ = Describe("dns", func() {
 
 			b.SetNginxIngressAddress("1.2.3.4", seedClient)
 
-			Expect(b.Shoot.Components.DNS.NginxEntry).To(BeNil())
+			Expect(b.Shoot.Components.Extensions.DNS.NginxEntry).To(BeNil())
 		})
 
 		It("does nothing when nginx is disabled", func() {
@@ -141,7 +143,7 @@ var _ = Describe("dns", func() {
 
 			b.SetNginxIngressAddress("1.2.3.4", seedClient)
 
-			Expect(b.Shoot.Components.DNS.NginxEntry).To(BeNil())
+			Expect(b.Shoot.Components.Extensions.DNS.NginxEntry).To(BeNil())
 		})
 
 		It("sets an entry which creates DNSEntry", func() {
@@ -154,8 +156,8 @@ var _ = Describe("dns", func() {
 
 			b.SetNginxIngressAddress("1.2.3.4", seedClient)
 
-			Expect(b.Shoot.Components.DNS.NginxEntry).ToNot(BeNil())
-			Expect(b.Shoot.Components.DNS.NginxEntry.Deploy(ctx)).ToNot(HaveOccurred())
+			Expect(b.Shoot.Components.Extensions.DNS.NginxEntry).ToNot(BeNil())
+			Expect(b.Shoot.Components.Extensions.DNS.NginxEntry.Deploy(ctx)).ToNot(HaveOccurred())
 
 			found := &dnsv1alpha1.DNSEntry{}
 			err := seedClient.Get(ctx, types.NamespacedName{Name: "ingress", Namespace: seedNS}, found)

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -75,22 +75,20 @@ func New(o *operation.Operation) (*Botanist, error) {
 		return nil, err
 	}
 
-	o.Shoot.Components.DNS.ExternalProvider = b.DefaultExternalDNSProvider(b.K8sSeedClient.DirectClient())
-	o.Shoot.Components.DNS.ExternalEntry = b.DefaultExternalDNSEntry(b.K8sSeedClient.DirectClient())
-	o.Shoot.Components.DNS.InternalProvider = b.DefaultInternalDNSProvider(b.K8sSeedClient.DirectClient())
-	o.Shoot.Components.DNS.InternalEntry = b.DefaultInternalDNSEntry(b.K8sSeedClient.DirectClient())
-
-	o.Shoot.Components.DNS.AdditionalProviders, err = b.AdditionalDNSProviders(context.TODO(), b.K8sGardenClient.Client(), b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.DNS.ExternalProvider = b.DefaultExternalDNSProvider(b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.DNS.ExternalEntry = b.DefaultExternalDNSEntry(b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.DNS.InternalProvider = b.DefaultInternalDNSProvider(b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.DNS.InternalEntry = b.DefaultInternalDNSEntry(b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.DNS.NginxEntry = b.DefaultNginxIngressDNSEntry(b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.DNS.AdditionalProviders, err = b.AdditionalDNSProviders(context.TODO(), b.K8sGardenClient.Client(), b.K8sSeedClient.DirectClient())
 	if err != nil {
 		return nil, err
 	}
+	o.Shoot.Components.Extensions.Infrastructure = b.DefaultInfrastructure(b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.Network = b.DefaultNetwork(b.K8sSeedClient.DirectClient())
 
-	o.Shoot.Components.DNS.NginxEntry = b.DefaultNginxIngressDNSEntry(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.ControlPlane.KubeAPIServerService = b.DefaultKubeAPIServerService()
 	o.Shoot.Components.ControlPlane.KubeAPIServerSNI = b.DefaultKubeAPIServerSNI()
-
-	// Extension CRD components
-	o.Shoot.Components.Network = b.DefaultNetwork(b.K8sSeedClient.DirectClient())
 
 	return b, nil
 }

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -1379,7 +1379,7 @@ func (b *Botanist) setAPIServerAddress(address string) {
 	b.Operation.APIServerAddress = address
 
 	if b.NeedsInternalDNS() {
-		b.Shoot.Components.DNS.InternalEntry = dns.NewDNSEntry(
+		b.Shoot.Components.Extensions.DNS.InternalEntry = dns.NewDNSEntry(
 			&dns.EntryValues{
 				Name:    DNSInternalName,
 				DNSName: common.GetAPIServerDomain(b.Shoot.InternalClusterDomain),
@@ -1395,7 +1395,7 @@ func (b *Botanist) setAPIServerAddress(address string) {
 	}
 
 	if b.NeedsExternalDNS() {
-		b.Shoot.Components.DNS.ExternalEntry = dns.NewDNSEntry(
+		b.Shoot.Components.Extensions.DNS.ExternalEntry = dns.NewDNSEntry(
 			&dns.EntryValues{
 				Name:    DNSExternalName,
 				DNSName: common.GetAPIServerDomain(*b.Shoot.ExternalClusterDomain),

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -67,14 +67,14 @@ func (b *Botanist) DeployExternalDNS(ctx context.Context) error {
 func (b *Botanist) ExternalDNS() component.Deployer {
 	if b.NeedsExternalDNS() {
 		return component.OpWaiter(
-			b.Shoot.Components.DNS.ExternalProvider,
-			b.Shoot.Components.DNS.ExternalEntry,
+			b.Shoot.Components.Extensions.DNS.ExternalProvider,
+			b.Shoot.Components.Extensions.DNS.ExternalEntry,
 		)
 	}
 
 	return component.OpWaiter(
-		b.Shoot.Components.DNS.ExternalEntry,
-		b.Shoot.Components.DNS.ExternalProvider,
+		b.Shoot.Components.Extensions.DNS.ExternalEntry,
+		b.Shoot.Components.Extensions.DNS.ExternalProvider,
 	)
 }
 
@@ -88,14 +88,14 @@ func (b *Botanist) DeployInternalDNS(ctx context.Context) error {
 func (b *Botanist) InternalDNS() component.Deployer {
 	if b.NeedsInternalDNS() {
 		return component.OpWaiter(
-			b.Shoot.Components.DNS.InternalProvider,
-			b.Shoot.Components.DNS.InternalEntry,
+			b.Shoot.Components.Extensions.DNS.InternalProvider,
+			b.Shoot.Components.Extensions.DNS.InternalEntry,
 		)
 	}
 
 	return component.OpWaiter(
-		b.Shoot.Components.DNS.InternalEntry,
-		b.Shoot.Components.DNS.InternalProvider,
+		b.Shoot.Components.Extensions.DNS.InternalEntry,
+		b.Shoot.Components.Extensions.DNS.InternalProvider,
 	)
 }
 

--- a/pkg/operation/botanist/extensions/infrastructure/infrastructure.go
+++ b/pkg/operation/botanist/extensions/infrastructure/infrastructure.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infrastructure
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/operation/shoot"
+)
+
+const (
+	// DefaultInterval is the default interval for retry operations.
+	DefaultInterval = 5 * time.Second
+	// DefaultSevereThreshold is the default threshold until an error reported by another component is treated as 'severe'.
+	DefaultSevereThreshold = 30 * time.Second
+	// DefaultTimeout is the default timeout and defines how long Gardener should wait
+	// for a successful reconciliation of an infrastructure resource.
+	DefaultTimeout = 5 * time.Minute
+)
+
+// TimeNow returns the current time. Exposed for testing.
+var TimeNow = time.Now
+
+// Values contains the values used to create an Infrastructure resources.
+type Values struct {
+	// Namespace is the Shoot namespace in the seed.
+	Namespace string
+	// Name is the name of the Infrastructure resource. Commonly the Shoot's name.
+	Name string
+	// Type is the type of infrastructure provider.
+	Type string
+	// ProviderConfig contains the provider config for the Infrastructure provider.
+	ProviderConfig *runtime.RawExtension
+	// Region is the region of the shoot.
+	Region string
+	// SSHPublicKey is the to-be-used SSH public key of the shoot.
+	SSHPublicKey []byte
+	// IsInCreationPhase indicates if the Shoot is in the creation phase.
+	IsInCreationPhase bool
+	// IsWakingUp indicates if the Shoot is being waked up.
+	IsWakingUp bool
+	// IsInRestorePhaseOfControlPlaneMigration indicates if the Shoot is in the restoration
+	// phase of the ControlPlane migration.
+	IsInRestorePhaseOfControlPlaneMigration bool
+	// DeploymentRequested indicates if the Infrastructure deployment was explicitly requested,
+	// i.e., if the Shoot was annotated with the "infrastructure" task.
+	DeploymentRequested bool
+}
+
+// New creates a new instance of an Infrastructure deployer.
+func New(
+	logger *logrus.Entry,
+	client client.Client,
+	values *Values,
+	waitInterval time.Duration,
+	waitSevereThreshold time.Duration,
+	waitTimeout time.Duration,
+) shoot.Infrastructure {
+	return &infrastructure{
+		client:              client,
+		logger:              logger,
+		values:              values,
+		waitInterval:        waitInterval,
+		waitSevereThreshold: waitSevereThreshold,
+		waitTimeout:         waitTimeout,
+	}
+}
+
+type infrastructure struct {
+	values              *Values
+	logger              *logrus.Entry
+	client              client.Client
+	waitInterval        time.Duration
+	waitSevereThreshold time.Duration
+	waitTimeout         time.Duration
+
+	providerStatus *runtime.RawExtension
+	nodesCIDR      *string
+}
+
+// Deploy uses the seed client to create or update the Infrastructure resource.
+func (i *infrastructure) Deploy(ctx context.Context) error {
+	var (
+		operation        = v1beta1constants.GardenerOperationReconcile
+		restorePhase     = i.values.IsInRestorePhaseOfControlPlaneMigration
+		requestOperation = i.values.IsInCreationPhase || i.values.IsWakingUp || i.values.IsInRestorePhaseOfControlPlaneMigration || i.values.DeploymentRequested
+		infrastructure   = &extensionsv1alpha1.Infrastructure{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      i.values.Name,
+				Namespace: i.values.Namespace,
+			},
+		}
+		providerConfig *runtime.RawExtension
+	)
+
+	if cfg := i.values.ProviderConfig; cfg != nil {
+		providerConfig = &runtime.RawExtension{
+			Raw: cfg.Raw,
+		}
+	}
+
+	if restorePhase {
+		operation = v1beta1constants.GardenerOperationWaitForState
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, i.client, infrastructure, func() error {
+		if requestOperation {
+			metav1.SetMetaDataAnnotation(&infrastructure.ObjectMeta, v1beta1constants.GardenerOperation, operation)
+			metav1.SetMetaDataAnnotation(&infrastructure.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		}
+
+		infrastructure.Spec = extensionsv1alpha1.InfrastructureSpec{
+			DefaultSpec: extensionsv1alpha1.DefaultSpec{
+				Type:           i.values.Type,
+				ProviderConfig: providerConfig,
+			},
+			Region:       i.values.Region,
+			SSHPublicKey: i.values.SSHPublicKey,
+			SecretRef: corev1.SecretReference{
+				Name:      v1beta1constants.SecretNameCloudProvider,
+				Namespace: infrastructure.Namespace,
+			},
+		}
+		return nil
+	})
+	return err
+}
+
+// Destroy deletes the Infrastructure resource.
+func (i *infrastructure) Destroy(ctx context.Context) error {
+	return common.DeleteExtensionCR(
+		ctx,
+		i.client,
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Infrastructure{} },
+		i.values.Namespace,
+		i.values.Name,
+	)
+}
+
+// Wait waits until the Infrastructure resource is ready.
+func (i *infrastructure) Wait(ctx context.Context) error {
+	return common.WaitUntilExtensionCRReady(
+		ctx,
+		i.client,
+		i.logger,
+		func() runtime.Object { return &extensionsv1alpha1.Infrastructure{} },
+		"Infrastructure",
+		i.values.Namespace,
+		i.values.Name,
+		i.waitInterval,
+		i.waitSevereThreshold,
+		i.waitTimeout,
+		func(obj runtime.Object) error {
+			infrastructure, ok := obj.(*extensionsv1alpha1.Infrastructure)
+			if !ok {
+				return fmt.Errorf("expected extensionsv1alpha1.Infrastructure but got %T", infrastructure)
+			}
+
+			i.providerStatus = infrastructure.Status.ProviderStatus
+			i.nodesCIDR = infrastructure.Status.NodesCIDR
+			return nil
+		},
+	)
+}
+
+// WaitCleanup waits until the Infrastructure resource is deleted.
+func (i *infrastructure) WaitCleanup(ctx context.Context) error {
+	return common.WaitUntilExtensionCRDeleted(
+		ctx,
+		i.client,
+		i.logger,
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Infrastructure{} },
+		"Infrastructure",
+		i.values.Namespace,
+		i.values.Name,
+		i.waitInterval,
+		i.waitTimeout,
+	)
+}
+
+// SetSSHPublicKey sets the SSH public key in the values.
+func (i *infrastructure) SetSSHPublicKey(key []byte) {
+	i.values.SSHPublicKey = key
+}
+
+// ProviderStatus returns the generated status of the provider.
+func (i *infrastructure) ProviderStatus() *runtime.RawExtension {
+	return i.providerStatus
+}
+
+// NodesCIDR returns the generated nodes CIDR of the provider.
+func (i *infrastructure) NodesCIDR() *string {
+	return i.nodesCIDR
+}

--- a/pkg/operation/botanist/extensions/infrastructure/infrastructure_suite_test.go
+++ b/pkg/operation/botanist/extensions/infrastructure/infrastructure_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infrastructure_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestInfrastructure(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Botanist Extensions Infrastructure Suite")
+}

--- a/pkg/operation/botanist/extensions/infrastructure/infrastructure_test.go
+++ b/pkg/operation/botanist/extensions/infrastructure/infrastructure_test.go
@@ -1,0 +1,339 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infrastructure_test
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/logger"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
+	"github.com/gardener/gardener/pkg/operation/botanist/extensions/infrastructure"
+	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/operation/shoot"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/test"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("#Infrastructure", func() {
+	const (
+		namespace    = "test-namespace"
+		name         = "test-deploy"
+		providerType = "foo"
+	)
+
+	var (
+		ctx context.Context
+		log *logrus.Entry
+
+		ctrl    *gomock.Controller
+		c       *mockclient.MockClient
+		mockNow *mocktime.MockNow
+		now     time.Time
+
+		region         string
+		sshPublicKey   []byte
+		providerConfig *runtime.RawExtension
+
+		infra        *extensionsv1alpha1.Infrastructure
+		values       *infrastructure.Values
+		deployWaiter shoot.Infrastructure
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		log = logrus.NewEntry(logger.NewNopLogger())
+
+		ctrl = gomock.NewController(GinkgoT())
+		c = mockclient.NewMockClient(ctrl)
+		mockNow = mocktime.NewMockNow(ctrl)
+
+		region = "europe"
+		sshPublicKey = []byte("secure")
+		providerConfig = &runtime.RawExtension{
+			Raw: []byte("very-provider-specific"),
+		}
+
+		values = &infrastructure.Values{
+			Namespace:      namespace,
+			Name:           name,
+			Type:           providerType,
+			ProviderConfig: providerConfig,
+			Region:         region,
+		}
+		infra = &extensionsv1alpha1.Infrastructure{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+		deployWaiter = infrastructure.New(log, c, values, time.Millisecond, 2*time.Millisecond, 3*time.Millisecond)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#Deploy", func() {
+		DescribeTable("correct Infrastructure is created", func(mutator func()) {
+			defer test.WithVars(
+				&infrastructure.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			c.
+				EXPECT().
+				Get(ctx, kutil.Key(namespace, name), infra.DeepCopy()).
+				Return(apierrors.NewNotFound(schema.GroupResource{}, name))
+
+			deployWaiter.SetSSHPublicKey(sshPublicKey)
+			infra.Spec = extensionsv1alpha1.InfrastructureSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type:           providerType,
+					ProviderConfig: providerConfig,
+				},
+				Region:       region,
+				SSHPublicKey: sshPublicKey,
+				SecretRef: corev1.SecretReference{
+					Name:      v1beta1constants.SecretNameCloudProvider,
+					Namespace: namespace,
+				},
+			}
+			mutator()
+
+			c.
+				EXPECT().
+				Create(ctx, infra)
+
+			Expect(deployWaiter.Deploy(ctx)).To(Succeed())
+		},
+			Entry("with no modification", func() {}),
+			Entry("without provider config", func() {
+				values.ProviderConfig = nil
+				infra.Spec.ProviderConfig = nil
+			}),
+			Entry("creation phase", func() {
+				values.IsInCreationPhase = true
+				infra.Annotations = map[string]string{
+					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				}
+			}),
+			Entry("wake up phase", func() {
+				values.IsWakingUp = true
+				infra.Annotations = map[string]string{
+					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				}
+			}),
+			Entry("deployment task", func() {
+				values.DeploymentRequested = true
+				infra.Annotations = map[string]string{
+					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				}
+			}),
+			Entry("restoration phase", func() {
+				values.IsInRestorePhaseOfControlPlaneMigration = true
+				infra.Annotations = map[string]string{
+					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationWaitForState,
+					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				}
+			}),
+		)
+	})
+
+	Describe("#Wait", func() {
+		It("should return error when it's not found", func() {
+			c.
+				EXPECT().
+				Get(gomock.Any(), kutil.Key(namespace, name), &extensionsv1alpha1.Infrastructure{}).
+				Return(apierrors.NewNotFound(schema.GroupResource{}, name)).
+				AnyTimes()
+
+			Expect(deployWaiter.Wait(ctx)).To(HaveOccurred())
+		})
+
+		It("should return error when it's not ready", func() {
+			description := "some error"
+
+			c.
+				EXPECT().
+				Get(gomock.Any(), kutil.Key(namespace, name), &extensionsv1alpha1.Infrastructure{}).
+				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *extensionsv1alpha1.Infrastructure) error {
+					obj.Status.LastError = &gardencorev1beta1.LastError{
+						Description: description,
+					}
+					return nil
+				}).
+				AnyTimes()
+
+			err := deployWaiter.Wait(ctx)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(description))
+		})
+
+		It("should return no error when is ready", func() {
+			nodesCIDR := "1.2.3.4/5"
+			providerStatus := &runtime.RawExtension{
+				Raw: []byte("foo"),
+			}
+
+			c.
+				EXPECT().
+				Get(gomock.Any(), kutil.Key(namespace, name), &extensionsv1alpha1.Infrastructure{}).
+				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *extensionsv1alpha1.Infrastructure) error {
+					obj.Status.LastError = nil
+					obj.ObjectMeta.Annotations = map[string]string{}
+					obj.Status.LastOperation = &gardencorev1beta1.LastOperation{
+						State: gardencorev1beta1.LastOperationStateSucceeded,
+					}
+					obj.Status.NodesCIDR = &nodesCIDR
+					obj.Status.ProviderStatus = providerStatus
+					return nil
+				})
+
+			Expect(deployWaiter.Wait(ctx)).To(Succeed())
+			Expect(deployWaiter.ProviderStatus()).To(Equal(providerStatus))
+			Expect(deployWaiter.NodesCIDR()).To(PointTo(Equal(nodesCIDR)))
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should not return error when it's not found", func() {
+			c.
+				EXPECT().
+				Get(gomock.Any(), kutil.Key(namespace, name), infra).
+				Return(apierrors.NewNotFound(schema.GroupResource{}, name))
+			c.
+				EXPECT().
+				Delete(ctx, infra).
+				Return(apierrors.NewNotFound(schema.GroupResource{}, name))
+
+			Expect(deployWaiter.Destroy(ctx)).ToNot(HaveOccurred())
+		})
+
+		It("should not return error when it's deleted successfully", func() {
+			defer test.WithVars(
+				&common.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			infraCopy := infra.DeepCopy()
+			infraCopy.Annotations = map[string]string{
+				common.ConfirmationDeletion:        "true",
+				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+			}
+
+			c.
+				EXPECT().
+				Get(ctx, kutil.Key(namespace, name), infra)
+			c.
+				EXPECT().
+				Update(ctx, infraCopy)
+			c.
+				EXPECT().
+				Delete(ctx, infraCopy)
+
+			Expect(deployWaiter.Destroy(ctx)).To(Succeed())
+		})
+
+		It("should return error when it's not deleted successfully", func() {
+			defer test.WithVars(
+				&common.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			infraCopy := infra.DeepCopy()
+			infraCopy.Annotations = map[string]string{
+				common.ConfirmationDeletion:        "true",
+				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+			}
+			fakeErr := errors.New("some random error")
+
+			c.
+				EXPECT().
+				Get(ctx, kutil.Key(namespace, name), infra)
+			c.
+				EXPECT().
+				Update(ctx, infraCopy)
+			c.
+				EXPECT().
+				Delete(ctx, infraCopy).
+				Return(fakeErr)
+
+			err := deployWaiter.Destroy(ctx)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fakeErr.Error()))
+		})
+	})
+
+	Describe("#WaitCleanup", func() {
+		It("should not return error when it's already removed", func() {
+			c.
+				EXPECT().
+				Get(gomock.Any(), kutil.Key(namespace, name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).
+				Return(apierrors.NewNotFound(schema.GroupResource{}, name))
+
+			Expect(deployWaiter.WaitCleanup(ctx)).To(Succeed())
+		})
+
+		It("should poll until it's removed", func() {
+			c.
+				EXPECT().
+				Get(gomock.Any(), kutil.Key(namespace, name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{}))
+			c.
+				EXPECT().
+				Get(gomock.Any(), kutil.Key(namespace, name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).
+				Return(apierrors.NewNotFound(schema.GroupResource{}, name))
+
+			Expect(deployWaiter.WaitCleanup(ctx)).To(Succeed())
+		})
+
+		It("should return unexpected errors", func() {
+			fakeErr := errors.New("fake")
+
+			c.
+				EXPECT().
+				Get(gomock.Any(), kutil.Key(namespace, name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).
+				Return(fakeErr)
+
+			err := deployWaiter.WaitCleanup(ctx)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fakeErr.Error()))
+		})
+	})
+})

--- a/pkg/operation/botanist/extensions/network/network.go
+++ b/pkg/operation/botanist/extensions/network/network.go
@@ -156,11 +156,15 @@ func (d *network) Wait(ctx context.Context) error {
 
 // WaitCleanup waits until the Network CRD is deleted
 func (d *network) WaitCleanup(ctx context.Context) error {
-	return common.DeleteExtensionCR(
+	return common.WaitUntilExtensionCRDeleted(
 		ctx,
 		d.client,
+		d.logger,
 		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Network{} },
+		"Network",
 		d.values.Namespace,
 		d.values.Name,
+		d.waitInterval,
+		d.waitTimeout,
 	)
 }

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -16,147 +16,81 @@ package botanist
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/operation/botanist/extensions/infrastructure"
 	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// InfrastructureDefaultTimeout is the default timeout and defines how long Gardener should wait
-// for a successful reconciliation of an infrastructure resource.
-const InfrastructureDefaultTimeout = 5 * time.Minute
+// DefaultInfrastructure creates the default deployer for the Infrastructure custom resource.
+func (b *Botanist) DefaultInfrastructure(seedClient client.Client) shoot.Infrastructure {
+	return infrastructure.New(
+		b.Logger,
+		seedClient,
+		&infrastructure.Values{
+			Namespace:                               b.Shoot.SeedNamespace,
+			Name:                                    b.Shoot.Info.Name,
+			Type:                                    b.Shoot.Info.Spec.Provider.Type,
+			ProviderConfig:                          b.Shoot.Info.Spec.Provider.InfrastructureConfig,
+			Region:                                  b.Shoot.Info.Spec.Region,
+			IsInCreationPhase:                       b.Shoot.Info.Status.LastOperation != nil && b.Shoot.Info.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeCreate,
+			IsWakingUp:                              !gardencorev1beta1helper.HibernationIsEnabled(b.Shoot.Info) && b.Shoot.Info.Status.IsHibernated,
+			IsInRestorePhaseOfControlPlaneMigration: b.isRestorePhase(),
+			DeploymentRequested:                     controllerutils.HasTask(b.Shoot.Info.Annotations, common.ShootTaskDeployInfrastructure),
+		},
+		infrastructure.DefaultInterval,
+		infrastructure.DefaultSevereThreshold,
+		infrastructure.DefaultTimeout,
+	)
+}
 
-// DeployInfrastructure creates the `Infrastructure` extension resource in the shoot namespace in the seed
-// cluster. Gardener waits until an external controller did reconcile the cluster successfully.
+// DeployInfrastructure deploys the Infrastructure custom resource and triggers the restore operation in case
+// the Shoot is in the restore phase of the control plane migration.
 func (b *Botanist) DeployInfrastructure(ctx context.Context) error {
-	var (
-		operation                      = v1beta1constants.GardenerOperationReconcile
-		lastOperation                  = b.Shoot.Info.Status.LastOperation
-		creationPhase                  = lastOperation != nil && lastOperation.Type == gardencorev1beta1.LastOperationTypeCreate
-		shootIsWakingUp                = !gardencorev1beta1helper.HibernationIsEnabled(b.Shoot.Info) && b.Shoot.Info.Status.IsHibernated
-		restorePhase                   = b.isRestorePhase()
-		requestInfrastructureOperation = creationPhase || shootIsWakingUp || restorePhase || controllerutils.HasTask(b.Shoot.Info.Annotations, common.ShootTaskDeployInfrastructure)
-		infrastructure                 = &extensionsv1alpha1.Infrastructure{
+	b.Shoot.Components.Extensions.Infrastructure.SetSSHPublicKey(b.Secrets[v1beta1constants.SecretNameSSHKeyPair].Data[secrets.DataKeySSHAuthorizedKeys])
+
+	if err := b.Shoot.Components.Extensions.Infrastructure.Deploy(ctx); err != nil {
+		return err
+	}
+
+	if b.isRestorePhase() {
+		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), &extensionsv1alpha1.Infrastructure{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      b.Shoot.Info.Name,
 				Namespace: b.Shoot.SeedNamespace,
 			},
-		}
-		providerConfig *runtime.RawExtension
-	)
-
-	if cfg := b.Shoot.Info.Spec.Provider.InfrastructureConfig; cfg != nil {
-		providerConfig = &runtime.RawExtension{
-			Raw: cfg.Raw,
-		}
+		}, extensionsv1alpha1.InfrastructureResource)
 	}
-
-	if restorePhase {
-		operation = v1beta1constants.GardenerOperationWaitForState
-	}
-
-	_, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), infrastructure, func() error {
-		if requestInfrastructureOperation {
-			metav1.SetMetaDataAnnotation(&infrastructure.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-			metav1.SetMetaDataAnnotation(&infrastructure.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
-		}
-
-		infrastructure.Spec = extensionsv1alpha1.InfrastructureSpec{
-			DefaultSpec: extensionsv1alpha1.DefaultSpec{
-				Type:           b.Shoot.Info.Spec.Provider.Type,
-				ProviderConfig: providerConfig,
-			},
-			Region:       b.Shoot.Info.Spec.Region,
-			SSHPublicKey: b.Secrets[v1beta1constants.SecretNameSSHKeyPair].Data[secrets.DataKeySSHAuthorizedKeys],
-			SecretRef: corev1.SecretReference{
-				Name:      v1beta1constants.SecretNameCloudProvider,
-				Namespace: infrastructure.Namespace,
-			},
-		}
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	if restorePhase {
-		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), infrastructure, extensionsv1alpha1.InfrastructureResource)
-	}
-
 	return nil
 }
 
-// DestroyInfrastructure deletes the `Infrastructure` extension resource in the shoot namespace in the seed cluster,
-// and it waits for a maximum of 10m until it is deleted.
-func (b *Botanist) DestroyInfrastructure(ctx context.Context) error {
-	return common.DeleteExtensionCR(
-		ctx,
-		b.K8sSeedClient.Client(),
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Infrastructure{} },
-		b.Shoot.SeedNamespace,
-		b.Shoot.Info.Name,
-	)
-}
+// WaitForInfrastructure waits until the infrastructure reconciliation has finished and extracts the provider status
+// out of it.
+func (b *Botanist) WaitForInfrastructure(ctx context.Context) error {
+	if err := b.Shoot.Components.Extensions.Infrastructure.Wait(ctx); err != nil {
+		return err
+	}
 
-// WaitUntilInfrastructureReady waits until the infrastructure resource has been reconciled successfully.
-func (b *Botanist) WaitUntilInfrastructureReady(ctx context.Context) error {
-	return common.WaitUntilExtensionCRReady(
-		ctx,
-		b.K8sSeedClient.DirectClient(),
-		b.Logger,
-		func() runtime.Object { return &extensionsv1alpha1.Infrastructure{} },
-		"Infrastructure",
-		b.Shoot.SeedNamespace,
-		b.Shoot.Info.Name,
-		DefaultInterval,
-		DefaultSevereThreshold,
-		InfrastructureDefaultTimeout,
-		func(obj runtime.Object) error {
-			infrastructure, ok := obj.(*extensionsv1alpha1.Infrastructure)
-			if !ok {
-				return fmt.Errorf("expected extensionsv1alpha1.Infrastructure but got %T", infrastructure)
-			}
+	if providerStatus := b.Shoot.Components.Extensions.Infrastructure.ProviderStatus(); providerStatus != nil {
+		b.Shoot.InfrastructureStatus = providerStatus.Raw
+	}
 
-			if infrastructure.Status.ProviderStatus != nil {
-				b.Shoot.InfrastructureStatus = infrastructure.Status.ProviderStatus.Raw
-			}
-
-			if infrastructure.Status.NodesCIDR != nil {
-				shootCopy := b.Shoot.Info.DeepCopy()
-				if err := b.UpdateShootAndCluster(ctx, shootCopy, func() error {
-					shootCopy.Spec.Networking.Nodes = infrastructure.Status.NodesCIDR
-					return nil
-				}); err != nil {
-					return err
-				}
-			}
+	if nodesCIDR := b.Shoot.Components.Extensions.Infrastructure.NodesCIDR(); nodesCIDR != nil {
+		shootCopy := b.Shoot.Info.DeepCopy()
+		return b.UpdateShootAndCluster(ctx, shootCopy, func() error {
+			shootCopy.Spec.Networking.Nodes = nodesCIDR
 			return nil
-		},
-	)
-}
+		})
+	}
 
-// WaitUntilInfrastructureDeleted waits until the infrastructure resource has been deleted.
-func (b *Botanist) WaitUntilInfrastructureDeleted(ctx context.Context) error {
-	return common.WaitUntilExtensionCRDeleted(
-		ctx,
-		b.K8sSeedClient.Client(),
-		b.Logger,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Infrastructure{} },
-		"Infrastructure",
-		b.Shoot.SeedNamespace,
-		b.Shoot.Info.Name,
-		DefaultInterval,
-		InfrastructureDefaultTimeout,
-	)
+	return nil
 }

--- a/pkg/operation/botanist/network.go
+++ b/pkg/operation/botanist/network.go
@@ -48,7 +48,7 @@ func (b *Botanist) DefaultNetwork(seedClient client.Client) component.DeployWait
 // DeployNetwork deploys the Network custom resource and triggers the restore operation in case
 // the Shoot is in the restore phase of the control plane migration
 func (b *Botanist) DeployNetwork(ctx context.Context) error {
-	if err := b.Shoot.Components.Network.Deploy(ctx); err != nil {
+	if err := b.Shoot.Components.Extensions.Network.Deploy(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -162,7 +162,9 @@ func (b *Builder) Build(ctx context.Context, c client.Client) (*Shoot, error) {
 	shoot.WantsAlertmanager = !shoot.IgnoreAlerts && shootObject.Spec.Monitoring != nil && shootObject.Spec.Monitoring.Alerting != nil && len(shootObject.Spec.Monitoring.Alerting.EmailReceivers) > 0
 	shoot.WantsVerticalPodAutoscaler = gardencorev1beta1helper.ShootWantsVerticalPodAutoscaler(shootObject)
 	shoot.Components = &Components{
-		DNS:          &DNS{},
+		Extensions: &Extensions{
+			DNS: &DNS{},
+		},
 		ControlPlane: &ControlPlane{},
 	}
 

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -27,6 +27,7 @@ import (
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -78,9 +79,21 @@ type Shoot struct {
 
 // Components contains different components deployed in the Shoot cluster.
 type Components struct {
-	DNS          *DNS
-	Network      component.DeployWaiter
+	Extensions   *Extensions
 	ControlPlane *ControlPlane
+}
+
+// ControlPlane contains references to K8S control plane components.
+type ControlPlane struct {
+	KubeAPIServerService component.DeployWaiter
+	KubeAPIServerSNI     component.DeployWaiter
+}
+
+// Extensions contains references to extension resources.
+type Extensions struct {
+	DNS            *DNS
+	Infrastructure Infrastructure
+	Network        component.DeployWaiter
 }
 
 // DNS contains references to internal and external DNSProvider and DNSEntry deployers.
@@ -93,10 +106,13 @@ type DNS struct {
 	NginxEntry          component.DeployWaiter
 }
 
-// ControlPlane contains references to K8S control plane components.
-type ControlPlane struct {
-	KubeAPIServerService component.DeployWaiter
-	KubeAPIServerSNI     component.DeployWaiter
+// Infrastructure contains references to an Infrastructure extension deployer and its generated
+// provider status.
+type Infrastructure interface {
+	component.DeployWaiter
+	SetSSHPublicKey([]byte)
+	ProviderStatus() *runtime.RawExtension
+	NodesCIDR() *string
 }
 
 // Networks contains pre-calculated subnets and IP address for various components.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Similar to #2442, this PR is now refactoring the management of the `Infrastructure` extension resource as part of the `Botanist` structure in a way to leverage the new `DeployWaiter` interface introduced with #1980.

It also fixes a wrongly called method in the `WaitCleanup` function of the `Network` extension management.

/invite @mvladev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
