### PR TITLE
Restrict event dumping to project namespace

### DIFF
--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -501,9 +501,11 @@ func (f *GardenerFramework) DumpState(ctx context.Context) {
 		f.Logger.Errorf("unable to dump seed status: %s", err.Error())
 	}
 
-	// dump all events if no shoot is given
-	if err := f.dumpEventsInAllNamespace(ctx, ctxIdentifier, f.GardenClient); err != nil {
-		f.Logger.Errorf("unable to dump Events from namespaces gardener: %s", err.Error())
+	// dump events if project namespace set
+	if f.ProjectNamespace != "" {
+		if err := f.dumpEventsInNamespace(ctx, ctxIdentifier, f.GardenClient, f.ProjectNamespace); err != nil {
+			f.Logger.Errorf("unable to dump gardener events from project namespace %s: %s", f.ProjectNamespace, err.Error())
+		}
 	}
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Previously all events were dumped upon shoot test creation failure which led to too much noise.
Now only the events of the resp. shoot's namespace are dumped.
