### PR TITLE
[GEP-7] Adds a DeployMigrateWaiter component to manage containerruntimes

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -346,12 +346,12 @@ func (c *Controller) runDeleteShootFlow(o *operation.Operation) *gardencorev1bet
 		})
 		deleteContainerRuntimeResources = g.Add(flow.Task{
 			Name:         "Deleting container runtime resources",
-			Fn:           flow.TaskFn(botanist.DeleteAllContainerRuntimeResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.ContainerRuntime.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(initializeShootClients, cleanKubernetesResources, cleanShootNamespaces),
 		})
 		waitUntilContainerRuntimeResourcesDeleted = g.Add(flow.Task{
 			Name:         "Waiting until stale container runtime resources are deleted",
-			Fn:           botanist.WaitUntilContainerRuntimeResourcesDeleted,
+			Fn:           botanist.Shoot.Components.Extensions.ContainerRuntime.WaitCleanup,
 			Dependencies: flow.NewTaskIDs(deleteContainerRuntimeResources),
 		})
 

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -89,6 +89,7 @@ func New(o *operation.Operation) (*Botanist, error) {
 	}
 	o.Shoot.Components.Extensions.Infrastructure = b.DefaultInfrastructure(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.Network = b.DefaultNetwork(b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.ContainerRuntime = b.DefaultContainerRuntime(b.K8sSeedClient.DirectClient())
 
 	// control plane components
 	o.Shoot.Components.ControlPlane.KubeAPIServerService = b.DefaultKubeAPIServerService()

--- a/pkg/operation/botanist/containerruntime.go
+++ b/pkg/operation/botanist/containerruntime.go
@@ -16,146 +16,33 @@ package botanist
 
 import (
 	"context"
-	"fmt"
-	"time"
 
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/operation/botanist/extensions/containerruntime"
 	"github.com/gardener/gardener/pkg/operation/shoot"
-	"github.com/gardener/gardener/pkg/utils/flow"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// DeployContainerRuntimeResources creates a `Container runtime` resource in the shoot namespace in the seed
-// cluster. Deploys one resource per CRI per Worker.
-// Gardener waits until an external controller has reconciled the resources successfully.
-func (b *Botanist) DeployContainerRuntimeResources(ctx context.Context) error {
-	var fns []flow.TaskFn
-
-	for _, worker := range b.Shoot.Info.Spec.Provider.Workers {
-		if worker.CRI == nil {
-			continue
-		}
-
-		for _, containerRuntime := range worker.CRI.ContainerRuntimes {
-			cr := containerRuntime
-			workerName := worker.Name
-
-			toApply := extensionsv1alpha1.ContainerRuntime{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      getContainerRuntimeKey(cr.Type, workerName),
-					Namespace: b.Shoot.SeedNamespace,
-				},
-			}
-
-			fns = append(fns, func(ctx context.Context) error {
-				_, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), &toApply, func() error {
-					metav1.SetMetaDataAnnotation(&toApply.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-					metav1.SetMetaDataAnnotation(&toApply.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
-					toApply.Spec.BinaryPath = extensionsv1alpha1.ContainerDRuntimeContainersBinFolder
-					toApply.Spec.Type = cr.Type
-					toApply.Spec.ProviderConfig = cr.ProviderConfig
-					toApply.Spec.WorkerPool.Name = workerName
-					toApply.Spec.WorkerPool.Selector.MatchLabels = map[string]string{v1beta1constants.LabelWorkerPool: workerName, v1beta1constants.LabelWorkerPoolDeprecated: workerName}
-					return nil
-				})
-				return err
-			})
-		}
-	}
-
-	return flow.Parallel(fns...)(ctx)
-}
-
-func getContainerRuntimeKey(criType, workerName string) string {
-	return fmt.Sprintf("%s-%s", criType, workerName)
-}
-
-// WaitUntilContainerRuntimeResourcesReady waits until all container runtime resources report `Succeeded` in their last operation state.
-// The state must be reported before the passed context is cancelled or a container runtime's timeout has been reached.
-// As soon as one timeout has been overstepped the function returns an error, further waits on container runtime will be aborted.
-func (b *Botanist) WaitUntilContainerRuntimeResourcesReady(ctx context.Context) error {
-	var fns []flow.TaskFn
-	for _, worker := range b.Shoot.Info.Spec.Provider.Workers {
-		if worker.CRI == nil {
-			continue
-		}
-
-		for _, containerRuntime := range worker.CRI.ContainerRuntimes {
-			fns = append(fns, func(ctx context.Context) error {
-				return common.WaitUntilExtensionCRReady(
-					ctx,
-					b.K8sSeedClient.DirectClient(),
-					b.Logger,
-					func() runtime.Object { return &extensionsv1alpha1.ContainerRuntime{} },
-					"ContainerRuntime",
-					b.Shoot.SeedNamespace,
-					getContainerRuntimeKey(containerRuntime.Type, worker.Name),
-					DefaultInterval,
-					DefaultSevereThreshold,
-					shoot.ExtensionDefaultTimeout,
-					nil,
-				)
-			})
-		}
-	}
-
-	return flow.ParallelExitOnError(fns...)(ctx)
-}
-
-// DeleteStaleContainerRuntimeResources deletes unused container runtime resources from the shoot namespace in the seed.
-func (b *Botanist) DeleteStaleContainerRuntimeResources(ctx context.Context) error {
-	wantedContainerRuntimeTypes := sets.NewString()
-	for _, worker := range b.Shoot.Info.Spec.Provider.Workers {
-		if worker.CRI != nil {
-			for _, containerRuntime := range worker.CRI.ContainerRuntimes {
-				key := getContainerRuntimeKey(containerRuntime.Type, worker.Name)
-				wantedContainerRuntimeTypes.Insert(key)
-			}
-		}
-	}
-	return b.deleteContainerRuntimeResources(ctx, wantedContainerRuntimeTypes)
-}
-
-// DeleteAllContainerRuntimeResources deletes all container runtime resources from the Shoot namespace in the Seed.
-func (b *Botanist) DeleteAllContainerRuntimeResources(ctx context.Context) error {
-	return b.deleteContainerRuntimeResources(ctx, sets.NewString())
-}
-
-func (b *Botanist) deleteContainerRuntimeResources(ctx context.Context, wantedContainerRuntimeTypes sets.String) error {
-	return common.DeleteExtensionCRs(
-		ctx,
-		b.K8sSeedClient.Client(),
-		&extensionsv1alpha1.ContainerRuntimeList{},
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ContainerRuntime{} },
-		b.Shoot.SeedNamespace,
-		func(obj extensionsv1alpha1.Object) bool {
-			cr, ok := obj.(*extensionsv1alpha1.ContainerRuntime)
-			if !ok {
-				return false
-			}
-			return !wantedContainerRuntimeTypes.Has(getContainerRuntimeKey(cr.Spec.Type, cr.Spec.WorkerPool.Name))
-		},
-	)
-}
-
-// WaitUntilContainerRuntimeResourcesDeleted waits until all container runtime resources are gone or the context is cancelled.
-func (b *Botanist) WaitUntilContainerRuntimeResourcesDeleted(ctx context.Context) error {
-	return common.WaitUntilExtensionCRsDeleted(
-		ctx,
-		b.K8sSeedClient.DirectClient(),
+// DefaultContainerRuntime creates the default deployer for the ContainerRuntime custom resource.
+func (b *Botanist) DefaultContainerRuntime(seedClient client.Client) shoot.ContainerRuntime {
+	return containerruntime.New(
 		b.Logger,
-		&extensionsv1alpha1.ContainerRuntimeList{},
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ContainerRuntime{} },
-		"ContainerRuntime",
-		b.Shoot.SeedNamespace,
-		DefaultInterval,
-		shoot.ExtensionDefaultTimeout,
-		nil,
+		seedClient,
+		&containerruntime.Values{
+			Namespace: b.Shoot.SeedNamespace,
+			Workers:   b.Shoot.Info.Spec.Provider.Workers,
+		},
+		containerruntime.DefaultInterval,
+		containerruntime.DefaultSevereThreshold,
+		containerruntime.DefaultTimeout,
 	)
+}
+
+// DeployContainerRuntime deploys the ContainerRuntime custom resources and triggers the restore operation in case
+// the Shoot is in the restore phase of the control plane migration
+func (b *Botanist) DeployContainerRuntime(ctx context.Context) error {
+	if b.isRestorePhase() {
+		return b.Shoot.Components.Extensions.ContainerRuntime.Restore(ctx, b.ShootState)
+	}
+	return b.Shoot.Components.Extensions.ContainerRuntime.Deploy(ctx)
 }

--- a/pkg/operation/botanist/extensions/containerruntime/containerruntime.go
+++ b/pkg/operation/botanist/extensions/containerruntime/containerruntime.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containerruntime
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/operation/shoot"
+	"github.com/gardener/gardener/pkg/utils/flow"
+
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	// DefaultInterval is the default interval for retry operations.
+	DefaultInterval = 5 * time.Second
+	// DefaultSevereThreshold is the default threshold until an error reported by another component is treated as 'severe'.
+	DefaultSevereThreshold = 30 * time.Second
+	// DefaultTimeout is the default timeout and defines how long Gardener should wait
+	// for a successful reconciliation of a containerruntime resource.
+	DefaultTimeout = 3 * time.Minute
+)
+
+// TimeNow returns the current time. Exposed for testing.
+var TimeNow = time.Now
+
+// Values contains the values used to create a ContainerRuntime resources.
+type Values struct {
+	Namespace string
+	Workers   []gardencorev1beta1.Worker
+}
+
+type containerruntime struct {
+	values              *Values
+	client              client.Client
+	logger              *logrus.Entry
+	waitInterval        time.Duration
+	waitSevereThreshold time.Duration
+	waitTimeout         time.Duration
+}
+
+// New creates a new instance of ContainerRuntime deployer.
+func New(
+	logger *logrus.Entry,
+	client client.Client,
+	values *Values,
+	waitInterval time.Duration,
+	waitSevereThreshold time.Duration,
+	waitTimeout time.Duration,
+) shoot.ContainerRuntime {
+	return &containerruntime{
+		values:              values,
+		client:              client,
+		logger:              logger,
+		waitInterval:        waitInterval,
+		waitSevereThreshold: waitSevereThreshold,
+		waitTimeout:         waitTimeout,
+	}
+}
+
+// Deploy uses the seed client to create or update the ContainerRuntime resources.
+func (d *containerruntime) Deploy(ctx context.Context) error {
+	fns := d.forEachContainerRuntime(func(ctx context.Context, workerName string, cr gardencorev1beta1.ContainerRuntime) error {
+		rd := resourceDeployer{d.values.Namespace, workerName, cr, d.client}
+		_, err := rd.deploy(ctx, v1beta1constants.GardenerOperationReconcile)
+		return err
+	})
+
+	return flow.Parallel(fns...)(ctx)
+}
+
+// Destroy deletes the ContainerRuntime resources.
+func (d *containerruntime) Destroy(ctx context.Context) error {
+	return d.deleteContainerRuntimeResources(ctx, sets.NewString())
+}
+
+// Wait waits until the ContainerRuntime resources are ready.
+func (d *containerruntime) Wait(ctx context.Context) error {
+	fns := d.forEachContainerRuntime(func(ctx context.Context, workerName string, cr gardencorev1beta1.ContainerRuntime) error {
+		return common.WaitUntilExtensionCRReady(
+			ctx,
+			d.client,
+			d.logger,
+			func() runtime.Object { return &extensionsv1alpha1.ContainerRuntime{} },
+			extensionsv1alpha1.ContainerRuntimeResource,
+			d.values.Namespace,
+			getContainerRuntimeKey(cr.Type, workerName),
+			d.waitInterval,
+			d.waitSevereThreshold,
+			d.waitTimeout,
+			nil,
+		)
+	})
+
+	return flow.ParallelExitOnError(fns...)(ctx)
+}
+
+// WaitCleanup waits until the ContainerRuntime resources are cleaned up.
+func (d *containerruntime) WaitCleanup(ctx context.Context) error {
+	return common.WaitUntilExtensionCRsDeleted(
+		ctx,
+		d.client,
+		d.logger,
+		&extensionsv1alpha1.ContainerRuntimeList{},
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ContainerRuntime{} },
+		"ContainerRuntime",
+		d.values.Namespace,
+		d.waitInterval,
+		d.waitTimeout,
+		nil,
+	)
+}
+
+// Restore uses the seed client and the ShootState to create the ContainereRuntime resources and restore their state.
+func (d *containerruntime) Restore(ctx context.Context, shootState *gardencorev1alpha1.ShootState) error {
+	fns := d.forEachContainerRuntime(func(ctx context.Context, workerName string, cr gardencorev1beta1.ContainerRuntime) error {
+		rd := resourceDeployer{d.values.Namespace, workerName, cr, d.client}
+		return common.RestoreExtensionWithDeployFunction(ctx, shootState, d.client, extensionsv1alpha1.ContainerRuntimeResource, d.values.Namespace, rd.deploy)
+	})
+
+	return flow.Parallel(fns...)(ctx)
+}
+
+// Migrate migrates the ContainerRuntime resources.
+func (d *containerruntime) Migrate(ctx context.Context) error {
+	return common.MigrateExtensionCRs(
+		ctx,
+		d.client,
+		&extensionsv1alpha1.ContainerRuntimeList{},
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ContainerRuntime{} },
+		d.values.Namespace,
+	)
+}
+
+// WaitMigrate waits until the ContainerRuntime resources are migrated successfully.
+func (d *containerruntime) WaitMigrate(ctx context.Context) error {
+	return common.WaitUntilExtensionCRsMigrated(
+		ctx,
+		d.client,
+		&extensionsv1alpha1.ContainerRuntimeList{},
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ContainerRuntime{} },
+		d.values.Namespace,
+		d.waitInterval,
+		d.waitTimeout,
+	)
+}
+
+// DeleteStaleResources deletes unused container runtime resources from the shoot namespace in the seed.
+func (d *containerruntime) DeleteStaleResources(ctx context.Context) error {
+	wantedContainerRuntimeTypes := sets.NewString()
+	for _, worker := range d.values.Workers {
+		if worker.CRI != nil {
+			for _, containerRuntime := range worker.CRI.ContainerRuntimes {
+				key := getContainerRuntimeKey(containerRuntime.Type, worker.Name)
+				wantedContainerRuntimeTypes.Insert(key)
+			}
+		}
+	}
+	return d.deleteContainerRuntimeResources(ctx, wantedContainerRuntimeTypes)
+}
+
+func (d *containerruntime) deleteContainerRuntimeResources(ctx context.Context, wantedContainerRuntimeTypes sets.String) error {
+	return common.DeleteExtensionCRs(
+		ctx,
+		d.client,
+		&extensionsv1alpha1.ContainerRuntimeList{},
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ContainerRuntime{} },
+		d.values.Namespace,
+		func(obj extensionsv1alpha1.Object) bool {
+			cr, ok := obj.(*extensionsv1alpha1.ContainerRuntime)
+			if !ok {
+				return false
+			}
+			return !wantedContainerRuntimeTypes.Has(getContainerRuntimeKey(cr.Spec.Type, cr.Spec.WorkerPool.Name))
+		},
+	)
+}
+
+func (d *containerruntime) forEachContainerRuntime(fn func(ctx context.Context, workerName string, cr gardencorev1beta1.ContainerRuntime) error) []flow.TaskFn {
+	var fns []flow.TaskFn
+	for _, worker := range d.values.Workers {
+		if worker.CRI == nil {
+			continue
+		}
+		for _, containerRuntime := range worker.CRI.ContainerRuntimes {
+			cr := containerRuntime
+			workerName := worker.Name
+			fns = append(fns, func(ctx context.Context) error {
+				return fn(ctx, workerName, cr)
+			})
+		}
+	}
+
+	return fns
+}
+
+func getContainerRuntimeKey(criType, workerName string) string {
+	return fmt.Sprintf("%s-%s", criType, workerName)
+}
+
+type resourceDeployer struct {
+	namespace        string
+	workerName       string
+	containerRuntime gardencorev1beta1.ContainerRuntime
+	client           client.Client
+}
+
+func (d *resourceDeployer) deploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
+	toApply := extensionsv1alpha1.ContainerRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getContainerRuntimeKey(d.containerRuntime.Type, d.workerName),
+			Namespace: d.namespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, d.client, &toApply, func() error {
+		metav1.SetMetaDataAnnotation(&toApply.ObjectMeta, v1beta1constants.GardenerOperation, operation)
+		metav1.SetMetaDataAnnotation(&toApply.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		toApply.Spec.BinaryPath = extensionsv1alpha1.ContainerDRuntimeContainersBinFolder
+		toApply.Spec.Type = d.containerRuntime.Type
+		toApply.Spec.ProviderConfig = d.containerRuntime.ProviderConfig
+		toApply.Spec.WorkerPool.Name = d.workerName
+		toApply.Spec.WorkerPool.Selector.MatchLabels = map[string]string{v1beta1constants.LabelWorkerPool: d.workerName, v1beta1constants.LabelWorkerPoolDeprecated: d.workerName}
+		return nil
+	})
+	return &toApply, err
+}

