### PR TITLE
Deny shoots referencing absent DNS provider secrets

### DIFF
--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -581,6 +581,17 @@ func (r *ReferenceManager) ensureShootReferences(ctx context.Context, attributes
 		}
 	}
 
+	if shoot.Spec.DNS != nil && shoot.DeletionTimestamp == nil {
+		for _, dnsProvider := range shoot.Spec.DNS.Providers {
+			if dnsProvider.SecretName == nil {
+				continue
+			}
+			if err := r.lookupSecret(shoot.Namespace, *dnsProvider.SecretName); err != nil {
+				return fmt.Errorf("failed to reference DNS provider secret %v", err)
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/kind api-change
/priority normal

**What this PR does / why we need it**:
This PR makes the `ResourceReferenceManager` admission plugin check if referenced DNS provider secrets (`shoot.spec.dns.providers[*].secretName`) exist in the project namespace.

**Which issue(s) this PR fixes**:
Fixes #2736

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
Gardener now checks if referenced DNS provider secrets (.spec.dns.providers[*].secretName) exist in the project namespace during shoot creation and update requests. Requests will be denied if the referenced secret is not available.
```
