### PR TITLE
Fix informer hasSyncFunc in validate-namespace-deletion webhook

### DIFF
--- a/pkg/admissioncontroller/server/handlers/webhooks/validate_namespace_deletion.go
+++ b/pkg/admissioncontroller/server/handlers/webhooks/validate_namespace_deletion.go
@@ -50,16 +50,16 @@ const waitForCachesToSyncTimeout = 5 * time.Minute
 func NewValidateNamespaceDeletionHandler(ctx context.Context, k8sGardenClient kubernetes.Interface) (http.HandlerFunc, error) {
 	// Initialize caches here to ensure http requests can be served quicker with pre-syncronized caches.
 	var hasSyncFuncs []cache.InformerSynced
-	informer, err := k8sGardenClient.Cache().GetInformer(ctx, &corev1.Secret{})
+	projectInformer, err := k8sGardenClient.Cache().GetInformer(ctx, &gardencorev1beta1.Project{})
 	if err != nil {
 		return nil, err
 	}
-	hasSyncFuncs = append(hasSyncFuncs, informer.HasSynced)
-	informer, err = k8sGardenClient.Cache().GetInformer(ctx, &gardencorev1beta1.Shoot{})
+	hasSyncFuncs = append(hasSyncFuncs, projectInformer.HasSynced)
+	shootInformer, err := k8sGardenClient.Cache().GetInformer(ctx, &gardencorev1beta1.Shoot{})
 	if err != nil {
 		return nil, err
 	}
-	hasSyncFuncs = append(hasSyncFuncs, informer.HasSynced)
+	hasSyncFuncs = append(hasSyncFuncs, shootInformer.HasSynced)
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, waitForCachesToSyncTimeout)
 	defer cancel()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/2832 we introduce a hasSyncFunc for Secret and Shoots. As far as I see there is no need for such wait for Secrets as I cannot see list or get for Secrets. The webhook seems to need hasSyncFunc for Project and Shoots (as it is doing list for shoots and projects).

Currently the gardener-admission-controller fails with:

```
$ k -n garden logs gardener-admission-controller-764647d74f-vs976
time="2020-09-23T08:16:13Z" level=info msg="Starting Gardener admission controller..."
time="2020-09-23T08:16:13Z" level=info msg="Creating new ClientSet for key \"garden\""
E0923 08:16:13.695908       1 reflector.go:178] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:136: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:garden:gardener-admission-controller" cannot list resource "secrets" in API group "" at the cluster scope
E0923 08:16:14.837144       1 reflector.go:178] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:136: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:garden:gardener-admission-controller" cannot list resource "secrets" in API group "" at the cluster scope
E0923 08:16:16.543679       1 reflector.go:178] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:136: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:garden:gardener-admission-controller" cannot list resource "secrets" in API group "" at the cluster scope
E0923 08:16:20.245943       1 reflector.go:178] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:136: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:garden:gardener-admission-controller" cannot list resource "secrets" in API group "" at the cluster scope
E0923 08:16:27.268387       1 reflector.go:178] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:136: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:garden:gardener-admission-controller" cannot list resource "secrets" in API group "" at the cluster scope
E0923 08:16:43.921821       1 reflector.go:178] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:136: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:garden:gardener-admission-controller" cannot list resource "secrets" in API group "" at the cluster scope
E0923 08:17:22.713198       1 reflector.go:178] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:136: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:garden:gardener-admission-controller" cannot list resource "secrets" in API group "" at the cluster scope
E0923 08:18:17.124085       1 reflector.go:178] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:136: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:garden:gardener-admission-controller" cannot list resource "secrets" in API group "" at the cluster scope
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
