### PR TITLE
Increase concurrent syncs for KCM controllers

### DIFF
--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -56,8 +56,15 @@ spec:
         - --cluster-name={{ .Values.clusterName }}
         - --cluster-signing-cert-file=/srv/kubernetes/ca/ca.crt
         - --cluster-signing-key-file=/srv/kubernetes/ca/ca.key
-        - --concurrent-deployment-syncs=10
-        - --concurrent-replicaset-syncs=10
+        - --concurrent-deployment-syncs=50
+        - --concurrent-endpoint-syncs=15
+        - --concurrent-gc-syncs=30
+        - --concurrent-namespace-syncs=50
+        - --concurrent-replicaset-syncs=50
+        - --concurrent-resource-quota-syncs=15
+        - --concurrent-service-endpoint-syncs=15
+        - --concurrent-serviceaccount-token-syncs=15
+        - --concurrent-statefulset-syncs=15
         {{- include "kube-controller-manager.featureGates" . | trimSuffix "," | indent 8 }}
         {{- if semverCompare "< 1.12" .Values.kubernetesVersion }}
         - --horizontal-pod-autoscaler-downscale-delay={{ .Values.horizontalPodAutoscaler.downscaleDelay }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/priority normal
/topology seed
/platform all
/exp beginner

**What this PR does / why we need it**:
Increase concurrent controller syncs on Shoot's kube-controller-manager to allow faster processing for larger clusters.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The number of concurrent controller syncs of the kube-controller-manager of Shoot clusters has been increased to allow faster processing of events.
```
