### PR TITLE
Store coordination.k8s.io/leases in the etcd-events

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -123,7 +123,7 @@ spec:
         - --etcd-certfile=/srv/kubernetes/etcd/client/tls.crt
         - --etcd-keyfile=/srv/kubernetes/etcd/client/tls.key
         - --etcd-servers=https://etcd-main-client:{{ .Values.etcdServicePort }}
-        - --etcd-servers-overrides=/events#https://etcd-events-client:{{ .Values.etcdServicePort }}
+        - --etcd-servers-overrides=/events#https://etcd-events-client:{{ .Values.etcdServicePort }},coordination.k8s.io/leases#https://etcd-events-client:{{ .Values.etcdServicePort }}
         {{- if .Values.enableEtcdEncryption }}
         - --encryption-provider-config=/etc/kubernetes/etcd-encryption-secret/encryption-configuration.yaml
         {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane performance storage
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Store coordination.k8s.io/leases in the etcd-events to reduce load on etcd-main. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `coordination.k8s.io/leases` resources are now stored in the `etcd-events`. With this change, the db of `etcd-main` will be less often updated, hence less snapshots will be taken.
```
