### PR TITLE
Refactor alerts

### DIFF
--- a/charts/seed-bootstrap/aggregate-prometheus-rules-tests/fluent-bit.rules.test.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules-tests/fluent-bit.rules.test.yaml
@@ -5,6 +5,8 @@ evaluation_interval: 30s
 
 tests:
 - interval: 30s
+  external_labels:
+    seed: aws
   input_series:
   # FluentBitDown
   - series: 'up{job="fluent-bit"}'
@@ -14,11 +16,11 @@ tests:
     alertname: FluentBitDown
     exp_alerts:
     - exp_labels:
-        service: fluent-bit
+        service: logging
         severity: warning
         type: seed
         visibility: operator
       exp_annotations:
-        description: There are no running fluent-bit pods. No logs will be collected.
+        description: "There are no fluent-bit pods running on seed: aws. No logs will be collected."
         summary: Fluent-bit is down
 

--- a/charts/seed-bootstrap/aggregate-prometheus-rules-tests/loki.rules.test.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules-tests/loki.rules.test.yaml
@@ -5,6 +5,8 @@ evaluation_interval: 30s
 
 tests:
 - interval: 30s
+  external_labels:
+    seed: aws
   input_series:
   # LokiDown
   - series: 'up{app="loki"}'
@@ -14,11 +16,11 @@ tests:
     alertname: LokiDown
     exp_alerts:
     - exp_labels:
-        service: loki
+        service: logging
         severity: warning
         type: seed
         visibility: operator
       exp_annotations:
-        description: There are no running loki pods. No logs will be collected.
+        description: "There are no loki pods running on seed: aws. No logs will be collected."
         summary: Loki is down
 

--- a/charts/seed-bootstrap/aggregate-prometheus-rules/fluent-bit.rules.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules/fluent-bit.rules.yaml
@@ -5,10 +5,10 @@ groups:
     expr: absent(up{job="fluent-bit"} == 1)
     for: 15m
     labels:
-      service: fluent-bit
+      service: logging
       severity: warning
       type: seed
       visibility: operator
     annotations:
-      description: There are no running fluent-bit pods. No logs will be collected.
+      description: "There are no fluent-bit pods running on seed: {{ .ExternalLabels.seed }}. No logs will be collected."
       summary: Fluent-bit is down

--- a/charts/seed-bootstrap/aggregate-prometheus-rules/loki.rules.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules/loki.rules.yaml
@@ -5,10 +5,10 @@ groups:
     expr: absent(up{app="loki"} == 1)
     for: 15m
     labels:
-      service: loki
+      service: logging
       severity: warning
       type: seed
       visibility: operator
     annotations:
-      description: There are no running loki pods. No logs will be collected.
+      description: "There are no loki pods running on seed: {{ .ExternalLabels.seed }}. No logs will be collected."
       summary: Loki is down

--- a/charts/seed-bootstrap/templates/alertmanager/_config.tpl
+++ b/charts/seed-bootstrap/templates/alertmanager/_config.tpl
@@ -6,7 +6,7 @@ templates:
 # The root route on which each incoming alert enters.
 route:
   # The labels by which incoming alerts are grouped together.
-  group_by: ['cluster']
+  group_by: ['service']
 
   # When a new group of alerts is created by an incoming alert, wait at
   # least 'group_wait' to send the initial notification.
@@ -21,7 +21,7 @@ route:
 
   # If an alert has successfully been sent, wait 'repeat_interval' to
   # resend them.
-  repeat_interval: 48h
+  repeat_interval: 72h
 
   # Send alerts by default to nowhere
   receiver: dev-null

--- a/charts/seed-bootstrap/templates/alertmanager/alertmanager.yaml
+++ b/charts/seed-bootstrap/templates/alertmanager/alertmanager.yaml
@@ -70,6 +70,11 @@ spec:
         - --web.listen-address=:9093
         - --storage.path=/var/alertmanager/data
         - --log.level=info
+        # Since v0.16 alertmanager runs as the user nobody. To run its maintenance the alertmanager
+        # must be able to write to its volume or it logs an error message. The alertmanager now runs as root
+        # to prevent these error messages.
+        securityContext:
+          runAsUser: 0
         env:
         - name: POD_IP
           valueFrom:

