### PR TITLE
[Release-v1.8] Prepare hotfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.14.5 AS builder
+FROM golang:1.14.7 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
@@ -52,6 +52,9 @@ spec:
       serviceAccountName: fluent-bit
       automountServiceAccountToken: true
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       volumes:
       - name: config
         configMap:

--- a/pkg/gardenlet/controller/federatedseed/extensions/artifact.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/artifact.go
@@ -60,7 +60,7 @@ func newControllerArtifacts() controllerArtifacts {
 
 	gvk := dnsv1alpha1.SchemeGroupVersion.WithKind(dnsv1alpha1.DNSProviderKind)
 	a.registerExtensionControllerArtifacts(
-		newControllerInstallationArtifact(gvk, &dnsv1alpha1.DNSProviderList{}, func(newObj, oldObj interface{}) bool {
+		newControllerInstallationArtifact(gvk, func() runtime.Object { return &dnsv1alpha1.DNSProviderList{} }, func(newObj, oldObj interface{}) bool {
 			var (
 				newExtensionObj, ok1 = newObj.(*dnsv1alpha1.DNSProvider)
 				oldExtensionObj, ok2 = oldObj.(*dnsv1alpha1.DNSProvider)
@@ -72,55 +72,55 @@ func newControllerArtifacts() controllerArtifacts {
 
 	gvk = extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.BackupBucketResource)
 	a.registerExtensionControllerArtifacts(
-		newControllerInstallationArtifact(gvk, &extensionsv1alpha1.BackupBucketList{}, extensionTypeChanged),
+		newControllerInstallationArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.BackupBucketList{} }, extensionTypeChanged),
 		disabledArtifact(),
 	)
 
 	gvk = extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.BackupEntryResource)
 	a.registerExtensionControllerArtifacts(
-		newControllerInstallationArtifact(gvk, &extensionsv1alpha1.BackupEntryList{}, extensionTypeChanged),
-		newStateArtifact(gvk, &extensionsv1alpha1.BackupEntry{}, extensionStateOrResourcesChanged),
+		newControllerInstallationArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.BackupEntryList{} }, extensionTypeChanged),
+		newStateArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.BackupEntry{} }, extensionStateOrResourcesChanged),
 	)
 
 	gvk = extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.ContainerRuntimeResource)
 	a.registerExtensionControllerArtifacts(
-		newControllerInstallationArtifact(gvk, &extensionsv1alpha1.ContainerRuntimeList{}, extensionTypeChanged),
-		newStateArtifact(gvk, &extensionsv1alpha1.ContainerRuntime{}, extensionStateOrResourcesChanged),
+		newControllerInstallationArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.ContainerRuntimeList{} }, extensionTypeChanged),
+		newStateArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.ContainerRuntime{} }, extensionStateOrResourcesChanged),
 	)
 
 	gvk = extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.ControlPlaneResource)
-	a.registerExtensionControllerArtifacts(newControllerInstallationArtifact(gvk, &extensionsv1alpha1.ControlPlaneList{}, extensionTypeChanged),
-		newStateArtifact(gvk, &extensionsv1alpha1.ControlPlane{}, extensionStateOrResourcesChanged),
+	a.registerExtensionControllerArtifacts(newControllerInstallationArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.ControlPlaneList{} }, extensionTypeChanged),
+		newStateArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.ControlPlane{} }, extensionStateOrResourcesChanged),
 	)
 
 	gvk = extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.ExtensionResource)
 	a.registerExtensionControllerArtifacts(
-		newControllerInstallationArtifact(gvk, &extensionsv1alpha1.ExtensionList{}, extensionTypeChanged),
-		newStateArtifact(gvk, &extensionsv1alpha1.Extension{}, extensionStateOrResourcesChanged),
+		newControllerInstallationArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.ExtensionList{} }, extensionTypeChanged),
+		newStateArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.Extension{} }, extensionStateOrResourcesChanged),
 	)
 
 	gvk = extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.InfrastructureResource)
 	a.registerExtensionControllerArtifacts(
-		newControllerInstallationArtifact(gvk, &extensionsv1alpha1.InfrastructureList{}, extensionTypeChanged),
-		newStateArtifact(gvk, &extensionsv1alpha1.Infrastructure{}, extensionStateOrResourcesChanged),
+		newControllerInstallationArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.InfrastructureList{} }, extensionTypeChanged),
+		newStateArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.Infrastructure{} }, extensionStateOrResourcesChanged),
 	)
 
 	gvk = extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.NetworkResource)
 	a.registerExtensionControllerArtifacts(
-		newControllerInstallationArtifact(gvk, &extensionsv1alpha1.NetworkList{}, extensionTypeChanged),
-		newStateArtifact(gvk, &extensionsv1alpha1.Network{}, extensionStateOrResourcesChanged),
+		newControllerInstallationArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.NetworkList{} }, extensionTypeChanged),
+		newStateArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.Network{} }, extensionStateOrResourcesChanged),
 	)
 
 	gvk = extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.OperatingSystemConfigResource)
 	a.registerExtensionControllerArtifacts(
-		newControllerInstallationArtifact(gvk, &extensionsv1alpha1.OperatingSystemConfigList{}, extensionTypeChanged),
-		newStateArtifact(gvk, &extensionsv1alpha1.OperatingSystemConfig{}, extensionStateOrResourcesChanged),
+		newControllerInstallationArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.OperatingSystemConfigList{} }, extensionTypeChanged),
+		newStateArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.OperatingSystemConfig{} }, extensionStateOrResourcesChanged),
 	)
 
 	gvk = extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.WorkerResource)
 	a.registerExtensionControllerArtifacts(
-		newControllerInstallationArtifact(gvk, &extensionsv1alpha1.WorkerList{}, extensionTypeChanged),
-		newStateArtifact(gvk, &extensionsv1alpha1.Worker{}, extensionStateOrResourcesChanged),
+		newControllerInstallationArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.WorkerList{} }, extensionTypeChanged),
+		newStateArtifact(gvk, func() runtime.Object { return &extensionsv1alpha1.Worker{} }, extensionStateOrResourcesChanged),
 	)
 
 	return a
