### PR TITLE
Add VPA definitions for VPA components

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
@@ -77,10 +77,10 @@ spec:
 {{- end }}
         resources:
           limits:
-            cpu: 200m
+            cpu: 120m
             memory: 500Mi
           requests:
-            cpu: 50m
+            cpu: 30m
             memory: 200Mi
         ports:
         - containerPort: {{ .Values.admissionController.port }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-exporter.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-exporter.yaml
@@ -57,13 +57,11 @@ spec:
           protocol: TCP
         resources:
           requests:
-            cpu: 50m
-            memory: 200Mi
-{{ if not .Values.exporter.enableVPA }}
+            cpu: 30m
+            memory: 50Mi
           limits:
-            cpu: 500m
-            memory: 1Gi
-{{ end }}
+            cpu: 120m
+            memory: 200Mi
 {{- if not .Values.exporter.enableServiceAccount }}
       volumes:
       - name: vpa-exporter

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
@@ -59,11 +59,11 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            cpu: 200m
-            memory: 1000Mi
-          requests:
-            cpu: 50m
+            cpu: 120m
             memory: 500Mi
+          requests:
+            cpu: 30m
+            memory: 200Mi
         ports:
         - containerPort: 8080
 {{- if not .Values.recommender.enableServiceAccount }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
@@ -60,11 +60,11 @@ spec:
 {{- end }}
         resources:
           limits:
-            cpu: 200m
-            memory: 1000Mi
-          requests:
-            cpu: 50m
+            cpu: 120m
             memory: 500Mi
+          requests:
+            cpu: 30m
+            memory: 200Mi
         ports:
         - containerPort: 8080
 {{- if not .Values.updater.enableServiceAccount }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/vpa-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/vpa-admission-controller.yaml
@@ -1,14 +1,14 @@
-{{- if .Values.exporter.enabled  }}
+{{- if .Values.admissionController.enabled }}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
-  name: vpa-exporter-vpa
+  name: vpa-admission-controller
   namespace: {{ .Release.Namespace }}
 spec:
   targetRef:
     apiVersion: {{ include "deploymentversion" . }}
     kind: Deployment
-    name: vpa-exporter
+    name: vpa-admission-controller
   updatePolicy:
     updateMode: "Auto"
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/vpa-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/vpa-recommender.yaml
@@ -1,14 +1,14 @@
-{{- if .Values.exporter.enabled  }}
+{{- if .Values.recommender.enabled }}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
-  name: vpa-exporter-vpa
+  name: vpa-recommender
   namespace: {{ .Release.Namespace }}
 spec:
   targetRef:
     apiVersion: {{ include "deploymentversion" . }}
     kind: Deployment
-    name: vpa-exporter
+    name: vpa-recommender
   updatePolicy:
     updateMode: "Auto"
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/vpa-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/vpa-updater.yaml
@@ -1,14 +1,14 @@
-{{- if .Values.exporter.enabled  }}
+{{- if .Values.updater.enabled }}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
-  name: vpa-exporter-vpa
+  name: vpa-updater
   namespace: {{ .Release.Namespace }}
 spec:
   targetRef:
     apiVersion: {{ include "deploymentversion" . }}
     kind: Deployment
-    name: vpa-exporter
+    name: vpa-updater
   updatePolicy:
     updateMode: "Auto"
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/values.yaml
+++ b/charts/seed-bootstrap/charts/vpa/values.yaml
@@ -26,7 +26,6 @@ exporter:
   podAnnotations: {}
   podLabels: {}
   enableServiceAccount: true
-  enableVPA: true
   enableService: true
   port: 9570
   servicePort: 9570


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/priority normal
/exp intermediate
/topology seed
/platform all

**What this PR does / why we need it**:
This PR adds missing VPA definitions for the VPA components themselves so that they get auto-scaled as well.

**Which issue(s) this PR fixes**:
Fixes #2684

**Special notes for your reviewer**:
I removed the `enableVPA` chart value as it was always set to `true`. Also, I reduced the requests/limits according to observations on larger landscapes.
/invite @wyb1 @amshuman-kr @ggaurav10 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The VPA components in the seed are now vertically auto-scaled as well.
```
