### PR TITLE
align shoot kube-apiserver mounts to be backwards compatible with  provider extensions

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -261,18 +261,39 @@ spec:
         # locations are taken from
         # https://github.com/golang/go/blob/1bb247a469e306c57a5e0eaba788efb8b3b1acef/src/crypto/x509/root_linux.go#L7-L15
         # we cannot be sure on which Node OS the Seed Cluster is running so, it's safer to mount them all
+          {{- if .Values.mountHostCADirectories.enabled }}
         - name: fedora-rhel6-openelec-cabundle
           mountPath: /etc/pki/tls
           readOnly: true
         - name: centos-rhel7-cabundle
           mountPath: /etc/pki/ca-trust/extracted/pem
           readOnly: true
-        - name: fedora-rhel6-alpine-openelec-cabundle
+        - name: etc-ssl
           mountPath: /etc/ssl
           readOnly: true
-        - name: usr-share-ca-certificates
+        - name: usr-share-cacerts
           mountPath: /usr/share/ca-certificates
           readOnly: true
+          {{- else }}
+        - name: debian-family-cabundle
+          mountPath: /etc/ssl/certs/ca-certificates.crt
+          readOnly: true
+        - name: fedora-rhel6-cabundle
+          mountPath: /etc/pki/tls/certs/ca-bundle.crt
+          readOnly: true
+        - name: opensuse-cabundle
+          mountPath: /etc/ssl/ca-bundle.pem
+          readOnly: true
+        - name: openelec-cabundle
+          mountPath: /etc/pki/tls/cacert.pem
+          readOnly: true
+        - name: centos-rhel7-cabundle
+          mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+          readOnly: true
+        - name:  alpine-linux-cabundle
+          mountPath: /etc/ssl/cert.pem
+          readOnly: true
+          {{- end }}
         {{- end }}
       {{- if .Values.konnectivityTunnel.enabled }}
       - name: konnectivity-server
@@ -450,6 +471,7 @@ spec:
       # locations are taken from
       # https://github.com/golang/go/blob/1bb247a469e306c57a5e0eaba788efb8b3b1acef/src/crypto/x509/root_linux.go#L7-L15
       # we cannot be sure on which Node OS the Seed Cluster is running so, it's safer to mount them all
+        {{- if .Values.mountHostCADirectories.enabled }}
       - hostPath:
           path: /etc/pki/tls
           type: "DirectoryOrCreate"
@@ -461,9 +483,29 @@ spec:
       - hostPath:
           path: /etc/ssl
           type: "DirectoryOrCreate"
-        name: fedora-rhel6-alpine-openelec-cabundle
+        name: etc-ssl
       - hostPath:
           path: /usr/share/ca-certificates
           type: "DirectoryOrCreate"
-        name: usr-share-ca-certificates
+        name: usr-share-cacerts
+        {{- else }}
+      - name: debian-family-cabundle
+        hostPath:
+          path: /etc/ssl/certs/ca-certificates.crt
+      - name: fedora-rhel6-cabundle
+        hostPath:
+          path: /etc/pki/tls/certs/ca-bundle.crt
+      - name: opensuse-cabundle
+        hostPath:
+          path: /etc/ssl/ca-bundle.pem
+      - name: openelec-cabundle
+        hostPath:
+          path: /etc/pki/tls/cacert.pem
+      - name: centos-rhel7-cabundle
+        hostPath:
+          path: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+      - name: alpine-linux-cabundle
+        hostPath:
+          path: /etc/ssl/cert.pem
+        {{- end }}
       {{- end }}

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -155,6 +155,9 @@ sni:
   enabled: false
   advertiseIP: 1.1.1.1
 
+mountHostCADirectories:
+  enabled: false
+
 # watchCacheSizes:
 #   default: 100
 #   resources:

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -25,6 +25,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | HVPAForShootedSeed | `false` | `Alpha` | `0.32` | |
 | ManagedIstio | `false` | `Alpha` | `1.5` | |
 | APIServerSNI | `false` | `Alpha` | `1.7` | |
+| MountHostCADirectories | `false` | `Alpha` | `1.11.0` | |
 
 ## Using a feature
 
