### PR TITLE
Remove GOMAXPROCS assignment

### DIFF
--- a/cmd/gardener-apiserver/main.go
+++ b/cmd/gardener-apiserver/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"flag"
 	"os"
-	"runtime"
 
 	"github.com/gardener/gardener/cmd/gardener-apiserver/app"
 	"github.com/gardener/gardener/pkg/apiserver/features"
@@ -31,10 +30,6 @@ func main() {
 
 	logs.InitLogs()
 	defer logs.FlushLogs()
-
-	if len(os.Getenv("GOMAXPROCS")) == 0 {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
 
 	stopCh := genericapiserver.SetupSignalHandler()
 	command := app.NewCommandStartGardenerAPIServer(os.Stdout, os.Stderr, stopCh)

--- a/cmd/gardener-controller-manager/main.go
+++ b/cmd/gardener-controller-manager/main.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"runtime"
 	"syscall"
 
 	"github.com/gardener/gardener/cmd/gardener-controller-manager/app"
@@ -27,10 +26,6 @@ import (
 )
 
 func main() {
-	if len(os.Getenv("GOMAXPROCS")) == 0 {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
-
 	features.RegisterFeatureGates()
 
 	// Setup signal handler if running inside a Kubernetes cluster

--- a/cmd/gardener-scheduler/main.go
+++ b/cmd/gardener-scheduler/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/gardener/gardener/cmd/gardener-scheduler/app"
 	"github.com/gardener/gardener/cmd/utils"
@@ -27,10 +26,6 @@ import (
 )
 
 func main() {
-	if len(os.Getenv("GOMAXPROCS")) == 0 {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
-
 	features.RegisterFeatureGates()
 
 	ctx := utils.ContextFromStopChannel(signals.SetupSignalHandler())

--- a/cmd/gardener-seed-admission-controller/main.go
+++ b/cmd/gardener-seed-admission-controller/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/gardener/gardener/cmd/gardener-seed-admission-controller/app"
 	"github.com/gardener/gardener/cmd/utils"
@@ -26,10 +25,6 @@ import (
 )
 
 func main() {
-	if len(os.Getenv("GOMAXPROCS")) == 0 {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
-
 	ctx := utils.ContextFromStopChannel(signals.SetupSignalHandler())
 	command := app.NewCommandStartGardenerSeedAdmissionController(ctx)
 

--- a/cmd/gardenlet/main.go
+++ b/cmd/gardenlet/main.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"runtime"
 	"syscall"
 
 	"github.com/gardener/gardener/cmd/gardenlet/app"
@@ -31,10 +30,6 @@ func main() {
 
 	if err := exec.Command("which", "openvpn").Run(); err != nil {
 		panic("openvpn is not installed or not executable. cannot start gardenlet.")
-	}
-
-	if len(os.Getenv("GOMAXPROCS")) == 0 {
-		runtime.GOMAXPROCS(runtime.NumCPU())
 	}
 
 	// Setup signal handler if running inside a Kubernetes cluster


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind cleanup
/priority normal

**What this PR does / why we need it**:
This PR removes the GOMAXPROCS assignment because since Go 1.5 it is set to the number of logical cores already by default, see [here](https://github.com/kubernetes/kubernetes/pull/63481). 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
