### PR TITLE
Dedicated scheme for manager in BackupBucket integration test

### DIFF
--- a/extensions/pkg/controller/backupbucket/backupbucket_test.go
+++ b/extensions/pkg/controller/backupbucket/backupbucket_test.go
@@ -37,6 +37,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -87,7 +88,15 @@ func createAndStartManager(ignoreOperationAnnotation bool) error {
 		framework.RemoveCleanupAction(cleanupHandle)
 	})
 
-	mgr, err := manager.New(restConfig, manager.Options{MetricsBindAddress: "0"})
+	mgrScheme := runtime.NewScheme()
+	if err := scheme.AddToScheme(mgrScheme); err != nil {
+		return err
+	}
+
+	mgr, err := manager.New(restConfig, manager.Options{
+		Scheme:             mgrScheme,
+		MetricsBindAddress: "0",
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing dev-productivity
/kind test bug
/priority normal

**What this PR does / why we need it**:
This PR fixes a data race in the `BackupBucket` extension controller integration test:

```
==================
WARNING: DATA RACE
Write at 0x00c0002dc150 by goroutine 56:
  runtime.mapassign()
      /usr/local/Cellar/go/1.15/libexec/src/runtime/map.go:571 +0x0
  k8s.io/apimachinery/pkg/runtime.(*Scheme).AddKnownTypeWithName()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/runtime/scheme.go:206 +0x399
  k8s.io/apimachinery/pkg/runtime.(*Scheme).AddKnownTypes()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/runtime/scheme.go:180 +0x284
  github.com/gardener/gardener/pkg/apis/extensions/v1alpha1.addKnownTypes()
      /Users/root/go/src/github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/register.go:45 +0xae4
  k8s.io/apimachinery/pkg/runtime.(*SchemeBuilder).AddToScheme()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/runtime/scheme_builder.go:29 +0xa1
  k8s.io/apimachinery/pkg/runtime.(*SchemeBuilder).AddToScheme-fm()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/runtime/scheme_builder.go:27 +0x4b
  github.com/gardener/gardener/extensions/pkg/controller/backupbucket_test.createAndStartManager()
      /Users/root/go/src/github.com/gardener/gardener/extensions/pkg/controller/backupbucket/backupbucket_test.go:95 +0x2dc
  github.com/gardener/gardener/extensions/pkg/controller/backupbucket_test.prepareAndRunTest()
      /Users/root/go/src/github.com/gardener/gardener/extensions/pkg/controller/backupbucket/backupbucket_test.go:61 +0x7e
  github.com/gardener/gardener/extensions/pkg/controller/backupbucket_test.glob..func2.3()
      /Users/root/go/src/github.com/gardener/gardener/extensions/pkg/controller/backupbucket/backupbucket_test.go:55 +0x33
  github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync()
      /Users/root/go/src/github.com/gardener/gardener/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:113 +0xfc
  github.com/onsi/ginkgo/internal/leafnodes.(*runner).run()
      /Users/root/go/src/github.com/gardener/gardener/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:64 +0x124
  github.com/onsi/ginkgo/internal/leafnodes.(*ItNode).Run()
      /Users/root/go/src/github.com/gardener/gardener/vendor/github.com/onsi/ginkgo/internal/leafnodes/it_node.go:26 +0x99
  github.com/onsi/ginkgo/internal/spec.(*Spec).runSample()
      /Users/root/go/src/github.com/gardener/gardener/vendor/github.com/onsi/ginkgo/internal/spec/spec.go:215 +0x713
  github.com/onsi/ginkgo/internal/spec.(*Spec).Run()
      /Users/root/go/src/github.com/gardener/gardener/vendor/github.com/onsi/ginkgo/internal/spec/spec.go:138 +0x187
  github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpec()
      /Users/root/go/src/github.com/gardener/gardener/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:200 +0x17b
  github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpecs()
      /Users/root/go/src/github.com/gardener/gardener/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:170 +0x22a
  github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).Run()
      /Users/root/go/src/github.com/gardener/gardener/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:66 +0x145
  github.com/onsi/ginkgo/internal/suite.(*Suite).Run()
      /Users/root/go/src/github.com/gardener/gardener/vendor/github.com/onsi/ginkgo/internal/suite/suite.go:79 +0x899
  github.com/onsi/ginkgo.RunSpecsWithCustomReporters()
      /Users/root/go/src/github.com/gardener/gardener/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:219 +0x35c
  github.com/onsi/ginkgo.RunSpecs()
      /Users/root/go/src/github.com/gardener/gardener/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:200 +0x258
  github.com/gardener/gardener/extensions/pkg/controller/backupbucket_test.TestBackupBucket()
      /Users/root/go/src/github.com/gardener/gardener/extensions/pkg/controller/backupbucket/backupbucket_suite_test.go:35 +0x108
  testing.tRunner()
      /usr/local/Cellar/go/1.15/libexec/src/testing/testing.go:1108 +0x202

Previous read at 0x00c0002dc150 by goroutine 153:
  runtime.mapaccess2()
      /usr/local/Cellar/go/1.15/libexec/src/runtime/map.go:452 +0x0
  k8s.io/apimachinery/pkg/runtime.(*Scheme).New()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/runtime/scheme.go:289 +0xb4
  k8s.io/apimachinery/pkg/runtime.UseOrCreateObject()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/runtime/codec.go:97 +0xc6
  k8s.io/apimachinery/pkg/runtime/serializer/json.(*Serializer).Decode()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go:258 +0x493
  k8s.io/apimachinery/pkg/runtime.WithoutVersionDecoder.Decode()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/runtime/helper.go:252 +0xac
  k8s.io/apimachinery/pkg/runtime.(*WithoutVersionDecoder).Decode()
      <autogenerated>:1 +0xd9
  k8s.io/apimachinery/pkg/runtime.Decode()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/runtime/codec.go:58 +0x2a1
  k8s.io/client-go/rest/watch.(*Decoder).Decode()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/rest/watch/decoder.go:62 +0x206
  k8s.io/apimachinery/pkg/watch.(*StreamWatcher).receive()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:104 +0x1d8

Goroutine 56 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.15/libexec/src/testing/testing.go:1159 +0x796
  testing.runTests.func1()
      /usr/local/Cellar/go/1.15/libexec/src/testing/testing.go:1430 +0xa6
  testing.tRunner()
      /usr/local/Cellar/go/1.15/libexec/src/testing/testing.go:1108 +0x202
  testing.runTests()
      /usr/local/Cellar/go/1.15/libexec/src/testing/testing.go:1428 +0x5aa
  testing.(*M).Run()
      /usr/local/Cellar/go/1.15/libexec/src/testing/testing.go:1338 +0x4eb
  main.main()
      _testmain.go:45 +0x236

Goroutine 153 (running) created at:
  k8s.io/apimachinery/pkg/watch.NewStreamWatcher()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/watch/streamwatcher.go:71 +0x158
  k8s.io/client-go/rest.(*Request).Watch()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/rest/request.go:684 +0xebc
  sigs.k8s.io/controller-runtime/pkg/cache/internal.createStructuredListWatch.func2()
      /Users/root/go/src/github.com/gardener/gardener/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:264 +0x336
  k8s.io/client-go/tools/cache.(*ListWatch).Watch()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/tools/cache/listwatch.go:111 +0x98
  k8s.io/client-go/tools/cache.(*Reflector).ListAndWatch()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/tools/cache/reflector.go:370 +0x61c
  k8s.io/client-go/tools/cache.(*Reflector).Run.func1()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/tools/cache/reflector.go:177 +0x4a
  k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x75
  k8s.io/apimachinery/pkg/util/wait.BackoffUntil()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xba
  k8s.io/client-go/tools/cache.(*Reflector).Run()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/tools/cache/reflector.go:176 +0x1f4
  k8s.io/client-go/tools/cache.(*Reflector).Run-fm()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/tools/cache/reflector.go:174 +0x4b
  k8s.io/apimachinery/pkg/util/wait.(*Group).StartWithChannel.func1()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:56 +0x45
  k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
      /Users/root/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:73 +0x6d
==================
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
