### PR TITLE
Remove shoot controller tasks immediately after they are completed

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -91,7 +91,6 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 		staticNodesCIDR                = o.Shoot.Info.Spec.Networking.Nodes != nil
 		useSNI                         = botanist.APIServerSNIEnabled()
 		generation                     = o.Shoot.Info.Generation
-		allTasks                       = controllerutils.GetTasks(o.Shoot.Info.Annotations)
 		requestControlPlanePodsRestart = controllerutils.HasTask(o.Shoot.Info.Annotations, common.ShootTaskRestartControlPlanePods)
 
 		g                      = flow.NewGraph("Shoot cluster reconciliation")
@@ -172,8 +171,13 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 			Dependencies: flow.NewTaskIDs(deploySecrets, deployCloudProviderSecret, deployReferencedResources),
 		})
 		waitUntilInfrastructureReady = g.Add(flow.Task{
-			Name:         "Waiting until shoot infrastructure has been reconciled",
-			Fn:           botanist.WaitForInfrastructure,
+			Name: "Waiting until shoot infrastructure has been reconciled",
+			Fn: func(ctx context.Context) error {
+				if err := botanist.WaitForInfrastructure(ctx); err != nil {
+					return err
+				}
+				return removeTaskAnnotation(o, generation, common.ShootTaskDeployInfrastructure)
+			},
 			Dependencies: flow.NewTaskIDs(deployInfrastructure),
 		})
 		_ = g.Add(flow.Task{
@@ -415,8 +419,13 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 			Dependencies: flow.NewTaskIDs(deleteStaleContainerRuntimeResources),
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Restart control plane pods",
-			Fn:           flow.TaskFn(botanist.RestartControlPlanePods).DoIf(requestControlPlanePodsRestart),
+			Name: "Restart control plane pods",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				if err := botanist.RestartControlPlanePods(ctx); err != nil {
+					return err
+				}
+				return removeTaskAnnotation(o, generation, common.ShootTaskRestartControlPlanePods)
+			}).DoIf(requestControlPlanePodsRestart),
 			Dependencies: flow.NewTaskIDs(deployKubeControllerManager, deployControlPlane, deployControlPlaneExposure),
 		})
 		deployVPA = g.Add(flow.Task{
@@ -446,20 +455,6 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 		return gardencorev1beta1helper.NewWrappedLastErrors(gardencorev1beta1helper.FormatLastErrDescription(err), flow.Errors(err))
 	}
 
-	// Remove completed tasks from Shoot if they were executed.
-	newShoot, err := kutil.TryUpdateShootAnnotations(o.K8sGardenClient.GardenCore(), retry.DefaultRetry, o.Shoot.Info.ObjectMeta,
-		func(shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
-			if shoot.Generation == generation {
-				controllerutils.RemoveTasks(shoot.Annotations, allTasks...)
-			}
-			return shoot, nil
-		},
-	)
-	if err != nil {
-		return gardencorev1beta1helper.NewWrappedLastErrors(gardencorev1beta1helper.FormatLastErrDescription(err), err)
-	}
-	o.Shoot.Info = newShoot
-
 	// ensure that shoot client is invalidated after it has been hibernated
 	if o.Shoot.HibernationEnabled {
 		if err := o.ClientMap.InvalidateClient(keys.ForShoot(o.Shoot.Info)); err != nil {
@@ -469,5 +464,22 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 	}
 
 	o.Logger.Infof("Successfully reconciled Shoot %q", o.Shoot.Info.Name)
+	return nil
+}
+
+func removeTaskAnnotation(o *operation.Operation, generation int64, tasksToRemove ...string) error {
+	newShoot, err := kutil.TryUpdateShootAnnotations(o.K8sGardenClient.GardenCore(), retry.DefaultRetry, o.Shoot.Info.ObjectMeta,
+		func(shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
+			if shoot.Generation == generation {
+				controllerutils.RemoveTasks(shoot.Annotations, tasksToRemove...)
+			}
+			return shoot, nil
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	o.Shoot.Info = newShoot
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness networking
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Earlier, the shoot tasks were only removed at the end of a successful reconciliation. Now they are removed immediately once the respective task completed successfully. This prevents that they are executed too often again and again in case a subsequent task fails and the whole shoot reconciliation must be retried.

**Which issue(s) this PR fixes**:
Fixes #2742

**Special notes for your reviewer**:
/cc @vlerenc 
/invite @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The shoot task annotation is now updated as soon as the respective task has completed successfully to prevent recurring executions in case the whole shoot reconciliation flow fails.
```
