### PR TITLE
Upgrade fluent-bit to version 0.26.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -194,7 +194,7 @@ images:
 - name: fluent-bit
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.25.0"
+  tag: "v0.26.0"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-configmap.yaml
@@ -327,6 +327,10 @@ data:
         tls.verify          Off
         K8S-Logging.Exclude Off
 
+    # Extensions
+{{ if .Values.additionalFilters }}
+{{- toString .Values.additionalFilters | indent 4 }}
+{{- end }}
     # Scripts
     [FILTER]
         Name                lua
@@ -334,10 +338,11 @@ data:
         script              modify_severity.lua
         call                cb_modify
 
-    # Extensions
-{{ if .Values.additionalFilters }}
-{{- toString .Values.additionalFilters | indent 4 }}
-{{- end }}
+    [FILTER]
+        Name                lua
+        Match               kubernetes.*
+        script              add_tag_to_record.lua
+        call                add_tag_to_record
 
   output.conf: |
     [Output]
@@ -355,7 +360,7 @@ data:
         DropSingleKey false
         AutoKubernetesLabels true
         LabelSelector gardener.cloud/role:shoot
-        RemoveKeys kubernetes,stream,type,time
+        RemoveKeys kubernetes,stream,type,time,tag
         LabelMapPath /fluent-bit/etc/kubernetes_label_map.json
         DynamicHostPath {"kubernetes": {"namespace_name": "namespace"}}
         DynamicHostPrefix http://loki.
@@ -370,6 +375,9 @@ data:
         QueueSegmentSize 300
         QueueSync normal
         QueueName gardener-kubernetes
+        FallbackToTagWhenMetadataIsMissing true
+        TagKey tag
+        DropLogEntryWithoutK8sMetadata true
 
     [Output]
         Name loki
@@ -534,6 +542,12 @@ data:
 
     function trim(s)
       return (s:gsub("^%s*(.-)%s*$", "%1"))
+    end
+
+  add_tag_to_record.lua: |-
+    function add_tag_to_record(tag, timestamp, record)
+      record["tag"] = tag
+      return 1, timestamp, record
     end
 
   kubernetes_label_map.json: |-


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR we upgrade fluent-bit to version 0.26.0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Upgrade fluent-bit-to-loki plugin to version 0.26.0
```

``` improvement operator github.com/gardener/logging #67 @vlvasilev
New flags are added to extract kubernetes metadata from a tag entry in the log. The metadata consist of `pod_name`, `namespace` and `container_id`.
```

``` improvement operator github.com/gardener/logging #67 @vlvasilev
Logs without kubernetes metadata can be dropped via setting a flag `DropLogEntryWithoutK8sMetadata`.
```

``` action operator github.com/gardener/logging #67 @vlvasilev
Flag `QueSegmentSize` is renamed to `QueueSegmentSize`
```

``` improvement operator github.com/gardener/logging #66 @vlvasilev
When "Out OF Order Timestamp" occurs the log message prints latest timestamp, incoming timestamp, host and label set of the log
```
