### PR TITLE
Fix ControllerInstallation required calculation

### DIFF
--- a/pkg/apis/core/validation/controllerregistration.go
+++ b/pkg/apis/core/validation/controllerregistration.go
@@ -61,6 +61,11 @@ func ValidateControllerRegistrationSpec(spec *core.ControllerRegistrationSpec, f
 		if len(resource.Kind) == 0 {
 			allErrs = append(allErrs, field.Required(idxPath.Child("kind"), "field is required"))
 		}
+
+		if !extensionsv1alpha1.ExtensionKinds.Has(resource.Kind) {
+			allErrs = append(allErrs, field.NotSupported(idxPath.Child("kind"), resource.Kind, extensionsv1alpha1.ExtensionKinds.UnsortedList()))
+		}
+
 		if len(resource.Type) == 0 {
 			allErrs = append(allErrs, field.Required(idxPath.Child("type"), "field is required"))
 		}

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -16,8 +16,11 @@ package v1alpha1
 
 import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // Status is the status of an Object.
@@ -68,3 +71,17 @@ type Object interface {
 	// GetExtensionStatus retrieves the object's status.
 	GetExtensionStatus() Status
 }
+
+// ExtensionKinds contains all supported extension kinds.
+var ExtensionKinds = sets.NewString(
+	BackupBucketResource,
+	BackupEntryResource,
+	ContainerRuntimeResource,
+	ControlPlaneResource,
+	dnsv1alpha1.DNSProviderKind,
+	ExtensionResource,
+	InfrastructureResource,
+	NetworkResource,
+	OperatingSystemConfigResource,
+	WorkerResource,
+)

--- a/pkg/gardenlet/controller/federatedseed/extensions/controllerinstallation_control.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/controllerinstallation_control.go
@@ -53,7 +53,7 @@ type controllerInstallationControl struct {
 // it enqueue all ControllerInstallations for the seed that are referring to ControllerRegistrations responsible for
 // the given kind.
 func (c *controllerInstallationControl) createExtensionRequiredReconcileFunc(ctx context.Context, kind string, newListObjFunc func() runtime.Object) reconcile.Func {
-	return func(req reconcile.Request) (reconcile.Result, error) {
+	return func(_ reconcile.Request) (reconcile.Result, error) {
 		listObj := newListObjFunc()
 		if err := c.seedClient.Client().List(ctx, listObj); err != nil {
 			return reconcile.Result{}, err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR fixes the calculation of ControllerInstallations. Earlier ControllerInstallations were still considered as required even though no corresponding extension resources or Shoot clusters existed. Please look at #2519 for more information.

We also added the validation for known extension kinds in ControllerRegistrations along the way.

Thanks to @rfranzke for collaborating on this PR.

**Which issue(s) this PR fixes**:
Fixes #2519 #2572

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue has been fixed which prevented not required ControllerInstallations from being deleted. As a side effect, it also blocked the deletion of Seed resources.
```
```improvement operator
Gardener now validates the extension kinds configured in `.spec.resources[].kind` in ControllerRegistrations. 
```
