### PR TITLE
Use Pod anti-affinity in clusterautoscaler test

### DIFF
--- a/test/framework/resources/templates/pod-anti-affinity-deployment.yaml.tpl
+++ b/test/framework/resources/templates/pod-anti-affinity-deployment.yaml.tpl
@@ -5,19 +5,29 @@ metadata:
   namespace: {{ .Namespace }}
   labels:
     app: kubernetes
-    role: reserve-capacity
+    role: pod-anti-affinity
 spec:
   replicas: {{ .Replicas }}
   selector:
     matchLabels:
       app: kubernetes
-      role: reserve-capacity
+      role: pod-anti-affinity
   template:
     metadata:
       labels:
         app: kubernetes
-        role: reserve-capacity
+        role: pod-anti-affinity
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: role
+                operator: In
+                values:
+                - pod-anti-affinity
+            topologyKey: "kubernetes.io/hostname"
       terminationGracePeriodSeconds: 5
       nodeSelector:
         worker.gardener.cloud/pool: {{ .WorkerPool }}
@@ -31,12 +41,5 @@ spec:
       - name: pause-container
         image: gcr.io/google_containers/pause-amd64:3.1
         imagePullPolicy: IfNotPresent
-        resources:
-          requests:
-            cpu: {{ .Requests.CPU }}
-            memory: {{ .Requests.Memory }}
-          limits:
-            cpu: {{ .Requests.CPU }}
-            memory: {{ .Requests.Memory }}
         securityContext:
           runAsUser: 1001

--- a/test/framework/resources/templates/templates.go
+++ b/test/framework/resources/templates/templates.go
@@ -14,17 +14,19 @@
 
 package templates
 
-// SimpleLoadDeploymentName is the name of the simple load deployment template
-const SimpleLoadDeploymentName = "simple-load-deployment.yaml.tpl"
+const (
+	// SimpleLoadDeploymentName is the name of the simple load deployment template
+	SimpleLoadDeploymentName = "simple-load-deployment.yaml.tpl"
 
-// NginxDaemonSetName is the name of the nginx deamonset template
-const NginxDaemonSetName = "network-nginx-deamonset.yaml.tpl"
+	// NginxDaemonSetName is the name of the nginx deamonset template
+	NginxDaemonSetName = "network-nginx-deamonset.yaml.tpl"
 
-// GuestbookAppName is the name if the guestbook app deployment template
-const GuestbookAppName = "guestbook-app.yaml.tpl"
+	// GuestbookAppName is the name if the guestbook app deployment template
+	GuestbookAppName = "guestbook-app.yaml.tpl"
 
-// LoggerAppName is the name of the logger app deployment template
-const LoggerAppName = "logger-app.yaml.tpl"
+	// LoggerAppName is the name of the logger app deployment template
+	LoggerAppName = "logger-app.yaml.tpl"
 
-// ReserveCapacityName is the name of the reserve capacity template
-const ReserveCapacityName = "reserve-capacity.yaml.tpl"
+	// PodAntiAffinityDeploymentName is the name of the pod anti affinity deployment template
+	PodAntiAffinityDeploymentName = "pod-anti-affinity-deployment.yaml.tpl"
+)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR modifies the clusterautoscaler test use Pod anti-affinity instead of Pod resources to reproduce unschedulable Pod (the event that is a trigger for the cluster-autoscaler).
As described in https://github.com/gardener/gardener/issues/2920#issuecomment-703915380, the Pod resources approach is not deterministic and we can easily end up with reserve-capacity Pod that does not fit the Node because of insufficient resources (for example Node joined first and most of the system components are scheduled on it).

**Which issue(s) this PR fixes**:
Fixes #2920 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
