### PR TITLE
Change fluent-bit version to v.0.23.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -183,7 +183,7 @@ images:
 - name: fluent-bit
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.22.0"
+  tag: "v0.23.0"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-role.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-role.yaml
@@ -7,6 +7,10 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - namespaces
   - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - extensions.gardener.cloud
+  resources:
+  - clusters
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR we upgrade the fluent-bit version where the fluent-bit-to-loki plugin watch cluster resource instead of namespaces.
Thus we prevent routing logs to shoot namespaces which purpose is `testing` or they are about to hibernate.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
``` improvement operator github.com/gardener/logging #59 @vlvasilev
- logs routing depends on the cluster resources in the seed
```