### PR TITLE
Use DirectClient to wait for deletion of Worker/ControlPlane

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -670,7 +670,7 @@ func (b *Botanist) WaitUntilControlPlaneDeleted(ctx context.Context) error {
 func (b *Botanist) waitUntilControlPlaneDeleted(ctx context.Context, name string) error {
 	return common.WaitUntilExtensionCRDeleted(
 		ctx,
-		b.K8sSeedClient.Client(),
+		b.K8sSeedClient.DirectClient(),
 		b.Logger,
 		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ControlPlane{} },
 		"ControlPlane",
@@ -1339,7 +1339,7 @@ func (b *Botanist) DefaultKubeAPIServerService() component.DeployWaiter {
 		b.K8sSeedClient.ChartApplier(),
 		b.ChartsRootPath,
 		b.Logger,
-		b.K8sSeedClient.Client(),
+		b.K8sSeedClient.DirectClient(),
 		nil,
 		b.setAPIServerServiceClusterIP,
 		b.setAPIServerAddress,

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -218,7 +218,7 @@ func (b *Botanist) WaitUntilWorkerReady(ctx context.Context) error {
 func (b *Botanist) WaitUntilWorkerDeleted(ctx context.Context) error {
 	return common.WaitUntilExtensionCRDeleted(
 		ctx,
-		b.K8sSeedClient.Client(),
+		b.K8sSeedClient.DirectClient(),
 		b.Logger,
 		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} },
 		"Worker",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup
/priority normal

**What this PR does / why we need it**:
I have found a few more places, where we should rather rely on the direct client when waiting (e.g. for deletion of Worker/ControlPlane) that haven't been adapted yet.
I haven't encountered any issues with these, but I would like to avoid any in some edge cases we haven't maybe hit yet.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
