### PR TITLE
[GEP-7] Add ability to register and delete seed in the integration tests

### DIFF
--- a/.test-defs/DeleteSeed.yaml
+++ b/.test-defs/DeleteSeed.yaml
@@ -1,0 +1,18 @@
+kind: TestDefinition
+metadata:
+  name: delete-shooted-seed
+spec:
+  owner: gardener-oq@listserv.sap.com
+  description: Tests the deletion of a shooted seed cluster.
+  activeDeadlineSeconds: 3600
+
+  command: [bash, -c]
+  args:
+  - >-
+    go test -timeout=0 -mod=vendor ./test/system/seed_deletion
+    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+    -seed-name=$SEED_NAME
+    -shoot-name=$SHOOT_NAME
+    -project-namespace=$PROJECT_NAMESPACE
+    -kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
+  image: golang:1.15.3

--- a/.test-defs/RegisterSeed.yaml
+++ b/.test-defs/RegisterSeed.yaml
@@ -1,0 +1,27 @@
+kind: TestDefinition
+metadata:
+  name: register-seed
+spec:
+  owner: gardener-oq@listserv.sap.com
+  description: Tests the registration of a seed.
+  activeDeadlineSeconds: 7200
+
+  command: [bash, -c]
+  args:
+  - >-
+    go test -timeout=0 -mod=vendor ./test/system/seed_registration
+    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+    -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
+    -seed-name=$SEED_NAME
+    -secret-binding=$SECRET_BINDING
+    -shoot-name=$SHOOT_NAME
+    -shoot-namespace=$PROJECT_NAMESPACE
+    -backup-secret-provider=$BACKUP_SECRET_PROVIDER
+    -provider-type=$PROVIDER_TYPE
+    -provider-region=$PROVIDER_REGION
+    -networking-blockcidrs=$NETWORKING_BLOCKCIDRS
+    -networking-pods=$NETWORKING_PODS
+    -networking-services=$NETWORKING_SERVICES
+    -networking-nodes=$NETWORKING_NODES
+    -deploy-gardenlet=$DEPLOY_GARDENLET
+image: golang:1.15.3

--- a/test/framework/gardenerframework.go
+++ b/test/framework/gardenerframework.go
@@ -158,3 +158,15 @@ func (f *GardenerFramework) NewShootFramework(shoot *gardencorev1beta1.Shoot) (*
 	}
 	return shootFramework, nil
 }
+
+// NewSeedRegistrationFramework creates a new SeedRegistrationFramework with the current gardener framework
+func (f *GardenerFramework) NewSeedRegistrationFramework(seed *gardencorev1beta1.Seed) (*SeedRegistrationFramework, error) {
+	seedFramework := &SeedRegistrationFramework{
+		GardenerFramework: f,
+		Config: &SeedRegistrationConfig{
+			GardenerConfig: f.GardenerFrameworkConfig,
+		},
+	}
+
+	return seedFramework, seedFramework.AddSeed(context.TODO(), seed)
+}

