### PR TITLE
[GEP-7] Add DNSOwner to Shoot operations to support migration scenario

### DIFF
--- a/charts/seed-dns/owner/Chart.yaml
+++ b/charts/seed-dns/owner/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: DNSOwner extension resource for declaration of DNS Entry owner.
+name: owner
+version: 0.1.0

--- a/charts/seed-dns/owner/templates/dnsowner.yaml
+++ b/charts/seed-dns/owner/templates/dnsowner.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSOwner
+metadata:
+  name: {{ .Release.Namespace }}-{{ .Values.name }}
+spec:
+  ownerId: {{ .Values.ownerID }}
+  active: {{ .Values.active }}

--- a/charts/seed-dns/owner/values.yaml
+++ b/charts/seed-dns/owner/values.yaml
@@ -1,0 +1,3 @@
+name: dns-owner-name
+ownerID: shoot--project--name
+active: true

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/operation/botanist"
-	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/utils/errors"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -428,8 +427,8 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation) *gardencorev1bet
 		})
 
 		destroyNginxIngressDNSRecord = g.Add(flow.Task{
-			Name:         "Destroying ingress DNS record",
-			Fn:           flow.TaskFn(component.OpDestroyAndWait(botanist.Shoot.Components.Extensions.DNS.NginxEntry).Destroy),
+			Name:         "Destroying nginx ingress DNS record",
+			Fn:           flow.TaskFn(botanist.DestroyIngressDNSRecord),
 			Dependencies: flow.NewTaskIDs(syncPointCleaned),
 		})
 		destroyInfrastructure = g.Add(flow.Task{
@@ -443,8 +442,8 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation) *gardencorev1bet
 			Dependencies: flow.NewTaskIDs(destroyInfrastructure),
 		})
 		destroyExternalDomainDNSRecord = g.Add(flow.Task{
-			Name:         "Destroying external DNS entry",
-			Fn:           flow.TaskFn(component.OpWaiter(botanist.Shoot.Components.Extensions.DNS.ExternalEntry).Destroy),
+			Name:         "Destroying external domain DNS record",
+			Fn:           flow.TaskFn(botanist.DestroyExternalDNS),
 			Dependencies: flow.NewTaskIDs(syncPointCleaned),
 		})
 
@@ -459,12 +458,12 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation) *gardencorev1bet
 		)
 
 		destroyInternalDomainDNSRecord = g.Add(flow.Task{
-			Name:         "Destroying internal DNS entry",
-			Fn:           flow.TaskFn(component.OpWaiter(botanist.Shoot.Components.Extensions.DNS.InternalEntry).Destroy),
+			Name:         "Destroying internal domain DNS record",
+			Fn:           flow.TaskFn(botanist.DestroyInternalDNS),
 			Dependencies: flow.NewTaskIDs(syncPoint),
 		})
 		deleteDNSProviders = g.Add(flow.Task{
-			Name:         "Deleting DNS providers",
+			Name:         "Deleting additional DNS providers",
 			Fn:           flow.TaskFn(botanist.DeleteDNSProviders),
 			Dependencies: flow.NewTaskIDs(destroyInternalDomainDNSRecord),
 		})

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -161,7 +161,7 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerServiceIsReady),
 		})
 		deployExternalDomainDNSRecord = g.Add(flow.Task{
-			Name:         "Deploying external domain",
+			Name:         "Deploying external domain DNS record",
 			Fn:           flow.TaskFn(botanist.DeployExternalDNS).DoIf(!o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilKubeAPIServerServiceIsReady),
 		})
@@ -333,7 +333,7 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 			Dependencies: flow.NewTaskIDs(deployManagedResources, initializeShootClients, waitUntilWorkerReady),
 		})
 		ensureIngressDomainDNSRecord = g.Add(flow.Task{
-			Name:         "Ensuring nginx ingress domain record",
+			Name:         "Ensuring nginx ingress DNS record",
 			Fn:           flow.TaskFn(botanist.EnsureIngressDNSRecord),
 			Dependencies: flow.NewTaskIDs(nginxLBReady),
 		})
