### PR TITLE
Auto-restart scheduler in shoot maintenance

### DIFF
--- a/charts/seed-controlplane/charts/kube-scheduler/templates/kube-scheduler.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/templates/kube-scheduler.yaml
@@ -47,6 +47,9 @@ spec:
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-shoot-apiserver: allowed
         networking.gardener.cloud/from-prometheus: allowed
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
     spec:
       containers:
       - name: kube-scheduler

--- a/charts/seed-controlplane/charts/kube-scheduler/values.yaml
+++ b/charts/seed-controlplane/charts/kube-scheduler/values.yaml
@@ -1,6 +1,7 @@
 kubernetesVersion: 1.13.1
 replicas: 1
 podAnnotations: {}
+podLabels: {}
 featureGates: {}
   # CustomResourceValidation: true
   # RotateKubeletServerCertificate: false

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -1315,6 +1315,9 @@ func (b *Botanist) DeployKubeScheduler(ctx context.Context) error {
 			"checksum/secret-kube-scheduler":        b.CheckSums[v1beta1constants.DeploymentNameKubeScheduler],
 			"checksum/secret-kube-scheduler-server": b.CheckSums[common.KubeSchedulerServerName],
 		},
+		"podLabels": map[string]interface{}{
+			v1beta1constants.LabelPodMaintenanceRestart: "true",
+		},
 	}
 
 	if b.ShootedSeed != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
The `kube-scheduler` is now auto-restarted in the shoot maintenance time window, similar to other controllers.

**Which issue(s) this PR fixes**:
Fixes #2722

**Special notes for your reviewer**:
As #2731 is still in discussion, I'm making this change now separately and rebase the PR later if necessary.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `kube-scheduler` is now auto-restarted in the shoot maintenance time window, similar to other controllers.
```
