### PR TITLE
Avoid running into timeouts when dumping shoot state

### DIFF
--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -99,7 +99,8 @@ func (f *ShootFramework) DumpState(ctx context.Context) {
 			f.Logger.Fatalf("Cannot decode shoot %s: %s", f.Shoot.GetName(), err)
 		}
 
-		if f.ShootClient != nil {
+		isRunning, err := f.IsAPIServerRunning(ctx)
+		if f.ShootClient != nil && isRunning && err == nil {
 			ctxIdentifier := fmt.Sprintf("[SHOOT %s]", f.Shoot.Name)
 			f.Logger.Info(ctxIdentifier)
 			if err := f.DumpDefaultResourcesInAllNamespaces(ctx, ctxIdentifier, f.ShootClient); err != nil {
@@ -108,6 +109,12 @@ func (f *ShootFramework) DumpState(ctx context.Context) {
 			if err := f.dumpNodes(ctx, ctxIdentifier, f.ShootClient); err != nil {
 				f.Logger.Errorf("unable to dump information of nodes from shoot %s: %s", f.Shoot.Name, err.Error())
 			}
+		} else {
+			errMsg := ""
+			if err != nil {
+				errMsg = ": " + err.Error()
+			}
+			f.Logger.Errorf("unable to dump resources from shoot %s: API server is currently not running%s", f.Shoot.Name, errMsg)
 		}
 	}
 


### PR DESCRIPTION
Co-authored-by: Tim Schrodi <tim.schrodi@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement
/priority normal

**What this PR does / why we need it**:
We see some integration test runs, where we run into timeouts when dumping the shoot's state, because the API server is not running.
With this PR we check if the API server is running before dumping, so we can avoid running into timeouts, so that the Seed state will still be dumped.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
