### PR TITLE
Add mount for KCM required for certain OS

### DIFF
--- a/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/charts/seed-controlplane/charts/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -130,6 +130,9 @@ spec:
           mountPath: /var/lib/kube-controller-manager
         - name: kube-controller-manager-server
           mountPath: /var/lib/kube-controller-manager-server
+        - name: usr-share-cacerts
+          mountPath: /usr/share/ca-certificates
+          readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -147,3 +150,7 @@ spec:
       - name: kube-controller-manager-server
         secret:
           secretName: kube-controller-manager-server
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: "DirectoryOrCreate"
+        name: usr-share-cacerts


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/kind bug
/priority normal

**What this PR does / why we need it**:

Adds a host path volume to the KCM that is required for certain OS.

The KCM discovers the Root CAs available on the node via [predefined locations](https://github.com/golang/go/blob/1bb247a469e306c57a5e0eaba788efb8b3b1acef/src/crypto/x509/root_linux.go#L7-L15).

```
	"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
	"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
	"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
	"/etc/pki/tls/cacert.pem",                           // OpenELEC
	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
	"/etc/ssl/cert.pem",                                 // Alpine Linux
```

This is why the kcm mounts the `etc/ssl` directory.

For certain OS (e.g coreos 2512.3.0), the `etc/ssl/certs` contains only symlinks to the actual `ca-certificates.crt` file.
```
lrwxrwxrwx. 1 root root    54 May 22 20:41  ca-certificates.crt -> ../../../usr/share/ca-certificates/ca-certificates.crt
```
 
However, the KCM cannot access `ca-certificates/ca-certificates.crt` , because it does not mount the correct directory.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Please also see [related issue on kubeadm for coreos](https://github.com/kubernetes/kubeadm/issues/671) and [this](https://github.com/kubernetes/kubernetes/pull/59122).

We can also think about mounting the other directories like `"/etc/pki/tls/certs/`. 
But I would like to talk about and first go ahead with this issue.
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
KCM mounts `/usr/share/ca-certificates` required for certain OS (e.g CoreOS 2512.3.0),
```
