### PR TITLE
Fix enqueuing namespaces for netpol controller

### DIFF
--- a/pkg/gardenlet/controller/federatedseed/networkpolicy/endpoints.go
+++ b/pkg/gardenlet/controller/federatedseed/networkpolicy/endpoints.go
@@ -45,7 +45,7 @@ func (c *Controller) enqueueNamespaces() {
 	}
 
 	for _, namespace := range namespaces.Items {
-		key, err := cache.MetaNamespaceKeyFunc(namespace)
+		key, err := cache.MetaNamespaceKeyFunc(&namespace)
 		if err != nil {
 			c.log.Errorf("Failed to enqueue namespaces to update NetworkPolicy %q for namespace %q - couldn't get key for namespace: %v", helper.AllowToSeedAPIServer, namespace.Name, err)
 			continue


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority blocker

**What this PR does / why we need it**:
This PR fixes a bug in the federated seed controller:

```
time="2020-08-04T07:59:43Z" level=error msg="Failed to enqueue namespaces to update NetworkPolicy \"allow-to-seed-apiserver\" for namespace \"shoot--foo--bar\" - couldn't get key for namespace: object has no meta: object does not implement the Object interfaces" Seed=foo
```

**Special notes for your reviewer**:
@rfranzke thanks for reporting!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
