### PR TITLE
VPA minAllowed config for etcd-druid

### DIFF
--- a/charts/seed-bootstrap/charts/etcd-druid/templates/vpa.yaml
+++ b/charts/seed-bootstrap/charts/etcd-druid/templates/vpa.yaml
@@ -11,3 +11,10 @@ spec:
     name: etcd-druid
   updatePolicy:
     updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        cpu: 50m
+        memory: 100M
+


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind post-mortem
/priority normal

**What this PR does / why we need it**:
VPA minAllowed configuration for etcd-druid to avoid crashloops if VPA scales down the resources too low from which automatic recovery doesn't happen.

**Which issue(s) this PR fixes**:
Fixes #2890 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
VPA minAllowed configuration for etcd-druid to avoid crashloops if VPA scales down the resources too low from which automatic recovery doesn't happen.
```