--- a/pkg/operation/botanist/extensions/containerruntime/containerruntime_suite_test.go
+++ b/pkg/operation/botanist/extensions/containerruntime/containerruntime_suite_test.go
@@ -12,24 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package extensions
+package containerruntime_test
 
 import (
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-// GetShootNamespacedCRsLists returns an empty CR list struct, for each CR used for Shoot managment
-func GetShootNamespacedCRsLists() []runtime.Object {
-	return []runtime.Object{
-		&extensionsv1alpha1.ControlPlaneList{},
-		&extensionsv1alpha1.ExtensionList{},
-		&extensionsv1alpha1.InfrastructureList{},
-		//The Network CR is now handled as a shoot component
-		//&extensionsv1alpha1.NetworkList{},
-		&extensionsv1alpha1.OperatingSystemConfigList{},
-		&extensionsv1alpha1.WorkerList{},
-		//The ContainerRuntime CR is now handled as a shoot component
-		//&extensionsv1alpha1.ContainerRuntimeList{},
-	}
+func TestContainerRuntime(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Botanist Extensions Container Runtime Suite")
 }

--- a/pkg/operation/botanist/extensions/containerruntime/containerruntime_test.go
+++ b/pkg/operation/botanist/extensions/containerruntime/containerruntime_test.go
@@ -1,0 +1,441 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containerruntime_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/logger"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
+	"github.com/gardener/gardener/pkg/operation/botanist/extensions/containerruntime"
+	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/operation/shoot"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/test/gomega"
+
+	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("#ContainerRuntimee", func() {
+	const (
+		namespace = "test-namespace"
+	)
+
+	var (
+		workerNames           = []string{"worker1", "worker2"}
+		containerRuntimeTypes = []string{"type1", "type2"}
+
+		ctrl *gomock.Controller
+
+		ctx      context.Context
+		c        client.Client
+		expected []*extensionsv1alpha1.ContainerRuntime
+		values   *containerruntime.Values
+		log      *logrus.Entry
+
+		defaultDepWaiter shoot.ContainerRuntime
+		workers          []gardencorev1beta1.Worker
+
+		mockNow *mocktime.MockNow
+		now     time.Time
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockNow = mocktime.NewMockNow(ctrl)
+
+		ctx = context.TODO()
+
+		log = logrus.NewEntry(logger.NewNopLogger())
+
+		s := runtime.NewScheme()
+		Expect(extensionsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())
+
+		c = fake.NewFakeClientWithScheme(s)
+
+		workers = make([]gardencorev1beta1.Worker, 0, len(workerNames))
+
+		for _, name := range workerNames {
+			containerRuntimes := make([]gardencorev1beta1.ContainerRuntime, 0, len(containerRuntimeTypes))
+			for _, runtimeType := range containerRuntimeTypes {
+				containerRuntimes = append(containerRuntimes, gardencorev1beta1.ContainerRuntime{
+					Type:           runtimeType,
+					ProviderConfig: nil,
+				})
+			}
+			workers = append(workers, gardencorev1beta1.Worker{
+				Name: name,
+				CRI: &gardencorev1beta1.CRI{
+					Name:              gardencorev1beta1.CRIName(name),
+					ContainerRuntimes: containerRuntimes,
+				},
+			})
+		}
+
+		expected = []*extensionsv1alpha1.ContainerRuntime{}
+		for _, name := range workerNames {
+			for _, runtimeType := range containerRuntimeTypes {
+				expected = append(expected, &extensionsv1alpha1.ContainerRuntime{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("%s-%s", runtimeType, name),
+						Namespace: namespace,
+						Annotations: map[string]string{
+							v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+							v1beta1constants.GardenerTimestamp: now.UTC().String(),
+						},
+					},
+					Spec: extensionsv1alpha1.ContainerRuntimeSpec{
+						BinaryPath: extensionsv1alpha1.ContainerDRuntimeContainersBinFolder,
+						DefaultSpec: extensionsv1alpha1.DefaultSpec{
+							Type:           runtimeType,
+							ProviderConfig: nil,
+						},
+						WorkerPool: extensionsv1alpha1.ContainerRuntimeWorkerPool{
+							Name: name,
+							Selector: metav1.LabelSelector{
+								MatchLabels: map[string]string{v1beta1constants.LabelWorkerPool: name, v1beta1constants.LabelWorkerPoolDeprecated: name},
+							},
+						},
+					},
+				})
+			}
+		}
+
+		values = &containerruntime.Values{
+			Namespace: namespace,
+			Workers:   workers,
+		}
+		defaultDepWaiter = containerruntime.New(log, c, values, time.Second, 2*time.Second, 3*time.Second)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#Deploy", func() {
+		It("should successfully deploy all containerruntime resources", func() {
+			defer test.WithVars(
+				&containerruntime.TimeNow, mockNow.Do,
+			)()
+
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+			for _, e := range expected {
+				actual := &extensionsv1alpha1.ContainerRuntime{}
+				err := c.Get(ctx, client.ObjectKey{Name: e.Name, Namespace: e.Namespace}, actual)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(actual).To(DeepDerivativeEqual(e))
+			}
+		})
+	})
+
+	Describe("#Wait", func() {
+		It("should return error when no resources are found", func() {
+			Expect(defaultDepWaiter.Wait(ctx)).To(HaveOccurred())
+		})
+
+		It("should return error when resource is not ready", func() {
+			for i := range expected {
+				expected[i].Status.LastError = &gardencorev1beta1.LastError{
+					Description: "Some error",
+				}
+				Expect(c.Create(ctx, expected[i])).ToNot(HaveOccurred(), "creating containerruntime succeeds")
+			}
+
+			Expect(defaultDepWaiter.Wait(ctx)).To(HaveOccurred(), "containerruntime indicates error")
+		})
+
+		It("should return no error when it's ready", func() {
+			for i := range expected {
+				// remove operation annotation
+				expected[i].ObjectMeta.Annotations = map[string]string{}
+				// set last operation
+				expected[i].Status.LastOperation = &gardencorev1beta1.LastOperation{
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+				}
+				Expect(c.Create(ctx, expected[i])).ToNot(HaveOccurred(), "creating containerruntime succeeds")
+			}
+
+			Expect(defaultDepWaiter.Wait(ctx)).ToNot(HaveOccurred(), "containerruntime is ready, should not return an error")
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should not return erorr when not found", func() {
+			Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
+		})
+
+		It("should not return error when deleted successfully", func() {
+			Expect(c.Create(ctx, expected[0])).ToNot(HaveOccurred(), "adding pre-existing containerruntime succeeds")
+			Expect(defaultDepWaiter.Destroy(ctx)).ToNot(HaveOccurred())
+		})
+
+		It("should return error if not deleted successfully", func() {
+			defer test.WithVars(
+				&common.TimeNow, mockNow.Do,
+			)()
+
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			worker := gardencorev1beta1.Worker{
+				Name: workerNames[0],
+				CRI: &gardencorev1beta1.CRI{
+					Name: gardencorev1beta1.CRIName(workerNames[0]),
+					ContainerRuntimes: []gardencorev1beta1.ContainerRuntime{
+						{
+							Type:           containerRuntimeTypes[0],
+							ProviderConfig: nil,
+						},
+					},
+				},
+			}
+
+			containerRuntimeName := fmt.Sprintf("%s-%s", containerRuntimeTypes[0], workerNames[0])
+
+			expectedContainerRuntime := extensionsv1alpha1.ContainerRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      containerRuntimeName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						common.ConfirmationDeletion:        "true",
+						v1beta1constants.GardenerTimestamp: now.UTC().String(),
+					},
+				},
+			}
+
+			mc := mockclient.NewMockClient(ctrl)
+			// check if the containerruntime exist
+			mc.EXPECT().List(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.ContainerRuntimeList{}), client.InNamespace(namespace)).SetArg(1, extensionsv1alpha1.ContainerRuntimeList{Items: []extensionsv1alpha1.ContainerRuntime{expectedContainerRuntime}})
+			mc.EXPECT().Get(ctx, kutil.Key(namespace, containerRuntimeName), gomock.AssignableToTypeOf(&extensionsv1alpha1.ContainerRuntime{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, n *extensionsv1alpha1.ContainerRuntime) error {
+				return nil
+			})
+			// add deletion confirmation and Timestamp annotation
+			mc.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.ContainerRuntime{})).Return(nil)
+			mc.EXPECT().Delete(ctx, &expectedContainerRuntime).Times(1).Return(fmt.Errorf("some random error"))
+
+			defaultDepWaiter = containerruntime.New(log, mc, &containerruntime.Values{
+				Namespace: namespace,
+				Workers:   []gardencorev1beta1.Worker{worker},
+			}, time.Second, 2*time.Second, 3*time.Second)
+
+			err := defaultDepWaiter.Destroy(ctx)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("#WaitCleanup", func() {
+		It("should not return error when resources are removed", func() {
+			Expect(defaultDepWaiter.WaitCleanup(ctx)).To(Succeed())
+		})
+
+		It("should not return error if resources exist but they don't have deletionTimestamp", func() {
+			Expect(c.Create(ctx, expected[0])).To(Succeed())
+			Expect(defaultDepWaiter.WaitCleanup(ctx)).To(Succeed())
+		})
+
+		It("should return error if resources with deletionTimestamp still exist", func() {
+			timeNow := metav1.Now()
+			expected[0].DeletionTimestamp = &timeNow
+			Expect(c.Create(ctx, expected[0])).To(Succeed())
+			Expect(defaultDepWaiter.WaitCleanup(ctx)).To(HaveOccurred())
+		})
+	})
+
+	Describe("#Restore", func() {
+		var (
+			shootState *gardencorev1alpha1.ShootState
+		)
+
+		BeforeEach(func() {
+			extensions := make([]gardencorev1alpha1.ExtensionResourceState, 0, len(workerNames)+len(containerRuntimeTypes))
+			for _, name := range workerNames {
+				for _, criType := range containerRuntimeTypes {
+					extensionName := fmt.Sprintf("%s-%s", criType, name)
+					extensions = append(extensions, gardencorev1alpha1.ExtensionResourceState{
+						Name:  &extensionName,
+						Kind:  extensionsv1alpha1.ContainerRuntimeResource,
+						State: &runtime.RawExtension{Raw: []byte("dummy state")},
+					})
+				}
+			}
+			shootState = &gardencorev1alpha1.ShootState{
+				Spec: gardencorev1alpha1.ShootStateSpec{
+					Extensions: extensions,
+				},
+			}
+		})
+
+		It("should properly restore the containerruntime state if it exists", func() {
+			defer test.WithVars(
+				&containerruntime.TimeNow, mockNow.Do,
+				&common.TimeNow, mockNow.Do,
+			)()
+
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			worker := gardencorev1beta1.Worker{
+				Name: workerNames[0],
+				CRI: &gardencorev1beta1.CRI{
+					Name: gardencorev1beta1.CRIName(workerNames[0]),
+					ContainerRuntimes: []gardencorev1beta1.ContainerRuntime{
+						{
+							Type:           containerRuntimeTypes[0],
+							ProviderConfig: nil,
+						},
+					},
+				},
+			}
+
+			expected[0].Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationWaitForState
+			expectedWithState := expected[0].DeepCopy()
+			expectedWithState.Status = extensionsv1alpha1.ContainerRuntimeStatus{
+				DefaultStatus: extensionsv1alpha1.DefaultStatus{State: &runtime.RawExtension{Raw: []byte("dummy state")}},
+			}
+			expectedWithRestore := expectedWithState.DeepCopy()
+			expectedWithRestore.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationRestore
+
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Get(ctx, kutil.Key(namespace, expected[0].Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.ContainerRuntime{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, n *extensionsv1alpha1.ContainerRuntime) error {
+				return apierrors.NewNotFound(extensionsv1alpha1.Resource("ContainerRuntime"), expected[0].Name)
+			})
+			mc.EXPECT().Create(ctx, expected[0]).Return(nil).Times(1)
+			mc.EXPECT().Status().DoAndReturn(func() *mockclient.MockClient {
+				return mc
+			})
+			mc.EXPECT().Update(ctx, expectedWithState).Return(nil)
+			mc.EXPECT().Patch(ctx, expectedWithRestore, client.MergeFrom(expectedWithState))
+
+			defaultDepWaiter = containerruntime.New(
+				log,
+				mc,
+				&containerruntime.Values{
+					namespace,
+					[]gardencorev1beta1.Worker{worker},
+				}, time.Second, 2*time.Second, 3*time.Second)
+
+			Expect(defaultDepWaiter.Restore(ctx, shootState)).To(Succeed())
+		})
+	})
+
+	Describe("#Migrate", func() {
+		It("should migrate the resources", func() {
+			Expect(c.Create(ctx, expected[0])).To(Succeed(), "creating containerruntime succeeds")
+
+			Expect(defaultDepWaiter.Migrate(ctx)).To(Succeed())
+
+			annotatedResource := &extensionsv1alpha1.ContainerRuntime{}
+			Expect(c.Get(ctx, client.ObjectKey{Name: expected[0].Name, Namespace: expected[0].Namespace}, annotatedResource)).To(Succeed())
+			Expect(annotatedResource.Annotations[v1beta1constants.GardenerOperation]).To(Equal(v1beta1constants.GardenerOperationMigrate))
+		})
+
+		It("should not return error if resource does not exist", func() {
+			Expect(defaultDepWaiter.Migrate(ctx)).To(Succeed())
+		})
+	})
+
+	Describe("#WaitMigrate", func() {
+		It("should not return error when resource is missing", func() {
+			Expect(defaultDepWaiter.WaitMigrate(ctx)).To(Succeed())
+		})
+
+		It("should return error if resource is not yet migrated successfully", func() {
+			expected[0].Status.LastError = &gardencorev1beta1.LastError{
+				Description: "Some error",
+			}
+			expected[0].Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateError,
+				Type:  gardencorev1beta1.LastOperationTypeMigrate,
+			}
+
+			Expect(c.Create(ctx, expected[0])).To(Succeed(), "creating containerruntime succeeds")
+			Expect(defaultDepWaiter.WaitMigrate(ctx)).To(HaveOccurred())
+		})
+
+		It("should not return error if resource gets migrated successfully", func() {
+			expected[0].Status.LastError = nil
+			expected[0].Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+				Type:  gardencorev1beta1.LastOperationTypeMigrate,
+			}
+
+			Expect(c.Create(ctx, expected[0])).ToNot(HaveOccurred(), "creating containerruntime succeeds")
+			Expect(defaultDepWaiter.WaitMigrate(ctx)).ToNot(HaveOccurred(), "containerruntime is ready, should not return an error")
+		})
+
+		It("should return error if one resources is not migrated succesfully and others are", func() {
+			for i := range expected[1:] {
+				expected[i].Status.LastError = nil
+				expected[i].Status.LastOperation = &gardencorev1beta1.LastOperation{
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+					Type:  gardencorev1beta1.LastOperationTypeMigrate,
+				}
+			}
+			expected[0].Status.LastError = &gardencorev1beta1.LastError{
+				Description: "Some error",
+			}
+			expected[0].Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateError,
+				Type:  gardencorev1beta1.LastOperationTypeMigrate,
+			}
+
+			for _, e := range expected {
+				Expect(c.Create(ctx, e)).To(Succeed(), "creating containerruntime succeeds")
+			}
+			Expect(defaultDepWaiter.WaitMigrate(ctx)).To(HaveOccurred())
+		})
+	})
+
+	Describe("#DeleteStaleResources", func() {
+		It("should delete stale containerruntime resources", func() {
+			staleContainerRuntime := expected[0].DeepCopy()
+			staleContainerRuntime.Name = fmt.Sprintf("%s-%s", "new-type", workerNames[0])
+			staleContainerRuntime.Spec.Type = "new-type"
+			Expect(c.Create(ctx, staleContainerRuntime)).To(Succeed(), "creating containerruntime succeeds")
+
+			for _, e := range expected {
+				Expect(c.Create(ctx, e)).To(Succeed(), "creating containerruntime succeeds")
+			}
+
+			Expect(defaultDepWaiter.DeleteStaleResources(ctx)).To(Succeed())
+
+			containerRuntimeList := &extensionsv1alpha1.ContainerRuntimeList{}
+			Expect(c.List(ctx, containerRuntimeList)).To(Succeed())
+
+			Expect(len(containerRuntimeList.Items)).To(Equal(4))
+			for _, item := range containerRuntimeList.Items {
+				Expect(item.Spec.Type).ToNot(Equal("new-type"))
+			}
+		})
+	})
+})

