### PR TITLE
change the shoot namespace matching regex to 'shoot-'

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
@@ -91,8 +91,8 @@
         Match kubernetes.*
         Url http://loki.garden.svc:3100/loki/api/v1/push
         LogLevel info
-        BatchWait 1
-        # (1sec)
+        BatchWait 30
+        # (30sec)
         BatchSize 30720
         # (30KiB)
         Labels {test="fluent-bit-go", lang="Golang"}
@@ -105,7 +105,7 @@
         DynamicHostPath {"kubernetes": {"namespace_name": "namespace"}}
         DynamicHostPrefix http://loki.
         DynamicHostSulfix .svc:3100/loki/api/v1/push
-        DynamicHostRegex shoot--
+        DynamicHostRegex shoot-
         MaxRetries 3
         Timeout 10
         MinBackoff 30
@@ -115,8 +115,8 @@
         Match journald.*
         Url http://loki.garden.svc:3100/loki/api/v1/push
         LogLevel info
-        BatchWait 1
-        # (1sec)
+        BatchWait 60
+        # (60sec)
         BatchSize 30720
         # (30KiB)
         Labels {test="fluent-bit-go", lang="Golang"}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug
/priority normal

**What this PR does / why we need it**:
When shoot namespace start with `shoot-`  and there is no consecutive dash the logs are send to the central garden Loki instance.
By changing the shoot namespace matching regex to `shoot-` now the logs are send to the right namespace.

Also we increase the promtail batch wait to 30 seconds in order to lower the number of send requests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Change the shoot namespace matching regex of fluent-bit to `shoot-`
```
```noteworthy operator
Change the promtail batch wait to 30 seconds
```