### PR TITLE
Do not wait for MachineDeployment deletion when mcm is scaled down

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -173,9 +173,16 @@ func (a *genericActuator) Reconcile(ctx context.Context, worker *extensionsv1alp
 		return errors.Wrapf(err, "failed to cleanup the orphaned machine class secrets")
 	}
 
-	// Wait until all unwanted machine deployments are deleted from the system.
-	if err := a.waitUntilUnwantedMachineDeploymentsDeleted(ctx, logger, worker, wantedMachineDeployments); err != nil {
-		return errors.Wrapf(err, "error while waiting for all undesired machine deployments to be deleted")
+	replicas, err := replicaFunc()
+	if err != nil {
+		return errors.Wrapf(err, "failed to get machine-controller-manager replicas")
+	}
+
+	if replicas > 0 {
+		// Wait until all unwanted machine deployments are deleted from the system.
+		if err := a.waitUntilUnwantedMachineDeploymentsDeleted(ctx, logger, worker, wantedMachineDeployments); err != nil {
+			return errors.Wrapf(err, "error while waiting for all undesired machine deployments to be deleted")
+		}
 	}
 
 	// Delete MachineSets having number of desired and actual replicas equaling 0


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality ops-productivity
/kind task
/priority normal

**What this PR does / why we need it**:
Currently the generic worker actuator waits until unwanted MachineDeployments are removed from the store (for example worker removal). This PR adds a check to perform such wait only when the machine-controller-manager is scaled up.
When Shoot is hibernated and a worker is removed, then the corresponding MachineDeployment will receive a deletionTimestamp but its finalizer will be released on next machine-controller-manager scale up (Shoot wake up or Shoot deletion).

**Which issue(s) this PR fixes**:
Fixes #2784 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The generic worker actuator does now wait for undesired MachineDeployment deletion only when the machine-controller-manager is scaled up.
```
