### PR TITLE
Add /usr/share/ca-certificates mount to kube-apiserver

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -270,6 +270,9 @@ spec:
         - name: fedora-rhel6-alpine-openelec-cabundle
           mountPath: /etc/ssl
           readOnly: true
+        - name: usr-share-ca-certificates
+          mountPath: /usr/share/ca-certificates
+          readOnly: true
         {{- end }}
       {{- if .Values.konnectivityTunnel.enabled }}
       - name: konnectivity-server
@@ -459,4 +462,8 @@ spec:
           path: /etc/ssl
           type: "DirectoryOrCreate"
         name: fedora-rhel6-alpine-openelec-cabundle
+      - hostPath:
+          path: /usr/share/ca-certificates
+          type: "DirectoryOrCreate"
+        name: usr-share-ca-certificates
       {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Part of #2791

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
