### PR TITLE
More flexibility for ControllerRegistrations deployments

### DIFF
--- a/docs/extensions/controllerregistration.md
+++ b/docs/extensions/controllerregistration.md
@@ -172,7 +172,7 @@ Again, similar to how Gardener is deployed to the garden cluster, these componen
 
 ### `Extension` resource configurations
 
-The `Extension` resource allows to inject arbitrary steps into the shoot reconciliation flow that are unknown to Gardener.
+The `Extension` resource allows injecting arbitrary steps into the shoot reconciliation flow that are unknown to Gardener.
 Hence, it is slightly special and allows further configuration when registering it:
 
 ```yaml
@@ -199,7 +199,8 @@ The `.spec.deployment` resource allows to configure a deployment `policy`.
 There are the following policies:
 
 * `OnDemand` (default): Gardener will demand the deployment and deletion of the extension controller to/from seed clusters dynamically. It will automatically determine (based on other resources like `Shoot`s) whether it is required and decide accordingly.
-* `Always`: Gardener will demand the deployment of the extension controller to seed clusters independent of whether it is actually required or not. This might be helpful if you want to add a new component/controller to all seed clusters by default. Another use-case is to minimize the durations until extension controllers are deployed and ready in case you have highly fluctuating seed clusters.
+* `Always`: Gardener will demand the deployment of the extension controller to seed clusters independent of whether it is actually required or not. This might be helpful if you want to add a new component/controller to all seed clusters by default. Another use-case is to minimize the durations until extension controllers get deployed and ready in case you have highly fluctuating seed clusters.
+* `AlwaysExceptNoShoots`: Similar to `Always`, but if the seed does not have any shoots then the extension is not being deployed. It will be deleted from a seed after the last shoot has been removed from it.
 
 Also, the `.spec.deployment.seedSelector` allows to specify a label selector for seed clusters.
 Only if it matches the labels of a seed then it will be deployed to it.

--- a/example/25-controllerregistration.yaml
+++ b/example/25-controllerregistration.yaml
@@ -19,7 +19,7 @@ spec:
         H4sIFAAAAAAA/yk...
       values:
         foo: bar
-  # policy: OnDemand|Always
+  # policy: OnDemand|Always|AlwaysExceptNoShoots
   # seedSelector:
   #   matchLabels:
   #     foo: bar

--- a/pkg/apis/core/types_controllerregistration.go
+++ b/pkg/apis/core/types_controllerregistration.go
@@ -91,6 +91,9 @@ const (
 	// resource. If nothing requires it then the controller shall not be deployed.
 	ControllerDeploymentPolicyOnDemand ControllerDeploymentPolicy = "OnDemand"
 	// ControllerDeploymentPolicyAlways specifies that the controller shall be deployed always, independent of whether
-	// another resource requires it.
+	// another resource requires it or the respective seed has shoots.
 	ControllerDeploymentPolicyAlways ControllerDeploymentPolicy = "Always"
+	// ControllerDeploymentPolicyAlwaysExceptNoShoots specifies that the controller shall be deployed always, independent of
+	// whether another resource requires it, but only when the respective seed has at least one shoot.
+	ControllerDeploymentPolicyAlwaysExceptNoShoots ControllerDeploymentPolicy = "AlwaysExceptNoShoots"
 )

--- a/pkg/apis/core/v1alpha1/types_controllerregistration.go
+++ b/pkg/apis/core/v1alpha1/types_controllerregistration.go
@@ -100,6 +100,9 @@ const (
 	// resource. If nothing requires it then the controller shall not be deployed.
 	ControllerDeploymentPolicyOnDemand ControllerDeploymentPolicy = "OnDemand"
 	// ControllerDeploymentPolicyAlways specifies that the controller shall be deployed always, independent of whether
-	// another resource requires it.
+	// another resource requires it or the respective seed has shoots.
 	ControllerDeploymentPolicyAlways ControllerDeploymentPolicy = "Always"
+	// ControllerDeploymentPolicyAlwaysExceptNoShoots specifies that the controller shall be deployed always, independent of
+	// whether another resource requires it, but only when the respective seed has at least one shoot.
+	ControllerDeploymentPolicyAlwaysExceptNoShoots ControllerDeploymentPolicy = "AlwaysExceptNoShoots"
 )

--- a/pkg/apis/core/v1beta1/types_controllerregistration.go
+++ b/pkg/apis/core/v1beta1/types_controllerregistration.go
@@ -100,6 +100,9 @@ const (
 	// resource. If nothing requires it then the controller shall not be deployed.
 	ControllerDeploymentPolicyOnDemand ControllerDeploymentPolicy = "OnDemand"
 	// ControllerDeploymentPolicyAlways specifies that the controller shall be deployed always, independent of whether
-	// another resource requires it.
+	// another resource requires it or the respective seed has shoots.
 	ControllerDeploymentPolicyAlways ControllerDeploymentPolicy = "Always"
+	// ControllerDeploymentPolicyAlwaysExceptNoShoots specifies that the controller shall be deployed always, independent of
+	// whether another resource requires it, but only when the respective seed has at least one shoot.
+	ControllerDeploymentPolicyAlwaysExceptNoShoots ControllerDeploymentPolicy = "AlwaysExceptNoShoots"
 )

--- a/pkg/apis/core/validation/controllerregistration.go
+++ b/pkg/apis/core/validation/controllerregistration.go
@@ -31,6 +31,7 @@ import (
 var availablePolicies = sets.NewString(
 	string(core.ControllerDeploymentPolicyOnDemand),
 	string(core.ControllerDeploymentPolicyAlways),
+	string(core.ControllerDeploymentPolicyAlwaysExceptNoShoots),
 )
 
 // ValidateControllerRegistration validates a ControllerRegistration object.

--- a/pkg/apis/core/validation/controllerregistration_test.go
+++ b/pkg/apis/core/validation/controllerregistration_test.go
@@ -183,6 +183,15 @@ var _ = Describe("validation", func() {
 			Expect(errorList).To(BeEmpty())
 		})
 
+		It("should allow setting the AlwaysExceptNoShoots policy", func() {
+			policy := core.ControllerDeploymentPolicyAlwaysExceptNoShoots
+			controllerRegistration.Spec.Deployment.Policy = &policy
+
+			errorList := ValidateControllerRegistration(controllerRegistration)
+
+			Expect(errorList).To(BeEmpty())
+		})
+
 		It("should forbid to set unsupported deployment policies", func() {
 			policy := core.ControllerDeploymentPolicy("foo")
 			controllerRegistration.Spec.Deployment.Policy = &policy


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability 
/kind enhancement bug
/priority normal

**What this PR does / why we need it**:
This PR enhances the `ControllerRegistration` in the following ways:
1. It fixes a bug that prevented `ControllerInstallation`s referring to registrations with deployment policy `Always` from being deleted when a seed shall be deleted.
1. It introduces a new `AlwaysExceptNoShoots` policy which is similar to `Always` but extensions are only deployed to seeds if they have at least one shoot.
1. `ControllerInstallation`s referring to a registration with policy `Always` will only be deleted if the seed has a deletion timestamp.

**Special notes for your reviewer**:
/cc @RaphaelVogel @amshuman-kr 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The `ControllerRegistration` resource does now support the new `AlwaysExceptNoShoots` deployment policy. Respective extension controllers using this policy are only being deployed to seeds if there is at least one shoot.
```
```improvement operator
A bug has been fixed which prevented the deletion of `ControllerInstallation` resources in case the `Seed` has a deletion timestamp.
```
