### PR TITLE
Add role label for shoot secrets in project

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -143,6 +143,10 @@ const (
 	GardenRoleMonitoring = "monitoring"
 	// GardenRoleOptionalAddon is the value of the GardenRole key indicating type 'optional-addon'.
 	GardenRoleOptionalAddon = "optional-addon"
+	// GardenRoleKubeconfig is the value of the GardenRole key indicating type 'kubeconfig'.
+	GardenRoleKubeconfig = "kubeconfig"
+	// GardenRoleSSHKeyPair is the value of the GardenRole key indicating type 'ssh-keypair'.
+	GardenRoleSSHKeyPair = "ssh-keypair"
 
 	// DeprecatedShootUID is an annotation key for the shoot namespace in the seed cluster,
 	// which value will be the value of `shoot.status.uid`

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/seed"
 	"github.com/gardener/gardener/pkg/operation/shootsecrets"
 	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/flow"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
@@ -291,6 +292,7 @@ type projectSecret struct {
 	secretName  string
 	suffix      string
 	annotations map[string]string
+	labels      map[string]string
 }
 
 // SyncShootCredentialsToGarden copies the kubeconfig generated for the user, the SSH keypair to
@@ -307,40 +309,47 @@ func (b *Botanist) SyncShootCredentialsToGarden(ctx context.Context) error {
 			secretName:  common.KubecfgSecretName,
 			suffix:      secretSuffixKubeConfig,
 			annotations: map[string]string{"url": "https://" + kubecfgURL},
+			labels:      map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleKubeconfig},
 		},
 		{
 			secretName: v1beta1constants.SecretNameSSHKeyPair,
 			suffix:     secretSuffixSSHKeyPair,
+			labels:     map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleSSHKeyPair},
 		},
 		{
 			secretName:  "monitoring-ingress-credentials-users",
 			suffix:      secretSuffixMonitoring,
 			annotations: map[string]string{"url": "https://" + b.ComputeGrafanaUsersHost()},
+			labels:      map[string]string{v1beta1constants.GardenRole: v1beta1constants.GardenRoleMonitoring},
 		},
 	}
 
+	var fns []flow.TaskFn
 	for _, projectSecret := range projectSecrets {
-		secretObj := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      computeProjectSecretName(b.Shoot.Info.Name, projectSecret.suffix),
-				Namespace: b.Shoot.Info.Namespace,
-			},
-		}
-
-		if _, err := controllerutil.CreateOrUpdate(ctx, b.K8sGardenClient.Client(), secretObj, func() error {
-			secretObj.OwnerReferences = []metav1.OwnerReference{
-				*metav1.NewControllerRef(b.Shoot.Info, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")),
+		s := projectSecret
+		fns = append(fns, func(ctx context.Context) error {
+			secretObj := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      computeProjectSecretName(b.Shoot.Info.Name, s.suffix),
+					Namespace: b.Shoot.Info.Namespace,
+				},
 			}
-			secretObj.Annotations = projectSecret.annotations
-			secretObj.Type = corev1.SecretTypeOpaque
-			secretObj.Data = b.Secrets[projectSecret.secretName].Data
-			return nil
-		}); err != nil {
+
+			_, err := controllerutil.CreateOrUpdate(ctx, b.K8sGardenClient.Client(), secretObj, func() error {
+				secretObj.OwnerReferences = []metav1.OwnerReference{
+					*metav1.NewControllerRef(b.Shoot.Info, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")),
+				}
+				secretObj.Annotations = s.annotations
+				secretObj.Labels = s.labels
+				secretObj.Type = corev1.SecretTypeOpaque
+				secretObj.Data = b.Secrets[s.secretName].Data
+				return nil
+			})
 			return err
-		}
+		})
 	}
 
-	return nil
+	return flow.Parallel(fns...)(ctx)
 }
 
 func (b *Botanist) cleanupTunnelSecrets(ctx context.Context, gardenerResourceDataList *gardencorev1alpha1helper.GardenerResourceDataList, secretNames ...string) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR Gardener managed secrets in project namespaces are labelled with:

- kubeconfig secrets: `gardener.cloud/role: kubeconfig`
- ssh-keypair secrets: `gardener.cloud/role: ssh-keypair`
- monitoring secrets: `gardener.cloud/role: monitoring`

Supporting clients to efficiently filter for those secret types mainly motivates this change. See #2771.

**Special notes for your reviewer**:
Changes of this PR should be released before #2771. Thanks @rfranzke for raising this concern.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
Gardener managed secrets, like `kubeconfig`, `ssh-keypair`, `monitoring`, are now labelled with `gardener.cloud/role` which enables clients to filter these secret types via label matchers.
```
```improvement operator
Gardener managed secrets, like `kubeconfig`, `ssh-keypair`, `monitoring`, are now labelled with `gardener.cloud/role` which enables clients to filter these secret types via label matchers.
```
