### PR TITLE
Fix health manager

### DIFF
--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -375,7 +375,6 @@ func (g *Gardenlet) Run(ctx context.Context) error {
 
 	// Initialize /healthz manager.
 	g.HealthManager = healthz.NewPeriodicHealthz(seedcontroller.LeaseResyncGracePeriodSeconds * time.Second)
-	g.HealthManager.Set(true)
 
 	// Start HTTPS server.
 	if g.Config.Server.HTTPS.TLS == nil {

--- a/pkg/healthz/default_test.go
+++ b/pkg/healthz/default_test.go
@@ -49,12 +49,29 @@ var _ = Describe("Default", func() {
 
 		Describe("#Set", func() {
 			It("should correctly set the status to true", func() {
+				d.Start()
 				d.Set(true)
 				Expect(d.health).To(BeTrue())
 			})
 
 			It("should correctly set the status to false", func() {
+				d.Start()
 				d.Set(false)
+				Expect(d.health).To(BeFalse())
+			})
+
+			It("should not set the status to true (HealthManager not started)", func() {
+				d.Set(true)
+				Expect(d.health).To(BeFalse())
+			})
+
+			It("should not set the status to true (HealthManager already stopped)", func() {
+				d.Start()
+				Expect(d.health).To(BeTrue())
+				d.Stop()
+				Expect(d.health).To(BeFalse())
+
+				d.Set(true)
 				Expect(d.health).To(BeFalse())
 			})
 		})
@@ -62,12 +79,12 @@ var _ = Describe("Default", func() {
 		Describe("#Get", func() {
 			It("should get the correct status (true)", func() {
 				d.health = true
-				Expect(d.health).To(BeTrue())
+				Expect(d.Get()).To(BeTrue())
 			})
 
 			It("should get the correct status (false)", func() {
 				d.health = false
-				Expect(d.health).To(BeFalse())
+				Expect(d.Get()).To(BeFalse())
 			})
 		})
 	})

--- a/pkg/healthz/healthz_test.go
+++ b/pkg/healthz/healthz_test.go
@@ -32,6 +32,7 @@ var _ = Describe("Healthz", func() {
 
 		BeforeEach(func() {
 			healthz = NewDefaultHealthz()
+			healthz.Start()
 			response = &fakeResponse{}
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/area robustness
/kind bug
/priority normal

**What this PR does / why we need it**:
The periodic health manager seemed to be unstable under CPU pressure/throttling (e.g. in our CI pipelines https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-pull-request-job/builds/17).
While I couldn't get the failing unit tests to break on my machine, it was easy to reproduce while running in a docker container with restricted CPU shares.

This PR makes the health manager(s) more robust for concurrent access by accurately locking access to the managers' state members.


**Which issue(s) this PR fixes**:
Ref #2532 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The gardenlet's `/healthz` endpoint has been improved to be more stable under certain circumstances like CPU throttling.
```
