### PR TITLE
Prevent seed-boostrap to delete Shoot VPA RBAC

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-actor.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-actor.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: system:vpa-actor
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:actor
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 rules:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-admission-controller.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: system:vpa-admission-controller
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:admission-controller
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 rules:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-checkpointer.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-checkpointer.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: system:vpa-checkpoint-actor
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:checkpoint-actor
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 rules:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-exporter.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-exporter.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: system:vpa-exporter-role
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:exporter
   labels:
 {{ toYaml .Values.labels | indent 4 }}
 rules:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-recommender.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: system:metrics-reader
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:metrics-reader
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 rules:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-target-reader.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-target-reader.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: system:vpa-target-reader
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:target-reader
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 rules:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-updater-evictioner.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-updater-evictioner.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: system:evictioner
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:evictioner
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 rules:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-actor.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-actor.yaml
@@ -2,13 +2,13 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: system:vpa-actor
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:actor
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:vpa-actor
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:actor
 {{- if or .Values.recommender.enabled .Values.updater.enabled }}
 subjects:
 {{- if .Values.recommender.enabled }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-admission-controller.yaml
@@ -2,13 +2,13 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: system:vpa-admission-controller
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:admission-controller
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:vpa-admission-controller
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:admission-controller
 {{- if .Values.admissionController.enabled }}
 subjects:
 {{- if .Values.admissionController.enableServiceAccount }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-checkpointer.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-checkpointer.yaml
@@ -2,13 +2,13 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: system:vpa-checkpoint-actor
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:checkpoint-actor
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:vpa-checkpoint-actor
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:checkpoint-actor
 {{- if .Values.recommender.enabled }}
 subjects:
 {{- if .Values.recommender.enableServiceAccount }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-exporter.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-exporter.yaml
@@ -2,13 +2,13 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: system:vpa-exporter-role-binding
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:exporter
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:vpa-exporter-role
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:exporter
 {{- if .Values.exporter.enabled }}
 subjects:
 {{- if .Values.exporter.enableServiceAccount }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-recommender.yaml
@@ -2,13 +2,13 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: system:metrics-reader
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:metrics-reader
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:metrics-reader
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:metrics-reader
 {{- if .Values.recommender.enabled }}
 subjects:
 {{- if .Values.recommender.enableServiceAccount }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-target-reader.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-target-reader.yaml
@@ -2,13 +2,13 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: system:vpa-target-reader-binding
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:target-reader
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:vpa-target-reader
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:target-reader
 {{- if or .Values.admissionController.enabled .Values.recommender.enabled .Values.updater.enabled }}
 subjects:
 {{- if .Values.recommender.enabled }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-updater-evictioner.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-updater-evictioner.yaml
@@ -2,13 +2,13 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: system:vpa-evictionter-binding
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:evictioner
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:evictioner
+  name: gardener.cloud:vpa:{{ .Values.clusterType }}:evictioner
 {{- if .Values.updater.enabled }}
 subjects:
 {{- if .Values.updater.enableServiceAccount }}

--- a/charts/seed-bootstrap/charts/vpa/values.yaml
+++ b/charts/seed-bootstrap/charts/vpa/values.yaml
@@ -8,6 +8,8 @@ global:
 labels:
   garden.sapcloud.io/role: vpa
 
+clusterType: seed
+
 admissionController:
   replicas: 1
   enabled: true

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -339,6 +339,7 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 			},
 		}
 		verticalPodAutoscaler = map[string]interface{}{
+			"clusterType":         "shoot",
 			"admissionController": map[string]interface{}{"enableServiceAccount": false},
 			"exporter":            map[string]interface{}{"enableServiceAccount": false},
 			"recommender":         map[string]interface{}{"enableServiceAccount": false},

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -347,6 +347,8 @@ func DeleteVpa(ctx context.Context, c client.Client, namespace string, isShoot b
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "vpa-updater", Namespace: namespace}},
 		)
 	} else {
+		// TODO: remove in a future release
+		// Clean up the stale RBAC resources
 		resources = append(resources,
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "system:vpa-actor"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "system:vpa-admission-controller"}},
@@ -362,6 +364,23 @@ func DeleteVpa(ctx context.Context, c client.Client, namespace string, isShoot b
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "system:metrics-reader"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "system:vpa-target-reader-binding"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "system:vpa-evictionter-binding"}},
+		)
+
+		resources = append(resources,
+			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:vpa:seed:actor"}},
+			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:vpa:seed:admission-controller"}},
+			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:vpa:seed:checkpoint-actor"}},
+			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:vpa:seed:exporter"}},
+			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:vpa:seed:metrics-reader"}},
+			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:vpa:seed:target-reader"}},
+			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:vpa:seed:evictioner"}},
+			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:vpa:seed:actor"}},
+			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:vpa:seed:admission-controller"}},
+			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:vpa:seed:checkpoint-actor"}},
+			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:vpa:seed:exporter"}},
+			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:vpa:seed:metrics-reader"}},
+			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:vpa:seed:target-reader"}},
+			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:vpa:seed:evictioner"}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "vpa-admission-controller", Namespace: namespace}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "vpa-exporter", Namespace: namespace}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "vpa-recommender", Namespace: namespace}},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug
/priority normal

**What this PR does / why we need it**:
Currently for a Shoot cluster which is registered as Seed, the seed controller wrongly deletes VPA RBAC from the cluster when the Shoot has`spec.kubernetes.verticalPodAutoscaler.enabled=true` and the corresponding Seed has 
 `spec.settings.verticalPodAutoscaler.enabled=false`.
The Shoot cluster SystemComponentsHealthy is constantly flapping (caused by the 2 control loops acting on the same resource - seed controller deleting it and gardener-resource-manager creating it):
```yaml
    - type: SystemComponentsHealthy
      status: 'False'
      lastTransitionTime: '2020-07-29T11:55:26Z'
      lastUpdateTime: '2020-07-29T11:57:26Z'
      reason: ClusterRoleMissing
      message: 'Required ClusterRole "system:evictioner" in namespace "" is missing.'
```

This PR adds the cluster type (shoot or seed) as part of the VPA RBAC name and in this way prevents the issue.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue causing the seed controller to delete VPA RBAC for ShootedSeed is now fixed.
```
