### PR TITLE
Enhance the precondition check in containerd integration test

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -39,7 +39,7 @@ Check out these repositories for implementations of the Gardener Extension contr
 - [Debian/Ubuntu (MetalStack)](https://github.com/metal-stack/os-metal-extension)
 - [Ubuntu](https://github.com/gardener/gardener-extension-os-ubuntu)
 - [Ubuntu (Alicloud)](https://github.com/gardener/gardener-extension-os-ubuntu-alicloud)
-- [SuSE JeOS](https://github.com/gardener/gardener-extension-os-suse-jeos)
+- [SuSE CHost](https://github.com/gardener/gardener-extension-os-suse-chost)
 
 ### Container Runtime
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Currently the containerd integration test has a hard-coded check for OS. The containerd support for gardenlinux (ref https://github.com/gardener/gardener-extension-os-gardenlinux/pull/5) was recently enabled but the test was not adapted (=> the test was always skipped for gardenlinux).
We already have constraints in the CloudProfile that allow machine images to specify whether the image supports containerd. This PR adapts the check to look in the CloudProfile to determine whether machine image supports containerd.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
