### PR TITLE
Fix skipped charts in check-charts

### DIFF
--- a/charts/seed-controlplane/Chart.yaml
+++ b/charts/seed-controlplane/Chart.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-description: Meta chart for control-plane resources in the Seed cluster
-name: seed-controlplane
-version: 0.1.0

--- a/hack/check-charts.sh
+++ b/hack/check-charts.sh
@@ -28,8 +28,9 @@ if [[ -d "$1" ]]; then
   fi
 
   echo "Checking whether all charts can be rendered"
-  for chart_file in $1/*/Chart.yaml; do
-    helm template "$(dirname "$chart_file")" 1> /dev/null
+  for chart_dir in $(find charts -type d -exec test -f '{}'/Chart.yaml \;  -print -prune | sort); do
+    [ -f "$chart_dir/values-test.yaml" ] && values_files="-f $chart_dir/values-test.yaml"
+    helm template $values_files "$chart_dir" 1> /dev/null
   done
 fi
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
Previously, `hack/check-charts.sh` was only checking charts one level under the given directory (`./charts` for g/g).
This led to many charts not being checked, that are contained in other directories for structuring (e.g. `seed-dns/{entry,provider}` or the charts under `seed-controlplane`).

This PR fixes this behaviour, so that all "top-level" charts will be checked from now on.
It also adds the possibility to add test values in `values-test.yaml` to the chart directories which will be merged into the default `values.yaml`. This is useful, if you want to check charts that have a `{{ required ... }}` statement, but don't want to specify default values.

Checked previously:
```
charts/cluster-identity
charts/global-network-policies
charts/seed-bootstrap
charts/seed-monitoring
charts/shoot-addons-kyma
charts/shoot-addons
charts/shoot-cloud-config-rbac
charts/shoot-cloud-config
charts/utils-templates
charts/utils-tls-cipher-suites
```

Checked now:
```
charts/cluster-identity
charts/garden-project/charts/project-rbac
charts/gardener/controlplane
charts/gardener/gardenlet
charts/global-network-policies
charts/istio/istio-crds
charts/istio/istio-ingress
charts/istio/istio-istiod
charts/istio/istio-proxy-protocol
charts/seed-bootstrap
charts/seed-controlplane/charts/cluster-autoscaler
charts/seed-controlplane/charts/etcd
charts/seed-controlplane/charts/gardener-resource-manager
charts/seed-controlplane/charts/kube-apiserver
charts/seed-controlplane/charts/kube-apiserver-service
charts/seed-controlplane/charts/kube-apiserver-sni
charts/seed-controlplane/charts/kube-controller-manager
charts/seed-controlplane/charts/kube-scheduler
charts/seed-controlplane/charts/network-policies
charts/seed-dns/entry
charts/seed-dns/provider
charts/seed-monitoring
charts/seed-operatingsystemconfig/downloader
charts/seed-operatingsystemconfig/original
charts/shoot-addons
charts/shoot-addons-kyma
charts/shoot-cloud-config
charts/shoot-cloud-config-rbac
charts/shoot-core/components
charts/shoot-core/namespaces
charts/utils-templates
charts/utils-tls-cipher-suites
```

**Which issue(s) this PR fixes**:
Ref #2580 
Ref https://github.com/gardener/gardener/pull/2471#issuecomment-656538626

**Special notes for your reviewer**:
/invite @swilen-iwanow 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
It is possible now to add a `values-test.yaml` file to helm charts to specify default values for chart checks, which will be merged into the default `values.yaml` when running `hack/check-charts.sh`. This is useful for the case, that charts have a `{{ required ... }}` statement, but don't specify default values in `values.yaml`.
```
