### PR TITLE
Custom 'uam' verb for project member user management

### DIFF
--- a/charts/garden-project/charts/project-rbac/templates/clusterrole-project-uam.yaml
+++ b/charts/garden-project/charts/project-rbac/templates/clusterrole-project-uam.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: gardener.cloud:system:project:{{ .Values.project.name }}
+  name: gardener.cloud:system:project-uam:{{ .Values.project.name }}
   ownerReferences:
   - apiVersion: core.gardener.cloud/v1beta1
     kind: Project
@@ -12,14 +12,6 @@ metadata:
     uid: {{ .Values.project.uid | quote }}
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - namespaces
-  resourceNames:
-  - {{ .Release.Namespace | quote }}
-  verbs:
-  - get
-- apiGroups:
   - core.gardener.cloud
   resources:
   - projects
@@ -27,7 +19,6 @@ rules:
   - {{ .Values.project.name | quote }}
   verbs:
   - get
-  - patch
   - manage-members
+  - patch
   - update
-  - delete

--- a/charts/garden-project/charts/project-rbac/templates/clusterrolebinding-project-uam.yaml
+++ b/charts/garden-project/charts/project-rbac/templates/clusterrolebinding-project-uam.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: gardener.cloud:system:project-uam:{{ .Values.project.name }}
+  ownerReferences:
+  - apiVersion: core.gardener.cloud/v1beta1
+    kind: Project
+    blockOwnerDeletion: false
+    controller: true
+    name: {{ .Values.project.name | quote }}
+    uid: {{ .Values.project.uid | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gardener.cloud:system:project-uam:{{ .Values.project.name }}
+{{- if .Values.project.uams }}
+subjects:
+{{ toYaml .Values.project.uams }}
+{{- else }}
+subjects: []
+{{- end }}

--- a/charts/garden-project/charts/project-rbac/values.yaml
+++ b/charts/garden-project/charts/project-rbac/values.yaml
@@ -13,6 +13,10 @@ project:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: bob.doe@example.com
+# uams:
+# - apiGroup: rbac.authorization.k8s.io
+#   kind: User
+#   name: bob.doe@example.com
 # extensions:
 # - name: foo
 #   subjects:

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@
 * [Gardener configuration and usage](usage/configuration.md)
 * [OpenIDConnect presets](usage/openidconnect-presets.md)
 * [Network Policies in the Shoot Cluster](usage/shoot_network_policies.md)
+* [Projects](usage/projects.md)
 * [Seed Bootstrapping](usage/seed_bootstrapping.md)
 * [Seed Settings](usage/seed_settings.md)
 * [Shoot cluster purposes](usage/shoot_purposes.md)

--- a/docs/extensions/project-roles.md
+++ b/docs/extensions/project-roles.md
@@ -1,11 +1,8 @@
 # Extending project roles
 
 The `Project` resource allows to specify a list of roles for every member (`.spec.members[*].roles`).
-There are a few standard roles defined by Gardener itself:
-
-* `owner` (describes the owner/main contact of the project (as of today only one owner can be specified))
-* `admin` (describes administrators with full read/write access to all resources concerning the project)
-* `viewer` (describes members with limited read access to some resources concerning the project)
+There are a few standard roles defined by Gardener itself.
+Please consult [this document](../usage/projects.md) for further information.
 
 However, extension controllers running in the garden cluster may also create `CustomResourceDefinition`s that project members might be able to CRUD.
 For this purpose Gardener also allows to specify extension roles.

--- a/docs/usage/projects.md
+++ b/docs/usage/projects.md
@@ -1,0 +1,88 @@
+# Projects
+
+The Gardener API server supports a cluster-scoped `Project` resource which is used to group usage of Gardener.
+For example, each development team has its own project to manage its own shoot clusters.
+
+Each `Project` is backed by a Kubernetes `Namespace` that contains the actual related Kubernetes resources like `Secret`s or `Shoot`s.
+
+**Example resource:**
+
+```yaml
+apiVersion: core.gardener.cloud/v1beta1
+kind: Project
+metadata:
+  name: dev
+spec:
+  namespace: garden-dev
+  description: "This is my first project"
+  purpose: "Experimenting with Gardener"
+  owner:
+    apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: john.doe@example.com
+  members:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: alice.doe@example.com
+    role: admin
+  # roles:
+  # - viewer 
+  # - uam
+  # - extension:foo
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: bob.doe@example.com
+    role: viewer
+# tolerations:
+#   defaults:
+#   - key: <some-key>
+#   whitelist:
+#   - key: <some-key>
+```
+
+The `.spec.namespace` field is optional and will be initialized if it's unset.
+The name of the resulting namespace will be generated and look like `garden-dev-5anj3`, i.e., it has a random suffix.
+It's also possible to adopt existing namespaces by labeling them `gardener.cloud/role=project` and `project.gardener.cloud/name=dev` beforehand (otherwise, they cannot be adopted). 
+
+The `spec.description` and `.spec.purpose` fields can be used to describe to fellow team members and Gardener operators what this project is used for.
+
+Each project has one dedicated owner, configured in `.spec.owner` using the `rbac.authorization.k8s.io/v1.Subject` type.
+The owner is the main contact person for Gardener operators.
+Please note that the `.spec.owner` field is deprecated and will be removed in future API versions in favor of the `owner` role, see below.
+
+The list of members (again a list in `.spec.members[]` using the `rbac.authorization.k8s.io/v1.Subject` type) contains all the people that are associated with the project in any way.
+Each project member must have at least one role (currently described in `.spec.members[].role`, additional roles can be added to `.spec.members[].roles[]`). The following roles exist:
+
+* `admin`: This allows to fully manage resources inside the project (e.g., secrets, shoots, configmaps, and similar).
+* `uam`: This allows to add/modify/remove human users or groups to/from the project member list. Technical users (service accounts) can be managed by all admins.
+* `viewer`: This allows to read all resources inside the project except secrets.
+* `owner`: This combines the `admin` and `uam` roles.
+* Extension roles (prefixed with `extension:`): Please refer to [this document](../extensions/project-roles.md).
+
+The [project controller](../concepts/controller-manager.md#project-controller) inside the Gardener Controller Manager is managing RBAC resources that grant the described privileges to the respective members.
+
+There are two central `ClusterRole`s `gardener.cloud:system:project-member` and `gardener.cloud:system:project-viewer` that grant the permissions for namespaced resources (e.g., `Secret`s, `Shoot`s, etc.).
+Via referring `RoleBinding`s created in the respective namespace the project members get bound to these `ClusterRole`s and, thus, the needed permissions.
+There are also project-specific `ClusterRole`s granting the permissions for cluster-scoped resources, e.g. the `Namespace` or `Project` itself.  
+For each role, the following `ClusterRole`s, `ClusterRoleBinding`s, and `RoleBinding`s are created:
+
+| Role | `ClusterRole` | `ClusterRoleBinding` | `RoleBinding` |
+| ---- | ----------- | ------------------ | ----------- |
+| `admin` | `gardener.cloud:system:project-member:<projectName>` | `gardener.cloud:system:project-member:<projectName>` | `gardener.cloud:system:project-member` |
+| `uam`   | `gardener.cloud:system:project-uam:<projectName>` | `gardener.cloud:system:project-uam:<projectName>` | |
+| `viewer` | `gardener.cloud:system:project-viewer:<projectName>` | `gardener.cloud:system:project-viewer:<projectName>` | `gardener.cloud:system:project-viewer` |
+| `owner` | `gardener.cloud:system:project:<projectName>` | `gardener.cloud:system:project:<projectName>` |  |
+| `extension:*` | `gardener.cloud:extension:project:<projectName>:<extensionRoleName>` | | `gardener.cloud:extension:project:<projectName>:<extensionRoleName>` |
+
+## User Access Management
+
+For `Project`s created before Gardener v1.8 all admins were allowed to manage other members.
+Beginning with v1.8 the new `uam` role is being introduced.
+It is backed by the `manage-members` custom RBAC verb which allows to add/modify/remove human users or groups to/from the project member list.
+Human users are subjects with `kind=User` and `name!=system:serviceaccount:*`, and groups are subjects with `kind=Group`.
+The management of service account subjects (`kind=ServiecAccount` or `name=system:serviceaccount:*`) is not controlled via the `uam` custom verb but with the standard `update`/`patch` verbs for projects.
+
+All newly created projects will only bind the owner to the `uam` role.
+The owner can still grant the `uam` role to other members if desired.
+For projects created before Gardener v1.8 the Gardener Controller Manager will migrate all projects to also assign the `uam` role to all `admin` members (to not break existing use-cases).
+The project owner can gradually remove these roles if desired. 

--- a/example/05-project-dev.yaml
+++ b/example/05-project-dev.yaml
@@ -17,6 +17,7 @@ spec:
     role: admin
   # roles: # Additional roles go here
   # - viewer
+  # - uam # User access manager
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: bob.doe@example.com

--- a/pkg/apis/core/types_project.go
+++ b/pkg/apis/core/types_project.go
@@ -113,7 +113,8 @@ const (
 	ProjectMemberOwner = "owner"
 	// ProjectMemberViewer is a const for a role that provides limited permissions to only view some resources.
 	ProjectMemberViewer = "viewer"
-
+	// ProjectMemberUserAccessManager is a const for a role that provides permissions to manage human user(s, (groups)).
+	ProjectMemberUserAccessManager = "uam"
 	// ProjectMemberExtensionPrefix is a prefix for custom roles that are not known by Gardener.
 	ProjectMemberExtensionPrefix = "extension:"
 )

--- a/pkg/apis/core/v1alpha1/types_project.go
+++ b/pkg/apis/core/v1alpha1/types_project.go
@@ -144,7 +144,8 @@ const (
 	ProjectMemberOwner = "owner"
 	// ProjectMemberViewer is a const for a role that provides limited permissions to only view some resources.
 	ProjectMemberViewer = "viewer"
-
+	// ProjectMemberUserAccessManager is a const for a role that provides permissions to manage human user(s, (groups)).
+	ProjectMemberUserAccessManager = "uam"
 	// ProjectMemberExtensionPrefix is a prefix for custom roles that are not known by Gardener.
 	ProjectMemberExtensionPrefix = "extension:"
 )

--- a/pkg/apis/core/v1beta1/types_project.go
+++ b/pkg/apis/core/v1beta1/types_project.go
@@ -142,9 +142,10 @@ const (
 	ProjectMemberAdmin = "admin"
 	// ProjectMemberOwner is a const for a role that provides full owner access.
 	ProjectMemberOwner = "owner"
+	// ProjectMemberUserAccessManager is a const for a role that provides permissions to manage human user(s, (groups)).
+	ProjectMemberUserAccessManager = "uam"
 	// ProjectMemberViewer is a const for a role that provides limited permissions to only view some resources.
 	ProjectMemberViewer = "viewer"
-
 	// ProjectMemberExtensionPrefix is a prefix for custom roles that are not known by Gardener.
 	ProjectMemberExtensionPrefix = "extension:"
 )

--- a/pkg/apis/core/validation/project.go
+++ b/pkg/apis/core/validation/project.go
@@ -144,9 +144,10 @@ func ValidateSubject(subject rbacv1.Subject, fldPath *field.Path) field.ErrorLis
 }
 
 var supportedRoles = sets.NewString(
+	core.ProjectMemberOwner,
 	core.ProjectMemberAdmin,
 	core.ProjectMemberViewer,
-	core.ProjectMemberOwner,
+	core.ProjectMemberUserAccessManager,
 )
 
 const extensionRoleMaxLength = 20

--- a/pkg/apis/core/validation/project_test.go
+++ b/pkg/apis/core/validation/project_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Project Validation Tests", func() {
 								Kind:     rbacv1.UserKind,
 								Name:     "bob.doe@example.com",
 							},
-							Roles: []string{core.ProjectMemberViewer},
+							Roles: []string{core.ProjectMemberViewer, core.ProjectMemberUserAccessManager},
 						},
 					},
 				},
