### PR TITLE
Shoot deletion from hibernation improvements

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -295,70 +295,6 @@ func (b *Botanist) DeleteClusterAutoscaler(ctx context.Context) error {
 	return client.IgnoreNotFound(b.K8sSeedClient.Client().Delete(ctx, deploy, kubernetes.DefaultDeleteOptions...))
 }
 
-// WakeUpControlPlane scales the replicas to 1 for the following deployments which are needed in case of shoot deletion:
-// * etcd-events
-// * etcd-main
-// * kube-apiserver
-// * kube-controller-manager
-func (b *Botanist) WakeUpControlPlane(ctx context.Context) error {
-	// use direct client here, as cached client sometimes causes scale functions not to work properly
-	// e.g. Deployments not scaled down/up
-	client := b.K8sSeedClient.DirectClient()
-
-	for _, etcd := range []string{v1beta1constants.ETCDEvents, v1beta1constants.ETCDMain} {
-		if err := kubernetes.ScaleEtcd(ctx, client, kutil.Key(b.Shoot.SeedNamespace, etcd), 1); err != nil {
-			return err
-		}
-	}
-	if err := b.WaitUntilEtcdReady(ctx); err != nil {
-		return err
-	}
-
-	if err := component.OpWaiter(b.Shoot.Components.ControlPlane.KubeAPIServerService).Deploy(ctx); err != nil {
-		return err
-	}
-
-	if b.APIServerSNIEnabled() {
-		if err := b.DestroyControlPlaneExposure(ctx); err != nil {
-			return err
-		}
-
-		if err := b.DeployKubeAPIServerSNI(ctx); err != nil {
-			return err
-		}
-	}
-
-	if err := b.DeployInternalDNS(ctx); err != nil {
-		return err
-	}
-
-	if err := b.DeployExternalDNS(ctx); err != nil {
-		return err
-	}
-
-	if err := b.DeployKubeAPIServer(ctx); err != nil {
-		return err
-	}
-
-	if err := kubernetes.ScaleDeployment(ctx, client, kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), 1); err != nil {
-		return err
-	}
-	if err := b.WaitUntilKubeAPIServerReady(ctx); err != nil {
-		return err
-	}
-
-	for _, deployment := range []string{
-		v1beta1constants.DeploymentNameKubeControllerManager,
-		v1beta1constants.DeploymentNameGardenerResourceManager,
-	} {
-		if err := kubernetes.ScaleDeployment(ctx, client, kutil.Key(b.Shoot.SeedNamespace, deployment), 1); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // WakeUpKubeAPIServer creates a service and ensures API Server is scaled up
 func (b *Botanist) WakeUpKubeAPIServer(ctx context.Context) error {
 	sniPhase := b.Shoot.Components.ControlPlane.KubeAPIServerSNIPhase.Done()
@@ -457,7 +393,7 @@ func (b *Botanist) HibernateControlPlane(ctx context.Context) error {
 // ScaleETCDToZero scales ETCD main and events to zero
 func (b *Botanist) ScaleETCDToZero(ctx context.Context) error {
 	for _, etcd := range []string{v1beta1constants.ETCDEvents, v1beta1constants.ETCDMain} {
-		if err := kubernetes.ScaleEtcd(ctx, b.K8sSeedClient.Client(), kutil.Key(b.Shoot.SeedNamespace, etcd), 0); client.IgnoreNotFound(err) != nil {
+		if err := kubernetes.ScaleEtcd(ctx, b.K8sSeedClient.DirectClient(), kutil.Key(b.Shoot.SeedNamespace, etcd), 0); client.IgnoreNotFound(err) != nil {
 			return err
 		}
 	}
@@ -467,16 +403,26 @@ func (b *Botanist) ScaleETCDToZero(ctx context.Context) error {
 // ScaleETCDToOne scales ETCD main and events replicas to one
 func (b *Botanist) ScaleETCDToOne(ctx context.Context) error {
 	for _, etcd := range []string{v1beta1constants.ETCDEvents, v1beta1constants.ETCDMain} {
-		if err := kubernetes.ScaleEtcd(ctx, b.K8sSeedClient.Client(), kutil.Key(b.Shoot.SeedNamespace, etcd), 1); err != nil {
+		if err := kubernetes.ScaleEtcd(ctx, b.K8sSeedClient.DirectClient(), kutil.Key(b.Shoot.SeedNamespace, etcd), 1); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
+// ScaleKubeAPIServerToOne scales kube-apiserver replicas to one
+func (b *Botanist) ScaleKubeAPIServerToOne(ctx context.Context) error {
+	return kubernetes.ScaleDeployment(ctx, b.K8sSeedClient.DirectClient(), kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), 1)
+}
+
+// ScaleKubeControllerManagerToOne scales kube-controller-manager replicas to one
+func (b *Botanist) ScaleKubeControllerManagerToOne(ctx context.Context) error {
+	return kubernetes.ScaleDeployment(ctx, b.K8sSeedClient.DirectClient(), kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeControllerManager), 1)
+}
+
 // ScaleGardenerResourceManagerToOne scales the gardener-resource-manager deployment
 func (b *Botanist) ScaleGardenerResourceManagerToOne(ctx context.Context) error {
-	return kubernetes.ScaleDeployment(ctx, b.K8sSeedClient.Client(), kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameGardenerResourceManager), 1)
+	return kubernetes.ScaleDeployment(ctx, b.K8sSeedClient.DirectClient(), kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameGardenerResourceManager), 1)
 }
 
 // PrepareKubeAPIServerForMigration deletes the kube-apiserver and deletes its hvpa


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind technical-debt
/priority normal

**What this PR does / why we need it**:

- Now all control plane-related steps from the standard reconciliation are executed
- Remove `WakeUpControlPlane` method

`WakeUpControlPlane` was attempting to do everything related to waking up a control plane of the cluster, but it was not doing things in parallel or any errors would cause the entire function to be executed from the start. There was quite a lot of duplication and missing steps which would result in a situations where the deletion would fail e.g. missing `DeployReferencedResources` step.

**Which issue(s) this PR fixes**:
Fixes #1240

**Special notes for your reviewer**:

A similar `WakeUpKubeAPIServer` method exists which would be fixed in the same manner in another PR. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
