### PR TITLE
Don't unnecessarily retrieve Seed secret

### DIFF
--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -300,7 +300,6 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 	seedObj, err := seedpkg.
 		NewBuilder().
 		WithSeedObject(seed).
-		WithSeedSecretFromClient(ctx, gardenClient.Client()).
 		Build()
 	if err != nil {
 		message := fmt.Sprintf("Failed to create a Seed object (%s).", err.Error())

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -231,7 +231,6 @@ func (c *Controller) initializeOperation(ctx context.Context, logger *logrus.Ent
 	seedObj, err := seedpkg.
 		NewBuilder().
 		WithSeedObject(seed).
-		WithSeedSecretFromClient(ctx, gardenClient.Client()).
 		Build()
 	if err != nil {
 		return nil, err

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -80,28 +80,6 @@ func (b *Builder) WithSeedObjectFromLister(seedLister gardencorelisters.SeedList
 	return b
 }
 
-// WithSeedSecret sets the seedSecretFunc attribute at the Builder.
-func (b *Builder) WithSeedSecret(seedSecret *corev1.Secret) *Builder {
-	b.seedSecretFunc = func(*corev1.SecretReference) (*corev1.Secret, error) { return seedSecret, nil }
-	return b
-}
-
-// WithSeedSecretFromClient sets the seedSecretFunc attribute at the Builder after reading it with the client.
-func (b *Builder) WithSeedSecretFromClient(ctx context.Context, c client.Client) *Builder {
-	b.seedSecretFunc = func(secretRef *corev1.SecretReference) (*corev1.Secret, error) {
-		if secretRef == nil {
-			return nil, fmt.Errorf("cannot fetch secret because spec.secretRef is nil")
-		}
-
-		secret := &corev1.Secret{}
-		if err := c.Get(ctx, kutil.Key(secretRef.Namespace, secretRef.Name), secret); err != nil {
-			return nil, err
-		}
-		return secret, nil
-	}
-	return b
-}
-
 // Build initializes a new Seed object.
 func (b *Builder) Build() (*Seed, error) {
 	seed := &Seed{}
@@ -111,14 +89,6 @@ func (b *Builder) Build() (*Seed, error) {
 		return nil, err
 	}
 	seed.Info = seedObject
-
-	if b.seedSecretFunc != nil && seedObject.Spec.SecretRef != nil {
-		seedSecret, err := b.seedSecretFunc(seedObject.Spec.SecretRef)
-		if err != nil {
-			return nil, err
-		}
-		seed.Secret = seedSecret
-	}
 
 	if seedObject.Spec.Settings != nil && seedObject.Spec.Settings.LoadBalancerServices != nil {
 		seed.LoadBalancerServiceAnnotations = seedObject.Spec.Settings.LoadBalancerServices.Annotations

--- a/pkg/operation/seed/types.go
+++ b/pkg/operation/seed/types.go
@@ -16,19 +16,15 @@ package seed
 
 import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 // Builder is an object that builds Seed objects.
 type Builder struct {
 	seedObjectFunc func() (*gardencorev1beta1.Seed, error)
-	seedSecretFunc func(*corev1.SecretReference) (*corev1.Secret, error)
 }
 
 // Seed is an object containing information about a Seed cluster.
 type Seed struct {
 	Info                           *gardencorev1beta1.Seed
-	Secret                         *corev1.Secret
 	LoadBalancerServiceAnnotations map[string]string
 }

--- a/pkg/operation/types.go
+++ b/pkg/operation/types.go
@@ -47,7 +47,7 @@ type Builder struct {
 	imageVectorFunc           func() (imagevector.ImageVector, error)
 	loggerFunc                func() (*logrus.Entry, error)
 	secretsFunc               func() (map[string]*corev1.Secret, error)
-	seedFunc                  func(context.Context, client.Client) (*seed.Seed, error)
+	seedFunc                  func(context.Context) (*seed.Seed, error)
 	shootFunc                 func(context.Context, client.Client, *garden.Garden, *seed.Seed) (*shoot.Shoot, error)
 	chartsRootPathFunc        func() string
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area cost quality
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Before this PR, the Seed kubeconfig secret was retrieved for each Shoot reconcile/care operation, although it is not needed anymore because the Seed client is already present in the ClientMap.
This PR removes all related code to avoid a lot of unnecessary API calls.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
