### PR TITLE
Rework logging dashboards

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-control-plane-status-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-control-plane-status-dashboard.json
@@ -1249,32 +1249,6 @@
       }
     },
     {
-      "datasource": "loki",
-      "gridPos": {
-        "h": 11,
-        "w": 24,
-        "x": 0,
-        "y": 37
-      },
-      "id": 52,
-      "options": {
-        "showLabels": false,
-        "showTime": true,
-        "sortOrder": "Descending",
-        "wrapLogMessage": false
-      },
-      "targets": [
-        {
-          "expr": "{container_name=\"kube-apiserver\"} |~ \"$search\"",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "API Server Logs",
-      "type": "logs"
-    },
-    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
@@ -1572,32 +1546,6 @@
             "align": false,
             "alignLevel": null
           }
-        },
-        {
-          "datasource": "loki",
-          "gridPos": {
-            "h": 11,
-            "w": 24,
-            "x": 0,
-            "y": 61
-          },
-          "id": 54,
-          "options": {
-            "showLabels": false,
-            "showTime": true,
-            "sortOrder": "Descending",
-            "wrapLogMessage": false
-          },
-          "targets": [
-            {
-              "expr": "{container_name=\"kube-controller-manager\"} |~ \"$search\"",
-              "refId": "A"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Kube-controller-manager logs",
-          "type": "logs"
         }
       ],
       "title": "Kube-controller-manager",
@@ -1997,32 +1945,6 @@
             "align": false,
             "alignLevel": null
           }
