### PR TITLE
Fix cluster-autoscaler test when .spec.kubernetes.allowPrivilegedContainers=false

### DIFF
--- a/test/framework/resources/templates/reserve-capacity.yaml.tpl
+++ b/test/framework/resources/templates/reserve-capacity.yaml.tpl
@@ -38,3 +38,5 @@ spec:
           limits:
             cpu: {{ .Requests.CPU }}
             memory: {{ .Requests.Memory }}
+        securityContext:
+          runAsUser: 1001


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug
/priority normal

**What this PR does / why we need it**:
Similarly to #2904, when the cluster-autorscaler test is executed with test flavor that does not allow privileged containers (` .spec.kubernetes.allowPrivilegedContainers=false`), the reserve-capacity Pod cannot be created:

```
$ k describe po reserve-capacity-7477797bc4-s9sld

Events:
  Type     Reason     Age               From                                                Message
  ----     ------     ----              ----                                                -------
  Normal   Scheduled  <unknown>                                                             Successfully assigned default/reserve-capacity-7477797bc4-s9sld to ip-10-222-0-40.eu-west-1.compute.internal
  Normal   Pulled     3s (x9 over 82s)  kubelet, ip-10-222-0-40.eu-west-1.compute.internal  Container image "gcr.io/google_containers/pause-amd64:3.1" already present on machine
  Warning  Failed     3s (x9 over 82s)  kubelet, ip-10-222-0-40.eu-west-1.compute.internal  Error: container has runAsNonRoot and image will run as root
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
