### PR TITLE
Nit: Use logrus.FieldLogger instead of logrus.Entry

### DIFF
--- a/pkg/operation/botanist/controlplane/kube_apiserver_service.go
+++ b/pkg/operation/botanist/controlplane/kube_apiserver_service.go
@@ -49,7 +49,7 @@ func NewKubeAPIService(
 	sniServiceKey *client.ObjectKey,
 	applier kubernetes.ChartApplier,
 	chartsRootPath string,
-	logger *logrus.Entry,
+	logger logrus.FieldLogger,
 	client client.Client,
 	waiter retry.Ops,
 	clusterIPFunc func(clusterIP string),
@@ -171,7 +171,7 @@ type kubeAPIService struct {
 	sniService *client.ObjectKey
 	kubernetes.ChartApplier
 	chartPath     string
-	logger        *logrus.Entry
+	logger        logrus.FieldLogger
 	client        client.Client
 	waiter        retry.Ops
 	clusterIPFunc func(clusterIP string)

--- a/pkg/operation/botanist/controlplane/kube_apiserver_service_test.go
+++ b/pkg/operation/botanist/controlplane/kube_apiserver_service_test.go
@@ -49,7 +49,7 @@ var _ = Describe("#KubeAPIServerService", func() {
 		ctx                context.Context
 		c                  client.Client
 		expected           *corev1.Service
-		log                *logrus.Entry
+		log                logrus.FieldLogger
 		defaultDepWaiter   component.DeployWaiter
 		ingressIP          string
 		clusterIP          string
@@ -63,7 +63,7 @@ var _ = Describe("#KubeAPIServerService", func() {
 
 	BeforeEach(func() {
 		ctx = context.TODO()
-		log = logrus.NewEntry(logger.NewNopLogger())
+		log = logger.NewNopLogger()
 
 		s := runtime.NewScheme()
 		Expect(corev1.AddToScheme(s)).NotTo(HaveOccurred())

--- a/pkg/operation/botanist/extensions/dns/dnsentry.go
+++ b/pkg/operation/botanist/extensions/dns/dnsentry.go
@@ -48,7 +48,7 @@ func NewDNSEntry(
 	shootNamespace string,
 	applier kubernetes.ChartApplier,
 	chartsRootPath string,
-	logger *logrus.Entry,
+	logger logrus.FieldLogger,
 	client client.Client,
 	waiter retry.Ops,
 
@@ -73,7 +73,7 @@ type dnsEntry struct {
 	shootNamespace string
 	kubernetes.ChartApplier
 	chartPath string
-	logger    *logrus.Entry
+	logger    logrus.FieldLogger
 	client    client.Client
 	waiter    retry.Ops
 }

--- a/pkg/operation/botanist/extensions/dns/dnsentry_test.go
+++ b/pkg/operation/botanist/extensions/dns/dnsentry_test.go
@@ -56,7 +56,7 @@ var _ = Describe("#DNSEntry", func() {
 		c                client.Client
 		expected         *dnsv1alpha1.DNSEntry
 		vals             *EntryValues
-		log              *logrus.Entry
+		log              logrus.FieldLogger
 		defaultDepWaiter component.DeployWaiter
 	)
 
@@ -64,7 +64,7 @@ var _ = Describe("#DNSEntry", func() {
 		ctrl = gomock.NewController(GinkgoT())
 
 		ctx = context.TODO()
-		log = logrus.NewEntry(logger.NewNopLogger())
+		log = logger.NewNopLogger()
 
 		s := runtime.NewScheme()
 		Expect(dnsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())

--- a/pkg/operation/botanist/extensions/dns/dnsprovider.go
+++ b/pkg/operation/botanist/extensions/dns/dnsprovider.go
@@ -56,7 +56,7 @@ func NewDNSProvider(
 	shootNamespace string,
 	applier kubernetes.ChartApplier,
 	chartsRootPath string,
-	logger *logrus.Entry,
+	logger logrus.FieldLogger,
 	client client.Client,
 	waiter retry.Ops,
 ) component.DeployWaiter {
@@ -80,7 +80,7 @@ type dnsProvider struct {
 	shootNamespace string
 	kubernetes.ChartApplier
 	chartPath string
-	logger    *logrus.Entry
+	logger    logrus.FieldLogger
 	client    client.Client
 	waiter    retry.Ops
 }

--- a/pkg/operation/botanist/extensions/dns/dnsprovider_test.go
+++ b/pkg/operation/botanist/extensions/dns/dnsprovider_test.go
@@ -59,7 +59,7 @@ var _ = Describe("#DNSProvider", func() {
 		expectedSecret   *corev1.Secret
 		expectedDNS      *dnsv1alpha1.DNSProvider
 		vals             *ProviderValues
-		log              *logrus.Entry
+		log              logrus.FieldLogger
 		defaultDepWaiter component.DeployWaiter
 	)
 
@@ -67,7 +67,7 @@ var _ = Describe("#DNSProvider", func() {
 		ctrl = gomock.NewController(GinkgoT())
 
 		ctx = context.TODO()
-		log = logrus.NewEntry(logger.NewNopLogger())
+		log = logger.NewNopLogger()
 
 		s := runtime.NewScheme()
 		Expect(corev1.AddToScheme(s)).NotTo(HaveOccurred())

--- a/pkg/operation/botanist/extensions/infrastructure/infrastructure.go
+++ b/pkg/operation/botanist/extensions/infrastructure/infrastructure.go
@@ -74,7 +74,7 @@ type Values struct {
 
 // New creates a new instance of an Infrastructure deployer.
 func New(
-	logger *logrus.Entry,
+	logger logrus.FieldLogger,
 	client client.Client,
 	values *Values,
 ) shoot.Infrastructure {
@@ -90,7 +90,7 @@ func New(
 
 type infrastructure struct {
 	values              *Values
-	logger              *logrus.Entry
+	logger              logrus.FieldLogger
 	client              client.Client
 	waitInterval        time.Duration
 	waitSevereThreshold time.Duration

--- a/pkg/operation/botanist/extensions/infrastructure/infrastructure_test.go
+++ b/pkg/operation/botanist/extensions/infrastructure/infrastructure_test.go
@@ -56,7 +56,7 @@ var _ = Describe("#Infrastructure", func() {
 
 	var (
 		ctx context.Context
-		log *logrus.Entry
+		log logrus.FieldLogger
 
 		ctrl    *gomock.Controller
 		c       *mockclient.MockClient
@@ -77,7 +77,7 @@ var _ = Describe("#Infrastructure", func() {
 
 	BeforeEach(func() {
 		ctx = context.TODO()
-		log = logrus.NewEntry(logger.NewNopLogger())
+		log = logger.NewNopLogger()
 
 		ctrl = gomock.NewController(GinkgoT())
 		c = mockclient.NewMockClient(ctrl)

--- a/pkg/operation/botanist/extensions/network/network.go
+++ b/pkg/operation/botanist/extensions/network/network.go
@@ -66,7 +66,7 @@ type Values struct {
 
 // New creates a new instance of DeployWaiter for a Network.
 func New(
-	logger *logrus.Entry,
+	logger logrus.FieldLogger,
 	client client.Client,
 	values *Values,
 	waitInterval time.Duration,
@@ -85,7 +85,7 @@ func New(
 
 type network struct {
 	values              *Values
-	logger              *logrus.Entry
+	logger              logrus.FieldLogger
 	client              client.Client
 	waitInterval        time.Duration
 	waitSevereThreshold time.Duration

--- a/pkg/operation/botanist/extensions/network/network_test.go
+++ b/pkg/operation/botanist/extensions/network/network_test.go
@@ -62,7 +62,7 @@ var _ = Describe("#Network", func() {
 		c                client.Client
 		expected         *extensionsv1alpha1.Network
 		values           *network.Values
-		log              *logrus.Entry
+		log              logrus.FieldLogger
 		defaultDepWaiter component.DeployMigrateWaiter
 
 		mockNow *mocktime.MockNow
@@ -78,7 +78,7 @@ var _ = Describe("#Network", func() {
 		mockNow = mocktime.NewMockNow(ctrl)
 
 		ctx = context.TODO()
-		log = logrus.NewEntry(logger.NewNopLogger())
+		log = logger.NewNopLogger()
 
 		s := runtime.NewScheme()
 		Expect(extensionsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())

--- a/pkg/operation/common/extensions.go
+++ b/pkg/operation/common/extensions.go
@@ -119,7 +119,7 @@ func SyncClusterResourceToSeed(ctx context.Context, client client.Client, cluste
 func WaitUntilExtensionCRReady(
 	ctx context.Context,
 	c client.Client,
-	logger *logrus.Entry,
+	logger logrus.FieldLogger,
 	newObjFunc func() runtime.Object,
 	kind string,
 	namespace string,
@@ -150,7 +150,7 @@ func WaitUntilExtensionCRReady(
 func WaitUntilObjectReadyWithHealthFunction(
 	ctx context.Context,
 	c client.Client,
-	logger *logrus.Entry,
+	logger logrus.FieldLogger,
 	healthFunc func(obj runtime.Object) error,
 	newObjFunc func() runtime.Object,
 	kind string,
@@ -273,7 +273,7 @@ func DeleteExtensionCRs(
 func WaitUntilExtensionCRsDeleted(
 	ctx context.Context,
 	c client.Client,
-	logger *logrus.Entry,
+	logger logrus.FieldLogger,
 	listObj runtime.Object,
 	newObjFunc func() extensionsv1alpha1.Object,
 	kind string,
@@ -328,7 +328,7 @@ func WaitUntilExtensionCRsDeleted(
 func WaitUntilExtensionCRDeleted(
 	ctx context.Context,
 	c client.Client,
-	logger *logrus.Entry,
+	logger logrus.FieldLogger,
 	newObjFunc func() extensionsv1alpha1.Object,
 	kind string,
 	namespace string,

--- a/pkg/operation/common/extensions_test.go
+++ b/pkg/operation/common/extensions_test.go
@@ -48,7 +48,7 @@ import (
 var _ = Describe("extensions", func() {
 	var (
 		ctx     context.Context
-		log     *logrus.Entry
+		log     logrus.FieldLogger
 		ctrl    *gomock.Controller
 		mockNow *mocktime.MockNow
 		now     time.Time
@@ -67,7 +67,7 @@ var _ = Describe("extensions", func() {
 
 	BeforeEach(func() {
 		ctx = context.TODO()
-		log = logrus.NewEntry(logger.NewNopLogger())
+		log = logger.NewNopLogger()
 		ctrl = gomock.NewController(GinkgoT())
 		mockNow = mocktime.NewMockNow(ctrl)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/priority normal

**What this PR does / why we need it**:
`logrus.FieldLogger` is interface that generalizes the `logrus.Entry` and `logrus.Logger` types. We should not restrict utility funcs (for example `WaitUntilExtensionCRReady`) to accept only `logrus.Entry` and it should be also possible passing `logrus.Logger`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
