### PR TITLE
Fix context cancel for garbage collection in care controller

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -235,9 +235,6 @@ func (c *defaultCareControl) Care(shootObj *gardencorev1beta1.Shoot, key string)
 
 	initializeShootClients := shootClientInitializer(ctx, botanist)
 
-	// Trigger garbage collection
-	go garbageCollection(ctx, initializeShootClients, botanist)
-
 	_ = flow.Parallel(
 		// Trigger health check
 		func(ctx context.Context) error {
@@ -264,6 +261,12 @@ func (c *defaultCareControl) Care(shootObj *gardencorev1beta1.Shoot, key string)
 		// Trigger constraint checks
 		func(ctx context.Context) error {
 			constraintHibernationPossible = botanist.ConstraintsChecks(ctx, initializeShootClients, constraintHibernationPossible)
+			return nil
+		},
+		// Trigger garbage collection
+		func(ctx context.Context) error {
+			garbageCollection(ctx, initializeShootClients, botanist)
+			// errors during garbage collection are only being logged and do not cause the care operation to fail
 			return nil
 		},
 	)(ctx)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:

Fixes Garbage collection problems in the Shoot care controller such as

```
Could not initialise Shoot client for garbage collection of shoot garden-dev/aws-glinux2: Get \"...../deployments/kube-apiserver\": context canceled
```

Introduces a dedicated  context for the garbage collection in the care controller. 

Currently the context to initialise the shoot clients gets canceled after the health checks are finished. The garbage collection uses the very same context underneath when initialising its clients.

So if the health checks complete before the garbage collection starts, garbage collection fails to create its clients due to an already canceled context.  
This happens often for hibernated clusters where the health checks complete right away.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is I think a different issue than reported in #2689
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fixes a bug that could cause Shoot garbage collection to fail in certain cases.
```
