### PR TITLE
Switch off gardener-apiserver's vertical scale down by hvpa

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/hvpa.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/hvpa.yaml
@@ -58,7 +58,7 @@ spec:
 {{- end }}
     scaleDown:
       updatePolicy:
-        updateMode: "Auto"
+        updateMode: "Off"
 {{- if .Values.global.apiserver.hvpa.vpaScaleDownStabilization }}
 {{ toYaml .Values.global.apiserver.hvpa.vpaScaleDownStabilization | indent 6 }}
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area auto-scaling
/priority normal

**What this PR does / why we need it**:
Switch off gardener-apiserver's vertical scale down by hvpa

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Switch off gardener-apiserver's vertical scale down by hvpa. Since VPA doesn't seem to be handling the resource usage spikes well, it can result in repeated oomkills. Turning off scale down should reduce such occurancces.
```
