### PR TITLE
Fix min/maxReplica setting for Seed vpa

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -995,15 +995,19 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 		foundDeployment = false
 	}
 
-	if b.ShootedSeed != nil && !hvpaEnabled {
+	if b.ShootedSeed != nil {
 		var (
 			apiServer  = b.ShootedSeed.APIServer
 			autoscaler = apiServer.Autoscaler
 		)
-		defaultValues["replicas"] = *apiServer.Replicas
 		minReplicas = *autoscaler.MinReplicas
 		maxReplicas = autoscaler.MaxReplicas
+	}
 
+	if b.ShootedSeed != nil && !hvpaEnabled {
+		apiServer := b.ShootedSeed.APIServer
+
+		defaultValues["replicas"] = *apiServer.Replicas
 		defaultValues["apiServerResources"] = map[string]interface{}{
 			"requests": map[string]interface{}{
 				"cpu":    "1750m",


### PR DESCRIPTION
This change fixes a bug that when hvpa is enabled the values
apiServer.autoscaler.minReplicas and maxReplicas are not respected
for shooted Seeds.

/area auto-scaling
/area control-plane

/kind bug
/priority normal

**What this PR does / why we need it**:
Again respecting min and maxReplicas for Seed API Server. Currently, system critical components like the Seed API server can be scaled down to 1 instance as minReplicas is not respected