@@ -170,10 +170,10 @@ func (c *controllerArtifacts) shutdownQueues() {
 	}
 }
 
-func newControllerInstallationArtifact(gvk schema.GroupVersionKind, list runtime.Object, fn predicateFn) *artifact {
+func newControllerInstallationArtifact(gvk schema.GroupVersionKind, newObjFunc func() runtime.Object, fn predicateFn) *artifact {
 	a := &artifact{
 		gvk:       gvk,
-		newFunc:   func() runtime.Object { return list },
+		newFunc:   newObjFunc,
 		queue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), fmt.Sprintf("controllerinstallation-extension-%s", gvk.Kind)),
 		predicate: fn,
 	}
@@ -189,10 +189,10 @@ func newControllerInstallationArtifact(gvk schema.GroupVersionKind, list runtime
 	return a
 }
 
-func newStateArtifact(gvk schema.GroupVersionKind, obj runtime.Object, fn predicateFn) *artifact {
+func newStateArtifact(gvk schema.GroupVersionKind, newObjFunc func() runtime.Object, fn predicateFn) *artifact {
 	a := &artifact{
 		gvk:       gvk,
-		newFunc:   func() runtime.Object { return obj },
+		newFunc:   newObjFunc,
 		queue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), fmt.Sprintf("shootstate-%s", gvk.Kind)),
 		predicate: fn,
 	}

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -118,7 +118,7 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 			Fn: flow.TaskFn(botanist.Shoot.Components.ControlPlane.KubeAPIServerService.Deploy).
 				RetryUntilTimeout(defaultInterval, defaultTimeout).
 				SkipIf(o.Shoot.HibernationEnabled && !useSNI),
-			Dependencies: flow.NewTaskIDs(deployNamespace),
+			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootClusterIdentity),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying Kubernetes API server service SNI settings in the Seed cluster",
@@ -331,7 +331,7 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 		nginxLBReady = g.Add(flow.Task{
 			Name:         "Waiting until nginx ingress LoadBalancer is ready",
 			Fn:           flow.TaskFn(botanist.WaitUntilNginxIngressServiceIsReady).DoIf(botanist.Shoot.NginxIngressEnabled()).SkipIf(o.Shoot.HibernationEnabled),
-			Dependencies: flow.NewTaskIDs(deployManagedResources, initializeShootClients, waitUntilWorkerReady),
+			Dependencies: flow.NewTaskIDs(deployManagedResources, initializeShootClients, waitUntilWorkerReady, ensureShootClusterIdentity),
 		})
 		ensureIngressDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Ensuring nginx ingress DNS record",

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -525,7 +525,7 @@ func DeleteOldLoggingStack(ctx context.Context, k8sClient client.Client, namespa
 	}
 
 	for _, resource := range resources {
-		if err := k8sClient.Delete(ctx, resource); client.IgnoreNotFound(err) != nil {
+		if err := k8sClient.Delete(ctx, resource); client.IgnoreNotFound(err) != nil && !meta.IsNoMatchError(err) {
 			return err
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority normal

**What this PR does / why we need it**:
Cherry-Picks for `release-v1.8` branch.

3b6d6cf59fea435a5e9d48c1e4d789aa6cf73c53
c4d4395aa608415a612d33730eb58b9ff6f18906
3b7b1548994725177fafc38b7593b358a82b6853
9c7f879a34c18626406a6f9fbcc3c8a3da6f3494
4ea921c222998280f31a8ed78cab229aedd66b82

**Special notes for your reviewer**:
/cc @rfranzke

**Release note**:

```improvement operator #2679 @plkokanov
Objects into which  `controllerinstallations` and `extensions` are retrieved during reconciliation by the ControllerInstallation controller and ShootState Sync controller are now created for each reconciliation, instead of the same object being reused multiple times per resource kind.
```

```improvement operator #2678 @timuthy 
An issue has been fixed which caused the Gardenlet to exit ungracefully due to the missing shoot cluster identify in the `.status`.
```

```improvement operator #2671 @einfachnuralex 
The fluent-bit DaemonSet is now tolerating the taint `node-role.kubernetes.io/master` with effect `NoSchedule`.
```