### PR TITLE
Flow progress reporter with frequency

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
@@ -80,6 +80,9 @@ data:
       {{- end }}
       shoot:
         concurrentSyncs: {{ required ".Values.global.gardenlet.config.controllers.shoot.concurrentSyncs is required" .Values.global.gardenlet.config.controllers.shoot.concurrentSyncs }}
+        {{- if .Values.global.gardenlet.config.controllers.shoot.progressReportPeriod }}
+        progressReportPeriod: {{ .Values.global.gardenlet.config.controllers.shoot.progressReportPeriod }}
+        {{- end }}
         {{- if .Values.global.gardenlet.config.controllers.shoot.respectSyncPeriodOverwrite }}
         respectSyncPeriodOverwrite: {{ .Values.global.gardenlet.config.controllers.shoot.respectSyncPeriodOverwrite }}
         {{- end }}

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -78,6 +78,7 @@ global:
           retryDuration: 12h
           respectSyncPeriodOverwrite: false
           reconcileInMaintenanceOnly: false
+        # progressReportPeriod: 5s
         shootCare:
           concurrentSyncs: 5
           syncPeriod: 30s

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -35,16 +35,18 @@ controllers:
     concurrentSyncs: 20
     syncPeriod: 1h
     retryDuration: 12h
-#    `respectSyncPeriodOverwrite` specifies whether Shoot owners can
-#    mark their Shoots ignored (no reconciliation) or change their sync period.
-#    respectSyncPeriodOverwrite: true
-#    `reconcileInMaintenanceOnly` specifies whether Shoot reconciliations
-#    can only happen during their maintenance time window or not.
-#    reconcileInMaintenanceOnly: true
+  # `respectSyncPeriodOverwrite` specifies whether Shoot owners can
+  # mark their Shoots ignored (no reconciliation) or change their sync Period.
+#   respectSyncPeriodOverwrite: true
+  # `reconcileInMaintenanceOnly` specifies whether Shoot reconciliations
+  # can only happen during their maintenance time window or not.
+#   reconcileInMaintenanceOnly: true
+  # `progressReportPeriod` specifies how often the progress of a shoot operation shall be reported in its status.
+#   progressReportPeriod: 5s
   shootCare:
     concurrentSyncs: 5
     syncPeriod: 30s
