### PR TITLE
Enabling SNI feature gate is now graceful

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver-service/templates/kube-apiserver-service.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver-service/templates/kube-apiserver-service.yaml
@@ -15,11 +15,11 @@ metadata:
   labels:
     app: kubernetes
     role: apiserver
-{{- if .Values.enableSNI }}
+{{- if .Values.gardenerManaged }}
     core.gardener.cloud/apiserver-exposure: gardener-managed
 {{- end }}
 spec:
-  type: {{ if .Values.enableSNI }}ClusterIP{{ else }}LoadBalancer{{ end }}
+  type: {{ .Values.serviceType }}
   selector:
     app: kubernetes
     role: apiserver

--- a/charts/seed-controlplane/charts/kube-apiserver-service/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver-service/values.yaml
@@ -4,3 +4,5 @@ enableSNI: false
 annotations: {}
 enableKonnectivityTunnel: false
 name: kube-apiserver
+serviceType: LoadBalancer
+gardenerManaged: false

--- a/pkg/operation/botanist/component/phase.go
+++ b/pkg/operation/botanist/component/phase.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package component
+
+// Phase is the phase of a component.
+type Phase int
+
+const (
+	// PhaseUnknown is in an unknown component phase.
+	PhaseUnknown Phase = iota
+	// PhaseEnabled is when a component was enabled before and it's still active.
+	PhaseEnabled
+	// PhaseDisabled is when a component was disabled before and it's still disabled.
+	PhaseDisabled
+	// PhaseEnabled is when a component was disabled before, but it's being activated.
+	PhaseEnabling
+	// PhaseDisabling is when a component was enabled before, but it's being disabled.
+	PhaseDisabling
+)
+
+// Done returns a completed phase. e.g.
+// Enabling -> Enabled
+// Disabling -> Disabled
+// otherwise returns the same phase.
+func (s Phase) Done() Phase {
+	switch s {
+	case PhaseEnabling:
+		return PhaseEnabled
+	case PhaseDisabling:
+		return PhaseDisabled
+	case PhaseEnabled, PhaseDisabled, PhaseUnknown:
+		return s
+	default:
+		return PhaseUnknown
+	}
+}

--- a/pkg/operation/botanist/component/phases_test.go
+++ b/pkg/operation/botanist/component/phases_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package component_test
+
+import (
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Phases' Done", func() {
+	DescribeTable("correct phase for", func(old, expected component.Phase) {
+		Expect(old.Done()).To(Equal(expected))
+	},
+		Entry("unknown is not changed", component.PhaseUnknown, component.PhaseUnknown),
+		Entry("not phase a is always unknown", component.Phase(1234), component.PhaseUnknown),
+		Entry("enabled is not changed", component.PhaseEnabled, component.PhaseEnabled),
+		Entry("disabled is not changed", component.PhaseDisabled, component.PhaseDisabled),
+		Entry("enabling is changed to enabled", component.PhaseEnabling, component.PhaseEnabled),
+		Entry("disabling is changed to disabled", component.PhaseDisabling, component.PhaseDisabled),
+	)
+})

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -540,7 +540,7 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 		}
 
 		chartApplier := k8sSeedClient.ChartApplier()
-		istioCRDs := istio.NewIstioCRD(chartApplier, "charts", k8sSeedClient.Client())
+		istioCRDs := istio.NewIstioCRD(chartApplier, common.ChartPath, k8sSeedClient.Client())
 		istiod := istio.NewIstiod(
 			&istio.IstiodValues{
 				TrustDomain: "cluster.local",
@@ -548,7 +548,7 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 			},
 			common.IstioNamespace,
 			chartApplier,
-			"charts",
+			common.ChartPath,
 			k8sSeedClient.Client(),
 		)
 
@@ -576,7 +576,7 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 			igwConfig,
 			common.IstioIngressGatewayNamespace,
 			chartApplier,
-			"charts",
+			common.ChartPath,
 			k8sSeedClient.Client(),
 		)
 
@@ -585,7 +585,7 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 		}
 	}
 
-	proxy := istio.NewProxyProtocolGateway(common.IstioIngressGatewayNamespace, chartApplier, "charts")
+	proxy := istio.NewProxyProtocolGateway(common.IstioIngressGatewayNamespace, chartApplier, common.ChartPath)
 
 	if gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI) {
 		if err := proxy.Deploy(ctx); err != nil {
@@ -674,7 +674,7 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 		"cluster-identity": map[string]interface{}{"clusterIdentity": &seed.Info.Status.ClusterIdentity},
 	})
 
-	if err := chartApplier.Apply(ctx, filepath.Join("charts", chartName), v1beta1constants.GardenNamespace, chartName, values, applierOptions); err != nil {
+	if err := chartApplier.Apply(ctx, filepath.Join(common.ChartPath, chartName), v1beta1constants.GardenNamespace, chartName, values, applierOptions); err != nil {
 		return err
 	}
 

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -91,10 +91,11 @@ type Components struct {
 
 // ControlPlane contains references to K8S control plane components.
 type ControlPlane struct {
-	KubeAPIServerService component.DeployWaiter
-	KubeAPIServerSNI     component.DeployWaiter
-	KubeScheduler        kubescheduler.KubeScheduler
-	ClusterAutoscaler    clusterautoscaler.ClusterAutoscaler
+	ClusterAutoscaler     clusterautoscaler.ClusterAutoscaler
+	KubeAPIServerService  component.DeployWaiter
+	KubeAPIServerSNI      component.DeployWaiter
+	KubeAPIServerSNIPhase component.Phase
+	KubeScheduler         kubescheduler.KubeScheduler
 }
 
 // Extensions contains references to extension resources.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:

With this change when SNI was disabled and then enabled during the reconciliation the following happens:

- kube-apiserver service is annotated with the istio's `exportTo` annotation to add it to the service mesh
- kube-apiserver service is kept of type `LoadBalancer` to keep traffic in
the cluster running as DNS cache will force traffic to go to the current
kube-apiserver Loadbalancer IP.
- istio resources are added so traffic from the service mesh can be send
to the istio ingress gateway (for newer clients)
- DNS entries are changed to point to the istio IGW Loadbalancer
- at the end of the reconciliation when the tunnel connection is working,
update the kube-apiserver to type of `ClusterIP`.

**Which issue(s) this PR fixes**:
Fixes gardener/dependency-watchdog#22

**Special notes for your reviewer**:

I would recommend to move the logic of kube-apiserver service management + SNI in a a separate controller. This would allow to update the DNSEntries only when the DNS's TTL has passed and ensure with 100% that end-users experience only a connection close and are able to to quickly reconnect to the istio IGW.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Enabling SNI feature gate now changes the type of kube-apiserver Service to `ClusterIP` only after `DNSEntries` are updated to point to the istio ingress gateway.
```
