### PR TITLE
Fix unknown flags for kube-controller-manager

### DIFF
--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -62,9 +62,11 @@ spec:
         - --concurrent-namespace-syncs=50
         - --concurrent-replicaset-syncs=50
         - --concurrent-resource-quota-syncs=15
+        {{- if semverCompare ">= 1.16" .Values.kubernetesVersion }}
         - --concurrent-service-endpoint-syncs=15
-        - --concurrent-serviceaccount-token-syncs=15
         - --concurrent-statefulset-syncs=15
+        {{- end}}
+        - --concurrent-serviceaccount-token-syncs=15
         {{- include "kube-controller-manager.featureGates" . | trimSuffix "," | indent 8 }}
         {{- if semverCompare "< 1.12" .Values.kubernetesVersion }}
         - --horizontal-pod-autoscaler-downscale-delay={{ .Values.horizontalPodAutoscaler.downscaleDelay }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
- `--concurrent-service-endpoint-syncs` is introduced in v1.16 - ref https://github.com/kubernetes/kubernetes/pull/81048.
https://github.com/kubernetes/kubernetes/pull/79169
- `--concurrent-statefulset-syncs` is introduced in v1.16 - https://github.com/kubernetes/kubernetes/pull/79169


With kubernetesVersion `< 1.16`, kube-controller-manager fails with:

```
$ k -n shoot--foo--bar logs kube-controller-manager-6dd5bc5558-hk5bl
unknown flag: --concurrent-service-endpoint-syncs
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@Kristian-ZH, thank you for reporting! ❤️ 


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
