### PR TITLE
Dedicated network policy for kube-apiserver-to-vpa communication

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/networkpolicy.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+{{- if eq .Values.clusterType "shoot" }}
+apiVersion: {{ include "networkpolicyversion" . }}
+kind: NetworkPolicy
+metadata:
+  annotations:
+    gardener.cloud/description: |
+      Allows Egress from pods shoot's kube-apiserver to talk to the
+      VPA admission controller.
+  name: allow-kube-apiserver-to-vpa-admission-controller
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app: kubernetes
+      garden.sapcloud.io/role: controlplane
+      role: apiserver
+  egress:
+  - to:
+    # Allow connections from the apiserver pod to the vpa-admission-controller
+    - podSelector:
+        matchLabels:
+          app: vpa-admission-controller
+    ports:
+    - protocol: TCP
+      port: {{ .Values.admissionController.port }}
+  policyTypes:
+  - Egress
+{{- end }}

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/networkpolicy-allow-kube-apiserver-policy.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/networkpolicy-allow-kube-apiserver-policy.yaml
@@ -34,16 +34,6 @@ spec:
       - protocol: TCP
         port: {{ required ".securePort is required" .Values.securePort }}
   {{- end }}
-  {{- if .Values.vpaEnabled }}
-  - to:
-    # Allow connections from the apiserver pod to the vpa-admission-controller
-    - podSelector:
-        matchLabels:
-          app: vpa-admission-controller
-    ports:
-    - protocol: TCP
-      port: 10250
-  {{- end }}
   ingress:
     # Allow connection from everything which needs to talk to the API server
   - from:

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -9,7 +9,6 @@ konnectivityTunnel:
   adminPort: 8133
   agentNamespace: kube-system
 probeCredentials: base64(user:pass)
-vpaEnabled: false
 shootNetworks:
   services: 10.0.1.0/24
   pods: 192.168.0.0/1

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -270,6 +270,7 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 				v1beta1constants.GardenRole:           v1beta1constants.GardenRoleControlPlane,
 				v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
 			},
+			"clusterType": "shoot",
 		}
 	)
 
@@ -925,7 +926,6 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 			"checksum/secret-service-account-key":    b.CheckSums["service-account-key"],
 			"checksum/secret-etcd-ca":                b.CheckSums[v1beta1constants.SecretNameCAETCD],
 			"checksum/secret-etcd-client-tls":        b.CheckSums["etcd-client-tls"],
-			"networkpolicy/vpa-enabled":              strconv.FormatBool(b.Shoot.WantsVerticalPodAutoscaler),
 			"networkpolicy/konnectivity-enabled":     strconv.FormatBool(b.Shoot.KonnectivityTunnelEnabled),
 		}
 		defaultValues = map[string]interface{}{
@@ -938,7 +938,6 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 			"konnectivityTunnel": map[string]interface{}{
 				"enabled": b.Shoot.KonnectivityTunnelEnabled,
 			},
-			"vpaEnabled": b.Shoot.WantsVerticalPodAutoscaler,
 			"hvpa": map[string]interface{}{
 				"enabled": hvpaEnabled,
 			},

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -348,6 +348,7 @@ func DeleteVpa(ctx context.Context, c client.Client, namespace string, isShoot b
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "vpa-recommender", Namespace: namespace}},
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "vpa-tls-certs", Namespace: namespace}},
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "vpa-updater", Namespace: namespace}},
+			&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-kube-apiserver-to-vpa-admission-controller", Namespace: namespace}},
 		)
 	} else {
 		// TODO: remove in a future release


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR adds a dedicated `NetworkPolicy` for the communication from the kube-apiserver to the VPA admission controller.
Earlier, this communication was allowed by the `allow-kube-apiserver` policy which is reconciled as part of the `DeployKubeAPIServer` step. However, as the `DeployVerticalPodAutoscaler` step only comes at the very end of the flow it's way better to let it manage the necessity resources altogether (this is not yet strictly pervaded, though, this is where we should get to).

**Special notes for your reviewer**:
/invite @timuthy 
thanks for noticing!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
