### PR TITLE
Increase leader election settings for shoot's GRM

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -24,7 +24,7 @@ images:
 - name: gardener-resource-manager
   sourceRepository: github.com/gardener/gardener-resource-manager
   repository: eu.gcr.io/gardener-project/gardener/gardener-resource-manager
-  tag: "v0.15.0"
+  tag: "v0.16.0"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog

--- a/charts/seed-controlplane/charts/gardener-resource-manager/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/templates/deployment.yaml
@@ -36,6 +36,15 @@ spec:
         - /gardener-resource-manager
         - --leader-election=true
         - --leader-election-namespace={{ .Release.Namespace }}
+        {{- if .Values.leaderElection.leaseDuration }}
+        - --leader-election-lease-duration={{ .Values.leaderElection.leaseDuration }}
+        {{- end }}
+        {{- if .Values.leaderElection.renewDeadline }}
+        - --leader-election-renew-deadline={{ .Values.leaderElection.renewDeadline }}
+        {{- end }}
+        {{- if .Values.leaderElection.retryPeriod }}
+        - --leader-election-retry-period={{ .Values.leaderElection.retryPeriod }}
+        {{- end }}
         {{- if .Values.controllers.cacheResyncPeriod }}
         - --cache-resync-period={{ .Values.controllers.cacheResyncPeriod }}
         {{- end }}

--- a/charts/seed-controlplane/charts/gardener-resource-manager/values.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/values.yaml
@@ -11,6 +11,11 @@ resources:
 
 replicas: 1
 
+leaderElection: {}
+# leaseDuration: 15s
+# renewDeadline: 10s
+# retryPeriod: 2s
+
 controllers:
 #  cacheResyncPeriod: 24h0m0s
   managedResource:

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -695,6 +695,16 @@ func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
 			"checksum/secret-" + name: b.CheckSums[name],
 		},
 		"replicas": b.Shoot.GetReplicas(1),
+		// We run one GRM per shoot control plane, and the GRM is doing its leader election via configmaps in the seed -
+		// by default every 2s. This can lead to a lot of PUT /v1/configmaps requests on the API server, and given that
+		// a seed is very busy anyways, we should not unnecessarily stress the API server with this leader election.
+		// The GRM's sync period is 1m anyways, so it doesn't matter too much if the leadership determination may take up
+		// to one minute.
+		"leaderElection": map[string]interface{}{
+			"leaseDuration": "40s",
+			"renewDeadline": "15s",
+			"retryPeriod":   "10s",
+		},
 	}
 
 	values, err := b.InjectSeedShootImages(defaultValues, common.GardenerResourceManagerImageName)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area cost networking robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
We run one GRM per shoot control plane, and the GRM is doing its leader election via configmaps in the seed - by default every `2s`. This can lead to a lot of `PUT /v1/configmaps` requests on the API server, and given that a seed is very busy anyways, we should not unnecessarily stress the API server with this leader election. The GRM's sync period is `1m` anyways, so it doesn't matter too much if the leadership determination may take up to one minute.

**Which issue(s) this PR fixes**:
Part of #1953 

**Special notes for your reviewer**:
✅ Depends on https://github.com/gardener/gardener-resource-manager/pull/72 and a new release.
/invite @timebertt @vlerenc 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
``` noteworthy operator github.com/gardener/gardener-resource-manager #72 @rfranzke
It is now possible to specify the leader election settings via the following command line parameters: `--leader-election-lease-duration` (default: `15s`), `--leader-election-renew-deadline` (default: `10s`), `--leader-election-retry-period` (default: `2s`).
```
```improvement operator
The leader election performed by the `gardener-resource-manager` deployments in shoot namespaces in the seed is now happening less frequently to prevent overloading the seed's API server unnecessarily.
```