### PR TITLE
Remove some already deprecated labels and annotations

### DIFF
--- a/charts/gardener/controlplane/charts/utils-common/templates/_secret-default-domain.yaml
+++ b/charts/gardener/controlplane/charts/utils-common/templates/_secret-default-domain.yaml
@@ -11,12 +11,10 @@ metadata:
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
+    # TODO: remove in a future release
     garden.sapcloud.io/role: default-domain
     gardener.cloud/role: default-domain
   annotations:
-    # keep deprecated dns.garden.sapcloud.io labels for backwards compatibility
-    dns.garden.sapcloud.io/provider: {{ ( required ".defaultDomains[].provider is required" $domain.provider ) }}
-    dns.garden.sapcloud.io/domain: {{ ( required ".defaultDomains[].domain is required" $domain.domain ) }}
     dns.gardener.cloud/provider: {{ ( required ".defaultDomains[].provider is required" $domain.provider ) }}
     dns.gardener.cloud/domain: {{ ( required ".defaultDomains[].domain is required" $domain.domain ) }}
 type: Opaque

--- a/charts/gardener/controlplane/charts/utils-common/templates/_secret_internal-domain.yaml
+++ b/charts/gardener/controlplane/charts/utils-common/templates/_secret_internal-domain.yaml
@@ -10,12 +10,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+    # TODO: remove in a future release
     garden.sapcloud.io/role: internal-domain
     gardener.cloud/role: internal-domain
   annotations:
-    # keep deprecated dns.garden.sapcloud.io labels for backwards compatibility
-    dns.garden.sapcloud.io/provider: {{ ( required ".internalDomain.provider is required" .Values.global.internalDomain.provider ) }}
-    dns.garden.sapcloud.io/domain: {{ ( required ".internalDomain.domain is required" .Values.global.internalDomain.domain ) }}
     dns.gardener.cloud/provider: {{ ( required ".internalDomain.provider is required" .Values.global.internalDomain.provider ) }}
     dns.gardener.cloud/domain: {{ ( required ".internalDomain.domain is required" .Values.global.internalDomain.domain ) }}
 type: Opaque

--- a/example/00-namespace-garden-dev.yaml
+++ b/example/00-namespace-garden-dev.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: garden-dev
-  annotations:
-    project.garden.sapcloud.io/owner: john.doe@example.com
   labels:
     gardener.cloud/role: project
     project.gardener.cloud/name: dev

--- a/pkg/controllermanager/controller/shoot/shoot_quota_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_quota_control.go
@@ -129,21 +129,11 @@ func (c *defaultQuotaControl) CheckQuota(shootObj *gardencorev1beta1.Shoot, key 
 		return fmt.Errorf("failed to get garden client: %w", err)
 	}
 
-	expirationTime, exits := shoot.Annotations[common.ShootExpirationTimestampDeprecated]
+	expirationTime, exits := shoot.Annotations[common.ShootExpirationTimestamp]
 	if !exits {
 		expirationTime = shoot.CreationTimestamp.Add(time.Duration(*clusterLifeTime*24) * time.Hour).Format(time.RFC3339)
 		metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, common.ShootExpirationTimestamp, expirationTime)
-		metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, common.ShootExpirationTimestampDeprecated, expirationTime)
 
