### PR TITLE
Don't persist machines without provider ID or node name

### DIFF
--- a/extensions/pkg/controller/worker/predicate.go
+++ b/extensions/pkg/controller/worker/predicate.go
@@ -21,21 +21,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// MachineStatusHasChanged is a predicate deciding wether the status of a MCM's Machine has been changed.
+// MachineStatusHasChanged is a predicate deciding whether the status of a Machine has been changed.
 func MachineStatusHasChanged() predicate.Predicate {
 	statusHasChanged := func(oldObj runtime.Object, newObj runtime.Object) bool {
 		oldMachine, ok := oldObj.(*machinev1alpha1.Machine)
 		if !ok {
 			return false
 		}
+
 		newMachine, ok := newObj.(*machinev1alpha1.Machine)
 		if !ok {
 			return false
 		}
-		oldStatus := oldMachine.Status
-		newStatus := newMachine.Status
 
-		return oldStatus.Node != newStatus.Node
+		return oldMachine.Spec.ProviderID != newMachine.Spec.ProviderID ||
+			oldMachine.Status.Node != newMachine.Status.Node
 	}
 
 	return predicate.Funcs{
@@ -43,8 +43,7 @@ func MachineStatusHasChanged() predicate.Predicate {
 			return true
 		},
 		UpdateFunc: func(event event.UpdateEvent) bool {
-			result := statusHasChanged(event.ObjectOld, event.ObjectNew)
-			return result
+			return statusHasChanged(event.ObjectOld, event.ObjectNew)
 		},
 		GenericFunc: func(event event.GenericEvent) bool {
 			return false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area cost scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Work-around for https://github.com/gardener/machine-controller-manager/issues/483 - we ignore machines without provider ID or node name and don't persist them in the `Worker` state 

**Special notes for your reviewer**:
/invite @timebertt @amshuman-kr @hardikdr @prashanth26 
/cc @plkokanov @swilen-iwanow @vlvasilev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Machines without `.spec.providerID` or `.status.node` will no longer be persisted in the `Worker`' `.status.state` field. This is to prevent unnecessary updates to the `ShootState` resources.
```
