### PR TITLE
Remove terminationGracePeriodSeconds from gardener manifests

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
@@ -105,7 +105,6 @@ spec:
 {{- if .Values.global.controller.additionalVolumeMounts }}
 {{ toYaml .Values.global.controller.additionalVolumeMounts | indent 8 }}
 {{- end }}
-      terminationGracePeriodSeconds: 3600
       volumes:
       - name: gardener-controller-manager-cert
         secret:

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
@@ -81,7 +81,6 @@ spec:
         {{- end }}
         - name: gardener-scheduler-config
           mountPath: /etc/gardener-scheduler/config
-      terminationGracePeriodSeconds: 3600
       volumes:
       {{- if .Values.global.scheduler.kubeconfig }}
       - name: gardener-scheduler-kubeconfig

--- a/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
@@ -145,7 +145,6 @@ spec:
 {{- if .Values.global.gardenlet.additionalVolumeMounts }}
 {{ toYaml .Values.global.gardenlet.additionalVolumeMounts | indent 8 }}
 {{- end }}
-      terminationGracePeriodSeconds: 3600
       volumes:
       {{- if .Values.global.gardenlet.config.gardenClientConnection.kubeconfig }}
       - name: gardenlet-kubeconfig-garden


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability robustness ops-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:
The `terminationGracePeriodSeconds=3600` setting is a left-over from a historic version of Gardener and no longer needed, so let's make the rolling update faster and don't wait unnecessarily.

**Which issue(s) this PR fixes**:
Fixes #2686 (we still have #1648)

**Special notes for your reviewer**:
/invite @timebertt 
/assign @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The explicit `terminationGracePeriodSeconds` configuration of the Gardener components has been removed.
```
