### PR TITLE
Don't invalidate clients on version change

### DIFF
--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/gardener/gardener/pkg/chartrenderer"
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
@@ -281,31 +280,12 @@ func newClientSet(conf *config) (Interface, error) {
 		return nil, err
 	}
 
-	serverVersion, err := kubernetes.Discovery().ServerVersion()
-	if err != nil {
-		return nil, err
-	}
-
-	if err := checkIfSupportedKubernetesVersion(serverVersion.GitVersion); err != nil {
-		return nil, err
-	}
-
-	applier := NewApplier(runtimeClient, conf.clientOptions.Mapper)
-	chartRenderer := chartrenderer.NewWithServerVersion(serverVersion)
-	chartApplier := NewChartApplier(chartRenderer, applier)
-
-	if err := checkIfSupportedKubernetesVersion(serverVersion.GitVersion); err != nil {
-		return nil, err
-	}
-
 	cs := &clientSet{
 		config:     conf.restConfig,
 		restMapper: conf.clientOptions.Mapper,
 		restClient: kubernetes.Discovery().RESTClient(),
 
-		applier:       applier,
-		chartRenderer: chartRenderer,
-		chartApplier:  chartApplier,
+		applier: NewApplier(runtimeClient, conf.clientOptions.Mapper),
 
 		client:       runtimeClient,
 		directClient: directClient,
@@ -315,8 +295,10 @@ func newClientSet(conf *config) (Interface, error) {
 		gardenCore:      gardenCore,
 		apiregistration: apiRegistration,
 		apiextension:    apiExtension,
+	}
 
-		version: serverVersion.GitVersion,
+	if _, err := cs.DiscoverVersion(); err != nil {
+		return nil, fmt.Errorf("error discovering kubernetes version: %w", err)
 	}
 
 	return cs, nil

--- a/pkg/client/kubernetes/fake/clientset.go
+++ b/pkg/client/kubernetes/fake/clientset.go
@@ -21,6 +21,7 @@ import (
 
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/version"
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	apiregistrationclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
@@ -121,6 +122,17 @@ func (c *ClientSet) RESTClient() rest.Interface {
 // Version returns the GitVersion of the Kubernetes client stored on the object.
 func (c *ClientSet) Version() string {
 	return c.version
+}
+
+// DiscoverVersion tries to retrieve the server version using the kubernetes discovery client.
+func (c *ClientSet) DiscoverVersion() (*version.Info, error) {
+	serverVersion, err := c.Kubernetes().Discovery().ServerVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	c.version = serverVersion.GitVersion
+	return serverVersion, nil
 }
 
 // Start does nothing as the fake ClientSet does not support it.

--- a/pkg/client/kubernetes/test/fake_kubernetes.go
+++ b/pkg/client/kubernetes/test/fake_kubernetes.go
@@ -27,12 +27,12 @@ var _ kubernetesclientset.Interface = &ClientSet{}
 // ClientSet implements k8s.io/client-go/kubernetes.Interface but allows to use a fake discovery client.
 type ClientSet struct {
 	kubernetesclientset.Interface
-	*fakediscovery.FakeDiscovery
+	discovery.DiscoveryInterface
 }
 
-// NewClientSetWithFakeDiscovery allows to easily fake calls to kubernetes.Interface.Discovery() by using the given
-// fake discovery interface.
-func NewClientSetWithFakeDiscovery(kubernetes kubernetesclientset.Interface, discovery *fakediscovery.FakeDiscovery) *ClientSet {
+// NewClientSetWithDiscovery allows to easily fake calls to kubernetes.Interface.Discovery() by using the given
+// discovery interface.
+func NewClientSetWithDiscovery(kubernetes kubernetesclientset.Interface, discovery discovery.DiscoveryInterface) *ClientSet {
 	return &ClientSet{kubernetes, discovery}
 }
 
@@ -41,7 +41,7 @@ func NewClientSetWithFakeDiscovery(kubernetes kubernetesclientset.Interface, dis
 func NewClientSetWithFakedServerVersion(kubernetes kubernetesclientset.Interface, version *version.Info) *ClientSet {
 	return &ClientSet{
 		Interface: kubernetes,
-		FakeDiscovery: &fakediscovery.FakeDiscovery{
+		DiscoveryInterface: &fakediscovery.FakeDiscovery{
 			Fake:               &testing.Fake{},
 			FakedServerVersion: version,
 		},
@@ -49,5 +49,5 @@ func NewClientSetWithFakedServerVersion(kubernetes kubernetesclientset.Interface
 }
 
 func (c *ClientSet) Discovery() discovery.DiscoveryInterface {
-	return c.FakeDiscovery
+	return c.DiscoveryInterface
 }

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/version"
 	autoscalingscheme "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	corescheme "k8s.io/client-go/kubernetes/scheme"
@@ -143,6 +144,10 @@ type Interface interface {
 
 	// Version returns the server version of the targeted Kubernetes cluster.
 	Version() string
+	// DiscoverVersion tries to retrieve the server version of the targeted Kubernetes cluster and updates the
+	// ClientSet's saved version accordingly. Use Version if you only want to retrieve the kubernetes version instead
+	// of refreshing the ClientSet's saved version.
+	DiscoverVersion() (*version.Info, error)
 
 	// Start starts the cache of the ClientSet's controller-runtime client and returns immediately.
 	// It must be called first before using the client to retrieve objects from the API server.

--- a/pkg/mock/gardener/client/kubernetes/mocks.go
+++ b/pkg/mock/gardener/client/kubernetes/mocks.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	clientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	meta "k8s.io/apimachinery/pkg/api/meta"
+	version "k8s.io/apimachinery/pkg/version"
 	kubernetes0 "k8s.io/client-go/kubernetes"
 	rest "k8s.io/client-go/rest"
 	clientset0 "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
@@ -166,6 +167,21 @@ func (m *MockInterface) DirectClient() client.Client {
 func (mr *MockInterfaceMockRecorder) DirectClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DirectClient", reflect.TypeOf((*MockInterface)(nil).DirectClient))
+}
+
+// DiscoverVersion mocks base method
+func (m *MockInterface) DiscoverVersion() (*version.Info, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DiscoverVersion")
+	ret0, _ := ret[0].(*version.Info)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DiscoverVersion indicates an expected call of DiscoverVersion
+func (mr *MockInterfaceMockRecorder) DiscoverVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiscoverVersion", reflect.TypeOf((*MockInterface)(nil).DiscoverVersion))
 }
 
 // ForwardPodPort mocks base method


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Previously, the generic ClientMap invalidated ClientSets if the server version of the targeted cluster changed.
Now, it just refreshes the internals (saved server version and chart renderer) when the version changes, so the caches/informers keep running.

Now, the garden and seed clients are never invalidated and kept running during the whole lifetime of the gardenlet instance, unless the gardenlet is responsible for multiple Seeds, which is not recommended for production use anyways (in that case the Seed clients may be invalidated/refreshed when the kubeconfig secret changes).
Therefore, it is now possible to use the informers retrieved from the controller-runtime cache to construct controllers the same way like with informers created by a `SharedInformerFactory`. I will open a second PR which makes use of this in the BackupBucket/BackupEntry controller as a simple example for that.

**Which issue(s) this PR fixes**:
Part of #2414 

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
You can now use the controller-runtime cache of our ClientSets (`kubernetes.Interface.Cache()`) to obtain informers for arbitrary API objects (via `GetInformer/GetInformerForKind`) to construct controllers.
```
