### PR TITLE
Improve worker controller/actuator logs

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
@@ -17,76 +17,59 @@ package genericactuator
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
-	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
-	appsv1 "k8s.io/api/apps/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
-	"k8s.io/apimachinery/pkg/util/wait"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/pkg/errors"
 )
 
 // Migrate removes all machine related resources (e.g. MachineDeployments, MachineClasses, MachineClassSecrets, MachineSets and Machines)
 // without waiting for machine-controller-manager to do that. Before removal it ensures that the MCM is deleted.
 func (a *genericActuator) Migrate(ctx context.Context, worker *extensionsv1alpha1.Worker, cluster *controller.Cluster) error {
+	logger := a.logger.WithValues("worker", kutil.KeyFromObject(worker), "operation", "migrate")
+
 	workerDelegate, err := a.delegateFactory.WorkerDelegate(ctx, worker, cluster)
 	if err != nil {
 		return errors.Wrap(err, "could not instantiate actuator context")
 	}
 
 	// Make sure machine-controller-manager is deleted before deleting the machines.
-	if err := a.deleteMachineControllerManager(ctx, worker); err != nil {
+	if err := a.deleteMachineControllerManager(ctx, logger, worker); err != nil {
 		return errors.Wrap(err, "failed deleting machine-controller-manager")
 	}
 
-	if err := a.waitUntilMachineControllerManagerIsDeleted(ctx, worker.Namespace); err != nil {
+	if err := a.waitUntilMachineControllerManagerIsDeleted(ctx, logger, worker.Namespace); err != nil {
 		return errors.Wrap(err, "failed deleting machine-controller-manager")
 	}
 
-	if err := a.shallowDeleteAllObjects(ctx, worker.Namespace, &machinev1alpha1.MachineList{}); err != nil {
+	if err := a.shallowDeleteAllObjects(ctx, logger, worker.Namespace, &machinev1alpha1.MachineList{}); err != nil {
 		return errors.Wrap(err, "shallow deletion of all machine failed")
 	}
 
-	if err := a.shallowDeleteAllObjects(ctx, worker.Namespace, &machinev1alpha1.MachineSetList{}); err != nil {
+	if err := a.shallowDeleteAllObjects(ctx, logger, worker.Namespace, &machinev1alpha1.MachineSetList{}); err != nil {
 		return errors.Wrap(err, "shallow deletion of all machineSets failed")
 	}
 
-	if err := a.shallowDeleteAllObjects(ctx, worker.Namespace, &machinev1alpha1.MachineDeploymentList{}); err != nil {
+	if err := a.shallowDeleteAllObjects(ctx, logger, worker.Namespace, &machinev1alpha1.MachineDeploymentList{}); err != nil {
 		return errors.Wrap(err, "shallow deletion of all machineDeployments failed")
 	}
 
-	if err := a.shallowDeleteAllObjects(ctx, worker.Namespace, workerDelegate.MachineClassList()); err != nil {
+	if err := a.shallowDeleteAllObjects(ctx, logger, worker.Namespace, workerDelegate.MachineClassList()); err != nil {
 		return errors.Wrap(err, "cleaning up machine classes failed")
 	}
 
-	if err := a.shallowDeleteMachineClassSecrets(ctx, worker.Namespace, nil); err != nil {
+	if err := a.shallowDeleteMachineClassSecrets(ctx, logger, worker.Namespace, nil); err != nil {
 		return errors.Wrap(err, "cleaning up machine class secrets failed")
 	}
 
 	// Wait until all machine resources have been properly deleted.
-	if err := a.waitUntilMachineResourcesDeleted(ctx, worker, workerDelegate); err != nil {
+	if err := a.waitUntilMachineResourcesDeleted(ctx, logger, worker, workerDelegate); err != nil {
 		return gardencorev1beta1helper.DetermineError(err, fmt.Sprintf("Failed while waiting for all machine resources to be deleted: '%s'", err.Error()))
 	}
 
 	return nil
-}
-
-func (a *genericActuator) waitUntilMachineControllerManagerIsDeleted(ctx context.Context, namespace string) error {
-	return wait.PollUntil(5*time.Second, func() (bool, error) {
-		machineControllerManagerDeployment := &appsv1.Deployment{}
-		if err := a.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: McmDeploymentName}, machineControllerManagerDeployment); err != nil {
-			if apierrors.IsNotFound(err) {
-				return true, nil
-			}
-			return false, err
-		}
-
-		return false, nil
-	}, ctx.Done())
 }

--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -17,31 +17,36 @@ package genericactuator
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
-	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
-	workercontroller "github.com/gardener/gardener/extensions/pkg/controller/worker"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardeneretry "github.com/gardener/gardener/pkg/utils/retry"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	workercontroller "github.com/gardener/gardener/extensions/pkg/controller/worker"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	gardeneretry "github.com/gardener/gardener/pkg/utils/retry"
 )
 
 // Restore uses the Worker's spec to figure out the wanted MachineDeployments. Then it parses the Worker's state.
 // If there is a record in the state corresponding to a wanted deployment then the Restore function
 // deploys that MachineDeployment with all related MachineSet and Machines.
 func (a *genericActuator) Restore(ctx context.Context, worker *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster) error {
+	logger := a.logger.WithValues("worker", kutil.KeyFromObject(worker), "operation", "restore")
+
 	workerDelegate, err := a.delegateFactory.WorkerDelegate(ctx, worker, cluster)
 	if err != nil {
 		return errors.Wrap(err, "could not instantiate actuator context")
 	}
 
 	// Generate the desired machine deployments.
+	logger.Info("Generating machine deployments")
 	wantedMachineDeployments, err := workerDelegate.GenerateMachineDeployments(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to generate the machine deployments")
@@ -55,40 +60,36 @@ func (a *genericActuator) Restore(ctx context.Context, worker *extensionsv1alpha
 
 	// Parse the worker state to a separate machineDeployment states and attach them to
 	// the corresponding machineDeployments which are to be deployed later
-	a.logger.Info("Extracting the worker status.state", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
-	if err := a.addStateToMachineDeployment(ctx, worker, wantedMachineDeployments); err != nil {
+	logger.Info("Extracting state from worker status")
+	if err := a.addStateToMachineDeployment(worker, wantedMachineDeployments); err != nil {
 		return err
 	}
 
 	wantedMachineDeployments = removeWantedDeploymentWithoutState(wantedMachineDeployments)
 
 	// Delete the machine-controller-manager. During restoration MCM must not exist
-	a.logger.Info("Deleting machine-controller-manager for a Worker restore operation during control-plane migration", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
-	if err := a.deleteMachineControllerManager(ctx, worker); err != nil {
+	if err := a.deleteMachineControllerManager(ctx, logger, worker); err != nil {
 		return errors.Wrap(err, "failed deleting machine-controller-manager")
 	}
 
-	a.logger.Info("Wait until machine-controller-manager is deleted", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
-	if err := a.waitUntilMachineControllerManagerIsDeleted(ctx, worker.Namespace); err != nil {
+	if err := a.waitUntilMachineControllerManagerIsDeleted(ctx, logger, worker.Namespace); err != nil {
 		return errors.Wrap(err, "failed deleting machine-controller-manager")
 	}
 
 	// Do the actual restoration
-	a.logger.Info("Deploying the Machines and MachineSets", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
-	if err := a.deployMachineSetsAndMachines(ctx, worker, wantedMachineDeployments); err != nil {
+	if err := a.deployMachineSetsAndMachines(ctx, logger, wantedMachineDeployments); err != nil {
 		return errors.Wrap(err, "failed restoration of the machineSet and the machines")
 	}
 
 	// Generate machine deployment configuration based on previously computed list of deployments and deploy them.
-	a.logger.Info("Deploying the MachineDeployments in Worker.Status.State", "worker", fmt.Sprintf("%s/%s", worker.Namespace, worker.Name))
-	if err := a.deployMachineDeployments(ctx, cluster, worker, existingMachineDeployments, wantedMachineDeployments, workerDelegate.MachineClassKind(), true); err != nil {
+	if err := a.deployMachineDeployments(ctx, logger, cluster, worker, existingMachineDeployments, wantedMachineDeployments, workerDelegate.MachineClassKind(), true); err != nil {
 		return errors.Wrap(err, "failed to restore the machine deployment config")
 	}
 
 	return nil
 }
 
-func (a *genericActuator) addStateToMachineDeployment(ctx context.Context, worker *extensionsv1alpha1.Worker, wantedMachineDeployments workercontroller.MachineDeployments) error {
+func (a *genericActuator) addStateToMachineDeployment(worker *extensionsv1alpha1.Worker, wantedMachineDeployments workercontroller.MachineDeployments) error {
 	if worker.Status.State == nil || len(worker.Status.State.Raw) <= 0 {
 		return nil
 	}
@@ -110,7 +111,8 @@ func (a *genericActuator) addStateToMachineDeployment(ctx context.Context, worke
 	return nil
 }
 
-func (a *genericActuator) deployMachineSetsAndMachines(ctx context.Context, worker *extensionsv1alpha1.Worker, wantedMachineDeployments workercontroller.MachineDeployments) error {
+func (a *genericActuator) deployMachineSetsAndMachines(ctx context.Context, logger logr.Logger, wantedMachineDeployments workercontroller.MachineDeployments) error {
+	logger.Info("Deploying Machines and MachineSets")
 	for _, wantedMachineDeployment := range wantedMachineDeployments {
 		machineSets := wantedMachineDeployment.State.MachineSets
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging quality
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR improves/refactors the worker controller and generic actuator logs to
- add the `"worker"` log field only once per operation (makes it more consistent and available across all logs)
- add the `"operation"` log field to easily identify the flow the controller/actuator is currently executing (one of `reconcile, delete, migrate, restore`)
- generally add more logs on each step

The main motivation for this is to make the logs more useful when debugging issues like #2453.
It might be used as a reference for improving log handling in the other extension controllers as well.

**Which issue(s) this PR fixes**:
Ref https://github.com/gardener/gardener/issues/2453#issuecomment-683759031

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Logs in the worker controller and generic actuator have been improved to make them more consistent and useful.
```
