### PR TITLE
fix etcd full backup will always alert when create new shoot

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -103,7 +103,7 @@ groups:
       description: No delta snapshot for the past at least 30 minutes.
       summary: Etcd delta snapshot failure.
   - alert: KubeEtcdFullBackupFailed
-    expr: (time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore",kind="Full",role="main"} > bool 86400) + (etcdbr_snapshot_required{kind="Full", role="main"} >= bool 1) == 2
+    expr: (time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore",kind="Full",role="main"} > bool 86400) + (etcdbr_snapshot_required{kind="Full", role="main"} >= bool 1) == 2 and etcdbr_snapshot_latest_revision{job="kube-etcd3-backup-restore",kind="Full",role="main"} !=0 
     for: 15m
     labels:
         service: etcd


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement
/priority normal

**What this PR does / why we need it**:

the `KubeEtcdFullBackupFailed` will always alert when creating a new shoot. I hope this just alerts when etcdbr_snapshot_latest_revision!=0

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
