### PR TITLE
Remove KSM-Seed from required Monitoring Seed Deployments

### DIFF
--- a/extensions/test/e2e/framework/networkpolicies/agnostic.go
+++ b/extensions/test/e2e/framework/networkpolicies/agnostic.go
@@ -231,24 +231,6 @@ func (a *Agnostic) Grafana() *SourcePod {
 	}
 }
 
-// KubeStateMetricsSeed points to cloud-agnostic kube-state-metrics-seed instance.
-func (a *Agnostic) KubeStateMetricsSeed() *SourcePod {
-	return &SourcePod{
-		Ports: NewSinglePort(8080),
-		Pod: NewPod("kube-state-metrics-seed", labels.Set{
-			"component":               "kube-state-metrics",
-			"garden.sapcloud.io/role": "monitoring",
-			"type":                    "seed",
-		}),
-		ExpectedPolicies: sets.NewString(
-			"allow-from-prometheus",
-			"allow-to-dns",
-			"allow-to-seed-apiserver",
-			"deny-all",
-		),
-	}
-}
-
 // KubeStateMetricsShoot points to cloud-agnostic kube-state-metrics-shoot instance.
 func (a *Agnostic) KubeStateMetricsShoot() *SourcePod {
 	return &SourcePod{

--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -68,9 +68,6 @@ const (
 	// DeploymentNameKubeStateMetricsShoot is a constant for the name of a Kubernetes deployment object that contains
 	// the kube-state-metrics pod.
 	DeploymentNameKubeStateMetricsShoot = "kube-state-metrics"
-	// DeploymentNameKubeStateMetricsSeed is a constant for the name of a Kubernetes deployment object that contains
-	// the kube-state-metrics-seed pod.
-	DeploymentNameKubeStateMetricsSeed = "kube-state-metrics-seed"
 
 	// StatefulSetNameAlertManager is a constant for the name of a Kubernetes stateful set object that contains
 	// the alertmanager pod.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -74,9 +74,6 @@ const (
 	// DeploymentNameKubeStateMetricsShoot is a constant for the name of a Kubernetes deployment object that contains
 	// the kube-state-metrics pod.
 	DeploymentNameKubeStateMetricsShoot = "kube-state-metrics"
-	// DeploymentNameKubeStateMetricsSeed is a constant for the name of a Kubernetes deployment object that contains
-	// the kube-state-metrics-seed pod.
-	DeploymentNameKubeStateMetricsSeed = "kube-state-metrics-seed"
 
 	// DeploymentNameVPAAdmissionController is a constant for the name of the VPA admission controller deployment.
 	DeploymentNameVPAAdmissionController = "vpa-admission-controller"

--- a/pkg/operation/botanist/health_check_test.go
+++ b/pkg/operation/botanist/health_check_test.go
@@ -260,13 +260,11 @@ var _ = Describe("health check", func() {
 
 		grafanaDeploymentOperators      = newDeployment(seedNamespace, v1beta1constants.DeploymentNameGrafanaOperators, v1beta1constants.GardenRoleMonitoring, true)
 		grafanaDeploymentUsers          = newDeployment(seedNamespace, v1beta1constants.DeploymentNameGrafanaUsers, v1beta1constants.GardenRoleMonitoring, true)
-		kubeStateMetricsSeedDeployment  = newDeployment(seedNamespace, v1beta1constants.DeploymentNameKubeStateMetricsSeed, v1beta1constants.GardenRoleMonitoring, true)
 		kubeStateMetricsShootDeployment = newDeployment(seedNamespace, v1beta1constants.DeploymentNameKubeStateMetricsShoot, v1beta1constants.GardenRoleMonitoring, true)
 
 		requiredMonitoringControlPlaneDeployments = []*appsv1.Deployment{
 			grafanaDeploymentOperators,
 			grafanaDeploymentUsers,
-			kubeStateMetricsSeedDeployment,
 			kubeStateMetricsShootDeployment,
 		}
 
@@ -670,7 +668,6 @@ var _ = Describe("health check", func() {
 			BeNil()),
 		Entry("required deployment set missing",
 			[]*appsv1.Deployment{
-				kubeStateMetricsSeedDeployment,
 				kubeStateMetricsShootDeployment,
 			},
 			requiredMonitoringControlPlaneStatefulSets,
@@ -689,7 +686,6 @@ var _ = Describe("health check", func() {
 			[]*appsv1.Deployment{
 				newDeployment(grafanaDeploymentOperators.Namespace, grafanaDeploymentOperators.Name, roleOf(grafanaDeploymentOperators), false),
 				grafanaDeploymentUsers,
-				kubeStateMetricsSeedDeployment,
 				kubeStateMetricsShootDeployment,
 			},
 			requiredMonitoringControlPlaneStatefulSets,

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -548,7 +548,6 @@ var (
 	RequiredMonitoringSeedDeployments = sets.NewString(
 		v1beta1constants.DeploymentNameGrafanaOperators,
 		v1beta1constants.DeploymentNameGrafanaUsers,
-		v1beta1constants.DeploymentNameKubeStateMetricsSeed,
 		v1beta1constants.DeploymentNameKubeStateMetricsShoot,
 	)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug
/priority normal

**What this PR does / why we need it**:
#2792 removed `kube-state-metrics-seed` from the shoot control planes but not from the required monitoring seed deployments. This would make all shoots report `false` for the control plane status. This PRs removes `kube-state-metrics-seed` as a requirement and removes any remaining artifacts of the `kube-state-metrics-seed` deployment.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