--- a/charts/seed-monitoring/charts/alertmanager/templates/_config.tpl
+++ b/charts/seed-monitoring/charts/alertmanager/templates/_config.tpl
@@ -18,7 +18,7 @@ route:
 
   # If an alert has successfully been sent, wait 'repeat_interval' to
   # resend them.
-  repeat_interval: 48h
+  repeat_interval: 72h
 
   # Send alerts by default to nowhere
   receiver: dev-null

--- a/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
@@ -75,6 +75,11 @@ spec:
         - --web.external-url=https://{{ .Values.ingress.host }}
         - --storage.path=/var/alertmanager/data
         - --log.level=info
+        # Since v0.16 alertmanager runs as the user nobody. To run its maintenance the alertmanager
+        # must be able to write to its volume or it logs an error message. The alertmanager now runs as root
+        # to prevent these error messages.
+        securityContext:
+          runAsUser: 0
         env:
         - name: ALERTMANAGER_NAMESPACE
           valueFrom:

--- a/charts/seed-monitoring/charts/core/charts/prometheus/optional-rules/cluster-autoscaler.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/optional-rules/cluster-autoscaler.rules.yaml
@@ -1,11 +1,10 @@
 groups:
 - name: cluster-autoscaler.rules
   rules:
-  - alert: ClusterAutoscallerDown
+  - alert: ClusterAutoscalerDown
     expr: absent(up{job="cluster-autoscaler"} == 1)
     for: 7m
     labels:
-      job: cluster-autoscaler
       service: cluster-autoscaler
       severity: critical
       type: seed

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-apiserver.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-apiserver.rules.test.yaml
@@ -18,10 +18,13 @@ tests:
   - series: 'process_max_fds{job="kube-apiserver", instance="instance"}'
     values: '100+0x60'
   # KubeApiServerLatency
-  - series: 'apiserver_request_duration_seconds_bucket{verb="POST", le="5000000"}'
-    values: '100+0x60'
+  # in this example the request duration is always greater than 3s and less than or equal to 5s.
   - series: 'apiserver_request_duration_seconds_bucket{verb="POST", le="+Inf"}'
-    values: '100+0x60'
+    values: '0+1x62'
+  - series: 'apiserver_request_duration_seconds_bucket{verb="POST", le="5"}'
+    values: '0+1x62'
+  - series: 'apiserver_request_duration_seconds_bucket{verb="POST", le="3"}'
+    values: '0+0x62'
   # KubeApiServerTooManyAuditlogFailures
   - series: 'apiserver_audit_error_total{plugin="webhook", job="kube-apiserver"}'
     values: '1+1x31'
@@ -75,7 +78,7 @@ tests:
       exp_annotations:
         description: 'The API server (instance) is using 81% of the available file/socket descriptors.'
         summary: 'The API server has too many open file descriptors'
-  - eval_time: 30m
+  - eval_time: 31m
     alertname: KubeApiServerLatency
     exp_alerts:
     - exp_labels:
@@ -85,15 +88,15 @@ tests:
         visibility: owner
         verb: POST
       exp_annotations:
-        description: Kube API server latency for verb POST is high. This could be because the shoot workers and the control plane are in different regions. 99th percentile of request latency is greater than 3 second.
+        description: Kube API server latency for verb POST is high. This could be because the shoot workers and the control plane are in different regions. 99th percentile of request latency is greater than 3 seconds.
         summary: Kubernetes API server latency is high
   - eval_time: 16m
     alertname: KubeApiServerTooManyAuditlogFailures
     exp_alerts:
     - exp_labels:
+        service: auditlog
         severity: critical
         type: seed
-        job: kube-apiserver
         visibility: operator
       exp_annotations:
         description: 'The API servers cumulative failure rate in logging audit events is 0.03%. This may be caused by an unavailable/unreachable AuditSink(s) and/or improper API server audit configuration.'

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-kubelet.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-kubelet.rules.test.yaml
@@ -30,7 +30,7 @@ tests:
     exp_alerts:
     - exp_labels:
         job: kube-kubelet
-        service: kube-kubelet-shoot
+        service: kube-kubelet
         severity: warning
         visibility: owner
         type: shoot
@@ -40,7 +40,7 @@ tests:
         summary: 'Shoot-kubelet has too many open file descriptors.'
     - exp_labels:
         job: kube-kubelet
