### PR TITLE
Switch BB/BE controller to controller-runtime informers

### DIFF
--- a/pkg/controllerutils/seedfilter.go
+++ b/pkg/controllerutils/seedfilter.go
@@ -15,11 +15,14 @@
 package controllerutils
 
 import (
+	"context"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // LabelsMatchFor checks whether the given label selector matches for the given set of labels.
@@ -79,6 +82,17 @@ func SeedLabelsMatch(seedLister gardencorelisters.SeedLister, seedName string, l
 	return LabelsMatchFor(seed.Labels, labelSelector)
 }
 
+// seedLabelsMatchWithClient fetches the given seed by its name from the client and then checks whether the given
+// label selector matches the seed labels.
+func seedLabelsMatchWithClient(ctx context.Context, c client.Client, seedName string, labelSelector *metav1.LabelSelector) bool {
+	seed := &gardencorev1beta1.Seed{}
+	if err := c.Get(ctx, client.ObjectKey{Name: seedName}, seed); err != nil {
+		return false
+	}
+
+	return LabelsMatchFor(seed.Labels, labelSelector)
+}
+
 // ControllerInstallationFilterFunc returns a filtering func for the seeds and the given label selector.
 func ControllerInstallationFilterFunc(seedName string, seedLister gardencorelisters.SeedLister, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
@@ -94,7 +108,7 @@ func ControllerInstallationFilterFunc(seedName string, seedLister gardencorelist
 }
 
 // BackupBucketFilterFunc returns a filtering func for the seeds and the given label selector.
-func BackupBucketFilterFunc(seedName string, seedLister gardencorelisters.SeedLister, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
+func BackupBucketFilterFunc(ctx context.Context, c client.Client, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		backupBucket, ok := obj.(*gardencorev1beta1.BackupBucket)
 		if !ok {
@@ -106,12 +120,12 @@ func BackupBucketFilterFunc(seedName string, seedLister gardencorelisters.SeedLi
 		if len(seedName) > 0 {
 			return *backupBucket.Spec.SeedName == seedName
 		}
-		return SeedLabelsMatch(seedLister, *backupBucket.Spec.SeedName, labelSelector)
+		return seedLabelsMatchWithClient(ctx, c, *backupBucket.Spec.SeedName, labelSelector)
 	}
 }
 
 // BackupEntryFilterFunc returns a filtering func for the seeds and the given label selector.
-func BackupEntryFilterFunc(seedName string, seedLister gardencorelisters.SeedLister, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
+func BackupEntryFilterFunc(ctx context.Context, c client.Client, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		backupEntry, ok := obj.(*gardencorev1beta1.BackupEntry)
 		if !ok {
@@ -123,6 +137,6 @@ func BackupEntryFilterFunc(seedName string, seedLister gardencorelisters.SeedLis
 		if len(seedName) > 0 {
 			return *backupEntry.Spec.SeedName == seedName
 		}
-		return SeedLabelsMatch(seedLister, *backupEntry.Spec.SeedName, labelSelector)
+		return seedLabelsMatchWithClient(ctx, c, *backupEntry.Spec.SeedName, labelSelector)
 	}
 }

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
@@ -70,7 +70,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	bb := &gardencorev1beta1.BackupBucket{}
-	if err := gardenClient.DirectClient().Get(r.ctx, request.NamespacedName, bb); err != nil {
+	if err := gardenClient.Client().Get(r.ctx, request.NamespacedName, bb); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.logger.Debugf("[BACKUPBUCKET RECONCILE] %s - skipping because BackupBucket has been deleted", request.NamespacedName)
 			return reconcile.Result{}, nil

--- a/pkg/gardenlet/controller/backupentry/backup_entry.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry.go
@@ -16,33 +16,37 @@ package backupentry
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
+	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	confighelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
+	"github.com/gardener/gardener/pkg/logger"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	runtimecache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/gardener/gardener/pkg/logger"
 )
 
 // Controller controls BackupEntries.
 type Controller struct {
-	config     *config.GardenletConfiguration
-	reconciler reconcile.Reconciler
-	recorder   record.EventRecorder
+	gardenClient client.Client
+	config       *config.GardenletConfiguration
+	reconciler   reconcile.Reconciler
+	recorder     record.EventRecorder
 
-	backupEntryQueue  workqueue.RateLimitingInterface
-	backupEntrySynced cache.InformerSynced
+	backupEntryInformer runtimecache.Informer
+	backupEntryQueue    workqueue.RateLimitingInterface
 
 	workerCh               chan int
 	numberOfRunningWorkers int
@@ -51,43 +55,43 @@ type Controller struct {
 // NewBackupEntryController takes a Kubernetes client for the Garden clusters <k8sGardenClient>, a struct
 // holding information about the acting Gardener, a <backupEntryInformer>, and a <recorder> for
 // event recording. It creates a new Gardener controller.
-func NewBackupEntryController(clientMap clientmap.ClientMap, gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory, config *config.GardenletConfiguration, recorder record.EventRecorder) *Controller {
-	var (
-		gardencorev1beta1Informer = gardenCoreInformerFactory.Core().V1beta1()
-		backupEntryInformer       = gardencorev1beta1Informer.BackupEntries()
-
-		seedInformer = gardencorev1beta1Informer.Seeds()
-		seedLister   = seedInformer.Lister()
-	)
-
-	backupEntryController := &Controller{
-		config:           config,
-		reconciler:       newReconciler(context.TODO(), clientMap, recorder, config),
-		recorder:         recorder,
-		backupEntryQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "BackupEntry"),
-		workerCh:         make(chan int),
+func NewBackupEntryController(ctx context.Context, clientMap clientmap.ClientMap, config *config.GardenletConfiguration, recorder record.EventRecorder) (*Controller, error) {
+	gardenClient, err := clientMap.GetClient(ctx, keys.ForGarden())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get garden client: %w", err)
 	}
 
-	backupEntryInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.BackupEntryFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister, config.SeedSelector),
-		Handler: cache.ResourceEventHandlerFuncs{
-			AddFunc:    backupEntryController.backupEntryAdd,
-			UpdateFunc: backupEntryController.backupEntryUpdate,
-			DeleteFunc: backupEntryController.backupEntryDelete,
-		},
-	})
+	backupEntryInformer, err := gardenClient.Cache().GetInformer(&gardencorev1beta1.BackupEntry{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get BackupEntry Informer: %w", err)
+	}
 
-	backupEntryController.backupEntrySynced = backupEntryInformer.Informer().HasSynced
-
-	return backupEntryController
+	return &Controller{
+		gardenClient:        gardenClient.Client(),
+		config:              config,
+		reconciler:          newReconciler(ctx, clientMap, recorder, config),
+		recorder:            recorder,
+		backupEntryInformer: backupEntryInformer,
+		backupEntryQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "BackupEntry"),
+		workerCh:            make(chan int),
+	}, nil
 }
 
 // Run runs the Controller until the given stop channel can be read from.
 func (c *Controller) Run(ctx context.Context, workers int) {
 	var waitGroup sync.WaitGroup
 
-	if !cache.WaitForCacheSync(ctx.Done(), c.backupEntrySynced) {
-		logger.Logger.Error("Timed out waiting for caches to sync")
+	c.backupEntryInformer.AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controllerutils.BackupEntryFilterFunc(ctx, c.gardenClient, confighelper.SeedNameFromSeedConfig(c.config.SeedConfig), c.config.SeedSelector),
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc:    c.backupEntryAdd,
+			UpdateFunc: c.backupEntryUpdate,
+			DeleteFunc: c.backupEntryDelete,
+		},
+	})
+
+	if !cache.WaitForCacheSync(ctx.Done(), c.backupEntryInformer.HasSynced) {
+		logger.Logger.Fatal("Timed out waiting for BackupEntry Informer to sync")
 		return
 	}
 

--- a/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
@@ -71,7 +71,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	be := &gardencorev1beta1.BackupEntry{}
-	if err := gardenClient.DirectClient().Get(r.ctx, request.NamespacedName, be); err != nil {
+	if err := gardenClient.Client().Get(r.ctx, request.NamespacedName, be); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.logger.Debugf("[BACKUPENTRY RECONCILE] %s - skipping because BackupEntry has been deleted", request.NamespacedName)
 			return reconcile.Result{}, nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/priority normal
/size s

**What this PR does / why we need it**:
This PR replaces the Informers created by the `SharedInformerFactory` in the BackupBucket and BackupEntry controllers by informers from the controller-runtime cache. 
This way, we rely on the same watch for those objects, which enables us to use the cached client in the respective reconcilers. This is analogous to the way we do it in many other controllers with client-go-style Informers and Listers.

This can be seen as a simple example on how to construct/refactor controllers in gardener by only relying on controller-runtime clients and informers.

**Which issue(s) this PR fixes**:
Ref #2581 
Ref #2568

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
