### PR TITLE
Nit: allow "make verify" to pass also with helm3

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
@@ -7,7 +7,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: vpa-admission-controller
+{{- if .Values.deploymentLabels }}
 {{ toYaml .Values.deploymentLabels | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.admissionController.replicas }}
   revisionHistoryLimit: 0

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-exporter.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-exporter.yaml
@@ -7,7 +7,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: vpa-exporter
+{{- if .Values.deploymentLabels }}
 {{ toYaml .Values.deploymentLabels | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.exporter.replicas }}
   revisionHistoryLimit: 0

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
@@ -7,7 +7,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: vpa-recommender
+{{- if .Values.deploymentLabels }}
 {{ toYaml .Values.deploymentLabels | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.recommender.replicas }}
   revisionHistoryLimit: 0

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: vpa-updater
+{{- if .Values.deploymentLabels }}
 {{ toYaml .Values.deploymentLabels | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.updater.replicas }}
   revisionHistoryLimit: 0


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind bug
/priority normal

**What this PR does / why we need it**:

`make verify`  on the current master throws a chart render error.

```
walk.go:74: found symbolic link in path: /Users/d060239/go/src/github.com/gardener/gardener/charts/seed-bootstrap/charts/loki/charts/utils-templates resolves to /Users/d060239/go/src/github.com/gardener/gardener/charts/utils-templates
walk.go:74: found symbolic link in path: /Users/d060239/go/src/github.com/gardener/gardener/charts/seed-bootstrap/charts/utils-templates resolves to /Users/d060239/go/src/github.com/gardener/gardener/charts/utils-templates
walk.go:74: found symbolic link in path: /Users/d060239/go/src/github.com/gardener/gardener/charts/seed-bootstrap/charts/vpa/charts/application/charts/utils-templates resolves to /Users/d060239/go/src/github.com/gardener/gardener/charts/utils-templates
walk.go:74: found symbolic link in path: /Users/d060239/go/src/github.com/gardener/gardener/charts/seed-bootstrap/charts/vpa/charts/application/values.yaml resolves to /Users/d060239/go/src/github.com/gardener/gardener/charts/seed-bootstrap/charts/vpa/values.yaml
walk.go:74: found symbolic link in path: /Users/d060239/go/src/github.com/gardener/gardener/charts/seed-bootstrap/charts/vpa/charts/runtime/charts/utils-templates resolves to /Users/d060239/go/src/github.com/gardener/gardener/charts/utils-templates
walk.go:74: found symbolic link in path: /Users/d060239/go/src/github.com/gardener/gardener/charts/seed-bootstrap/charts/vpa/charts/runtime/values.yaml resolves to /Users/d060239/go/src/github.com/gardener/gardener/charts/seed-bootstrap/charts/vpa/values.yaml
Error: YAML parse error on seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml: error converting YAML to JSON: yaml: line 9: could not find expected ':'

Use --debug flag to render out invalid YAML
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

@timuthy 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