@@ -205,7 +205,7 @@ var _ = Describe("Project Validation Tests", func() {
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeForbidden),
-				"Field": Equal("spec.members[1].roles[1]"),
+				"Field": Equal("spec.members[1].roles[2]"),
 			}))))
 		})
 

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -84,7 +84,8 @@ func (f *GardenControllerFactory) Run(ctx context.Context) {
 		csrInformer         = f.k8sInformers.Certificates().V1beta1().CertificateSigningRequests().Informer()
 		namespaceInformer   = f.k8sInformers.Core().V1().Namespaces().Informer()
 		secretInformer      = f.k8sInformers.Core().V1().Secrets().Informer()
-		rolebindingInformer = f.k8sInformers.Rbac().V1().RoleBindings().Informer()
+		clusterRoleInformer = f.k8sInformers.Rbac().V1().ClusterRoles().Informer()
+		roleBindingInformer = f.k8sInformers.Rbac().V1().RoleBindings().Informer()
 		leaseInformer       = f.k8sInformers.Coordination().V1().Leases().Informer()
 	)
 
@@ -103,7 +104,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) {
 	}
 
 	f.k8sInformers.Start(ctx.Done())
-	if !cache.WaitForCacheSync(ctx.Done(), configMapInformer.HasSynced, csrInformer.HasSynced, namespaceInformer.HasSynced, secretInformer.HasSynced, rolebindingInformer.HasSynced, leaseInformer.HasSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), configMapInformer.HasSynced, csrInformer.HasSynced, namespaceInformer.HasSynced, secretInformer.HasSynced, clusterRoleInformer.HasSynced, roleBindingInformer.HasSynced, leaseInformer.HasSynced) {
 		panic("Timed out waiting for Kube caches to sync")
 	}
 

