### PR TITLE
Fix version information in docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 
 # Exclude folders relevant for build
 !.git
+!.dockerignore
 !charts/
 !cmd/
 !extensions/

--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-REGISTRY                           := eu.gcr.io/gardener-project/gardener
-APISERVER_IMAGE_REPOSITORY         := $(REGISTRY)/apiserver
-CONROLLER_MANAGER_IMAGE_REPOSITORY := $(REGISTRY)/controller-manager
-SCHEDULER_IMAGE_REPOSITORY         := $(REGISTRY)/scheduler
-SEED_ADMISSION_IMAGE_REPOSITORY    := $(REGISTRY)/seed-admission-controller
-GARDENLET_IMAGE_REPOSITORY         := $(REGISTRY)/gardenlet
-PUSH_LATEST_TAG                    := false
-VERSION                            := $(shell cat VERSION)
-EFFECTIVE_VERSION                  := $(VERSION)-$(shell git rev-parse HEAD)
-REPO_ROOT                          := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-LOCAL_GARDEN_LABEL                 := local-garden
+REGISTRY                            := eu.gcr.io/gardener-project/gardener
+APISERVER_IMAGE_REPOSITORY          := $(REGISTRY)/apiserver
+CONTROLLER_MANAGER_IMAGE_REPOSITORY := $(REGISTRY)/controller-manager
+SCHEDULER_IMAGE_REPOSITORY          := $(REGISTRY)/scheduler
+SEED_ADMISSION_IMAGE_REPOSITORY     := $(REGISTRY)/seed-admission-controller
+GARDENLET_IMAGE_REPOSITORY          := $(REGISTRY)/gardenlet
+PUSH_LATEST_TAG                     := false
+VERSION                             := $(shell cat VERSION)
+EFFECTIVE_VERSION                   := $(VERSION)-$(shell git rev-parse HEAD)
+REPO_ROOT                           := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+LOCAL_GARDEN_LABEL                  := local-garden
 
 ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
 	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty
@@ -92,16 +92,16 @@ start-gardenlet:
 
 .PHONY: install
 install:
-	@./hack/install.sh ./...
+	@EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) ./hack/install.sh ./...
 
 .PHONY: docker-images
 docker-images:
 	@echo "Building docker images with version and tag $(EFFECTIVE_VERSION)"
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(APISERVER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)         -t $(APISERVER_IMAGE_REPOSITORY):latest         -f Dockerfile --target apiserver .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(CONROLLER_MANAGER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION) -t $(CONROLLER_MANAGER_IMAGE_REPOSITORY):latest -f Dockerfile --target controller-manager .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(SCHEDULER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)         -t $(SCHEDULER_IMAGE_REPOSITORY):latest         -f Dockerfile --target scheduler .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(SEED_ADMISSION_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)    -t $(SEED_ADMISSION_IMAGE_REPOSITORY):latest    -f Dockerfile --target seed-admission-controller .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(GARDENLET_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)         -t $(GARDENLET_IMAGE_REPOSITORY):latest         -f Dockerfile --target gardenlet .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(APISERVER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)          -t $(APISERVER_IMAGE_REPOSITORY):latest          -f Dockerfile --target apiserver .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(CONTROLLER_MANAGER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION) -t $(CONTROLLER_MANAGER_IMAGE_REPOSITORY):latest -f Dockerfile --target controller-manager .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(SCHEDULER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)          -t $(SCHEDULER_IMAGE_REPOSITORY):latest          -f Dockerfile --target scheduler .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(SEED_ADMISSION_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)     -t $(SEED_ADMISSION_IMAGE_REPOSITORY):latest     -f Dockerfile --target seed-admission-controller .
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(GARDENLET_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)          -t $(GARDENLET_IMAGE_REPOSITORY):latest          -f Dockerfile --target gardenlet .
 
 .PHONY: docker-login
 docker-login:
