### PR TITLE
Add unit tests for admission handlers

### DIFF
--- a/pkg/admissioncontroller/server/handlers/webhooks/utils.go
+++ b/pkg/admissioncontroller/server/handlers/webhooks/utils.go
@@ -29,6 +29,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const (
+	// maxRequestBody is the maximum size of the `AdmissionReview` body.
+	// Same, fixed value from API server for general safety to reduce the odds of OOM issues while reading the body.
+	// https://github.com/kubernetes/kubernetes/blob/d8eac8df28e6b50cd0f5380e23fc57daaf92972e/staging/src/k8s.io/apiserver/pkg/server/config.go#L322
+	maxRequestBody = 3 * 1024 * 1024
+)
+
 func admissionResponse(allowed bool, msg string) *admissionv1beta1.AdmissionResponse {
 	response := &admissionv1beta1.AdmissionResponse{
 		Allowed: allowed,

--- a/pkg/admissioncontroller/server/handlers/webhooks/utils_test.go
+++ b/pkg/admissioncontroller/server/handlers/webhooks/utils_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 
 	. "github.com/gardener/gardener/pkg/admissioncontroller/server/handlers/webhooks"
 	core "github.com/gardener/gardener/pkg/apis/core/install"
@@ -53,7 +54,7 @@ var _ = Describe("Utils tests", func() {
 			scheme  = runtime.NewScheme()
 			decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
 
-			sizeRequest = int64(336)
+			sizeRequest = int64(342)
 
 			request = func() *http.Request {
 				return createHTTPRequest(&corev1.Secret{
@@ -61,7 +62,7 @@ var _ = Describe("Utils tests", func() {
 						Kind:       "Secret",
 						APIVersion: corev1.SchemeGroupVersion.String(),
 					},
-				}, scheme, authenticationv1.UserInfo{})
+				}, scheme, authenticationv1.UserInfo{}, admissionv1beta1.Create)
 			}
 		)
 
@@ -100,10 +101,10 @@ var _ = Describe("Utils tests", func() {
 	})
 })
 
