### PR TITLE
Fix premature deletion of vpa-webhook-config for ShootedSeed

### DIFF
--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -352,12 +352,6 @@ func DeleteVpa(ctx context.Context, c client.Client, namespace string, isShoot b
 			&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-kube-apiserver-to-vpa-admission-controller", Namespace: namespace}},
 		)
 	} else {
-		// TODO: remove in a future release
-		// Clean up the stale MutatingWebhookConfiguration
-		resources = append(resources,
-			&admissionregistrationv1beta1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "vpa-webhook-config"}},
-		)
-
 		resources = append(resources,
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:vpa:seed:actor"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:vpa:seed:admission-controller"}},

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -674,6 +674,18 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 		}
 	}
 
+	// TODO: remove in a future release
+	// Clean up the stale vpa-webhook-config MutatingWebhookConfiguration.
+	// We can delete vpa-webhook-config as the new vpa-webhook-config-seed will be created with the apply of the seed-boostrap chart.
+	if vpaEnabled {
+		webhook := &admissionregistrationv1beta1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: "vpa-webhook-config"},
+		}
+		if err := k8sSeedClient.Client().Delete(ctx, webhook); client.IgnoreNotFound(err) != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug
/priority critical

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/2886 is basically fixing naming collision for VPA webhook between seed boostrap and shoot control reconcile/ (via ManagedResource). But there is also one more case affecting ShootedSeed.
Currently for a ShootedSeed with `spec.kubernetes.verticalPodAutoscaler.enabled=true`, the seed bootstrap will prematurely delete the stale `vpa-webhook-config` which will leave the ShootedSeed without any VPA webhook until upcoming reconciliation in the maintenance time window which will create `vpa-webhook-config-shoot`.
Such situation without any VPA webhook leads to Pods eviction at each `~2m` with reason `EvictedByVPA`.

This PR also cleans up the `vpa-webhook-config` webhook from Shoots as `vpa-webhook-config-shoot` should be the acting one.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue causing premature deletion of the stale VPA webhook before the creation of the new VPA webhook for ShootedSeeds is now fixed.  
```

```improvement operator
An issue causing the stale VPA webhook to do not be cleaned up is now fixed.
```
