### PR TITLE
Promote HVPA feature gates to beta

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -33,12 +33,12 @@ const (
 
 	// HVPA enables simultaneous horizontal and vertical scaling in Seed Clusters.
 	// owner @ggaurav10, @amshuman-kr
-	// alpha: v0.31.0
+	// alpha: v0.31.0, beta: v1.9.0
 	HVPA featuregate.Feature = "HVPA"
 
 	// HVPAForShootedSeed enables simultaneous horizontal and vertical scaling in shooted seed Clusters.
 	// owner @ggaurav10, @amshuman-kr
-	// alpha: v0.32.0
+	// alpha: v0.32.0, beta: v1.9.0
 	HVPAForShootedSeed featuregate.Feature = "HVPAForShootedSeed"
 
 	// ManagedIstio installs minimal Istio components in istio-system.

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -26,8 +26,8 @@ var (
 	FeatureGate  = featuregate.NewFeatureGate()
 	featureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 		features.Logging:              {Default: false, PreRelease: featuregate.Alpha},
-		features.HVPA:                 {Default: false, PreRelease: featuregate.Alpha},
-		features.HVPAForShootedSeed:   {Default: false, PreRelease: featuregate.Alpha},
+		features.HVPA:                 {Default: true, PreRelease: featuregate.Beta},
+		features.HVPAForShootedSeed:   {Default: true, PreRelease: featuregate.Beta},
 		features.ManagedIstio:         {Default: false, PreRelease: featuregate.Alpha},
 		features.KonnectivityTunnel:   {Default: false, PreRelease: featuregate.Alpha},
 		features.APIServerSNI:         {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR we promote the HVPA feature gates to beta as the features are quite stable meanwhile.

**Which issue(s) this PR fixes**:
Fixes #2724

**Special notes for your reviewer**:
/invite @ggaurav10 @amshuman-kr 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The `HVPA` and `HVPAForShootedSeed` feature gates have been promoted and are enabled by default. You can still disable them explicitly if you prefer so.
```
