### PR TITLE
Disable cached runtime-client for Shoots

### DIFF
--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -251,7 +251,7 @@ func newClientSet(conf *config) (Interface, error) {
 	}
 
 	var runtimeClient client.Client
-	if UseCachedRuntimeClients {
+	if UseCachedRuntimeClients && !conf.disableCachedClient {
 		runtimeClient, err = newRuntimeClientWithCache(conf.restConfig, conf.clientOptions, runtimeCache)
 		if err != nil {
 			return nil, err

--- a/pkg/client/kubernetes/clientmap/internal/garden_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/internal/garden_clientmap_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("GardenClientMap", func() {
@@ -72,6 +73,10 @@ var _ = Describe("GardenClientMap", func() {
 		It("should correctly construct a new ClientSet", func() {
 			fakeCS := fakeclientset.NewClientSetBuilder().WithRESTConfig(restConfig).Build()
 			internal.NewClientSetWithConfig = func(fns ...kubernetes.ConfigFunc) (i kubernetes.Interface, err error) {
+				Expect(fns).To(kubernetes.ConsistOfConfigFuncs(
+					kubernetes.WithRESTConfig(restConfig),
+					kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.GardenScheme}),
+				))
 				return fakeCS, nil
 			}
 

--- a/pkg/client/kubernetes/clientmap/internal/plant_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/internal/plant_clientmap_test.go
@@ -155,6 +155,11 @@ var _ = Describe("PlantClientMap", func() {
 				Expect(c).To(BeIdenticalTo(fakeGardenClient.Client()))
 				Expect(namespace).To(Equal(plant.Namespace))
 				Expect(secretName).To(Equal(plant.Spec.SecretRef.Name))
+				Expect(fns).To(kubernetes.ConsistOfConfigFuncs(
+					kubernetes.WithClientOptions(client.Options{
+						Scheme: kubernetes.PlantScheme,
+					}),
+				))
 				return fakeCS, nil
 			}
 

--- a/pkg/client/kubernetes/clientmap/internal/shoot_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/shoot_clientmap.go
@@ -109,12 +109,14 @@ func (f *ShootClientSetFactory) NewClientSet(ctx context.Context, k clientmap.Cl
 	clientSet, err := NewClientFromSecret(ctx, seedClient.Client(), seedNamespace, secretName,
 		kubernetes.WithClientConnectionOptions(f.ClientConnectionConfig),
 		kubernetes.WithClientOptions(clientOptions),
+		kubernetes.WithDisabledCachedClient(),
 	)
 
 	if secretName == v1beta1constants.SecretNameGardenerInternal && err != nil && apierrors.IsNotFound(err) {
 		clientSet, err = NewClientFromSecret(ctx, seedClient.Client(), seedNamespace, v1beta1constants.SecretNameGardener,
 			kubernetes.WithClientConnectionOptions(f.ClientConnectionConfig),
 			kubernetes.WithClientOptions(clientOptions),
+			kubernetes.WithDisabledCachedClient(),
 		)
 	}
 

--- a/pkg/client/kubernetes/options.go
+++ b/pkg/client/kubernetes/options.go
@@ -24,9 +24,10 @@ import (
 )
 
 type config struct {
-	clientOptions client.Options
-	restConfig    *rest.Config
-	cacheResync   *time.Duration
+	clientOptions       client.Options
+	restConfig          *rest.Config
+	cacheResync         *time.Duration
+	disableCachedClient bool
 }
 
 // ConfigFunc is a function that mutates a Config struct.
@@ -70,6 +71,15 @@ func WithClientOptions(opt client.Options) ConfigFunc {
 func WithCacheResyncPeriod(resync time.Duration) ConfigFunc {
 	return func(config *config) error {
 		config.cacheResync = &resync
+		return nil
+	}
+}
+
+// WithDisabledCachedClient disables the cache in the controller-runtime client, so Client() will be equivalent to
+// DirectClient().
+func WithDisabledCachedClient() ConfigFunc {
+	return func(config *config) error {
+		config.disableCachedClient = true
 		return nil
 	}
 }

--- a/pkg/client/kubernetes/options_matchers.go
+++ b/pkg/client/kubernetes/options_matchers.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	gomegatypes "github.com/onsi/gomega/types"
+	"k8s.io/client-go/rest"
+)
+
+// ConsistOfConfigFuncs returns a composed `ConsistsOf` matcher with `MatchConfigFunc` for each ConfigFn in `fns`.
+// This is useful for making assertions on a given slice of ConfigFns which can't be compared by value.
+// e.g.:
+// 	Expect(fns).To(kubernetes.ConsistOfConfigFuncs(
+//		kubernetes.WithClientConnectionOptions(clientConnectionConfig),
+//		kubernetes.WithClientOptions(clientOptions),
+//		kubernetes.WithDisabledCachedClient(),
+//	))
+func ConsistOfConfigFuncs(fns ...interface{}) gomegatypes.GomegaMatcher {
+	var matchers []gomegatypes.GomegaMatcher
+
+	for _, fn := range fns {
+		matchers = append(matchers, MatchConfigFunc(fn))
+	}
+
+	return gomega.ConsistOf(matchers)
+}
+
+// MatchConfigFunc returns a matcher that checks if the config produced by the actual ConfigFn is deeply equal to the
+// config produced by `fn`. This is useful for making assertions on given ConfigFns which can't be compared by value.
+// e.g.:
+// 	Expect(fn).Should(MatchConfigFunc(WithClientConnectionOptions(clientConnectionConfig)))
+func MatchConfigFunc(fn interface{}) gomegatypes.GomegaMatcher {
+	return &configFuncMatcher{expected: fn}
+}
+
+type configFuncMatcher struct {
+	expected interface{}
+
+	expectedConfig *config
+	actualConfig   *config
+}
+
+func (m *configFuncMatcher) Match(actual interface{}) (success bool, err error) {
+	if m.expected == nil {
+		return false, fmt.Errorf("Refusing to compare <nil> to <nil>.\nBe explicit and use BeNil() instead.  This is to avoid mistakes where both sides of an assertion are erroneously uninitialized.")
+	}
+	if actual == nil {
+		return false, nil
+	}
+
+	actualConfigFunc, ok := actual.(ConfigFunc)
+	if !ok {
+		return false, fmt.Errorf("actual is not a ConfigFunc, but %T", actual)
+	}
+	actualConfig := &config{restConfig: &rest.Config{}}
+	if err := actualConfigFunc(actualConfig); err != nil {
+		return false, fmt.Errorf("actual returned an error when calling: %w", err)
+	}
+
+	expectedConfigFunc, ok := m.expected.(ConfigFunc)
+	if !ok {
+		return false, fmt.Errorf("expected is not a ConfigFunc, but %T", m.expected)
+	}
+	expectedConfig := &config{restConfig: &rest.Config{}}
+	if err := expectedConfigFunc(expectedConfig); err != nil {
+		return false, fmt.Errorf("expected returned an error when calling: %w", err)
+	}
+
+	return reflect.DeepEqual(expectedConfig, actualConfig), nil
+}
+
+func (m *configFuncMatcher) FailureMessage(actual interface{}) (message string) {
+	if m.actualConfig == nil || m.expectedConfig == nil {
+		return format.Message(actual, "to produce an equal config to the one produced by", m.expected)
+	}
+
+	return format.MessageWithDiff(fmt.Sprintf("%+v", m.actualConfig), "to produce an equal config to the one produced by", fmt.Sprintf("%+v", m.expectedConfig))
+}
+
+func (m *configFuncMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	if m.actualConfig == nil || m.expectedConfig == nil {
+		return format.Message(actual, "to not produce an equal config to the one produced by", m.expected)
+	}
+
+	return format.MessageWithDiff(fmt.Sprintf("%+v", m.actualConfig), "to not produce an equal config to the one produced by", fmt.Sprintf("%+v", m.expectedConfig))
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area cost
/kind enhancement
/priority normal

**What this PR does / why we need it**:
After observing the `CachedRuntimeClients` for some weeks, we see an increased memory footprint of the gardenlet.
This was expected because the gardenlet now caches even more API objects. Nevertheless, we might not want to enable the cache for Shoot client's as there might be hundreds of Shoots on some Seeds in big gardener installations which might increase the memory footprint too much and we don't really benefit so much from it, as the communication to the Shoot API servers is anyways happening in-cluster.

That's why this PR disables the cached controller-runtime clients for all Shoot ClientSet's, so that `Client()` will be equivalent to `DirectcClient()` for those.

**Which issue(s) this PR fixes**:
Ref #2414 

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The cached controller-runtime clients have been disabled for Shoot clients to decrease the gardenlet's memory footprint in case the `CachedRuntimeClients` feature gate is enabled.
```