@@ -110,14 +110,14 @@ docker-login:
 .PHONY: docker-push
 docker-push:
 	@if ! docker images $(APISERVER_IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(EFFECTIVE_VERSION); then echo "$(APISERVER_IMAGE_REPOSITORY) version $(EFFECTIVE_VERSION) is not yet built. Please run 'make docker-images'"; false; fi
-	@if ! docker images $(CONROLLER_MANAGER_IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(EFFECTIVE_VERSION); then echo "$(CONROLLER_MANAGER_IMAGE_REPOSITORY) version $(EFFECTIVE_VERSION) is not yet built. Please run 'make docker-images'"; false; fi
+	@if ! docker images $(CONTROLLER_MANAGER_IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(EFFECTIVE_VERSION); then echo "$(CONTROLLER_MANAGER_IMAGE_REPOSITORY) version $(EFFECTIVE_VERSION) is not yet built. Please run 'make docker-images'"; false; fi
 	@if ! docker images $(SCHEDULER_IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(EFFECTIVE_VERSION); then echo "$(SCHEDULER_IMAGE_REPOSITORY) version $(EFFECTIVE_VERSION) is not yet built. Please run 'make docker-images'"; false; fi
 	@if ! docker images $(SEED_ADMISSION_IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(EFFECTIVE_VERSION); then echo "$(SEED_ADMISSION_IMAGE_REPOSITORY) version $(EFFECTIVE_VERSION) is not yet built. Please run 'make docker-images'"; false; fi
 	@if ! docker images $(GARDENLET_IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(EFFECTIVE_VERSION); then echo "$(GARDENLET_IMAGE_REPOSITORY) version $(EFFECTIVE_VERSION) is not yet built. Please run 'make docker-images'"; false; fi
 	@gcloud docker -- push $(APISERVER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)
 	@if [[ "$(PUSH_LATEST_TAG)" == "true" ]]; then gcloud docker -- push $(APISERVER_IMAGE_REPOSITORY):latest; fi
-	@gcloud docker -- push $(CONROLLER_MANAGER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)
-	@if [[ "$(PUSH_LATEST_TAG)" == "true" ]]; then gcloud docker -- push $(CONROLLER_MANAGER_IMAGE_REPOSITORY):latest; fi
+	@gcloud docker -- push $(CONTROLLER_MANAGER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)
+	@if [[ "$(PUSH_LATEST_TAG)" == "true" ]]; then gcloud docker -- push $(CONTROLLER_MANAGER_IMAGE_REPOSITORY):latest; fi
 	@gcloud docker -- push $(SCHEDULER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)
 	@if [[ "$(PUSH_LATEST_TAG)" == "true" ]]; then gcloud docker -- push $(SCHEDULER_IMAGE_REPOSITORY):latest; fi
 	@gcloud docker -- push $(SEED_ADMISSION_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)

--- a/hack/get-build-ld-flags.sh
+++ b/hack/get-build-ld-flags.sh
@@ -19,7 +19,15 @@ VERSION_PATH="${2:-$(dirname $0)/../VERSION}"
 VERSION_VERSIONFILE="$(cat "$VERSION_PATH")"
 VERSION="${EFFECTIVE_VERSION:-$VERSION_VERSIONFILE}"
 
+# .dockerignore ignores all files unrelevant for build (e.g. docs) to only copy relevant source files to the build
+# container. Hence, git will always detect a dirty work tree when building in a container (many deleted files).
+# This command filters out all deleted files that are ignored by .dockerignore to only detect changes to relevant files
+# as a dirty work tree.
+# Additionally, it filters out changes to the `VERSION` file, as this is currently the only way to inject the
+# version-to-build in our pipelines (see https://github.com/gardener/cc-utils/issues/431).
+TREE_STATE="$([ -z "$(git status --porcelain 2>/dev/null | grep -vf <(git ls-files --deleted --ignored --exclude-from=.dockerignore) -e 'VERSION')" ] && echo clean || echo dirty)"
+
 echo "-X $SOURCE_REPOSITORY/pkg/version.gitVersion=$VERSION
-      -X $SOURCE_REPOSITORY/pkg/version.gitTreeState=$([ -z git status --porcelain 2>/dev/null ] && echo clean || echo dirty)
+      -X $SOURCE_REPOSITORY/pkg/version.gitTreeState=$TREE_STATE
       -X $SOURCE_REPOSITORY/pkg/version.gitCommit=$(git rev-parse --verify HEAD)
       -X $SOURCE_REPOSITORY/pkg/version.buildDate=$(date '+%Y-%m-%dT%H:%M:%S%z' | sed 's/\([0-9][0-9]\)$/:\1/g')"

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -40,7 +40,7 @@ if [[ "$(uname -s)" == "Linux" && "$(uname -r)" =~ "microsoft-standard" ]]; then
   --bind-address=127.0.0.1"
 fi
 
-ldflags="$("$(dirname $0)"/../get-build-ld-flags.sh)"
+ld_flags="$("$(dirname $0)"/../get-build-ld-flags.sh)"
 case $(k8s_env) in
     $KIND)
         echo "Found kind ..."

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -23,29 +23,35 @@ import (
 )
 
 var (
-	gitVersion   = "0.0.0-dev"
+	gitVersion   = "v0.0.0-dev"
 	gitCommit    string
 	gitTreeState string
 	buildDate    = "1970-01-01T00:00:00Z"
+
+	version *apimachineryversion.Info
 )
 
 // Get returns the overall codebase version. It's for detecting
 // what code a binary was built from.
 // These variables typically come from -ldflags settings and in
-// their absence fallback to the settings in pkg/version/base.go
+// their absence fallback to the settings in pkg/version/version.go
 func Get() apimachineryversion.Info {
+	return *version
+}
+
+func init() {
 	var (
-		version  = strings.Split(gitVersion, ".")
-		gitMajor string
-		gitMinor string
+		versionParts = strings.Split(gitVersion, ".")
+		gitMajor     string
+		gitMinor     string
 	)
 
-	if len(version) >= 2 {
-		gitMajor = version[0]
-		gitMinor = version[1]
+	if len(versionParts) >= 2 {
+		gitMajor = strings.TrimPrefix(versionParts[0], "v")
+		gitMinor = versionParts[1]
 	}
 
-	return apimachineryversion.Info{
+	version = &apimachineryversion.Info{
 		Major:        gitMajor,
 		Minor:        gitMinor,
 		GitVersion:   gitVersion,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
Before, we were always building our docker images with `version.gitTreeState=dirty`.
This PR ignores changes to the following files while checking the git tree state during build time:
- `VERSION`: the version file is currently the only way to inject the version-to-build in our pipelines (see https://github.com/gardener/cc-utils/issues/431). Hopefully, this can be replaced by setting the `EFFECTIVE_VERSION` docker build arg in our pipelines in the future.
- all files ignored by `.dockerignore`: these files are not present in the build container -> git detects them as deleted

The PR also removes the `v`-Prefix from `version.major`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The version information in docker images has been updated to correctly display `version.major` without the `v`-Prefix and `version.gitTreeState` as `clean`.
```
