### PR TITLE
Forward user information to GAPI in local setup

### DIFF
--- a/hack/local-development/local-garden/run-kube-apiserver
+++ b/hack/local-development/local-garden/run-kube-apiserver
@@ -29,6 +29,9 @@ docker run -d --name kube-apiserver -l $LABEL $ADD_HOSTS --network gardener-dev 
   --tls-cert-file="/certs/kube-apiserver.crt" \
   --tls-private-key-file="/keys/kube-apiserver.key" \
   --requestheader-client-ca-file="/certs/ca.crt" \
+  --requestheader-extra-headers-prefix=X-Remote-Extra- \
+  --requestheader-group-headers=X-Remote-Group \
+  --requestheader-username-headers=X-Remote-User \
   --client-ca-file="/certs/ca.crt" \
   --proxy-client-key-file="/keys/front-proxy-client.key" \
   --proxy-client-cert-file="/certs/front-proxy-client.crt" \


### PR DESCRIPTION
See https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/#kubernetes-apiserver-client-authentication

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug
/priority normal

**What this PR does / why we need it**:
Configure the kube-apiserver correctly to forward the user information to the Gardener API server (otherwise, it will always use the proxy client certificate for authenticating with GAPI).

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The kube-apiserver used for the local garden development does now properly forward the client information to the gardener-apiserver.
```
