### PR TITLE
Fix metrics-test when .spec.kubernetes.allowPrivilegedContainers=false

### DIFF
--- a/test/framework/resources/templates/simple-load-deployment.yaml.tpl
+++ b/test/framework/resources/templates/simple-load-deployment.yaml.tpl
@@ -22,3 +22,5 @@ spec:
         {{ end }}
         args:
         - while true; do echo "testing"; done;
+        securityContext:
+          runAsUser: 1001


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug
/priority normal

**What this PR does / why we need it**:
Currently metrics test fails when it is executed against Shoot with `.spec.kubernetes.allowPrivilegedContainers=false`:

```
$ k -n gardener-e2e-m789p describe po metrics-test-6664f98d67-65v4x

Events:
  Type     Reason     Age               From                                                Message
  ----     ------     ----              ----                                                -------
  Normal   Scheduled  <unknown>                                                             Successfully assigned gardener-e2e-m789p/metrics-test-6664f98d67-65v4x to ip-10-222-0-33.eu-west-1.compute.internal
  Normal   Pulled     3s (x5 over 29s)  kubelet, ip-10-222-0-33.eu-west-1.compute.internal  Container image "alpine:3.11" already present on machine
  Warning  Failed     3s (x5 over 29s)  kubelet, ip-10-222-0-33.eu-west-1.compute.internal  Error: container has runAsNonRoot and image will run as root
```


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
