### PR TITLE
Increase default QPS for Seed Clients

### DIFF
--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -54,8 +54,8 @@ global:
       seedClientConnection:
         acceptContentTypes: application/json
         contentType: application/json
-        qps: 25
-        burst: 50
+        qps: 100
+        burst: 130
       # kubeconfig: |
       #   Specify a kubeconfig for the seed cluster here if you don't want to use the Gardenlet's service account.
       shootClientConnection:

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -9,8 +9,8 @@ gardenClientConnection:
 seedClientConnection:
   acceptContentTypes: application/json
   contentType: application/json
-  qps: 25
-  burst: 50
+  qps: 100
+  burst: 130
 shootClientConnection:
   acceptContentTypes: application/json
   contentType: application/json


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR increases the default QPS value for Seed Clients.
Bevor my refactoring in #2449, every Shoot operation created its own Seed client, so the configured QPS setting in the GardenletConfiguration was actually applied only to each individual Seed client (per Shoot operation). That in turn means, that in sum the maximum QPS was actually not respected when talking to the Seed's API server.

This is a problem when many Shoot's are created in parallel and the gardenlet sends a lot of requests to the Seed's API server.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
/invite @ialidzhikov 
/cc @zanetworker 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The default QPS setting for Seed Clients in the gardenlet has been increased to adapt to the actual amount concurrent of API calls.
```
