### PR TITLE
Ensure Seed client is invalidated after deletion

### DIFF
--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -91,6 +91,10 @@ func (c *Controller) reconcileSeedKey(key string) error {
 	seed, err := c.seedLister.Get(name)
 	if apierrors.IsNotFound(err) {
 		logger.Logger.Debugf("[SEED RECONCILE] %s - skipping because Seed has been deleted", key)
+
+		if err := c.clientMap.InvalidateClient(keys.ForSeedWithName(name)); err != nil {
+			return fmt.Errorf("failed to invalidate seed client: %w", err)
+		}
 		return nil
 	}
 	if err != nil {

--- a/pkg/gardenlet/controller/seed/seed_lease_control.go
+++ b/pkg/gardenlet/controller/seed/seed_lease_control.go
@@ -57,6 +57,11 @@ func (c *Controller) reconcileSeedLeaseKey(key string) error {
 	seed, err := c.seedLister.Get(name)
 	if apierrors.IsNotFound(err) {
 		logger.Logger.Infof("[SEED LEASE] Stopping lease operations for Seed %s since it has been deleted", key)
+
+		if err := c.clientMap.InvalidateClient(keys.ForSeedWithName(name)); err != nil {
+			return fmt.Errorf("failed to invalidate seed client: %w", err)
+		}
+
 		c.seedLeaseQueue.Done(key)
 		return nil
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR ensures the seed clients are invalidated after the seed deletion.
This wasn't always the case before, because the seed lease controller always requeues the Seed also after successful deletion and could therefore create a new clientset again, even though the seed might already have been completely deleted.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug has been fixed, which caused Seed clients not to be invalidated properly on Seed deletion.
```