--- a/pkg/operation/botanist/extensions/network/network.go
+++ b/pkg/operation/botanist/extensions/network/network.go
@@ -51,9 +51,6 @@ type Values struct {
 	Namespace string
 	// Name is the name of the Network extension. Commonly the Shoot's name.
 	Name string
-	// isInRestorePhaseOfControlPlaneMigration indicates if the Shoot is in the restore
-	// Phase of the ControlPlane migration
-	IsInRestorePhaseOfControlPlaneMigration bool
 	// Type is the type of Network plugin/extension (e.g calico)
 	Type string
 	// ProviderConfig contains the provider config for the Network extension.

--- a/pkg/operation/botanist/extensions/network/network_test.go
+++ b/pkg/operation/botanist/extensions/network/network_test.go
@@ -95,13 +95,12 @@ var _ = Describe("#Network", func() {
 		}
 
 		values = &network.Values{
-			Name:                                    "test-deploy",
-			Namespace:                               networkNs,
-			IsInRestorePhaseOfControlPlaneMigration: false,
-			Type:                                    networkType,
-			ProviderConfig:                          nil,
-			PodCIDR:                                 &podCIDR,
-			ServiceCIDR:                             &serviceCIDR,
+			Name:           "test-deploy",
+			Namespace:      networkNs,
+			Type:           networkType,
+			ProviderConfig: nil,
+			PodCIDR:        &podCIDR,
+			ServiceCIDR:    &serviceCIDR,
 		}
 
 		expected = &extensionsv1alpha1.Network{

--- a/pkg/operation/botanist/migration_test.go
+++ b/pkg/operation/botanist/migration_test.go
@@ -16,8 +16,11 @@ package botanist_test
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/gardener/gardener/pkg/api/extensions"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	extensionsclient "github.com/gardener/gardener/pkg/client/extensions/clientset/versioned/scheme"
@@ -25,6 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/botanist"
+	"github.com/gardener/gardener/pkg/operation/botanist/extensions/containerruntime"
 	"github.com/gardener/gardener/pkg/operation/botanist/extensions/network"
 	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/sirupsen/logrus"
@@ -33,26 +37,51 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("control plane migration", func() {
+	const (
+		testSeedNamespace    = "test-seed-namespace"
+		workerName           = "test-worker"
+		networkName          = "test-network"
+		containerRuntimeName = "testContainerRuntime"
+	)
+
 	var (
-		ctrl              *gomock.Controller
-		fakeClient        client.Client
-		k8sSeedClient     *fakeclientset.ClientSet
-		testSeedNamespace = "test-seed-namespace"
+		ctrl          *gomock.Controller
+		fakeClient    client.Client
+		k8sSeedClient *fakeclientset.ClientSet
+		expected      []runtime.Object
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
+		expected = []runtime.Object{
+			&extensionsv1alpha1.Worker{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workerName,
+					Namespace: testSeedNamespace,
+				},
+			},
+			&extensionsv1alpha1.Network{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      networkName,
+					Namespace: testSeedNamespace,
+				},
+			},
+			&extensionsv1alpha1.ContainerRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      containerRuntimeName,
+					Namespace: testSeedNamespace,
+				},
+			},
+		}
 
-		fakeClient = fakeclient.NewFakeClientWithScheme(extensionsclient.Scheme, &extensionsv1alpha1.Worker{ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-worker",
-			Namespace: testSeedNamespace,
-		}})
+		fakeClient = fakeclient.NewFakeClientWithScheme(extensionsclient.Scheme, expected...)
 		k8sSeedClient = fakeclientset.NewClientSetBuilder().WithClient(fakeClient).WithDirectClient(fakeClient).Build()
 	})
 
