### PR TITLE
Increase resource requests for fluent-bit

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
@@ -38,8 +38,8 @@ spec:
             cpu: 300m
             memory: 400Mi
           requests:
-            cpu: 20m
-            memory: 80Mi
+            cpu: 150m
+            memory: 150Mi
         ports:
         - name: metrics
           containerPort: 2020


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Increase resource requests for fluent-bit

On large landscapes with large seed nodes the fluent bit is handling a lot more logs. With this change its requests are closer to the real usage so it can have more guaranteed resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @vlvasilev @Kristian-ZH 
/assign @vlvasilev @Kristian-ZH 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The resource requests for the `fluent-bit` DaemonSet running in the seed clusters have been increased.
```
