### PR TITLE
Use vanity domain after VDF

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -82,7 +82,7 @@ images:
   tag: "0.19.0"
 - name: konnectivity-server
   sourceRepository: github.com/kubernetes-sigs/apiserver-network-proxy
-  repository: eu.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-server
+  repository: k8s.gcr.io/kas-network-proxy/proxy-server
   tag: "v0.0.12"
 
 # Monitoring
@@ -132,7 +132,7 @@ images:
   tag: "0.19.0"
 - name: konnectivity-agent
   sourceRepository: github.com/kubernetes-sigs/apiserver-network-proxy
-  repository: eu.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent
+  repository: k8s.gcr.io/kas-network-proxy/proxy-agent
   tag: "v0.0.12"
 - name: coredns
   sourceRepository: github.com/coredns/coredns
@@ -198,15 +198,15 @@ images:
 # VPA
 - name: vpa-admission-controller
   sourceRepository: github.com/kubernetes/autoscaler
-  repository: eu.gcr.io/k8s-artifacts-prod/autoscaling/vpa-admission-controller
+  repository: k8s.gcr.io/autoscaling/vpa-admission-controller
   tag: "0.8.0"
 - name: vpa-recommender
   sourceRepository: github.com/kubernetes/autoscaler
-  repository: eu.gcr.io/k8s-artifacts-prod/autoscaling/vpa-recommender
+  repository: k8s.gcr.io/autoscaling/vpa-recommender
   tag: "0.8.0"
 - name: vpa-updater
   sourceRepository: github.com/kubernetes/autoscaler
-  repository: eu.gcr.io/k8s-artifacts-prod/autoscaling/vpa-updater
+  repository: k8s.gcr.io/autoscaling/vpa-updater
   tag: "0.8.0"
 - name: vpa-exporter
   sourceRepository: github.com/gardener/vpa-exporter


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind task
/priority normal

**What this PR does / why we need it**:
As the [vanity domain flip](https://github.com/kubernetes/k8s.io/blob/master/k8s.gcr.io/Vanity-Domain-Flip.md) is now completed, we can again use the vanity domain.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
