### PR TITLE
Fix seed bootstrap for new seeds

### DIFF
--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -525,7 +525,7 @@ func DeleteOldLoggingStack(ctx context.Context, k8sClient client.Client, namespa
 	}
 
 	for _, resource := range resources {
-		if err := k8sClient.Delete(ctx, resource); client.IgnoreNotFound(err) != nil {
+		if err := k8sClient.Delete(ctx, resource); client.IgnoreNotFound(err) != nil && !meta.IsNoMatchError(err) {
 			return err
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority critical

**What this PR does / why we need it**:
This PR fixes the seed bootstrap procedure for new seed clusters that are registered manually or shooted seed clusters for which the shoot doesn't enable VPA.

**Special notes for your reviewer**:
Many thanks to @Diaphteiros for reporting this issue.

/cc @vlvasilev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issues has been fixed which prevented the bootstrapping of new seed clusters.
```
