### PR TITLE
Require Cluster identity values in helm charts

### DIFF
--- a/charts/cluster-identity/templates/configmap-cluster-identity.yaml
+++ b/charts/cluster-identity/templates/configmap-cluster-identity.yaml
@@ -5,4 +5,4 @@ metadata:
   name: cluster-identity
   namespace: kube-system
 data:
-  cluster-identity: "{{ .Values.clusterIdentity }}"
+  cluster-identity: "{{ required ".Values.clusterIdentity is required" .Values.clusterIdentity }}"

--- a/charts/cluster-identity/values-test.yaml
+++ b/charts/cluster-identity/values-test.yaml
@@ -1,0 +1,1 @@
+ clusterIdentity: shoot-namesapce-shoot-ui-garden-cluster-identity

--- a/charts/cluster-identity/values.yaml
+++ b/charts/cluster-identity/values.yaml
@@ -1,1 +1,1 @@
-clusterIdentity: shoot-namesapce-shoot-ui-garden-cluster-identity
+# clusterIdentity: shoot-namesapce-shoot-ui-garden-cluster-identity

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -171,9 +171,7 @@ spec:
         - --audit-webhook-version={{ .Values.global.apiserver.audit.webhook.version }}
         {{- end }}
         - --authorization-always-allow-paths=/healthz
-        {{- if .Values.global.apiserver.clusterIdentity }}
-        - --cluster-identity={{ .Values.global.apiserver.clusterIdentity }}
-        {{- end }}
+        - --cluster-identity={{ required ".Values.global.apiserver.clusterIdentity is required" .Values.global.apiserver.clusterIdentity }}
         {{- if .Values.global.apiserver.disableAdmissionPlugins }}
         - --disable-admission-plugins={{ .Values.global.apiserver.disableAdmissionPlugins | join "," }}
         {{- end }}

--- a/charts/gardener/controlplane/values-test.yaml
+++ b/charts/gardener/controlplane/values-test.yaml
@@ -1,0 +1,3 @@
+global:
+  apiserver:
+    clusterIdentity: garden-cluster-identity

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -172,7 +172,7 @@ global:
  #      truncateMaxBatchSize: 10485760
  #      truncateMaxEventSize: 102400
  #      version: audit.k8s.io/v1
-    clusterIdentity: garden-cluster-identity
+ #  clusterIdentity: garden-cluster-identity
   # Gardener controller manager configuration values
   controller:
     enabled: true

--- a/charts/seed-bootstrap/values-test.yaml
+++ b/charts/seed-bootstrap/values-test.yaml
@@ -1,0 +1,2 @@
+cluster-identity:
+  clusterIdentity: seed-cluster-identity

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -137,8 +137,8 @@ ingress:
   # admin : admin base64 encoded
   basicAuthSecret: YWRtaW46JGFwcjEkSWRSaVM5c3MkR3U1MHMxaGUwL2Z6Tzh2elE4S1BEMQ==
 
-cluster-identity:
-  clusterIdentity: seed-cluster-identity
+# cluster-identity:
+#   clusterIdentity: seed-cluster-identity
 
 reserveExcessCapacity: true
 

--- a/charts/shoot-core/components/values-test.yaml
+++ b/charts/shoot-core/components/values-test.yaml
@@ -1,0 +1,2 @@
+cluster-identity:
+  clusterIdentity: shoot-namesapce-shoot-ui-garden-cluster-identity

--- a/charts/shoot-core/components/values.yaml
+++ b/charts/shoot-core/components/values.yaml
@@ -73,5 +73,5 @@ vpn-shoot:
     vpn-shoot: image-repository:image-tag
 vertical-pod-autoscaler:
   enabled: false
-cluster-identity:
-  clusterIdentity: shoot-namesapce-shoot-ui-garden-cluster-identity
+# cluster-identity:
+#   clusterIdentity: shoot-namesapce-shoot-ui-garden-cluster-identity

--- a/hack/check-charts.sh
+++ b/hack/check-charts.sh
@@ -26,10 +26,9 @@ if [[ -d "$1" ]]; then
     echo "$BROKEN_SYMLINKS"
     exit 1
   fi
-
   echo "Checking whether all charts can be rendered"
   for chart_dir in $(find charts -type d -exec test -f '{}'/Chart.yaml \;  -print -prune | sort); do
-    [ -f "$chart_dir/values-test.yaml" ] && values_files="-f $chart_dir/values-test.yaml"
+    [ -f "$chart_dir/values-test.yaml" ] && values_files="-f $chart_dir/values-test.yaml" || unset values_files
     helm template $values_files "$chart_dir" 1> /dev/null
   done
 fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@timuthy @tim-ebert, wdyt? I ran the hack/check-charts.sh, no errors. 
```
$ hack/check-charts.sh 
> Check Helm charts
All checks successful
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
