### PR TITLE
Fix flaky infrastructure test

### DIFF
--- a/pkg/operation/botanist/extensions/infrastructure/infrastructure.go
+++ b/pkg/operation/botanist/extensions/infrastructure/infrastructure.go
@@ -77,17 +77,14 @@ func New(
 	logger *logrus.Entry,
 	client client.Client,
 	values *Values,
-	waitInterval time.Duration,
-	waitSevereThreshold time.Duration,
-	waitTimeout time.Duration,
 ) shoot.Infrastructure {
 	return &infrastructure{
 		client:              client,
 		logger:              logger,
 		values:              values,
-		waitInterval:        waitInterval,
-		waitSevereThreshold: waitSevereThreshold,
-		waitTimeout:         waitTimeout,
+		waitInterval:        DefaultInterval,
+		waitSevereThreshold: DefaultSevereThreshold,
+		waitTimeout:         DefaultTimeout,
 	}
 }
 

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -26,8 +26,8 @@ import (
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/secrets"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -47,9 +47,6 @@ func (b *Botanist) DefaultInfrastructure(seedClient client.Client) shoot.Infrast
 			IsInRestorePhaseOfControlPlaneMigration: b.isRestorePhase(),
 			DeploymentRequested:                     controllerutils.HasTask(b.Shoot.Info.Annotations, common.ShootTaskDeployInfrastructure),
 		},
-		infrastructure.DefaultInterval,
-		infrastructure.DefaultSevereThreshold,
-		infrastructure.DefaultTimeout,
 	)
 }
 

--- a/pkg/utils/retry/fake/retry.go
+++ b/pkg/utils/retry/fake/retry.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gardener/gardener/pkg/utils/retry"
+)
+
+var _ retry.Ops = &Ops{}
+
+// Ops implements retry.Ops and can be used to mock calls to retry.Until and retry.UntilTimeout in unit tests.
+// This implementation ignores the `interval` parameter and doesn't wait between retries, which makes it useful for
+// writing quick and stable unit tests.
+type Ops struct {
+	// MaxAttempts configures the maximum amount of attempts before returning a retryError. If it is set to 0, it
+	// fails immediately and f is never called.
+	MaxAttempts int
+}
+
+// Until implements retry.Ops without waiting between retries.
+func (o *Ops) Until(ctx context.Context, _ time.Duration, f retry.Func) error {
+	var minorErr error
+	attempts := 0
+
+	for {
+		attempts++
+		if attempts > o.MaxAttempts {
+			return retry.NewRetryError(fmt.Errorf("max attempts reached"), minorErr)
+		}
+
+		done, err := f(ctx)
+		if err != nil {
+			if done {
+				return err
+			}
+
+			minorErr = err
+		} else if done {
+			return nil
+		}
+	}
+}
+
+// UntilTimeout implements retry.Ops without waiting between retries. UntilTimeout ignores the timeout
+// parameter and instead uses Ops.MaxAttempts to configure, how often f is retried.
+func (o *Ops) UntilTimeout(ctx context.Context, interval, _ time.Duration, f retry.Func) error {
+	return o.Until(ctx, interval, f)
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug
/priority normal
/size m

**What this PR does / why we need it**:
We have seen some flaky unit tests in the past few weeks, which were all time sensitive unit tests and seem to get quite unstable under CPU pressure/throttling (e.g. in our pipelines: https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-pull-request-job/builds/50).
One of these occurrences has already been fixed in #2609, this PR fixes the infrastructure component test.
It adds a fake implementation for `retry.{Until,UntilTimeout}`, which doesn't wait between retries to make tests quicker and more stable (because they are not time-sensitive anymore).

**Which issue(s) this PR fixes**:
See https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-pull-request-job/builds/50

**Special notes for your reviewer**:
We have some other unit tests and components, that either don't correctly test the retries and/or still rely on proper timing.
We should fix them and replace the real `retry` funcs with the fake implementation added in this PR.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