-        service: kube-kubelet-shoot
+        service: kube-kubelet
         severity: critical
         type: shoot
         visibility: owner
@@ -53,7 +53,7 @@ tests:
     exp_alerts:
     - exp_labels:
         job: kube-kubelet-seed
-        service: kube-kubelet-seed
+        service: kube-kubelet
         severity: critical
         visibility: operator
         type: seed
@@ -66,7 +66,7 @@ tests:
     exp_alerts:
     - exp_labels:
         job: kube-kubelet
-        service: kube-kubelet-seed
+        service: kube-kubelet
         severity: critical
         type: seed
         visibility: operator
@@ -79,7 +79,7 @@ tests:
     exp_alerts:
     - exp_labels:
         job: kube-kubelet
-        service: kube-kubelet-seed
+        service: kube-kubelet
         severity: warning
         type: seed
         visibility: operator

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-state-metrics.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-state-metrics.rules.test.yaml
@@ -7,10 +7,10 @@ tests:
   input_series:
   # KubeStateMetricsShootDown
   - series: 'up{job="kube-state-metrics", type="shoot"}'
-    values: '0+0x20'
+    values: '0+0x30'
   # KubeStateMetricsSeedDown
   - series: 'up{job="kube-state-metrics", type="seed"}'
-    values: '0+0x20'
+    values: '0+0x30'
   # NoWorkerNodes
   - series: 'kube_node_spec_unschedulable'
     values: '2+0x20'
@@ -19,7 +19,7 @@ tests:
   - series: 'kube_node_info'
     values: '1+0x50'
   alert_rule_test:
-  - eval_time: 5m
+  - eval_time: 15m
     alertname: KubeStateMetricsShootDown
     exp_alerts:
     - exp_labels:
@@ -30,7 +30,7 @@ tests:
       exp_annotations:
         summary: Kube-state-metrics for shoot cluster metrics is down.
         description: There are no running kube-state-metric pods for the shoot cluster. No kubernetes resource metrics can be scraped.
-  - eval_time: 5m
+  - eval_time: 15m
     alertname: KubeStateMetricsSeedDown
     exp_alerts:
     - exp_labels:

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-apiserver.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-apiserver.rules.yaml
@@ -23,10 +23,8 @@ groups:
     annotations:
       description: All API server replicas are down/unreachable, or all API server could not be found.
       summary: API server unreachable.
-  # Some verbs excluded because they are expected to be long-lasting:
-  # WATCHLIST is long-poll, CONNECT is `kubectl exec`.
-  - alert: KubeApiServerLatency
-    expr: histogram_quantile(0.99, sum without (instance,resource) (apiserver_request_duration_seconds_bucket{subresource!="log",verb!~"CONNECT|WATCHLIST|WATCH|PROXY proxy"})) > 3.0
+  - alert: KubeApiServerTooManyOpenFileDescriptors
+    expr: 100 * process_open_fds{job="kube-apiserver"} / process_max_fds > 50
     for: 30m
     labels:
       service: kube-apiserver
@@ -34,21 +32,32 @@ groups:
       type: seed
       visibility: owner
     annotations:
-      description: Kube API server latency for verb {{ $labels.verb }} is high. This could be because the shoot workers and the control plane are in different regions. 99th percentile of request latency is greater than 3 second.
+      description: 'The API server ({{ $labels.instance }}) is using {{ $value }}% of the available file/socket descriptors.'
+      summary: 'The API server has too many open file descriptors'
+  - alert: KubeApiServerTooManyOpenFileDescriptors
+    expr: 100 * process_open_fds{job="kube-apiserver"} / process_max_fds{job="kube-apiserver"} > 80
+    for: 30m
+    labels:
+      service: kube-apiserver
+      severity: critical
+      type: seed
+      visibility: owner
+    annotations:
+      description: 'The API server ({{ $labels.instance }}) is using {{ $value }}% of the available file/socket descriptors.'
+      summary: 'The API server has too many open file descriptors'
+  # Some verbs excluded because they are expected to be long-lasting:
+  # WATCHLIST is long-poll, CONNECT is `kubectl exec`.
+  - alert: KubeApiServerLatency
+    expr: histogram_quantile(0.99, sum without (instance,resource) (rate(apiserver_request_duration_seconds_bucket{subresource!="log",verb!~"CONNECT|WATCHLIST|WATCH|PROXY proxy"}[5m]))) > 3
+    for: 30m
+    labels:
+      service: kube-apiserver
+      severity: warning
+      type: seed
+      visibility: owner
+    annotations:
+      description: Kube API server latency for verb {{ $labels.verb }} is high. This could be because the shoot workers and the control plane are in different regions. 99th percentile of request latency is greater than 3 seconds.
       summary: Kubernetes API server latency is high
