### PR TITLE
Report failed machines for hibernated clusters

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -360,8 +360,8 @@ func (a *genericActuator) waitUntilWantedMachineDeploymentsAvailable(ctx context
 			// We want to wait until all wanted machine deployments have as many
 			// available replicas as desired (specified in the .spec.replicas).
 			// However, if we see any error in the status of the deployment then we return it.
-			for _, failedMachine := range deployment.Status.FailedMachines {
-				return retryutils.SevereError(fmt.Errorf("machine %s failed: %s", failedMachine.Name, failedMachine.LastOperation.Description))
+			if machineErrs := workerhelper.ReportFailedMachines(deployment.Status); machineErrs != nil {
+				return retryutils.SevereError(machineErrs)
 			}
 
 			numberOfAwakeMachines += deployment.Status.Replicas

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -357,9 +357,16 @@ func (a *genericActuator) waitUntilWantedMachineDeploymentsAvailable(ctx context
 				}
 			}
 
-			// If the shoot get hibernated we want to wait until all wanted machine deployments have been deleted
-			// entirely.
+			// We want to wait until all wanted machine deployments have as many
+			// available replicas as desired (specified in the .spec.replicas).
+			// However, if we see any error in the status of the deployment then we return it.
+			for _, failedMachine := range deployment.Status.FailedMachines {
+				return retryutils.SevereError(fmt.Errorf("machine %s failed: %s", failedMachine.Name, failedMachine.LastOperation.Description))
+			}
+
 			numberOfAwakeMachines += deployment.Status.Replicas
+
+			// Skip further checks if cluster is hibernated because MachineControllerManager is usually scaled down during hibernation.
 			if controller.IsHibernated(cluster) {
 				continue
 			}
@@ -368,13 +375,6 @@ func (a *genericActuator) waitUntilWantedMachineDeploymentsAvailable(ctx context
 			// machine class for the machine deployment is deployed by the machine controller manager
 			if machineSet := workerhelper.GetMachineSetWithMachineClass(wantedDeployment.Name, wantedDeployment.ClassName, ownerReferenceToMachineSet); machineSet == nil {
 				return retryutils.MinorError(fmt.Errorf("waiting for the machine controller manager to create the updated machine set for the machine deployment (%s/%s)", deployment.Namespace, deployment.Name))
-			}
-
-			// If the Shoot is not hibernated we want to wait until all wanted machine deployments have as many
-			// available replicas as desired (specified in the .spec.replicas). However, if we see any error in the
-			// status of the deployment then we return it.
-			for _, failedMachine := range deployment.Status.FailedMachines {
-				return retryutils.SevereError(fmt.Errorf("machine %s failed: %s", failedMachine.Name, failedMachine.LastOperation.Description))
 			}
 
 			// If the Shoot is not hibernated we want to wait until all wanted machine deployments have as many


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR fixes an issues which prevented machine error from being reported if the shoot is being hibernated. More details can be found in the linked issue.

I tested the change/scenario with a re-vendored GCP provider extension successfully.

**Which issue(s) this PR fixes**:
Fixes #2691

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The generic worker actuator now also reports failed machines from the corresponding machine deployment in case the shoot cluster is being hibernated. Earlier scale down issues during hibernation were not reported to users, e.g. if something was wrong with the configured cloud provider account and thus the machine deletion was denied.
```