@@ -368,12 +368,12 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 			Dependencies: flow.NewTaskIDs(initializeShootClients, deploySeedMonitoring, deploySeedLogging, deployClusterAutoscaler),
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Destroying External DNS Entry", // delete DNS entries during hibernation.
+			Name:         "Destroying external domain DNS record if hibernated", // delete DNS entries during hibernation.
 			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.DNS.ExternalEntry.Destroy).DoIf(o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Destroying Internal DNS Entry", // delete DNS entries during hibernation.
+			Name:         "Destroying internal domain DNS record if hibernated", // delete DNS entries during hibernation.
 			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.DNS.InternalEntry.Destroy).DoIf(o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(hibernateControlPlane),
 		})

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -77,9 +77,12 @@ func New(o *operation.Operation) (*Botanist, error) {
 	}
 
 	o.Shoot.Components.Extensions.DNS.ExternalProvider = b.DefaultExternalDNSProvider(b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.DNS.ExternalOwner = b.DefaultExternalDNSOwner(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.DNS.ExternalEntry = b.DefaultExternalDNSEntry(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.DNS.InternalProvider = b.DefaultInternalDNSProvider(b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.DNS.InternalOwner = b.DefaultInternalDNSOwner(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.DNS.InternalEntry = b.DefaultInternalDNSEntry(b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.DNS.NginxOwner = b.DefaultNginxIngressDNSOwner(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.DNS.NginxEntry = b.DefaultNginxIngressDNSEntry(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.DNS.AdditionalProviders, err = b.AdditionalDNSProviders(context.TODO(), b.K8sGardenClient.Client(), b.K8sSeedClient.DirectClient())
 	if err != nil {

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -57,46 +57,54 @@ func GenerateDNSProviderName(secretName, providerType string) string {
 	}
 }
 
-// DeployExternalDNS deploys the external DNSProvider and DNSEntry.
+// DeployExternalDNS deploys the external DNSOwner, DNSProvider, and DNSEntry resources.
 func (b *Botanist) DeployExternalDNS(ctx context.Context) error {
-	return b.ExternalDNS().Deploy(ctx)
-}
-
-// ExternalDNS returns the external DNSProvider which deploys / destroys
-// the external DNSProvider and DNSEntry.
-func (b *Botanist) ExternalDNS() component.Deployer {
 	if b.NeedsExternalDNS() {
+		if b.isRestorePhase() {
+			return dnsRestoreDeployer{
+				provider: b.Shoot.Components.Extensions.DNS.ExternalProvider,
+				entry:    b.Shoot.Components.Extensions.DNS.ExternalEntry,
+				owner:    b.Shoot.Components.Extensions.DNS.ExternalOwner,
+			}.Deploy(ctx)
+		}
+
 		return component.OpWaiter(
+			b.Shoot.Components.Extensions.DNS.ExternalOwner,
 			b.Shoot.Components.Extensions.DNS.ExternalProvider,
 			b.Shoot.Components.Extensions.DNS.ExternalEntry,
-		)
+		).Deploy(ctx)
 	}
 
 	return component.OpWaiter(
 		b.Shoot.Components.Extensions.DNS.ExternalEntry,
 		b.Shoot.Components.Extensions.DNS.ExternalProvider,
-	)
+		b.Shoot.Components.Extensions.DNS.ExternalOwner,
+	).Deploy(ctx)
 }
 
-// DeployInternalDNS deploys the internal DNSProvider and DNSEntry.
+// DeployInternalDNS deploys the internal DNSOwner, DNSProvider, and DNSEntry resources.
 func (b *Botanist) DeployInternalDNS(ctx context.Context) error {
-	return b.InternalDNS().Deploy(ctx)
-}
-
-// InternalDNS returns the internal DNSProvider which deploys / destroys
-// the internal DNSProvider and DNSEntry.
-func (b *Botanist) InternalDNS() component.Deployer {
 	if b.NeedsInternalDNS() {
+		if b.isRestorePhase() {
+			return dnsRestoreDeployer{
+				provider: b.Shoot.Components.Extensions.DNS.InternalProvider,
+				entry:    b.Shoot.Components.Extensions.DNS.InternalEntry,
+				owner:    b.Shoot.Components.Extensions.DNS.InternalOwner,
+			}.Deploy(ctx)
+		}
+
 		return component.OpWaiter(
+			b.Shoot.Components.Extensions.DNS.InternalOwner,
 			b.Shoot.Components.Extensions.DNS.InternalProvider,
 			b.Shoot.Components.Extensions.DNS.InternalEntry,
-		)
+		).Deploy(ctx)
 	}
 
 	return component.OpWaiter(
 		b.Shoot.Components.Extensions.DNS.InternalEntry,
 		b.Shoot.Components.Extensions.DNS.InternalProvider,
-	)
+		b.Shoot.Components.Extensions.DNS.InternalOwner,
+	).Deploy(ctx)
 }
 
 // DefaultExternalDNSProvider returns the external DNSProvider if external DNS is
@@ -156,6 +164,19 @@ func (b *Botanist) DefaultExternalDNSEntry(seedClient client.Client) component.D
 	))
 }
 
+// DefaultExternalDNSOwner returns DeployWaiter which removes the external DNSOwner.
+func (b *Botanist) DefaultExternalDNSOwner(seedClient client.Client) component.DeployWaiter {
+	return component.OpDestroy(dns.NewDNSOwner(
+		&dns.OwnerValues{
+			Name: DNSExternalName,
+		},
+		b.Shoot.SeedNamespace,
+		b.K8sSeedClient.ChartApplier(),
+		b.ChartsRootPath,
+		seedClient,
+	))
+}
+
 // DefaultInternalDNSProvider returns the internal DNSProvider if internal DNS is
 // enabled and if not, DeployWaiter which removes the internal DNSProvider.
 func (b *Botanist) DefaultInternalDNSProvider(seedClient client.Client) component.DeployWaiter {
@@ -209,6 +230,19 @@ func (b *Botanist) DefaultInternalDNSEntry(seedClient client.Client) component.D
 		b.Logger,
 		seedClient,
 		nil,
+	))
+}
+
+// DefaultInternalDNSOwner returns a DeployWaiter which removes the internal DNSOwner.
+func (b *Botanist) DefaultInternalDNSOwner(seedClient client.Client) component.DeployWaiter {
+	return component.OpDestroy(dns.NewDNSOwner(
+		&dns.OwnerValues{
+			Name: DNSInternalName,
+		},
+		b.Shoot.SeedNamespace,
+		b.K8sSeedClient.ChartApplier(),
+		b.ChartsRootPath,
+		seedClient,
 	))
 }
 
