### PR TITLE
Fix flapping Plant region

### DIFF
--- a/pkg/controllermanager/controller/plant/plant_utils.go
+++ b/pkg/controllermanager/controller/plant/plant_utils.go
@@ -79,15 +79,20 @@ func getCloudProviderForNode(providerID string) string {
 	return provider[0]
 }
 
+var regionLabels = []string{
+	corev1.LabelZoneRegionStable,
+	corev1.LabelZoneRegion,
+	corev1.LabelZoneFailureDomainStable,
+	corev1.LabelZoneFailureDomain,
+}
+
 func getRegionNameForNode(node corev1.Node) string {
-	for key, value := range node.Labels {
-		if key == corev1.LabelZoneRegion {
-			return value
-		}
-		if key == corev1.LabelZoneFailureDomain {
-			return value
+	for _, label := range regionLabels {
+		if region, ok := node.Labels[label]; ok && len(region) > 0 {
+			return region
 		}
 	}
+
 	return Unknown
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
Previously, the Plant controller falsely tried to obtain the region of the Plant cluster from the zone Node label, although this is supposed to be a fallback to the region label.
As maps are unsorted in go, the plant controller sometimes used the zone and sometimes the region for reporting the Plant's CloudInfo.
This PR fixes this behaviour and adds an additional cross-check to the Plant integration test.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug has been fixed, which caused the discovered Plant region to alternate between region and zone of the Nodes.
```
