### PR TITLE
Use DirectClient to wait for OSC

### DIFF
--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -366,7 +366,7 @@ func (b *Botanist) applyAndWaitForShootOperatingSystemConfig(ctx context.Context
 
 	if err := common.WaitUntilExtensionCRReady(
 		ctx,
-		b.K8sSeedClient.Client(),
+		b.K8sSeedClient.DirectClient(),
 		b.Logger,
 		func() runtime.Object { return &extensionsv1alpha1.OperatingSystemConfig{} },
 		"OperatingSystemConfig",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
When adapting the gardenlet's seed client usage in f120f2c74a503ab4a388aa055cd08d4081eaf5ed, I missed one usage of `common.WaitUntilExtensionCRReady` in `applyAndWaitForShootOperatingSystemConfig`, which should have also been switched to the `DirectClient`.
Therefore, the `cloud-config` script in the Shoot was not properly updated after some change in the worker config or similar in case the `CachedRuntimeClients` feature gate was activated. In that case, only after a second reconciliation the secret was updated correctly.
This PR fixes this bug.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @zanetworker 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug has been fixed, which caused the `cloud-config` secret in the Shoot to not get updated correctly after a change to the worker config in case the `CachedRuntimeClients` feature gate was activated.
```
