### PR TITLE
Fix gardener-admission-controller config mountPath

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
@@ -91,7 +91,7 @@ spec:
           readOnly: true
         {{- end }}
         - name: gardener-admission-controller-config
-          mountPath: /etc/gardener-admission-controller-config/config
+          mountPath: /etc/gardener-admission-controller/config
       volumes:
       - name: gardener-admission-controller-cert
         secret:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
Currently gardener-admission-controller would fail with

```
$ k -n garden logs gardener-admission-controller-64c7b7fd44-9kgvc
Error: open /etc/gardener-admission-controller/config/config.yaml: no such file or directory
open /etc/gardener-admission-controller/config/config.yaml: no such file or directory
Usage:
  gardener-admission-controller [flags]

Flags:
      --config string   Path to configuration file.
  -h, --help            help for gardener-admission-controller
```

The config volume mountPath is `/etc/gardener-admission-controller-config/config` but the container is started with `- --config=/etc/gardener-admission-controller/config/config.yaml`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
