### PR TITLE
Delete VolumeAttachments on hibernation

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -412,6 +412,19 @@ func (b *Botanist) HibernateControlPlane(ctx context.Context) error {
 		if err := b.WaitUntilEndpointsDoNotContainPodIPs(ctxWithTimeOut); err != nil {
 			return err
 		}
+
+		// TODO: remove this mitigation once there is a garbage collection for VolumeAttachments (ref https://github.com/kubernetes/kubernetes/issues/77324)
+		// Currently on hibernation Machines are forecefully deleted and machine-controller-manager does not wait volumes to be detached.
+		// In this case kube-controller-manager cannot delete the corresponding VolumeAttachment objects and they are orphaned.
+		// Such orphaned VolumeAttachments then prevent/block PV deletion. For more details see https://github.com/gardener/gardener-extension-provider-gcp/issues/172.
+		// As the Nodes are already deleted, we can delete all VolumeAttachments.
+		if err := DeleteVolumeAttachments(ctxWithTimeOut, b.K8sShootClient.Client()); err != nil {
+			return err
+		}
+
+		if err := WaitUntilVolumeAttachmentsDeleted(ctxWithTimeOut, b.K8sShootClient.Client(), b.Logger); err != nil {
+			return err
+		}
 	}
 
 	// invalidate shoot client here before scaling down API server

--- a/pkg/operation/botanist/volumeattachments.go
+++ b/pkg/operation/botanist/volumeattachments.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gardener/gardener/pkg/utils/retry"
+
+	"github.com/sirupsen/logrus"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DeleteVolumeAttachments deletes all VolumeAttachments.
+func DeleteVolumeAttachments(ctx context.Context, c client.Client) error {
+	return c.DeleteAllOf(
+		ctx,
+		&storagev1beta1.VolumeAttachment{},
+	)
+}
+
+// WaitUntilVolumeAttachmentsDeleted waits until no VolumeAttachments exist anymore.
+func WaitUntilVolumeAttachmentsDeleted(ctx context.Context, c client.Client, log *logrus.Entry) error {
+	return retry.Until(ctx, 5*time.Second, func(ctx context.Context) (done bool, err error) {
+		vaList := &storagev1beta1.VolumeAttachmentList{}
+		if err := c.List(ctx, vaList); err != nil {
+			return retry.SevereError(err)
+		}
+
+		if len(vaList.Items) == 0 {
+			return retry.Ok()
+		}
+
+		log.Infof("Waiting until all VolumeAttachments have been deleted in the shoot cluster...")
+		return retry.MinorError(fmt.Errorf("not all VolumeAttachments have been deleted in the shoot cluster"))
+	})
+}

--- a/pkg/operation/botanist/volumeattachments_test.go
+++ b/pkg/operation/botanist/volumeattachments_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/gardener/gardener/pkg/logger"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	"github.com/gardener/gardener/pkg/operation/botanist"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("VolumeAttachments", func() {
+
+	var (
+		ctrl *gomock.Controller
+		c    *mockclient.MockClient
+		log  *logrus.Entry
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		c = mockclient.NewMockClient(ctrl)
+		log = logrus.NewEntry(logger.NewNopLogger())
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#WaitUntilVolumeAttachmentsDeleted", func() {
+		It("should return nil when there are no VolumeAttachments", func() {
+			c.EXPECT().List(context.TODO(), gomock.AssignableToTypeOf(&storagev1beta1.VolumeAttachmentList{})).Return(nil)
+
+			err := botanist.WaitUntilVolumeAttachmentsDeleted(context.TODO(), c, log)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return err when the context is cancelled", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&storagev1beta1.VolumeAttachmentList{})).DoAndReturn(func(_ context.Context, list *storagev1beta1.VolumeAttachmentList, _ ...client.ListOption) error {
+				items := []storagev1beta1.VolumeAttachment{
+					{ObjectMeta: metav1.ObjectMeta{Name: "csi-a8d88f2004683df6a875c361481931bbf033f6af92e39e60acf14f891d9c0731"}},
+				}
+				*list = storagev1beta1.VolumeAttachmentList{Items: items}
+				return nil
+			})
+
+			err := botanist.WaitUntilVolumeAttachmentsDeleted(ctx, c, log)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind bug
/priority normal

**What this PR does / why we need it**:
Delete VolumeAttachments on hibernation.

**Which issue(s) this PR fixes**:
Fixes #2545
Fixes https://github.com/gardener/gardener-extension-provider-gcp/issues/172
Fixes #2958


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
gardenlet is now deleting all `VolumeAttachment`s on shoot hibernation. As during hibernation machine-controller-manager performs a "force" deletion of machines and does not wait for volumes to detach, kube-controller-manager is not able to delete the corresponding `VolumeAttachment`s (and also the external-attacher to notice this deletion and remove its finalizer from the VolumeAttachment). Deleting `VolumeAttachment`s on hibernation should prevent `VolumeAttachment`s to be orphaned. Currently in the upstream kube-controller-manager, there is no garbage collection for `VolumeAttachment`s (see [kubernetes/kubernetes#77324](https://github.com/kubernetes/kubernetes/issues/77324)).
```
