### PR TITLE
improve Seed deletion with configured Backup Bucket

### DIFF
--- a/docs/concepts/apiserver_admission_plugins.md
+++ b/docs/concepts/apiserver_admission_plugins.md
@@ -73,7 +73,7 @@ However, it also has some special behaviours for certain resources:
 _(enabled by default)_
 
 This admission controller reacts on `DELETE` operations for `Seed`s.
-It checks whether the seed cluster is referenced by a `BackupBucket`(s) and/or `Shoot`(s). If any of this is true, the deletion request is rejected.
+Rejects the deletion if `Shoot`(s) reference the seed cluster.
 
 ## `ShootDNS`
 

--- a/plugin/pkg/seed/validator/admission_test.go
+++ b/plugin/pkg/seed/validator/admission_test.go
@@ -98,15 +98,14 @@ var _ = Describe("validator", func() {
 				Expect(err).To(BeForbiddenError())
 			})
 
-			It("should disallow seed deletion because it is still referenced by a backupbucket", func() {
+			It("should allow seed deletion even though it is still referenced by a backupbucket (will be cleaned up during Seed reconciliation)", func() {
 				backupBucket.Spec.SeedName = &seedName
 				Expect(coreInformerFactory.Core().InternalVersion().BackupBuckets().Informer().GetStore().Add(&backupBucket)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&seed, nil, core.Kind("Seed").WithVersion("version"), "", seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
 
 				err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(BeForbiddenError())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("should disallow seed deletion because shoot migration is yet not finished", func() {

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -543,7 +543,7 @@ var _ = Describe("validator", func() {
 				Expect(err).To(BeForbiddenError())
 			})
 
-			It("should reject removal of the annotation when the respective seed is used by backupbucket", func() {
+			It("should allow removal of the annotation event though the respective seed is used by a backupbucket (Bucket will be deleted during Seed reconciliation)", func() {
 				bucket := core.BackupBucket{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "backupbucket",
@@ -563,32 +563,7 @@ var _ = Describe("validator", func() {
 				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(BeForbiddenError())
-			})
-
-			It("should reject removal of the annotation when the respective seed is used by backupbucket", func() {
-				bucket := core.BackupBucket{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "backupbucket",
-					},
-					Spec: core.BackupBucketSpec{
-						SeedName: &shoot.Name,
-					},
-				}
-				delete(shoot.Annotations, useAsSeedKey)
-
-				Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&gardenProject)).To(Succeed())
-				Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-				Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-				Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&shootedSeed)).To(Succeed())
-				Expect(coreInformerFactory.Core().InternalVersion().BackupBuckets().Informer().GetStore().Add(&bucket)).To(Succeed())
-
-				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
-
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(BeForbiddenError())
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 

--- a/plugin/pkg/utils/miscellaneous.go
+++ b/plugin/pkg/utils/miscellaneous.go
@@ -58,13 +58,3 @@ func IsSeedUsedByShoot(seedName string, shoots []*core.Shoot) bool {
 	}
 	return false
 }
-
-// IsSeedUsedByBackupBucket checks whether there is a backupbucket refering the provided seed name
-func IsSeedUsedByBackupBucket(seedName string, backupbuckets []*core.BackupBucket) bool {
-	for _, backupbucket := range backupbuckets {
-		if backupbucket.Spec.SeedName != nil && *backupbucket.Spec.SeedName == seedName {
-			return true
-		}
-	}
-	return false
-}

--- a/plugin/pkg/utils/miscellaneous_test.go
+++ b/plugin/pkg/utils/miscellaneous_test.go
@@ -68,25 +68,7 @@ var _ = Describe("Miscellaneous", func() {
 				SeedName: nil,
 			},
 		}
-
-		backupBucket1 = gardenercore.BackupBucket{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "bucket1",
-			},
-			Spec: gardenercore.BackupBucketSpec{
-				SeedName: pointer.StringPtr("seed1"),
-			},
-		}
-		backupBucket2 = gardenercore.BackupBucket{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "bucket2",
-			},
-		}
 	)
-	backupBuckets := []*gardenercore.BackupBucket{
-		&backupBucket1,
-		&backupBucket2,
-	}
 
 	shoots := []*gardenercore.Shoot{
 		&shoot1,
@@ -115,13 +97,4 @@ var _ = Describe("Miscellaneous", func() {
 		Entry("is used by shoot in migration", "seed2", true),
 		Entry("is unused", "seed3", false),
 	)
-
-	DescribeTable("#UsedByBackupBucket",
-		func(seedName string, expected bool) {
-			Expect(utils.IsSeedUsedByBackupBucket(seedName, backupBuckets)).To(Equal(expected))
-		},
-		Entry("is used by backupbucket", "seed1", true),
-		Entry("is not used by backupbucket", "seed2", false),
-	)
-
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/priority normal

**What this PR does / why we need it**:

Currently an admission plugin blocks seed deletion if there is still a backup Bucket referencing it.
When manually deleting it, it will be recreated during the next Seed reconcile.
You have to be "quick" to delete the Seed resource before another reconciliation kicks in that creates the BB again.
This in combination with #2925 makes it hard to delete a Seed cluster.

- Allow setting a deletion timestamp on seeds with referencing BB (@vpnachev )
- Do not delete the BB during the Seed reconciliation
- Do not remove finalizer during Seed reconcile if still referenced by Shoot or BB

The same goal is reached: do not allow Seed deletion if still referenced by Shoot or BB.
However by setting the deletion timestamp on the Seed
 - the controllerinstallations are removed
 - the BB is not deployed again

**How to reproduce**:
 - Create a Seed with backup enable that has no deployed Shoots
 - Delete the Bucket manually
 - Observe that the Backup is recreated 
 - Seed cannot be deleted again (circular)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

@vpnachev could you check if that makes sense to you ? 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Deletion of a Seed is now possible with an existing Backup Bucket (but having no Shoots deployed!). The Bucket is deleted automatically during the Seed reconciliation flow. 
```
