### PR TITLE
Revert labels for seed VPA deployment

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
@@ -9,6 +9,8 @@ metadata:
     app: vpa-admission-controller
 {{- if .Values.deploymentLabels }}
 {{ toYaml .Values.deploymentLabels | indent 4 }}
+{{- else }}
+{{ toYaml .Values.labels | indent 4 }}
 {{- end }}
 spec:
   replicas: {{ .Values.admissionController.replicas }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-exporter.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-exporter.yaml
@@ -9,6 +9,8 @@ metadata:
     app: vpa-exporter
 {{- if .Values.deploymentLabels }}
 {{ toYaml .Values.deploymentLabels | indent 4 }}
+{{- else }}
+{{ toYaml .Values.labels | indent 4 }}
 {{- end }}
 spec:
   replicas: {{ .Values.exporter.replicas }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
@@ -9,6 +9,8 @@ metadata:
     app: vpa-recommender
 {{- if .Values.deploymentLabels }}
 {{ toYaml .Values.deploymentLabels | indent 4 }}
+{{- else }}
+{{ toYaml .Values.labels | indent 4 }}
 {{- end }}
 spec:
   replicas: {{ .Values.recommender.replicas }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
@@ -8,6 +8,8 @@ metadata:
     app: vpa-updater
 {{- if .Values.deploymentLabels }}
 {{ toYaml .Values.deploymentLabels | indent 4 }}
+{{- else }}
+{{ toYaml .Values.labels | indent 4 }}
 {{- end }}
 spec:
   replicas: {{ .Values.updater.replicas }}

--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -507,18 +507,18 @@ func (b *Botanist) checkControlPlane(
 ) (*gardencorev1beta1.Condition, error) {
 	cluster, err := gardenerextensions.GetCluster(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace)
 	if err != nil {
-		msg := "failed to start control plane health check"
 		if apierrors.IsNotFound(err) {
-			msg = "control plane is not yet ready"
+			c := checker.FailedCondition(condition, "ControlPlaneNotReady", "Control plane is not yet ready because of missing cluster resource.")
+			return &c, nil
 		}
-		b.Logger.Errorf("%s: %v", msg, err)
-		return nil, errors.New(msg)
+		b.Logger.Errorf("Failed to execute control plane health checks: %v", err)
+		return nil, err
 	}
 	// Use shoot from cluster resource here because it reflects the actual or "active" spec to determine which health checks are required.
 	// With the "confineSpecUpdateRollout" feature enabled, shoot resources have a spec which is not yet active.
 	shoot := cluster.Shoot
 	if shoot == nil {
-		return nil, errors.New("failed to start control plane health check because shoot is not yet synced to cluster resource")
+		return nil, errors.New("failed to execute control plane health checks because shoot is missing in cluster resource")
 	}
 
 	if exitCondition, err := checker.CheckControlPlane(shoot, b.Shoot.SeedNamespace, condition, seedDeploymentLister, seedEtcdLister, seedWorkerLister); err != nil || exitCondition != nil {

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -628,9 +628,6 @@ func BootstrapCluster(k8sGardenClient, k8sSeedClient kubernetes.Interface, seed 
 		"vpa": map[string]interface{}{
 			"enabled": vpaEnabled,
 			"runtime": map[string]interface{}{
-				"deploymentLabels": map[string]interface{}{
-					v1beta1constants.GardenRole: v1beta1constants.GardenRoleSeed,
-				},
 				"admissionController": map[string]interface{}{
 					"podAnnotations": map[string]interface{}{
 						"checksum/secret-vpa-tls-certs": utils.ComputeSHA256Hex(jsonString),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Parts of #2698 changed the role label for seed VPA deployments from `garden.sapcloud.io/role: vpa` -> `gardener.cloud/role: seed`. However, we don't use the `seed` value for seed deployments so far and thus only having it for VPA makes this handling even more inconsistent. Additionally, the labels of the deployment diverged unnecessarily from the ones of the pod(s).

This PR reverts to the previously used label.

**Special notes for your reviewer**:
An improvement for the `ControlPlaneHealthy` condition has been implemented along the way.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
