### PR TITLE
Add VPA control plane health check

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: vpa-admission-controller
-{{ toYaml .Values.labels | indent 4 }}
+{{ toYaml .Values.deploymentLabels | indent 4 }}
 spec:
   replicas: {{ .Values.admissionController.replicas }}
   revisionHistoryLimit: 0

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-exporter.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-exporter.yaml
@@ -3,11 +3,11 @@
 apiVersion: {{ include "deploymentversion" . }}
 kind: Deployment
 metadata:
-  labels:
-    app: vpa-exporter
-{{ toYaml .Values.labels | indent 4 }}
   name: vpa-exporter
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: vpa-exporter
+{{ toYaml .Values.deploymentLabels | indent 4 }}
 spec:
   replicas: {{ .Values.exporter.replicas }}
   revisionHistoryLimit: 0

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: vpa-recommender
-{{ toYaml .Values.labels | indent 4 }}
+{{ toYaml .Values.deploymentLabels | indent 4 }}
 spec:
   replicas: {{ .Values.recommender.replicas }}
   revisionHistoryLimit: 0

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: vpa-updater
-{{ toYaml .Values.labels | indent 4 }}
+{{ toYaml .Values.deploymentLabels | indent 4 }}
 spec:
   replicas: {{ .Values.updater.replicas }}
   revisionHistoryLimit: 0

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -78,6 +78,15 @@ const (
 	// the kube-state-metrics-seed pod.
 	DeploymentNameKubeStateMetricsSeed = "kube-state-metrics-seed"
 
+	// DeploymentNameVPAAdmissionController is a constant for the name of the VPA admission controller deployment.
+	DeploymentNameVPAAdmissionController = "vpa-admission-controller"
+	// DeploymentNameVPAExporter is a constant for the name of the VPA exporter deployment.
+	DeploymentNameVPAExporter = "vpa-exporter"
+	// DeploymentNameVPARecommender is a constant for the name of the VPA recommender deployment.
+	DeploymentNameVPARecommender = "vpa-recommender"
+	// DeploymentNameVPAUpdater is a constant for the name of the VPA updater deployment.
+	DeploymentNameVPAUpdater = "vpa-updater"
+
 	// StatefulSetNameAlertManager is a constant for the name of a Kubernetes stateful set object that contains
 	// the alertmanager pod.
 	StatefulSetNameAlertManager = "alertmanager"

--- a/pkg/apis/core/v1beta1/constants/utils.go
+++ b/pkg/apis/core/v1beta1/constants/utils.go
@@ -34,3 +34,12 @@ func getDeprecatedAnnotation(annotations map[string]string, annotationKey, depre
 
 	return val, ok
 }
+
+// GetShootVPADeploymentNames returns the names of all VPA related deployments related to shoot clusters.
+func GetShootVPADeploymentNames() []string {
+	return []string{
+		DeploymentNameVPAAdmissionController,
+		DeploymentNameVPARecommender,
+		DeploymentNameVPAUpdater,
+	}
+}

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -238,7 +238,7 @@ func (c *defaultCareControl) Care(shootObj *gardencorev1beta1.Shoot, key string)
 			)
 			return nil
 		},
-		// Fetch seed conditions of shoot is a seed
+		// Fetch seed conditions if shoot is a seed
 		func(ctx context.Context) error {
 			seedConditions, err = retrieveSeedConditions(ctx, botanist)
 			if err != nil {

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -266,6 +266,10 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 			"exporter":            exporter,
 			"recommender":         recommender,
 			"updater":             updater,
+			"deploymentLabels": map[string]interface{}{
+				v1beta1constants.GardenRole:           v1beta1constants.GardenRoleControlPlane,
+				v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
+			},
 		}
 	)
 

--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -265,6 +265,12 @@ func computeRequiredControlPlaneDeployments(
 		}
 	}
 
+	if gardencorev1beta1helper.ShootWantsVerticalPodAutoscaler(shoot) {
+		for _, vpaDeployment := range v1beta1constants.GetShootVPADeploymentNames() {
+			requiredControlPlaneDeployments.Insert(vpaDeployment)
+		}
+	}
+
 	return requiredControlPlaneDeployments, nil
 }
 

