### PR TITLE
Fix for missing  DNSOwner CRD when shootDNS is disabled

### DIFF
--- a/charts/seed-bootstrap/templates/extensions/crd-dnsowner.yaml
+++ b/charts/seed-bootstrap/templates/extensions/crd-dnsowner.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: dnsowners.dns.gardener.cloud
+  labels:
+    gardener.cloud/deletion-protected: "true"
+spec:
+  conversion:
+    strategy: None
+  group: dns.gardener.cloud
+  names:
+    kind: DNSOwner
+    listKind: DNSOwnerList
+    plural: dnsowners
+    shortNames:
+      - dnso
+    singular: dnsowner
+  scope: Cluster
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+  additionalPrinterColumns:
+    - JSONPath: .spec.ownerId
+      description: Owner Id
+      name: OWNERID
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+          properties:
+             ownerId:
+               type: string
+             active:
+               type: boolean
+               nullable: true
+          required:
+            - ownerId
+        status:
+          properties:
+            amount:
+              type: int
+            types:
+              additionalProperties:
+                type: int
+              nullable: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority normal

**What this PR does / why we need it**:
With this PR the CRD `DNSOwner` will be deployed in all seed clusters regardless of the DNS settings (similarly to `DNSProvider` and `DNSEntry`). With this PR, the shoot reconciliation loop can be completed even when the `external-dns-management` extension is not deployed on the seed cluster. Previously the reconciliation loop would fail due to the missing CRD in the seed.

**Which issue(s) this PR fixes**:
Fixes #2785 

**Special notes for your reviewer**:
The CRD is created based on the [external-dns repo](https://github.com/gardener/external-dns-management/blob/master/charts/external-dns-management/templates/crds.yaml#L223-L257) with added validation (based on [this struct](https://github.com/gardener/external-dns-management/blob/master/pkg/apis/dns/v1alpha1/dnsowner.go).

Due the added validation there is a discrepancy between the original source in the external-dns repo, which can be resolved either by removing the validation or adding validation to external-dns repo's CRD.  

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