-        },
-        {
-          "datasource": "loki",
-          "gridPos": {
-            "h": 11,
-            "w": 24,
-            "x": 0,
-            "y": 62
-          },
-          "id": 56,
-          "options": {
-            "showLabels": false,
-            "showTime": true,
-            "sortOrder": "Descending",
-            "wrapLogMessage": false
-          },
-          "targets": [
-            {
-              "expr": "{container_name=\"kube-scheduler\"} |~ \"$search\"",
-              "refId": "A"
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Kube-scheduler logs",
-          "type": "logs"
         }
       ],
       "title": "Kube-scheduler",

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-dashboards-configmap.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-dashboards-configmap.yaml
@@ -29,4 +29,8 @@ data:
 {{ end }}
 {{- if .Values.extensions.dashboards }}
 {{- toString .Values.extensions.dashboards | indent 2 }}
+{{ end }}
+{{ range $component := .Values.exposedComponents }}
+  {{ $component.fileName }}: |-
+{{ include "logging-dashboard" $component | indent 4 }}
 {{- end }}

--- a/charts/seed-monitoring/charts/grafana/templates/logging-dashboard.tpl
+++ b/charts/seed-monitoring/charts/grafana/templates/logging-dashboard.tpl
@@ -1,0 +1,481 @@
+{{- define "logging-dashboard" -}}
+{
+    "annotations": {
+      "list": []
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "iteration": 1601888883889,
+    "links": [],
+    "panels": [
+      {
+        "cacheTimeout": null,
+        "colorBackground": false,
+        "colorValue": false,
+        "colors": [
+          "rgba(245, 54, 54, 0.9)",
+          "rgba(237, 129, 40, 0.89)",
+          "rgba(50, 172, 45, 0.97)"
+        ],
+        "datasource": "prometheus",
+        "description": "Current uptime status.",
+        "editable": false,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "format": "percent",
+        "gauge": {
+          "maxValue": 100,
+          "minValue": 0,
+          "show": true,
+          "thresholdLabels": false,
+          "thresholdMarkers": true
+        },
+        "gridPos": {
+          "h": 7,
+          "w": 4,
+          "x": 0,
+          "y": 0
+        },
+        "hideTimeOverride": false,
+        "id": 1,
+        "interval": null,
+        "links": [],
+        "mappingType": 1,
+        "mappingTypes": [
+          {
+            "name": "value to text",
+            "value": 1
+          },
+          {
+            "name": "range to text",
+            "value": 2
+          }
+        ],
+        "maxDataPoints": 100,
+        "nullPointMode": "connected",
+        "nullText": null,
+        "postfix": "",
+        "postfixFontSize": "50%",
+        "prefix": "",
+        "prefixFontSize": "50%",
+        "rangeMaps": [
+          {
+            "from": "null",
+            "text": "N/A",
+            "to": "null"
+          }
+        ],
+        "sparkline": {
+          "fillColor": "rgba(31, 118, 189, 0.18)",
+          "full": false,
+          "lineColor": "rgb(31, 120, 193)",
+          "show": false
+        },
+        "tableColumn": "",
+        "targets": [
+          {
+            "expr": "(sum(up{job=\"{{ $.jobName }}\"} == 1) / sum(up{job=\"{{ $.jobName }}\"})) * 100",
+            "format": "time_series",
+            "intervalFactor": 2,
+            "refId": "A",
+            "step": 600
+          }
+        ],
+        "thresholds": "50, 80",
+        "title": "UP Time",
+        "type": "singlestat",
+        "valueFontSize": "80%",
+        "valueMaps": [
+          {
+            "op": "=",
+            "text": "N/A",
+            "value": "null"
+          }
+        ],
+        "valueName": "avg"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "description": "Shows the CPU usage and shows the requests and limits.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 0,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 10,
+          "x": 4,
+          "y": 0
+        },
+        "hiddenSeries": false,
+        "id": 41,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {                                                     
+            "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"{{ $.podPrefix }}-(.+)\"}[5m])) by (pod)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "{{ "{{" }}pod}}-current",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(kube_pod_container_resource_limits_cpu_cores{pod=~\"{{ $.podPrefix }}-(.+)\"}) by (pod)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "{{ "{{" }}pod}}-limits",
+            "refId": "C"
+          },
+          {
+            "expr": "sum(kube_pod_container_resource_requests_cpu_cores{pod=~\"{{ $.podPrefix }}-(.+)\"}) by (pod)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "{{ "{{" }}pod}}-requests",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "CPU usage",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "description": "Shows the memory usage.",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 0,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 10,
+          "x": 14,
+          "y": 0
+        },
+        "hiddenSeries": false,
+        "id": 24,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(container_memory_working_set_bytes{pod=~\"{{ $.podPrefix }}-(.+)\"}) by (pod)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "{{ "{{" }}pod}}-current",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(kube_pod_container_resource_limits_memory_bytes{pod=~\"{{ $.podPrefix }}-(.+)\"}) by (pod)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "{{ "{{" }}pod}}-limits",
+            "refId": "B"
+          },
+          {
+            "expr": "sum(kube_pod_container_resource_requests_memory_bytes{pod=~\"{{ $.podPrefix }}-(.+)\"}) by (pod)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "{{ "{{" }}pod}}-requests",
+            "refId": "C"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Memory Usage",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "bytes",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "none",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "datasource": "loki",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 17,
+          "w": 24,
+          "x": 0,
+          "y": 7
+        },
+        "id": 43,
+        "interval": "",
+        "options": {
+          "showLabels": false,
+          "showTime": true,
+          "sortOrder": "Descending",
+          "wrapLogMessage": false
+        },
+        "targets": [
+          {
+            "expr": "{pod_name=~\"{{ $.podPrefix }}-(.+)\", severity=~\"$severity\"} |~ \"$search\"",
+            "refId": "A"
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Logs",
+        "type": "logs"
+      }
+    ],
+    "refresh": "1m",
+    "schemaVersion": 25,
+    "style": "dark",
+    "tags": [
+      "controlplane",
+      "seed",
+      "logging"
+    ],
+    "templating": {
+      "list": [
+        {
+            "allValue": ".+",
+            "current": {
+            "selected": true,
+            "tags": [],
+            "text": "All",
+            "value": [
+                "$__all"
+            ]
+            },
+            "hide": 0,
+            "includeAll": true,
+            "label": "Severity",
+            "multi": true,
+            "name": "severity",
+            "options": [
+            {
+                "selected": true,
+                "text": "All",
+                "value": "$__all"
+            },
+            {
+                "selected": false,
+                "text": "INFO",
+                "value": "INFO"
+            },
+            {
+                "selected": false,
+                "text": "WARN",
+                "value": "WARN"
+            },
+            {
+                "selected": false,
+                "text": "ERR",
+                "value": "ERR"
+            },
+            {
+                "selected": false,
+                "text": "DBG",
+                "value": "DBG"
+            },
+            {
+                "selected": false,
+                "text": "NOTICE",
+                "value": "NOTICE"
+            },
+            {
+                "selected": false,
+                "text": "FATAL",
+                "value": "FATAL"
+            }
+            ],
+            "query": "INFO,WARN,ERR,DBG,NOTICE,FATAL",
+            "queryValue": "",
+            "skipUrlSync": false,
+            "type": "custom"
+        },
+        {
+          "current": {
+            "selected": false,
+            "text": "",
+            "value": ""
+          },
+          "hide": 0,
+          "label": "Search",
+          "name": "search",
+          "options": [
+            {
+              "selected": true,
+              "text": "",
+              "value": ""
+            }
+          ],
+          "query": "",
+          "skipUrlSync": false,
+          "type": "textbox"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-30m",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "3h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "14d"
+      ]
+    },
+    "timezone": "browser",
+    "title": "{{ $.dashboardName }}",
+    "uid": "{{ $.jobName }}",
+    "version": 1
+  }
+{{- end -}}

