### PR TITLE
Set revisionHistoryLimit=0 for Deployments when missing

### DIFF
--- a/charts/seed-bootstrap/charts/etcd-druid/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/etcd-druid/templates/controller-deployment.yaml
@@ -8,6 +8,7 @@ metadata:
 {{ toYaml .Values.labels | indent 4 }}
 spec:
   replicas: 1
+  revisionHistoryLimit: 0
   selector:
     matchLabels:
       gardener.cloud/role: etcd-druid

--- a/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
@@ -16,6 +16,7 @@ metadata:
 {{ toYaml .Values.labels | indent 4 }}
 spec:
   replicas: 1
+  revisionHistoryLimit: 0
   selector:
     matchLabels:
       app: hvpa-controller

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
@@ -10,6 +10,7 @@ metadata:
 {{ toYaml .Values.labels | indent 4 }}
 spec:
   replicas: {{ .Values.admissionController.replicas }}
+  revisionHistoryLimit: 0
   selector:
     matchLabels:
       app: vpa-admission-controller

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-exporter.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-exporter.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.exporter.replicas }}
+  revisionHistoryLimit: 0
   selector:
     matchLabels:
       app: vpa-exporter

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
@@ -10,6 +10,7 @@ metadata:
 {{ toYaml .Values.labels | indent 4 }}
 spec:
   replicas: {{ .Values.recommender.replicas }}
+  revisionHistoryLimit: 0
   selector:
     matchLabels:
       app: vpa-recommender

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
@@ -9,6 +9,7 @@ metadata:
 {{ toYaml .Values.labels | indent 4 }}
 spec:
   replicas: {{ .Values.updater.replicas }}
+  revisionHistoryLimit: 0
   selector:
     matchLabels:
       app: vpa-updater


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Some `Deployment`s weren't setting `.spec.revisionHistoryLimit=0` (i.e., it got defaulted to `10`).
This PR fixes this.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
