### PR TITLE
Update Istio to 1.6.4

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -237,11 +237,11 @@ images:
 - name: istio-proxy
   sourceRepository: github.com/istio/istio
   repository: docker.io/istio/proxyv2
-  tag: "1.6.3"
+  tag: "1.6.4"
 - name: istio-istiod
   sourceRepository: github.com/istio/istio
   repository: docker.io/istio/pilot
-  tag: "1.6.3"
+  tag: "1.6.4"
 
 # API Server SNI
 - name: apiserver-proxy

--- a/charts/istio/istio-ingress/templates/bootstrap-config-override.yaml
+++ b/charts/istio/istio-ingress/templates/bootstrap-config-override.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-custom-bootstrap-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ .Values.labels | toYaml | indent 4 }}
+data:
+  custom_bootstrap.yaml: |
+    layered_runtime:
+      layers:
+      - name: static_layer_0
+        static_layer:
+          overload:
+            # Fix for https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8663
+            # https://istio.io/latest/news/security/istio-security-2020-007/
+            global_downstream_max_connections: 750000
+      - name: admin
+        admin_layer: {}

--- a/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/charts/istio/istio-ingress/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         service.istio.io/canonical-revision: "1.5"
       annotations:
         sidecar.istio.io/inject: "false"
+        checksum/configmap-bootstrap-config-override: {{ include (print $.Template.BasePath "/bootstrap-config-override.yaml") . | sha256sum }}
     spec:
       serviceAccountName: istio-ingressgateway
       containers:
@@ -127,9 +128,14 @@ spec:
           value: sni-dnat
         - name: ISTIO_META_CLUSTER_ID
           value: "Kubernetes"
+        - name: ISTIO_BOOTSTRAP_OVERRIDE
+          value: /etc/istio/custom-bootstrap/custom_bootstrap.yaml
         volumeMounts:
         - mountPath: /var/run/secrets/istio
           name: istiod-ca-cert
+        - mountPath: /etc/istio/custom-bootstrap
+          name: custom-bootstrap-volume
+          readOnly: true
         - name: istio-token
           mountPath: /var/run/secrets/tokens
           readOnly: true
@@ -141,6 +147,9 @@ spec:
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
+      - name: custom-bootstrap-volume
+        configMap:
+          name: istio-custom-bootstrap-config
       - name: podinfo
         downwardAPI:
           items:

--- a/charts/istio/istio-ingress/templates/envoy-filter.yaml
+++ b/charts/istio/istio-ingress/templates/envoy-filter.yaml
@@ -1,25 +1,31 @@
-# this adds "envoy.listener.proxy_protocol" filter to the listener.
+{{- if .Values.ports }}
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
-  name: proxy-protocol
+  name: istio-ingressgateway
   namespace: {{ .Release.Namespace }}
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 spec:
-  workloadSelector:
-    labels:
-{{ .Values.labels | toYaml | indent 6 }}
   configPatches:
+{{- range .Values.ports }}
   - applyTo: LISTENER
     match:
       context: GATEWAY
       listener:
-        portNumber: 8443
-        name: 0.0.0.0_8443
+        portNumber: {{ .port }}
     patch:
       operation: MERGE
       value:
         per_connection_buffer_limit_bytes: 32768 # 32 KiB
-        listener_filters:
-        - name: envoy.listener.proxy_protocol
+  - applyTo: CLUSTER
+    match:
+      context: GATEWAY
+      cluster:
+        portNumber: {{ .port }}
+    patch:
+      operation: MERGE
+      value:
+        per_connection_buffer_limit_bytes: 32768 # 32 KiB
+{{- end }}
+{{- end }}

--- a/pkg/operation/seed/istio/ingress_gateway_test.go
+++ b/pkg/operation/seed/istio/ingress_gateway_test.go
@@ -96,7 +96,7 @@ var _ = Describe("ingress", func() {
 			Expect(c.Get(ctx, client.ObjectKey{Name: "istio-ingressgateway", Namespace: deployNS}, actualDeploy)).ToNot(HaveOccurred())
 			envs := actualDeploy.Spec.Template.Spec.Containers[0].Env
 
-			Expect(envs).To(HaveLen(18))
+			Expect(envs).To(HaveLen(19))
 			Expect(envs).To(ContainElement(env))
 		},
 		Entry("NODE_NAME is projected", fieldEnv("NODE_NAME", "spec.nodeName")),
@@ -112,11 +112,14 @@ var _ = Describe("ingress", func() {
 		Entry("Use SDS", simplEnv("ISTIO_META_USER_SDS", "true")),
 		Entry("istiod address is set", simplEnv("CA_ADDR", "istiod.istio-test-system.svc:15012")),
 		Entry("workload name is set", simplEnv("ISTIO_META_WORKLOAD_NAME", "istio-ingressgateway")),
-		Entry("meta owner is igw", simplEnv("ISTIO_META_OWNER", "kubernetes://apis/apps/v1/namespaces/test-ingress/deployments/istio-ingressgateway")),
+		Entry("meta owner is igw",
+			simplEnv("ISTIO_META_OWNER", "kubernetes://apis/apps/v1/namespaces/test-ingress/deployments/istio-ingressgateway")),
 		Entry("mesh id is the trust domain", simplEnv("ISTIO_META_MESH_ID", "foo.bar")),
 		Entry("auto mTLS is enabled", simplEnv("ISTIO_AUTO_MTLS_ENABLED", "true")),
 		Entry("router mode is sni-dnat", simplEnv("ISTIO_META_ROUTER_MODE", "sni-dnat")),
 		Entry("ISTIO_META_CLUSTER_ID is Kubernetes", simplEnv("ISTIO_META_CLUSTER_ID", "Kubernetes")),
+		Entry("ISTIO_BOOTSTRAP_OVERRIDE is set to override",
+			simplEnv("ISTIO_BOOTSTRAP_OVERRIDE", "/etc/istio/custom-bootstrap/custom_bootstrap.yaml")),
 	)
 
 	It("ingress gateway service has load balancer annotations", func() {


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement 
/priority normal

**What this PR does / why we need it**:

Update Istio to 1.6.4. 
Fix CVE-2020-8663 by setting `overload.global_downstream_max_connections`.

Listener and cluster buffer limit to 32KiB.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Update Istio to `1.6.4`. Fix CVE-2020-8663 by setting `overload.global_downstream_max_connections` on the istio-ingress gateway.
```