--- a/test/framework/seedregistrationframework.go
+++ b/test/framework/seedregistrationframework.go
@@ -1,0 +1,374 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/operation/common"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	"github.com/onsi/ginkgo"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var seedRegistrationConfig *SeedRegistrationConfig
+
+const (
+	kubeconfigString = "kubeconfig"
+)
+
+// SeedRegistrationFramework represents the seed test framework that includes
+// test functions that can be executed on a specific seed
+type SeedRegistrationFramework struct {
+	*GardenerFramework
+	TestDescription
+	Config *SeedRegistrationConfig
+
+	SeedClient kubernetes.Interface
+	Seed       *gardencorev1beta1.Seed
+	Secret     *corev1.Secret //the secret that will be created and used for seed.Spec.SecretRef
+}
+
+// SeedRegistrationConfig is the configuration for a seed registration framework that will be filled with user provided data
+type SeedRegistrationConfig struct {
+	GardenerConfig         *GardenerConfig
+	SeedName               string
+	SecretBinding          string
+	BackupSecretProvider   string
+	ShootedSeedName        string
+	ShootedSeedNamespace   string
+	ProviderRegion         string
+	ProviderType           string
+	NetworkingPods         string
+	NetworkingServices     string
+	NetworkingNodes        string
+	NetworkingBlockCIDRs   string
+	DeployGardenletOnShoot string
+}
+
+// NewSeedRegistrationFramework creates a new simple SeedRegistrationFramework
+func NewSeedRegistrationFramework(cfg *SeedRegistrationConfig) *SeedRegistrationFramework {
+	var gardenerConfig *GardenerConfig
+	if cfg != nil {
+		gardenerConfig = cfg.GardenerConfig
+	}
+
+	f := &SeedRegistrationFramework{
+		GardenerFramework: NewGardenerFrameworkFromConfig(gardenerConfig),
+		TestDescription:   NewTestDescription("SEED"),
+		Config:            cfg,
+	}
+
+	CBeforeEach(func(ctx context.Context) {
+		f.CommonFramework.BeforeEach()
+		f.GardenerFramework.BeforeEach()
+		f.BeforeEach(ctx)
+	}, 8*time.Minute)
+	CAfterEach(f.AfterEach, 10*time.Minute)
+	return f
+}
+
+// NewSeedRegistrationFrameworkFromConfig creates a new SeedRegistrationFramework from a seed configuration without registering ginkgo
+func NewSeedRegistrationFrameworkFromConfig(cfg *SeedRegistrationConfig) (*SeedRegistrationFramework, error) {
+	var gardenerConfig *GardenerConfig
+	if cfg != nil {
+		gardenerConfig = cfg.GardenerConfig
+	}
+	f := &SeedRegistrationFramework{
+		GardenerFramework: NewGardenerFrameworkFromConfig(gardenerConfig),
+		TestDescription:   NewTestDescription("SEED"),
+		Config:            cfg,
+	}
+	return f, nil
+}
+
+// BeforeEach should be called in ginkgo's BeforeEach.
+// It sets up the seed registration framework.
+func (f *SeedRegistrationFramework) BeforeEach(ctx context.Context) {
+	f.Config = mergeSeedConfig(f.Config, seedRegistrationConfig)
+	validateSeedConfig(f.Config)
+}
+
+// AfterEach should be called in ginkgo's AfterEach.
+// Cleans up resources and dumps the seed state if the test failed
+func (f *SeedRegistrationFramework) AfterEach(ctx context.Context) {
+	if ginkgo.CurrentGinkgoTestDescription().Failed {
+		f.DumpState(ctx)
+	}
+}
+
+func validateSeedConfig(cfg *SeedRegistrationConfig) {
+	if cfg == nil {
+		ginkgo.Fail("no seed registration framework configuration provided")
+	}
+	if !StringSet(cfg.SeedName) {
+		ginkgo.Fail("You should specify a name for the new Seed")
+	}
+	if !StringSet(cfg.SecretBinding) {
+		ginkgo.Fail("You should specify a secret binding for the secret that will be created for this seed")
+	}
+	if !StringSet(cfg.ShootedSeedName) || !StringSet(cfg.ShootedSeedNamespace) {
+		ginkgo.Fail("You should specify Shooted Seed name and namespace to test against")
+	}
+	if !StringSet(cfg.ProviderRegion) || !StringSet(cfg.ProviderType) {
+		ginkgo.Fail("You should specify a Provider and Provider type")
+	}
+	if !StringSet(cfg.NetworkingPods) || !StringSet(cfg.NetworkingServices) || !StringSet(cfg.NetworkingNodes) {
+		ginkgo.Fail("Networking settings are missing or incomplete")
+	}
+	if StringSet(cfg.DeployGardenletOnShoot) {
+		if _, err := strconv.ParseBool(cfg.DeployGardenletOnShoot); err != nil {
+			ginkgo.Fail("-deploy-gardenlet is not a boolean value")
+		}
+	} else {
+		cfg.DeployGardenletOnShoot = "true"
+	}
+}
+
+func mergeSeedConfig(base, overwrite *SeedRegistrationConfig) *SeedRegistrationConfig {
+	if base == nil {
+		return overwrite
+	}
+	if overwrite == nil {
+		return base
+	}
+	if overwrite.GardenerConfig != nil {
+		base.GardenerConfig = overwrite.GardenerConfig
+	}
+	if StringSet(overwrite.SeedName) {
+		base.SeedName = overwrite.SeedName
+	}
+	if StringSet(overwrite.SecretBinding) {
+		base.SecretBinding = overwrite.SecretBinding
+	}
+	if StringSet(overwrite.BackupSecretProvider) {
+		base.BackupSecretProvider = overwrite.BackupSecretProvider
+	}
+	if StringSet(overwrite.ShootedSeedName) {
+		base.ShootedSeedName = overwrite.ShootedSeedName
+	}
+	if StringSet(overwrite.ShootedSeedNamespace) {
+		base.ShootedSeedNamespace = overwrite.ShootedSeedNamespace
+	}
+	if StringSet(overwrite.ProviderRegion) {
+		base.ProviderRegion = overwrite.ProviderRegion
+	}
+	if StringSet(overwrite.ProviderType) {
+		base.ProviderType = overwrite.ProviderType
+	}
+	if StringSet(overwrite.NetworkingBlockCIDRs) {
+		base.NetworkingBlockCIDRs = overwrite.NetworkingBlockCIDRs
+	}
+	if StringSet(overwrite.NetworkingPods) {
+		base.NetworkingPods = overwrite.NetworkingPods
+	}
+	if StringSet(overwrite.NetworkingServices) {
+		base.NetworkingServices = overwrite.NetworkingServices
+	}
+	if StringSet(overwrite.NetworkingNodes) {
+		base.NetworkingNodes = overwrite.NetworkingNodes
+	}
+	if StringSet(overwrite.DeployGardenletOnShoot) {
+		base.DeployGardenletOnShoot = overwrite.DeployGardenletOnShoot
+	}
+	return base
+}
+
+// RegisterSeedRegistrationFrameworkFlags adds all flags that are needed to configure a seed registration framework to the provided flagset.
+func RegisterSeedRegistrationFrameworkFlags() *SeedRegistrationConfig {
+	_ = RegisterGardenerFrameworkFlags()
+
+	newCfg := &SeedRegistrationConfig{}
+
+	flag.StringVar(&newCfg.SeedName, "seed-name", "", "Name of the seed")
+	flag.StringVar(&newCfg.SecretBinding, "secret-binding", "", "Secret binding parameter")
+	flag.StringVar(&newCfg.BackupSecretProvider, "backup-secret-provider", "", "Provider of the backup secret reference")
+	// Shooted seed reference
+	flag.StringVar(&newCfg.ShootedSeedName, "shoot-name", "", "Name of the shoot")
+	flag.StringVar(&newCfg.ShootedSeedNamespace, "shoot-namespace", "", "Namespace of the shoot")
+	// Provider
+	flag.StringVar(&newCfg.ProviderType, "provider-type", "", "Provider type e.g. aws, azure, gcp")
+	flag.StringVar(&newCfg.ProviderRegion, "provider-region", "", "Provider region e.g. eu-west-1")
+	// Network
+	flag.StringVar(&newCfg.NetworkingBlockCIDRs, "networking-blockcidrs", "", "Comma-separated values for seed.Spec.Networks.BlockCIDRs.")
+	flag.StringVar(&newCfg.NetworkingPods, "networking-pods", "", "Value for Seed.Spec.Networks.Pods")
+	flag.StringVar(&newCfg.NetworkingServices, "networking-services", "", "Value for Seed.Spec.Networks.Services")
+	flag.StringVar(&newCfg.NetworkingNodes, "networking-nodes", "", "Value for Seed.Spec.Networks.Nodes")
+	flag.StringVar(&newCfg.DeployGardenletOnShoot, "deploy-gardenlet", "", "Specify if a gardanlet instance should be installed on the shoot. Default = true")
+
+	seedRegistrationConfig = newCfg
+
+	return seedRegistrationConfig
+}
+
+// AddSeed function tries to get an existing seed using the configured GardenClient
+// and the given seed parameter and adds it to the SeedRegistrationFramework
+func (f *SeedRegistrationFramework) AddSeed(ctx context.Context, seed *gardencorev1beta1.Seed) error {
+	if f.GardenClient == nil {
+		return errors.New("no gardener client is defined")
+	}
+	if err := f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Name: seed.Name}, seed); err != nil {
+		return err
+	}
+	f.Seed = seed
+	return nil
+}
+
+// RegisterSeed registers a new seed and its secret reference (seed.Spec.SecretRef)
+// according to the configuration provided for the SeedRegistrationFramework
+func (f *SeedRegistrationFramework) RegisterSeed(ctx context.Context) (err error) {
+	if f.GardenClient == nil {
+		return errors.New("no gardener client is defined")
+	}
+
+	refShoot := &gardencorev1beta1.Shoot{}
+	if err = f.GardenClient.DirectClient().Get(ctx, kutil.Key(f.Config.ShootedSeedNamespace, f.Config.ShootedSeedName), refShoot); err != nil {
+		return err
+	}
+
+	if deploy, _ := strconv.ParseBool(f.Config.DeployGardenletOnShoot); deploy {
+		return f.annotateShootToBeUsedAsSeed(ctx, refShoot)
+	}
+
+	secretBinding := &gardencorev1beta1.SecretBinding{}
+	if err = f.GardenClient.DirectClient().Get(ctx, kutil.Key(f.Config.ShootedSeedNamespace, f.Config.SecretBinding), secretBinding); err != nil {
+		return err
+	}
+
+	f.Seed = f.buildSeedObject(secretBinding, refShoot)
+
+	if err = f.buildSeedSecret(ctx, secretBinding); err != nil {
+		f.Logger.Errorf("Cannot build seed secret %s", err)
+		return err
+	}
+	f.Logger.Infof("Creating seed secret %s in namespace %s", f.Secret.GetName(), f.Secret.GetNamespace())
+	// Apply secret to the cluster
+	if err = f.GardenClient.DirectClient().Create(ctx, f.Secret); err != nil {
+		f.Logger.Errorf("Cannot create seed secret %s: %s", f.Secret.GetName(), err)
+		return err
+	}
+	f.Logger.Infof("Secret resource %s was created!", f.Secret.Name)
+
+	f.Logger.Infof("Registering seed %s", f.Seed.GetName())
+	if err := PrettyPrintObject(f.Seed); err != nil {
+		f.Logger.Errorf("Cannot decode seed %s: %s", f.Seed.GetName(), err)
+		return err
+	}
+	return f.GardenerFramework.CreateSeed(ctx, f.Seed)
+}
+
+func (f *SeedRegistrationFramework) annotateShootToBeUsedAsSeed(ctx context.Context, refShoot *gardencorev1beta1.Shoot) (err error) {
+	annotations := map[string]string{
+		v1beta1constants.AnnotationShootUseAsSeed: "true,protected,invisible,with-secret-ref",
+	}
+	f.Logger.Infof("Annotating shoot with: %v", annotations)
+	if err = f.GardenerFramework.AnnotateShoot(ctx, refShoot, annotations); err != nil {
+		f.Logger.Errorf("Unable to annotate shoot due to: %s", err.Error())
+		return err
+	}
+	return f.GardenerFramework.UpdateShoot(ctx, refShoot, func(shoot *gardencorev1beta1.Shoot) error {
+		vpa := &gardencorev1beta1.VerticalPodAutoscaler{
+			Enabled: true,
+		}
+		shoot.Spec.Kubernetes.VerticalPodAutoscaler = vpa
+
+		return nil
+	})
+}
+
+func (f *SeedRegistrationFramework) buildSeedObject(secretBinding *gardencorev1beta1.SecretBinding, refShoot *gardencorev1beta1.Shoot) *gardencorev1beta1.Seed {
+	// TODO: Enable .spec.volume.minimumVolumeSize when implementing support for all providers
+	seed := &gardencorev1beta1.Seed{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: f.Config.SeedName,
+			Labels: map[string]string{
+				v1beta1constants.GardenRole: v1beta1constants.GardenRoleSeed,
+			},
+		},
+		Spec: gardencorev1beta1.SeedSpec{
+			DNS: gardencorev1beta1.SeedDNS{
+				IngressDomain: fmt.Sprintf("%s.%s", common.IngressPrefix, *refShoot.Spec.DNS.Domain),
+			},
+			SecretRef: &corev1.SecretReference{
+				Namespace: f.Config.ShootedSeedNamespace,
+				Name:      fmt.Sprintf("seed-%s", f.Config.SeedName),
+			},
+			Provider: gardencorev1beta1.SeedProvider{
+				Region: f.Config.ProviderRegion,
+				Type:   f.Config.ProviderType,
+			},
+			Networks: gardencorev1beta1.SeedNetworks{
+				BlockCIDRs: strings.Split(f.Config.NetworkingBlockCIDRs, ","),
+				Nodes:      &f.Config.NetworkingNodes,
+				Pods:       f.Config.NetworkingPods,
+				Services:   f.Config.NetworkingServices,
+			},
+			Settings: &gardencorev1beta1.SeedSettings{
+				Scheduling: &gardencorev1beta1.SeedSettingScheduling{
+					Visible: false,
+				},
+			},
+		},
+	}
+
+	if StringSet(f.Config.BackupSecretProvider) {
+		seed.Spec.Backup = &gardencorev1beta1.SeedBackup{
+			SecretRef: corev1.SecretReference{
+				Name:      secretBinding.SecretRef.Name,
+				Namespace: secretBinding.SecretRef.Namespace,
+			},
+			Provider: f.Config.BackupSecretProvider,
+		}
+	}
+	return seed
+}
+
+func (f *SeedRegistrationFramework) buildSeedSecret(ctx context.Context, secretBinding *gardencorev1beta1.SecretBinding) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: f.Config.ShootedSeedNamespace,
+			Name:      fmt.Sprintf("seed-%s", f.Config.SeedName),
+		},
+	}
+
+	kubeconfigSecret := &corev1.Secret{}
+	if err := f.GardenClient.DirectClient().Get(ctx, kutil.Key(f.Config.ShootedSeedNamespace, (f.Config.ShootedSeedName+".kubeconfig")), kubeconfigSecret); err != nil {
+		return err
+	}
+	kubecfgData := kubeconfigSecret.Data["kubeconfig"]
+
+	referenceSecret := &corev1.Secret{}
+	if err := f.GardenClient.DirectClient().Get(ctx, kutil.Key(secretBinding.SecretRef.Namespace, secretBinding.SecretRef.Name), referenceSecret); err != nil {
+		return err
+	}
+	secret.Data = referenceSecret.Data
+	secret.Data[kubeconfigString] = kubecfgData
+
+	f.Secret = secret
+
+	return nil
+}

