### PR TITLE
Treat machines w/o status as pending

### DIFF
--- a/extensions/pkg/controller/healthcheck/worker/helpers.go
+++ b/extensions/pkg/controller/healthcheck/worker/helpers.go
@@ -108,8 +108,8 @@ func checkNodesScalingUp(machineList *machinev1alpha1.MachineList, readyNodes, d
 		case machinev1alpha1.MachineRunning, machinev1alpha1.MachineAvailable:
 			// machine is already running fine
 			continue
-		case machinev1alpha1.MachinePending:
-			// machine is being created
+		case machinev1alpha1.MachinePending, "": // https://github.com/gardener/machine-controller-manager/issues/466
+			// machine is in the process of being created
 			pendingMachines++
 		default:
 			// undesired machine phase

--- a/extensions/pkg/controller/healthcheck/worker/helpers_test.go
+++ b/extensions/pkg/controller/healthcheck/worker/helpers_test.go
@@ -243,7 +243,7 @@ var _ = Describe("health", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("should return progressing when detecting a regular scale up", func() {
+		It("should return progressing when detecting a regular scale up (pending status)", func() {
 			machineList := &machinev1alpha1.MachineList{
 				Items: []machinev1alpha1.Machine{
 					{
@@ -251,6 +251,20 @@ var _ = Describe("health", func() {
 							CurrentStatus: machinev1alpha1.CurrentStatus{Phase: machinev1alpha1.MachinePending},
 						},
 					},
+				},
+			}
+
+			status, reason, err := checkNodesScalingUp(machineList, 0, 1)
+
+			Expect(status).To(Equal(gardencorev1beta1.ConditionProgressing))
+			Expect(reason).To(Equal("PendingMachines"))
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return progressing when detecting a regular scale up (no status)", func() {
+			machineList := &machinev1alpha1.MachineList{
+				Items: []machinev1alpha1.Machine{
+					{},
 				},
 			}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:
In some situations the machine status is updated late although the creation has already started, see https://github.com/gardener/machine-controller-manager/issues/466, so we should treat this similar as when the status is `Pending`.

**Special notes for your reviewer**:
/invite @hardikdr @prashanth26 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
