### PR TITLE
Backup{Bucket,Entry} resources are only reconciled once per 24h

### DIFF
--- a/pkg/controllerutils/miscellaneous.go
+++ b/pkg/controllerutils/miscellaneous.go
@@ -16,9 +16,13 @@ package controllerutils
 
 import (
 	"strings"
+	"time"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const separator = ","
@@ -82,4 +86,40 @@ func setTaskAnnotations(annotations map[string]string, tasks []string) {
 	}
 
 	annotations[common.ShootTasks] = strings.Join(tasks, separator)
+}
+
+var (
+	// Now is a function for returning the current time.
+	Now = time.Now
+	// RandomDuration is a function for returning a random duration.
+	RandomDuration = utils.RandomDuration
+)
+
+// ReconcileOncePer24hDuration returns the duration until the next reconciliation should happen while respecting that
+// only one reconciliation should happen per 24h. If the deletion timestamp is set or the generation has changed or the
+// last operation does not indicate success or indicates that the last reconciliation happened more than 24h ago then 0
+// will be returned.
+func ReconcileOncePer24hDuration(objectMeta metav1.ObjectMeta, observedGeneration int64, lastOperation *gardencorev1beta1.LastOperation) time.Duration {
+	if objectMeta.DeletionTimestamp != nil {
+		return 0
+	}
+
+	if objectMeta.Generation != observedGeneration {
+		return 0
+	}
+
+	if lastOperation == nil ||
+		lastOperation.State != gardencorev1beta1.LastOperationStateSucceeded ||
+		(lastOperation.Type != gardencorev1beta1.LastOperationTypeCreate && lastOperation.Type != gardencorev1beta1.LastOperationTypeReconcile) {
+		return 0
+	}
+
+	// If last reconciliation happened more than 24h ago then we want to reconcile immediately, so let's only compute
+	// a delay if the last reconciliation was within the last 24h.
+	if lastReconciliation := lastOperation.LastUpdateTime.Time; Now().UTC().Before(lastReconciliation.UTC().Add(24 * time.Hour)) {
+		durationUntilLastReconciliationWas24hAgo := lastReconciliation.UTC().Add(24 * time.Hour).Sub(Now().UTC())
+		return RandomDuration(durationUntilLastReconciliationWas24hAgo)
+	}
+
+	return 0
 }