--- a/test/system/seed_deletion/delete_suite_test.go
+++ b/test/system/seed_deletion/delete_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seed_deletion
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSeedApplications(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Seed Deletion Test Suite")
+}

--- a/test/system/seed_deletion/delete_test.go
+++ b/test/system/seed_deletion/delete_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+	Overview
+		- Tests the deletion of a seed
+ **/
+
+package seed_deletion
+
+import (
+	"context"
+	"flag"
+	"os"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/test/framework"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var seedName *string
+
+func init() {
+	seedName = flag.String("seed-name", "", "name of the seed")
+	framework.RegisterGardenerFrameworkFlags()
+}
+
+func validateFlags() {
+	if !framework.StringSet(*seedName) {
+		Fail("flag '-seed-name' needs to be specified")
+	}
+}
+
+var _ = Describe("Seed deletion testing", func() {
+
+	f := framework.NewGardenerFramework(nil)
+
+	framework.CIt("Testing if Seed can be deleted", func(ctx context.Context) {
+		validateFlags()
+		if err := deleteSeed(ctx, f); client.IgnoreNotFound(err) != nil {
+			Fail(err.Error())
+		}
+	}, 1*time.Hour)
+})
+
+func dumpStateOnTMPhaseExit(ctx context.Context, f *framework.GardenerFramework, seedFramework *framework.SeedRegistrationFramework, shootFramework *framework.ShootFramework) {
+	// Dump gardener state if delete seed or shoot is in exit handler
+	if os.Getenv("TM_PHASE") == "Exit" {
+		if seedFramework != nil {
+			seedFramework.DumpState(ctx)
+		} else if shootFramework != nil {
+			shootFramework.DumpState(ctx)
+		} else {
+			f.DumpState(ctx)
+		}
+	}
+}
+
+func deleteSeed(ctx context.Context, f *framework.GardenerFramework) error {
+	seed := &gardencorev1beta1.Seed{ObjectMeta: metav1.ObjectMeta{Name: *seedName}}
+	seedFramework, err := f.NewSeedRegistrationFramework(seed)
+	if err != nil {
+		f.DumpState(ctx)
+		return err
+	}
+	dumpStateOnTMPhaseExit(ctx, f, seedFramework, nil)
+
+	f.Logger.Info("Deleting backupbucket...")
+	if err := deleteBackupbucket(ctx, f, *seedName); client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	f.Logger.Info("Deleting seed...")
+	if err := f.DeleteSeedAndWaitForDeletion(ctx, seed); client.IgnoreNotFound(err) != nil {
+		f.Logger.Errorf("Cannot delete seed %s: %s", *seedName, err.Error())
+		return err
+	}
+
+	f.Logger.Info("Deleting secret...")
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: seed.Spec.SecretRef.Name, Namespace: seed.Spec.SecretRef.Namespace}}
+	if err := f.GardenClient.DirectClient().Delete(ctx, secret); client.IgnoreNotFound(err) != nil {
+		err = errors.Wrapf(err, "Secret %s/%s can't be deleted", seed.Spec.SecretRef.Namespace, seed.Spec.SecretRef.Name)
+		return err
+	}
+	f.Logger.Infof("Secret %s/%s deleted successfully", seed.Spec.SecretRef.Namespace, seed.Spec.SecretRef.Name)
+	return nil
+}
+
+func deleteBackupbucket(ctx context.Context, f *framework.GardenerFramework, seedName string) error {
+	backupbuckets := &gardencorev1beta1.BackupBucketList{}
+
+	if err := f.GardenClient.DirectClient().List(ctx, backupbuckets); err != nil {
+		return err
+	}
+
+	for _, backupbucket := range backupbuckets.Items {
+		if backupbucket.Spec.SeedName != nil && *backupbucket.Spec.SeedName == seedName {
+			f.Logger.Infof("Backupbucket found: %s", backupbucket.Name)
+			return f.GardenClient.DirectClient().Delete(ctx, &backupbucket)
+		}
+	}
+	return nil
+}

