### PR TITLE
Prevent deletion of seed cluster which is still in use

### DIFF
--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gardener/gardener/plugin/pkg/global/extensionvalidation"
 	"github.com/gardener/gardener/plugin/pkg/global/resourcereferencemanager"
 	plantvalidator "github.com/gardener/gardener/plugin/pkg/plant"
+	seedvalidator "github.com/gardener/gardener/plugin/pkg/seed/validator"
 	shootdns "github.com/gardener/gardener/plugin/pkg/shoot/dns"
 	"github.com/gardener/gardener/plugin/pkg/shoot/oidc/clusteropenidconnectpreset"
 	"github.com/gardener/gardener/plugin/pkg/shoot/oidc/openidconnectpreset"
@@ -164,6 +165,7 @@ func (o *Options) complete() error {
 	shootquotavalidator.Register(o.Recommended.Admission.Plugins)
 	shootdns.Register(o.Recommended.Admission.Plugins)
 	shootvalidator.Register(o.Recommended.Admission.Plugins)
+	seedvalidator.Register(o.Recommended.Admission.Plugins)
 	controllerregistrationresources.Register(o.Recommended.Admission.Plugins)
 	plantvalidator.Register(o.Recommended.Admission.Plugins)
 	openidconnectpreset.Register(o.Recommended.Admission.Plugins)
@@ -178,6 +180,7 @@ func (o *Options) complete() error {
 		shootdns.PluginName,
 		shootquotavalidator.PluginName,
 		shootvalidator.PluginName,
+		seedvalidator.PluginName,
 		controllerregistrationresources.PluginName,
 		plantvalidator.PluginName,
 		deletionconfirmation.PluginName,

--- a/docs/concepts/apiserver_admission_plugins.md
+++ b/docs/concepts/apiserver_admission_plugins.md
@@ -68,15 +68,20 @@ However, it also has some special behaviours for certain resources:
 * `Seed`s: It rejects changing the `.spec.settings.shootDNS.enabled` value if there is at least one `Shoot` that refers to this seed.
 * `Shoot`s: It sets the `gardener.cloud/created-by=<username>` annotation for newly created `Shoot` resources.
 
+## `SeedValidator`
+
+_(enabled by default)_
+
+This admission controller reacts on `DELETE` operations for `Seed`s.
+It checks whether the seed cluster is referenced by a `BackupBucket`(s) and/or `Shoot`(s). If any of this is true, the deletion request is rejected.
+
 ## `ShootDNS`
 
 _(enabled by default)_
 
 This admission controller reacts on `CREATE` and `UPDATE` operations for `Shoot`s.
 It tries to assign a default domain to the `Shoot` if it gets scheduled to a seed that enables DNS for shoots (`.spec.settings.shootDNS.enabled=true`).
-It also validates that the DNS configuration (`.spec.dns`) is not set if the seed disables DNS for shoots. 
-
- 
+It also validates that the DNS configuration (`.spec.dns`) is not set if the seed disables DNS for shoots.
 
 ## `ShootQuotaValidator`
 

--- a/plugin/pkg/seed/validator/admission.go
+++ b/plugin/pkg/seed/validator/admission.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
+	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
+	corelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
+	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const (
+	// PluginName is the name of this admission plugin.
+	PluginName = "SeedValidator"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return New()
+	})
+}
+
+// ValidateSeed contains listers and and admission handler.
+type ValidateSeed struct {
+	*admission.Handler
+	seedLister         corelisters.SeedLister
+	shootLister        corelisters.ShootLister
+	backupBucketLister corelisters.BackupBucketLister
+	readyFunc          admission.ReadyFunc
+}
+
+var (
+	_ = admissioninitializer.WantsInternalCoreInformerFactory(&ValidateSeed{})
+
+	readyFuncs = []admission.ReadyFunc{}
+)
+
+// New creates a new ValidateSeed admission plugin.
+func New() (*ValidateSeed, error) {
+	return &ValidateSeed{
+		Handler: admission.NewHandler(admission.Delete),
+	}, nil
+}
+
+// AssignReadyFunc assigns the ready function to the admission handler.
+func (v *ValidateSeed) AssignReadyFunc(f admission.ReadyFunc) {
+	v.readyFunc = f
+	v.SetReadyFunc(f)
+}
+
+// SetInternalCoreInformerFactory gets Lister from SharedInformerFactory.
+func (v *ValidateSeed) SetInternalCoreInformerFactory(f coreinformers.SharedInformerFactory) {
+	seedInformer := f.Core().InternalVersion().Seeds()
+	v.seedLister = seedInformer.Lister()
+
+	shootInformer := f.Core().InternalVersion().Shoots()
+	v.shootLister = shootInformer.Lister()
+
+	backupBucketInformer := f.Core().InternalVersion().BackupBuckets()
+	v.backupBucketLister = backupBucketInformer.Lister()
+
+	readyFuncs = append(readyFuncs, seedInformer.Informer().HasSynced, shootInformer.Informer().HasSynced, backupBucketInformer.Informer().HasSynced)
+}
+
+// ValidateInitialization checks whether the plugin was correctly initialized.
+func (v *ValidateSeed) ValidateInitialization() error {
+	if v.seedLister == nil {
+		return errors.New("missing seed lister")
+	}
+	if v.shootLister == nil {
+		return errors.New("missing shoot lister")
+	}
+	if v.backupBucketLister == nil {
+		return errors.New("missing backupbucket lister")
+	}
+	return nil
+}
+
+var _ admission.ValidationInterface = &ValidateSeed{}
+
+// Validate validates the Seed details against existing Shoots and BackupBuckets
+func (v *ValidateSeed) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	// Wait until the caches have been synced
+	if v.readyFunc == nil {
+		v.AssignReadyFunc(func() bool {
+			for _, readyFunc := range readyFuncs {
+				if !readyFunc() {
+					return false
+				}
+			}
+			return true
+		})
+	}
+	if !v.WaitForReady() {
+		return admission.NewForbidden(a, errors.New("not yet ready to handle request"))
+	}
+
+	// Ignore all kinds other than Seed
+	if a.GetKind().GroupKind() != core.Kind("Seed") {
+		return nil
+	}
+
+	// Ignore updates to status or other subresources
+	if a.GetSubresource() != "" {
+		return nil
+	}
+
+	seedName := a.GetName()
+
+	shoots, err := v.shootLister.List(labels.Everything())
+	if err != nil {
+		return apierrors.NewInternalError(err)
+	}
+
+	backupbuckets, err := v.backupBucketLister.List(labels.Everything())
+	if err != nil {
+		return apierrors.NewInternalError(err)
+	}
+
+	if admissionutils.IsSeedUsedByShoot(seedName, shoots) {
+		return admission.NewForbidden(a, fmt.Errorf("cannot delete seed '%s' which is still used by shoot(s)", seedName))
+	}
+
+	if admissionutils.IsSeedUsedByBackupBucket(seedName, backupbuckets) {
+		return admission.NewForbidden(a, fmt.Errorf("cannot delete seed '%s' which is still used by backupbucket(s)", seedName))
+	}
+
+	return nil
+}

