### PR TITLE
Restore the original settings

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
@@ -91,24 +91,32 @@
         Match kubernetes.*
         Url http://loki.garden.svc:3100/loki/api/v1/push
         LogLevel info
-        BatchWait 30
-        # (30sec)
+        BatchWait 40
         BatchSize 30720
-        # (30KiB)
         Labels {test="fluent-bit-go", lang="Golang"}
         LineFormat json
+        ReplaceOutOfOrderTS true
         DropSingleKey false
         AutoKubernetesLabels true
         LabelSelector gardener.cloud/role:shoot
-        RemoveKeys kubernetes,stream,type,time
+        RemoveKeys kubernetes,stream,type,time,tag
         LabelMapPath /fluent-bit/etc/kubernetes_label_map.json
         DynamicHostPath {"kubernetes": {"namespace_name": "namespace"}}
         DynamicHostPrefix http://loki.
-        DynamicHostSulfix .svc:3100/loki/api/v1/push
+        DynamicHostSuffix .svc:3100/loki/api/v1/push
         DynamicHostRegex shoot-
         MaxRetries 3
         Timeout 10
         MinBackoff 30
+        Buffer true
+        BufferType dque
+        QueueDir  /fluent-bit/buffers
+        QueueSegmentSize 300
+        QueueSync normal
+        QueueName gardener-kubernetes
+        FallbackToTagWhenMetadataIsMissing true
+        TagKey tag
+        DropLogEntryWithoutK8sMetadata true
 
     [Output]
         Name loki
@@ -116,16 +124,21 @@
         Url http://loki.garden.svc:3100/loki/api/v1/push
         LogLevel info
         BatchWait 60
-        # (60sec)
         BatchSize 30720
-        # (30KiB)
         Labels {test="fluent-bit-go", lang="Golang"}
         LineFormat json
+        ReplaceOutOfOrderTS true
         DropSingleKey false
-        RemoveKeys kubernetes,steram,hostname,unit
+        RemoveKeys kubernetes,stream,hostname,unit
         LabelMapPath /fluent-bit/etc/systemd_label_map.json
         MaxRetries 3
         Timeout 10
         MinBackoff 30
+        Buffer true
+        BufferType dque
+        QueueDir  /fluent-bit/buffers
+        QueueSegmentSize 300
+        QueueSync normal
+        QueueName gardener-journald
 {{ end }}
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug
/priority critical

**What this PR does / why we need it**:
With the PR [Expose Fluent-bit configurations](https://github.com/gardener/gardener/pull/2796) we have delete the actual logging configuration by mistake, with such one that does not work. With this PR we restore the previously deleted configurations.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Restore the working logging configuration
```