--- a/charts/seed-monitoring/charts/grafana/values.yaml
+++ b/charts/seed-monitoring/charts/grafana/values.yaml
@@ -20,3 +20,21 @@ extensions:
 
 konnectivityTunnel:
   enabled: false
+
+exposedComponents:
+- dashboardName: "Kube Apiserver"
+  jobName: "kube-apiserver"
+  podPrefix: "kube-apiserver"
+  fileName: "kube-apiserver.json"
+- dashboardName: "Kube Controller Manager"
+  jobName: "kube-controller-manager"
+  podPrefix: "kube-controller-manager"
+  fileName: "kube-controller-manager.json"
+- dashboardName: "Kube Scheduler"
+  jobName: "kube-scheduler"
+  podPrefix: "kube-scheduler"
+  fileName: "kube-scheduler.json"
+- dashboardName: "Cluster Autoscaler"
+  jobName: "cluster-autoscaler"
+  podPrefix: "cluster-autoscaler"
+  fileName: "cluster-autoscaler.json"

--- a/docs/extensions/logging-and-monitoring.md
+++ b/docs/extensions/logging-and-monitoring.md
@@ -149,11 +149,14 @@ The three types of Grafana instances found in a seed cluster are configured to e
   - [Pod Logs](../../charts/seed-bootstrap/dashboards/pod-logs.json)
   - [Extensions](../../charts/seed-bootstrap/dashboards/extensions-dashboard.json)
   - [Systemd Logs](../../charts/seed-bootstrap/dashboards/systemd-logs.json)
-- Shoot Operator Grafana dashboards expose logs from the shoot cluster namespace where they belong
-  - [Kubernetes Pods](../../charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json)
-  - [Kubernetes Control Plane Status](../../charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-control-plane-status-dashboard.json)
 - Shoot User Grafana dashboards expose a subset of the logs shown to operators
-  - [Kubernetes Control Plane Status](../../charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-control-plane-status-dashboard.json)
+  - Kube Apiserver
+  - Kube Controller Manager
+  - Kube Scheduler
+  - Cluster Autoscaler
+- Shoot Operator Grafana dashboards expose logs from the shoot cluster namespace where they belong
+  - All user's dashboards
+  - [Kubernetes Pods](../../charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json)
 
 If the type of logs exposed in the Grafana instances needs to be changed, it is necessary to update the coresponding instance dashboard configurations.
 

--- a/docs/usage/logging.md
+++ b/docs/usage/logging.md
@@ -25,10 +25,22 @@ or with regex:
     * Extensions
     * Systemd Logs
   * User Grafana
-    * Kubernetes Control Plane Status
-  * Operator Grafana 
+    * Kube Apiserver
+    * Kube Controller Manager
+    * Kube Scheduler
+    * Cluster Autoscaler  * Operator Grafana
+  * Operator Grafana
+    * All user's dashboards
     * Kubernetes Pods
-    * Kubernetes Control Plane Status
+
+### Expose logs for component to User Grafana
+Exposing logs for a new component to the User's Grafana happens with adding a new component section into: charts/seed-monitoring/charts/grafana/values.yaml
+
+* dashboardName: The name of the dashboard. Use prefix `Logging` to make it recognizable for the users.
+* jobName: The job name of the component defined in the prometheus.
+* podPrefix: The prefix of the pod e.g. `kube-apiserver`
+* fileName: File which will be created in the container's disk with the dashboard configuration.
+
 
 ### Configuration
 #### Fluent-bit


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
New logging dashboard is added prefixed with `Logging ....` for each exposed component.
Logging panels from `Kubernetes Control Plane Status` are removed

**Which issue(s) this PR fixes**:
Fixes # https://github.com/gardener/logging/issues/72

**Special notes for your reviewer**:
@wyb1 @vlvasilev @rfranzke 

@g-pavlov Can you please take a look on the documentation changes?

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
New logging dashboards are added, prefixed with `Logging` for each exposed component.
Logging panels in `Kubernetes Controlplane Status` are removed
```
