### PR TITLE
Modify etcd failed proposals alert

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
@@ -20,7 +20,7 @@ tests:
     values: '0+0x30'
   # KubeEtcd3HighNumberOfFailedProposals
   - series: 'etcd_server_proposals_failed_total{job="kube-etcd3", pod="etcd"}'
-    values: '0+1x81 81+0x39'
+    values: '0+2x60 121+0x60'
   # KubeEtcd3DbSizeLimitApproaching
   # KubeEtcd3DbSizeLimitCrossed
   - series: 'etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3",role="main"}'
@@ -94,7 +94,7 @@ tests:
         pod: etcd
         job: kube-etcd3
       exp_annotations:
-        description: Etcd3 pod etcd has seen 81 proposal failures within the last hour.
+        description: Etcd3 pod etcd has seen 121 proposal failures within the last hour.
         summary: High number of failed etcd proposals
   - eval_time: 5m
     alertname: KubeEtcd3DbSizeLimitApproaching

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -54,8 +54,9 @@ groups:
   # Note: Increasing the failedProposals count to 80, known issue in etcd, fix in progress
   # https://github.com/kubernetes/kubernetes/pull/64539 - fix in Kubernetes to be released with v1.15
   # https://github.com/etcd-io/etcd/issues/9360 - ongoing discussion in etcd
+  # TODO (shreyas-s-rao): change value from 120 to 5 after upgrading to etcd 3.4
   - alert: KubeEtcd3HighNumberOfFailedProposals
-    expr: increase(etcd_server_proposals_failed_total{job="kube-etcd3"}[1h]) > 80
+    expr: increase(etcd_server_proposals_failed_total{job="kube-etcd3"}[1h]) > 120
     labels:
       service: etcd
       severity: warning


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/priority normal

**What this PR does / why we need it**:
This PR modifies Prometheus alerts for etcd failed proposals until shoot etcds are upgraded to 3.4. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```

/review @swapnilgm 