### PR TITLE
Fix restore of extension objects during migration.

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -525,7 +525,7 @@ func (b *Botanist) DeployControlPlane(ctx context.Context) error {
 	}
 
 	if restorePhase {
-		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), cp, extensionsv1alpha1.ControlPlaneResource)
+		return b.restoreExtensionObject(ctx, b.K8sSeedClient.DirectClient(), cp, extensionsv1alpha1.ControlPlaneResource)
 	}
 
 	return nil
@@ -575,7 +575,7 @@ func (b *Botanist) DeployControlPlaneExposure(ctx context.Context) error {
 	}
 
 	if restorePhase {
-		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), cp, extensionsv1alpha1.ControlPlaneResource)
+		return b.restoreExtensionObject(ctx, b.K8sSeedClient.DirectClient(), cp, extensionsv1alpha1.ControlPlaneResource)
 	}
 	return nil
 }

--- a/pkg/operation/botanist/extension.go
+++ b/pkg/operation/botanist/extension.go
@@ -70,7 +70,7 @@ func (b *Botanist) DeployExtensionResources(ctx context.Context) error {
 			})
 
 			if restorePhase {
-				return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), &toApply, extensionsv1alpha1.ExtensionResource)
+				return b.restoreExtensionObject(ctx, b.K8sSeedClient.DirectClient(), &toApply, extensionsv1alpha1.ExtensionResource)
 			}
 
 			return err

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -63,7 +63,7 @@ func (b *Botanist) DeployInfrastructure(ctx context.Context) error {
 	}
 
 	if b.isRestorePhase() {
-		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), &extensionsv1alpha1.Infrastructure{
+		return b.restoreExtensionObject(ctx, b.K8sSeedClient.DirectClient(), &extensionsv1alpha1.Infrastructure{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      b.Shoot.Info.Name,
 				Namespace: b.Shoot.SeedNamespace,

--- a/pkg/operation/botanist/migration.go
+++ b/pkg/operation/botanist/migration.go
@@ -95,6 +95,10 @@ func (b *Botanist) applyFuncToAllExtensionCRs(ctx context.Context, applyFunc fun
 }
 
 func (b *Botanist) restoreExtensionObject(ctx context.Context, client client.Client, extensionObj extensionsv1alpha1.Object, resourceKind string) error {
+	if err := client.Get(ctx, kutil.KeyFromObject(extensionObj), extensionObj); err != nil {
+		return err
+	}
+
 	if err := b.restoreExtensionObjectState(ctx, client, extensionObj, resourceKind, extensionObj.GetName(), extensionObj.GetExtensionSpec().GetExtensionPurpose()); err != nil {
 		return err
 	}

--- a/pkg/operation/botanist/network.go
+++ b/pkg/operation/botanist/network.go
@@ -53,7 +53,7 @@ func (b *Botanist) DeployNetwork(ctx context.Context) error {
 	}
 
 	if b.isRestorePhase() {
-		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), &extensionsv1alpha1.Network{
+		return b.restoreExtensionObject(ctx, b.K8sSeedClient.DirectClient(), &extensionsv1alpha1.Network{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      b.Shoot.Info.Name,
 				Namespace: b.Shoot.SeedNamespace,

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -171,7 +171,7 @@ func (b *Botanist) DeployWorker(ctx context.Context) error {
 	}
 
 	if restorePhase {
-		return b.restoreExtensionObject(ctx, b.K8sSeedClient.Client(), worker, extensionsv1alpha1.WorkerResource)
+		return b.restoreExtensionObject(ctx, b.K8sSeedClient.DirectClient(), worker, extensionsv1alpha1.WorkerResource)
 	}
 
 	return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug
/priority normal

**What this PR does / why we need it**:
With "componentization" the botanist, restoration of extension objects during migration was broken. 
Previously the extension resources were created by botanist and the botanist had the latest object state, that was passed to the restore function. Now an empty objects are created and passed to the restoreExtensionObject ((botanist.Botanist).DeployNetwork) func that causes a nil pointer dereference error.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