-  ### API latency ###
-  - record: apiserver_latency_seconds:quantile
-    expr: histogram_quantile(0.99, rate(apiserver_request_duration_seconds_bucket[5m]))
-    labels:
-      quantile: "0.99"
-  - record: apiserver_latency:quantile
-    expr: histogram_quantile(0.9, rate(apiserver_request_duration_seconds_bucket[5m]))
-    labels:
-      quantile: "0.9"
-  - record: apiserver_latency_seconds:quantile
-    expr: histogram_quantile(0.5, rate(apiserver_request_duration_seconds_bucket[5m]))
-    labels:
-      quantile: "0.5"
   # TODO replace with better metrics in the future (wyb1)
   - record: shoot:apiserver_watch_duration:quantile
     expr: histogram_quantile(0.2, sum(rate(apiserver_request_duration_seconds_bucket{verb="WATCH",resource=~"configmaps|deployments|secrets|daemonsets|services|nodes|pods|namespaces|endpoints|statefulsets|clusterroles|roles"}[5m])) by (le,scope,resource))
@@ -74,40 +83,31 @@ groups:
     expr: histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket{verb="WATCH",group=~".+garden.+"}[5m])) by (le,scope,resource))
     labels:
       quantile: "0.9"
-  - alert: KubeApiServerTooManyOpenFileDescriptors
-    expr: 100 * process_open_fds{job="kube-apiserver"} / process_max_fds > 50
-    for: 30m
-    labels:
-      service: kube-apiserver
-      severity: warning
-      type: seed
-      visibility: owner
-    annotations:
-      description: 'The API server ({{ $labels.instance }}) is using {{ $value }}% of the available file/socket descriptors.'
-      summary: 'The API server has too many open file descriptors'
-  - alert: KubeApiServerTooManyOpenFileDescriptors
-    expr: 100 * process_open_fds{job="kube-apiserver"} / process_max_fds{job="kube-apiserver"} > 80
-    for: 30m
-    labels:
-      service: kube-apiserver
-      severity: critical
-      type: seed
-      visibility: owner
-    annotations:
-      description: 'The API server ({{ $labels.instance }}) is using {{ $value }}% of the available file/socket descriptors.'
-      summary: 'The API server has too many open file descriptors'
   ### API auditlog ###
   - alert: KubeApiServerTooManyAuditlogFailures
     expr: sum(rate (apiserver_audit_error_total{plugin="webhook"} [5m])) by (app ,role) / ignoring(plugin) sum(rate(apiserver_audit_event_total [5m])) by (app, role) > 0.02
     for: 15m
     labels:
+      service: auditlog
       severity: critical
       type: seed
-      job: kube-apiserver
       visibility: operator
     annotations:
         description: 'The API servers cumulative failure rate in logging audit events is {{ printf "%0.2f" $value }}%. This may be caused by an unavailable/unreachable AuditSink(s) and/or improper API server audit configuration.'
         summary: 'The API server has too many failed attempts to log audit events'
+  ### API latency ###
+  - record: apiserver_latency_seconds:quantile
+    expr: histogram_quantile(0.99, rate(apiserver_request_duration_seconds_bucket[5m]))
+    labels:
+      quantile: "0.99"
+  - record: apiserver_latency:quantile
+    expr: histogram_quantile(0.9, rate(apiserver_request_duration_seconds_bucket[5m]))
+    labels:
+      quantile: "0.9"
+  - record: apiserver_latency_seconds:quantile
+    expr: histogram_quantile(0.5, rate(apiserver_request_duration_seconds_bucket[5m]))
+    labels:
+      quantile: "0.5"
 
   - record: shoot:kube_apiserver:sum_by_pod
     expr: sum(up{job="kube-apiserver"}) by (pod)

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -67,9 +67,6 @@ groups:
         within the last hour.
       summary: High number of failed etcd proposals
 
