### PR TITLE
Fix seed boostrap for v1.19 clusters

### DIFF
--- a/charts/seed-bootstrap/templates/aggregate-prometheus/ingress.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/ingress.yaml
@@ -18,6 +18,14 @@ spec:
     http:
       paths:
       - backend:
+          {{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: aggregate-prometheus-web
+            port:
+              number: 80
+          {{- else }}
           serviceName: aggregate-prometheus-web
           servicePort: 80
+          {{- end }}
         path: /
+        pathType: Prefix

--- a/charts/seed-bootstrap/templates/grafana/ingress.yaml
+++ b/charts/seed-bootstrap/templates/grafana/ingress.yaml
@@ -18,6 +18,14 @@ spec:
     http:
       paths:
       - backend:
+          {{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: grafana
+            port:
+              number: 3000
+          {{- else }}
           serviceName: grafana
           servicePort: 3000
+          {{- end }}
         path: /
+        pathType: Prefix

--- a/charts/seed-monitoring/charts/alertmanager/templates/ingress.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/ingress.yaml
@@ -22,8 +22,16 @@ spec:
     http:
       paths:
       - backend:
+          {{- if semverCompare ">= 1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: alertmanager-client
+            port:
+              number: 9093
+          {{- else }}
           serviceName: alertmanager-client
           servicePort: 9093
+          {{- end }}
         path: /
+        pathType: Prefix
   {{- end }}
 

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/ingress.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/ingress.yaml
@@ -21,7 +21,15 @@ spec:
     http:
       paths:
       - backend:
+          {{- if semverCompare ">= 1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: prometheus-web
+            port:
+              number: 80
+          {{- else }}
           serviceName: prometheus-web
           servicePort: 80
+          {{- end }}
         path: /
+        pathType: Prefix
   {{- end }}

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-ingress.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-ingress.yaml
@@ -24,7 +24,15 @@ spec:
     http:
       paths:
       - backend:
-          servicePort: {{ required ".ports.grafana is required" $.Values.ports.grafana }}
+          {{- if semverCompare ">= 1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: grafana-{{ $.Values.role }}
+            port:
+              number: {{ required ".ports.grafana is required" $.Values.ports.grafana }}
+          {{- else }}
           serviceName: grafana-{{ $.Values.role }}
+          servicePort: {{ required ".ports.grafana is required" $.Values.ports.grafana }}
+          {{- end }}
         path: /
+        pathType: Prefix
   {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
Fix seed boostrap for v1.19 clusters.

This PR is based on @Diaphteiros's work under https://github.com/Diaphteiros/gardener/commits/fix-seed-bootstrap. @Diaphteiros, thank you for reporting this issue and doing all of the work.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/2891

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue causing Seed bootrap to fail for v1.19 clusters is now fixed.
```
