### PR TITLE
Ignore gardener-specific labels while balancing node-groups in autoscaler

### DIFF
--- a/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler.go
@@ -323,6 +323,12 @@ func (c *clusterAutoscaler) computeCommand() []string {
 	var (
 		scaleDownUnneededTime  = metav1.Duration{Duration: 30 * time.Minute}
 		scaleDownDelayAfterAdd = metav1.Duration{Duration: time.Hour}
+		balancingIgnoreLabels  = []string{
+			v1beta1constants.LabelWorkerPool,
+			v1beta1constants.LabelWorkerPoolDeprecated,
+			corev1.LabelZoneFailureDomainStable,
+			corev1.LabelZoneRegionStable,
+		}
 
 		command = []string{
 			"./cluster-autoscaler",
@@ -367,6 +373,10 @@ func (c *clusterAutoscaler) computeCommand() []string {
 
 	for _, machineDeployment := range c.machineDeployments {
 		command = append(command, fmt.Sprintf("--nodes=%d:%d:%s.%s", machineDeployment.Minimum, machineDeployment.Maximum, c.namespace, machineDeployment.Name))
+	}
+
+	for _, ignoreLabel := range balancingIgnoreLabels {
+		command = append(command, fmt.Sprintf("--balancing-ignore-label=%s", ignoreLabel))
 	}
 
 	return command


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/priority normal

**What this PR does / why we need it**: Autoscaler balances similar node-groups by comparing the labels on the nodes belonging to diff node-groups. We need to configure autoscaler to ignore gardener-specific labels for functionality to work properly, the PR does the same.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
```
