### PR TITLE
Use DirectClient in BB/BE reconciler

### DIFF
--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
@@ -70,7 +70,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	bb := &gardencorev1beta1.BackupBucket{}
-	if err := gardenClient.Client().Get(r.ctx, request.NamespacedName, bb); err != nil {
+	if err := gardenClient.DirectClient().Get(r.ctx, request.NamespacedName, bb); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.logger.Debugf("[BACKUPBUCKET RECONCILE] %s - skipping because BackupBucket has been deleted", request.NamespacedName)
 			return reconcile.Result{}, nil
@@ -95,7 +95,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 func (r *reconciler) reconcileBackupBucket(gardenClient kubernetes.Interface, backupBucket *gardencorev1beta1.BackupBucket) (reconcile.Result, error) {
 	backupBucketLogger := logger.NewFieldLogger(logger.Logger, "backupbucket", backupBucket.Name)
 
-	if err := controllerutils.EnsureFinalizer(r.ctx, gardenClient.Client(), backupBucket, gardencorev1beta1.GardenerName); err != nil {
+	if err := controllerutils.EnsureFinalizer(r.ctx, gardenClient.DirectClient(), backupBucket, gardencorev1beta1.GardenerName); err != nil {
 		backupBucketLogger.Errorf("Failed to ensure gardener finalizer on backupbucket: %+v", err)
 		return reconcile.Result{}, err
 	}

--- a/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
@@ -71,7 +71,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	be := &gardencorev1beta1.BackupEntry{}
-	if err := gardenClient.Client().Get(r.ctx, request.NamespacedName, be); err != nil {
+	if err := gardenClient.DirectClient().Get(r.ctx, request.NamespacedName, be); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.logger.Debugf("[BACKUPENTRY RECONCILE] %s - skipping because BackupEntry has been deleted", request.NamespacedName)
 			return reconcile.Result{}, nil
@@ -90,7 +90,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 func (r *reconciler) reconcileBackupEntry(gardenClient kubernetes.Interface, backupEntry *gardencorev1beta1.BackupEntry) (reconcile.Result, error) {
 	backupEntryLogger := logger.NewFieldLogger(logger.Logger, "backupentry", backupEntry.Name)
 
-	if err := controllerutils.EnsureFinalizer(r.ctx, gardenClient.Client(), backupEntry, gardencorev1beta1.GardenerName); err != nil {
+	if err := controllerutils.EnsureFinalizer(r.ctx, gardenClient.DirectClient(), backupEntry, gardencorev1beta1.GardenerName); err != nil {
 		backupEntryLogger.Errorf("Failed to ensure gardener finalizer on backupentry: %+v", err)
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
If the `CachedRuntimeClients` feature gate is enabled, the backup entry/bucket reconciler in the gardenlet might not execute any reconciliation the first time the backup bucket/entry is deployed.
That's because we are using an Informer created by the SharedInformerFactory [here](https://github.com/tim-ebert/gardener/blob/379bf51c9251722cae7ca23c33417ea4e3c3c9df/pkg/gardenlet/controller/backupbucket/backup_bucket.go#L76-L83) for receiving watch events, but we are actually using a cached runtime client for retrieving the object [in the reconciler](https://github.com/tim-ebert/gardener/blob/379bf51c9251722cae7ca23c33417ea4e3c3c9df/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go#L73) which uses a separate watch. This in turn means, that the cached runtime client might not have received the add event for a backup bucket/entry, while the Informer already has received an event and enqueued the object for reconciliation. The cached runtime client the gets a `NotFound` error and the reconciler exits early. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
In general, we should always use the same informers for registering event handlers which we also use in our controllers to retrieve the object in the beginning of the reconciliation. For example an Informer from the `SharedInformerFactory` and the respective `Lister` or an Informer from the controller-runtime cache and the cached runtime client.
I will do this refactoring in a separate PR, as it requires to not invalidate the Garden ClientSet in any case (also for version changes) which I will have to tackle first.
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug has been fixed, that caused that newly created `BackupBuckets`/`BackupEntries` where not reconciled by the `gardenlet` immediately when the `CachedRuntimeClients` feature gate was enabled.
```
