### PR TITLE
Improve alert for failed audit logging of the shoot's kube-apiserver

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-apiserver.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-apiserver.rules.test.yaml
@@ -95,9 +95,9 @@ tests:
     exp_alerts:
     - exp_labels:
         service: auditlog
-        severity: critical
+        severity: warning
         type: seed
         visibility: operator
       exp_annotations:
-        description: 'The API servers cumulative failure rate in logging audit events is 0.03%. This may be caused by an unavailable/unreachable AuditSink(s) and/or improper API server audit configuration.'
-        summary: 'The API server has too many failed attempts to log audit events'
+        description: 'The API servers cumulative failure rate in logging audit events is greater than 2%.'
+        summary: 'The kubernetes API server has too many failed attempts to log audit events'

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-apiserver.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-apiserver.rules.yaml
@@ -85,16 +85,16 @@ groups:
       quantile: "0.9"
   ### API auditlog ###
   - alert: KubeApiServerTooManyAuditlogFailures
-    expr: sum(rate (apiserver_audit_error_total{plugin="webhook"} [5m])) by (app ,role) / ignoring(plugin) sum(rate(apiserver_audit_event_total [5m])) by (app, role) > 0.02
+    expr: sum(rate (apiserver_audit_error_total{plugin="webhook",job="kube-apiserver"}[5m])) / sum(rate(apiserver_audit_event_total{job="kube-apiserver"}[5m])) > bool 0.02 == 1
     for: 15m
     labels:
       service: auditlog
-      severity: critical
+      severity: warning
       type: seed
       visibility: operator
     annotations:
-        description: 'The API servers cumulative failure rate in logging audit events is {{ printf "%0.2f" $value }}%. This may be caused by an unavailable/unreachable AuditSink(s) and/or improper API server audit configuration.'
-        summary: 'The API server has too many failed attempts to log audit events'
+      description: 'The API servers cumulative failure rate in logging audit events is greater than 2%.'
+      summary: 'The kubernetes API server has too many failed attempts to log audit events'
   ### API latency ###
   - record: apiserver_latency_seconds:quantile
     expr: histogram_quantile(0.99, rate(apiserver_request_duration_seconds_bucket[5m]))

--- a/docs/monitoring/operator_alerts.md
+++ b/docs/monitoring/operator_alerts.md
@@ -5,7 +5,7 @@
 |CoreDNSDown|critical|shoot|`CoreDNS could not be found. Cluster DNS resolution will not work.`|
 |ApiServerNotReachable|blocker|seed|`API server not reachable via external endpoint: {{ $labels.instance }}.`|
 |KubeApiserverDown|blocker|seed|`All API server replicas are down/unreachable, or all API server could not be found.`|
-|KubeApiServerTooManyAuditlogFailures|critical|seed|`The API servers cumulative failure rate in logging audit events is {{ printf "%0.2f" $value }}%. This may be caused by an unavailable/unreachable AuditSink(s) and/or improper API server audit configuration.`|
+|KubeApiServerTooManyAuditlogFailures|warning|seed|`The API servers cumulative failure rate in logging audit events is greater than 2%.`|
 |KubeControllerManagerDown|critical|seed|`Deployments and replication controllers are not making progress.`|
 |KubeEtcdMainDown|blocker|seed|`Etcd3 cluster main is unavailable or cannot be scraped. As long as etcd3 main is down the cluster is unreachable.`|
 |KubeEtcdEventsDown|critical|seed|`Etcd3 cluster events is unavailable or cannot be scraped. Cluster events cannot be collected.`|


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area audit-logging monitoring
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Improve alert for failed audit logging of the shoot's kube-apiserver.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @wyb1 @istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
