### PR TITLE
[release-v1.7] Fix WaitCleanup for Network

### DIFF
--- a/pkg/operation/botanist/extensions/network/network.go
+++ b/pkg/operation/botanist/extensions/network/network.go
@@ -156,11 +156,15 @@ func (d *network) Wait(ctx context.Context) error {
 
 // WaitCleanup waits until the Network CRD is deleted
 func (d *network) WaitCleanup(ctx context.Context) error {
-	return common.DeleteExtensionCR(
+	return common.WaitUntilExtensionCRDeleted(
 		ctx,
 		d.client,
+		d.logger,
 		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Network{} },
+		"Network",
 		d.values.Namespace,
 		d.values.Name,
+		d.waitInterval,
+		d.waitTimeout,
 	)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
Currently gardenelet does not properly wait for Network cleanup.

https://github.com/gardener/gardener/blob/354cc3ca8651a0f22019d0cd79ad5de10e92eb20/pkg/operation/botanist/extensions/network/network.go#L158-L166

It should rather wait until the CR is removed from store instead of simply deleting it. 


The issue is fixed in the master branch with https://github.com/gardener/gardener/pull/2548 (thank you @rfranzke ).


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue preventing gardenlet to wait for `network.extensions.gardener.cloud` deletion is now fixed.
```
