### PR TITLE
make vpa scale modes for gardener-apiserver's hvpa configurable

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/hvpa.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/hvpa.yaml
@@ -52,13 +52,13 @@ spec:
     deploy: true
     scaleUp:
       updatePolicy:
-        updateMode: "Auto"
+        updateMode: {{ .Values.global.apiserver.hvpa.vpaScaleUpMode }}
 {{- if .Values.global.apiserver.hvpa.vpaScaleUpStabilization }}
 {{ toYaml .Values.global.apiserver.hvpa.vpaScaleUpStabilization | indent 6 }}
 {{- end }}
     scaleDown:
       updatePolicy:
-        updateMode: "Auto"
+        updateMode: {{ .Values.global.apiserver.hvpa.vpaScaleDownMode }}
 {{- if .Values.global.apiserver.hvpa.vpaScaleDownStabilization }}
 {{ toYaml .Values.global.apiserver.hvpa.vpaScaleDownStabilization | indent 6 }}
 {{- end }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -84,6 +84,8 @@ global:
       minReplicas: 1
       targetAverageUtilizationCpu: 80
       targetAverageUtilizationMemory: 80
+      vpaScaleUpMode: "Auto"
+      vpaScaleDownMode: "Auto"
       vpaScaleUpStabilization:
         stabilizationDuration: "3m"
         minChange:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area auto-scaling
/priority normal

**What this PR does / why we need it**:
make vpa scale modes for gardener-apiserver's hvpa configurable

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@amshuman-kr 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Make VPA scale modes for gardener-apiserver's hvpa configurable.
```
