### PR TITLE
Specify default rolling update settings for gardener-apiserver

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -12,6 +12,11 @@ metadata:
     heritage: "{{ .Release.Service }}"
 spec:
   replicas: {{ required ".Values.global.apiserver.replicaCount is required" .Values.global.apiserver.replicaCount }}
+  minReadySeconds: {{ .Values.global.apiserver.minReadySeconds }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+{{ toYaml .Values.global.apiserver.rollingUpdate | indent 6 }}
   selector:
     matchLabels:
       app: gardener

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -30,6 +30,10 @@ global:
         memory: 256Mi
   # podAnnotations: # YAML formated annotations used for pod template
   # podLabels: # YAML formated labels used for pod template
+    minReadySeconds: 30
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
     encryption:
       config: |
         apiVersion: apiserver.config.k8s.io/v1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
We now specify maxSurge=1, maxUnavailable=0, minReadySeconds=30 as default settings for the rolling update of the gardener-apiserver. This is to make the updates slower and more stable as there might be lots of gardenlets that have to recreate their watches when the gardener-apiserver they are talking to is terminating.

**Which issue(s) this PR fixes**:
Fixes #2814

**Special notes for your reviewer**:
/invite @timebertt @amshuman-kr @ggaurav10 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The default rolling update settings of the gardener-apiserver (`maxSurge=1`, `maxUnavailable=0`, `minReadySeconds=30`) can now be controlled in the `gardener/controlplane` Helm chart.
```