-  - record: shoot:etcd_object_counts:sum_by_resource
-    expr: sum(etcd_object_counts) by (resource)
-
   # etcd DB size alerts
   - alert: KubeEtcd3DbSizeLimitApproaching
     expr: (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"} > bool 7516193000) + (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3"} <= bool 8589935000) == 2 # between 7GB and 8GB
@@ -128,3 +125,6 @@ groups:
     annotations:
       description: Etcd data restoration was triggered, but has failed.
       summary: Etcd data restoration failure.
+
+  - record: shoot:etcd_object_counts:sum_by_resource
+    expr: sum(etcd_object_counts) by (resource)

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-kubelet.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-kubelet.rules.yaml
@@ -12,21 +12,11 @@ groups:
     annotations:
       description: The kubelet {{ $labels.instance }} has been unavailable/unreachable for more than 1 hour. Workloads on the affected node may not be schedulable.
       summary: Kubelet unavailable
-  - alert: KubeKubeletTooManyPods
-    expr: kubelet_running_pod_count > 100
-    for: 30m
-    labels:
-      service: kube-kubelet
-      severity: warning
-      visibility: owner
-    annotations:
-      description: Kubelet {{ $labels.instance }} is running {{ $value }} pods, close to the limit of 110
-      summary: Too many pods on node
   - alert: KubeletTooManyOpenFileDescriptorsShoot
     expr: 100 * process_open_fds{job=~"^(?:kube-kubelet)$"} / process_max_fds{job=~"^(?:kube-kubelet)$"} > 50
     for: 30m
     labels:
-      service: kube-kubelet-shoot
+      service: kube-kubelet
       severity: warning
       type: shoot
       visibility: owner
@@ -37,7 +27,7 @@ groups:
     expr: 100 * process_open_fds{job="kube-kubelet"} / process_max_fds{job="kube-kubelet"} > 80
     for: 30m
     labels:
-      service: kube-kubelet-shoot
+      service: kube-kubelet
       severity: critical
       type: shoot
       visibility: owner
@@ -48,7 +38,7 @@ groups:
     expr: 100 * process_open_fds{job="kube-kubelet-seed"} / process_max_fds{job="kube-kubelet-seed"} > 80
     for: 30m
     labels:
-      service: kube-kubelet-seed
+      service: kube-kubelet
       severity: critical
       type: seed
       visibility: operator
@@ -59,7 +49,7 @@ groups:
     expr: 100 * kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes < 5
     for: 1h
     labels:
-      service: kube-kubelet-seed
+      service: kube-kubelet
       severity: critical
       type: seed
       visibility: operator
@@ -77,7 +67,7 @@ groups:
       predict_linear(kubelet_volume_stats_available_bytes{type="seed", persistentvolumeclaim!~"loki-.*"}[30m], 4 * 24 * 3600) <= 0
     for: 1h
     labels:
-      service: kube-kubelet-seed
+      service: kube-kubelet
       severity: warning
       type: seed
       visibility: operator

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-state-metrics.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-state-metrics.rules.yaml
@@ -3,7 +3,7 @@ groups:
   rules:
   - alert: KubeStateMetricsShootDown
     expr: absent(up{job="kube-state-metrics", type="shoot"} == 1)
-    for: 5m
+    for: 15m
     labels:
       service: kube-state-metrics-shoot
       severity: info
@@ -15,7 +15,7 @@ groups:
 
   - alert: KubeStateMetricsSeedDown
     expr: absent(up{job="kube-state-metrics", type="seed"} == 1)
-    for: 5m
+    for: 15m
     labels:
       service: kube-state-metrics-seed
       severity: critical


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind cleanup
/priority normal

**What this PR does / why we need it**:

Alert factoring includes:
* typo fixes
* improved descriptions
* fixed the `KubeApiServerLatency` alert
* Email alerts will now be grouped by the `service` label instead of the `cluster` label
* Alerts that haven't resolved will be resent after 3 days instead of 2 days to reduce alert frequency
* The alertmanager should no longer log error message when it performs its maintenance

Most changes are to reduce alert frequency or improve consistency.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Improve alerting for operators. Alerts should fire less frequently and are now grouped by the `service` label instead of cluster which should also reduce the amount of alerts sent
```
```improvement user
Fixed an error in the `KubeApiServerLatency` alert
```

