### PR TITLE
Cherry-pick release-1.7 Fix istiod port by allowing it to run on 443

### DIFF
--- a/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/charts/istio/istio-istiod/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       serviceAccountName: istiod
       securityContext:
-        fsGroup: 1337
+        fsGroup: 0
       containers:
       - name: discovery
         image: "{{ .Values.image }}"
@@ -34,7 +34,7 @@ spec:
         - --monitoringAddr=
         - --grpcAddr=
         - --httpAddr=localhost:8080
-        - --httpsAddr=":{{ .Values.ports.https }}"
+        - --httpsAddr=:{{ .Values.ports.https }}
         - --log_output_level=all:warn,ads:error
         - --domain={{ .Values.trustDomain }}
         - --plugins=authn,authz,health # remove mixer plugin
@@ -96,12 +96,14 @@ spec:
             cpu: 1000m
             memory: 2048Mi
         securityContext:
-          runAsUser: 1337
-          runAsGroup: 1337
-          runAsNonRoot: true
+          runAsUser: 0
+          runAsGroup: 0
+          runAsNonRoot: false
           capabilities:
             drop:
             - ALL
+            add:
+            - NET_BIND_SERVICE
         volumeMounts:
         - name: config-volume
           mountPath: /etc/istio/config


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority normal

**What this PR does / why we need it**:

Fixing istiod by setting correct uid and groupid on the container. All capabilities are dropped except for `NET_BIND_SERVICE`.

**Which issue(s) this PR fixes**:

```
2020-07-22T04:51:21.261088Z     info    FLAG: --trust-domain="cluster.local"
2020-07-22T04:51:21.713999Z     warn    listen tcp 0.0.0.0:443: bind: permission denied
2020-07-22T04:51:26.840403Z     warn    https webhook server not ready: 500
2020-07-22T04:51:31.811403Z     warn    https webhook server not ready: 500
```

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixed a bug where `istiod` cannot listen on `443` due to insufficient privileges.   
```
