### PR TITLE
Add etcds/finalizers to etcd-druid RBAC role

### DIFF
--- a/charts/seed-bootstrap/charts/etcd-druid/templates/druid-clusterrole.yaml
+++ b/charts/seed-bootstrap/charts/etcd-druid/templates/druid-clusterrole.yaml
@@ -75,6 +75,7 @@ rules:
   - druid.gardener.cloud
   resources:
   - etcds/status
+  - etcds/finalizers
   verbs:
   - get
   - update


### PR DESCRIPTION
**How to categorize this PR?**

/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
Adds `etcds/finalizers` to the `etcd-druid` RBAC role. This is needed on clusters where the [OwnerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) is enabled (on by default in all OpenShift clusters). Otherwise, the attempt to add an owner reference to the service with the etcd resource as an owner fails.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```