--- a/test/system/seed_registration/create_seed_test.go
+++ b/test/system/seed_registration/create_seed_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+	Overview
+		- Tests the registration of a seed
+	Test: Seed registration
+	Expected Output
+		- Successful reconciliation after Seed registration
+ **/
+
+package seed_registration
+
+import (
+	"context"
+	"time"
+
+	"github.com/gardener/gardener/test/framework"
+
+	. "github.com/onsi/ginkgo"
+)
+
+const (
+	CreateAndReconcileTimeout = 2 * time.Hour
+)
+
+func init() {
+	framework.RegisterSeedRegistrationFrameworkFlags()
+}
+
+var _ = Describe("Seed Registration testing", func() {
+
+	f := framework.NewSeedRegistrationFramework(&framework.SeedRegistrationConfig{
+		GardenerConfig: &framework.GardenerConfig{
+			CommonConfig: &framework.CommonConfig{
+				ResourceDir: "../../framework/resources",
+			},
+		},
+	})
+
+	f.CIt("Register and Reconcile Seed", func(ctx context.Context) {
+		err := f.RegisterSeed(ctx)
+		framework.ExpectNoError(err)
+	}, CreateAndReconcileTimeout)
+})

--- a/test/system/seed_registration/create_suite_test.go
+++ b/test/system/seed_registration/create_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seed_registration
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMigrationApplications(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Create Test Suite")
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/area testing
/kind test
/priority normal

**What this PR does / why we need it**:
This PR introduces functionality in the integration tests suite that registers and deletes shooter seed. This will later be used in the CP migration integration tests to migrate the shoot to the newly created shooter seed.
**Which issue(s) this PR fixes**:
Part of #1631 

**Special notes for your reviewer**:
Currently uses AWS specific access key variables, but we will change this to include all cloud providers.
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.
Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
