### PR TITLE
Allow again some seed taints to be used

### DIFF
--- a/docs/concepts/scheduler.md
+++ b/docs/concepts/scheduler.md
@@ -71,7 +71,7 @@ Once this list has been computed the scheduler tries to find the best one out of
 It filters out `Seed`s
 
 * whose networks have intersections with the `Shoot`'s networks (due to the VPN connectivity between seeds and shoots their networks must be disjoint)
-* that are tainted with the `seed.gardener.cloud/disable-dns` taint (only if the shoot specifies a DNS domain or does not use the `unmanaged` DNS provider)
+* that have `.spec.settings.shootDNS.enabled=false` (only if the shoot specifies a DNS domain or does not use the `unmanaged` DNS provider)
 * whose labels don't match the `.spec.seedSelector` field of the `CloudProfile` that is used in the `Shoot` (there might be multiple environments for the same provider type, e.g., you might have multiple OpenStack systems connected to Gardener)
 
 After this filtering process the least utilized seed, i.e., the one with the least number of shoot control planes, will be the winner and written to the `.spec.seedName` field of the `Shoot`.

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -55,7 +55,7 @@ When the `gardenlet` starts it scans the `garden` namespace of the garden cluste
   * Not every end-user/stakeholder/customer has its own domain, however, Gardener needs to create a DNS record for every shoot cluster.
   * As landscape operator you might want to define a default domain owned and controlled by you that is used for all shoot clusters that don't specify their own domain.
 
-:warning: Please note that the mentioned domain secrets are only needed if you have at least one seed cluster that is not tainted with `seed.gardener.cloud/disable-dns`.
+:warning: Please note that the mentioned domain secrets are only needed if you have at least one seed cluster that is not specifing `.spec.settings.shootDNS.enabled=false`.
 Seeds with this taint don't create any DNS records for shoots scheduled on it, hence, if you only have such seeds, you don't need to create the domain secrets.
 
 * **Alerting secrets** (optional), contain the alerting configuration and credentials for the [AlertManager](https://prometheus.io/docs/alerting/alertmanager/) to send email alerts. It is also possible to configure the monitoring stack to send alerts to an AlertManager not deployed by Gardener to handle alerting. Please see [this](../../example/10-secret-alerting.yaml) for an example.

--- a/pkg/apis/core/v1alpha1/defaults.go
+++ b/pkg/apis/core/v1alpha1/defaults.go
@@ -117,20 +117,6 @@ func SetDefaults_Seed(obj *Seed) {
 	if obj.Spec.Settings.VerticalPodAutoscaler == nil {
 		obj.Spec.Settings.VerticalPodAutoscaler = &SeedSettingVerticalPodAutoscaler{Enabled: true}
 	}
-
-	// TODO: remove taints removal in version >=1.13
-	taintsToRemove := []string{
-		"seed.gardener.cloud/disable-capacity-reservation",
-		"seed.gardener.cloud/disable-dns",
-		"seed.gardener.cloud/invisible",
-	}
-	for _, taint := range taintsToRemove {
-		for i := len(obj.Spec.Taints) - 1; i >= 0; i-- {
-			if obj.Spec.Taints[i].Key == taint {
-				obj.Spec.Taints = append(obj.Spec.Taints[:i], obj.Spec.Taints[i+1:]...)
-			}
-		}
-	}
 }
 
 // SetDefaults_Shoot sets default values for Shoot objects.

--- a/pkg/apis/core/v1alpha1/defaults_test.go
+++ b/pkg/apis/core/v1alpha1/defaults_test.go
@@ -233,12 +233,13 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Spec.Settings.VerticalPodAutoscaler.Enabled).To(BeTrue())
 		})
 