@@ -70,8 +99,12 @@ var _ = Describe("control plane migration", func() {
 					Components: &shoot.Components{
 						Extensions: &shoot.Extensions{
 							Network: network.New(log, fakeClient, &network.Values{
-								Namespace: "test-network",
-								Name:      testSeedNamespace,
+								Namespace: testSeedNamespace,
+								Name:      networkName,
+							}, time.Second, 2*time.Second, 3*time.Second),
+							ContainerRuntime: containerruntime.New(log, fakeClient, &containerruntime.Values{
+								Namespace: testSeedNamespace,
+								Workers:   []gardencorev1beta1.Worker{},
 							}, time.Second, 2*time.Second, 3*time.Second),
 						},
 					},
@@ -87,14 +120,19 @@ var _ = Describe("control plane migration", func() {
 			err := botanist.AnnotateExtensionCRsForMigration(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
-			actualWorker := &extensionsv1alpha1.Worker{}
-			err = fakeClient.Get(ctx, types.NamespacedName{
-				Name:      "test-worker",
-				Namespace: testSeedNamespace,
-			}, actualWorker)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(actualWorker.GetAnnotations()).NotTo(BeNil())
-			Expect(actualWorker.GetAnnotations()[v1beta1constants.GardenerOperation]).To(Equal(v1beta1constants.GardenerOperationMigrate))
+			for _, obj := range expected {
+				actual, err := extensions.Accessor(obj)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(
+					fakeClient.Get(ctx, types.NamespacedName{Name: actual.GetName(), Namespace: testSeedNamespace}, actual),
+				).To(Succeed())
+
+				Expect(actual.GetAnnotations()).NotTo(BeNil(), fmt.Sprintf("%s should have annotations", actual.GetName()))
+				Expect(
+					actual.GetAnnotations()[v1beta1constants.GardenerOperation],
+				).To(Equal(v1beta1constants.GardenerOperationMigrate), fmt.Sprintf("%s should have migrate annotation", actual.GetName()))
+			}
 		})
 	})
 })

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -97,9 +97,10 @@ type ControlPlane struct {
 
 // Extensions contains references to extension resources.
 type Extensions struct {
-	DNS            *DNS
-	Infrastructure Infrastructure
-	Network        component.DeployMigrateWaiter
+	DNS              *DNS
+	Infrastructure   Infrastructure
+	Network          component.DeployMigrateWaiter
+	ContainerRuntime ContainerRuntime
 }
 
 // DNS contains references to internal and external DNSProvider and DNSEntry deployers.
@@ -122,6 +123,12 @@ type Infrastructure interface {
 	SetSSHPublicKey([]byte)
 	ProviderStatus() *runtime.RawExtension
 	NodesCIDR() *string
+}
+
+// ContainerRuntime contains references to a ContainerRuntime extension deployer.
+type ContainerRuntime interface {
+	component.DeployMigrateWaiter
+	DeleteStaleResources(ctx context.Context) error
 }
 
 // Networks contains pre-calculated subnets and IP address for various components.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area control-plane-migration
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR Refactors the deployment of ContainerRuntime resources and  adopts the DeployMigrateWaiter functionality so that ContainerRuntime CRs can be deployed, destroyed, migrated and restored.

Previously the state of ContainerRuntime CRs weren't annotated with the `gardenr.cloud/operation=restore` annotation and their state wasn't properly added.

**Which issue(s) this PR fixes**:
part of #1631 

**Special notes for your reviewer**:
Executed the following tests with the gvisor extension:
1. Created a shoot with two worker definitions so that two gvisor containerruntime resources are created
2. Hibernated the shoot cluster
3. Woke up the shoot cluster
4. Migrated the shoot cluster to a new seed
5. Deleted one of the worker definitions and verified that the stale containerruntime resource also gets deleted

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
ContainerRuntimes are now annotated with `gardener.cloud/operation=restore` during the `restore` phase of Control Plane Migration and their state (if any) is copied from the `ShootState` to the CRs' `status.state` field. 
```
