### PR TITLE
Use StrategicMergePatch to scale resources

### DIFF
--- a/pkg/client/kubernetes/scaling.go
+++ b/pkg/client/kubernetes/scaling.go
@@ -16,48 +16,58 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	appsv1 "k8s.io/api/apps/v1"
 
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ScaleStatefulSet scales a StatefulSet.
 func ScaleStatefulSet(ctx context.Context, c client.Client, key client.ObjectKey, replicas int32) error {
-	// TODO: replace this with call to scale subresource once controller-runtime supports it
-	// see: https://github.com/kubernetes-sigs/controller-runtime/issues/172
-	statefulset := &appsv1.StatefulSet{}
-	if err := c.Get(ctx, key, statefulset); err != nil {
-		return err
+	statefulset := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
 	}
 
-	statefulset.Spec.Replicas = &replicas
-	return c.Update(ctx, statefulset)
+	return scaleResource(ctx, c, statefulset, replicas)
 }
 
 // ScaleEtcd scales a Etcd resource.
 func ScaleEtcd(ctx context.Context, c client.Client, key client.ObjectKey, replicas int) error {
-	// TODO: replace this with call to scale subresource once controller-runtime supports it
-	// see: https://github.com/kubernetes-sigs/controller-runtime/issues/172
-	etcd := &druidv1alpha1.Etcd{}
-	if err := c.Get(ctx, key, etcd); err != nil {
-		return err
+	etcd := &druidv1alpha1.Etcd{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
 	}
 
-	etcd.Spec.Replicas = replicas
-	return c.Update(ctx, etcd)
+	return scaleResource(ctx, c, etcd, int32(replicas))
 }
 
 // ScaleDeployment scales a Deployment.
 func ScaleDeployment(ctx context.Context, c client.Client, key client.ObjectKey, replicas int32) error {
-	// TODO: replace this with call to scale subresource once controller-runtime supports it
-	// see: https://github.com/kubernetes-sigs/controller-runtime/issues/172
-	deployment := &appsv1.Deployment{}
-	if err := c.Get(ctx, key, deployment); err != nil {
-		return err
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
 	}
 
-	deployment.Spec.Replicas = &replicas
-	return c.Update(ctx, deployment)
+	return scaleResource(ctx, c, deployment, replicas)
+}
+
+// scaleResource scales resource's 'spec.replicas' to replicas count
+func scaleResource(ctx context.Context, c client.Client, obj runtime.Object, replicas int32) error {
+	patch := []byte(fmt.Sprintf(`{"spec":{"replicas":%d}}`, replicas))
+
+	// TODO: replace this with call to scale subresource once controller-runtime supports it
+	// see: https://github.com/kubernetes-sigs/controller-runtime/issues/172
+	return c.Patch(ctx, obj, client.RawPatch(types.StrategicMergePatchType, patch))
 }

--- a/pkg/client/kubernetes/scaling_test.go
+++ b/pkg/client/kubernetes/scaling_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes_test
+
+import (
+	"context"
+
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	. "github.com/gardener/gardener/pkg/client/kubernetes"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+var _ = Describe("scale", func() {
+	var (
+		ctx context.Context
+		c   client.Client
+		key client.ObjectKey
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		key = client.ObjectKey{Name: "foo", Namespace: "bar"}
+		om := metav1.ObjectMeta{Name: "foo", Namespace: "bar"}
+
+		s := runtime.NewScheme()
+		Expect(appsv1.AddToScheme(s)).NotTo(HaveOccurred(), "adding apps to schema succeeds")
+		Expect(druidv1alpha1.AddToScheme(s)).NotTo(HaveOccurred(), "adding druid to schema succeeds")
+
+		c = fake.NewFakeClientWithScheme(s,
+			&appsv1.StatefulSet{ObjectMeta: om},
+			&appsv1.Deployment{ObjectMeta: om},
+			&druidv1alpha1.Etcd{ObjectMeta: om},
+		)
+	})
+
+	Context("ScaleStatefulSet", func() {
+		It("sets scale to 2", func() {
+			Expect(ScaleStatefulSet(ctx, c, key, 2)).NotTo(HaveOccurred(), "scale succeeds")
+
+			updated := &appsv1.StatefulSet{}
+			Expect(c.Get(ctx, key, updated)).NotTo(HaveOccurred(), "could get the updated resource")
+
+			Expect(updated.Spec.Replicas).To(PointTo(BeEquivalentTo(2)), "updated replica")
+		})
+	})
+
+	Context("ScaleDeployment", func() {
+		It("sets scale to 2", func() {
+			Expect(ScaleDeployment(ctx, c, key, 2)).NotTo(HaveOccurred(), "scale succeeds")
+
+			updated := &appsv1.Deployment{}
+			Expect(c.Get(ctx, key, updated)).NotTo(HaveOccurred(), "could get the updated resource")
+
+			Expect(updated.Spec.Replicas).To(PointTo(BeEquivalentTo(2)), "updated replica")
+		})
+	})
+
+	Context("ScaleEtcd", func() {
+		It("sets scale to 2", func() {
+			Expect(ScaleEtcd(ctx, c, key, 2)).NotTo(HaveOccurred(), "scale succeeds")
+
+			updated := &druidv1alpha1.Etcd{}
+			Expect(c.Get(ctx, key, updated)).NotTo(HaveOccurred(), "could get the updated resource")
+
+			Expect(updated.Spec.Replicas).To(BeEquivalentTo(2), "updated replica")
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup
/priority normal

**What this PR does / why we need it**:

Strategic Merge Patch always updates the resource, regardless of current `resourceVersion` (the api call doesn't fail if the resource was updated). This is the desired behavior of the function.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
