### PR TITLE
some nits after migration to loki

### DIFF
--- a/extensions/test/e2e/framework/networkpolicies/agnostic.go
+++ b/extensions/test/e2e/framework/networkpolicies/agnostic.go
@@ -196,8 +196,8 @@ func (a *Agnostic) CloudControllerManagerSecured() *SourcePod {
 	}
 }
 
-// LokiSearch points to cloud-agnostic loki instance.
-func (a *Agnostic) LokiSearch() *SourcePod {
+// Loki points to cloud-agnostic loki instance.
+func (a *Agnostic) Loki() *SourcePod {
 	return &SourcePod{
 		Ports: []Port{
 			{Name: "metrics", Port: 3100},

--- a/test/framework/common.go
+++ b/test/framework/common.go
@@ -24,7 +24,7 @@ const (
 	// KubeconfigSecretKeyName ist the name of the key in a secret that holds the kubeconfig of a shoot
 	KubeconfigSecretKeyName = "kubeconfig"
 
-	// LoggingUserName is the admin user name for the elasticserach logging instance of a shoot
+	// LoggingUserName is the admin user name for the loki instance of a shoot
 	lokiLogging = "loki"
 	lokiPort    = 3100
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Minor nits after #2515 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
