### PR TITLE
Clean up TODOs from labels migration

### DIFF
--- a/charts/gardener/controlplane/charts/utils-common/templates/_secret-default-domain.yaml
+++ b/charts/gardener/controlplane/charts/utils-common/templates/_secret-default-domain.yaml
@@ -11,8 +11,6 @@ metadata:
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
-    # TODO: remove in a future release
-    garden.sapcloud.io/role: default-domain
     gardener.cloud/role: default-domain
   annotations:
     dns.gardener.cloud/provider: {{ ( required ".defaultDomains[].provider is required" $domain.provider ) }}

--- a/charts/gardener/controlplane/charts/utils-common/templates/_secret_internal-domain.yaml
+++ b/charts/gardener/controlplane/charts/utils-common/templates/_secret_internal-domain.yaml
@@ -10,8 +10,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-    # TODO: remove in a future release
-    garden.sapcloud.io/role: internal-domain
     gardener.cloud/role: internal-domain
   annotations:
     dns.gardener.cloud/provider: {{ ( required ".internalDomain.provider is required" .Values.global.internalDomain.provider ) }}

--- a/pkg/controllerutils/miscellaneous.go
+++ b/pkg/controllerutils/miscellaneous.go
@@ -75,8 +75,6 @@ func RemoveTasks(annotations map[string]string, tasksToRemove ...string) {
 // RemoveAllTasks removes the ShootTasks annotation from the passed map.
 func RemoveAllTasks(annotations map[string]string) {
 	delete(annotations, common.ShootTasks)
-	// TODO: remove in a future release
-	delete(annotations, common.ShootTasksDeprecated)
 }
 
 func setTaskAnnotations(annotations map[string]string, tasks []string) {

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -48,7 +48,6 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/retry"
 )
 
 // DefaultImageVector is a constant for the path to the default image vector file.
@@ -130,16 +129,6 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 
 	secrets, err := garden.ReadGardenSecrets(f.k8sInformers, f.k8sGardenCoreInformers)
 	runtime.Must(err)
-
-	// TODO: remove in a future release
-	// Add also the 'gardener.cloud/role' label to the 'global-monitoring' secret
-	if secret, ok := secrets[common.GardenRoleGlobalMonitoring]; ok && len(secret.Labels[v1beta1constants.GardenRole]) == 0 {
-		err := kutil.TryUpdate(ctx, retry.DefaultBackoff, k8sGardenClient.Client(), secret, func() error {
-			kutil.SetMetaDataLabel(secret, v1beta1constants.GardenRole, common.GardenRoleGlobalMonitoring)
-			return nil
-		})
-		runtime.Must(err)
-	}
 
 	if secret, ok := secrets[common.GardenRoleInternalDomain]; ok {
 		shootList, err := f.k8sGardenCoreInformers.Core().V1beta1().Shoots().Lister().List(labels.Everything())

--- a/pkg/gardenlet/controller/shoot/shoot_utils.go
+++ b/pkg/gardenlet/controller/shoot/shoot_utils.go
@@ -64,8 +64,6 @@ func (s Status) OrWorse(other Status) Status {
 // StatusLabelTransform transforms the shoot labels depending on the given Status.
 func StatusLabelTransform(status Status) func(*gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
 	return func(shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
-		// TODO: remove in a future version
-		delete(shoot.Labels, common.ShootStatusDeprecated)
 		kubernetes.SetMetaDataLabel(&shoot.ObjectMeta, common.ShootStatus, string(status))
 		return shoot, nil
 	}

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -1190,17 +1190,6 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 		}
 	}
 
-	// Remove deprecated blackbox exporter configmap
-	// TODO: Remove in a future version
-	if err := b.K8sSeedClient.Client().Delete(ctx, &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "blackbox-exporter-config-apiserver",
-			Namespace: b.Shoot.SeedNamespace,
-		},
-	}); client.IgnoreNotFound(err) != nil {
-		return err
-	}
-
 	return b.K8sSeedClient.ChartApplier().Apply(ctx, filepath.Join(chartPathControlPlane, v1beta1constants.DeploymentNameKubeAPIServer), b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer, kubernetes.Values(values))
 }
 

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -286,11 +286,6 @@ const (
 	// ShootStatus is a constant for a label on a Shoot resource indicating that the Shoot's health.
 	ShootStatus = "shoot.gardener.cloud/status"
 
-	// ShootStatusDeprecated is a constant for a label on a Shoot resource indicating that the Shoot's health.
-	//
-	// Deprecated: Use `ShootStatus` instead.
-	ShootStatusDeprecated = "shoot.garden.sapcloud.io/status"
-
 	// ShootOperationDeprecated is a constant for an annotation on a Shoot in a failed state indicating that an operation shall be performed.
 	//
 	// Deprecated: Use `v1beta1constants.GardenerOperation` instead.
@@ -309,11 +304,6 @@ const (
 
 	// ShootTasks is a constant for an annotation on a Shoot which states that certain tasks should be done.
 	ShootTasks = "shoot.gardener.cloud/tasks"
-
-	// ShootTasksDeprecated is a constant for an annotation on a Shoot which states that certain tasks should be done.
-	//
-	// Deprecated: Use `ShootTasks` instead.
-	ShootTasksDeprecated = "shoot.garden.sapcloud.io/tasks"
 
 	// ShootTaskDeployInfrastructure is a name for a Shoot's infrastructure deployment task.
 	ShootTaskDeployInfrastructure = "deployInfrastructure"

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -173,27 +173,6 @@ func ReadGardenSecrets(k8sInformers kubeinformers.SharedInformerFactory, k8sGard
 		numberOfAlertingSecrets             = 0
 	)
 
-	selector, err := labels.Parse(v1beta1constants.DeprecatedGardenRole)
-	if err != nil {
-		return nil, err
-	}
-	secrets, err := k8sInformers.Core().V1().Secrets().Lister().Secrets(v1beta1constants.GardenNamespace).List(selector)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, obj := range secrets {
-		secret := obj.DeepCopy()
-
-		// Retrieving basic auth secret for aggregate monitoring with a label
-		// indicating the Garden role global-monitoring.
-		if secret.Labels[v1beta1constants.DeprecatedGardenRole] == common.GardenRoleGlobalMonitoring {
-			monitoringSecret := secret
-			secretsMap[common.GardenRoleGlobalMonitoring] = monitoringSecret
-			logger.Logger.Infof("Found monitoring basic auth secret %s.", secret.Name)
-		}
-	}
-
 	selectorGardenRole, err := labels.Parse(v1beta1constants.GardenRole)
 	if err != nil {
 		return nil, err
@@ -258,6 +237,14 @@ func ReadGardenSecrets(k8sInformers kubeinformers.SharedInformerFactory, k8sGard
 			secretsMap[common.GardenRoleAlerting] = alertingSecret
 			logger.Logger.Infof("Found alerting secret %s.", secret.Name)
 			numberOfAlertingSecrets++
+		}
+
+		// Retrieving basic auth secret for aggregate monitoring with a label
+		// indicating the Garden role global-monitoring.
+		if secret.Labels[v1beta1constants.GardenRole] == common.GardenRoleGlobalMonitoring {
+			monitoringSecret := secret
+			secretsMap[common.GardenRoleGlobalMonitoring] = monitoringSecret
+			logger.Logger.Infof("Found monitoring basic auth secret %s.", secret.Name)
 		}
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Clean up TODOs from labels migration from https://github.com/gardener/gardener/pull/2603.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