--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -119,6 +119,7 @@ func (c *defaultControl) reconcile(ctx context.Context, project *gardencorev1bet
 	// role to ensure access for listing shoots, creating secrets, etc.
 	var (
 		admins     []rbacv1.Subject
+		uams       []rbacv1.Subject
 		viewers    []rbacv1.Subject
 		extensions []map[string]interface{}
 
@@ -132,6 +133,9 @@ func (c *defaultControl) reconcile(ctx context.Context, project *gardencorev1bet
 		for _, role := range allRoles {
 			if role == gardencorev1beta1.ProjectMemberAdmin || role == gardencorev1beta1.ProjectMemberOwner {
 				admins = append(admins, member.Subject)
+			}
+			if role == gardencorev1beta1.ProjectMemberUserAccessManager {
+				uams = append(uams, member.Subject)
 			}
 			if role == gardencorev1beta1.ProjectMemberViewer {
 				viewers = append(viewers, member.Subject)
@@ -158,6 +162,7 @@ func (c *defaultControl) reconcile(ctx context.Context, project *gardencorev1bet
 			"uid":        project.UID,
 			"owner":      project.Spec.Owner,
 			"members":    admins,
+			"uams":       uams,
 			"viewers":    viewers,
 			"extensions": extensions,
 		},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area user-management
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR introduces the new `uam` custom verb and `uam` project role (next to `admin` and `viewer`). The new behaviour is that only users bound to the `uam` verb are allowed to add/modify/remove human users from the `.spec.members` list of `Project`s. Service account users can still be managed via `update`/`patch`.

For existing `Project`s, the `uam` role will be automatically granted to all `admin` members by GCM before starting the `Project` controller. The owner can remove this role from the members as desired.
For new `Project`s only the owner will be bound to the `uam` verb by default, i.e., no `admin` member is allowed to manage human members by default.

**Which issue(s) this PR fixes**:
Fixes #2592

**Special notes for your reviewer**:
* I fixed a bug in the `customauthorizer` admission plugin for the `modify-spec-tolerations-whitelist` verb along the way.
* /cc @donistz 
* /cc @gardener/dashboard-maintainers 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
A new `uam` role was introduced for `Project`s (next to `owner`, `admin`, and `viewer`). Members with this role will be bound to the `uam` custom RBAC verb for the respective `Project`. Only users bound to this verb are now allowed to add/modify/remove human users or groups from the `.spec.members[]` list of the `Project`. Please find more information [here](https://github.com/gardener/gardener/blob/master/docs/usage/projects.md).
```
