### PR TITLE
Fix VPA webhook port configuration

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
@@ -47,7 +47,10 @@ spec:
         {{- if .Values.admissionController.registerByURL }}
         - --register-by-url=true
         - --webhook-address=https://vpa-webhook.{{.Release.Namespace}}
-        - --webhook-port={{ .Values.admissionController.port }}
+        - --webhook-port={{ .Values.admissionController.servicePort }} # the port is only respected if register-by-url is true, that's why it's in this if-block
+                                                                       # if it's false it will not set the port during registration, i.e., it will be defaulted to 443,
+                                                                       # so the servicePort has to be 443 in this case
+                                                                       # see https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/admission-controller/config.go#L70-L74
         {{- end }}
         image: {{ index .Values.global.images "vpa-admission-controller" }}
         imagePullPolicy: IfNotPresent

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-exporter.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-exporter.yaml
@@ -35,6 +35,7 @@ spec:
       containers:
       - command:
         - /usr/local/bin/vpa-exporter
+        - --port={{ .Values.exporter.port }}
         image: {{ index .Values.global.images "vpa-exporter" }}
         imagePullPolicy: IfNotPresent
         name: exporter
@@ -51,7 +52,7 @@ spec:
 {{- end }}
         ports:
         - name: metrics
-          containerPort: 9570
+          containerPort: {{ .Values.exporter.port }}
           protocol: TCP
         resources:
           requests:

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/service-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/service-admission-controller.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-    - port: 443
+    - port: {{ .Values.admissionController.servicePort }}
       targetPort: {{ .Values.admissionController.port }}
   selector:
     app: vpa-admission-controller

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/service-exporter.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/service-exporter.yaml
@@ -15,6 +15,6 @@ spec:
   ports:
   - name: metrics
     protocol: TCP
-    port: 9570
-    targetPort: 9570
+    port: {{ .Values.exporter.servicePort }}
+    targetPort: {{ .Values.exporter.port }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/values.yaml
+++ b/charts/seed-bootstrap/charts/vpa/values.yaml
@@ -18,6 +18,7 @@ admissionController:
   enableServiceAccount: true
   registerByURL: false
   port: 10250
+  servicePort: 443
 
 exporter:
   replicas: 1
@@ -27,6 +28,8 @@ exporter:
   enableServiceAccount: true
   enableVPA: true
   enableService: true
+  port: 9570
+  servicePort: 9570
 
 recommender:
   replicas: 1

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/networkpolicy-allow-kube-apiserver-policy.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/networkpolicy-allow-kube-apiserver-policy.yaml
@@ -42,7 +42,7 @@ spec:
           app: vpa-admission-controller
     ports:
     - protocol: TCP
-      port: 443
+      port: 10250
   {{- end }}
   ingress:
     # Allow connection from everything which needs to talk to the API server


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/priority normal

**What this PR does / why we need it**:
With #2660 the VPA port configuration was changed, however, there are some left overs. The webhook port (= service port) is still 443, and the network policy for the kube-apiserver needs to be updated to the correct new 10250 server port.

**Special notes for your reviewer**:
Thanks @timebertt for helping me with this!
/cc @stoyanr

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