--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -26,6 +26,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	gardenerextensions "github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/logger"
@@ -40,6 +41,7 @@ import (
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -481,6 +483,7 @@ func (b *HealthChecker) CheckExtensionCondition(condition gardencorev1beta1.Cond
 
 // checkControlPlane checks whether the control plane of the Shoot cluster is healthy.
 func (b *Botanist) checkControlPlane(
+	ctx context.Context,
 	checker *HealthChecker,
 	condition gardencorev1beta1.Condition,
 	seedDeploymentLister kutil.DeploymentLister,
@@ -489,7 +492,23 @@ func (b *Botanist) checkControlPlane(
 	seedWorkerLister kutil.WorkerLister,
 	extensionConditions []ExtensionCondition,
 ) (*gardencorev1beta1.Condition, error) {
-	if exitCondition, err := checker.CheckControlPlane(b.Shoot.Info, b.Shoot.SeedNamespace, condition, seedDeploymentLister, seedEtcdLister, seedWorkerLister); err != nil || exitCondition != nil {
+	cluster, err := gardenerextensions.GetCluster(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace)
+	if err != nil {
+		msg := "failed to start control plane health check"
+		if apierrors.IsNotFound(err) {
+			msg = "control plane is not yet ready"
+		}
+		b.Logger.Errorf("%s: %v", msg, err)
+		return nil, errors.New(msg)
+	}
+	// Use shoot from cluster resource here because it reflects the actual or "active" spec to determine which health checks are required.
+	// With the "confineSpecUpdateRollout" feature enabled, shoot resources have a spec which is not yet active.
+	shoot := cluster.Shoot
+	if shoot == nil {
+		return nil, errors.New("failed to start control plane health check because shoot is not yet synced to cluster resource")
+	}
+
+	if exitCondition, err := checker.CheckControlPlane(shoot, b.Shoot.SeedNamespace, condition, seedDeploymentLister, seedEtcdLister, seedWorkerLister); err != nil || exitCondition != nil {
 		return exitCondition, err
 	}
 	if exitCondition, err := checker.CheckMonitoringControlPlane(b.Shoot.SeedNamespace, b.Shoot.GetPurpose() == gardencorev1beta1.ShootPurposeTesting, b.Shoot.WantsAlertmanager, condition, seedDeploymentLister, seedStatefulSetLister); err != nil || exitCondition != nil {
@@ -761,7 +780,7 @@ func (b *Botanist) healthChecks(
 		nodes = gardencorev1beta1helper.UpdatedConditionUnknownErrorMessage(nodes, message)
 		systemComponents = gardencorev1beta1helper.UpdatedConditionUnknownErrorMessage(systemComponents, message)
 
-		newControlPlane, err := b.checkControlPlane(checker, controlPlane, seedDeploymentLister, seedStatefulSetLister, seedEtcdLister, seedWorkerLister, extensionConditionsControlPlaneHealthy)
+		newControlPlane, err := b.checkControlPlane(ctx, checker, controlPlane, seedDeploymentLister, seedStatefulSetLister, seedEtcdLister, seedWorkerLister, extensionConditionsControlPlaneHealthy)
 		controlPlane = newConditionOrError(controlPlane, newControlPlane, err)
 		return apiserverAvailability, controlPlane, nodes, systemComponents
 	}
@@ -770,7 +789,7 @@ func (b *Botanist) healthChecks(
 		apiserverAvailability = b.checkAPIServerAvailability(checker, apiserverAvailability)
 		return nil
 	}, func(ctx context.Context) error {
-		newControlPlane, err := b.checkControlPlane(checker, controlPlane, seedDeploymentLister, seedStatefulSetLister, seedEtcdLister, seedWorkerLister, extensionConditionsControlPlaneHealthy)
+		newControlPlane, err := b.checkControlPlane(ctx, checker, controlPlane, seedDeploymentLister, seedStatefulSetLister, seedEtcdLister, seedWorkerLister, extensionConditionsControlPlaneHealthy)
 		controlPlane = newConditionOrError(controlPlane, newControlPlane, err)
 		return nil
 	}, func(ctx context.Context) error {

--- a/pkg/operation/botanist/health_check_test.go
+++ b/pkg/operation/botanist/health_check_test.go
@@ -233,9 +233,7 @@ var _ = Describe("health check", func() {
 
 		withVpaDeployments = func(deploys ...*appsv1.Deployment) []*appsv1.Deployment {
 			var deployments = make([]*appsv1.Deployment, 0, len(deploys))
-			for _, deploy := range deploys {
-				deployments = append(deployments, deploy)
-			}
+			deployments = append(deployments, deploys...)
 			for _, deploymentName := range v1beta1constants.GetShootVPADeploymentNames() {
 				deployments = append(deployments, newDeployment(seedNamespace, deploymentName, v1beta1constants.GardenRoleControlPlane, true))
 			}
@@ -1061,9 +1059,3 @@ var _ = Describe("health check", func() {
 			beConditionWithStatus(gardencorev1beta1.ConditionFalse)),
 	)
 })
-
-func deployments(deploys ...*appsv1.Deployment) []*appsv1.Deployment {
-	var deployments []*appsv1.Deployment
-	deployments = append(deployments, deploys...)
-	return deployments
-}

--- a/pkg/operation/botanist/health_check_test.go
+++ b/pkg/operation/botanist/health_check_test.go
@@ -158,6 +158,17 @@ func beConditionWithStatus(status gardencorev1beta1.ConditionStatus) types.Gomeg
 	}))
 }
 
+func beConditionWithMissingRequiredDeployment(deployments []*appsv1.Deployment) types.GomegaMatcher {
+	var names = make([]string, 0, len(deployments))
+	for _, deploy := range deployments {
+		names = append(names, deploy.Name)
+	}
+	return PointTo(MatchFields(IgnoreExtras, Fields{
+		"Status":  Equal(gardencorev1beta1.ConditionFalse),
+		"Message": ContainSubstring("%s", names),
+	}))
+}
+
 func beConditionWithStatusAndCodes(status gardencorev1beta1.ConditionStatus, codes ...gardencorev1beta1.ErrorCode) types.GomegaMatcher {
 	return PointTo(MatchFields(IgnoreExtras, Fields{
 		"Status": Equal(status),
@@ -193,6 +204,16 @@ var _ = Describe("health check", func() {
 			},
 		}
 
+		gcpShootWantsVPA = &gardencorev1beta1.Shoot{
+			Spec: gardencorev1beta1.ShootSpec{
+				Kubernetes: gardencorev1beta1.Kubernetes{
+					VerticalPodAutoscaler: &gardencorev1beta1.VerticalPodAutoscaler{
+						Enabled: true,
+					},
+				},
+			},
+		}
+
 		seedNamespace = "shoot--foo--bar"
 
 		// control plane deployments
@@ -208,6 +229,17 @@ var _ = Describe("health check", func() {
 			kubeControllerManagerDeployment,
 			kubeSchedulerDeployment,
 			clusterAutoscalerDeployment,
+		}
+
+		withVpaDeployments = func(deploys ...*appsv1.Deployment) []*appsv1.Deployment {
+			var deployments = make([]*appsv1.Deployment, 0, len(deploys))
+			for _, deploy := range deploys {
+				deployments = append(deployments, deploy)
+			}
+			for _, deploymentName := range v1beta1constants.GetShootVPADeploymentNames() {
+				deployments = append(deployments, newDeployment(seedNamespace, deploymentName, v1beta1constants.GardenRoleControlPlane, true))
+			}
+			return deployments
 		}
 
 		// control plane etcds
@@ -295,8 +327,24 @@ var _ = Describe("health check", func() {
 						State: gardencorev1beta1.LastOperationStateSucceeded}}}},
 			},
 			BeNil()),
-		Entry("missing required deployment",
-			gcpShoot,
+		Entry("all healthy (needs VPA)",
+			gcpShootWantsVPA,
+			"gcp",
+			withVpaDeployments(
+				gardenerResourceManagerDeployment,
+				kubeAPIServerDeployment,
+				kubeControllerManagerDeployment,
+				kubeSchedulerDeployment,
+			),
+			requiredControlPlaneEtcds,
+			[]*extensionsv1alpha1.Worker{
+				{Status: extensionsv1alpha1.WorkerStatus{DefaultStatus: extensionsv1alpha1.DefaultStatus{
+					LastOperation: &gardencorev1beta1.LastOperation{
+						State: gardencorev1beta1.LastOperationStateSucceeded}}}},
+			},
+			BeNil()),
+		Entry("missing required deployments",
+			gcpShootWantsVPA,
 			"gcp",
 			[]*appsv1.Deployment{
 				kubeAPIServerDeployment,
@@ -305,7 +353,7 @@ var _ = Describe("health check", func() {
 			},
 			requiredControlPlaneEtcds,
 			nil,
-			beConditionWithStatus(gardencorev1beta1.ConditionFalse)),
+			beConditionWithMissingRequiredDeployment(withVpaDeployments(gardenerResourceManagerDeployment))),
 		Entry("required deployment unhealthy",
 			gcpShoot,
 			"gcp",
@@ -1013,3 +1061,9 @@ var _ = Describe("health check", func() {
 			beConditionWithStatus(gardencorev1beta1.ConditionFalse)),
 	)
 })
+
+func deployments(deploys ...*appsv1.Deployment) []*appsv1.Deployment {
+	var deployments []*appsv1.Deployment
+	deployments = append(deployments, deploys...)
+	return deployments
+}

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -329,10 +329,10 @@ func DeleteHvpa(k8sClient kubernetes.Interface, namespace string) error {
 // DeleteVpa delete all resources required for the VPA in the given namespace.
 func DeleteVpa(ctx context.Context, c client.Client, namespace string, isShoot bool) error {
 	resources := []runtime.Object{
-		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "vpa-admission-controller", Namespace: namespace}},
-		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "vpa-exporter", Namespace: namespace}},
-		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "vpa-recommender", Namespace: namespace}},
-		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "vpa-updater", Namespace: namespace}},
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameVPAAdmissionController, Namespace: namespace}},
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameVPAExporter, Namespace: namespace}},
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameVPARecommender, Namespace: namespace}},
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameVPAUpdater, Namespace: namespace}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "vpa-webhook", Namespace: namespace}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "vpa-exporter", Namespace: namespace}},
 		&autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "vpa-exporter-vpa", Namespace: namespace}},

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -628,6 +628,9 @@ func BootstrapCluster(k8sGardenClient, k8sSeedClient kubernetes.Interface, seed 
 		"vpa": map[string]interface{}{
 			"enabled": vpaEnabled,
 			"runtime": map[string]interface{}{
+				"deploymentLabels": map[string]interface{}{
+					v1beta1constants.GardenRole: v1beta1constants.GardenRoleSeed,
+				},
 				"admissionController": map[string]interface{}{
 					"podAnnotations": map[string]interface{}{
 						"checksum/secret-vpa-tls-certs": utils.ComputeSHA256Hex(jsonString),

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -627,9 +627,11 @@ func BootstrapCluster(k8sGardenClient, k8sSeedClient kubernetes.Interface, seed 
 		"alertmanager": alertManagerConfig,
 		"vpa": map[string]interface{}{
 			"enabled": vpaEnabled,
-			"admissionController": map[string]interface{}{
-				"podAnnotations": map[string]interface{}{
-					"checksum/secret-vpa-tls-certs": utils.ComputeSHA256Hex(jsonString),
+			"runtime": map[string]interface{}{
+				"admissionController": map[string]interface{}{
+					"podAnnotations": map[string]interface{}{
+						"checksum/secret-vpa-tls-certs": utils.ComputeSHA256Hex(jsonString),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR enables health checks for VPA deployments belonging to a shoot cluster. It is visible as part of `.status.conditions[type=ControlPlaneHealthy]`.

**Which issue(s) this PR fixes**:
Fixes #2685

**Special notes for your reviewer**:
An issues with the VPA deployment in the seed bootstrap was fixed along the way. Due to the `runtime` and `application` split in https://github.com/gardener/gardener/pull/2478, configured `values` in the seed bootstrap were not respected anymore. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Control plane health checks have been added for VPA components of shoot clusters. These are executed regularly as soon as the shoot uses the Vertical-Pod-Autoscaling feature (https://github.com/gardener/gardener/blob/master/docs/usage/shoot_autoscaling.md#vertical-pod-auto-scaling).
```
