### PR TITLE
[GEP-7] Don't add entries with empty data in ShootState

### DIFF
--- a/pkg/operation/shootsecrets/secrets_manager.go
+++ b/pkg/operation/shootsecrets/secrets_manager.go
@@ -271,12 +271,6 @@ func (s *SecretsManager) generateInfoDataAndUpdateResourceList(secretConfig secr
 	if err != nil {
 		return err
 	}
-
-	// No data was generated, means that nothing should be saved in the ShootState
-	if data == nil {
-		return nil
-	}
-
 	return infodata.UpsertInfoData(&s.GardenerResourceDataList, secretConfig.GetName(), data)
 }
 

--- a/pkg/operation/shootsecrets/secrets_manager_test.go
+++ b/pkg/operation/shootsecrets/secrets_manager_test.go
@@ -116,10 +116,16 @@ var _ = Describe("SecretsManager", func() {
 				},
 			},
 			caName: {
-				Data: map[string][]byte{},
+				Data: map[string][]byte{
+					secrets.DataKeyCertificateCA: []byte(cacert),
+					secrets.DataKeyPrivateKeyCA:  []byte(cakey),
+				},
 			},
 			certName: {
-				Data: map[string][]byte{},
+				Data: map[string][]byte{
+					fmt.Sprintf("%s.crt", certName): []byte(cacert),
+					fmt.Sprintf("%s.key", certName): []byte(cakey),
+				},
 			},
 		}
 	})

--- a/pkg/utils/infodata/infodata.go
+++ b/pkg/utils/infodata/infodata.go
@@ -69,6 +69,10 @@ func GetInfoData(resourceDataList gardencorev1alpha1helper.GardenerResourceDataL
 
 // UpsertInfoData updates or inserts an InfoData object into the GardenerResourceDataList
 func UpsertInfoData(resourceDataList *gardencorev1alpha1helper.GardenerResourceDataList, name string, data InfoData) error {
+	if _, ok := data.(*emptyInfoData); ok {
+		return nil
+	}
+
 	bytes, err := data.Marshal()
 	if err != nil {
 		return err

--- a/pkg/utils/infodata/infodata_test.go
+++ b/pkg/utils/infodata/infodata_test.go
@@ -144,6 +144,14 @@ var _ = Describe("InfoData", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(gardenerResourceDataList)).To(Equal(1))
 			})
+
+			It("should not do anything if provided infodata is emptyInfoData", func() {
+				gardenerResourceDataList := gardencorev1alpha1helper.GardenerResourceDataList([]gardencorev1alpha1.GardenerResourceData{})
+
+				err := UpsertInfoData(&gardenerResourceDataList, "emptyData", EmptyInfoData)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(gardenerResourceDataList)).To(Equal(0))
+			})
 		})
 	})
 })

--- a/pkg/utils/infodata/types.go
+++ b/pkg/utils/infodata/types.go
@@ -35,3 +35,16 @@ type InfoData interface {
 type Loader interface {
 	LoadFromSecretData(map[string][]byte) (InfoData, error)
 }
+
+type emptyInfoData struct{}
+
+func (*emptyInfoData) Marshal() ([]byte, error) {
+	return nil, nil
+}
+
+func (*emptyInfoData) TypeVersion() TypeVersion {
+	return ""
+}
+
+// EmptyInfoData is an infodata which does not contain any information.
+var EmptyInfoData = &emptyInfoData{}

--- a/pkg/utils/secrets/control_plane.go
+++ b/pkg/utils/secrets/control_plane.go
@@ -71,7 +71,7 @@ func (s *ControlPlaneSecretConfig) GenerateInfoData() (infodata.InfoData, error)
 	}
 
 	if len(cert.PrivateKeyPEM) == 0 && len(cert.CertificatePEM) == 0 {
-		return nil, nil
+		return infodata.EmptyInfoData, nil
 	}
 
 	return NewCertificateInfoData(cert.PrivateKeyPEM, cert.CertificatePEM), nil
@@ -115,6 +115,10 @@ func (s *ControlPlaneSecretConfig) GenerateFromInfoData(infoData infodata.InfoDa
 func (s *ControlPlaneSecretConfig) LoadFromSecretData(secretData map[string][]byte) (infodata.InfoData, error) {
 	privateKeyPEM := secretData[fmt.Sprintf("%s.key", s.Name)]
 	certificatePEM := secretData[fmt.Sprintf("%s.crt", s.Name)]
+
+	if len(privateKeyPEM) == 0 && len(certificatePEM) == 0 {
+		return infodata.EmptyInfoData, nil
+	}
 
 	return NewCertificateInfoData(privateKeyPEM, certificatePEM), nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Previously the ShootState contained entries which don't actually have any data e.g.: 
```
- data:
       certificate: null
       privateKey: null
   name: kubecfg
   type: certificate
```

This PR makes it so that when trying to extract infodata from existing secrets and the secrets do not contain any data which has to be saved, these empty entries are not added to the ShootState.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Entries with empty data are no longer added to the ShootState.
```
