### PR TITLE
Always allow project admins to manage non-human users

### DIFF
--- a/plugin/pkg/global/customverbauthorizer/admission.go
+++ b/plugin/pkg/global/customverbauthorizer/admission.go
@@ -176,8 +176,10 @@ func mustCheckProjectMembers(oldMembers, members []core.ProjectMember, owner *rb
 	var oldHumanUsers, newHumanUsers = findHumanUsers(oldMembers), findHumanUsers(members)
 	// Remove owner subject from `members` list to always allow it to be added
 	if owner != nil && isHumanUser(*owner) {
+		oldHumanUsers.Delete(humanMemberKey(*owner))
 		newHumanUsers.Delete(humanMemberKey(*owner))
 	}
+
 	return !oldHumanUsers.Equal(newHumanUsers)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area user-management
/kind bug
/priority normal

**What this PR does / why we need it**:
There was a bug that prevented regular project admins from managing non-human users in their `Project` resources. This PR fixes this issue by consistently removing the owner from the lists (earlier it was only removed from the new member list).

**Special notes for your reviewer**:
/cc @Diaphteiros @holgerkoser

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
An issue that prevented regular project admins from managing non-human users has been resolved.
```
