### PR TITLE
minAllowed for vpa-recommender

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/vpa-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/vpa-recommender.yaml
@@ -5,6 +5,12 @@ metadata:
   name: vpa-recommender
   namespace: {{ .Release.Namespace }}
 spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        cpu: 10m
+        memory: 40Mi
   targetRef:
     apiVersion: {{ include "deploymentversion" . }}
     kind: Deployment


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
On one seed I have seen that the `vpa-recommender` was OOM-Killed because of downsized VPA memory recommendations. The `vpa-recommender` crashed all the time and the recommendations never improved.
With setting a minAllowed value, this vicious circle should be resolved.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
