### PR TITLE
Improve BackupBucket controller test

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaking-test.md
+++ b/.github/ISSUE_TEMPLATE/flaking-test.md
@@ -1,7 +1,7 @@
 ---
 name: Flaking Test
 about: Report flaky tests or jobs in Gardener CI
-title: "[Flaky Test]: FLAKING TEST/SUITE"
+title: "[Flaky Test] FLAKING TEST/SUITE"
 labels: kind/flake
 
 ---

--- a/pkg/operation/common/extensions.go
+++ b/pkg/operation/common/extensions.go
@@ -151,7 +151,7 @@ func WaitUntilObjectReadyWithHealthFunction(
 	ctx context.Context,
 	c client.Client,
 	logger logrus.FieldLogger,
-	healthFunc func(obj runtime.Object) error,
+	healthFunc health.Func,
 	newObjFunc func() runtime.Object,
 	kind string,
 	namespace string,

--- a/pkg/utils/kubernetes/health/and.go
+++ b/pkg/utils/kubernetes/health/and.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Func is a type for a function that checks the health of a runtime.Object.
+type Func func(runtime.Object) error
+
+// And combines multiple health check funcs to a single func, checking all funcs sequentially and return the first
+// error that occurs or nil if no error occurs.¬
+func And(fns ...Func) Func {
+	return func(o runtime.Object) error {
+		for _, fn := range fns {
+			if err := fn(o); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/pkg/utils/kubernetes/health/and_test.go
+++ b/pkg/utils/kubernetes/health/and_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+)
+
+var _ = Describe("And", func() {
+	var (
+		obj                runtime.Object
+		healthy, unhealthy health.Func
+	)
+
+	BeforeEach(func() {
+		obj = &corev1.Pod{}
+		healthy = func(o runtime.Object) error {
+			return nil
+		}
+		unhealthy = func(o runtime.Object) error {
+			return fmt.Errorf("unhealthy")
+		}
+	})
+
+	It("should succeed if no funcs are given", func() {
+		Expect(health.And()(obj)).To(Succeed())
+	})
+	It("should succeed if all funcs succeed", func() {
+		Expect(health.And(healthy)(obj)).To(Succeed())
+		Expect(health.And(healthy, healthy)(obj)).To(Succeed())
+	})
+	It("should fail if at least one func fails", func() {
+		Expect(health.And(unhealthy)(obj)).NotTo(Succeed())
+		Expect(health.And(healthy, unhealthy)(obj)).NotTo(Succeed())
+		Expect(health.And(unhealthy, healthy)(obj)).NotTo(Succeed())
+	})
+	It("should fail if all funcs fail", func() {
+		Expect(health.And(unhealthy, unhealthy)(obj)).NotTo(Succeed())
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake
/priority critical

**What this PR does / why we need it**:
Improve the BackupBucket extension controller test by
- increasing some wait timeouts
- using a new health check function `ExtensionOperationHasBeenUpdatedSince` to ensure that reconciliation was started instead of statically waiting 2s
- using `ExpectWithOffset(1, ...` in verification helper func

**Which issue(s) this PR fixes**:
Ref #2915 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