@@ -368,4 +402,90 @@ func (b *Botanist) DeleteDNSProviders(ctx context.Context) error {
 		5*time.Second,
 		client.InNamespace(b.Shoot.SeedNamespace),
 	)
+}
+
+// DestroyInternalDNS destroys the internal DNSEntry, DNSOwner, and DNSProvider resources.
+func (b *Botanist) DestroyInternalDNS(ctx context.Context) error {
+	return component.OpDestroyAndWait(
+		b.Shoot.Components.Extensions.DNS.InternalEntry,
+		b.Shoot.Components.Extensions.DNS.InternalProvider,
+		b.Shoot.Components.Extensions.DNS.InternalOwner,
+	).Destroy(ctx)
+}
+
+// DestroyExternalDNS destroys the external DNSEntry, DNSOwner, and DNSProvider resources.
+func (b *Botanist) DestroyExternalDNS(ctx context.Context) error {
+	return component.OpDestroyAndWait(
+		b.Shoot.Components.Extensions.DNS.ExternalEntry,
+		b.Shoot.Components.Extensions.DNS.ExternalProvider,
+		b.Shoot.Components.Extensions.DNS.ExternalOwner,
+	).Destroy(ctx)
+}
+
+// MigrateInternalDNS destroys the internal DNSEntry, DNSOwner, and DNSProvider resources,
+// without removing the entry from the DNS provider.
+func (b *Botanist) MigrateInternalDNS(ctx context.Context) error {
+	return component.OpDestroy(
+		b.Shoot.Components.Extensions.DNS.InternalOwner,
+		b.Shoot.Components.Extensions.DNS.InternalProvider,
+		b.Shoot.Components.Extensions.DNS.InternalEntry,
+	).Destroy(ctx)
+}
+
+// MigrateExternalDNS destroys the external DNSEntry, DNSOwner, and DNSProvider resources,
+// without removing the entry from the DNS provider.
+func (b *Botanist) MigrateExternalDNS(ctx context.Context) error {
+	return component.OpDestroy(
+		b.Shoot.Components.Extensions.DNS.ExternalOwner,
+		b.Shoot.Components.Extensions.DNS.ExternalProvider,
+		b.Shoot.Components.Extensions.DNS.ExternalEntry,
+	).Destroy(ctx)
+}
+
+// dnsRestoreDeployer implements special deploy logic for DNS providers, entries, and owners to be executed only
+// during the restore phase.
+type dnsRestoreDeployer struct {
+	provider component.DeployWaiter
+	entry    component.DeployWaiter
+	owner    component.DeployWaiter
+}
+
+func (d dnsRestoreDeployer) Deploy(ctx context.Context) error {
+	// Deploy the provider and wait for it to become ready
+	if d.provider != nil {
+		if err := d.provider.Deploy(ctx); err != nil {
+			return err
+		}
+		if err := d.provider.Wait(ctx); err != nil {
+			return err
+		}
+	}
+
+	// Deploy the entry and wait for it to be reconciled, but ignore any errors due to Invalid or Error status
+	// This is done in order to ensure that the entry exists and has been reconciled before the owner is reconciled
+	if err := d.entry.Deploy(ctx); err != nil {
+		return err
+	}
+	if err := d.entry.Wait(ctx); err != nil && !strings.Contains(err.Error(), "status=") {
+		return err
+	}
+
+	// Deploy the owner and wait for it to become ready
+	if err := d.owner.Deploy(ctx); err != nil {
+		return err
+	}
+	if err := d.owner.Wait(ctx); err != nil {
+		return err
+	}
+
+	// Wait for the entry to become ready
+	if err := d.entry.Wait(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d dnsRestoreDeployer) Destroy(ctx context.Context) error {
+	return nil
 }

--- a/pkg/operation/botanist/dns_test.go
+++ b/pkg/operation/botanist/dns_test.go
@@ -201,7 +201,7 @@ var _ = Describe("dns", func() {
 	})
 
 	Context("DefaultExternalDNSEntry", func() {
-		It("should delete when calling Deploy", func() {
+		It("should delete the entry when calling Deploy", func() {
 			Expect(seedClient.Create(ctx, &dnsv1alpha1.DNSEntry{
 				ObjectMeta: metav1.ObjectMeta{Name: "external", Namespace: seedNS},
 			})).ToNot(HaveOccurred())
@@ -210,6 +210,20 @@ var _ = Describe("dns", func() {
 
 			found := &dnsv1alpha1.DNSEntry{}
 			err := seedClient.Get(ctx, types.NamespacedName{Name: "external", Namespace: seedNS}, found)
+			Expect(err).To(BeNotFoundError())
+		})
+	})
+
+	Context("DefaultExternalDNSOwner", func() {
+		It("should delete the owner when calling Deploy", func() {
+			Expect(seedClient.Create(ctx, &dnsv1alpha1.DNSOwner{
+				ObjectMeta: metav1.ObjectMeta{Name: seedNS + "-external"},
+			})).ToNot(HaveOccurred())
+
+			Expect(b.DefaultExternalDNSOwner(seedClient).Deploy(ctx)).ToNot(HaveOccurred())
+
+			found := &dnsv1alpha1.DNSOwner{}
+			err := seedClient.Get(ctx, types.NamespacedName{Name: seedNS + "-external"}, found)
 			Expect(err).To(BeNotFoundError())
 		})
 	})
@@ -224,6 +238,20 @@ var _ = Describe("dns", func() {
 
 			found := &dnsv1alpha1.DNSEntry{}
 			err := seedClient.Get(ctx, types.NamespacedName{Name: "internal", Namespace: seedNS}, found)
+			Expect(err).To(BeNotFoundError())
+		})
+	})
+
+	Context("DefaultInternalDNSOwner", func() {
+		It("should delete the owner when calling Deploy", func() {
+			Expect(seedClient.Create(ctx, &dnsv1alpha1.DNSOwner{
+				ObjectMeta: metav1.ObjectMeta{Name: seedNS + "-internal"},
+			})).ToNot(HaveOccurred())
+
+			Expect(b.DefaultInternalDNSOwner(seedClient).Deploy(ctx)).ToNot(HaveOccurred())
+
+			found := &dnsv1alpha1.DNSOwner{}
+			err := seedClient.Get(ctx, types.NamespacedName{Name: seedNS + "-internal"}, found)
 			Expect(err).To(BeNotFoundError())
 		})
 	})

--- a/pkg/operation/botanist/extensions/dns/dnsowner.go
+++ b/pkg/operation/botanist/extensions/dns/dnsowner.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dns
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// OwnerValues contains the values used for DNSOwner creation
+type OwnerValues struct {
+	Name    string `json:"name,omitempty"`
+	OwnerID string `json:"ownerID,omitempty"`
+	Active  bool   `json:"active,omitempty"`
+}
+
+// NewDNSOwner creates a new instance of DeployWaiter for a specific DNS owner.
+func NewDNSOwner(
+	values *OwnerValues,
+	shootNamespace string,
+	applier kubernetes.ChartApplier,
+	chartsRootPath string,
+	client client.Client,
+) component.DeployWaiter {
+	return &dnsOwner{
+		values:         values,
+		shootNamespace: shootNamespace,
+		ChartApplier:   applier,
+		chartPath:      filepath.Join(chartsRootPath, "seed-dns", "owner"),
+		client:         client,
+	}
+}
+
+type dnsOwner struct {
+	values         *OwnerValues
+	shootNamespace string
+	kubernetes.ChartApplier
+	chartPath string
+	client    client.Client
+}
+
+// Deploy implements Deployer and creates DNSOwner for the provided values
+func (d *dnsOwner) Deploy(ctx context.Context) error {
+	return d.Apply(ctx, d.chartPath, d.shootNamespace, d.values.Name, kubernetes.Values(d.values))
+}
+
+// Destroy implements Deployer and deletes the DNSOwner
+func (d *dnsOwner) Destroy(ctx context.Context) error {
+	return client.IgnoreNotFound(d.client.Delete(ctx, d.owner()))
+}
+
+// WaitCleanup implements Waiter
+func (d *dnsOwner) WaitCleanup(ctx context.Context) error {
+	return kutil.WaitUntilResourceDeleted(ctx, d.client, d.owner(), 5*time.Second)
+}
+
+// Wait implements Waiter, not applicable for the DNSOwner
+func (d *dnsOwner) Wait(ctx context.Context) error { return nil }
+
+// owner returns an empty DNSOwner used for deletion.
+func (d *dnsOwner) owner() *dnsv1alpha1.DNSOwner {
+	return &dnsv1alpha1.DNSOwner{ObjectMeta: metav1.ObjectMeta{Name: d.shootNamespace + "-" + d.values.Name}}
+}

--- a/pkg/operation/botanist/extensions/dns/dnsowner_test.go
+++ b/pkg/operation/botanist/extensions/dns/dnsowner_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dns_test
+
+import (
+	"context"
+	"fmt"
+
+	cr "github.com/gardener/gardener/pkg/chartrenderer"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	. "github.com/gardener/gardener/pkg/operation/botanist/extensions/dns"
+	. "github.com/gardener/gardener/test/gomega"
+
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("#DNSOwner", func() {
+	const (
+		deployNS     = "test-chart-namespace"
+		dnsOwnerName = "test-deploy"
+		ownerID      = "owner-id"
+	)
+
+	var (
+		ctrl             *gomock.Controller
+		ca               kubernetes.ChartApplier
+		ctx              context.Context
+		c                client.Client
+		expectedDNSOwner *dnsv1alpha1.DNSOwner
+		vals             *OwnerValues
+		defaultDepWaiter component.DeployWaiter
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+
+		ctx = context.TODO()
+
+		s := runtime.NewScheme()
+		Expect(corev1.AddToScheme(s)).NotTo(HaveOccurred())
+		Expect(dnsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())
+
+		c = fake.NewFakeClientWithScheme(s)
+
+		vals = &OwnerValues{
+			Name:    "test-deploy",
+			Active:  true,
+			OwnerID: ownerID,
+		}
+
+		expectedDNSOwner = &dnsv1alpha1.DNSOwner{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: deployNS + "-" + dnsOwnerName,
+			},
+			Spec: dnsv1alpha1.DNSOwnerSpec{
+				OwnerId: ownerID,
+				Active:  pointer.BoolPtr(true),
+			},
+		}
+
+		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion, dnsv1alpha1.SchemeGroupVersion})
+		mapper.Add(dnsv1alpha1.SchemeGroupVersion.WithKind("DNSOwner"), meta.RESTScopeRoot)
+		ca = kubernetes.NewChartApplier(cr.NewWithServerVersion(&version.Info{}), kubernetes.NewApplier(c, mapper))
+		Expect(ca).NotTo(BeNil(), "should return chart applier")
+
+		defaultDepWaiter = NewDNSOwner(vals, deployNS, ca, chartsRoot(), c)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#Deploy", func() {
+		It("should create correct DNSOwner", func() {
+			Expect(defaultDepWaiter.Deploy(ctx)).ToNot(HaveOccurred())
+
+			actualDNSOwner := &dnsv1alpha1.DNSOwner{}
+			err := c.Get(ctx, client.ObjectKey{Name: deployNS + "-" + dnsOwnerName}, actualDNSOwner)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(actualDNSOwner).To(DeepDerivativeEqual(expectedDNSOwner))
+		})
+	})
+	Describe("#Destroy", func() {
+		It("should not return error when it's not found", func() {
+			Expect(defaultDepWaiter.Destroy(ctx)).ToNot(HaveOccurred())
+		})
+
+		It("should not return error when it's deleted successfully", func() {
+			Expect(c.Create(ctx, expectedDNSOwner)).ToNot(HaveOccurred(), "adding pre-existing entry succeeds")
+
+			Expect(defaultDepWaiter.Destroy(ctx)).ToNot(HaveOccurred())
+		})
+
+		It("should return err when fails to delete", func() {
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Delete(ctx, &dnsv1alpha1.DNSOwner{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: deployNS + "-" + dnsOwnerName,
+				}}).Times(1).Return(fmt.Errorf("some random error"))
+
+			Expect(NewDNSOwner(vals, deployNS, ca, chartsRoot(), mc).Destroy(ctx)).To(HaveOccurred())
+		})
+	})
+
+	Describe("#WaitCleanup", func() {
+		It("should not return error when it's already removed", func() {
+			Expect(defaultDepWaiter.WaitCleanup(ctx)).ToNot(HaveOccurred())
+		})
+	})
+
+})

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -99,11 +99,14 @@ type Extensions struct {
 
 // DNS contains references to internal and external DNSProvider and DNSEntry deployers.
 type DNS struct {
+	ExternalOwner       component.DeployWaiter
 	ExternalProvider    component.DeployWaiter
 	ExternalEntry       component.DeployWaiter
+	InternalOwner       component.DeployWaiter
 	InternalProvider    component.DeployWaiter
 	InternalEntry       component.DeployWaiter
 	AdditionalProviders map[string]component.DeployWaiter
+	NginxOwner          component.DeployWaiter
 	NginxEntry          component.DeployWaiter
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Adds DNSOwner as part of the Shoot's control plane. The DNSOwner is responsible of holding the information of the owner of DNSEntries. DNSEntries will point to this DNSOwner by their `spec.owner` field. We need it to enable migration scenario in which DNS entries are not deleted from the DNS provider during migration (_we target only change of the IP, without destroying and then recreating the DNS_). Crucial part of the lifecycle of the DNS is the order by they are deployed/desroyed depending on the desired result. This order was defined by the dns-controller. 

**Which issue(s) this PR fixes**:
Fixes #2335 

**Special notes for your reviewer**:
To test this you can run a reconciliation of a Shoot and check if the owner of the DNS Record has changed to the cluster-identity of the Shoot. To test it for the migration scenario you will have to disable the validation of the API Server for the `Shoots.Spec.seedName` that doesn't allow change. You can do this by commenting the code inside `pkg/apis/core/validation/shoot.go` lines 169-172

```go
if oldSpec.SeedName != nil {
		// allow initial seed assignment
		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.SeedName, oldSpec.SeedName, fldPath.Child("seedName"))...)
	}

```
Then you can change the `shoot.spec.seedName` to point to another seed (that has the same cloud provider). This will trigger the migration. You then monitor the DNS record in the provider, that only has to change the IP without it being destroyed. Hopefully everything goes fine and you have healthy migrated cluster. 

P.S: Use the latest extension controllers

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
The shoot reconciliation does now create `DNSOwner` objects in the seed cluster to manage the ownership of the DNS entries. You should run at least [`v0.7.16`](https://github.com/gardener/external-dns-management/releases/tag/v0.7.16) of the [external-dns-management](https://github.com/gardener/external-dns-management/) extension.
```
