### PR TITLE
Add field selectors for ControllerInstallation

### DIFF
--- a/pkg/apis/core/field_constants.go
+++ b/pkg/apis/core/field_constants.go
@@ -24,6 +24,13 @@ const (
 	// the Seed cluster of a core.gardener.cloud/v1beta1 BackupEntry.
 	BackupEntrySeedName = "spec.seedName"
 
+	// RegistrationRefName is the field selector path for finding
+	// the ControllerRegistration name of a core.gardener.cloud/{v1beta1,v1beta1} ControllerInstallation.
+	RegistrationRefName = "spec.registrationRef.name"
+	// SeedRefName is the field selector path for finding
+	// the Seed name of a core.gardener.cloud/{v1beta1,v1beta1} ControllerInstallation.
+	SeedRefName = "spec.seedRef.name"
+
 	// ShootCloudProfileName is the field selector path for finding
 	// the CloudProfile name of a core.gardener.cloud/{v1alpha1,v1beta1} Shoot.
 	ShootCloudProfileName = "spec.cloudProfileName"

--- a/pkg/apis/core/v1alpha1/conversions.go
+++ b/pkg/apis/core/v1alpha1/conversions.go
@@ -25,6 +25,20 @@ import (
 )
 
 func addConversionFuncs(scheme *runtime.Scheme) error {
+	if err := scheme.AddFieldLabelConversionFunc(
+		SchemeGroupVersion.WithKind("ControllerInstallation"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name", core.RegistrationRefName, core.SeedRefName:
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		},
+	); err != nil {
+		return err
+	}
+
 	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Shoot"),
 		func(label, value string) (string, string, error) {
 			switch label {

--- a/pkg/apis/core/v1beta1/conversions.go
+++ b/pkg/apis/core/v1beta1/conversions.go
@@ -53,6 +53,20 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	}
 
 	if err := scheme.AddFieldLabelConversionFunc(
+		SchemeGroupVersion.WithKind("ControllerInstallation"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name", core.RegistrationRefName, core.SeedRefName:
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		},
+	); err != nil {
+		return err
+	}
+
+	if err := scheme.AddFieldLabelConversionFunc(
 		SchemeGroupVersion.WithKind("Shoot"),
 		func(label, value string) (string, string, error) {
 			switch label {

--- a/pkg/registry/core/controllerinstallation/storage/storage.go
+++ b/pkg/registry/core/controllerinstallation/storage/storage.go
@@ -53,6 +53,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
 		NewFunc:                  func() runtime.Object { return &core.ControllerInstallation{} },
 		NewListFunc:              func() runtime.Object { return &core.ControllerInstallationList{} },
+		PredicateFunc:            controllerinstallation.MatchControllerInstallation,
 		DefaultQualifiedResource: core.Resource("controllerinstallations"),
 		EnableGarbageCollection:  true,
 

--- a/pkg/registry/core/controllerinstallation/strategy_test.go
+++ b/pkg/registry/core/controllerinstallation/strategy_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerinstallation_test
+
+import (
+	"testing"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/registry/core/controllerinstallation"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+func TestControllerInstallation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Registry ControllerInstallation Suite")
+}
+
+var _ = Describe("ToSelectableFields", func() {
+	It("should return correct fields", func() {
+		result := controllerinstallation.ToSelectableFields(newControllerInstallation())
+
+		Expect(result).To(HaveLen(3))
+		Expect(result.Has("metadata.name")).To(BeTrue())
+		Expect(result.Get("metadata.name")).To(Equal("test"))
+		Expect(result.Has(core.RegistrationRefName)).To(BeTrue())
+		Expect(result.Get(core.RegistrationRefName)).To(Equal("baz"))
+		Expect(result.Has(core.SeedRefName)).To(BeTrue())
+		Expect(result.Get(core.SeedRefName)).To(Equal("qux"))
+	})
+})
+
+var _ = Describe("GetAttrs", func() {
+	It("should return error when object is not ControllerInstallation", func() {
+		_, _, err := controllerinstallation.GetAttrs(&core.ControllerRegistration{})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return correct result", func() {
+		ls, fs, err := controllerinstallation.GetAttrs(newControllerInstallation())
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ls).To(HaveLen(1))
+		Expect(ls.Get("foo")).To(Equal("bar"))
+		Expect(fs.Get(core.SeedRefName)).To(Equal("qux"))
+	})
+})
+
+var _ = Describe("MatchControllerInstallation", func() {
+	It("should return correct predicate", func() {
+		ls, _ := labels.Parse("app=test")
+		fs := fields.OneTermEqualSelector(core.SeedRefName, "foo")
+
+		result := controllerinstallation.MatchControllerInstallation(ls, fs)
+
+		Expect(result.Label).To(Equal(ls))
+		Expect(result.Field).To(Equal(fs))
+	})
+})
+
+func newControllerInstallation() *core.ControllerInstallation {
+	return &core.ControllerInstallation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test",
+			Labels: map[string]string{"foo": "bar"},
+		},
+		Spec: core.ControllerInstallationSpec{
+			RegistrationRef: corev1.ObjectReference{
+				Name: "baz",
+			},
+			SeedRef: corev1.ObjectReference{
+				Name: "qux",
+			},
+		},
+	}
+}

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -407,10 +407,10 @@ var _ = Describe("GetAttrs", func() {
 	It("should return correct result", func() {
 		ls, fs, err := shootregistry.GetAttrs(newShoot("foo"))
 
+		Expect(err).NotTo(HaveOccurred())
 		Expect(ls).To(HaveLen(1))
 		Expect(ls.Get("foo")).To(Equal("bar"))
 		Expect(fs.Get(core.ShootSeedName)).To(Equal("foo"))
-		Expect(err).NotTo(HaveOccurred())
 	})
 })
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind task
/priority normal

**What this PR does / why we need it**:
Add field selectors for ControllerInstallation.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`gardener-apiserver` does now support a field selector for `ControllerInstallation`s by `spec.registrationRef.name` and `spec.seedRef.name`.
```
