### PR TITLE
Reduce unnecessary reconciles in ControllerInstallationRequired controller

### DIFF
--- a/pkg/gardenlet/controller/federatedseed/extensions/artifact.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/artifact.go
@@ -181,9 +181,9 @@ func newControllerInstallationArtifact(gvk schema.GroupVersionKind, newObjFunc f
 
 	a.addEventHandlerFn = func() {
 		a.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-			AddFunc:    createEnqueueFunc(a.queue),
-			UpdateFunc: createEnqueueOnUpdateFunc(a.queue, a.predicate),
-			DeleteFunc: createEnqueueFunc(a.queue),
+			AddFunc:    createEnqueueEmptyRequestFunc(a.queue),
+			UpdateFunc: createEnqueueEmptyRequestOnUpdateFunc(a.queue, a.predicate),
+			DeleteFunc: createEnqueueEmptyRequestFunc(a.queue),
 		})
 	}
 

--- a/pkg/gardenlet/controller/federatedseed/extensions/controllerinstallation_control.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/controllerinstallation_control.go
@@ -52,6 +52,8 @@ type controllerInstallationControl struct {
 // extension resources of the given kind and stores the respective types in the `kindToRequiredTypes` map. Afterwards,
 // it enqueue all ControllerInstallations for the seed that are referring to ControllerRegistrations responsible for
 // the given kind.
+// The returned reconciler doesn't care about which object was created/updated/deleted, it just cares about being
+// triggered when some object of the kind, it is responsible for, is created/updated/deleted.
 func (c *controllerInstallationControl) createExtensionRequiredReconcileFunc(ctx context.Context, kind string, newListObjFunc func() runtime.Object) reconcile.Func {
 	return func(_ reconcile.Request) (reconcile.Result, error) {
 		listObj := newListObjFunc()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Before, on startup of the gardenlet the ControllerInstallationRequired reconcile function was executed for every extension object in the Seed, although the function actually doesn't care about the enqueued object and rather does the same computation over and over again for each extension object.
This resulted in a lot of unnecessary API calls in large Seeds and might have caused the gardenlet to run into client-side rate limits when talking to the garden cluster, as the number of API calls were growing with the number of Shoots.

Now the ControllerInstallation artifacts enqueue an empty `reconcile.Request`, which make the reconcile functions only run once for each extension kind on startup instead of for each extension object.

**Which issue(s) this PR fixes**:
Part of #2689

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The gardenlet's `ControllerInstallationRequired` controller was optimized to execute less API calls to improve stability on startup of the gardenlet.
```
