### PR TITLE
Fix WaitUntilExtensionCRsMigrated test

### DIFF
--- a/pkg/operation/common/extensions_test.go
+++ b/pkg/operation/common/extensions_test.go
@@ -75,9 +75,9 @@ var _ = Describe("extensions", func() {
 		Expect(extensionsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())
 		c = fake.NewFakeClientWithScheme(s)
 
-		defaultInterval = 1 * time.Second
-		defaultTimeout = 1 * time.Second
-		defaultThreshold = 1 * time.Second
+		defaultInterval = 1 * time.Millisecond
+		defaultTimeout = 1 * time.Millisecond
+		defaultThreshold = 1 * time.Millisecond
 
 		namespace = "test-namespace"
 		name = "test-name"
@@ -588,9 +588,10 @@ var _ = Describe("extensions", func() {
 		DescribeTable("should return error if migration times out",
 			func(lastOperations []*gardencorev1beta1.LastOperation, match func() GomegaMatcher) {
 				for i, lastOp := range lastOperations {
-					expected.Status.LastOperation = lastOp
-					expected.Name = fmt.Sprintf("worker-%d", i)
-					Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
+					existing := expected.DeepCopy()
+					existing.Status.LastOperation = lastOp
+					existing.Name = fmt.Sprintf("worker-%d", i)
+					Expect(c.Create(ctx, existing)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
 				}
 				err := WaitUntilExtensionCRsMigrated(
 					ctx,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test
/priority normal

**What this PR does / why we need it**:
Fixes the failing `#WaitUntilExtensionCRsMigrated` test.
Wasn't caught in #2801 because it was based on a commit before #2762.

**Which issue(s) this PR fixes**:
Fixes https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-head-update-job/builds/149

**Special notes for your reviewer**:
/invite @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
