### PR TITLE
Allow admission authentication via Service Account Token Projection

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/_helpers.tpl
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/_helpers.tpl
@@ -3,3 +3,22 @@
 - --feature-gates={{ range $feature, $enabled := .Values.global.apiserver.featureGates }}{{ $feature }}={{ $enabled }},{{ end }}
 {{- end }}
 {{- end -}}
+
+{{- define "gardener-apiserver.hasAdmissionPlugins" -}}
+{{- if or .Values.global.apiserver.admission.validatingWebhook.kubeconfig .Values.global.apiserver.admission.mutatingWebhook.kubeconfig .Values.global.apiserver.admission.plugins -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "gardener-apiserver.hasWebhookTokens" -}}
+{{- if or .Values.global.apiserver.admission.validatingWebhook.token.enabled .Values.global.apiserver.admission.mutatingWebhook.token.enabled }}
+true
+{{- end -}}
+{{- end -}}
+
+
+{{- define "gardener-apiserver.hasAdmissionKubeconfig" -}}
+{{- if or .Values.global.apiserver.admission.validatingWebhook.kubeconfig .Values.global.apiserver.admission.mutatingWebhook.kubeconfig  }}
+true
+{{- end -}}
+{{- end -}}

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/configmap-admission-config.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/configmap-admission-config.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.global.apiserver.enabled .Values.global.apiserver.admissionConfig }}
+{{- if and .Values.global.apiserver.enabled (include "gardener-apiserver.hasAdmissionPlugins" .) }}
+{{- with .Values.global.apiserver.admission }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,10 +8,30 @@ metadata:
   labels:
     app: gardener
     role: apiserver
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
 data:
   configuration.yaml: |-
-{{ .Values.global.apiserver.admissionConfig | indent 4 }}
+    apiVersion: apiserver.config.k8s.io/v1
+    kind: AdmissionConfiguration
+    plugins:
+    {{- if .validatingWebhook.kubeconfig }}
+    - name: ValidatingAdmissionWebhook
+      configuration:
+        apiVersion: apiserver.config.k8s.io/v1
+        kind: WebhookAdmissionConfiguration
+        kubeConfigFile: /var/run/secrets/admission-kubeconfig/validating-webhook
+    {{- end }}
+    {{- if .mutatingWebhook.kubeconfig }}
+    - name: MutatingAdmissionWebhook
+      configuration:
+        apiVersion: apiserver.config.k8s.io/v1
+        kind: WebhookAdmissionConfiguration
+        kubeConfigFile: /var/run/secrets/admission-kubeconfig/mutating-webhook
+    {{- end }}
+    {{- if .plugins }}
+{{ toYaml .plugins | indent 4}}
+    {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         checksum/secret-gardener-apiserver-encryption-config: {{ include (print $.Template.BasePath "/apiserver/secret-gardener-apiserver-encryption-config.yaml") . | sha256sum }}
         {{- end }}
         checksum/secret-gardener-apiserver-kubeconfig: {{ include (print $.Template.BasePath "/apiserver/secret-kubeconfig.yaml") . | sha256sum }}
-        {{- if .Values.global.apiserver.admissionConfig }}
+        {{- if (include "gardener-apiserver.hasAdmissionPlugins" .) }}
         checksum/configmap-gardener-apiserver-admission-config: {{ include (print $.Template.BasePath "/apiserver/configmap-admission-config.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.global.apiserver.podAnnotations }}
@@ -79,7 +79,7 @@ spec:
         imagePullPolicy: {{ .Values.global.apiserver.image.pullPolicy }}
         command:
         - /gardener-apiserver
-        {{- if .Values.global.apiserver.admissionConfig }}
+        {{- if (include "gardener-apiserver.hasAdmissionPlugins" .) }}
         - --admission-control-config-file=/etc/gardener-apiserver/admission/configuration.yaml
         {{- end }}
         {{- if .Values.global.apiserver.audit.dynamicConfiguration }}
@@ -266,9 +266,17 @@ spec:
         - name: gardener-audit-webhook-config
           mountPath: /etc/gardener-apiserver/auditwebhook
         {{- end }}
-        {{- if .Values.global.apiserver.admissionConfig }}
+        {{- if (include "gardener-apiserver.hasAdmissionPlugins" .) }}
         - name: gardener-apiserver-admission-config
           mountPath: /etc/gardener-apiserver/admission
+        {{- end }}
+        {{- if (include "gardener-apiserver.hasAdmissionKubeconfig" .) }}
+        - name: gardener-apiserver-admission-kubeconfig
+          mountPath: /var/run/secrets/admission-kubeconfig
+        {{- end }}
+        {{- if (include "gardener-apiserver.hasWebhookTokens" .) }}
+        - name: gardener-apiserver-admission-tokens
+          mountPath: /var/run/secrets/admission-tokens
         {{- end }}
       {{- if .Values.global.apiserver.etcd.useSidecar }}
       - name: etcd
@@ -331,10 +339,32 @@ spec:
         secret:
           secretName: gardener-audit-webhook-config
       {{- end }}
-      {{- if .Values.global.apiserver.admissionConfig }}
+      {{- if (include "gardener-apiserver.hasAdmissionPlugins" .) }}
       - name: gardener-apiserver-admission-config
         configMap:
           name: gardener-apiserver-admission-config
+      {{- end }}
+      {{- if (include "gardener-apiserver.hasAdmissionKubeconfig" .) }}
+      - name: gardener-apiserver-admission-kubeconfig
+        secret:
+          secretName: gardener-apiserver-admission-kubeconfig
+      {{- end }}
+      {{- if (include "gardener-apiserver.hasWebhookTokens" .) }}
+      - name: gardener-apiserver-admission-tokens
+        projected:
+          sources:
+          {{- if .Values.global.apiserver.admission.validatingWebhook.token.enabled }}
+          - serviceAccountToken:
+              path: validating-webhook-token
+              expirationSeconds: {{ .Values.global.apiserver.admission.validatingWebhook.token.expirationSeconds }}
+              audience: {{ .Values.global.apiserver.admission.validatingWebhook.token.audience }}
+          {{- end }}
+          {{- if .Values.global.apiserver.admission.mutatingWebhook.token.enabled }}
+          - serviceAccountToken:
+              path: mutating-webhook-token
+              expirationSeconds: {{ .Values.global.apiserver.admission.mutatingWebhook.token.expirationSeconds }}
+              audience: {{ .Values.global.apiserver.admission.mutatingWebhook.token.audience }}
+          {{- end }}
       {{- end }}
 {{- if .Values.global.apiserver.etcd.useSidecar }}
 ---

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/secret-admission-kubeconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/secret-admission-kubeconfig.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.global.apiserver.enabled (include "gardener-apiserver.hasAdmissionKubeconfig" .) }}
+{{- with .Values.global.apiserver.admission }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gardener-apiserver-admission-kubeconfig
+  namespace: garden
+  labels:
+    app: gardener
+    role: apiserver
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+type: Opaque
+data:
+  {{- if .validatingWebhook.kubeconfig }}
+  validating-webhook: {{ .validatingWebhook.kubeconfig | b64enc }}
+  {{- end }}
+  {{- if .mutatingWebhook.kubeconfig }}
+  mutating-webhook: {{ .mutatingWebhook.kubeconfig | b64enc }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/gardener/controlplane/values-test.yaml
+++ b/charts/gardener/controlplane/values-test.yaml
@@ -1,3 +1,40 @@
 global:
   apiserver:
     clusterIdentity: garden-cluster-identity
+    admission:
+      validatingWebhook: # validation webhook plugin configuration
+        # see https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers
+        # The path where the service account token is mounted via service account token projection is
+        # /var/run/secrets/admission-tokens/validating-webhook-token
+
+        kubeconfig: |
+          apiVersion: v1
+          kind: Config
+          users:
+          - name: '*'
+            user:
+              tokenFile: /var/run/secrets/admission-tokens/validating-webhook-token
+        token:
+          # if enabled, Service Account Token Projection is used to generate the token.
+          # if disabled, a static configuration should be provided in the kubeconfig configuration from above.
+          enabled: true
+          audience: validating-webhook
+          expirationSeconds: 3600
+      mutatingWebhook: # mutating webhook plugin configuration
+        # see https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers
+        # The path where the service account token is mounted via service account token projection is
+        # /var/run/secrets/admission-tokens/mutating-webhook-token
+
+        kubeconfig: |
+          apiVersion: v1
+          kind: Config
+          users:
+          - name: '*'
+            user:
+              tokenFile: /var/run/secrets/admission-tokens/mutating-webhook-token
+        token:
+          # if enabled, Service Account Token Projection is used to generate the token.
+          # if disabled, a static configuration should be provided in the kubeconfig configuration from above.
+          enabled: true
+          audience: mutating-webhook
+          expirationSeconds: 3600

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -79,8 +79,55 @@ global:
     featureGates: {}
   # enableAdmissionPlugins: [] # List of admission plugins to be enabled in addition to default enabled ones.
   # disableAdmissionPlugins: [] # List of admission plugins that should be disabled although they are in the default enabled plugins list.
-  # admissionConfig: |
-  #   configuration for the admission plugins. See example/20-admissionconfiguration.yaml
+    admission:
+      plugins: []
+      # plugins: # list of admission plugins. Mutation and Validation admission plugins must not be added.
+      # - name: ShootTolerationRestriction
+      #   configuration:
+      #     apiVersion: shoottolerationrestriction.admission.gardener.cloud/v1alpha1
+      #     kind: Configuration
+      #     defaults:
+      #     - key: foo
+      #     whitelist:
+      #     - key: foo
+      #     - key: bar
+      #       value: baz
+      validatingWebhook: # validation webhook plugin configuration
+        # see https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers
+        # The path where the service account token is mounted via service account token projection is
+        # /var/run/secrets/admission-tokens/validating-webhook-token
+
+        # kubeconfig: |
+        #   apiVersion: v1
+        #   kind: Config
+        #   users:
+        #   - name: '*'
+        #     user:
+        #       tokenFile: /var/run/secrets/admission-tokens/validating-webhook-token
+        token:
+          # if enabled, Service Account Token Projection is used to generate the token.
+          # if disabled, a static configuration should be provided in the kubeconfig configuration from above.
+          enabled: false
+          audience: validating-webhook
+          expirationSeconds: 3600
+      mutatingWebhook: # mutating webhook plugin configuration
+        # see https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers
+        # The path where the service account token is mounted via service account token projection is
+        # /var/run/secrets/admission-tokens/mutating-webhook-token
+
+        # kubeconfig: |
+        #   apiVersion: v1
+        #   kind: Config
+        #   users:
+        #   - name: '*'
+        #     user:
+        #       tokenFile: /var/run/secrets/admission-tokens/mutating-webhook-token
+        token:
+          # if enabled, Service Account Token Projection is used to generate the token.
+          # if disabled, a static configuration should be provided in the kubeconfig configuration from above.
+          enabled: false
+          audience: mutating-webhook
+          expirationSeconds: 3600
     vpa: false
     hvpa:
       enabled: false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area security
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Gardener API server can now optionally use [authentication](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers) when talking to Mutating/Validating webhook endpoints. If enabled, [Service Account Token Volume Projection](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) is used to generate tokens which are send to webhooks.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
`global.apiserver.admissionConfig` configuration of `charts/gardener/controlplane` is no longer used. Existing plugin configuration must be migrated to use the new `global.apiserver.admission.plugins` list. `ValidatingAdmissionWebhook` or `MutatingAdmissionWebhook` plugins must not be used.
```

```noteworthy operator
`global.apiserver.admission.plugins` can now be used to configure admission plugins of the Gardener API Server. ValidatingAdmissionWebhook` or `MutatingAdmissionWebhook` plugins must not be used.
```

```noteworthy operator
`global.apiserver.admission.validatingWebhook` and `global.apiserver.admission.mutatingWebhook` can now be used to configure validating/mutating admission plugins of the Gardener API Server. If enabled, [Service Account Token Volume Projection](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) is could be used to generate tokens which are used for authentication against webhooks.
```
