### PR TITLE
Fix make test-cov

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,4 +185,4 @@ test-prometheus:
 verify: check format test
 
 .PHONY: verify-extended
-verify-extended: install-requirements check-generate check format test-cov test-cov-clean test-prometheus
+verify-extended: install-requirements check-generate check format test-cov test-cov-clean

--- a/hack/test-cover.sh
+++ b/hack/test-cover.sh
@@ -24,8 +24,8 @@ COVERPROFILE_TMP="$(dirname $0)/../test.coverprofile.tmp"
 COVERPROFILE_HTML="$(dirname $0)/../test.coverage.html"
 
 echo "mode: set" > "$COVERPROFILE_TMP"
-find . -name "*.coverprofile" -type f | xargs cat | grep -v mode: | sort -r | awk '{if($$1 != last) {print $$0;last=$$1}}' >> "$COVERPROFILE_TMP"
-cat "$COVERPROFILE_TMP" | grep -vE "\.pb\.go|\/test\/|zz_generated" > "$COVERPROFILE"
+find . -name "*.coverprofile" -type f | xargs cat | grep -v mode: | sort -r | awk '{if($1 != last) {print $0;last=$1}}' >> "$COVERPROFILE_TMP"
+cat "$COVERPROFILE_TMP" | grep -vE "\.pb\.go|zz_generated" > "$COVERPROFILE"
 rm -rf "$COVERPROFILE_TMP"
 go tool cover -html="$COVERPROFILE" -o="$COVERPROFILE_HTML"
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity testing
/kind test
/priority normal

**What this PR does / why we need it**:
This PR
- fixes `make test-cov`, which currently yields an error like this one:
```
Test Suite Passed
awk: illegal field $(github.com/gardener/gardener/some/file.go:41.3,41.83), name "1"
 input record number 1, file
 source line number 1
make: *** [Makefile:154: test-cov] Error 2
```
- un-excludes `/test/` from coverage calculation
- removes duplicate invocation of `test-prometheus` on `make verify-extended`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