@@ -67,3 +68,4 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 * `HVPAForShootedSeed`  enables simultaneous horizontal and vertical scaling in shooted Seed clusters.
 * `ManagedIstio` enables a Gardener-tailored [Istio](https://istio.io) in each Seed cluster. Disable this feature if Istio is already installed in the cluster. Istio is not automatically removed if this feature is disabled. See the [detailed documentation](../usage/istio.md) for more information.
 * `APIServerSNI` enables only one LoadBalancer to be used for every Shoot cluster API server in a Seed. Enable this feature when `ManagedIstio` is enabled or Istio is manually deployed in Seed cluster. See [GEP-8](../proposals/08-shoot-apiserver-via-sni.md) for more details.
+* `MountHostCADirectories` enables mounting common CA certificate directories in the Shoot API server pod that might be required for webhooks or OIDC. 

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -85,6 +85,7 @@ featureGates:
   APIServerSNI: false
   CachedRuntimeClients: true
   NodeLocalDNS: true
+  MountHostCADirectories: false
 seedSelector: {} # selects all seeds, only use for development purposes
 # seedConfig:
 #   metadata:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -72,4 +72,9 @@ const (
 	// owner @zanetworker
 	// alpha: v1.7.0
 	NodeLocalDNS featuregate.Feature = "NodeLocalDNS"
+
+	// MountHostCADirectories enables mounting common CA certificate directories in the Shoot API server pod that might be required for webhooks or OIDC.
+	// owner @danielfoehrKn
+	// alpha: v1.11.0
+	MountHostCADirectories featuregate.Feature = "MountHostCADirectories"
 )

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -25,14 +25,15 @@ var (
 	// FeatureGate is a shared global FeatureGate for Gardenlet flags.
 	FeatureGate  = featuregate.NewFeatureGate()
 	featureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		features.Logging:              {Default: false, PreRelease: featuregate.Alpha},
-		features.HVPA:                 {Default: false, PreRelease: featuregate.Alpha},
-		features.HVPAForShootedSeed:   {Default: false, PreRelease: featuregate.Alpha},
-		features.ManagedIstio:         {Default: false, PreRelease: featuregate.Alpha},
-		features.KonnectivityTunnel:   {Default: false, PreRelease: featuregate.Alpha},
-		features.APIServerSNI:         {Default: false, PreRelease: featuregate.Alpha},
-		features.CachedRuntimeClients: {Default: false, PreRelease: featuregate.Alpha},
-		features.NodeLocalDNS:         {Default: false, PreRelease: featuregate.Alpha},
+		features.Logging:                {Default: false, PreRelease: featuregate.Alpha},
+		features.HVPA:                   {Default: false, PreRelease: featuregate.Alpha},
+		features.HVPAForShootedSeed:     {Default: false, PreRelease: featuregate.Alpha},
+		features.ManagedIstio:           {Default: false, PreRelease: featuregate.Alpha},
+		features.KonnectivityTunnel:     {Default: false, PreRelease: featuregate.Alpha},
+		features.APIServerSNI:           {Default: false, PreRelease: featuregate.Alpha},
+		features.CachedRuntimeClients:   {Default: false, PreRelease: featuregate.Alpha},
+		features.NodeLocalDNS:           {Default: false, PreRelease: featuregate.Alpha},
+		features.MountHostCADirectories: {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -908,6 +908,7 @@ func (b *Botanist) DeployNetworkPolicies(ctx context.Context) error {
 func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 	var (
 		hvpaEnabled               = gardenletfeatures.FeatureGate.Enabled(features.HVPA)
+		mountHostCADirectories    = gardenletfeatures.FeatureGate.Enabled(features.MountHostCADirectories)
 		memoryMetricForHpaEnabled = false
 	)
 
@@ -1131,6 +1132,10 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 	serviceAccountConfigVals["issuer"] = serviceAccountTokenIssuerURL
 	defaultValues["serviceAccountConfig"] = serviceAccountConfigVals
 	defaultValues["admissionPlugins"] = admissionPlugins
+
+	defaultValues["mountHostCADirectories"] = map[string]interface{}{
+		"enabled": mountHostCADirectories,
+	}
 
 	tunnelComponentImageName := common.VPNSeedImageName
 	if b.Shoot.KonnectivityTunnelEnabled {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority normal

**What this PR does / why we need it**:

[I introduced changes to the Shoot kube-apiserver mounts](https://github.com/gardener/gardener/commit/f6493ad9c81dc15149a0f20b45ae31f3d78ea8fd) that are not backwards compatible with the latest provider extensions. Thanks @ialidzhikov  for spotting.

This solves the issue for every extension but openstack.
This version of the Gardener is incompatible with the openstack provider for Shoots with certain Kubernetes versions.
This is because openstack already has a conflicting apiserver mount.  

To give stakeholders time to migrate to a compatible version of the extension providers and try it out - a feature flag was added.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Please see the corresponding [Openstack provider  PR](https://github.com/gardener/gardener-extension-provider-openstack/pull/147)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Add the feature flag `MountHostCADirectories`  that enables mounting common CA certificate directories in the Shoot API server pod that might be required for webhooks or OIDC.  
Enabling this feature gate removes mounting common CA files directly - as this can lead to problems. 
The reason for adding this as a feature flag is that there are known compatibility issues with the openstack extension provider (can lead to failed kube-apiserver deployments for certain Kubernetes versions) and the provider-aws/gcp/azure (can lead to missing `/etc/ssl/` mounts in the Shoot API Server).
Please consult the compatibility docs under `/docs` in the extension repository.  
```
