### PR TITLE
Enable race detector, switch to go test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,12 +165,12 @@ format:
 
 .PHONY: test
 test:
-	@./hack/test.sh -r ./cmd/... ./extensions/... ./pkg/... ./plugin/...
+	@./hack/test.sh ./cmd/... ./extensions/... ./pkg/... ./plugin/...
 	$(MAKE) test-prometheus
 
 .PHONY: test-cov
 test-cov:
-	@./hack/test-cover.sh -r ./cmd/... ./extensions/... ./pkg/... ./plugin/...
+	@./hack/test-cover.sh ./cmd/... ./extensions/... ./pkg/... ./plugin/...
 	$(MAKE) test-prometheus
 
 .PHONY: test-cov-clean

--- a/hack/test-cover.sh
+++ b/hack/test-cover.sh
@@ -17,7 +17,7 @@ set -e
 
 echo "> Test Cover"
 
-"$(dirname $0)"/test.sh -cover $@
+GO111MODULE=on ginkgo -cover -race -mod=vendor $@
 
 COVERPROFILE="$(dirname $0)/../test.coverprofile"
 COVERPROFILE_TMP="$(dirname $0)/../test.coverprofile.tmp"

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -17,4 +17,4 @@ set -e
 
 echo "> Test"
 
-GO111MODULE=on ginkgo -mod=vendor $@
+GO111MODULE=on go test -race -mod=vendor $@ | grep -v 'no test files'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality robustness dev-productivity testing
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR does 3 things around unit testing:
- `make test` now executes `go test` instead of `ginkgo` to make use of cached test results ([ref](https://golang.org/pkg/cmd/go/internal/test/))
  - `make test-cov` (executed in pipelines) still uses `ginkgo` which produces a more helpful output in case you want to reproduce pipeline test runs/failures (only my opinion, can be discussed)
- enables the go race detector to find at least obvious race conditions in unit tests ([ref](https://blog.golang.org/race-detector))
- makes the period health manager test race-free

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
`make test` now makes use of cached test results to reduce turn-around times when writing unit tests.
```
```improvement developer
The go race detector was enabled for unit tests.
```
```action developer
`./hack/test.sh` now executes tests via `go test` instead of `ginkgo`. Please adapt your extensions' `Makefile`s, if you use the vendored hack scripts.
```