### PR TITLE
fix secrets.Interface not matching implementing struct secrets.Secrets

### DIFF
--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -355,7 +355,7 @@ func (a *actuator) deleteControlPlaneExposure(
 	// Delete secrets
 	if a.exposureSecrets != nil {
 		a.logger.Info("Deleting secrets for control plane with purpose exposure", "controlplane", kutil.ObjectName(cp))
-		if err := a.exposureSecrets.Delete(a.clientset, cp.Namespace); client.IgnoreNotFound(err) != nil {
+		if err := a.exposureSecrets.Delete(ctx, a.clientset, cp.Namespace); client.IgnoreNotFound(err) != nil {
 			return errors.Wrapf(err, "could not delete secrets for controlplane exposure '%s'", kutil.ObjectName(cp))
 		}
 	}
@@ -406,7 +406,7 @@ func (a *actuator) deleteControlPlane(
 
 	// Delete secrets
 	a.logger.Info("Deleting secrets", "controlplane", kutil.ObjectName(cp))
-	if err := a.secrets.Delete(a.clientset, cp.Namespace); client.IgnoreNotFound(err) != nil {
+	if err := a.secrets.Delete(ctx, a.clientset, cp.Namespace); client.IgnoreNotFound(err) != nil {
 		return errors.Wrapf(err, "could not delete secrets for controlplane '%s'", kutil.ObjectName(cp))
 	}
 

--- a/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -347,7 +347,7 @@ var _ = Describe("Actuator", func() {
 
 			// Create mock secrets and charts
 			secrets := mocksecretsutil.NewMockInterface(ctrl)
-			secrets.EXPECT().Delete(gomock.Any(), namespace).Return(nil)
+			secrets.EXPECT().Delete(ctx, gomock.Any(), namespace).Return(nil)
 			var configChart chart.Interface
 			if configName != "" {
 				cc := mockchartutil.NewMockInterface(ctrl)
@@ -415,7 +415,7 @@ var _ = Describe("Actuator", func() {
 
 			// Create mock secrets and charts
 			exposureSecrets := mocksecretsutil.NewMockInterface(ctrl)
-			exposureSecrets.EXPECT().Delete(gomock.Any(), namespace).Return(nil)
+			exposureSecrets.EXPECT().Delete(ctx, gomock.Any(), namespace).Return(nil)
 
 			cpExposureChart := mockchartutil.NewMockInterface(ctrl)
 			cpExposureChart.EXPECT().Delete(ctx, client, namespace).Return(nil)

--- a/pkg/mock/gardener/utils/secrets/mocks.go
+++ b/pkg/mock/gardener/utils/secrets/mocks.go
@@ -38,17 +38,17 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockInterface) Delete(arg0 kubernetes0.Interface, arg1 string) error {
+func (m *MockInterface) Delete(arg0 context.Context, arg1 kubernetes0.Interface, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockInterfaceMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockInterface)(nil).Delete), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockInterface)(nil).Delete), arg0, arg1, arg2)
 }
 
 // Deploy mocks base method.

--- a/pkg/utils/secrets/secrets.go
+++ b/pkg/utils/secrets/secrets.go
@@ -30,7 +30,7 @@ type Interface interface {
 	// Deploy generates and deploys the secrets into the given namespace, taking into account existing secrets.
 	Deploy(context.Context, kubernetes.Interface, gardenerkubernetes.Interface, string) (map[string]*corev1.Secret, error)
 	// Delete deletes the secrets from the given namespace.
-	Delete(kubernetes.Interface, string) error
+	Delete(context.Context, kubernetes.Interface, string) error
 }
 
 // Secrets represents a set of secrets that can be deployed and deleted.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     control-plane
"/kind" identifiers:     api-change
"/priority" identifiers: blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind api-change
/priority normal

**What this PR does / why we need it**:
The implementation of `pkg/utils/secrets/secrets.go::Secrets` changed. As a result it no longer implements the interface ` pkg/utils/secrets/secrets.go::Interface` which results in compilation failing in the extensions when gardener is revendored there.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fix `secrets.Interface` not matching the implementing struct `Secrets`
```
