### PR TITLE
Fix setup-envtest.sh for vendoring repos

### DIFF
--- a/hack/setup-envtest.sh
+++ b/hack/setup-envtest.sh
@@ -101,7 +101,7 @@ function fetch_envtest_tools {
   tar -C "${dest_dir}" --strip-components=1 -zvxf "$envtest_tools_archive_path"
 }
 
-bin_dir="$(realpath "$(dirname $0)/../bin")"
+bin_dir="$(git rev-parse --show-toplevel)/bin"
 kb_root_dir="$bin_dir/kubebuilder"
 
 mkdir -p            "$kb_root_dir"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug
/priority normal

**What this PR does / why we need it**:
Repos that vendor gardener and use the vendored hack scripts for test execution (e.g. our extensions) will fetch the kubebuilder tools to `$REPO_ROOT/vendor/github.com/gardener/gardener/bin` on `make test`.
As this dir is most likely not ignored, this PR changes `setup-envtest.sh` to use `$REPO_ROOT/bin` (works for g/g and vendoring repos).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