-#    staleExtensionHealthCheckThreshold: 5m
+#   staleExtensionHealthCheckThreshold: 5m
     conditionThresholds:
     - type: APIServerAvailable
       duration: 1m

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -176,6 +176,11 @@ type ShootControllerConfiguration struct {
 	// ConcurrentSyncs is the number of workers used for the controller to work on
 	// events.
 	ConcurrentSyncs *int
+	// ProgressReportPeriod is the period how often the progress of a shoot operation will be reported in the
+	// Shoot's `.status.lastOperation` field. By default, the progress will be reported immediately after a task of the
+	// respective flow has been completed. If you set this to a value > 0 (e.g., 5s) then it will be only reported every
+	// 5 seconds. Any tasks that were completed in the meantime will not be reported.
+	ProgressReportPeriod *metav1.Duration
 	// ReconcileInMaintenanceOnly determines whether Shoot reconciliations happen only
 	// during its maintenance time window.
 	ReconcileInMaintenanceOnly *bool

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -233,6 +233,12 @@ type ShootControllerConfiguration struct {
 	// events.
 	// +optional
 	ConcurrentSyncs *int `json:"concurrentSyncs,omitempty"`
+	// ProgressReportPeriod is the period how often the progress of a shoot operation will be reported in the
+	// Shoot's `.status.lastOperation` field. By default, the progress will be reported immediately after a task of the
+	// respective flow has been completed. If you set this to a value > 0 (e.g., 5s) then it will be only reported every
+	// 5 seconds. Any tasks that were completed in the meantime will not be reported.
+	// +optional
+	ProgressReportPeriod *metav1.Duration `json:"progressReportPeriod,omitempty"`
 	// ReconcileInMaintenanceOnly determines whether Shoot reconciliations happen only
 	// during its maintenance time window.
 	// +optional

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -856,6 +856,7 @@ func Convert_config_ShootClientConnection_To_v1alpha1_ShootClientConnection(in *
 
 func autoConvert_v1alpha1_ShootControllerConfiguration_To_config_ShootControllerConfiguration(in *ShootControllerConfiguration, out *config.ShootControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = (*int)(unsafe.Pointer(in.ConcurrentSyncs))
+	out.ProgressReportPeriod = (*v1.Duration)(unsafe.Pointer(in.ProgressReportPeriod))
 	out.ReconcileInMaintenanceOnly = (*bool)(unsafe.Pointer(in.ReconcileInMaintenanceOnly))
 	out.RespectSyncPeriodOverwrite = (*bool)(unsafe.Pointer(in.RespectSyncPeriodOverwrite))
 	out.RetryDuration = (*v1.Duration)(unsafe.Pointer(in.RetryDuration))
@@ -870,6 +871,7 @@ func Convert_v1alpha1_ShootControllerConfiguration_To_config_ShootControllerConf
 
 func autoConvert_config_ShootControllerConfiguration_To_v1alpha1_ShootControllerConfiguration(in *config.ShootControllerConfiguration, out *ShootControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = (*int)(unsafe.Pointer(in.ConcurrentSyncs))
+	out.ProgressReportPeriod = (*v1.Duration)(unsafe.Pointer(in.ProgressReportPeriod))
 	out.ReconcileInMaintenanceOnly = (*bool)(unsafe.Pointer(in.ReconcileInMaintenanceOnly))
 	out.RespectSyncPeriodOverwrite = (*bool)(unsafe.Pointer(in.RespectSyncPeriodOverwrite))
 	out.RetryDuration = (*v1.Duration)(unsafe.Pointer(in.RetryDuration))

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -568,6 +568,11 @@ func (in *ShootControllerConfiguration) DeepCopyInto(out *ShootControllerConfigu
 		*out = new(int)
 		**out = **in
 	}
+	if in.ProgressReportPeriod != nil {
+		in, out := &in.ProgressReportPeriod, &out.ProgressReportPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.ReconcileInMaintenanceOnly != nil {
 		in, out := &in.ReconcileInMaintenanceOnly, &out.ReconcileInMaintenanceOnly
 		*out = new(bool)

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -574,6 +574,11 @@ func (in *ShootControllerConfiguration) DeepCopyInto(out *ShootControllerConfigu
 		*out = new(int)
 		**out = **in
 	}
+	if in.ProgressReportPeriod != nil {
+		in, out := &in.ProgressReportPeriod, &out.ProgressReportPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.ReconcileInMaintenanceOnly != nil {
 		in, out := &in.ReconcileInMaintenanceOnly, &out.ReconcileInMaintenanceOnly
 		*out = new(bool)

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
@@ -88,7 +88,7 @@ func (a *actuator) Reconcile(ctx context.Context) error {
 
 	return f.Run(flow.Opts{
 		Logger:           a.logger,
-		ProgressReporter: a.reportBackupBucketProgress,
+		ProgressReporter: flow.NewImmediateProgressReporter(a.reportBackupBucketProgress),
 		Context:          ctx,
 	})
 }
@@ -109,7 +109,7 @@ func (a *actuator) Delete(ctx context.Context) error {
 	)
 	return f.Run(flow.Opts{
 		Logger:           a.logger,
-		ProgressReporter: a.reportBackupBucketProgress,
+		ProgressReporter: flow.NewImmediateProgressReporter(a.reportBackupBucketProgress),
 		Context:          ctx,
 	})
 }

--- a/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
@@ -88,7 +88,7 @@ func (a *actuator) Reconcile(ctx context.Context) error {
 
 	return f.Run(flow.Opts{
 		Logger:           a.logger,
-		ProgressReporter: a.reportBackupEntryProgress,
+		ProgressReporter: flow.NewImmediateProgressReporter(a.reportBackupEntryProgress),
 		Context:          ctx,
 	})
 }
@@ -112,7 +112,7 @@ func (a *actuator) Delete(ctx context.Context) error {
 
 	return f.Run(flow.Opts{
 		Logger:           a.logger,
-		ProgressReporter: a.reportBackupEntryProgress,
+		ProgressReporter: flow.NewImmediateProgressReporter(a.reportBackupEntryProgress),
 		Context:          ctx,
 	})
 }

--- a/pkg/gardenlet/controller/shoot/shoot.go
+++ b/pkg/gardenlet/controller/shoot/shoot.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	confighelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -265,4 +266,11 @@ func (c *Controller) getShootQueue(obj interface{}) workqueue.RateLimitingInterf
 		return c.shootSeedQueue
 	}
 	return c.shootQueue
+}
+
+func (c *Controller) newProgressReporter(reporterFn flow.ProgressReporterFn) flow.ProgressReporter {
+	if c.config.Controllers.Shoot != nil && c.config.Controllers.Shoot.ProgressReportPeriod != nil {
+		return flow.NewDelayingProgressReporter(reporterFn, c.config.Controllers.Shoot.ProgressReportPeriod.Duration)
+	}
+	return flow.NewImmediateProgressReporter(reporterFn)
 }

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -469,7 +469,7 @@ func (c *Controller) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 
 	if err := f.Run(flow.Opts{
 		Logger:           o.Logger,
-		ProgressReporter: o.ReportShootProgress,
+		ProgressReporter: c.newProgressReporter(o.ReportShootProgress),
 		ErrorCleaner:     o.CleanShootTaskError,
 		ErrorContext:     errorContext,
 	}); err != nil {

--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -294,7 +294,12 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 		f = g.Compile()
 	)
 
-	if err := f.Run(flow.Opts{Logger: o.Logger, ProgressReporter: o.ReportShootProgress, ErrorContext: errorContext, ErrorCleaner: o.CleanShootTaskError}); err != nil {
+	if err := f.Run(flow.Opts{
+		Logger:           o.Logger,
+		ProgressReporter: c.newProgressReporter(o.ReportShootProgress),
+		ErrorContext:     errorContext,
+		ErrorCleaner:     o.CleanShootTaskError,
+	}); err != nil {
 		o.Logger.Errorf("Failed to prepare Shoot %q for migration: %+v", o.Shoot.Info.Name, err)
 		return gardencorev1beta1helper.NewWrappedLastErrors(gardencorev1beta1helper.FormatLastErrDescription(err), flow.Errors(err))
 	}

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -465,7 +465,12 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 
 	f := g.Compile()
 
-	if err := f.Run(flow.Opts{Logger: o.Logger, ProgressReporter: o.ReportShootProgress, ErrorContext: errorContext, ErrorCleaner: o.CleanShootTaskError}); err != nil {
+	if err := f.Run(flow.Opts{
+		Logger:           o.Logger,
+		ProgressReporter: c.newProgressReporter(o.ReportShootProgress),
+		ErrorContext:     errorContext,
+		ErrorCleaner:     o.CleanShootTaskError,
+	}); err != nil {
 		o.Logger.Errorf("Failed to reconcile Shoot %q: %+v", o.Shoot.Info.Name, err)
 		return gardencorev1beta1helper.NewWrappedLastErrors(gardencorev1beta1helper.FormatLastErrDescription(err), flow.Errors(err))
 	}

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -347,8 +347,11 @@ func (o *Operation) GetSecretKeysOfRole(kind string) []string {
 }
 
 func makeDescription(stats *flow.Stats) string {
+	if stats.ProgressPercent() == 0 {
+		return "Starting " + stats.FlowName
+	}
 	if stats.ProgressPercent() == 100 {
-		return "Execution finished"
+		return stats.FlowName + " finished"
 	}
 	return strings.Join(stats.Running.StringList(), ", ")
 }
@@ -370,7 +373,9 @@ func (o *Operation) ReportShootProgress(ctx context.Context, stats *flow.Stats) 
 			if shoot.Status.LastOperation.LastUpdateTime.After(lastUpdateTime.Time) {
 				return nil, fmt.Errorf("last operation of Shoot %s/%s was updated mid-air", shoot.Namespace, shoot.Name)
 			}
-			shoot.Status.LastOperation.Description = description
+			if description != "" {
+				shoot.Status.LastOperation.Description = description
+			}
 			shoot.Status.LastOperation.Progress = progress
 			shoot.Status.LastOperation.LastUpdateTime = lastUpdateTime
 			return shoot, nil

--- a/pkg/utils/flow/flow.go
+++ b/pkg/utils/flow/flow.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/logger"
 	utilerrors "github.com/gardener/gardener/pkg/utils/errors"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -32,9 +33,6 @@ const (
 	logKeyFlow = "flow"
 	logKeyTask = "task"
 )
-
-// ProgressReporter is continuously called on progress in a flow.
-type ProgressReporter func(context.Context, *Stats)
 
 // ErrorCleaner is called when a task which errored during the previous reconciliation phase completes with success
 type ErrorCleaner func(context.Context, string)
@@ -101,7 +99,7 @@ func (n *node) addTargets(taskIDs ...TaskID) {
 // are left blank and don't affect the Flow.
 type Opts struct {
 	Logger           logrus.FieldLogger
-	ProgressReporter func(ctx context.Context, stats *Stats)
+	ProgressReporter ProgressReporter
 	ErrorCleaner     func(ctx context.Context, taskID string)
 	ErrorContext     *utilerrors.ErrorContext
 	Context          context.Context
@@ -124,6 +122,7 @@ type nodeResult struct {
 
 // Stats are the statistics of a Flow execution.
 type Stats struct {
+	FlowName  string
 	All       TaskIDs
 	Succeeded TaskIDs
 	Failed    TaskIDs
@@ -140,6 +139,7 @@ func (s *Stats) ProgressPercent() int32 {
 // Copy deeply copies a Stats object.
 func (s *Stats) Copy() *Stats {
 	return &Stats{
+		s.FlowName,
 		s.All.Copy(),
 		s.Succeeded.Copy(),
 		s.Failed.Copy(),
@@ -150,8 +150,9 @@ func (s *Stats) Copy() *Stats {
 
 // InitialStats creates a new Stats object with the given set of initial TaskIDs.
 // The initial TaskIDs are added to all TaskIDs as well as to the pending ones.
-func InitialStats(all TaskIDs) *Stats {
+func InitialStats(flowName string, all TaskIDs) *Stats {
 	return &Stats{
+		flowName,
 		all,
 		NewTaskIDs(),
 		NewTaskIDs(),
@@ -160,7 +161,7 @@ func InitialStats(all TaskIDs) *Stats {
 	}
 }
 
-func newExecution(flow *Flow, log logrus.FieldLogger, reporter ProgressReporter, errorCleaner ErrorCleaner, errorContext *utilerrors.ErrorContext) *execution {
+func newExecution(flow *Flow, log logrus.FieldLogger, progressReporter ProgressReporter, errorCleaner ErrorCleaner, errorContext *utilerrors.ErrorContext) *execution {
 	all := NewTaskIDs()
 
 	for name := range flow.nodes {
@@ -174,10 +175,10 @@ func newExecution(flow *Flow, log logrus.FieldLogger, reporter ProgressReporter,
 
 	return &execution{
 		flow,
-		InitialStats(all),
+		InitialStats(flow.name, all),
 		nil,
 		log,
-		reporter,
+		progressReporter,
 		errorCleaner,
 		errorContext,
 		make(chan *nodeResult),
@@ -258,12 +259,20 @@ func (e *execution) cleanErrors(ctx context.Context, taskID TaskID) {
 
 func (e *execution) reportProgress(ctx context.Context) {
 	if e.progressReporter != nil {
-		e.progressReporter(ctx, e.stats.Copy())
+		e.progressReporter.Report(ctx, e.stats.Copy())
 	}
 }
 
 func (e *execution) run(ctx context.Context) error {
 	defer close(e.done)
+
+	if e.progressReporter != nil {
+		if err := e.progressReporter.Start(ctx); err != nil {
+			return err
+		}
+		defer e.progressReporter.Stop()
+	}
+
 	e.log.Info("Starting")
 	e.reportProgress(ctx)
 
@@ -274,9 +283,9 @@ func (e *execution) run(ctx context.Context) error {
 	for name := range roots {
 		if cancelErr = ctx.Err(); cancelErr == nil {
 			e.runNode(ctx, name)
-			e.reportProgress(ctx)
 		}
 	}
+	e.reportProgress(ctx)
 
 	for e.stats.Running.Len() > 0 {
 		result := <-e.done

--- a/pkg/utils/flow/progress_reporter.go
+++ b/pkg/utils/flow/progress_reporter.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow
+
+import (
+	"context"
+)
+
+// ProgressReporterFn is continuously called on progress in a flow.
+type ProgressReporterFn func(context.Context, *Stats)
+
+// ProgressReporter is used to report the current progress of a flow.
+type ProgressReporter interface {
+	// Start starts the progress reporter.
+	Start(context.Context) error
+	// Stop stops the progress reporter.
+	Stop()
+	// Report reports the progress using the current statistics.
+	Report(context.Context, *Stats)
+}

--- a/pkg/utils/flow/progress_reporter_delaying.go
+++ b/pkg/utils/flow/progress_reporter_delaying.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type progressReporterDelaying struct {
+	lock                sync.Mutex
+	ctx                 context.Context
+	ctxCancel           context.CancelFunc
+	reporterFn          ProgressReporterFn
+	period              time.Duration
+	timer               *time.Timer
+	pendingProgress     *Stats
+	delayProgressReport bool
+}
+
+// NewDelayingProgressReporter returns a new progress reporter with the given function and the configured period. A
+// period of `0` will lead to immediate reports as soon as flow tasks are completed.
+func NewDelayingProgressReporter(reporterFn ProgressReporterFn, period time.Duration) ProgressReporter {
+	return &progressReporterDelaying{
+		reporterFn: reporterFn,
+		period:     period,
+	}
+}
+
+func (p *progressReporterDelaying) Start(ctx context.Context) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.timer != nil {
+		return fmt.Errorf("progress reporter has already been started")
+	}
+
+	// We store the context on the progressReporterDelaying object so that we can call the reporterFn with the original
+	// context - otherwise, the final state cannot be reported because the cancel context will already be canceled
+	p.ctx = ctx
+
+	if p.period > 0 {
+		p.timer = time.NewTimer(p.period)
+
+		ctx, cancel := context.WithCancel(ctx)
+		p.ctxCancel = cancel
+
+		go p.run(ctx)
+	}
+
+	return nil
+}
+
+func (p *progressReporterDelaying) Stop() {
+	p.lock.Lock()
+
+	if p.ctxCancel != nil {
+		p.ctxCancel()
+	}
+
+	p.ctxCancel = nil
+	p.timer = nil
+	p.lock.Unlock()
+	p.report()
+}
+
+func (p *progressReporterDelaying) Report(_ context.Context, pendingProgress *Stats) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.timer != nil && p.delayProgressReport {
+		p.pendingProgress = pendingProgress
+		return
+	}
+
+	p.reporterFn(p.ctx, pendingProgress)
+	p.delayProgressReport = true
+}
+
+func (p *progressReporterDelaying) run(ctx context.Context) {
+	timer := p.timer
+	for timer != nil {
+		select {
+		case <-timer.C:
+			timer.Reset(p.period)
+			p.report()
+
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		}
+	}
+}
+
+func (p *progressReporterDelaying) report() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.pendingProgress != nil {
+		p.reporterFn(p.ctx, p.pendingProgress)
+		p.pendingProgress = nil
+	}
+}

--- a/pkg/utils/flow/progress_reporter_immediate.go
+++ b/pkg/utils/flow/progress_reporter_immediate.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow
+
+import (
+	"context"
+)
+
+type progressReporterImmediate struct {
+	reporterFn ProgressReporterFn
+}
+
+// NewImmediateProgressReporter returns a new progress reporter with the given function.
+func NewImmediateProgressReporter(reporterFn ProgressReporterFn) ProgressReporter {
+	return progressReporterImmediate{
+		reporterFn: reporterFn,
+	}
+}
+
+func (p progressReporterImmediate) Start(context.Context) error { return nil }
+func (p progressReporterImmediate) Stop()                       {}
+func (p progressReporterImmediate) Report(ctx context.Context, stats *Stats) {
+	p.reporterFn(ctx, stats)
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability cost
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR we enhance the flow's progress reporter in a way that it can delay the progress reporting. This might helpful in large landscape where a lot of shoots exist to limit the number of updates to the `Shoot`s' `status` sections.

**Special notes for your reviewer**:
Any opinions on whether we should default the `progressReportFrequency` field in the gardenlet config, or should we rather keep it to the Gardener operator to configure it properly?

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
It is now possible to delay the progress reporting for shoot operations by setting the `.controllers.shoot.progressReportPeriod` field in the gardenlet component config. This might helpful in large landscape where a lot of shoots exist to limit the number of updates to the `Shoot`s' `status` sections.
```
```action developer
The `flow` package's progress reporter option has been changed to return the new `ProgressReporter` interface. You can call `flow.NewImmediateProgressReporter` with your reporter function as a replacement.
```