-func createHTTPRequest(obj runtime.Object, scheme *runtime.Scheme, user authenticationv1.UserInfo) *http.Request {
+func createHTTPRequest(obj runtime.Object, scheme *runtime.Scheme, user authenticationv1.UserInfo, op admissionv1beta1.Operation) *http.Request {
 	admissionReview := &admissionv1beta1.AdmissionReview{}
 
-	if obj != nil {
+	if obj != nil && !reflect.ValueOf(obj).IsNil() {
 		writer := bytes.NewBuffer(nil)
 		jsonSerializer := runtimeserializer.NewSerializerWithOptions(
 			runtimeserializer.DefaultMetaFactory,
@@ -128,7 +129,15 @@ func createHTTPRequest(obj runtime.Object, scheme *runtime.Scheme, user authenti
 			Version:  gvr.Version,
 			Resource: gvr.Resource,
 		}
+
+		var name string
+		if meta, ok := obj.(metav1.Object); ok {
+			name = meta.GetName()
+		}
+
 		admissionReview.Request = &admissionv1beta1.AdmissionRequest{
+			Name:            name,
+			Operation:       op,
 			Resource:        v1Gvr,
 			RequestResource: &v1Gvr,
 			UserInfo:        user,

--- a/pkg/admissioncontroller/server/handlers/webhooks/validate_kubeconfig_secrets_test.go
+++ b/pkg/admissioncontroller/server/handlers/webhooks/validate_kubeconfig_secrets_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooks_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/gardener/gardener/pkg/admissioncontroller/server/handlers/webhooks"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ = Describe("ValidateKubeconfigSecret", func() {
+	var (
+		empty = func() runtime.Object {
+			return nil
+		}
+
+		configMap = func() runtime.Object {
+			return &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+				},
+			}
+		}
+
+		secretTypeMeta = metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		}
+
+		noKubeconfigSecret = func() runtime.Object {
+			return &corev1.Secret{
+				TypeMeta: secretTypeMeta,
+				Data: map[string][]byte{
+					"foo": {},
+				},
+			}
+		}
+
+		validKubeconfig = `
+---
+apiVersion: v1
+kind: Config
+current-context: local-garden
+clusters:
+- name: local-garden
+  cluster:
+    certificate-authority-data: Z2FyZGVuZXIK
+    server: https://localhost:2443
+contexts:
+- name: local-garden
+  context:
+    cluster: local-garden
+    user: local-garden
+users:
+- name: local-garden
+  user:
+    client-certificate-data: Z2FyZGVuZXIK
+    client-key-data: Z2FyZGVuZXIK
+`
+
+		validKubeconfigSecret = func() runtime.Object {
+			return &corev1.Secret{
+				TypeMeta: secretTypeMeta,
+				Data: map[string][]byte{
+					"kubeconfig": []byte(validKubeconfig),
+				},
+			}
+		}
+
+		invalidKubeconfig = `
+---
+apiVersion: v1
+kind: Config
+current-context: local-garden
+clusters:
+- name: local-garden
+  cluster:
+    certificate-authority-data: Z2FyZGVuZXIK
+    server: https://localhost:2443
+contexts:
+- name: local-garden
+  context:
+    cluster: local-garden
+    user: local-garden
+users:
+- name: local-garden
+  user:
+    exec:
+      command: /bin/sh
+`
+
+		invalidKubeconfigSecret = func() runtime.Object {
+			return &corev1.Secret{
+				TypeMeta: secretTypeMeta,
+				Data: map[string][]byte{
+					"kubeconfig": []byte(invalidKubeconfig),
+				},
+			}
+		}
+
+		invalidKubeconfigYamlSecret = func() runtime.Object {
+			return &corev1.Secret{
+				TypeMeta: secretTypeMeta,
+				Data: map[string][]byte{
+					"kubeconfig": []byte("foo"),
+				},
+			}
+		}
+	)
+
+	DescribeTable("Validate Kubeconfig",
+		func(objFn func() runtime.Object, op admissionv1beta1.Operation, expectedAllowed bool, expectedMsg string) {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			user := func() authenticationv1.UserInfo {
+				return authenticationv1.UserInfo{
+					Username: "user",
+					Groups:   []string{"group"},
+				}
+			}
+			response := httptest.NewRecorder()
+			validator := NewValidateKubeconfigSecretsHandler()
+
+			request := createHTTPRequest(objFn(), scheme, user(), op)
+
+			validator.ServeHTTP(response, request)
+
+			admissionReview := &admissionv1beta1.AdmissionReview{}
+			Expect(decodeAdmissionResponse(response, admissionReview)).To(Succeed())
+			Expect(response).Should(HaveHTTPStatus(http.StatusOK))
+			Expect(admissionReview.Response).To(Not(BeNil()))
+			Expect(admissionReview.Response.Allowed).To(Equal(expectedAllowed))
+			if expectedMsg != "" {
+				Expect(admissionReview.Response.Result).To(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Message": ContainSubstring(expectedMsg),
+					})))
+			}
+
+		},
+		Entry("request is empty (create)", empty, admissionv1beta1.Create, false, "missing admission request"),
+		Entry("request contains configMap", configMap, admissionv1beta1.Create, false, "expect resource to be { v1 secrets}"),
+		Entry("should pass because no Kubeconfig is found (create)", noKubeconfigSecret, admissionv1beta1.Create, true, emptyMessage),
+		Entry("should pass because Kubeconfig is valid (create)", validKubeconfigSecret, admissionv1beta1.Create, true, emptyMessage),
+		Entry("should fail because Kubeconfig is invalid (create)", invalidKubeconfigSecret, admissionv1beta1.Create, false, "exec configurations are not supported"),
+		Entry("should fail because Kubeconfig has invalid content (create)", invalidKubeconfigYamlSecret, admissionv1beta1.Create, false, "cannot unmarshal string into Go value of type struct"),
+		Entry("request is empty (update)", empty, admissionv1beta1.Update, false, "missing admission request"),
+		Entry("should pass because no Kubeconfig is found (update)", noKubeconfigSecret, admissionv1beta1.Update, true, emptyMessage),
+		Entry("should pass because Kubeconfig is valid (update)", validKubeconfigSecret, admissionv1beta1.Update, true, emptyMessage),
+		Entry("should fail because Kubeconfig is invalid (update)", invalidKubeconfigSecret, admissionv1beta1.Update, false, "exec configurations are not supported"),
+		Entry("should fail because Kubeconfig has invalid content (update)", invalidKubeconfigYamlSecret, admissionv1beta1.Update, false, "cannot unmarshal string into Go value of type struct"),
+		Entry("should pass because operation is delete", invalidKubeconfigSecret, admissionv1beta1.Delete, true, emptyMessage),
+	)
+})

