### PR TITLE
Upgrade resource-manager and enable always-update for Shoots

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -24,7 +24,7 @@ images:
 - name: gardener-resource-manager
   sourceRepository: github.com/gardener/gardener-resource-manager
   repository: eu.gcr.io/gardener-project/gardener/gardener-resource-manager
-  tag: "v0.13.1"
+  tag: "v0.14.0"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog

--- a/charts/seed-controlplane/charts/gardener-resource-manager/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/templates/deployment.yaml
@@ -36,10 +36,14 @@ spec:
         - /gardener-resource-manager
         - --leader-election=true
         - --leader-election-namespace={{ .Release.Namespace }}
+        {{- if .Values.controllers.cacheResyncPeriod }}
+        - --cache-resync-period={{ .Values.controllers.cacheResyncPeriod }}
+        {{- end }}
         - --sync-period={{ .Values.controllers.managedResource.syncPeriod }}
         - --max-concurrent-workers={{ .Values.controllers.managedResource.concurrentSyncs }}
         - --health-sync-period={{ .Values.controllers.managedResourceHealth.syncPeriod }}
         - --health-max-concurrent-workers={{ .Values.controllers.managedResourceHealth.concurrentSyncs }}
+        - --always-update={{ .Values.controllers.managedResource.alwaysUpdate }}
         - --namespace={{ .Release.Namespace }}
         - --target-kubeconfig=/etc/gardener-resource-manager/kubeconfig
         {{- if .Values.resources }}

--- a/charts/seed-controlplane/charts/gardener-resource-manager/values.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/values.yaml
@@ -12,9 +12,11 @@ resources:
 replicas: 1
 
 controllers:
+#  cacheResyncPeriod: 24h0m0s
   managedResource:
     syncPeriod: 1m0s
     concurrentSyncs: 20
+    alwaysUpdate: true
   managedResourceHealth:
     syncPeriod: 1m0s
     concurrentSyncs: 10


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
Upgrade resource-manager and enable the new `--always-update` flag for the resource-manager in the Shoot ControlPlane.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-aws/issues/134

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
``` improvement operator github.com/gardener/gardener-resource-manager #71 @tim-ebert
Missing RBAC rules for updating and patching secrets were added.
```

``` improvement developer github.com/gardener/gardener-resource-manager #70 @rfranzke
The new `--always-update` command line parameter (default: `false`) allows to configure whether to always send a `PUT` request for managed resources regardless of whether their desired state differs from their actual state.
```

``` improvement operator github.com/gardener/gardener-resource-manager #68 @tim-ebert
A bug has been fixed, that caused new Services to get assigned a different ClusterIP than specified.
```
