### PR TITLE
Set vpa minAllowed resource policy for gardener components

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/vpa.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/vpa.yaml
@@ -11,4 +11,10 @@ spec:
     name: gardener-admission-controller
   updatePolicy:
     updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        minAllowed:
+          cpu: 20m
+          memory: 25Mi
 {{- end }}

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/vpa.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/vpa.yaml
@@ -18,5 +18,11 @@ spec:
     name: gardener-apiserver
   updatePolicy:
     updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        minAllowed:
+          cpu: 50m
+          memory: 256Mi
 {{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/vpa.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/vpa.yaml
@@ -11,4 +11,10 @@ spec:
     name: gardener-controller-manager
   updatePolicy:
     updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        minAllowed:
+          cpu: 30m
+          memory: 300Mi
 {{- end }}

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/vpa.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/vpa.yaml
@@ -11,4 +11,10 @@ spec:
     name: gardener-scheduler
   updatePolicy:
     updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        minAllowed:
+          cpu: 10m
+          memory: 25Mi
 {{- end }}

--- a/charts/gardener/gardenlet/charts/runtime/templates/vpa.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/vpa.yaml
@@ -11,4 +11,10 @@ spec:
     name: gardenlet
   updatePolicy:
     updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        minAllowed:
+          cpu: 50m
+          memory: 200Mi
 {{- end }}


### PR DESCRIPTION
In some cases the vpa can downscale components below the bare minimum the process needs to function. This PR prevents the vpa from doing that for the gardener components.

Solves the same problem as:
https://github.com/gardener/gardener/pull/2848

/area robustness
/kind enhancement
/priority normal
