### PR TITLE
Add unit tests for flow progress reporters

### DIFF
--- a/pkg/utils/flow/flow_suite_test.go
+++ b/pkg/utils/flow/flow_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestFlow(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Flow Suite")
+}

--- a/pkg/utils/flow/flow_test.go
+++ b/pkg/utils/flow/flow_test.go
@@ -16,25 +16,19 @@ package flow_test
 
 import (
 	"context"
+	"errors"
+	"sync"
 
-	mockflow "github.com/gardener/gardener/pkg/mock/gardener/utils/flow"
-	utilerrors "github.com/gardener/gardener/pkg/utils/errors"
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/go-multierror"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"errors"
-	"sync"
-	"testing"
+	mockflow "github.com/gardener/gardener/pkg/mock/gardener/utils/flow"
+	utilerrors "github.com/gardener/gardener/pkg/utils/errors"
 
 	"github.com/gardener/gardener/pkg/utils/flow"
 )
-
-func TestUtils(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Flow Suite")
-}
 
 type AtomicStringList struct {
 	lock   sync.RWMutex

--- a/pkg/utils/flow/progress_reporter_delaying_test.go
+++ b/pkg/utils/flow/progress_reporter_delaying_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ProgressReporterDelaying", func() {
+	It("should behave correctly", func() {
+		var (
+			ctx           = context.TODO()
+			period        = 50 * time.Millisecond
+			reportedStats atomic.Value
+			reporterFn    = func(_ context.Context, stats *Stats) { reportedStats.Store(stats) }
+			p             = NewDelayingProgressReporter(reporterFn, period)
+		)
+
+		Expect(p.Start(ctx)).To(Succeed())
+		Expect(reportedStats.Load()).To(BeNil())
+
+		stats1 := &Stats{FlowName: "1"}
+		p.Report(ctx, stats1)
+		Expect(reportedStats.Load()).To(Equal(stats1))
+
+		stats2 := &Stats{FlowName: "2"}
+		p.Report(ctx, stats2)
+		Consistently(reportedStats.Load, period/2, time.Millisecond).Should(Equal(stats1))
+		Eventually(reportedStats.Load, period, period/5).Should(Equal(stats2))
+
+		stats3 := &Stats{FlowName: "3"}
+		p.Report(ctx, stats3)
+		Consistently(reportedStats.Load, period/2, time.Millisecond).Should(Equal(stats2))
+		Eventually(reportedStats.Load, period, period/5).Should(Equal(stats3))
+
+		stats4 := &Stats{FlowName: "4"}
+		p.Report(ctx, stats4)
+		stats5 := &Stats{FlowName: "5"}
+		p.Report(ctx, stats5)
+		Consistently(reportedStats.Load, period/2, time.Millisecond).Should(Equal(stats3))
+		Eventually(reportedStats.Load, period, period/5).Should(Equal(stats5))
+
+		stats6 := &Stats{FlowName: "6"}
+		p.Report(ctx, stats6)
+		p.Stop()
+		Expect(reportedStats.Load()).To(Equal(stats6))
+	})
+})

--- a/pkg/utils/flow/progress_reporter_immediate_test.go
+++ b/pkg/utils/flow/progress_reporter_immediate_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow_test
+
+import (
+	"context"
+
+	. "github.com/gardener/gardener/pkg/utils/flow"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ProgressReporterImmediate", func() {
+	var ctx = context.TODO()
+
+	Describe("#Start", func() {
+		It("should do nothing", func() {
+			pr := NewImmediateProgressReporter(nil)
+			Expect(pr.Start(ctx)).To(Succeed())
+		})
+	})
+
+	Describe("#Report", func() {
+		It("should call the reporter function", func() {
+			var (
+				resultContext context.Context
+				resultStats   *Stats
+
+				stats = &Stats{FlowName: "foo"}
+				pr    = NewImmediateProgressReporter(func(ctx context.Context, stats *Stats) {
+					resultContext = ctx
+					resultStats = stats
+				})
+			)
+
+			pr.Report(ctx, stats)
+
+			Expect(resultContext).To(Equal(ctx))
+			Expect(resultStats).To(Equal(stats))
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test
/priority normal

**What this PR does / why we need it**:
This PR adds unit tests for the flow progress reporters added with #2908.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