--- a/pkg/admissioncontroller/server/handlers/webhooks/validate_namespace_deletion.go
+++ b/pkg/admissioncontroller/server/handlers/webhooks/validate_namespace_deletion.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -77,46 +76,18 @@ func NewValidateNamespaceDeletionHandler(ctx context.Context, k8sGardenClient ku
 // ValidateNamespaceDeletion is a HTTP handler for validating whether a namespace deletion is allowed or not.
 func (h *namespaceDeletionHandler) ValidateNamespaceDeletion(w http.ResponseWriter, r *http.Request) {
 	var (
-		body []byte
-
 		deserializer   = h.codecs.UniversalDeserializer()
-		receivedReview = admissionv1beta1.AdmissionReview{}
-
-		wantedContentType = runtime.ContentTypeJSON
-		wantedOperation   = admissionv1beta1.Delete
+		receivedReview = &admissionv1beta1.AdmissionReview{}
 	)
 
-	// Read HTTP request body into variable.
-	if r.Body != nil {
-		if data, err := ioutil.ReadAll(r.Body); err == nil {
-			body = data
-		}
-	}
-
-	// Verify that the correct content-type header has been sent.
-	if contentType := r.Header.Get("Content-Type"); contentType != wantedContentType {
-		err := fmt.Errorf("contentType=%s, expect %s", contentType, wantedContentType)
+	if err := DecodeAdmissionRequest(r, deserializer, receivedReview, maxRequestBody); err != nil {
 		logger.Logger.Errorf(err.Error())
 		respond(w, errToAdmissionResponse(err))
 		return
 	}
 
-	// Deserialize HTTP request body into admissionv1beta1.AdmissionReview object.
-	if _, _, err := deserializer.Decode(body, nil, &receivedReview); err != nil {
-		logger.Logger.Errorf(err.Error())
-		respond(w, errToAdmissionResponse(err))
-		return
-	}
-
-	// If the request field is empty then do not admit (invalid body).
-	if receivedReview.Request == nil {
-		err := fmt.Errorf("invalid request body (missing admission request)")
-		logger.Logger.Errorf(err.Error())
-		respond(w, errToAdmissionResponse(err))
-		return
-	}
 	// If the request does not indicate the correct operation (DELETE) we allow the review without further doing.
-	if receivedReview.Request.Operation != wantedOperation {
+	if receivedReview.Request.Operation != admissionv1beta1.Delete {
 		respond(w, admissionResponse(true, ""))
 		return
 	}

--- a/pkg/admissioncontroller/server/handlers/webhooks/validate_namespace_deletion_test.go
+++ b/pkg/admissioncontroller/server/handlers/webhooks/validate_namespace_deletion_test.go
@@ -1,0 +1,262 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooks_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/gardener/gardener/pkg/admissioncontroller/server/handlers/webhooks"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	"github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	mockcache "github.com/gardener/gardener/pkg/mock/controller-runtime/cache"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("ValidateNamespaceDeletion", func() {
+	var (
+		ctx       = context.Background()
+		namespace = func() *corev1.Namespace {
+			return &corev1.Namespace{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+			}
+		}
+	)
+
+	DescribeTable("Namespace deletion admission",
+		func(namespace func() *corev1.Namespace, mock *mockClient, op admissionv1beta1.Operation, expectedAllowed bool, expectedMsg string) {
+			defer mock.ctrl.Finish()
+			cache := mockcache.NewMockCache(mock.ctrl)
+
+			coreInformerFactory := coreinformers.NewSharedInformerFactory(nil, 0)
+			projectInformer := newSyncedInformer(coreInformerFactory.Core().V1beta1().Projects().Informer())
+			cache.EXPECT().GetInformer(gomock.Any(), &gardencorev1beta1.Project{}).Return(projectInformer, nil)
+			shootInformer := newSyncedInformer(coreInformerFactory.Core().V1beta1().Shoots().Informer())
+			cache.EXPECT().GetInformer(gomock.Any(), &gardencorev1beta1.Shoot{}).Return(shootInformer, nil)
+
+			clientSet := fake.NewClientSetBuilder().WithClient(mock).WithDirectClient(mock).WithCache(cache).Build()
+			validationHandler, err := webhooks.NewValidateNamespaceDeletionHandler(ctx, clientSet)
+			Expect(err).ToNot(HaveOccurred())
+
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			user := authenticationv1.UserInfo{
+				Username: "user",
+				Groups:   []string{"group"},
+			}
+
+			request := createHTTPRequest(namespace(), scheme, user, op)
+			response := httptest.NewRecorder()
+
+			validationHandler.ServeHTTP(response, request)
+
+			admissionReview := &admissionv1beta1.AdmissionReview{}
+			Expect(decodeAdmissionResponse(response, admissionReview)).To(Succeed())
+			Expect(response).Should(HaveHTTPStatus(http.StatusOK))
+			Expect(admissionReview.Response).To(Not(BeNil()))
+			Expect(admissionReview.Response.Allowed).To(Equal(expectedAllowed))
+			if expectedMsg != "" {
+				Expect(admissionReview.Response.Result).To(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Message": ContainSubstring(expectedMsg),
+					})))
+			}
+
+		},
+		Entry("should pass because no project or shoots available", namespace,
+			newMockClient().withProjects(),
+			admissionv1beta1.Delete, true, emptyMessage),
+		Entry("should fail because of empty request", func() *corev1.Namespace { return nil },
+			newMockClient(), admissionv1beta1.Delete, false, "invalid request body (missing admission request)"),
+		Entry("should pass because of update request", namespace,
+			newMockClient(), admissionv1beta1.Update, true, emptyMessage),
+		Entry("should pass because namespace is not project related", namespace,
+			newMockClient().
+				withProjects(
+					project("namespace1", "project1"),
+					project("namespace2", "project2"),
+				), admissionv1beta1.Delete, true, emptyMessage),
+		Entry("should pass because namespace is used by project w/ deletionTimestamp", namespace,
+			newMockClient().
+				withProjects(
+					project("namespace1", "project1"),
+					func() gardencorev1beta1.Project {
+						p := project(namespace().Name, "project2")
+						t := metav1.Now()
+						p.SetDeletionTimestamp(&t)
+						return p
+					}(),
+				).
+				withNamespace(namespace()).
+				withShoots(client.InNamespace(namespace().Name)),
+			admissionv1beta1.Delete, true, emptyMessage),
+		Entry("should not pass because namespace is used by project w/ deletionTimestamp but has shoots", namespace,
+			newMockClient().
+				withProjects(
+					project("namespace1", "project1"),
+					func() gardencorev1beta1.Project {
+						p := project(namespace().Name, "project2")
+						t := metav1.Now()
+						p.SetDeletionTimestamp(&t)
+						return p
+					}(),
+				).
+				withNamespace(namespace()).
+				withShoots(client.InNamespace(namespace().Name), shoot("namespace1", "shoot1")),
+			admissionv1beta1.Delete, false, "there are still Shoots"),
+		Entry("should not pass because namespace is used by project", namespace,
+			newMockClient().
+				withProjects(
+					project("namespace1", "project1"),
+					project(namespace().Name, "project2"),
+				).
+				withNamespace(namespace()),
+			admissionv1beta1.Delete, false, "you must delete the corresponding project \"project2\""),
+		Entry("should pass because namespace is used by project but not found by client", namespace,
+			func() client.Client {
+				cl := newMockClient().
+					withProjects(
+						project("namespace1", "project1"),
+						project(namespace().Name, "project2"),
+					)
+				cl.EXPECT().Get(gomock.Any(), kutil.Key(namespace().Name), &corev1.Namespace{}).Return(apierrors.NewNotFound(corev1.Resource("namespace"), namespace().Name))
+				return cl
+			}(),
+			admissionv1beta1.Delete, true, emptyMessage),
+		Entry("should pass because namespace already has a deletionTimestamp", namespace,
+			newMockClient().
+				withProjects(
+					project("namespace1", "project1"),
+					project(namespace().Name, "project2"),
+				).
+				withNamespace(func() *corev1.Namespace {
+					n := namespace()
+					t := metav1.Now()
+					n.SetDeletionTimestamp(&t)
+					return n
+				}()),
+			admissionv1beta1.Delete, true, emptyMessage),
+		Entry("should not pass because namespace cannot be fetched", namespace,
+			func() client.Client {
+				cl := newMockClient().withProjects(
+					project("namespace1", "project1"),
+					project(namespace().Name, "project2"),
+				)
+				cl.EXPECT().Get(gomock.Any(), kutil.Key(namespace().Name), &corev1.Namespace{}).Return(errors.New("foo"))
+				return cl
+			}(),
+			admissionv1beta1.Delete, false, "foo"),
+		Entry("should not pass because projects cannot be fetched", namespace,
+			func() client.Client {
+				cl := newMockClient()
+				cl.EXPECT().List(gomock.Any(), &gardencorev1beta1.ProjectList{}).Return(errors.New("foo"))
+				return cl
+			}(),
+			admissionv1beta1.Delete, false, "foo"),
+	)
+})
+
+type mockClient struct {
+	*mockclient.MockClient
+	ctrl *gomock.Controller
+}
+
+func newMockClient() *mockClient {
+	ctrl := gomock.NewController(GinkgoT())
+	return &mockClient{ctrl: ctrl, MockClient: mockclient.NewMockClient(ctrl)}
+}
+
+func (c *mockClient) withShoots(listOption client.ListOption, shoots ...gardencorev1beta1.Shoot) *mockClient {
+	c.EXPECT().List(gomock.Any(), &gardencorev1beta1.ShootList{}, listOption).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
+		list.Items = shoots
+		return nil
+	})
+	return c
+}
+
+func (c *mockClient) withProjects(projects ...gardencorev1beta1.Project) *mockClient {
+	c.EXPECT().List(gomock.Any(), &gardencorev1beta1.ProjectList{}).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ProjectList, _ ...client.ListOption) error {
+		list.Items = projects
+		return nil
+	})
+	return c
+}
+
+func (c *mockClient) withNamespace(namespace *corev1.Namespace) *mockClient {
+	c.EXPECT().Get(gomock.Any(), kutil.Key(namespace.Name), &corev1.Namespace{}).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Namespace) error {
+		*obj = *namespace
+		return nil
+	})
+	return c
+}
+
+func project(namespace, name string) gardencorev1beta1.Project {
+	namespaceRef := namespace
+	return gardencorev1beta1.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: gardencorev1beta1.ProjectSpec{
+			Namespace: &namespaceRef,
+		},
+	}
+}
+
+func shoot(namespace, name string) gardencorev1beta1.Shoot {
+	return gardencorev1beta1.Shoot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func newSyncedInformer(informer cache.SharedIndexInformer) cache.SharedIndexInformer {
+	return &syncedInformer{informer}
+}
+
+// syncedInformer is an SharedIndexInformer that is always synced and thus doesn't need to be started against a running API.
+type syncedInformer struct {
+	cache.SharedIndexInformer
+}
+
+func (i *syncedInformer) HasSynced() bool {
+	return true
+}

--- a/pkg/admissioncontroller/server/handlers/webhooks/validate_resource_size.go
+++ b/pkg/admissioncontroller/server/handlers/webhooks/validate_resource_size.go
@@ -37,10 +37,9 @@ import (
 )
 
 type objectSizeHandler struct {
-	config         *apisconfig.ResourceAdmissionConfiguration
-	codecs         serializer.CodecFactory
-	logger         logrus.FieldLogger
-	maxRequestBody int64
+	config *apisconfig.ResourceAdmissionConfiguration
+	codecs serializer.CodecFactory
+	logger logrus.FieldLogger
 }
 
 const (
@@ -56,10 +55,6 @@ func NewValidateResourceSizeHandler(config *apisconfig.ResourceAdmissionConfigur
 		config: config,
 		codecs: serializer.NewCodecFactory(scheme),
 		logger: logger.NewFieldLogger(logger.Logger, "component", validatorName),
-
-		// Take the same, fixed value from API server for general safety to reduce the odds of OOM issues while reading the body.
-		// https://github.com/kubernetes/kubernetes/blob/d8eac8df28e6b50cd0f5380e23fc57daaf92972e/staging/src/k8s.io/apiserver/pkg/server/config.go#L322
-		maxRequestBody: int64(3 * 1024 * 1024),
 	}
 	return h.ValidateResourceSize
 }
@@ -71,7 +66,7 @@ func (h *objectSizeHandler) ValidateResourceSize(w http.ResponseWriter, r *http.
 		receivedReview = &admissionv1beta1.AdmissionReview{}
 	)
 
-	if err := DecodeAdmissionRequest(r, deserializer, receivedReview, h.maxRequestBody); err != nil {
+	if err := DecodeAdmissionRequest(r, deserializer, receivedReview, maxRequestBody); err != nil {
 		h.logger.Errorf(err.Error())
 		respond(w, errToAdmissionResponse(err))
 		return

--- a/pkg/admissioncontroller/server/handlers/webhooks/validate_resource_size_test.go
+++ b/pkg/admissioncontroller/server/handlers/webhooks/validate_resource_size_test.go
@@ -188,7 +188,7 @@ var _ = Describe("ValidateResourceSizeHandler", func() {
 			response := httptest.NewRecorder()
 			validator := NewValidateResourceSizeHandler(config)
 
-			request := createHTTPRequest(objFn(), scheme, userFn())
+			request := createHTTPRequest(objFn(), scheme, userFn(), admissionv1beta1.Update)
 			if subresource != "" {
 				request = createHTTPRequestForSubresource(subresource)
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR refactors the Gardener admission webhooks and adds unit tests for the different handlers.

**Which issue(s) this PR fixes**:
Fixes #2854

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