-		shootUpdated, err := gardenClient.GardenCore().CoreV1beta1().Shoots(shoot.Namespace).Update(shoot)
-		if err != nil {
-			return err
-		}
-		shoot = shootUpdated
-	}
-
-	if shoot.Annotations[common.ShootExpirationTimestamp] != expirationTime {
-		metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, common.ShootExpirationTimestamp, expirationTime)
 		shootUpdated, err := gardenClient.GardenCore().CoreV1beta1().Shoots(shoot.Namespace).Update(shoot)
 		if err != nil {
 			return err

--- a/pkg/controllerutils/miscellaneous.go
+++ b/pkg/controllerutils/miscellaneous.go
@@ -26,7 +26,7 @@ const separator = ","
 // GetTasks returns the list of tasks in the ShootTasks annotation.
 func GetTasks(annotations map[string]string) []string {
 	var tasks []string
-	if val, _ := common.GetTasksAnnotation(annotations); len(val) > 0 {
+	if val := annotations[common.ShootTasks]; len(val) > 0 {
 		tasks = strings.Split(val, separator)
 	}
 	return tasks
@@ -71,6 +71,7 @@ func RemoveTasks(annotations map[string]string, tasksToRemove ...string) {
 // RemoveAllTasks removes the ShootTasks annotation from the passed map.
 func RemoveAllTasks(annotations map[string]string) {
 	delete(annotations, common.ShootTasks)
+	// TODO: remove in a future release
 	delete(annotations, common.ShootTasksDeprecated)
 }
 
@@ -81,5 +82,4 @@ func setTaskAnnotations(annotations map[string]string, tasks []string) {
 	}
 
 	annotations[common.ShootTasks] = strings.Join(tasks, separator)
-	annotations[common.ShootTasksDeprecated] = strings.Join(tasks, separator)
 }

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -399,7 +399,7 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Maintain shoot annotations",
-			Fn:           flow.TaskFn(botanist.MaintainShootAnnotations).SkipIf(o.Shoot.HibernationEnabled),
+			Fn:           flow.TaskFn(botanist.MaintainShootAnnotations),
 			Dependencies: flow.NewTaskIDs(deleteStaleExtensionResources),
 		})
 		deployContainerRuntimeResources = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot_utils.go
+++ b/pkg/gardenlet/controller/shoot/shoot_utils.go
@@ -64,8 +64,9 @@ func (s Status) OrWorse(other Status) Status {
 // StatusLabelTransform transforms the shoot labels depending on the given Status.
 func StatusLabelTransform(status Status) func(*gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
 	return func(shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
+		// TODO: remove in a future version
+		delete(shoot.Labels, common.ShootStatusDeprecated)
 		kubernetes.SetMetaDataLabel(&shoot.ObjectMeta, common.ShootStatus, string(status))
-		kubernetes.SetMetaDataLabel(&shoot.ObjectMeta, common.ShootStatusDeprecated, string(status))
 		return shoot, nil
 	}
 }

--- a/pkg/gardenlet/controller/shoot/shoot_utils_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot_utils_test.go
@@ -123,16 +123,13 @@ var _ = Describe("Shoot Utils", func() {
 				Expect(modified.Labels).To(Equal(expectedLabels))
 			},
 			Entry("StatusHealthy", shoot.StatusHealthy, map[string]string{
-				common.ShootStatus:           string(shoot.StatusHealthy),
-				common.ShootStatusDeprecated: string(shoot.StatusHealthy),
+				common.ShootStatus: string(shoot.StatusHealthy),
 			}),
 			Entry("StatusProgressing", shoot.StatusProgressing, map[string]string{
-				common.ShootStatus:           string(shoot.StatusProgressing),
-				common.ShootStatusDeprecated: string(shoot.StatusProgressing),
+				common.ShootStatus: string(shoot.StatusProgressing),
 			}),
 			Entry("StatusUnhealthy", shoot.StatusUnhealthy, map[string]string{
-				common.ShootStatus:           string(shoot.StatusUnhealthy),
-				common.ShootStatusDeprecated: string(shoot.StatusUnhealthy),
+				common.ShootStatus: string(shoot.StatusUnhealthy),
 			}),
 		)
 	})

