### PR TITLE
Try to output YAML diff in matcher

### DIFF
--- a/test/gomega/deep_derivative.go
+++ b/test/gomega/deep_derivative.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/onsi/gomega/format"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -40,16 +41,23 @@ func (m *deepDerivativeMatcher) Match(actual interface{}) (success bool, err err
 }
 
 func (m *deepDerivativeMatcher) FailureMessage(actual interface{}) (message string) {
-	actualString, actualOK := actual.(string)
-	expectedString, expectedOK := m.expected.(string)
+	actualYAML, actualErr := yaml.Marshal(actual)
+	expectedYAML, expectedErr := yaml.Marshal(m.expected)
 
-	if actualOK && expectedOK {
-		return format.MessageWithDiff(actualString, "to deep derivative equal", expectedString)
+	if actualErr == nil && expectedErr == nil {
+		return format.MessageWithDiff(string(actualYAML), "to deep derivative equal", string(expectedYAML))
 	}
 
 	return format.Message(actual, "to deep derivative equal", m.expected)
 }
 
 func (m *deepDerivativeMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	actualYAML, actualErr := yaml.Marshal(actual)
+	expectedYAML, expectedErr := yaml.Marshal(m.expected)
+
+	if actualErr == nil && expectedErr == nil {
+		return format.MessageWithDiff(string(actualYAML), "not to deep derivative equal", string(expectedYAML))
+	}
+
 	return format.Message(actual, "not to deep derivative equal", m.expected)
 }

--- a/test/gomega/matchers.go
+++ b/test/gomega/matchers.go
@@ -15,6 +15,7 @@
 package gomega
 
 import (
+	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -23,6 +24,12 @@ import (
 // ignored (not compared). This allows us to focus on the fields that matter to
 // the semantic comparison.
 func DeepDerivativeEqual(expected interface{}) types.GomegaMatcher {
+	// if CharactersAroundMismatchToInclude is to small, then format.MessageWithDiff will be unable to output our
+	// mismatch message
+	if format.CharactersAroundMismatchToInclude < 10 {
+		format.CharactersAroundMismatchToInclude = 10
+	}
+
 	return &deepDerivativeMatcher{
 		expected: expected,
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity testing
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR enhances the `DeepDerivative` matcher to output a nice truncated yaml diff instead of printing the whole go syntax representation of structs.
This will come in handy, when we will proceed with #2754 and refactor all critical component charts into go structs like proposed in #2731.

**Which issue(s) this PR fixes**:
Helps with #2754

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
