### PR TITLE
VPA admission controller shouldn't self register mutatingWebhook

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/vpa-webhook-config.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/vpa-webhook-config.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.admissionController.enabled }}
+{{- if not .Values.admissionController.registerWebhook }}
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: vpa-webhook-config
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: {{ .Values.admissionController.caCert }}
+{{- if .Values.admissionController.registerByURL }}
+    url: https://vpa-webhook.{{.Values.admissionController.controlNamespace}}:{{.Values.admissionController.servicePort}} # the port is only respected if register-by-url is true, that's why it's in this if-block
+                                                                                                                          # if it's false it will not set the port during registration, i.e., it will be defaulted to 443,
+                                                                                                                          # so the servicePort has to be 443 in this case
+                                                                                                                          # see https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/admission-controller/config.go#L70-L74
+{{- else }}
+    service:
+      name: vpa-webhook
+      namespace: {{ .Values.admissionController.controlNamespace }}
+      port: 443
+{{- end }}
+  failurePolicy: Ignore
+  matchPolicy: Exact
+  name: vpa.k8s.io
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+    scope: '*'
+  - apiGroups:
+    - autoscaling.k8s.io
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - verticalpodautoscalers
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10
+  {{- end }}
+  {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/vpa-webhook-config.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/vpa-webhook-config.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.admissionController.enabled }}
-{{- if not .Values.admissionController.registerWebhook }}
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: {{ include "webhookadmissionregistration" . }}
 kind: MutatingWebhookConfiguration
 metadata:
   name: vpa-webhook-config
@@ -10,7 +9,7 @@ webhooks:
   - v1beta1
   clientConfig:
     caBundle: {{ .Values.admissionController.caCert }}
-{{- if .Values.admissionController.registerByURL }}
+{{- if eq .Values.clusterType "shoot" }}
     url: https://vpa-webhook.{{.Values.admissionController.controlNamespace}}:{{.Values.admissionController.servicePort}} # the port is only respected if register-by-url is true, that's why it's in this if-block
                                                                                                                           # if it's false it will not set the port during registration, i.e., it will be defaulted to 443,
                                                                                                                           # so the servicePort has to be 443 in this case
@@ -47,5 +46,4 @@ webhooks:
     scope: '*'
   sideEffects: None
   timeoutSeconds: 10
-  {{- end }}
   {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
@@ -49,15 +49,7 @@ spec:
         - --tls-private-key=/etc/tls-certs/tls.key
         - --address=:8944
         - --port={{ .Values.admissionController.port }}
-        - --register-webhook={{.Values.admissionController.registerWebhook}}
-        {{- if .Values.admissionController.registerByURL }}
-        - --register-by-url=true
-        - --webhook-address=https://vpa-webhook.{{.Release.Namespace}}
-        - --webhook-port={{ .Values.admissionController.servicePort }} # the port is only respected if register-by-url is true, that's why it's in this if-block
-                                                                       # if it's false it will not set the port during registration, i.e., it will be defaulted to 443,
-                                                                       # so the servicePort has to be 443 in this case
-                                                                       # see https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/admission-controller/config.go#L70-L74
-        {{- end }}
+        - --register-webhook=false
         image: {{ index .Values.global.images "vpa-admission-controller" }}
         imagePullPolicy: IfNotPresent
         env:

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
@@ -49,6 +49,7 @@ spec:
         - --tls-private-key=/etc/tls-certs/tls.key
         - --address=:8944
         - --port={{ .Values.admissionController.port }}
+        - --register-webhook={{.Values.admissionController.registerWebhook}}
         {{- if .Values.admissionController.registerByURL }}
         - --register-by-url=true
         - --webhook-address=https://vpa-webhook.{{.Release.Namespace}}

--- a/charts/seed-bootstrap/charts/vpa/values.yaml
+++ b/charts/seed-bootstrap/charts/vpa/values.yaml
@@ -16,6 +16,9 @@ admissionController:
   podAnnotations: {}
   podLabels: {}
   enableServiceAccount: true
+  registerWebhook: false
+  caCert: abcd
+  controlNamespace: abcd
   registerByURL: false
   port: 10250
   servicePort: 443

--- a/charts/seed-bootstrap/charts/vpa/values.yaml
+++ b/charts/seed-bootstrap/charts/vpa/values.yaml
@@ -16,10 +16,8 @@ admissionController:
   podAnnotations: {}
   podLabels: {}
   enableServiceAccount: true
-  registerWebhook: false
   caCert: abcd
   controlNamespace: abcd
-  registerByURL: false
   port: 10250
   servicePort: 443
 

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -408,7 +408,6 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 			"admissionController": map[string]interface{}{
 				"enableServiceAccount": false,
 				"controlNamespace":     b.Shoot.SeedNamespace,
-				"registerByURL":        true,
 			},
 			"exporter":    map[string]interface{}{"enableServiceAccount": false},
 			"recommender": map[string]interface{}{"enableServiceAccount": false},
@@ -434,8 +433,8 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 		nodeNetwork = b.Shoot.GetNodeNetwork()
 	)
 
