### PR TITLE
Fix vpn dashboard

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/vpn.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/vpn.rules.test.yaml
@@ -10,7 +10,7 @@ tests:
   - series: 'kube_deployment_status_replicas_available{deployment="vpn-shoot"}'
     values: '0+0x60'
   # VPNConnectionDown
-  - series: 'probe_success{job="vpn-connection"}'
+  - series: 'probe_success{job="tunnel-probe-apiserver-proxy"}'
     values: '0+0x20'
   # VPNProbeAPIServerProxyFailed
   - series: 'probe_http_status_code{job="tunnel-probe-apiserver-proxy"}'

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/vpn-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/vpn-dashboard.json
@@ -46,7 +46,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "probe_success{job=\"vpn-connection\", type=\"seed\"}",
+          "expr": "probe_success{job=\"tunnel-probe-apiserver-proxy\", type=\"seed\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "API Server Proxy test ({{instance}})",
@@ -750,7 +750,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "probe_success{job=\"vpn-connection\",type=\"seed\"}",
+              "expr": "probe_success{job=\"tunnel-probe-apiserver-proxy\",type=\"seed\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "API Server Proxy test ({{instance}})",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug
/priority normal

**What this PR does / why we need it**:
Fixes the dashboard for the VPN. The job name for the vpn connection changed with the konnectivity tunnel change and the dashboard was not updated.

**Which issue(s) this PR fixes**:
Fixes #2787

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue causing the 'VPN Connection' tile in Grafana to show always 'No data' is now fixed.
```
