### PR TITLE
Kube apiserver mount ssl directories instead of files

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -258,26 +258,17 @@ spec:
           readOnly: true
         {{- end }}
         {{- if semverCompare ">= 1.17" .Values.kubernetesVersion }}
-        # All those locations are taken from
+        # locations are taken from
         # https://github.com/golang/go/blob/1bb247a469e306c57a5e0eaba788efb8b3b1acef/src/crypto/x509/root_linux.go#L7-L15
-        # we cannot be sure on which Seed Cluster Node OS is running so, it's safer to mount them all
-        - name: debian-family-cabundle
-          mountPath: /etc/ssl/certs/ca-certificates.crt
-          readOnly: true
-        - name: fedora-rhel6-cabundle
-          mountPath: /etc/pki/tls/certs/ca-bundle.crt
-          readOnly: true
-        - name: opensuse-cabundle
-          mountPath: /etc/ssl/ca-bundle.pem
-          readOnly: true
-        - name: openelec-cabundle
-          mountPath: /etc/pki/tls/cacert.pem
+        # we cannot be sure on which Node OS the Seed Cluster is running so, it's safer to mount them all
+        - name: fedora-rhel6-openelec-cabundle
+          mountPath: /etc/pki/tls
           readOnly: true
         - name: centos-rhel7-cabundle
-          mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+          mountPath: /etc/pki/ca-trust/extracted/pem
           readOnly: true
-        - name:  alpine-linux-cabundle
-          mountPath: /etc/ssl/cert.pem
+        - name: fedora-rhel6-alpine-openelec-cabundle
+          mountPath: /etc/ssl
           readOnly: true
         {{- end }}
       {{- if .Values.konnectivityTunnel.enabled }}
@@ -453,25 +444,19 @@ spec:
           secretName: etcd-encryption-secret
       {{- end }}
       {{- if semverCompare ">= 1.17" .Values.kubernetesVersion }}
-      # All those locations are taken from
+      # locations are taken from
       # https://github.com/golang/go/blob/1bb247a469e306c57a5e0eaba788efb8b3b1acef/src/crypto/x509/root_linux.go#L7-L15
-      # we cannot be sure on which Seed Cluster Node OS is running so, it's safer to mount them all
-      - name: debian-family-cabundle
-        hostPath:
-          path: /etc/ssl/certs/ca-certificates.crt
-      - name: fedora-rhel6-cabundle
-        hostPath:
-          path: /etc/pki/tls/certs/ca-bundle.crt
-      - name: opensuse-cabundle
-        hostPath:
-          path: /etc/ssl/ca-bundle.pem
-      - name: openelec-cabundle
-        hostPath:
-          path: /etc/pki/tls/cacert.pem
-      - name: centos-rhel7-cabundle
-        hostPath:
-          path: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-      - name: alpine-linux-cabundle
-        hostPath:
-          path: /etc/ssl/cert.pem
+      # we cannot be sure on which Node OS the Seed Cluster is running so, it's safer to mount them all
+      - hostPath:
+          path: /etc/pki/tls
+          type: "DirectoryOrCreate"
+        name: fedora-rhel6-openelec-cabundle
+      - hostPath:
+          path: /etc/pki/ca-trust/extracted/pem
+          type: "DirectoryOrCreate"
+        name: centos-rhel7-cabundle
+      - hostPath:
+          path: /etc/ssl
+          type: "DirectoryOrCreate"
+        name: fedora-rhel6-alpine-openelec-cabundle
       {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/priority normal

**What this PR does / why we need it**:

The current apiserver tries to mount certain files such as `/etc/ssl/ca-bundle.pem`.
If these files do not exist, they will be created as a **directory**  (also see [docs](https://v1-15.docs.kubernetes.io/docs/concepts/storage/volumes/#hostpath)).

We have seen confusing error messages in the KCM such as 

```
error listing AWS instances: “RequestError: send request failed\ncaused by: Post https://ec2.us-gov-west-1.amazonaws.com/: x509: certificate signed by unknown authority: /etc/ssl/certs/ca-certificates.crt is a directory 
```
Possibly the erroneous file `/etc/ssl/ca-bundle.pem` was only accessed due to missing `/etc/ssl/certs/ca-certificates.crt` (as such it might be [related to this PR](https://github.com/gardener/gardener/pull/2789)).

Nevertheless I think these directories (with filenames) should not be created because this might lead to confusion and confusing error messages.

Therefore I see two options
 - change the current file mounts to have [hostpath type `FileOrCreate`](https://v1-15.docs.kubernetes.io/docs/concepts/storage/volumes/#hostpath)  so that no directories are created, but files
 - only mount directories with  [hostpath type `DirectoryOrCreate `](https://v1-15.docs.kubernetes.io/docs/concepts/storage/volumes/#hostpath). I prefer having an empty directory created if it does not exist, over a dummy file. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Shoot Kube apiserver mounts ssl directories instead of files to avoid creation of empty files. 
This includes directory `/etc/ssl/`.
```
```improvement operator
Please update your provider extension to version >= 1.16.0. Previous provider extensions  remove the `/etc/ssl/` directory mount from the kube-apiserver deployment via webhook . This is a problem when the Shoot Kubernetes version > 1.17 and CSI is enabled, as the Shoot API Server could require the Root CAs in  `/etc/ssl/` to make requests to OIDC providers or webhook endpoints.
The Gardenlet now always adds the `/etc/ssl/` mount - a provider extension with a previous version would remove the `/etc/ssl/` mount from the deployment if the Shoot Kubernetes version > 1.17 and CSI is enabled.
```