-	if _, ok := b.Secrets["vpa-tls-certs"]; ok {
-		verticalPodAutoscaler["admissionController"].(map[string]interface{})["caCert"] = b.Secrets["vpa-tls-certs"].Data[secrets.DataKeyCertificateCA]
+	if _, ok := b.Secrets[common.VPASecretName]; ok {
+		verticalPodAutoscaler["admissionController"].(map[string]interface{})["caCert"] = b.Secrets[common.VPASecretName].Data[secrets.DataKeyCertificateCA]
 	}
 
 	proxyConfig := b.Shoot.Info.Spec.Kubernetes.KubeProxy

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -404,11 +404,15 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 			},
 		}
 		verticalPodAutoscaler = map[string]interface{}{
-			"clusterType":         "shoot",
-			"admissionController": map[string]interface{}{"enableServiceAccount": false},
-			"exporter":            map[string]interface{}{"enableServiceAccount": false},
-			"recommender":         map[string]interface{}{"enableServiceAccount": false},
-			"updater":             map[string]interface{}{"enableServiceAccount": false},
+			"clusterType": "shoot",
+			"admissionController": map[string]interface{}{
+				"enableServiceAccount": false,
+				"controlNamespace":     b.Shoot.SeedNamespace,
+				"registerByURL":        true,
+			},
+			"exporter":    map[string]interface{}{"enableServiceAccount": false},
+			"recommender": map[string]interface{}{"enableServiceAccount": false},
+			"updater":     map[string]interface{}{"enableServiceAccount": false},
 		}
 
 		shootInfo = map[string]interface{}{
@@ -429,6 +433,10 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 
 		nodeNetwork = b.Shoot.GetNodeNetwork()
 	)
+
+	if _, ok := b.Secrets["vpa-tls-certs"]; ok {
+		verticalPodAutoscaler["admissionController"].(map[string]interface{})["caCert"] = b.Secrets["vpa-tls-certs"].Data[secrets.DataKeyCertificateCA]
+	}
 
 	proxyConfig := b.Shoot.Info.Spec.Kubernetes.KubeProxy
 	if proxyConfig != nil {

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -228,14 +228,13 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 		admissionController = map[string]interface{}{
 			"replicas": b.Shoot.GetReplicas(1),
 			"podAnnotations": map[string]interface{}{
-				"checksum/secret-vpa-tls-certs":            b.CheckSums["vpa-tls-certs"],
+				"checksum/secret-vpa-tls-certs":            b.CheckSums[common.VPASecretName],
 				"checksum/secret-vpa-admission-controller": b.CheckSums["vpa-admission-controller"],
 			},
 			"podLabels": utils.MergeMaps(podLabels, map[string]interface{}{
 				v1beta1constants.LabelNetworkPolicyFromShootAPIServer: "allowed",
 			}),
 			"enableServiceAccount": false,
-			"registerByURL":        true,
 		}
 		exporter = map[string]interface{}{
 			"enabled":  false,

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -680,7 +680,7 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 		)
 
 		secretList = append(secretList, &secrets.CertificateSecretConfig{
-			Name:       "vpa-tls-certs",
+			Name:       common.VPASecretName,
 			CommonName: commonName,
 			DNSNames:   dnsNames,
 			CertType:   secrets.ServerCert,

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -240,6 +240,9 @@ const (
 	// StaticTokenSecretName is the name of the secret containing static tokens for the kube-apiserver.
 	StaticTokenSecretName = "static-token"
 
+	// VPASecretName is the name of the secret used by VPA
+	VPASecretName = "vpa-tls-certs"
+
 	// ProjectPrefix is the prefix of namespaces representing projects.
 	ProjectPrefix = "garden-"
 

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -347,7 +347,7 @@ func DeleteVpa(ctx context.Context, c client.Client, namespace string, isShoot b
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "vpa-admission-controller", Namespace: namespace}},
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "vpa-exporter", Namespace: namespace}},
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "vpa-recommender", Namespace: namespace}},
-			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "vpa-tls-certs", Namespace: namespace}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: VPASecretName, Namespace: namespace}},
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "vpa-updater", Namespace: namespace}},
 			&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-kube-apiserver-to-vpa-admission-controller", Namespace: namespace}},
 		)
