### PR TITLE
Cleanup usage of deprecated extensionspredicate.Or

### DIFF
--- a/extensions/pkg/controller/backupbucket/controller.go
+++ b/extensions/pkg/controller/backupbucket/controller.go
@@ -18,13 +18,14 @@ import (
 	extensionshandler "github.com/gardener/gardener/extensions/pkg/handler"
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
 const (
@@ -62,7 +63,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 	}
 
 	return []predicate.Predicate{
-		extensionspredicate.Or(
+		predicate.Or(
 			extensionspredicate.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
 			extensionspredicate.IsDeleting(),

--- a/extensions/pkg/controller/backupentry/controller.go
+++ b/extensions/pkg/controller/backupentry/controller.go
@@ -62,7 +62,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 	}
 
 	return []predicate.Predicate{
-		extensionspredicate.Or(
+		predicate.Or(
 			extensionspredicate.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
 			extensionspredicate.IsDeleting(),

--- a/extensions/pkg/controller/containerruntime/controller.go
+++ b/extensions/pkg/controller/containerruntime/controller.go
@@ -71,7 +71,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 		}
 	}
 	return []predicate.Predicate{
-		extensionspredicate.Or(
+		predicate.Or(
 			extensionspredicate.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
 			extensionspredicate.IsDeleting(),

--- a/extensions/pkg/controller/controlplane/controller.go
+++ b/extensions/pkg/controller/controlplane/controller.go
@@ -61,7 +61,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 	}
 
 	return []predicate.Predicate{
-		extensionspredicate.Or(
+		predicate.Or(
 			extensionspredicate.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
 			extensionspredicate.IsDeleting(),

--- a/extensions/pkg/controller/extension/reconciler.go
+++ b/extensions/pkg/controller/extension/reconciler.go
@@ -85,7 +85,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 		}
 	}
 	return []predicate.Predicate{
-		extensionspredicate.Or(
+		predicate.Or(
 			extensionspredicate.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
 			extensionspredicate.IsDeleting(),

--- a/extensions/pkg/controller/infrastructure/controller.go
+++ b/extensions/pkg/controller/infrastructure/controller.go
@@ -65,7 +65,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 	}
 
 	return []predicate.Predicate{
-		extensionspredicate.Or(
+		predicate.Or(
 			extensionspredicate.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
 			extensionspredicate.IsDeleting(),

--- a/extensions/pkg/controller/network/controller.go
+++ b/extensions/pkg/controller/network/controller.go
@@ -61,7 +61,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 	}
 
 	return []predicate.Predicate{
-		extensionspredicate.Or(
+		predicate.Or(
 			extensionspredicate.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
 			extensionspredicate.IsDeleting(),

--- a/extensions/pkg/controller/operatingsystemconfig/controller.go
+++ b/extensions/pkg/controller/operatingsystemconfig/controller.go
@@ -67,7 +67,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 	}
 
 	return []predicate.Predicate{
-		extensionspredicate.Or(
+		predicate.Or(
 			extensionspredicate.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
 			extensionspredicate.IsDeleting(),

--- a/extensions/pkg/controller/worker/controller.go
+++ b/extensions/pkg/controller/worker/controller.go
@@ -65,7 +65,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 	}
 
 	return []predicate.Predicate{
-		extensionspredicate.Or(
+		predicate.Or(
 			extensionspredicate.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
 			extensionspredicate.IsDeleting(),
@@ -115,7 +115,7 @@ func addStateUpdatingController(mgr manager.Manager, options controller.Options,
 		}
 
 		machinePredicates = []predicate.Predicate{
-			extensionspredicate.Or(
+			predicate.Or(
 				MachineStatusHasChanged(),
 				predicate.GenerationChangedPredicate{},
 			),

--- a/extensions/pkg/predicate/predicate.go
+++ b/extensions/pkg/predicate/predicate.go
@@ -174,9 +174,8 @@ func AddTypePredicate(predicates []predicate.Predicate, extensionTypes ...string
 	for _, extensionType := range extensionTypes {
 		orPreds = append(orPreds, HasType(extensionType))
 	}
-	orPred := Or(orPreds...)
 
-	return append(resultPredicates, orPred)
+	return append(resultPredicates, predicate.Or(orPreds...))
 }
 
 // HasPurpose filters the incoming Controlplanes  for the given spec.purpose


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Cleanup usage of deprecated `extensionspredicate.Or` (missed that in 347089a466e5d9dd37c6be639327778dd188f8c9)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
