### PR TITLE
Fix template issue for admissionPlugin config

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/configmap-admission-config.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/configmap-admission-config.yaml
@@ -17,6 +17,6 @@ data:
 {{- range $i, $plugin := .Values.admissionPlugins }}
 {{- if $plugin.config }}
   {{ lower $plugin.name }}.yaml: |
-{{ $plugin.config | indent 4 }}
+{{ toYaml $plugin.config | indent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -52,7 +52,7 @@ admissionPlugins:
 - name: ValidatingAdmissionWebhook
 - name: ResourceQuota
 # - name: PodNodeSelector
-#   config: |
+#   config:
 #     podNodeSelectorPluginConfig:
 #       clusterDefaultNodeSelector: <node-selectors-labels>
 #       namespace1: <node-selectors-labels>


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
Currently trying to specify admission plugins such as

```yaml
spec:
  kubernetes:
    kubeAPIServer:
      admissionPlugins:
      - config:
          apiVersion: eventratelimit.admission.k8s.io/v1alpha1
          kind: Configuration
          limits:
          - burst: 100
            cacheSize: 2000
            qps: 50
            type: Namespace
          - burst: 50
            qps: 10
            type: User
        name: EventRateLimit
```

fails with

```yaml
  lastErrors:
  - description: 'task "Deploying Kubernetes API server" failed: retry failed with
      context deadline exceeded, last error: render error in "kube-apiserver/templates/deployment.yaml":
      template: kube-apiserver/templates/deployment.yaml:36:48: executing "kube-apiserver/templates/deployment.yaml"
      at <include (print $.Template.BasePath "/configmap-admission-config.yaml") .>:
      error calling include: template: kube-apiserver/templates/configmap-admission-config.yaml:20:27:
      executing "kube-apiserver/templates/configmap-admission-config.yaml" at <4>:
      wrong type for value; expected string; got map[string]interface {}'
```


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue preventing an admission plugin config (`.spec.kubernetes.kubeAPIServer.admissionPlugins[*].config`) to be specified for the Kubernetes apiserver is now fixed.
```
