### PR TITLE
konnectivity server now logs to stdout

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -281,9 +281,7 @@ spec:
           - /proxy-server
         args:
         - --uds-name=/etc/srv/kubernetes/konnectivity-server/konnectivity-server.socket
-        - --log-file=/var/log/konnectivity-server/info.log
-        - --logtostderr=false
-        - --log-file-max-size=12
+        - --logtostderr=true
         - --cluster-cert=/certs/konnectivity-server/konnectivity-server.crt
         - --cluster-key=/certs/konnectivity-server/konnectivity-server.key
         - --agent-namespace={{ .Values.konnectivityTunnel.agentNamespace }}
@@ -310,9 +308,6 @@ spec:
             mountPath: /etc/srv/kubernetes/konnectivity-server-kubeconfig
           - name: konnectivity-uds
             mountPath: /etc/srv/kubernetes/konnectivity-server
-            readOnly: false
-          - name: konnectivity-server-log
-            mountPath: /var/log/konnectivity-server
             readOnly: false
       {{- else }}
       - name: vpn-seed
@@ -430,8 +425,6 @@ spec:
       - name: egress-selection-config
         configMap:
           name: kube-apiserver-egress-selector-configuration
-      - name: konnectivity-server-log
-        emptyDir: {}
       {{- else }}
       - name: vpn-seed
         secret:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane networking ops-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Konnectivity ~agent and~ server logs to stdout. Currently these components are dumping their logs in files in the pod ephemeral filesystem, but the container images comes without shell and basic tools which means that the logs cannot be consumed. Switching to stdout allows plain `kubectl logs <pod-name>` to be used, also the logs from the seed component will be preserved in the Loki instance (cc @Kristian-ZH @vlvasilev new log parser might be needed for this container).


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `konnectivity-server` is now logging to the stdout.
```
