### PR TITLE
Increase the DB size limit in alert rule for Etcd

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
@@ -24,7 +24,7 @@ tests:
   # KubeEtcd3DbSizeLimitApproaching
   # KubeEtcd3DbSizeLimitCrossed
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3",role="main"}'
-    values: '966367641+107374182x20' # 0.9GB 1GB 1.1GB .. 1.9GB
+    values: '7194070000+107374182x20' # 6.7GB 6.8GB 6.9GB .. 7.7GB
   # KubeEtcdDeltaBackupFailed
   - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore",role="main",kind="Incr"}'
     values: '0+0x62'
@@ -107,7 +107,7 @@ tests:
         type: seed
         visibility: all
       exp_annotations:
-        description: Etcd3 main DB size is approaching its current practical limit of 2GB.
+        description: Etcd3 main DB size is approaching its current practical limit of 8GB. Etcd quota might need to be increased.
         summary: Etcd3 main DB size is approaching its current practical limit.
   - eval_time: 10m
     alertname: KubeEtcd3DbSizeLimitCrossed
@@ -120,7 +120,7 @@ tests:
         type: seed
         visibility: all
       exp_annotations:
-        description: Etcd3 main DB size has crossed its current practical limit of 2GB. Etcd might now require more memory to continue serving traffic with low latency, and might face request throttling.
+        description: Etcd3 main DB size has crossed its current practical limit of 8GB. Etcd quota must be increased to allow updates.
         summary: Etcd3 main DB size has crossed its current practical limit.
   - eval_time: 31m
     alertname: KubeEtcdDeltaBackupFailed

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -71,25 +71,25 @@ groups:
 
   # etcd DB size alerts
   - alert: KubeEtcd3DbSizeLimitApproaching
-    expr: (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"} > bool 1610612736) + (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"} <= bool 2147483648) == 2 # between 1.5GB and 2GB
+    expr: (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"} > bool 7516193000) + (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"} <= bool 8589935000) == 2 # between 7GB and 8GB
     labels:
       service: etcd
       severity: warning
       type: seed
       visibility: all
     annotations:
-      description: Etcd3 {{ $labels.role }} DB size is approaching its current practical limit of 2GB.
+      description: Etcd3 {{ $labels.role }} DB size is approaching its current practical limit of 8GB. Etcd quota might need to be increased.
       summary: Etcd3 {{ $labels.role }} DB size is approaching its current practical limit.
 
   - alert: KubeEtcd3DbSizeLimitCrossed
-    expr: etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"} > 2147483648 # above 2GB
+    expr: etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"} > 8589935000 # above 8GB
     labels:
       service: etcd
       severity: critical
       type: seed
       visibility: all
     annotations:
-      description: Etcd3 {{ $labels.role }} DB size has crossed its current practical limit of 2GB. Etcd might now require more memory to continue serving traffic with low latency, and might face request throttling.
+      description: Etcd3 {{ $labels.role }} DB size has crossed its current practical limit of 8GB. Etcd quota must be increased to allow updates.
       summary: Etcd3 {{ $labels.role }} DB size has crossed its current practical limit.
 
   # etcd backup failure alerts
@@ -127,4 +127,3 @@ groups:
     annotations:
       description: Etcd data restoration was triggered, but has failed.
       summary: Etcd data restoration failure.
-

--- a/docs/monitoring/operator_alerts.md
+++ b/docs/monitoring/operator_alerts.md
@@ -12,8 +12,8 @@
 |KubeEtcd3MainNoLeader|critical|seed|`Etcd3 main has no leader. No communication with etcd main possible. Apiserver is read only.`|
 |KubeEtcd3EventsNoLeader|critical|seed|`Etcd3 events has no leader. No communication with etcd events possible. New cluster events cannot be collected. Events can only be read.`|
 |KubeEtcd3HighNumberOfFailedProposals|warning|seed|`Etcd3 pod {{ $labels.pod }} has seen {{ $value }} proposal failures within the last hour.`|
-|KubeEtcd3DbSizeLimitApproaching|warning|seed|`Etcd3 {{ $labels.role }} DB size is approaching its current practical limit of 2GB.`|
-|KubeEtcd3DbSizeLimitCrossed|critical|seed|`Etcd3 {{ $labels.role }} DB size has crossed its current practical limit of 2GB. Etcd might now require more memory to continue serving traffic with low latency, and might face request throttling.`|
+|KubeEtcd3DbSizeLimitApproaching|warning|seed|`Etcd3 {{ $labels.role }} DB size is approaching its current practical limit of 8GB. Etcd quota might need to be increased.`|
+|KubeEtcd3DbSizeLimitCrossed|critical|seed|`Etcd3 {{ $labels.role }} DB size has crossed its current practical limit of 8GB. Etcd quota must be increased to allow updates.`|
 |KubeEtcdDeltaBackupFailed|critical|seed|`No delta snapshot for the past at least 30 minutes.`|
 |KubeEtcdFullBackupFailed|critical|seed|`No full snapshot taken in the past day.`|
 |KubeEtcdRestorationFailed|critical|seed|`Etcd data restoration was triggered, but has failed.`|

--- a/docs/monitoring/user_alerts.md
+++ b/docs/monitoring/user_alerts.md
@@ -8,8 +8,8 @@
 |KubeApiServerTooManyOpenFileDescriptors|warning|seed|`The API server ({{ $labels.instance }}) is using {{ $value }}% of the available file/socket descriptors.`|
 |KubeApiServerTooManyOpenFileDescriptors|critical|seed|`The API server ({{ $labels.instance }}) is using {{ $value }}% of the available file/socket descriptors.`|
 |KubeControllerManagerDown|critical|seed|`Deployments and replication controllers are not making progress.`|
-|KubeEtcd3DbSizeLimitApproaching|warning|seed|`Etcd3 {{ $labels.role }} DB size is approaching its current practical limit of 2GB.`|
-|KubeEtcd3DbSizeLimitCrossed|critical|seed|`Etcd3 {{ $labels.role }} DB size has crossed its current practical limit of 2GB. Etcd might now require more memory to continue serving traffic with low latency, and might face request throttling.`|
+|KubeEtcd3DbSizeLimitApproaching|warning|seed|`Etcd3 {{ $labels.role }} DB size is approaching its current practical limit of 8GB. Etcd quota might need to be increased.`|
+|KubeEtcd3DbSizeLimitCrossed|critical|seed|`Etcd3 {{ $labels.role }} DB size has crossed its current practical limit of 8GB. Etcd quota must be increased to allow updates.`|
 |KubeKubeletNodeDown|warning|shoot|`The kubelet {{ $labels.instance }} has been unavailable/unreachable for more than 1 hour. Workloads on the affected node may not be schedulable.`|
 |KubeKubeletTooManyPods|warning||`Kubelet {{ $labels.instance }} is running {{ $value }} pods, close to the limit of 110`|
 |KubeletTooManyOpenFileDescriptorsShoot|warning|shoot|`Shoot-kubelet ({{ $labels.kubernetes_io_hostname }}) is using {{ $value }}% of the available file/socket descriptors. Kubelet could be under heavy load.`|


### PR DESCRIPTION
Signed-off-by: Swapnil Mhamane <swapnil.mhamane@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind task
/priority normal

**What this PR does / why we need it**:
Initially we kept the etcd DB size alert limit to 2GB. But with hvpa enabled for etcd sts, it can handle more DB size without hitting OOMKill issue.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
/review @shreyas-s-rao  
/review @wyb1
cc @amshuman-kr 