### PR TITLE
Fix tryUpdate utility functions to retry on conflict as expected

### DIFF
--- a/extensions/pkg/controller/utils.go
+++ b/extensions/pkg/controller/utils.go
@@ -224,6 +224,7 @@ func tryUpdate(ctx context.Context, backoff wait.Backoff, c client.Client, obj r
 		return err
 	}
 
+	resetCopy := obj.DeepCopyObject()
 	return exponentialBackoff(ctx, backoff, func() (bool, error) {
 		if err := c.Get(ctx, key, obj); err != nil {
 			return false, err
@@ -240,6 +241,7 @@ func tryUpdate(ctx context.Context, backoff wait.Backoff, c client.Client, obj r
 
 		if err := updateFunc(ctx, obj); err != nil {
 			if apierrors.IsConflict(err) {
+				reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(resetCopy).Elem())
 				return false, nil
 			}
 			return false, err

--- a/pkg/utils/kubernetes/update.go
+++ b/pkg/utils/kubernetes/update.go
@@ -43,6 +43,7 @@ func tryUpdate(ctx context.Context, backoff wait.Backoff, c client.Client, obj r
 		return err
 	}
 
+	resetCopy := obj.DeepCopyObject()
 	return exponentialBackoff(ctx, backoff, func() (bool, error) {
 		if err := c.Get(ctx, key, obj); err != nil {
 			return false, err
@@ -59,6 +60,7 @@ func tryUpdate(ctx context.Context, backoff wait.Backoff, c client.Client, obj r
 
 		if err := updateFunc(ctx, obj); err != nil {
 			if apierrors.IsConflict(err) {
+				reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(resetCopy).Elem())
 				return false, nil
 			}
 			return false, err

--- a/pkg/utils/kubernetes/update.go
+++ b/pkg/utils/kubernetes/update.go
@@ -60,6 +60,11 @@ func tryUpdate(ctx context.Context, backoff wait.Backoff, c client.Client, obj r
 
 		if err := updateFunc(ctx, obj); err != nil {
 			if apierrors.IsConflict(err) {
+				// In case of a conflict we are resetting the obj to its original version, as it was
+				// passed to the function, to ensure that, on the next iteration the
+				// equality check of the obj recieved from the server and the object after
+				// its transformation would be valid. Otherwise the obj would be with mutated
+				// fields in result of the transform function from previous iteration.
 				reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(resetCopy).Elem())
 				return false, nil
 			}

--- a/pkg/utils/kubernetes/update_test.go
+++ b/pkg/utils/kubernetes/update_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+
+	. "github.com/onsi/ginkgo"
+
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("#tryUpdate", func() {
+	It("should set state to obj, when conflict occurs", func() {
+		s := runtime.NewScheme()
+		Expect(extensionsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())
+		objInFakeClient := newInfraObj()
+		objInFakeClient.Status.Conditions = []v1beta1.Condition{
+			{Type: "Health", Reason: "reason", Message: "messages", Status: "status", LastUpdateTime: metav1.Now()},
+		}
+
+		c := fake.NewFakeClientWithScheme(s, objInFakeClient)
+		infraObj := newInfraObj()
+		transform := func() error {
+			infraState, _ := json.Marshal(state{"someState"})
+			infraObj.GetExtensionStatus().SetState(&runtime.RawExtension{Raw: infraState})
+			return nil
+		}
+
+		u := &conflictErrManager{
+			conflictsBeforeUpdate: 2,
+			client:                c,
+		}
+
+		tryUpdateErr := tryUpdate(context.TODO(), retry.DefaultRetry, c, infraObj, u.updateFunc, transform)
+		Expect(tryUpdateErr).NotTo(HaveOccurred())
+
+		objFromFakeClient := &extensionsv1alpha1.Infrastructure{}
+		err := c.Get(context.TODO(), Key("infraNamespace", "infraName"), objFromFakeClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(objFromFakeClient).To(Equal(infraObj))
+	})
+})
+
+type state struct {
+	Name string `json:"name"`
+}
+
+func newInfraObj() *extensionsv1alpha1.Infrastructure {
+	return &extensionsv1alpha1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "infraName",
+			Namespace: "infraNamespace",
+		},
+	}
+}
+
+type conflictErrManager struct {
+	conflictsBeforeUpdate int
+	conflictsOccured      int
+	client                client.Client
+}
+
+func (c *conflictErrManager) updateFunc(ctx context.Context, obj runtime.Object, o ...client.UpdateOption) error {
+	if c.conflictsBeforeUpdate == c.conflictsOccured {
+		return c.client.Status().Update(ctx, obj, o...)
+	}
+
+	c.conflictsOccured++
+	return apierrors.NewConflict(schema.GroupResource{}, "", nil)
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
Adds runtime.Scheme to tryUpdate functions API, in order to get the actual object from the server.
**Which issue(s) this PR fixes**:
Fixes #2454

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue causing TryUpdate and TryUpdateStatus funcs to do not retry on conflict in a corner case is now resolved.
```
