### PR TITLE
Allow latest machine image version to have an expiration date

### DIFF
--- a/docs/usage/shoot_versions.md
+++ b/docs/usage/shoot_versions.md
@@ -97,6 +97,10 @@ The Gardener API server enforces the following requirements for versions:
 **Adding a version** 
 - A version must not have an expiration date in the past.
 - There can be only one `supported` version per minor version.
+- The latest Kubernetes version cannot have an expiration date.
+- The latest version for a machine image can have an expiration date. [*]
+
+<sub>[*] Useful for cases in which support for given machine image needs to be deprecated and removed (for example the machine image reaches end of life).</sub>
 
 ## Forceful migration of expired versions
  

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -252,12 +252,6 @@ func validateMachineImages(machineImages []core.MachineImage, fldPath *field.Pat
 		allErrs = append(allErrs, field.Invalid(fldPath, latestMachineImages, err.Error()))
 	}
 
-	for imageName, latestImage := range latestMachineImages {
-		if latestImage.ExpirationDate != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("expirationDate"), latestImage.ExpirationDate, fmt.Sprintf("expiration date of latest image ('%s','%s') must not be set", imageName, latestImage.Version)))
-		}
-	}
-
 	duplicateNameVersion := sets.String{}
 	duplicateName := sets.String{}
 	for i, image := range machineImages {

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -392,7 +392,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 					}))))
 				})
 
-				It("should forbid expiration date on latest machine image version", func() {
+				It("should allow expiration date on latest machine image version", func() {
 					expirationDate := &metav1.Time{Time: time.Now().AddDate(0, 0, 1)}
 					cloudProfile.Spec.MachineImages = []core.MachineImage{
 						{
@@ -422,16 +422,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 					}
 
 					errorList := ValidateCloudProfile(cloudProfile)
-
-					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(field.ErrorTypeInvalid),
-						"Field":  Equal("spec.machineImages.expirationDate"),
-						"Detail": ContainSubstring("some-machineimage"),
-					})), PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(field.ErrorTypeInvalid),
-						"Field":  Equal("spec.machineImages.expirationDate"),
-						"Detail": ContainSubstring("xy"),
-					}))))
+					Expect(errorList).To(BeEmpty())
 				})
 
 				It("should forbid invalid classification for machine image versions", func() {

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -386,7 +386,7 @@ func shouldMachineImageBeUpdated(logger *logrus.Entry, autoUpdateMachineImageVer
 
 		// otherwise, there should always be a qualifying version (at least the Shoot's machine image version itself).
 		if !qualifyingVersionFound {
-			return false, nil, nil, fmt.Errorf("no latest qualifying Shoot machine image could be determined for machine image %q. This is most likely a misconfiguration in the CloudProfile. Make sure the machine image in the CloudProfile has at least one version that is not expired, not in preview and greater or equal to the current Shoot image version %q", machineImage.Name, *shootMachineImage.Version)
+			return false, nil, nil, fmt.Errorf("no latest qualifying Shoot machine image could be determined for machine image %q. Either the machine image is reaching end of life and migration to another machine image is required or there is a misconfiguration in the CloudProfile. If it is the latter, make sure the machine image in the CloudProfile has at least one version that is not expired, not in preview and greater or equal to the current Shoot image version %q", machineImage.Name, *shootMachineImage.Version)
 		}
 
 		if *latestShootMachineImage.Version == *shootMachineImage.Version {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind task
/priority normal

**What this PR does / why we need it**:
Currently the gardener-apiserver does not allow setting expiration date for the latest machine image version. This of course makes sense semantically. But there are also cases where this restriction is not handy - for example when deprecating and removing support for machine image (machine image reached EoL and needs to be removed; machine image "renamed" and available under new name). This PR allows setting expiration date to the latest machine image version to improve the process of deprecation and removal of machine image - when the latest version expires, no new Shoots creation will be allows with that version.

With this PR when the latest machine image expires, the maintenance controller creates event like:
```
  Warning  MaintenanceError   2s                    gardener-controller-manager  Could not maintain machine image version: no latest qualifying Shoot machine image could be determined for machine image "foo". Either the machine image is reaching end of life and migration to another machine image is required or there is a misconfiguration in the CloudProfile. If it is the latter, make sure the machine image in the CloudProfile has at least one version that is not expired, not in preview and greater or equal to the current Shoot image version "1.0.0"
```


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
It is now allowed to set an expiration date for the latest machine image version in the `CloudProfile`s.
```