--- a/pkg/controllerutils/miscellaneous_test.go
+++ b/pkg/controllerutils/miscellaneous_test.go
@@ -16,20 +16,23 @@ package controllerutils_test
 
 import (
 	"strings"
+	"time"
 
-	"github.com/gardener/gardener/pkg/controllerutils"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/common"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("controller", func() {
 	Describe("utils", func() {
 		DescribeTable("#GetTasks",
 			func(existingTasks map[string]string, expectedResult []string) {
-				result := controllerutils.GetTasks(existingTasks)
+				result := GetTasks(existingTasks)
 				Expect(result).To(Equal(expectedResult))
 			},
 
@@ -41,7 +44,7 @@ var _ = Describe("controller", func() {
 
 		DescribeTable("#AddTasks",
 			func(existingTasks map[string]string, tasks []string, expectedTasks []string) {
-				controllerutils.AddTasks(existingTasks, tasks...)
+				AddTasks(existingTasks, tasks...)
 
 				if expectedTasks == nil {
 					Expect(existingTasks[common.ShootTasks]).To(BeEmpty())
@@ -70,7 +73,7 @@ var _ = Describe("controller", func() {
 
 		DescribeTable("#RemoveTasks",
 			func(existingTasks map[string]string, tasks []string, expectedTasks []string) {
-				controllerutils.RemoveTasks(existingTasks, tasks...)
+				RemoveTasks(existingTasks, tasks...)
 
 				if expectedTasks == nil {
 					Expect(existingTasks[common.ShootTasks]).To(BeEmpty())
@@ -101,7 +104,7 @@ var _ = Describe("controller", func() {
 
 		DescribeTable("#HasTask",
 			func(existingTasks map[string]string, task string, expectedResult bool) {
-				result := controllerutils.HasTask(existingTasks, task)
+				result := HasTask(existingTasks, task)
 				Expect(result).To(Equal(expectedResult))
 			},
 
@@ -111,4 +114,27 @@ var _ = Describe("controller", func() {
 			Entry("task in list", map[string]string{common.ShootTasks: "some-task" + "," + common.ShootTaskDeployInfrastructure}, "some-task", true),
 		)
 	})
+
+	var deletionTimestamp = metav1.Now()
+	DescribeTable("#ReconcileOncePer24hDuration",
+		func(objectMeta metav1.ObjectMeta, observedGeneration int64, lastOperation *gardencorev1beta1.LastOperation, expectedDuration time.Duration) {
+			oldNow := Now
+			defer func() { Now = oldNow }()
+			Now = func() time.Time { return time.Date(1, 1, 2, 1, 0, 0, 0, time.UTC) }
+
+			oldRandomDuration := RandomDuration
+			defer func() { RandomDuration = oldRandomDuration }()
+			RandomDuration = func(time.Duration) time.Duration { return time.Minute }
+
+			Expect(ReconcileOncePer24hDuration(objectMeta, observedGeneration, lastOperation)).To(Equal(expectedDuration))
+		},
+
+		Entry("deletion timestamp set", metav1.ObjectMeta{DeletionTimestamp: &deletionTimestamp}, int64(0), nil, time.Duration(0)),
+		Entry("generation not equal observed generation", metav1.ObjectMeta{Generation: int64(1)}, int64(0), nil, time.Duration(0)),
+		Entry("last operation is nil", metav1.ObjectMeta{}, int64(0), nil, time.Duration(0)),
+		Entry("last operation state is succeeded", metav1.ObjectMeta{}, int64(0), &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateSucceeded}, time.Duration(0)),
+		Entry("last operation type is not create or reconcile", metav1.ObjectMeta{}, int64(0), &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateSucceeded, Type: gardencorev1beta1.LastOperationTypeRestore}, time.Duration(0)),
+		Entry("last reconciliation was more than 24h ago", metav1.ObjectMeta{}, int64(0), &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateSucceeded, Type: gardencorev1beta1.LastOperationTypeReconcile, LastUpdateTime: metav1.Time{Time: time.Date(1, 1, 1, 0, 30, 0, 0, time.UTC)}}, time.Duration(0)),
+		Entry("last reconciliation was not more than 24h ago", metav1.ObjectMeta{}, int64(0), &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateSucceeded, Type: gardencorev1beta1.LastOperationTypeReconcile, LastUpdateTime: metav1.Time{Time: time.Date(1, 1, 1, 1, 30, 0, 0, time.UTC)}}, time.Minute),
+	)
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR we are adapting the `Backup{Bucket,Entry}` controller inside the gardenlet to prevent too many (unnecessary) reconciliations of `BackupBucket` and `BackupEntry` resources from happening. Earlier, the gardenlet reconciled all of these resources ~almost immediately after start-up. Now it's delaying the reconciliations so that only one reconciliation happens every 24h.

**Which issue(s) this PR fixes**:
Kind of related to #2822 and #1953 

**Special notes for your reviewer**:
This will improve two problems:
1. Less load on the gardener-apiserver when the gardenlet starts-up (yes, the `BackupEntry` reconciliation was already randomized by <= 1 minute, though, now it's spread even better, resulting in both less load on GAPI after start-up of gardenlet, and less load overall).
1. Less update requests to `BackupEntry` resources, especially when the gardenlet is scaled up/down by VPA, we no longer unnecessarily reconcile the many `BackupEntry` resources.

/assign @vlerenc @timebertt @amshuman-kr @shreyas-s-rao 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `BackupBucket` and `BackupEntry` resources in the garden cluster are now only reconciled once per 24h by the gardenlet.
```
