### PR TITLE
Fix kube-apiserver certificate when DNS is disabled

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -131,20 +131,20 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 			Dependencies: flow.NewTaskIDs(deployKubeAPIServerService),
 		})
 		loadSecrets = g.Add(flow.Task{
-			Name:         "Loading existing secrets into ShootState",
-			Fn:           flow.TaskFn(botanist.LoadExistingSecretsIntoShootState),
-			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootStateExists),
-		})
-		generateSecrets = g.Add(flow.Task{
-			Name: "Generating secrets and saving them into ShootState",
-			Fn:   flow.TaskFn(botanist.GenerateAndSaveSecrets),
+			Name: "Loading existing secrets into ShootState",
+			Fn:   flow.TaskFn(botanist.LoadExistingSecretsIntoShootState),
 			Dependencies: func() flow.TaskIDs {
-				taskIDs := flow.NewTaskIDs(deployNamespace, loadSecrets, ensureShootStateExists)
+				taskIDs := flow.NewTaskIDs(deployNamespace, ensureShootStateExists)
 				if !dnsEnabled && !o.Shoot.HibernationEnabled {
 					taskIDs.Insert(waitUntilKubeAPIServerServiceIsReady)
 				}
 				return taskIDs
 			}(),
+		})
+		generateSecrets = g.Add(flow.Task{
+			Name:         "Generating secrets and saving them into ShootState",
+			Fn:           flow.TaskFn(botanist.GenerateAndSaveSecrets),
+			Dependencies: flow.NewTaskIDs(deployNamespace, loadSecrets, ensureShootStateExists),
 		})
 		deploySecrets = g.Add(flow.Task{
 			Name:         "Deploying Shoot certificates / keys",


### PR DESCRIPTION
**How to categorize this PR?**
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
When DNS is disabled, the `kube-apiserver` certificate should contain the LoadBalancer address of the `kube-apiserver` service. This is broken with the current flow, I was able to reproduce it a few times in our OpenShift test cluster. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The fix introduces a dependency from the `loadSecrets` task to the `waitUntilKubeAPIServerServiceIsReady` in the reconciliation flow when DNS is disabled (or rather, moves that dependency from `generateSecrets` to `loadSecrets`). I tested the fix in our OpenShift test cluster and I wasn't able to reproduce the issue with it.

**Release note**:
```improvement operator
NONE
```
