### PR TITLE
Ensure cluster identity in deletion flow

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -128,7 +128,7 @@ func (b *Botanist) EnsureClusterIdentity(ctx context.Context) error {
 	}
 
 	latestShoot := &gardencorev1beta1.Shoot{}
-	if err := b.K8sGardenClient.Client().Get(ctx, kutil.Key(b.Shoot.Info.Namespace, b.Shoot.Info.Name), latestShoot); err != nil {
+	if err := b.K8sGardenClient.DirectClient().Get(ctx, kutil.Key(b.Shoot.Info.Namespace, b.Shoot.Info.Name), latestShoot); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority critical

**What this PR does / why we need it**:
The cluster identity is required to ensure the kube-apiserver service, but it wasn't computed in shoot deletion flow. Hence, if a shoot already has a deletion timestamp and Gardener v1.8 gets deployed then the Gardenlet will panic because the cluster identity is missing:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x18ac35d]
goroutine 59999 [running]:
github.com/gardener/gardener/pkg/operation/botanist.(*Botanist).setAPIServerAddress(0xc00a0d0bd0, 0xc00c868af0, 0x4a, 0x2084b80, 0xc00e67b110)
	/go/src/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go:1416 +0x80d
github.com/gardener/gardener/pkg/operation/botanist.(*Botanist).DefaultKubeAPIServerService.func1(0xc00c868af0, 0x4a)
	/go/src/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go:1363 +0x77
github.com/gardener/gardener/pkg/operation/botanist/controlplane.(*kubeAPIService).Wait.func1(0x206eec0, 0xc0270f53e0, 0xc01bcce950, 0xc00a567ab0, 0x13fc637)
	/go/src/github.com/gardener/gardener/pkg/operation/botanist/controlplane/kube_apiserver_service.go:143 +0x1c1
github.com/gardener/gardener/pkg/utils/retry.UntilFor(0x206eec0, 0xc0270f53e0, 0xc020e72e40, 0x2059000, 0xc01bcce950, 0xc01d4d4b70, 0x1be8680, 0xc0270f5301)
	/go/src/github.com/gardener/gardener/pkg/utils/retry/retry.go:146 +0x3e
github.com/gardener/gardener/pkg/utils/retry.(*ops).Until(0xc0002e5ce0, 0x206eec0, 0xc0270f53e0, 0x12a05f200, 0xc01d4d4b70, 0xc01bcce940, 0x1)
	/go/src/github.com/gardener/gardener/pkg/utils/retry/retry.go:190 +0xa2
github.com/gardener/gardener/pkg/operation/botanist/controlplane.(*kubeAPIService).Wait(0xc00e2a03f0, 0x206eec0, 0xc0270f53e0, 0x0, 0x0)
	/go/src/github.com/gardener/gardener/pkg/operation/botanist/controlplane/kube_apiserver_service.go:136 +0x18a
github.com/gardener/gardener/pkg/operation/botanist/component.(*deploy).Deploy(0xc01f9748a0, 0x206ee80, 0xc000058018, 0x0, 0x0)
	/go/src/github.com/gardener/gardener/pkg/operation/botanist/component/deploy.go:72 +0xf4
github.com/gardener/gardener/pkg/operation/botanist.(*Botanist).WakeUpControlPlane(0xc00a0d0bd0, 0x206ee80, 0xc000058018, 0x2ad340ce, 0xc00f71e710)
	/go/src/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go:335 +0x32c
github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode.func1(0xc01620ede0, 0x1dadfaa, 0x3d, 0x206ee80, 0xc000058018)
	/go/src/github.com/gardener/gardener/pkg/utils/flow/flow.go:218 +0x1d4
created by github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode
	/go/src/github.com/gardener/gardener/pkg/utils/flow/flow.go:213 +0x14d
runtime: note: your Linux kernel may be buggy
runtime: note: see https://golang.org/wiki/LinuxKernelSignalVectorBug
runtime: note: mlock workaround for kernel bug failed with errno 12
```

/cc @timuthy 
/assign @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug has been fixed which could cause a nil pointer exception in case the v1.8 Gardenlet tries to delete a shoot that wasn't reconciled yet.
```
