### PR TITLE
Defrag shooted seed etcd-main every day.

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -1510,7 +1510,7 @@ func (b *Botanist) DeployETCD(ctx context.Context) error {
 			foundStatefulset = false
 		}
 
-		defragmentSchedule, err := DetermineDefragmentSchedule(b.Shoot.Info, etcd)
+		defragmentSchedule, err := DetermineDefragmentSchedule(b.Shoot.Info, etcd, b.ShootedSeed, role)
 		if err != nil {
 			return err
 		}
@@ -1666,12 +1666,16 @@ func DetermineBackupSchedule(shoot *gardencorev1beta1.Shoot, etcd *druidv1alpha1
 }
 
 // DetermineDefragmentSchedule determines the defragment schedule based on the shoot creation and maintenance time window.
-func DetermineDefragmentSchedule(shoot *gardencorev1beta1.Shoot, etcd *druidv1alpha1.Etcd) (string, error) {
+func DetermineDefragmentSchedule(shoot *gardencorev1beta1.Shoot, etcd *druidv1alpha1.Etcd, shootedSeed *gardencorev1beta1helper.ShootedSeed, role string) (string, error) {
 	if etcd.Spec.Etcd.DefragmentationSchedule != nil {
 		return *etcd.Spec.Etcd.DefragmentationSchedule, nil
 	}
 
 	schedule := "%d %d */3 * *"
+	if shootedSeed != nil && role == common.EtcdRoleMain {
+		// defrag etcd-main of shooted seeds daily in the maintenance window
+		schedule = "%d %d * * *"
+	}
 
 	return determineSchedule(shoot, schedule, func(maintenanceTimeWindow *utils.MaintenanceTimeWindow, shootUID types.UID) string {
 		// Randomize the defragment timing but within the maintainence window.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind post-mortem
/priority critical

**What this PR does / why we need it**:
Defrag shooted seed etcd-main every day. This is to temporarily mitigate the high load on seed apiserver from recent changes.

**Which issue(s) this PR fixes**:
A temporary mitigation for -> https://github.tools.sap/kubernetes-canary/issues-canary/issues/155#issuecomment-119374

**Special notes for your reviewer**:
This is only a temporary mitigation until the issue with high load into the seed apiserver is addressed.

Less than `24h` schedule is not going to help unless we also chaning `auto-compaction-retention` which is currently set to [`24h`](https://github.com/gardener/etcd-druid/blob/master/charts/etcd/templates/etcd-bootstrap-configmap.yaml#L130) which is not exposed as a field in the `Etcd` CRD of druid. @shreyas-s-rao Does it make sense to already introduce the `autoCompactionRetention` as a field in the the `Etcd` CRD and create a patch release (without including the volume deletion changes)? I think we need to be prepared for any issues on azure seeds. Most of them have relatively high DB sizes.

/cc @shreyas-s-rao  @rfranzke @vlerenc 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Defrag shooted seed etcd-main every day. This is to temporarily mitigate the high load on seed apiserver from recent changes.
```
