### PR TITLE
Scale down VPA on shoot hibernation

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
@@ -9,7 +9,7 @@ metadata:
     app: vpa-admission-controller
 {{ toYaml .Values.labels | indent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.admissionController.replicas }}
   selector:
     matchLabels:
       app: vpa-admission-controller

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-exporter.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-exporter.yaml
@@ -9,7 +9,7 @@ metadata:
   name: vpa-exporter
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.exporter.replicas }}
   selector:
     matchLabels:
       app: vpa-exporter

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
@@ -9,7 +9,7 @@ metadata:
     app: vpa-recommender
 {{ toYaml .Values.labels | indent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.recommender.replicas }}
   selector:
     matchLabels:
       app: vpa-recommender

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
@@ -8,7 +8,7 @@ metadata:
     app: vpa-updater
 {{ toYaml .Values.labels | indent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.updater.replicas }}
   selector:
     matchLabels:
       app: vpa-updater

--- a/charts/seed-bootstrap/charts/vpa/values.yaml
+++ b/charts/seed-bootstrap/charts/vpa/values.yaml
@@ -9,6 +9,7 @@ labels:
   garden.sapcloud.io/role: vpa
 
 admissionController:
+  replicas: 1
   enabled: true
   podAnnotations: {}
   podLabels: {}
@@ -16,6 +17,7 @@ admissionController:
   registerByURL: false
 
 exporter:
+  replicas: 1
   enabled: true
   podAnnotations: {}
   podLabels: {}
@@ -24,6 +26,7 @@ exporter:
   enableService: true
 
 recommender:
+  replicas: 1
   enabled: true
   podAnnotations: {}
   podLabels: {}
@@ -32,6 +35,7 @@ recommender:
   recommendationMarginFraction: 0.05
 
 updater:
+  replicas: 1
   enabled: true
   podAnnotations: {}
   podLabels: {}

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -223,6 +223,7 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 			v1beta1constants.LabelNetworkPolicyToShootAPIServer: "allowed",
 		}
 		admissionController = map[string]interface{}{
+			"replicas": b.Shoot.GetReplicas(1),
 			"podAnnotations": map[string]interface{}{
 				"checksum/secret-vpa-tls-certs":            b.CheckSums["vpa-tls-certs"],
 				"checksum/secret-vpa-admission-controller": b.CheckSums["vpa-admission-controller"],
@@ -234,9 +235,11 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 			"registerByURL":        true,
 		}
 		exporter = map[string]interface{}{
-			"enabled": false,
+			"enabled":  false,
+			"replicas": 0,
 		}
 		recommender = map[string]interface{}{
+			"replicas": b.Shoot.GetReplicas(1),
 			"podAnnotations": map[string]interface{}{
 				"checksum/secret-vpa-recommender": b.CheckSums["vpa-recommender"],
 			},
@@ -246,6 +249,7 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 			"interval":                     gardencorev1beta1.DefaultRecommenderInterval,
 		}
 		updater = map[string]interface{}{
+			"replicas": b.Shoot.GetReplicas(1),
 			"podAnnotations": map[string]interface{}{
 				"checksum/secret-vpa-updater": b.CheckSums["vpa-updater"],
 			},

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -165,7 +165,7 @@ func (b *Botanist) DeploySecrets(ctx context.Context) error {
 	}
 
 	if b.Shoot.WantsVerticalPodAutoscaler {
-		if err := b.storeStaticTokenAsSecrets(ctx, secretsManager.StaticToken, existingSecrets[v1beta1constants.SecretNameCACluster].Data[secrets.DataKeyCertificateCA], vpaSecrets); err != nil {
+		if err := b.storeStaticTokenAsSecrets(ctx, secretsManager.StaticToken, secretsManager.DeployedSecrets[v1beta1constants.SecretNameCACluster].Data[secrets.DataKeyCertificateCA], vpaSecrets); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug
/priority normal

**What this PR does / why we need it**:
The VPA components for the shoots weren't scaled down on hibernation. This PR fixes the behaviour.
Also, a nil pointer exception that occurred when a new shoot was created with VPA=enabled has been fixed.

Thanks @wyb1 for noticing!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The VPA for shoots running in the seed is now correctly scaled down when the shoot is being hibernated.
```
