### PR TITLE
Reserve excess capacity for etcd-main.

### DIFF
--- a/charts/seed-bootstrap/templates/reserve-excess-capacity/deployment-etcd.yaml
+++ b/charts/seed-bootstrap/templates/reserve-excess-capacity/deployment-etcd.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.reserveExcessCapacity }}
+apiVersion: {{ include "deploymentversion" . }}
+kind: Deployment
+metadata:
+  name: reserve-excess-capacity-etcd
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: etcd-statefulset
+    role: main
+spec:
+  revisionHistoryLimit: 0
+  replicas: {{ index .Values.replicas "reserve-excess-capacity" }}
+  selector:
+    matchLabels:
+      app: etcd-statefulset
+      role: main
+  template:
+    metadata:
+      labels:
+        app: etcd-statefulset
+        role: main
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: pause-container
+        image: {{ index .Values.global.images "pause-container" }}
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 300m
+            memory: 1Gi
+          limits:
+            cpu: 900m
+            memory: 3Gi
+      priorityClassName: gardener-reserve-excess-capacity
+{{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area auto-scaling
/kind enhancement
/priority normal

**What this PR does / why we need it**:
If [gardener/kupid](https://github.com/gardener/kupid) is used as a gardener extension to schedule `etcd-main` workloads onto dedicated worker nodes, the existing reserve excess capacity pods will not reserve excess capacity on the dedicated worker nodes.

This PR introduces reserve excess capacity pods that will get scheduled on the same set of nodes as `etcd-main` workloads are likely to be scheduled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
1. For the reserve excess capacity pods, I have used the pod template with the same `selector` and `labels` as those of `etcd-main` to make sure they get injected with the same `nodeAffinity` and `tolerations` as `etcd-main`. Is this OK or should I introduce some specific label(s) for dedicated workload (e.g. `dedicated: etcd`)? Then I will need to modify the labels for `etcd-main` as well.
1. I have used the minimum values for `requests` assuming the minimum values were used to calculate the existing reserve capacity. Hope this is OK.
1. I have not reduced the `requests` for the common reserve excess capacity pods to subtract the `requests` for `etcd-main`. Should I?

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Reserve excess capacity on the nodes where etcd-main workloads are likely to be scheduled. This helps if etcd-main workloads are scheduled on dedicated worker nodes in the seed cluster.
```
