### PR TITLE
Set minimum resources for nginx VPA

### DIFF
--- a/charts/shoot-addons/charts/nginx-ingress/templates/vpa.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/vpa.yaml
@@ -5,6 +5,12 @@ metadata:
   name: addons-nginx-ingress-controller
   namespace: {{ .Release.Namespace }}
 spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        cpu: 100m
+        memory: 128Mi
   targetRef:
     apiVersion: {{ include "deploymentversion" . }}
     kind: Deployment


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Set minimum resources for nginx VPA.

In some cases the VPA scale to very low values the CPU requests and limits for the nginx controller:
```bash
$ k get pod -l app=nginx-ingress,component=controller -o json | jq '.items[].spec.containers[].resources' -cr;  k top pod -l app=nginx-ingress,component=controller
{"limits":{"cpu":"92m","memory":"3254996328"},"requests":{"cpu":"23m","memory":"813749082"}}
NAME                                               CPU(cores)   MEMORY(bytes)
addons-nginx-ingress-controller-5865b5dbf4-c2kq9   19m          635Mi
```

But there are spike loads in the controller that the VPA cannot react fast enough and then it ends in the `CrashLoopBackOff`. In this example the resources seems fine, but when a spike occurs and something like 400m CPU are needed, it will start failing.
```bash
$ k get pod -l app=nginx-ingress,component=controller -o json | jq '.items[].spec.containers[].resources' -cr;  k top pod -l {"limits":{"cpu":"92m","memory":"992613920"},"requests":{"cpu":"23m","memory":"248153480"}}
NAME                                               CPU(cores)   MEMORY(bytes)
addons-nginx-ingress-controller-6c87957d9c-gz6qb   16m          172Mi
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @amshuman-kr @wyb1 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The VPA for the nginx addon is now set to guarantee at least 100m cpu and 128Mi memory for the controller pod.
```
