### PR TITLE
resize prometheus pvc size to 20Gi

### DIFF
--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -2,7 +2,7 @@ cloudProvider: aws
 
 prometheus:
   port: 9090
-  storage: 10Gi
+  storage: 20Gi
 
 aggregatePrometheus:
   port: 9090


### PR DESCRIPTION
resize prometheus pvc size to 20Gi, because the minimum pvc size of alicloud is 20Gi.