### PR TITLE
Clean up obsolete defaulting logic

### DIFF
--- a/cmd/gardener-admission-controller/app/gardener_admission_controller.go
+++ b/cmd/gardener-admission-controller/app/gardener_admission_controller.go
@@ -109,22 +109,6 @@ func (o *options) decodeConfig(data []byte) (*config.AdmissionControllerConfigur
 	return config, nil
 }
 
-func (o *options) applyDefaults(in *config.AdmissionControllerConfiguration) (*config.AdmissionControllerConfiguration, error) {
-	external, err := o.scheme.ConvertToVersion(in, admissioncontrollerconfigv1alpha1.SchemeGroupVersion)
-	if err != nil {
-		return nil, err
-	}
-	o.scheme.Default(external)
-
-	internal, err := o.scheme.ConvertToVersion(external, config.SchemeGroupVersion)
-	if err != nil {
-		return nil, err
-	}
-	out := internal.(*config.AdmissionControllerConfiguration)
-
-	return out, nil
-}
-
 // AdmissionController contains all necessary information to run the admission controller.
 type AdmissionController struct {
 	Config    *config.AdmissionControllerConfiguration
@@ -134,10 +118,6 @@ type AdmissionController struct {
 func (o *options) run(ctx context.Context) error {
 	c, err := o.loadConfigFromFile(o.configFile)
 	if err != nil {
-		return err
-	}
-
-	if c, err = o.applyDefaults(c); err != nil {
 		return err
 	}
 

--- a/cmd/gardener-controller-manager/app/gardener_controller_manager.go
+++ b/cmd/gardener-controller-manager/app/gardener_controller_manager.go
@@ -23,7 +23,6 @@ import (
 	"os"
 
 	"github.com/gardener/gardener/cmd/utils"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
@@ -47,7 +46,6 @@ import (
 	"k8s.io/client-go/informers"
 	kubeinformers "k8s.io/client-go/informers"
 	kubernetesclientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/record"
 )
@@ -79,9 +77,6 @@ func NewOptions() (*Options, error) {
 		return nil, err
 	}
 	if err := controllermanagerconfigv1alpha1.AddToScheme(o.scheme); err != nil {
-		return nil, err
-	}
-	if err := gardencorev1beta1.AddToScheme(scheme.Scheme); err != nil {
 		return nil, err
 	}
 

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -96,9 +96,6 @@ func NewOptions() (*Options, error) {
 	if err := configv1alpha1.AddToScheme(o.scheme); err != nil {
 		return nil, err
 	}
-	if err := gardencorev1beta1.AddToScheme(o.scheme); err != nil {
-		return nil, err
-	}
 
 	return o, nil
 }

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -138,32 +138,11 @@ func (o *Options) validate(args []string) error {
 	return nil
 }
 
-func (o *Options) applyDefaults(in *config.GardenletConfiguration) (*config.GardenletConfiguration, error) {
-	external, err := o.scheme.ConvertToVersion(in, configv1alpha1.SchemeGroupVersion)
-	if err != nil {
-		return nil, err
-	}
-	o.scheme.Default(external)
-
-	internal, err := o.scheme.ConvertToVersion(external, config.SchemeGroupVersion)
-	if err != nil {
-		return nil, err
-	}
-	out := internal.(*config.GardenletConfiguration)
-
-	return out, nil
-}
-
 func run(ctx context.Context, o *Options) error {
 	if len(o.ConfigFile) > 0 {
 		c, err := o.loadConfigFromFile(o.ConfigFile)
 		if err != nil {
 			return fmt.Errorf("unable to read the configuration file: %v", err)
-		}
-
-		c, err = o.applyDefaults(c)
-		if err != nil {
-			return err
 		}
 
 		if errs := configvalidation.ValidateGardenletConfiguration(c); len(errs) > 0 {

--- a/cmd/utils/miscellaneous.go
+++ b/cmd/utils/miscellaneous.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
-// CreateRecorder creates a record.EventRecorder that is not limited to a namespace having a specific eventSourceName
+// CreateRecorder creates a record.EventRecorder that is not limited to a namespace having a specific eventSourceName.
 func CreateRecorder(kubeClient k8s.Interface, eventSourceName string) record.EventRecorder {
 	scheme := scheme.Scheme
 

--- a/pkg/scheduler/apis/config/loader/loader.go
+++ b/pkg/scheduler/apis/config/loader/loader.go
@@ -18,19 +18,18 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/client-go/kubernetes/scheme"
-
 	"github.com/gardener/gardener/pkg/scheduler/apis/config"
 	"github.com/gardener/gardener/pkg/scheduler/apis/config/install"
+
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
-var Scheme *runtime.Scheme
+var scheme *runtime.Scheme
 
 func init() {
-	Scheme = scheme.Scheme
-	install.Install(Scheme)
+	scheme = runtime.NewScheme()
+	install.Install(scheme)
 }
 
 // LoadFromFile takes a filename and de-serializes the contents into SchedulerConfiguration object.
@@ -52,7 +51,7 @@ func Load(data []byte) (*config.SchedulerConfiguration, error) {
 		return cfg, nil
 	}
 
-	configObj, gvk, err := serializer.NewCodecFactory(Scheme).UniversalDecoder().Decode(data, nil, cfg)
+	configObj, gvk, err := serializer.NewCodecFactory(scheme).UniversalDecoder().Decode(data, nil, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scheduler/apis/config/loader/loader.go
+++ b/pkg/scheduler/apis/config/loader/loader.go
@@ -24,27 +24,13 @@ import (
 	"github.com/gardener/gardener/pkg/scheduler/apis/config"
 	"github.com/gardener/gardener/pkg/scheduler/apis/config/install"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
-	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
 )
 
-var (
-	Codec  runtime.Codec
-	Scheme *runtime.Scheme
-)
+var Scheme *runtime.Scheme
 
 func init() {
 	Scheme = scheme.Scheme
 	install.Install(Scheme)
-	yamlSerializer := json.NewYAMLSerializer(json.DefaultMetaFactory, Scheme, Scheme)
-	Codec = versioning.NewDefaultingCodecForScheme(
-		Scheme,
-		yamlSerializer,
-		yamlSerializer,
-		schema.GroupVersion{Version: "v1alpha1"},
-		runtime.InternalGroupVersioner,
-	)
 }
 
 // LoadFromFile takes a filename and de-serializes the contents into SchedulerConfiguration object.

--- a/pkg/scheduler/apis/config/v1alpha1/types.go
+++ b/pkg/scheduler/apis/config/v1alpha1/types.go
@@ -27,7 +27,7 @@ const (
 	// MinimalDistance Strategy determines a seed candidate for a shoot if the cloud profile are identical. Then chooses the seed with the minimal distance to the shoot.
 	MinimalDistance CandidateDeterminationStrategy = "MinimalDistance"
 	// Default Strategy is the default strategy to use when there is no configuration provided
-	Default CandidateDeterminationStrategy = SameRegion
+	Default = SameRegion
 	// SchedulerDefaultLockObjectNamespace is the default lock namespace for leader election.
 	SchedulerDefaultLockObjectNamespace = "garden"
 	// SchedulerDefaultLockObjectName is the default lock name for leader election.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind cleanup
/priority normal

**What this PR does / why we need it**:
This PR removes the manual invocation of defaulting functions for several config APIs since these are implicitly called by [Decode](https://github.com/kubernetes/kubernetes/blob/1b4fa94c2131dd0b11b470a280b967b0b10ffe2d/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go#L78-L79).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