-		It("should remove deprecated taints from the seed settings (w/ taints)", func() {
-			obj.Spec.Taints = []SeedTaint{
+		It("should allow taints that were not allowed in version v1.12", func() {
+			taints := []SeedTaint{
 				{Key: "seed.gardener.cloud/disable-capacity-reservation"},
 				{Key: "seed.gardener.cloud/disable-dns"},
 				{Key: "seed.gardener.cloud/invisible"},
 			}
+			obj.Spec.Taints = taints
 
 			SetDefaults_Seed(obj)
 
@@ -246,25 +247,8 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Spec.Settings.Scheduling.Visible).To(BeTrue())
 			Expect(obj.Spec.Settings.ShootDNS.Enabled).To(BeTrue())
 			Expect(obj.Spec.Settings.VerticalPodAutoscaler.Enabled).To(BeTrue())
-			Expect(obj.Spec.Taints).To(BeEmpty())
-		})
-
-		It("should keep non-deprecated taints from the seed settings (w/ taints)", func() {
-			obj.Spec.Taints = []SeedTaint{
-				{Key: "seed.gardener.cloud/disable-capacity-reservation"},
-				{Key: "seed.gardener.cloud/disable-dns"},
-				{Key: "seed.gardener.cloud/invisible"},
-				{Key: SeedTaintProtected},
-			}
-
-			SetDefaults_Seed(obj)
-
-			Expect(obj.Spec.Settings.ExcessCapacityReservation.Enabled).To(BeTrue())
-			Expect(obj.Spec.Settings.Scheduling.Visible).To(BeTrue())
-			Expect(obj.Spec.Settings.ShootDNS.Enabled).To(BeTrue())
-			Expect(obj.Spec.Settings.VerticalPodAutoscaler.Enabled).To(BeTrue())
-			Expect(obj.Spec.Taints).To(HaveLen(1))
-			Expect(obj.Spec.Taints[0].Key).To(Equal(SeedTaintProtected))
+			Expect(obj.Spec.Taints).To(HaveLen(3))
+			Expect(obj.Spec.Taints).To(Equal(taints))
 		})
 
 		It("should not default the seed settings because they were provided", func() {

--- a/pkg/apis/core/v1beta1/defaults.go
+++ b/pkg/apis/core/v1beta1/defaults.go
@@ -117,20 +117,6 @@ func SetDefaults_Seed(obj *Seed) {
 	if obj.Spec.Settings.VerticalPodAutoscaler == nil {
 		obj.Spec.Settings.VerticalPodAutoscaler = &SeedSettingVerticalPodAutoscaler{Enabled: true}
 	}
-
-	// TODO: remove taints removal in version >=1.13
-	taintsToRemove := []string{
-		"seed.gardener.cloud/disable-capacity-reservation",
-		"seed.gardener.cloud/disable-dns",
-		"seed.gardener.cloud/invisible",
-	}
-	for _, taint := range taintsToRemove {
-		for i := len(obj.Spec.Taints) - 1; i >= 0; i-- {
-			if obj.Spec.Taints[i].Key == taint {
-				obj.Spec.Taints = append(obj.Spec.Taints[:i], obj.Spec.Taints[i+1:]...)
-			}
-		}
-	}
 }
 
 // SetDefaults_Shoot sets default values for Shoot objects.

--- a/pkg/apis/core/v1beta1/defaults_test.go
+++ b/pkg/apis/core/v1beta1/defaults_test.go
@@ -234,12 +234,13 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Spec.Settings.VerticalPodAutoscaler.Enabled).To(BeTrue())
 		})
 
-		It("should remove deprecated taints from the seed settings (w/ taints)", func() {
-			obj.Spec.Taints = []SeedTaint{
+		It("should allow taints that were not allowed in version v1.12", func() {
+			taints := []SeedTaint{
 				{Key: "seed.gardener.cloud/disable-capacity-reservation"},
 				{Key: "seed.gardener.cloud/disable-dns"},
 				{Key: "seed.gardener.cloud/invisible"},
 			}
+			obj.Spec.Taints = taints
 
 			SetDefaults_Seed(obj)
 
@@ -247,25 +248,8 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Spec.Settings.Scheduling.Visible).To(BeTrue())
 			Expect(obj.Spec.Settings.ShootDNS.Enabled).To(BeTrue())
 			Expect(obj.Spec.Settings.VerticalPodAutoscaler.Enabled).To(BeTrue())
-			Expect(obj.Spec.Taints).To(BeEmpty())
-		})
-
-		It("should keep non-deprecated taints from the seed settings (w/ taints)", func() {
-			obj.Spec.Taints = []SeedTaint{
-				{Key: "seed.gardener.cloud/disable-capacity-reservation"},
-				{Key: "seed.gardener.cloud/disable-dns"},
-				{Key: "seed.gardener.cloud/invisible"},
-				{Key: SeedTaintProtected},
-			}
-
-			SetDefaults_Seed(obj)
-
-			Expect(obj.Spec.Settings.ExcessCapacityReservation.Enabled).To(BeTrue())
-			Expect(obj.Spec.Settings.Scheduling.Visible).To(BeTrue())
-			Expect(obj.Spec.Settings.ShootDNS.Enabled).To(BeTrue())
-			Expect(obj.Spec.Settings.VerticalPodAutoscaler.Enabled).To(BeTrue())
-			Expect(obj.Spec.Taints).To(HaveLen(1))
-			Expect(obj.Spec.Taints[0].Key).To(Equal(SeedTaintProtected))
+			Expect(obj.Spec.Taints).To(HaveLen(3))
+			Expect(obj.Spec.Taints).To(Equal(taints))
 		})
 
 		It("should not default the seed settings because they were provided", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind cleanup
/priority normal

**What this PR does / why we need it**:
Allows again some seed taints to be used.

**Which issue(s) this PR fixes**:
Follow up on #2955 

**Special notes for your reviewer**:
Merge after v1.12 is released.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
It is again allowed the seed taints `seed.gardener.cloud/disable-capacity-reservation`, `seed.gardener.cloud/disable-dns` and `seed.gardener.cloud/invisible` to be used. Note, these taints have been replaced by `seed.spec.settings` fields and there is no special semantic behind them anymore.
```
