### PR TITLE
Fix kube-apiserver service type when SNI is enabled

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -1359,12 +1359,6 @@ func (b *Botanist) SNIPhase(ctx context.Context) (component.Phase, error) {
 	}
 
 	switch {
-	case svc == nil && sniEnabled:
-		// initial cluster creation with SNI enabled (enabling only relevant for migration)
-		return component.PhaseEnabled, nil
-	case svc == nil && !sniEnabled:
-		// initial cluster creation without SNI enabled
-		return component.PhaseDisabled, nil
 	case svc.Spec.Type == corev1.ServiceTypeLoadBalancer && sniEnabled:
 		return component.PhaseEnabling, nil
 	case svc.Spec.Type == corev1.ServiceTypeClusterIP && sniEnabled:
@@ -1372,6 +1366,11 @@ func (b *Botanist) SNIPhase(ctx context.Context) (component.Phase, error) {
 	case svc.Spec.Type == corev1.ServiceTypeClusterIP && !sniEnabled:
 		return component.PhaseDisabling, nil
 	default:
+		if sniEnabled {
+			// initial cluster creation with SNI enabled (enabling only relevant for migration).
+			return component.PhaseEnabled, nil
+		}
+		// initial cluster creation with SNI disabled.
 		return component.PhaseDisabled, nil
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind regression
/priority normal

**What this PR does / why we need it**:

kube-apiserver service is now properly created with type `ClusterIP` when SNI is enabled and it doesn't exist.

**Which issue(s) this PR fixes**:
Fixes # n/a

**Special notes for your reviewer**:

Unfortunately due to the fix in #2877 a bug was introduced - `svc` is never `nil` and therefore the kube-apiserver service was always created with type `LoadBalancer`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