--- a/pkg/operation/botanist/metadata.go
+++ b/pkg/operation/botanist/metadata.go
@@ -27,24 +27,19 @@ import (
 // MaintainShootAnnotations ensures that given deprecated Shoot annotations are maintained also
 // with their new equivalent in the Shoot metadata.
 func (b *Botanist) MaintainShootAnnotations(ctx context.Context) error {
-	annotationsToAdd := make(map[string]string)
-
-	// Maintain common.GardenCreatedByDeprecated annotation
-	deprecatedValue, deprecatedExists := b.Shoot.Info.Annotations[common.GardenCreatedByDeprecated]
-	_, newExists := b.Shoot.Info.Annotations[common.GardenCreatedBy]
-	if deprecatedExists && !newExists {
-		annotationsToAdd[common.GardenCreatedBy] = deprecatedValue
-	}
-
-	if len(annotationsToAdd) > 0 {
-		if _, err := kutil.TryUpdateShootAnnotations(b.K8sGardenClient.GardenCore(), retry.DefaultRetry, b.Shoot.Info.ObjectMeta, func(shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
-			for key, value := range annotationsToAdd {
-				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, key, value)
+	if _, err := kutil.TryUpdateShootAnnotations(b.K8sGardenClient.GardenCore(), retry.DefaultRetry, b.Shoot.Info.ObjectMeta, func(shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
+		deprecatedValue, deprecatedExists := shoot.Annotations[common.GardenCreatedByDeprecated]
+		_, newExists := shoot.Annotations[common.GardenCreatedBy]
+		if deprecatedExists {
+			if !newExists {
+				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, common.GardenCreatedBy, deprecatedValue)
 			}
-			return shoot, nil
-		}); err != nil {
-			return err
+			delete(shoot.Annotations, common.GardenCreatedByDeprecated)
 		}
+
+		return shoot, nil
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -64,18 +64,6 @@ const (
 	// manager stores its configuration.
 	ControllerManagerInternalConfigMapName = "gardener-controller-manager-internal-config"
 
-	// DNSProviderDeprecated is the key for an annotation on a Kubernetes Secret object whose value must point to a valid
-	// DNS provider.
-	//
-	// Deprecated: Use `DNSProvider` instead.
-	DNSProviderDeprecated = "dns.garden.sapcloud.io/provider"
-
-	// DNSDomainDeprecated is the key for an annotation on a Kubernetes Secret object whose value must point to a valid
-	// domain name.
-	//
-	// Deprecated: Use `DNSDomain` instead.
-	DNSDomainDeprecated = "dns.garden.sapcloud.io/domain"
-
 	// DNSProvider is the key for an annotation on a Kubernetes Secret object whose value must point to a valid
 	// DNS provider.
 	DNSProvider = "dns.gardener.cloud/provider"
@@ -304,13 +292,6 @@ const (
 	// of referenced quotas.
 	ShootExpirationTimestamp = "shoot.gardener.cloud/expiration-timestamp"
 
-	// ShootExpirationTimestampDeprecated is an annotation on a Shoot resource whose value represents the time when the Shoot lifetime
-	// is expired. The lifetime can be extended, but at most by the minimal value of the 'clusterLifetimeDays' property
-	// of referenced quotas.
-	//
-	// Deprecated: Use `ShootExpirationTimestamp` instead.
-	ShootExpirationTimestampDeprecated = "shoot.garden.sapcloud.io/expirationTimestamp"
-
 	// ShootNoCleanup is a constant for a label on a resource indicating the the Gardener cleaner should not delete this
 	// resource when cleaning a shoot during the deletion flow.
 	ShootNoCleanup = "shoot.gardener.cloud/no-cleanup"
@@ -365,25 +346,10 @@ const (
 	// changed then the reconciliation flow will be executed.
 	ShootSyncPeriod = "shoot.gardener.cloud/sync-period"
 
-	// ShootSyncPeriodDeprecated is a constant for an annotation on a Shoot which may be used to overwrite the global Shoot controller sync period.
-	// The value must be a duration. It can also be used to disable the reconciliation at all by setting it to 0m. Disabling the reconciliation
-	// does only mean that the period reconciliation is disabled. However, when the Gardener is restarted/redeployed or the specification is
-	// changed then the reconciliation flow will be executed.
-	//
-	// Deprecated: Use `ShootSyncPeriod` instead.
-	ShootSyncPeriodDeprecated = "shoot.garden.sapcloud.io/sync-period"
-
 	// ShootIgnore is a constant for an annotation on a Shoot which may be used to tell the Gardener that the Shoot with this name should be
 	// ignored completely. That means that the Shoot will never reach the reconciliation flow (independent of the operation (create/update/
 	// delete)).
 	ShootIgnore = "shoot.gardener.cloud/ignore"
-
-	// ShootIgnoreDeprecated is a constant for an annotation on a Shoot which may be used to tell the Gardener that the Shoot with this name should be
-	// ignored completely. That means that the Shoot will never reach the reconciliation flow (independent of the operation (create/update/
-	// delete)).
-	//
-	// Deprecated: Use `ShootIgnore` instead.
-	ShootIgnoreDeprecated = "shoot.garden.sapcloud.io/ignore"
 
 	// ManagedResourceShootCoreName is the name of the shoot core managed resource.
 	ManagedResourceShootCoreName = "shoot-core"

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -579,16 +579,10 @@ func GetDomainInfoFromAnnotations(annotations map[string]string) (provider strin
 		return "", "", nil, nil, fmt.Errorf("domain secret has no annotations")
 	}
 
-	if providerAnnotation, ok := annotations[DNSProviderDeprecated]; ok {
-		provider = providerAnnotation
-	}
 	if providerAnnotation, ok := annotations[DNSProvider]; ok {
 		provider = providerAnnotation
 	}
 
-	if domainAnnotation, ok := annotations[DNSDomainDeprecated]; ok {
-		domain = domainAnnotation
-	}
 	if domainAnnotation, ok := annotations[DNSDomain]; ok {
 		domain = domainAnnotation
 	}
@@ -633,7 +627,7 @@ func ShouldIgnoreShoot(respectSyncPeriodOverwrite bool, shoot *gardencorev1beta1
 		return false
 	}
 
-	value, ok := GetShootIgnoreAnnotation(shoot.Annotations)
+	value, ok := shoot.Annotations[ShootIgnore]
 	if !ok {
 		return false
 	}
@@ -675,7 +669,7 @@ func SyncPeriodOfShoot(respectSyncPeriodOverwrite bool, defaultMinSyncPeriod tim
 		return defaultMinSyncPeriod
 	}
 
-	syncPeriodOverwrite, ok := GetShootSyncPeriodAnnotation(shoot.Annotations)
+	syncPeriodOverwrite, ok := shoot.Annotations[ShootSyncPeriod]
 	if !ok {
 		return defaultMinSyncPeriod
 	}
@@ -761,34 +755,10 @@ func GetConfirmationDeletionAnnotation(annotations map[string]string) (string, b
 	return getDeprecatedAnnotation(annotations, ConfirmationDeletion, ConfirmationDeletionDeprecated)
 }
 
-// GetShootExpirationTimestampAnnotation fetches the value for ShootExpirationTimestamp annotation.
-// If not present, it fallbacks to ShootExpirationTimestampDeprecated.
-func GetShootExpirationTimestampAnnotation(annotations map[string]string) (string, bool) {
-	return getDeprecatedAnnotation(annotations, ShootExpirationTimestamp, ShootExpirationTimestampDeprecated)
-}
-
 // GetShootOperationAnnotation fetches the value for v1beta1constants.GardenerOperation annotation.
 // If not present, it fallbacks to ShootOperationDeprecated.
 func GetShootOperationAnnotation(annotations map[string]string) (string, bool) {
 	return getDeprecatedAnnotation(annotations, v1beta1constants.GardenerOperation, ShootOperationDeprecated)
-}
-
-// GetShootSyncPeriodAnnotation fetches the value for ShootSyncPeriod annotation.
-// If not present, it fallbacks to ShootSyncPeriodDeprecated.
-func GetShootSyncPeriodAnnotation(annotations map[string]string) (string, bool) {
-	return getDeprecatedAnnotation(annotations, ShootSyncPeriod, ShootSyncPeriodDeprecated)
-}
-
-// GetShootIgnoreAnnotation fetches the value for ShootIgnore annotation.
-// If not present, it fallbacks to ShootIgnoreDeprecated.
-func GetShootIgnoreAnnotation(annotations map[string]string) (string, bool) {
-	return getDeprecatedAnnotation(annotations, ShootIgnore, ShootIgnoreDeprecated)
-}
-
-// GetTasksAnnotation fetches the value for ShootTasks annotation.
-// If not present, it falls back to ShootTasksDeprecated.
-func GetTasksAnnotation(annotations map[string]string) (string, bool) {
-	return getDeprecatedAnnotation(annotations, ShootTasks, ShootTasksDeprecated)
 }
 
 func getDeprecatedAnnotation(annotations map[string]string, annotationKey, deprecatedAnnotationKey string) (string, bool) {

--- a/plugin/pkg/global/deletionconfirmation/admission.go
+++ b/plugin/pkg/global/deletionconfirmation/admission.go
@@ -259,7 +259,7 @@ func shootIgnored(obj metav1.Object) bool {
 		return false
 	}
 	ignore := false
-	if value, ok := common.GetShootIgnoreAnnotation(annotations); ok {
+	if value, ok := annotations[common.ShootIgnore]; ok {
 		ignore, _ = strconv.ParseBool(value)
 	}
 	return ignore

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -263,7 +263,6 @@ func (r *ReferenceManager) Admit(ctx context.Context, a admission.Attributes, o 
 				annotations = map[string]string{}
 			}
 			annotations[common.GardenCreatedBy] = a.GetUserInfo().GetName()
-			annotations[common.GardenCreatedByDeprecated] = a.GetUserInfo().GetName()
 			shoot.Annotations = annotations
 		}
 		err = r.ensureShootReferences(ctx, a, shoot)

--- a/plugin/pkg/global/resourcereferencemanager/admission_test.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission_test.go
@@ -496,13 +496,11 @@ var _ = Describe("resourcereferencemanager", func() {
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
 				Expect(shoot.Annotations).NotTo(HaveKeyWithValue(common.GardenCreatedBy, user.Name))
-				Expect(shoot.Annotations).NotTo(HaveKeyWithValue(common.GardenCreatedByDeprecated, user.Name))
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(shoot.Annotations).To(HaveKeyWithValue(common.GardenCreatedBy, user.Name))
-				Expect(shoot.Annotations).To(HaveKeyWithValue(common.GardenCreatedByDeprecated, user.Name))
 			})
 
 			It("should accept because all referenced objects have been found", func() {

--- a/plugin/pkg/plant/admission.go
+++ b/plugin/pkg/plant/admission.go
@@ -134,7 +134,6 @@ func (a *Handler) Admit(ctx context.Context, attrs admission.Attributes, o admis
 
 	if attrs.GetOperation() == admission.Create {
 		metav1.SetMetaDataAnnotation(&plant.ObjectMeta, common.GardenCreatedBy, attrs.GetUserInfo().GetName())
-		metav1.SetMetaDataAnnotation(&plant.ObjectMeta, common.GardenCreatedByDeprecated, attrs.GetUserInfo().GetName())
 	}
 
 	return nil

--- a/plugin/pkg/plant/admission_test.go
+++ b/plugin/pkg/plant/admission_test.go
@@ -82,13 +82,11 @@ var _ = Describe("Admission", func() {
 			attrs := admission.NewAttributesRecord(&plant, nil, core.Kind("Plant").WithVersion("version"), plant.Namespace, plant.Name, core.Resource("plants").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
 			Expect(plant.Annotations).NotTo(HaveKeyWithValue(common.GardenCreatedBy, defaultUserName))
-			Expect(plant.Annotations).NotTo(HaveKeyWithValue(common.GardenCreatedByDeprecated, defaultUserName))
 
 			err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(plant.Annotations).To(HaveKeyWithValue(common.GardenCreatedBy, defaultUserName))
-			Expect(plant.Annotations).To(HaveKeyWithValue(common.GardenCreatedByDeprecated, defaultUserName))
 		})
 
 		It("should reject Plant resources referencing same kubeconfig secret", func() {

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -32,7 +32,6 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils"
 	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
 
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/admission"
@@ -326,26 +325,14 @@ func assignDefaultDomainIfNeeded(shoot *core.Shoot, projectLister corelisters.Pr
 }
 
 func getDefaultDomains(secretLister kubecorev1listers.SecretLister) ([]string, error) {
-	var domainSecrets []*corev1.Secret
-	deprecatedSelector, err := labels.Parse(fmt.Sprintf("%s=%s", v1beta1constants.DeprecatedGardenRole, common.GardenRoleDefaultDomain))
-	if err != nil {
-		return nil, apierrors.NewInternalError(err)
-	}
-	secrets, err := secretLister.Secrets(v1beta1constants.GardenNamespace).List(deprecatedSelector)
-	if err != nil {
-		return nil, apierrors.NewInternalError(err)
-	}
-	domainSecrets = append(domainSecrets, secrets...)
-
 	selector, err := labels.Parse(fmt.Sprintf("%s=%s", v1beta1constants.GardenRole, common.GardenRoleDefaultDomain))
 	if err != nil {
 		return nil, apierrors.NewInternalError(err)
 	}
-	secrets, err = secretLister.Secrets(v1beta1constants.GardenNamespace).List(selector)
+	domainSecrets, err := secretLister.Secrets(v1beta1constants.GardenNamespace).List(selector)
 	if err != nil {
 		return nil, apierrors.NewInternalError(err)
 	}
-	domainSecrets = append(domainSecrets, secrets...)
 
 	var defaultDomains []string
 	for _, domainSecret := range domainSecrets {

--- a/plugin/pkg/shoot/quotavalidator/admission.go
+++ b/plugin/pkg/shoot/quotavalidator/admission.go
@@ -220,7 +220,7 @@ func (q *QuotaValidator) Validate(ctx context.Context, a admission.Attributes, o
 	}
 
 	// Admit Shoot lifetime changes
-	if lifetime, exists := common.GetShootExpirationTimestampAnnotation(shoot.Annotations); checkLifetime && exists && maxShootLifetime != nil {
+	if lifetime, exists := shoot.Annotations[common.ShootExpirationTimestamp]; checkLifetime && exists && maxShootLifetime != nil {
 		var (
 			plannedExpirationTime     time.Time
 			maxPossibleExpirationTime time.Time
@@ -451,11 +451,11 @@ func getShootWorkerResources(shoot *core.Shoot, cloudProfile *core.CloudProfile)
 }
 
 func lifetimeVerificationNeeded(new, old core.Shoot) bool {
-	oldLifetime, ok := common.GetShootExpirationTimestampAnnotation(old.Annotations)
+	oldLifetime, ok := old.Annotations[common.ShootExpirationTimestamp]
 	if !ok {
 		oldLifetime = old.CreationTimestamp.String()
 	}
-	newLifetime, _ := common.GetShootExpirationTimestampAnnotation(new.Annotations)
+	newLifetime := new.Annotations[common.ShootExpirationTimestamp]
 	return oldLifetime != newLifetime
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority normal

**What this PR does / why we need it**:
This PR adapts the listing for most of the garden Secrets to be with the non-deprecated role label.
It also perform cleanup for deprecation from https://github.com/gardener/gardener/pull/1833.

**Which issue(s) this PR fixes**:
Part of #1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The label used to list the internal-domain, default-domain and openvpn Secrets is now `gardener.cloud/role`. If you manually manage these Secrets (e.g you are not using the controlplane chart), please make sure that they have the required label.
```

```noteworthy user
Already deprecated `dns.garden.sapcloud.io/provider`, `dns.garden.sapcloud.io/domain`, `shoot.garden.sapcloud.io/expirationTimestamp`, `shoot.garden.sapcloud.io/tasks`, `garden.sapcloud.io/createdBy`, `shoot.garden.sapcloud.io/sync-period`, `shoot.garden.sapcloud.io/ignore` annotations and `shoot.garden.sapcloud.io/status` label are now removed.
```