--- a/plugin/pkg/seed/validator/admission_test.go
+++ b/plugin/pkg/seed/validator/admission_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator_test
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
+	. "github.com/gardener/gardener/plugin/pkg/seed/validator"
+	. "github.com/gardener/gardener/test/gomega"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("validator", func() {
+	Describe("#Admit", func() {
+		var (
+			admissionHandler    *ValidateSeed
+			coreInformerFactory coreinformers.SharedInformerFactory
+			backupBucket        core.BackupBucket
+			seed                core.Seed
+			shoot               core.Shoot
+
+			backupBucketName = "backupbucket"
+			seedName         = "seed"
+			namespaceName    = "garden-my-project"
+
+			seedBase = core.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: seedName,
+				},
+			}
+			shootBase = core.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "shoot",
+					Namespace: namespaceName,
+				},
+				Spec: core.ShootSpec{
+					CloudProfileName:  "profile",
+					Region:            "europe",
+					SecretBindingName: "my-secret",
+					SeedName:          &seedName,
+				},
+			}
+
+			backupBucketBase = core.BackupBucket{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: backupBucketName,
+				},
+			}
+		)
+
+		BeforeEach(func() {
+			backupBucket = backupBucketBase
+			seed = seedBase
+			shoot = *shootBase.DeepCopy()
+
+			admissionHandler, _ = New()
+			admissionHandler.AssignReadyFunc(func() bool { return true })
+			coreInformerFactory = coreinformers.NewSharedInformerFactory(nil, 0)
+			admissionHandler.SetInternalCoreInformerFactory(coreInformerFactory)
+		})
+
+		// The verification of protection is independent of the Cloud Provider (being checked before).
+		Context("Seed deletion", func() {
+
+			BeforeEach(func() {
+				shoot = *shootBase.DeepCopy()
+
+				// set seed name
+				shoot.Spec.SeedName = &seedName
+			})
+
+			It("should disallow seed deletion because it still hosts shoot clusters", func() {
+				Expect(coreInformerFactory.Core().InternalVersion().Shoots().Informer().GetStore().Add(&shoot)).To(Succeed())
+				attrs := admission.NewAttributesRecord(&seed, nil, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(BeForbiddenError())
+			})
+
+			It("should disallow seed deletion because it is still referenced by a backupbucket", func() {
+				backupBucket.Spec.SeedName = &seedName
+				Expect(coreInformerFactory.Core().InternalVersion().BackupBuckets().Informer().GetStore().Add(&backupBucket)).To(Succeed())
+				attrs := admission.NewAttributesRecord(&seed, nil, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(BeForbiddenError())
+			})
+
+			It("should disallow seed deletion because shoot migration is yet not finished", func() {
+				shoot.Spec.SeedName = pointer.StringPtr(seedName + "-1")
+				shoot.Status.SeedName = &seedName
+
+				Expect(coreInformerFactory.Core().InternalVersion().Shoots().Informer().GetStore().Add(&shoot)).To(Succeed())
+				attrs := admission.NewAttributesRecord(&seed, nil, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(BeForbiddenError())
+			})
+
+			It("should allow deletion of empty seed", func() {
+				shoot.Spec.SeedName = pointer.StringPtr(seedName + "-1")
+
+				Expect(coreInformerFactory.Core().InternalVersion().Shoots().Informer().GetStore().Add(&shoot)).To(Succeed())
+				attrs := admission.NewAttributesRecord(&seed, nil, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
+
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+		})
+	})
+
+	Describe("#Register", func() {
+		It("should register the plugin", func() {
+			plugins := admission.NewPlugins()
+			Register(plugins)
+
+			registered := plugins.Registered()
+			Expect(registered).To(HaveLen(1))
+			Expect(registered).To(ContainElement(PluginName))
+		})
+	})
+
+	Describe("#New", func() {
+		It("should handle only DELETE operations", func() {
+			dr, err := New()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dr.Handles(admission.Create)).NotTo(BeTrue())
+			Expect(dr.Handles(admission.Update)).NotTo(BeTrue())
+			Expect(dr.Handles(admission.Connect)).NotTo(BeTrue())
+			Expect(dr.Handles(admission.Delete)).To(BeTrue())
+		})
+	})
+
+	Describe("#ValidateInitialization", func() {
+		It("should return error if no ShootLister or SeedLister is set", func() {
+			dr, _ := New()
+
+			err := dr.ValidateInitialization()
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should not return error if ShootLister and SeedLister are set", func() {
+			dr, _ := New()
+			dr.SetInternalCoreInformerFactory(coreinformers.NewSharedInformerFactory(nil, 0))
+
+			err := dr.ValidateInitialization()
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+})

--- a/plugin/pkg/seed/validator/validator_suite_test.go
+++ b/plugin/pkg/seed/validator/validator_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Admission SeedValidator Suite")
+}

--- a/plugin/pkg/utils/miscellaneous.go
+++ b/plugin/pkg/utils/miscellaneous.go
@@ -45,3 +45,26 @@ func GetProject(namespace string, projectLister corelisters.ProjectLister) (*cor
 
 	return nil, fmt.Errorf("no project found for namespace %q", namespace)
 }
+
+// IsSeedUsedByShoot checks whether there is a shoot cluster refering the provided seed name
+func IsSeedUsedByShoot(seedName string, shoots []*core.Shoot) bool {
+	for _, shoot := range shoots {
+		if shoot.Spec.SeedName != nil && *shoot.Spec.SeedName == seedName {
+			return true
+		}
+		if shoot.Status.SeedName != nil && *shoot.Status.SeedName == seedName {
+			return true
+		}
+	}
+	return false
+}
+
+// IsSeedUsedByBackupBucket checks whether there is a backupbucket refering the provided seed name
+func IsSeedUsedByBackupBucket(seedName string, backupbuckets []*core.BackupBucket) bool {
+	for _, backupbucket := range backupbuckets {
+		if backupbucket.Spec.SeedName != nil && *backupbucket.Spec.SeedName == seedName {
+			return true
+		}
+	}
+	return false
+}

--- a/plugin/pkg/utils/miscellaneous_test.go
+++ b/plugin/pkg/utils/miscellaneous_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	"testing"
+
+	gardenercore "github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/plugin/pkg/utils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/utils/pointer"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Admission Utils Suite")
+}
+
+var _ = Describe("Miscellaneous", func() {
+
+	var (
+		shoot1 = gardenercore.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shoot1",
+				Namespace: "garden-pr1",
+			},
+			Spec: gardenercore.ShootSpec{
+				SeedName: pointer.StringPtr("seed1"),
+			},
+		}
+
+		shoot2 = gardenercore.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shoot2",
+				Namespace: "garden-pr1",
+			},
+			Spec: gardenercore.ShootSpec{
+				SeedName: pointer.StringPtr("seed1"),
+			},
+			Status: gardenercore.ShootStatus{
+				SeedName: pointer.StringPtr("seed2"),
+			},
+		}
+
+		shoot3 = gardenercore.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shoot3",
+				Namespace: "garden-pr1",
+			},
+			Spec: gardenercore.ShootSpec{
+				SeedName: nil,
+			},
+		}
+
+		backupBucket1 = gardenercore.BackupBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bucket1",
+			},
+			Spec: gardenercore.BackupBucketSpec{
+				SeedName: pointer.StringPtr("seed1"),
+			},
+		}
+		backupBucket2 = gardenercore.BackupBucket{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bucket2",
+			},
+		}
+	)
+	backupBuckets := []*gardenercore.BackupBucket{
+		&backupBucket1,
+		&backupBucket2,
+	}
+
+	shoots := []*gardenercore.Shoot{
+		&shoot1,
+		&shoot2,
+		&shoot3,
+	}
+	now := metav1.Now()
+
+	DescribeTable("#SkipVerification",
+		func(operation admission.Operation, metadata metav1.ObjectMeta, expected bool) {
+			Expect(utils.SkipVerification(operation, metadata)).To(Equal(expected))
+		},
+		Entry("operation create with nil metadata", admission.Create, nil, false),
+		Entry("operation connect with nil metadata", admission.Connect, nil, false),
+		Entry("operation delete with nil metadata", admission.Delete, nil, false),
+		Entry("operation create and object with deletion timestamp", admission.Create, metav1.ObjectMeta{DeletionTimestamp: &now}, false),
+		Entry("operation update and object with deletion timestamp", admission.Update, metav1.ObjectMeta{DeletionTimestamp: &now}, true),
+		Entry("operation update and object without deletion timestamp", admission.Update, metav1.ObjectMeta{Name: "obj1"}, false),
+	)
+
+	DescribeTable("#UsedByShoot",
+		func(seedName string, expected bool) {
+			Expect(utils.IsSeedUsedByShoot(seedName, shoots)).To(Equal(expected))
+		},
+		Entry("is used by shoot", "seed1", true),
+		Entry("is used by shoot in migration", "seed2", true),
+		Entry("is unused", "seed3", false),
+	)
+
+	DescribeTable("#UsedByBackupBucket",
+		func(seedName string, expected bool) {
+			Expect(utils.IsSeedUsedByBackupBucket(seedName, backupBuckets)).To(Equal(expected))
+		},
+		Entry("is used by backupbucket", "seed1", true),
+		Entry("is not used by backupbucket", "seed2", false),
+	)
+
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Prevent deletion of seed cluster which is still in use by:
1. Admission plugin that disallow the `delete` call to seeds that are still used by shoots or backupbuckets
1. Admission plugin that disallow removal of `use-as-seed` annotation from the shooted seed that is still in use.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
It is not possible a seed cluster to be deleted, directly or via removal of the `shoot.gardener.cloud/use-as-seed` annotation on the shoot, if the seed is still used by a `BackupBucket` or it is hosting the control plane of a shoot cluster.
```
