### PR TITLE
Clean up list call with deprecated purpose label

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -178,35 +178,14 @@ func (a *genericActuator) cleanupMachineClasses(ctx context.Context, logger logr
 
 func (a *genericActuator) listMachineClassSecrets(ctx context.Context, namespace string) (*corev1.SecretList, error) {
 	var (
-		secretList           = &corev1.SecretList{}
-		deprecatedSecretList = &corev1.SecretList{}
-		labels               = map[string]string{
+		secretList = &corev1.SecretList{}
+		labels     = map[string]string{
 			v1beta1constants.GardenerPurpose: GardenPurposeMachineClass,
-		}
-		deprecatedLabels = map[string]string{
-			"garden.sapcloud.io/purpose": GardenPurposeMachineClass,
 		}
 	)
 
 	if err := a.client.List(ctx, secretList, client.InNamespace(namespace), client.MatchingLabels(labels)); err != nil {
 		return nil, err
-	}
-
-	if err := a.client.List(ctx, deprecatedSecretList, client.InNamespace(namespace), client.MatchingLabels(deprecatedLabels)); err != nil {
-		return nil, err
-	}
-
-	for _, depSecret := range deprecatedSecretList.Items {
-		exists := false
-		for _, secret := range secretList.Items {
-			if depSecret.Name == secret.Name {
-				exists = true
-				break
-			}
-		}
-		if !exists {
-			secretList.Items = append(secretList.Items, depSecret)
-		}
 	}
 
 	return secretList, nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Clean up the list call for machine secrets with the deprecated label. It was introduced in https://github.com/gardener-attic/gardener-extensions/pull/608 to allow smooth transition. We can now clean it up. For some Shoots hibernated from a long period of time (~1 year) there still might be a machine class secret with the label  `garden.sapcloud.io/purpose` but it should already have a deletionTimestamp and should be deleted when machine-controller-manager is scaled up again (on wake up or deletion).

**Which issue(s) this PR fixes**:
Contributes to https://github.com/gardener/gardener/issues/1649

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The generic worker actuator does no longer consider machine class secrets with the label `garden.sapcloud.io/purpose`.
```
