### PR TITLE
Wait until deployment/mcm is updated

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -33,11 +33,13 @@ import (
 	"github.com/gardener/gardener/pkg/utils/secrets"
 )
 
-// McmShootResourceName is the name of the managed resource that contains the Machine Controller Manager
-const McmShootResourceName = "extension-worker-mcm-shoot"
+const (
+	// McmShootResourceName is the name of the managed resource that contains the Machine Controller Manager
+	McmShootResourceName = "extension-worker-mcm-shoot"
 
-// McmDeploymentName is the name of the deployment that spawn machine-cotroll-manager pods
-const McmDeploymentName = "machine-controller-manager"
+	// McmDeploymentName is the name of the deployment that spawn machine-cotroll-manager pods
+	McmDeploymentName = "machine-controller-manager"
+)
 
 // ReplicaCount determines the number of replicas.
 type ReplicaCount func() (int32, error)
@@ -68,6 +70,10 @@ func (a *genericActuator) deployMachineControllerManager(ctx context.Context, wo
 
 	if err := a.applyMachineControllerManagerShootChart(ctx, workerDelegate, workerObj, cluster); err != nil {
 		return errors.Wrapf(err, "could not apply machine-controller-manager shoot chart")
+	}
+
+	if err := util.WaitUntilDeploymentRolloutIsComplete(ctx, a.client, workerObj.Namespace, McmDeploymentName, 5*time.Second, 300*time.Second); err != nil {
+		return errors.Wrapf(err, "waiting until deployment/%s is updated", McmDeploymentName)
 	}
 
 	return nil

--- a/extensions/pkg/util/deployments.go
+++ b/extensions/pkg/util/deployments.go
@@ -16,7 +16,11 @@ package util
 
 import (
 	"context"
+	"fmt"
+	"time"
 
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/retry"
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -25,4 +29,42 @@ import (
 func ScaleDeployment(ctx context.Context, client client.Client, deployment *appsv1.Deployment, replicas int32) error {
 	deployment.Spec.Replicas = &replicas
 	return client.Update(ctx, deployment)
+}
+
+// HasDeploymentRolloutCompleted checks for the number of updated &
+// available replicas to be equal to the deployment's desired replicas count.
+// Thus confirming a successful rollout of the deployment.
+func HasDeploymentRolloutCompleted(ctx context.Context, client client.Client, namespace, name string) (bool, error) {
+	var (
+		deployment      = &appsv1.Deployment{}
+		desiredReplicas = int32(0)
+	)
+
+	if err := client.Get(ctx, kutil.Key(namespace, name), deployment); err != nil {
+		return retry.SevereError(err)
+	}
+
+	if deployment.Spec.Replicas != nil {
+		desiredReplicas = *deployment.Spec.Replicas
+	}
+
+	if deployment.Generation != deployment.Status.ObservedGeneration {
+		return retry.MinorError(fmt.Errorf("%q not observed at latest generation (%d/%d)", name,
+			deployment.Status.ObservedGeneration, deployment.Generation))
+	}
+
+	if deployment.Status.Replicas == desiredReplicas && deployment.Status.UpdatedReplicas == desiredReplicas && deployment.Status.AvailableReplicas == desiredReplicas {
+		return retry.Ok()
+	}
+
+	return retry.MinorError(fmt.Errorf("deployment %q currently has Updated/Available: %d/%d replicas. Desired: %d", name, deployment.Status.UpdatedReplicas, deployment.Status.AvailableReplicas, desiredReplicas))
+}
+
+// WaitUntilDeploymentRolloutIsComplete waits for the number of updated &
+// available replicas to be equal to the deployment's desired replicas count.
+// It keeps retrying until timeout
+func WaitUntilDeploymentRolloutIsComplete(ctx context.Context, client client.Client, namespace string, name string, interval, timeout time.Duration) error {
+	return retry.UntilTimeout(ctx, interval, timeout, func(ctx context.Context) (done bool, err error) {
+		return HasDeploymentRolloutCompleted(ctx, client, namespace, name)
+	})
 }


### PR DESCRIPTION
#**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Currently, the deployment of MCM pod and it's machine CRs (machine deployments and machine classes) occurs done in parallel. However, it is desirable in some situations (like migration/fixes) where the new MCM is deployed first before deploying the new/updated machine CRs. 

This especially will help the migration of machinesClasses from `ProviderMachineClasses` to `MachineClasses`, where only the MCM updated first and only after which the new CRs are deployed to avoid rolling updates of machines.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I have added some unit tests and kept the methods generic enough to be reused in the future. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Wait until MCM deployment is rolled out before proceeding with other reconciliation tasks.
```
