### PR TITLE
Fix a bug where admission plugins of one shoot can be applied to all shoots on the same seed

### DIFF
--- a/pkg/client/kubernetes/admissionplugins.go
+++ b/pkg/client/kubernetes/admissionplugins.go
@@ -55,6 +55,10 @@ var (
 // If the given Kubernetes version does not explicitly define admission plugins the set of names for the next
 // available version will be returned (e.g., for version X not defined the set of version X-1 will be returned).
 func GetAdmissionPluginsForVersion(v string) []gardencorev1beta1.AdmissionPlugin {
+	return copyPlugins(getAdmissionPluginsForVersionInternal(v))
+}
+
+func getAdmissionPluginsForVersionInternal(v string) []gardencorev1beta1.AdmissionPlugin {
 	version, err := semver.NewVersion(v)
 	if err != nil {
 		return admissionPlugins[lowestSupportedKubernetesVersionMajorMinor]
@@ -78,4 +82,13 @@ func GetAdmissionPluginsForVersion(v string) []gardencorev1beta1.AdmissionPlugin
 
 func formatMajorMinor(major, minor int64) string {
 	return fmt.Sprintf("%d.%d", major, minor)
+}
+
+func copyPlugins(admissionPlugins []gardencorev1beta1.AdmissionPlugin) []gardencorev1beta1.AdmissionPlugin {
+	dst := make([]gardencorev1beta1.AdmissionPlugin, 0)
+	for _, plugin := range admissionPlugins {
+		pluginPointer := &plugin
+		dst = append(dst, *pluginPointer.DeepCopy())
+	}
+	return dst
 }

--- a/pkg/client/kubernetes/admissionplugins_test.go
+++ b/pkg/client/kubernetes/admissionplugins_test.go
@@ -73,5 +73,17 @@ var _ = Describe("kubernetes", func() {
 				Expect(plugins).To(ContainElement(gardencorev1beta1.AdmissionPlugin{Name: plugin}))
 			}
 		})
+
+		It("should return copy of the default plugins", func() {
+			expected := []string{"Priority", "NamespaceLifecycle", "LimitRanger", "ServiceAccount", "NodeRestriction", "DefaultStorageClass", "DefaultTolerationSeconds", "ResourceQuota", "StorageObjectInUseProtection", "MutatingAdmissionWebhook", "ValidatingAdmissionWebhook"}
+
+			plugins := GetAdmissionPluginsForVersion("1.14.0")
+			plugins2 := GetAdmissionPluginsForVersion("1.14.0")
+			plugins[0].Name = "MissingPlugin"
+
+			for _, plugin := range expected {
+				Expect(plugins2).To(ContainElement(gardencorev1beta1.AdmissionPlugin{Name: plugin}))
+			}
+		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority critical

**What this PR does / why we need it**:
Fix a bug where custom admission plugins of one shoot can be applied to all shoots on the same seed.

The issue is that every call of `GetAdmissionPluginsForVersion` returns always the same slice. If a shoot is customizing a default admission plugin it will overwrite the shared slice here https://github.com/gardener/gardener/blob/95e8072608731a52f74fd46027f37c389aba4d1c/pkg/operation/botanist/controlplane.go#L1104 and with the next reconciliation other shoots reconciled by the same gardenlet are getting the same custom config even though they have not customized it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Thanks you @BeckerMax @ialidzhikov @schrodit @dansible (I hope do not miss anybody) for the help debugging this issue.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue where the custom admission plugin settings might of one shoot cluster can be applied to other shoots reconciled by the same seed cluster has been fixed.
```
