### PR TITLE
Add origin=gardener label to konnectivity agent

### DIFF
--- a/charts/shoot-core/components/charts/konnectivity-agent/templates/daemonset.yaml
+++ b/charts/shoot-core/components/charts/konnectivity-agent/templates/daemonset.yaml
@@ -23,6 +23,7 @@ spec:
         app: konnectivity-agent
         gardener.cloud/role: system-component
         garden.sapcloud.io/role: system-component
+        origin: gardener
       annotations:
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup
/priority normal

**What this PR does / why we need it**:
The konnectivity agent does not have the label `origin: gardener`. This PR adds the label for consistency and because an [alert](https://github.com/gardener/gardener/blob/master/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-pods.rules.yaml#L5) for end users looks for this label 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