@@ -390,9 +390,6 @@ func DeleteVpa(ctx context.Context, c client.Client, namespace string, isShoot b
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "vpa-exporter", Namespace: namespace}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "vpa-recommender", Namespace: namespace}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "vpa-updater", Namespace: namespace}},
-		)
-
-		resources = append(resources,
 			&admissionregistrationv1beta1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "vpa-webhook-config"}},
 		)
 	}

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gardener/gardener/pkg/version"
 
 	jsoniter "github.com/json-iterator/go"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -389,6 +390,10 @@ func DeleteVpa(ctx context.Context, c client.Client, namespace string, isShoot b
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "vpa-exporter", Namespace: namespace}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "vpa-recommender", Namespace: namespace}},
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "vpa-updater", Namespace: namespace}},
+		)
+
+		resources = append(resources,
+			&admissionregistrationv1beta1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "vpa-webhook-config"}},
 		)
 	}
 

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -157,7 +157,7 @@ func generateWantedSecrets(seed *Seed, certificateAuthorities map[string]*secret
 
 	secretList := []secretsutils.ConfigInterface{
 		&secretsutils.CertificateSecretConfig{
-			Name: "vpa-tls-certs",
+			Name: common.VPASecretName,
 
 			CommonName:   "vpa-webhook.garden.svc",
 			Organization: nil,
@@ -409,7 +409,7 @@ func BootstrapCluster(k8sGardenClient, k8sSeedClient kubernetes.Interface, seed 
 	if err != nil {
 		return err
 	}
-	jsonString, err := json.Marshal(deployedSecretsMap["vpa-tls-certs"].Data)
+	jsonString, err := json.Marshal(deployedSecretsMap[common.VPASecretName].Data)
 	if err != nil {
 		return err
 	}
@@ -643,7 +643,7 @@ func BootstrapCluster(k8sGardenClient, k8sSeedClient kubernetes.Interface, seed 
 			"application": map[string]interface{}{
 				"admissionController": map[string]interface{}{
 					"controlNamespace": v1beta1constants.GardenNamespace,
-					"caCert":           deployedSecretsMap["vpa-tls-certs"].Data[secretsutils.DataKeyCertificateCA],
+					"caCert":           deployedSecretsMap[common.VPASecretName].Data[secretsutils.DataKeyCertificateCA],
 				},
 			},
 		},

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -640,6 +640,12 @@ func BootstrapCluster(k8sGardenClient, k8sSeedClient kubernetes.Interface, seed 
 					},
 				},
 			},
+			"application": map[string]interface{}{
+				"admissionController": map[string]interface{}{
+					"controlNamespace": v1beta1constants.GardenNamespace,
+					"caCert":           deployedSecretsMap["vpa-tls-certs"].Data[secretsutils.DataKeyCertificateCA],
+				},
+			},
 		},
 		"hvpa": map[string]interface{}{
 			"enabled": hvpaEnabled,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area auto-scaling
/kind task
/priority normal

**What this PR does / why we need it**:
If VPA admission controller self registers mutatingWebhook, default timeout of 30s is used which can result in API call failures. This PR disables self registration of vpa webhook, and enables Gardener to manage it instead.

**Which issue(s) this PR fixes**:
Fixes #2779

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Disable self-registration of vpa-webhook by vpa-admission-controller. Now Gardener manages the vpa-webhook
```
