### PR TITLE
Add liveness probe for gardener-apiserver

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -212,6 +212,16 @@ spec:
               - sh
               - -c
               - sleep 5
+        livenessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /livez
+            port: 443
+          initialDelaySeconds: {{ .Values.global.apiserver.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.global.apiserver.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.global.apiserver.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.global.apiserver.livenessProbe.failureThreshold }}
+          timeoutSeconds: {{ .Values.global.apiserver.livenessProbe.timeoutSeconds }}
         {{- if .Values.global.apiserver.resources }}
         resources:
 {{ toYaml .Values.global.apiserver.resources | indent 10 }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -9,6 +9,12 @@ global:
       repository: eu.gcr.io/gardener-project/gardener/apiserver
       tag: latest
       pullPolicy: IfNotPresent
+    livenessProbe:
+      initialDelaySeconds: 15
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
+      timeoutSeconds: 15
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/area high-availability
/kind task
/priority normal

**What this PR does / why we need it**:
Add liveness probe for gardener-apiserver.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2633

**Special notes for your reviewer**:
I will also create PR for readinessProbe once the upstream issue is resolved - ref https://github.com/gardener/gardener/issues/2633#issuecomment-667077374.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`gardener-apiserver` Deployment does now define a liveness probe.
```
