### PR TITLE
Support management of external machine dependencies

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -99,6 +99,11 @@ func (a *genericActuator) Delete(ctx context.Context, worker *extensionsv1alpha1
 		return errors.Wrapf(err, "failed deleting machine-controller-manager")
 	}
 
+	// Cleanup machine dependencies.
+	if err := workerDelegate.CleanupMachineDependencies(ctx); err != nil {
+		return errors.Wrap(err, "failed to cleanup machine dependencies")
+	}
+
 	return nil
 }
 

--- a/extensions/pkg/controller/worker/genericactuator/interface.go
+++ b/extensions/pkg/controller/worker/genericactuator/interface.go
@@ -43,10 +43,17 @@ type WorkerDelegate interface {
 	// GenerateMachineDeployments generates the configuration for the desired machine deployments.
 	GenerateMachineDeployments(context.Context) (worker.MachineDeployments, error)
 
-	// GetMachineImages returns the list of used machine images for this `Worker` resource. It will be stored in the
-	// `.status.providerStatus` field of the `Worker` resource such that the controller can look up its provider-specific
-	// machine image information in case the required version has been removed from its componentconfig.
-	GetMachineImages(context.Context) (runtime.Object, error)
+	// UpdateMachineImagesStatus will store a list of machine images used by the
+	// machines associated with this Worker resource in its provider status.
+	// The controller can look up its provider-specific machine image information
+	// in case the required version has been removed from the `CloudProfile`.
+	UpdateMachineImagesStatus(context.Context) error
+
+	// DeployMachineDependencies is a hook to create external machine dependencies.
+	DeployMachineDependencies(context.Context) error
+
+	// CleanupMachineDependencies is a hook to cleanup external machine dependencies.
+	CleanupMachineDependencies(context.Context) error
 }
 
 // DelegateFactory acts upon Worker resources.


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Extend the worker controller in the Gardener extension library to allow provider extensions to manage external machine dependencies within the worker control loops.

Examples for external machine dependencies could be Azure AvailabilitySet or OpenStack ServerGroups which are created for the machines of a workerpool. Those external dependencies are bound to the lifecycle of the workerpool e.g. they need to be created when a new workerpool is configured, the need to be deleted when the workerpool is gone or they need to be replaced when workerpool configuration has changed.

This PR extend the `WorkerDelegate` interface with hooks to deploy and cleanup those external dependencies in the worker controller. The hooks need to be implemented by the provider extensions. The hooks are called within the `Worker` reconciliation and deletion flow.

This is still work in progress. Opened to gather feedback.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action developer
Machine dependency hook methods `DeployMachineDependencies` and `DeployMachineDependencies` need to be implemented in the worker controllers of the provider extensions.
```

```action developer
The provider extension need to transform the existing `GetMachineImages()` in the implementation of the `WorkerDelegate` interface to the new `UpdateMachineImageStatus()` method. The provider extensions need now to update the provider status on their own in the new `UpdateMachineImageStatus()` method instead of returning it.
```
