### PR TITLE
Fix VPA deletion in both seed and shoot

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -24,7 +24,7 @@ images:
 - name: gardener-resource-manager
   sourceRepository: github.com/gardener/gardener-resource-manager
   repository: eu.gcr.io/gardener-project/gardener/gardener-resource-manager
-  tag: "v0.16.0"
+  tag: "v0.17.0"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/crd-verticalpodautoscalercheckpoints.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/crd-verticalpodautoscalercheckpoints.yaml
@@ -4,6 +4,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
+  annotations:
+    resources.gardener.cloud/keep-object: "true"
   labels:
 {{ toYaml .Values.labels | indent 4 }}
 spec:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/crd-verticalpodautoscalers.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/crd-verticalpodautoscalers.yaml
@@ -4,6 +4,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: verticalpodautoscalers.autoscaling.k8s.io
+  annotations:
+    resources.gardener.cloud/keep-object: "true"
   labels:
 {{ toYaml .Values.labels | indent 4 }}
 spec:

--- a/docs/usage/shoot_autoscaling.md
+++ b/docs/usage/shoot_autoscaling.md
@@ -44,5 +44,5 @@ The `Shoot` API allows to configure a few flags of the `vertical-pod-autoscaler`
 * `.spec.kubernetes.verticalPodAutoscaler.updaterInterval` is the interval how often the updater should run (default: `1m0s`).
 * `.spec.kubernetes.verticalPodAutoscaler.RecommenderInterval` is the interval how often metrics should be fetched (default: `1m0s`).
 
-⚠️ Please note that if you disable the VPA again then the related `CustomResourceDefintion`s will be removed from your shoot cluster.
-This will transitively also delete all existing `VerticalPodAutoscaler` objects, including those that might be created by you.
+⚠️ Please note that if you disable the VPA again then the related `CustomResourceDefinition`s will remain in your shoot cluster (although, nobody will act on them).
+This will also keep all existing `VerticalPodAutoscaler` objects in the system, including those that might be created by you. You can delete the `CustomResourceDefinition`s yourself using `kubectl delete crd` if you want to get rid of them.

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -335,7 +335,10 @@ func DeleteVpa(ctx context.Context, c client.Client, namespace string, isShoot b
 		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameVPAUpdater, Namespace: namespace}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "vpa-webhook", Namespace: namespace}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "vpa-exporter", Namespace: namespace}},
-		&autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "vpa-exporter-vpa", Namespace: namespace}},
+		&autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameVPAAdmissionController, Namespace: namespace}},
+		&autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameVPAExporter + "-vpa", Namespace: namespace}},
+		&autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameVPARecommender, Namespace: namespace}},
+		&autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameVPAUpdater, Namespace: namespace}},
 	}
 
 	if isShoot {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR fixes two bugs:
1. Deletion of VPA in seed did not clean up the newly introduced `VerticalPodAutoscaler` objects (#2696)
1. Deletion of VPA in shoot did clean up the `CustomResourceDefintion`s (which is especially bad if the shoot is used as seed cluster) - this was desired behaviour but comes with the downside that the (potentially many) `VerticalPodAutoscaler` objects get lost (FYI: I'm adding the new `resources.gardener.cloud/keep-object` annotation also for the CRDs in the seed even if they are not managed by the GRM yet (though, they will be managed by it in future, @timebertt is already working on it as part of #1633 and #1825)).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
When the VPA for shoots is disabled then the `CustomResourceDefinition`s are no longer deleted (they will remain in the system, together with all the `VerticalPodAutoscaler` objects - if you don't need them anymore you can remove them with `kubectl delete crd <crd-names>`).
```
``` noteworthy developer github.com/gardener/gardener-resource-manager #73 @rfranzke
The new `resources.gardener.cloud/keep-object` annotation can be used on resources managed by `ManagedResource` objects in order to keep them in the system in case they get removed from the `ManagedResource` or the `ManagedResource` itself is being deleted.
```