### PR TITLE
Clean-up DNS provider migration

### DIFF
--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -761,10 +761,6 @@ func FindPrimaryDNSProvider(providers []gardencorev1beta1.DNSProvider) *gardenco
 			return &primaryProvider
 		}
 	}
-	// TODO: timuthy - Only required for migration and can be removed in a future version.
-	if len(providers) > 0 {
-		return &providers[0]
-	}
 	return nil
 }
 

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -791,7 +791,7 @@ var _ = Describe("helper", func() {
 		Entry("no providers", nil, BeNil()),
 		Entry("one non primary provider", []gardencorev1beta1.DNSProvider{
 			{Type: pointer.StringPtr("provider")},
-		}, Equal(&gardencorev1beta1.DNSProvider{Type: pointer.StringPtr("provider")})),
+		}, BeNil()),
 		Entry("one primary provider", []gardencorev1beta1.DNSProvider{{Type: pointer.StringPtr("provider"),
 			Primary: pointer.BoolPtr(true)}}, Equal(&gardencorev1beta1.DNSProvider{Type: pointer.StringPtr("provider"), Primary: pointer.BoolPtr(true)})),
 		Entry("multiple w/ one primary provider", []gardencorev1beta1.DNSProvider{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind cleanup
/priority normal

**What this PR does / why we need it**:
This PR removes migration logic which was once introduced by https://github.com/gardener/gardener/pull/1959 to migrate primary DNS providers. Furthermore, functionless DNS providers (non-primary provider w/o a secret ref) are now removed and logged by the DNS admission plugin, not by the shoot controller anymore. 

We once put this to the controller to prevent spec changes for shoot resources that would have happened outside of the maintenance time window (due to regular `shoot.gardener.cloud/status` labelling). But since we have this migration logic for a while we can be sure, that each shoot was at least reconciled once with one of the previously released g/g versions.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
