### PR TITLE
Fix test-cover.sh output files for vendoring repos

### DIFF
--- a/hack/test-cover.sh
+++ b/hack/test-cover.sh
@@ -21,9 +21,10 @@ echo "> Test Cover"
 
 GO111MODULE=on ginkgo -cover -race -mod=vendor $@
 
-COVERPROFILE="$(dirname $0)/../test.coverprofile"
-COVERPROFILE_TMP="$(dirname $0)/../test.coverprofile.tmp"
-COVERPROFILE_HTML="$(dirname $0)/../test.coverage.html"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+COVERPROFILE="$REPO_ROOT/test.coverprofile"
+COVERPROFILE_TMP="$REPO_ROOT/test.coverprofile.tmp"
+COVERPROFILE_HTML="$REPO_ROOT/test.coverage.html"
 
 echo "mode: set" > "$COVERPROFILE_TMP"
 find . -name "*.coverprofile" -type f | xargs cat | grep -v mode: | sort -r | awk '{if($1 != last) {print $0;last=$1}}' >> "$COVERPROFILE_TMP"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity testing
/kind task
/priority normal

**What this PR does / why we need it**:
With this PR `hack/test-cover.sh` outputs its coverage reports in the git root dir, so it will not be written to `vendor/github.com/gardener/gardener/...` if the script is used in a project vendoring g/g.
This is similar to #2934.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
