### PR TITLE
added machineclasses CRD for out-of-tree machine controllers

### DIFF
--- a/extensions/pkg/controller/worker/machine_crds.go
+++ b/extensions/pkg/controller/worker/machine_crds.go
@@ -166,6 +166,31 @@ func init() {
 				},
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "machineclasses.machine.sapcloud.io",
+			},
+			Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+				Group:   machineGroup,
+				Version: machineVersion,
+				Scope:   apiextensionsv1beta1.NamespaceScoped,
+				Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+					Kind:       "MachineClass",
+					Plural:     "machineclasses",
+					Singular:   "machineclass",
+					ShortNames: []string{"machcls"},
+				},
+				AdditionalPrinterColumns: []apiextensionsv1beta1.CustomResourceColumnDefinition{
+					{
+						Name:        "Provider",
+						Type:        "string",
+						JSONPath:    ".provider",
+						Description: "Name of the provider which acts on the machine class object",
+					},
+					agePrinterColumn,
+				},
+			},
+		},
 	}
 
 	type machineClass struct {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
The CRD of the generic machineclass used by all out-of-tree machine controllers is added to the well-known list of machine CRDs. This avoids that every infrastructure provider using OOT MCM has to deploy it explicitly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
added machineclasses CRD for out-of-tree machine controllers
```
