### PR TITLE
Add Testrun for extensions controllers integration test

### DIFF
--- a/.ci/testruns/extensions-controllers.yaml
+++ b/.ci/testruns/extensions-controllers.yaml
@@ -1,0 +1,11 @@
+apiVersion: testmachinery.sapcloud.io/v1beta1
+kind: Testrun
+metadata:
+  generateName: tm-gardener-extensions-controllers-
+  namespace: default
+spec:
+  ttlSecondsAfterFinished: 172800 # 2 days
+  testflow:
+  - name: extensions-controllers
+    definition:
+      name: extensions-controllers

--- a/.ci/tm-config.yaml
+++ b/.ci/tm-config.yaml
@@ -1,3 +1,5 @@
+test-single:
+  testrunPath: .ci/testruns/extensions-controllers.yaml
 
 # configure default values for pull request tests
 test:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity quality robustness
/kind test
/priority normal

**What this PR does / why we need it**:
In order to enable the TestMachinery bot to execute the extensions controllers integration test (introduced in #2830) we have to define the `Testrun` in the `master` branch. This means that this PR must be merged before we can trigger `/test-single extensions-controllers` on #2830.

**Which issue(s) this PR fixes**:
Part of #2751 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
