### PR TITLE
Local Garden Dev on Windows

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -111,6 +111,18 @@ brew install coreutils gnu-sed
 
 This will create symbolic links for the GNU utilities with `g` prefix in `/usr/local/bin`, e.g., `gsed` or `gbase64`. To allow using them without the `g` prefix please put `/usr/local/opt/coreutils/libexec/gnubin` at the beginning of your `PATH` environment variable, e.g., `export PATH=/usr/local/opt/coreutils/libexec/gnubin:$PATH`.
 
+## [Windows] WSL2
+
+Apart from Linux distributions and MacOS, the local gardener setup can also run on the Windows Subsystem for Linux 2. 
+
+While WSL1, plain docker for windows and various Linux distributions and local Kubernetes environments may be supported, this setup was verified with:
+* [WSL2](https://docs.microsoft.com/en-us/windows/wsl/wsl2-index) 
+* [Docker Desktop WSL2 Engine](https://docs.docker.com/docker-for-windows/wsl/)
+* [Ubuntu 18.04 LTS on WSL2](https://ubuntu.com/blog/ubuntu-on-wsl-2-is-generally-available)  
+* Nodeless local garden (see below)
+
+The Gardener repository and all the above-mentioned tools (git, golang, kubectl, ...) should be installed in your WSL2 distro, according to the distribution-specific Linux installation instructions. 
+
 ## [Optional] Installing gcloud SDK
 
 In case you have to create a new release or a new hotfix of the Gardener you have to push the resulting Docker image into a Docker registry. Currently, we are using the Google Container Registry (this could change in the future). Please follow the official [installation instructions from Google](https://cloud.google.com/sdk/downloads).

--- a/hack/local-development/dev-setup-register-gardener
+++ b/hack/local-development/dev-setup-register-gardener
@@ -27,6 +27,9 @@ APISERVICE_PORT_STRING=""
 APISERVER_EXTERNALNAME=docker.for.mac.localhost
 if [[ "$(uname -s)" != *"Darwin"* ]]; then
   APISERVER_EXTERNALNAME=gardener.localhost
+  if [[ "$(uname -s)" == "Linux" && "$(uname -r)" =~ "microsoft-standard" ]]; then
+    APISERVER_EXTERNALNAME=host.docker.internal
+  fi
 fi
 
 CORE_V1ALPHA1_APISERVICE_NAME="v1alpha1.core.gardener.cloud"
@@ -40,6 +43,9 @@ CONTROLLER_MANAGER_SERVICE_PORT=443
 CONTROLLER_MANAGER_EXTERNALNAME=docker.for.mac.localhost
 if [[ "$(uname -s)" != *"Darwin"* ]]; then
   CONTROLLER_MANAGER_EXTERNALNAME=gardener.localhost
+  if [[ "$(uname -s)" == "Linux" && "$(uname -r)" =~ "microsoft-standard" ]]; then
+    CONTROLLER_MANAGER_EXTERNALNAME=host.docker.internal
+  fi
 fi
 
 if [[ $(k8s_env) == "$NODELESS" ]]; then

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -35,6 +35,11 @@ apiserver_flags="
   --tls-private-key-file $tls_dir/tls.key \
   --v 2"
 
+if [[ "$(uname -s)" == "Linux" && "$(uname -r)" =~ "microsoft-standard" ]]; then
+  apiserver_flags="${apiserver_flags} \
+  --bind-address=127.0.0.1"
+fi
+
 ldflags="$("$(dirname $0)"/../get-build-ld-flags.sh)"
 case $(k8s_env) in
     $KIND)


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Fixes local-garden containers' [host machine address](https://docs.docker.com/docker-for-windows/networking/#use-cases-and-workarounds) and api-server binding, such that the nodeless gardener dev env will work on [WSL2 ](https://docs.microsoft.com/en-us/windows/wsl/wsl2-index) with [WSL2-integrated docker for windows](https://docs.docker.com/docker-for-windows/wsl/). 

**Release note**:
```improvement developer
The Nodeless Development Environment also works on windows, using WSL2 and docker for windows
```
