### PR TITLE
Make AfterSuite hooks ordered

### DIFF
--- a/test/framework/cleanup.go
+++ b/test/framework/cleanup.go
@@ -1,35 +1,50 @@
-// Copied from https://github.com/kubernetes/kubernetes/blob/de66c643c479f420b1902f8897636ea41ac2b3c3/test/e2e/framework/cleanup.go
 /*
 Copyright 2016 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+This file was copied from the kubernetes/kubernetes project
+https://github.com/kubernetes/kubernetes/blob/v1.19.0-rc.4/test/e2e/framework/cleanup.go
+
+Modifications Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
 */
 
 package framework
 
-import "sync"
+import (
+	"sync"
+)
 
 // CleanupActionHandle is an integer pointer type for handling cleanup action
 type CleanupActionHandle *int
+type cleanupFuncHandle struct {
+	actionHandle CleanupActionHandle
+	actionHook   func()
+}
 
 var cleanupActionsLock sync.Mutex
-var cleanupActions = map[CleanupActionHandle]func(){}
+var cleanupHookList = []cleanupFuncHandle{}
 
 // AddCleanupAction installs a function that will be called in the event of the
 // whole test being terminated.  This allows arbitrary pieces of the overall
 // test to hook into SynchronizedAfterSuite().
+// The hooks are called in last-in-first-out order.
 func AddCleanupAction(fn func()) CleanupActionHandle {
 	p := CleanupActionHandle(new(int))
 	cleanupActionsLock.Lock()
 	defer cleanupActionsLock.Unlock()
-	cleanupActions[p] = fn
+	c := cleanupFuncHandle{actionHandle: p, actionHook: fn}
+	cleanupHookList = append([]cleanupFuncHandle{c}, cleanupHookList...)
 	return p
 }
 
@@ -38,7 +53,12 @@ func AddCleanupAction(fn func()) CleanupActionHandle {
 func RemoveCleanupAction(p CleanupActionHandle) {
 	cleanupActionsLock.Lock()
 	defer cleanupActionsLock.Unlock()
-	delete(cleanupActions, p)
+	for i, item := range cleanupHookList {
+		if item.actionHandle == p {
+			cleanupHookList = append(cleanupHookList[:i], cleanupHookList[i+1:]...)
+			break
+		}
+	}
 }
 
 // RunCleanupActions runs all functions installed by AddCleanupAction.  It does
@@ -49,8 +69,8 @@ func RunCleanupActions() {
 	func() {
 		cleanupActionsLock.Lock()
 		defer cleanupActionsLock.Unlock()
-		for _, fn := range cleanupActions {
-			list = append(list, fn)
+		for _, p := range cleanupHookList {
+			list = append(list, p.actionHook)
 		}
 	}()
 	// Run unlocked.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind task
/priority normal

**What this PR does / why we need it**:
This PR syncs the upstream change https://github.com/kubernetes/kubernetes/commit/708261e06c754ed9f757e1c91fd12e446857b702. The guaranteed order of execution of the cleanup actions is needed for https://github.com/gardener/gardener-extension-provider-gcp/pull/159. 


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
