### PR TITLE
Remove log-exclusion annotation for non-{testing,hibernated} shoots

### DIFF
--- a/extensions/pkg/controller/cluster.go
+++ b/extensions/pkg/controller/cluster.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,140 +14,22 @@
 
 package controller
 
-import (
-	"context"
-
-	gardencoreinstall "github.com/gardener/gardener/pkg/apis/core/install"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-
-	"github.com/gardener/gardener/pkg/apis/core"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-var gardenscheme *runtime.Scheme
-
-func init() {
-	gardenscheme = runtime.NewScheme()
-	gardencoreinstall.Install(gardenscheme)
-}
+import "github.com/gardener/gardener/pkg/extensions"
 
 // Cluster contains the decoded resources of Gardener's extension Cluster resource.
-type Cluster struct {
-	ObjectMeta   metav1.ObjectMeta
-	CloudProfile *gardencorev1beta1.CloudProfile
-	Seed         *gardencorev1beta1.Seed
-	Shoot        *gardencorev1beta1.Shoot
-}
+type Cluster = extensions.Cluster
 
-// GetCluster tries to read Gardener's Cluster extension resource in the given namespace.
-func GetCluster(ctx context.Context, c client.Client, namespace string) (*Cluster, error) {
-	cluster := &extensionsv1alpha1.Cluster{}
-	if err := c.Get(ctx, kutil.Key(namespace), cluster); err != nil {
-		return nil, err
-	}
-
-	decoder, err := NewGardenDecoder()
-	if err != nil {
-		return nil, err
-	}
-
-	cloudProfile, err := CloudProfileFromCluster(decoder, cluster)
-	if err != nil {
-		return nil, err
-	}
-	seed, err := SeedFromCluster(decoder, cluster)
-	if err != nil {
-		return nil, err
-	}
-	shoot, err := ShootFromCluster(decoder, cluster)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Cluster{cluster.ObjectMeta, cloudProfile, seed, shoot}, nil
-}
-
-// CloudProfileFromCluster returns the CloudProfile resource inside the Cluster resource.
-func CloudProfileFromCluster(decoder runtime.Decoder, cluster *extensionsv1alpha1.Cluster) (*gardencorev1beta1.CloudProfile, error) {
-	var (
-		cloudProfileInternal = &core.CloudProfile{}
-		cloudProfile         = &gardencorev1beta1.CloudProfile{}
-	)
-
-	if cluster.Spec.CloudProfile.Raw == nil {
-		return nil, nil
-	}
-	if _, _, err := decoder.Decode(cluster.Spec.CloudProfile.Raw, nil, cloudProfileInternal); err != nil {
-		return nil, err
-	}
-	if err := gardenscheme.Convert(cloudProfileInternal, cloudProfile, nil); err != nil {
-		return nil, err
-	}
-
-	return cloudProfile, nil
-}
-
-// SeedFromCluster returns the Seed resource inside the Cluster resource.
-func SeedFromCluster(decoder runtime.Decoder, cluster *extensionsv1alpha1.Cluster) (*gardencorev1beta1.Seed, error) {
-	var (
-		seedInternal = &core.Seed{}
-		seed         = &gardencorev1beta1.Seed{}
-	)
-
-	if cluster.Spec.Seed.Raw == nil {
-		return nil, nil
-	}
-	if _, _, err := decoder.Decode(cluster.Spec.Seed.Raw, nil, seedInternal); err != nil {
-		return nil, err
-	}
-	if err := gardenscheme.Convert(seedInternal, seed, nil); err != nil {
-		return nil, err
-	}
-
-	return seed, nil
-}
-
-// ShootFromCluster returns the Shoot resource inside the Cluster resource.
-func ShootFromCluster(decoder runtime.Decoder, cluster *extensionsv1alpha1.Cluster) (*gardencorev1beta1.Shoot, error) {
-	var (
-		shootInternal = &core.Shoot{}
-		shoot         = &gardencorev1beta1.Shoot{}
-	)
-
-	if cluster.Spec.Shoot.Raw == nil {
-		return nil, nil
-	}
-	if _, _, err := decoder.Decode(cluster.Spec.Shoot.Raw, nil, shootInternal); err != nil {
-		return nil, err
-	}
-	if err := gardenscheme.Convert(shootInternal, shoot, nil); err != nil {
-		return nil, err
-	}
-
-	return shoot, nil
-}
-
-// GetShoot tries to read Gardener's Cluster extension resource in the given namespace and return the embedded Shoot resource.
-func GetShoot(ctx context.Context, c client.Client, namespace string) (*gardencorev1beta1.Shoot, error) {
-	cluster := &extensionsv1alpha1.Cluster{}
-	if err := c.Get(ctx, kutil.Key(namespace), cluster); err != nil {
-		return nil, err
-	}
-
-	decoder, err := NewGardenDecoder()
-	if err != nil {
-		return nil, err
-	}
-
-	return ShootFromCluster(decoder, cluster)
-}
-
-// NewGardenDecoder returns a new Garden API decoder.
-func NewGardenDecoder() (runtime.Decoder, error) {
-	return serializer.NewCodecFactory(gardenscheme).UniversalDecoder(), nil
-}
+var (
+	// NewGardenDecoder returns a new Garden API decoder.
+	NewGardenDecoder = extensions.NewGardenDecoder
+	// GetCluster tries to read Gardener's Cluster extension resource in the given namespace.
+	GetCluster = extensions.GetCluster
+	// CloudProfileFromCluster returns the CloudProfile resource inside the Cluster resource.
+	CloudProfileFromCluster = extensions.CloudProfileFromCluster
+	// SeedFromCluster returns the Seed resource inside the Cluster resource.
+	SeedFromCluster = extensions.SeedFromCluster
+	// ShootFromCluster returns the Shoot resource inside the Cluster resource.
+	ShootFromCluster = extensions.ShootFromCluster
+	// GetShoot tries to read Gardener's Cluster extension resource in the given namespace and return the embedded Shoot resource.
+	GetShoot = extensions.GetShoot
+)

--- a/pkg/extensions/cluster.go
+++ b/pkg/extensions/cluster.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencoreinstall "github.com/gardener/gardener/pkg/apis/core/install"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var gardenscheme *runtime.Scheme
+
+func init() {
+	gardenscheme = runtime.NewScheme()
+	gardencoreinstall.Install(gardenscheme)
+}
+
+// Cluster contains the decoded resources of Gardener's extension Cluster resource.
+type Cluster struct {
+	ObjectMeta   metav1.ObjectMeta
+	CloudProfile *gardencorev1beta1.CloudProfile
+	Seed         *gardencorev1beta1.Seed
+	Shoot        *gardencorev1beta1.Shoot
+}
+
+// GetCluster tries to read Gardener's Cluster extension resource in the given namespace.
+func GetCluster(ctx context.Context, c client.Client, namespace string) (*Cluster, error) {
+	cluster := &extensionsv1alpha1.Cluster{}
+	if err := c.Get(ctx, kutil.Key(namespace), cluster); err != nil {
+		return nil, err
+	}
+
+	decoder, err := NewGardenDecoder()
+	if err != nil {
+		return nil, err
+	}
+
+	cloudProfile, err := CloudProfileFromCluster(decoder, cluster)
+	if err != nil {
+		return nil, err
+	}
+	seed, err := SeedFromCluster(decoder, cluster)
+	if err != nil {
+		return nil, err
+	}
+	shoot, err := ShootFromCluster(decoder, cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Cluster{cluster.ObjectMeta, cloudProfile, seed, shoot}, nil
+}
+
+// CloudProfileFromCluster returns the CloudProfile resource inside the Cluster resource.
+func CloudProfileFromCluster(decoder runtime.Decoder, cluster *extensionsv1alpha1.Cluster) (*gardencorev1beta1.CloudProfile, error) {
+	var (
+		cloudProfileInternal = &core.CloudProfile{}
+		cloudProfile         = &gardencorev1beta1.CloudProfile{}
+	)
+
+	if cluster.Spec.CloudProfile.Raw == nil {
+		return nil, nil
+	}
+	if _, _, err := decoder.Decode(cluster.Spec.CloudProfile.Raw, nil, cloudProfileInternal); err != nil {
+		return nil, err
+	}
+	if err := gardenscheme.Convert(cloudProfileInternal, cloudProfile, nil); err != nil {
+		return nil, err
+	}
+
+	return cloudProfile, nil
+}
+
+// SeedFromCluster returns the Seed resource inside the Cluster resource.
+func SeedFromCluster(decoder runtime.Decoder, cluster *extensionsv1alpha1.Cluster) (*gardencorev1beta1.Seed, error) {
+	var (
+		seedInternal = &core.Seed{}
+		seed         = &gardencorev1beta1.Seed{}
+	)
+
+	if cluster.Spec.Seed.Raw == nil {
+		return nil, nil
+	}
+	if _, _, err := decoder.Decode(cluster.Spec.Seed.Raw, nil, seedInternal); err != nil {
+		return nil, err
+	}
+	if err := gardenscheme.Convert(seedInternal, seed, nil); err != nil {
+		return nil, err
+	}
+
+	return seed, nil
+}
+
+// ShootFromCluster returns the Shoot resource inside the Cluster resource.
+func ShootFromCluster(decoder runtime.Decoder, cluster *extensionsv1alpha1.Cluster) (*gardencorev1beta1.Shoot, error) {
+	var (
+		shootInternal = &core.Shoot{}
+		shoot         = &gardencorev1beta1.Shoot{}
+	)
+
+	if cluster.Spec.Shoot.Raw == nil {
+		return nil, nil
+	}
+	if _, _, err := decoder.Decode(cluster.Spec.Shoot.Raw, nil, shootInternal); err != nil {
+		return nil, err
+	}
+	if err := gardenscheme.Convert(shootInternal, shoot, nil); err != nil {
+		return nil, err
+	}
+
+	return shoot, nil
+}
+
+// GetShoot tries to read Gardener's Cluster extension resource in the given namespace and return the embedded Shoot resource.
+func GetShoot(ctx context.Context, c client.Client, namespace string) (*gardencorev1beta1.Shoot, error) {
+	cluster := &extensionsv1alpha1.Cluster{}
+	if err := c.Get(ctx, kutil.Key(namespace), cluster); err != nil {
+		return nil, err
+	}
+
+	decoder, err := NewGardenDecoder()
+	if err != nil {
+		return nil, err
+	}
+
+	return ShootFromCluster(decoder, cluster)
+}
+
+// NewGardenDecoder returns a new Garden API decoder.
+func NewGardenDecoder() (runtime.Decoder, error) {
+	return serializer.NewCodecFactory(gardenscheme).UniversalDecoder(), nil
+}

--- a/pkg/mock/gardener/extensions/controller/controlplane/genericactuator/mocks.go
+++ b/pkg/mock/gardener/extensions/controller/controlplane/genericactuator/mocks.go
@@ -6,8 +6,8 @@ package genericactuator
 
 import (
 	context "context"
-	controller "github.com/gardener/gardener/extensions/pkg/controller"
 	v1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	extensions "github.com/gardener/gardener/pkg/extensions"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -36,7 +36,7 @@ func (m *MockValuesProvider) EXPECT() *MockValuesProviderMockRecorder {
 }
 
 // GetConfigChartValues mocks base method
-func (m *MockValuesProvider) GetConfigChartValues(arg0 context.Context, arg1 *v1alpha1.ControlPlane, arg2 *controller.Cluster) (map[string]interface{}, error) {
+func (m *MockValuesProvider) GetConfigChartValues(arg0 context.Context, arg1 *v1alpha1.ControlPlane, arg2 *extensions.Cluster) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConfigChartValues", arg0, arg1, arg2)
 	ret0, _ := ret[0].(map[string]interface{})
@@ -51,7 +51,7 @@ func (mr *MockValuesProviderMockRecorder) GetConfigChartValues(arg0, arg1, arg2 
 }
 
 // GetControlPlaneChartValues mocks base method
-func (m *MockValuesProvider) GetControlPlaneChartValues(arg0 context.Context, arg1 *v1alpha1.ControlPlane, arg2 *controller.Cluster, arg3 map[string]string, arg4 bool) (map[string]interface{}, error) {
+func (m *MockValuesProvider) GetControlPlaneChartValues(arg0 context.Context, arg1 *v1alpha1.ControlPlane, arg2 *extensions.Cluster, arg3 map[string]string, arg4 bool) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetControlPlaneChartValues", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(map[string]interface{})
@@ -66,7 +66,7 @@ func (mr *MockValuesProviderMockRecorder) GetControlPlaneChartValues(arg0, arg1,
 }
 
 // GetControlPlaneExposureChartValues mocks base method
-func (m *MockValuesProvider) GetControlPlaneExposureChartValues(arg0 context.Context, arg1 *v1alpha1.ControlPlane, arg2 *controller.Cluster, arg3 map[string]string) (map[string]interface{}, error) {
+func (m *MockValuesProvider) GetControlPlaneExposureChartValues(arg0 context.Context, arg1 *v1alpha1.ControlPlane, arg2 *extensions.Cluster, arg3 map[string]string) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetControlPlaneExposureChartValues", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(map[string]interface{})
@@ -81,7 +81,7 @@ func (mr *MockValuesProviderMockRecorder) GetControlPlaneExposureChartValues(arg
 }
 
 // GetControlPlaneShootChartValues mocks base method
-func (m *MockValuesProvider) GetControlPlaneShootChartValues(arg0 context.Context, arg1 *v1alpha1.ControlPlane, arg2 *controller.Cluster, arg3 map[string]string) (map[string]interface{}, error) {
+func (m *MockValuesProvider) GetControlPlaneShootChartValues(arg0 context.Context, arg1 *v1alpha1.ControlPlane, arg2 *extensions.Cluster, arg3 map[string]string) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetControlPlaneShootChartValues", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(map[string]interface{})
@@ -96,7 +96,7 @@ func (mr *MockValuesProviderMockRecorder) GetControlPlaneShootChartValues(arg0, 
 }
 
 // GetStorageClassesChartValues mocks base method
-func (m *MockValuesProvider) GetStorageClassesChartValues(arg0 context.Context, arg1 *v1alpha1.ControlPlane, arg2 *controller.Cluster) (map[string]interface{}, error) {
+func (m *MockValuesProvider) GetStorageClassesChartValues(arg0 context.Context, arg1 *v1alpha1.ControlPlane, arg2 *extensions.Cluster) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStorageClassesChartValues", arg0, arg1, arg2)
 	ret0, _ := ret[0].(map[string]interface{})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug
/priority normal

**What this PR does / why we need it**:
When a shoot's purpose is changed from `testing` to something else or when a shoot is woken up then the Gardener Seed Admission Controller does now remove the fluentbit log exclusion annotation from pods again.
Earlier, these annotations were simply kept and only a pod restart was fixing it (i.e., the annotation was not added again). This may have led to prolonged times in which no logs were collected.

**Which issue(s) this PR fixes**:
Fixes #2593

**Special notes for your reviewer**:
/invite @vlvasilev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug was fixed that prevented the log collection for control plane components that belong to shoots whose purpose was changed from `testing` to something else or for those that were woken up.
```
