### PR TITLE
Upgrade Logging stack with fluent-bit-to-loki v0.25

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -183,7 +183,7 @@ images:
 - name: fluent-bit
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.24.0"
+  tag: "v0.25.0"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-configmap.yaml
@@ -357,6 +357,7 @@ data:
         # (30KiB)
         Labels {test="fluent-bit-go", lang="Golang"}
         LineFormat json
+        ReplaceOutOfOrderTS true
         DropSingleKey false
         AutoKubernetesLabels true
         LabelSelector gardener.cloud/role:shoot
@@ -364,11 +365,17 @@ data:
         LabelMapPath /fluent-bit/etc/kubernetes_label_map.json
         DynamicHostPath {"kubernetes": {"namespace_name": "namespace"}}
         DynamicHostPrefix http://loki.
-        DynamicHostSulfix .svc:3100/loki/api/v1/push
+        DynamicHostSuffix .svc:3100/loki/api/v1/push
         DynamicHostRegex shoot--
         MaxRetries 3
         Timeout 10
         MinBackoff 30
+        Buffer true
+        BufferType dque
+        QueueDir  /fluent-bit/buffers
+        QueueSegmentSize 300
+        QueueSync normal
+        QueueName gardener-kubernetes
 
     [Output]
         Name loki
@@ -381,12 +388,19 @@ data:
         # (30KiB)
         Labels {test="fluent-bit-go", lang="Golang"}
         LineFormat json
+        ReplaceOutOfOrderTS true
         DropSingleKey false
         RemoveKeys kubernetes,steram,hostname,unit
         LabelMapPath /fluent-bit/etc/systemd_label_map.json
         MaxRetries 3
         Timeout 10
         MinBackoff 30
+        Buffer true
+        BufferType dque
+        QueueDir  /fluent-bit/buffers
+        QueueSegmentSize 300
+        QueueSync normal
+        QueueName gardener-journald
 
   parsers.conf: |-
     [PARSER]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Whit this PR we upgrade the Logging stack to use the custom fluent-bit-to-loki plugin which is with improved performance.
The upgrade is from v0.24.0 to v0.25.0

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->

``` improvement operator github.com/gardener/logging #64 @vlvasilev
Upgrade fluent-bit version to 1.5.4.
```

``` improvement operator github.com/gardener/logging #64 @vlvasilev
Implement buffered Loki client.
```

``` improvement operator github.com/gardener/logging #64 @vlvasilev
A mitigation has been implemented for the `out of order` error in the fluent bit plugin. It can be enabled by setting the flag ReplaceOutOfOrderTS to true.
```

``` improvement operator github.com/gardener/logging #64 @vlvasilev
The usage of mutex locks in the custom plugin dispatching the logs between the different loki instances have been improved
```

``` action operator github.com/gardener/logging #64 @vlvasilev
Because the dynamic host field contains only the namespace the flags DynamicHostPrefix and   DynamicHostSuffix must be set to `http://<loki-service>` and `.svc:3100/loki/api/v1/push`
```