### PR TITLE
Enh/pv testframework

### DIFF
--- a/test/framework/shootframework.go
+++ b/test/framework/shootframework.go
@@ -140,6 +140,10 @@ func (f *ShootFramework) AfterEach(ctx context.Context) {
 			}
 		}
 		err = f.WaitUntilNamespaceIsDeleted(ctx, f.ShootClient, f.Namespace)
+		if err != nil {
+			err2 := f.DumpDefaultResourcesInNamespace(ctx, fmt.Sprintf("[SHOOT %s] [NAMESPACE %s]", f.Shoot.Name, f.Namespace), f.ShootClient, f.Namespace)
+			ExpectNoError(err2)
+		}
 		ExpectNoError(err)
 		f.Namespace = ""
 		ginkgo.By(fmt.Sprintf("deleted test namespace %s", f.Namespace))

--- a/test/integration/shoots/applications/shoot_app.go
+++ b/test/integration/shoots/applications/shoot_app.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	guestbookAppTimeout       = 30 * time.Minute
-	finalizationTimeout       = 10 * time.Minute
+	finalizationTimeout       = 15 * time.Minute
 	downloadKubeconfigTimeout = 600 * time.Second
 	dashboardAvailableTimeout = 60 * time.Minute
 )


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement
/priority normal

**What this PR does / why we need it**:

- added PVs and PVCs to the dumbed resources
- added state dump of a namespace if the framework failed to delete it
- increased the timeout of the guestbook cleanup to 15m

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
