### PR TITLE
Update Kubernetes dashboard versions

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -156,8 +156,13 @@ images:
 - name: kubernetes-dashboard
   sourceRepository: github.com/kubernetes/dashboard
   repository: kubernetesui/dashboard
-  tag: v2.0.0
-  targetVersion: ">= 1.16"
+  tag: v2.0.3
+  targetVersion: ">= 1.16, < 1.19"
+- name: kubernetes-dashboard
+  sourceRepository: github.com/kubernetes/dashboard
+  repository: kubernetesui/dashboard
+  tag: v2.0.4
+  targetVersion: ">= 1.19"
 - name: kubernetes-dashboard-metrics-scraper
   sourceRepository: github.com/kubernetes/dashboard
   repository: kubernetesui/metrics-scraper


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Update Kubernetes Dashboard versions, ref https://github.com/kubernetes/dashboard/releases/tag/v2.0.4

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The version of the Kubernetes Dashboard addon has been bumped from `v2.0.0` to `v2.0.3`. For 1.19 shoot clusters the `v2.0.4` version will be used.
```
