### PR TITLE
Add toleration for fluent-bit to run on masters

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
@@ -52,6 +52,9 @@ spec:
       serviceAccountName: fluent-bit
       automountServiceAccountToken: true
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
**How to categorize this PR?**

/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR adds tolerations to the fluent-bit daemonset, which runs on all seeds. For the gardener initial cluster these tolerations are needed to also collect logs from master nodes.

**Which issue(s) this PR fixes**:
Fixes #2638 

**Special notes for your reviewer**:

**Release note**:

```improvement operator
The fluent-bit DaemonSet is now tolerating the taint `node-role.kubernetes.io/master` with effect `NoSchedule`.
```
