### PR TITLE
[GEP-7] Fix restoration of Machines and MachineSets

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -163,7 +163,7 @@ func removeWantedDeploymentWithoutState(wantedMachineDeployments workercontrolle
 
 	reducedMachineDeployments := make(workercontroller.MachineDeployments, 0)
 	for _, wantedMachineDeployment := range wantedMachineDeployments {
-		if wantedMachineDeployment.State != nil && len(wantedMachineDeployment.State.MachineSets) < 1 {
+		if wantedMachineDeployment.State != nil && len(wantedMachineDeployment.State.MachineSets) > 0 {
 			reducedMachineDeployments = append(reducedMachineDeployments, wantedMachineDeployment)
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug
/priority normal

**What this PR does / why we need it**:
Fixes a bug where machines were being recreated during migration scenario. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@vlvasilev can you "throw an eye"

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
