### PR TITLE
[GEP-7] Add ability to migrate shoot in the integration tests

### DIFF
--- a/.test-defs/MigrateShoot.yaml
+++ b/.test-defs/MigrateShoot.yaml
@@ -1,0 +1,18 @@
+kind: TestDefinition
+metadata:
+  name: migrate-shoot
+spec:
+  owner: gardener-oq@listserv.sap.com
+  description: Tests the migration of a shoot.
+  activeDeadlineSeconds: 3600
+
+  command: [bash, -c]
+  args:
+  - >-
+    go test -timeout=0 -mod=vendor ./test/system/shoot_cp_migration
+    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+    -target-seed-name=$SEED_NAME
+    -shoot-name=$SHOOT_NAME
+    -shoot-namespace=$PROJECT_NAMESPACE
+    -kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
+  image: golang:1.15.3

--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -312,10 +312,13 @@ func ShootCreationCompleted(newShoot *gardencorev1beta1.Shoot) (bool, string) {
 
 	if newShoot.Status.LastOperation != nil {
 		if newShoot.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeCreate ||
-			newShoot.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeReconcile {
+			newShoot.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeReconcile ||
+			newShoot.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeRestore {
 			if newShoot.Status.LastOperation.State != gardencorev1beta1.LastOperationStateSucceeded {
-				return false, "last operation type was create or reconcile but state was not succeeded"
+				return false, "last operation type was create, reconcile or restore but state was not succeeded"
 			}
+		} else if newShoot.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeMigrate {
+			return false, "last operation type was migrate, the migration process is not finished yet"
 		}
 	}
 

--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -37,7 +37,7 @@ import (
 
 // ShootSeedNamespace gets the shoot namespace in the seed
 func (f *ShootFramework) ShootSeedNamespace() string {
-	return computeTechnicalID(f.Project.Name, f.Shoot)
+	return ComputeTechnicalID(f.Project.Name, f.Shoot)
 }
 
 // ShootKubeconfigSecretName gets the name of the secret with the kubeconfig of the shoot

--- a/test/framework/shootframework.go
+++ b/test/framework/shootframework.go
@@ -218,7 +218,7 @@ func (f *ShootFramework) AddShoot(ctx context.Context, shootName, shootNamespace
 		return errors.Wrap(err, "could not add schemes to shoot scheme")
 	}
 	if err := retry.UntilTimeout(ctx, k8sClientInitPollInterval, k8sClientInitTimeout, func(ctx context.Context) (bool, error) {
-		shootClient, err = kubernetes.NewClientFromSecret(ctx, f.SeedClient.DirectClient(), computeTechnicalID(f.Project.Name, shoot), gardencorev1beta1.GardenerName, kubernetes.WithClientOptions(client.Options{
+		shootClient, err = kubernetes.NewClientFromSecret(ctx, f.SeedClient.DirectClient(), ComputeTechnicalID(f.Project.Name, shoot), gardencorev1beta1.GardenerName, kubernetes.WithClientOptions(client.Options{
 			Scheme: shootScheme,
 		}))
 		if err != nil {

--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -1,0 +1,224 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"sort"
+
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+
+	"github.com/pkg/errors"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ShootMigrationTest represents a shoot migration test.
+// It can be used to test the migration of shoots between various seeds.
+type ShootMigrationTest struct {
+	GardenerFramework                 *GardenerFramework
+	Config                            *ShootMigrationConfig
+	TargetSeedClient                  kubernetes.Interface
+	SourceSeedClient                  kubernetes.Interface
+	ShootClient                       kubernetes.Interface
+	TargetSeed                        *gardencorev1beta1.Seed
+	SourceSeed                        *gardencorev1beta1.Seed
+	ComparisonElementsBeforeMigration ShootComparisonElements
+	ComparisonElementsAfterMigration  ShootComparisonElements
+	Shoot                             gardencorev1beta1.Shoot
+	SeedShootNamespace                string
+	MigrationTime                     metav1.Time
+}
+
+// ShootMigrationConfig is the configuration for a shoot migration test that will be filled with user provided data
+type ShootMigrationConfig struct {
+	TargetSeedName string
+	SourceSeedName string
+	ShootName      string
+	ShootNamespace string
+}
+
+// ShootComparisonElements contains details about Machines and Nodes that will be compared during the tests
+type ShootComparisonElements struct {
+	MachineNames []string
+	MachineNodes []string
+	NodeNames    []string
+}
+
+// NewShootMigrationTest creates a new simple shoot migration test
+func NewShootMigrationTest(f *GardenerFramework, cfg *ShootMigrationConfig) *ShootMigrationTest {
+	t := &ShootMigrationTest{
+		GardenerFramework: f,
+		Config:            cfg,
+	}
+	return t
+}
+
+// MigrateShoot triggers shoot migration by changing the value of "shoot.Spec.SeedName" to the value of "ShootMigrationConfig.TargetSeedName"
+func (t *ShootMigrationTest) MigrateShoot(ctx context.Context) error {
+	// Dump gardener state if delete shoot is in exit handler
+	if os.Getenv("TM_PHASE") == "Exit" {
+		if shootFramework, err := t.GardenerFramework.NewShootFramework(&t.Shoot); err == nil {
+			shootFramework.DumpState(ctx)
+		} else {
+			t.GardenerFramework.DumpState(ctx)
+		}
+	}
+
+	if err := t.GardenerFramework.UpdateShoot(ctx, &t.Shoot, func(shoot *gardencorev1beta1.Shoot) error {
+		t := gardencorev1beta1.Toleration{}
+		t.Key = core.SeedTaintProtected
+
+		if shoot.Spec.Tolerations == nil {
+			shoot.Spec.Tolerations = make([]gardencorev1beta1.Toleration, 0)
+		} else {
+			for _, t := range shoot.Spec.Tolerations {
+				if t.Key == core.SeedTaintProtected {
+					return nil
+				}
+			}
+		}
+		shoot.Spec.Tolerations = append(shoot.Spec.Tolerations, t)
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	t.MigrationTime = metav1.Now()
+	return t.GardenerFramework.MigrateShoot(ctx, &t.Shoot, t.TargetSeed)
+}
+
+// GetNodeNames uses the shootClient to fetch all Node names from the Shoot
+func (t *ShootMigrationTest) GetNodeNames(ctx context.Context, shootClient kubernetes.Interface) (nodeNames []string, err error) {
+	nodeList := corev1.NodeList{}
+	t.GardenerFramework.Logger.Infof("Getting node names...")
+	if err := shootClient.Client().List(ctx, &nodeList); err != nil {
+		return nil, err
+	}
+
+	nodeNames = make([]string, len(nodeList.Items))
+	for i, node := range nodeList.Items {
+		t.GardenerFramework.Logger.Infof("%d. %s", i, node.Name)
+		nodeNames[i] = node.Name
+	}
+	sort.Strings(nodeNames)
+	return
+}
+
+// GetMachineDetails uses the seedClient to fetch all Machine names and the names of their corresponding Nodes
+func (t *ShootMigrationTest) GetMachineDetails(ctx context.Context, seedClient kubernetes.Interface) (machineNames, machineNodes []string, err error) {
+	machineList := unstructured.UnstructuredList{}
+	machineList.SetAPIVersion("machine.sapcloud.io/v1alpha1")
+	machineList.SetKind("Machine")
+	t.GardenerFramework.Logger.Infof("Getting machine details in namespace: %s", t.SeedShootNamespace)
+	if err := seedClient.Client().List(ctx, &machineList, client.InNamespace(t.SeedShootNamespace)); err != nil {
+		t.GardenerFramework.Logger.Errorf("Error while getting Machine details, %s", err.Error())
+		return nil, nil, err
+	}
+
+	t.GardenerFramework.Logger.Infof("Found: %d Machine items", len(machineList.Items))
+
+	machineNames = make([]string, len(machineList.Items))
+	machineNodes = make([]string, len(machineList.Items))
+	for i, machine := range machineList.Items {
+		t.GardenerFramework.Logger.Infof("%d. Machine Name: %s, Node Name: %s", i, machine.GetName(), machine.GetLabels()["node"])
+		machineNames[i] = machine.GetName()
+		machineNodes[i] = machine.GetLabels()["node"]
+	}
+	sort.Strings(machineNames)
+	sort.Strings(machineNodes)
+	return
+}
+
+// PopulateBeforeMigrationComparisonElements fills the ShootMigrationTest.ComparisonElementsBeforeMigration with the necessary Machine details and Node names
+func (t *ShootMigrationTest) PopulateBeforeMigrationComparisonElements(ctx context.Context) (err error) {
+	t.ComparisonElementsBeforeMigration.MachineNames, t.ComparisonElementsBeforeMigration.MachineNodes, err = t.GetMachineDetails(ctx, t.SourceSeedClient)
+	if err != nil {
+		return
+	}
+	t.ComparisonElementsBeforeMigration.NodeNames, err = t.GetNodeNames(ctx, t.ShootClient)
+	return
+}
+
+// PopulateAfterMigrationComparisonElements fills the ShootMigrationTest.ComparisonElementsAfterMigration with the necessary Machine details and Node names
+func (t *ShootMigrationTest) PopulateAfterMigrationComparisonElements(ctx context.Context) (err error) {
+	t.ComparisonElementsAfterMigration.MachineNames, t.ComparisonElementsAfterMigration.MachineNodes, err = t.GetMachineDetails(ctx, t.TargetSeedClient)
+	if err != nil {
+		return
+	}
+	t.ComparisonElementsAfterMigration.NodeNames, err = t.GetNodeNames(ctx, t.ShootClient)
+	return
+}
+
+// CompareElementsAfterMigration compares the Machine details, Node names and Pod statuses before and after migration and returns error if there are diferences.
+func (t *ShootMigrationTest) CompareElementsAfterMigration() error {
+	if !reflect.DeepEqual(t.ComparisonElementsBeforeMigration.MachineNames, t.ComparisonElementsAfterMigration.MachineNames) {
+		return errors.Errorf("initial Machines %s, do not match after-migrate Machines %s", t.ComparisonElementsBeforeMigration.MachineNames, t.ComparisonElementsAfterMigration.MachineNames)
+	}
+	if !reflect.DeepEqual(t.ComparisonElementsBeforeMigration.MachineNodes, t.ComparisonElementsAfterMigration.MachineNodes) {
+		return errors.Errorf("initial Machine Nodes (label) %s, do not match after-migrate Machine Nodes (label) %s", t.ComparisonElementsBeforeMigration.MachineNodes, t.ComparisonElementsAfterMigration.MachineNodes)
+	}
+	if !reflect.DeepEqual(t.ComparisonElementsBeforeMigration.NodeNames, t.ComparisonElementsAfterMigration.NodeNames) {
+		return errors.Errorf("initial Nodes %s, do not match after-migrate Nodes %s", t.ComparisonElementsBeforeMigration.NodeNames, t.ComparisonElementsAfterMigration.NodeNames)
+	}
+	if !reflect.DeepEqual(t.ComparisonElementsAfterMigration.MachineNodes, t.ComparisonElementsAfterMigration.NodeNames) {
+		return errors.Errorf("machine Nodes (label) %s, do not match after-migrate Nodes %s", t.ComparisonElementsAfterMigration.MachineNodes, t.ComparisonElementsAfterMigration.NodeNames)
+	}
+	return nil
+}
+
+// Check the timestamp of all objects that the resource-manager creates in the Shoot cluster.
+// The timestamp should not be after the ShootMigrationTest.MigrationTime
+func (t *ShootMigrationTest) CheckObjectsTimestamp(ctx context.Context) error {
+	mrList := &resourcesv1alpha1.ManagedResourceList{}
+	if err := t.TargetSeedClient.DirectClient().List(
+		ctx,
+		mrList,
+		client.InNamespace(t.SeedShootNamespace),
+	); err != nil {
+		return err
+	}
+
+	for _, mr := range mrList.Items {
+		if mr.Spec.Class == nil || *mr.Spec.Class != "seed" {
+			t.GardenerFramework.Logger.Infof("=== Managed Resource: %s/%s ===", mr.Namespace, mr.Name)
+			for _, r := range mr.Status.Resources {
+				obj := &unstructured.Unstructured{}
+				obj.SetAPIVersion(r.APIVersion)
+				obj.SetKind(r.Kind)
+
+				if err := t.ShootClient.Client().Get(ctx, client.ObjectKey{Namespace: r.Namespace, Name: r.Name}, obj); err != nil {
+					return err
+				}
+
+				createionTimestamp := obj.GetCreationTimestamp()
+				t.GardenerFramework.Logger.Infof("Object: %s %s/%s Created At: %s", obj.GetKind(), obj.GetNamespace(), obj.GetName(), createionTimestamp)
+				if t.MigrationTime.Before(&createionTimestamp) {
+					return errors.Errorf("object: %s %s/%s Created At: %s is created after the Shoot migration %s", obj.GetKind(), obj.GetNamespace(), obj.GetName(), createionTimestamp, t.MigrationTime)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/test/framework/utils.go
+++ b/test/framework/utils.go
@@ -79,7 +79,8 @@ func Set(dst, src interface{}) {
 	dstValue.Elem().Set(srcValue)
 }
 
-func computeTechnicalID(projectName string, shoot *gardencorev1beta1.Shoot) string {
+//ComputeTechnicalID computes the technical ID of a shoot
+func ComputeTechnicalID(projectName string, shoot *gardencorev1beta1.Shoot) string {
 	// Use the stored technical ID in the Shoot's status field if it's there.
 	// For backwards compatibility we keep the pattern as it was before we had to change it
 	// (double hyphens).

--- a/test/system/shoot_cp_migration/migrate_suite_test.go
+++ b/test/system/shoot_cp_migration/migrate_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cp_migration_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCPMigrationApplications(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CP Migration Test Suite")
+}

--- a/test/system/shoot_cp_migration/migrate_test.go
+++ b/test/system/shoot_cp_migration/migrate_test.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+	Overview
+		- Tests the migration of a shoot by using the "framework/shootmigrationtest.go"
+		- Performs sanity checks on the migrated shoot to verify that migration is working as expected.
+ **/
+
+package cp_migration_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/gardener/gardener/test/framework"
+	"github.com/gardener/gardener/test/framework/applications"
+	"github.com/onsi/ginkgo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ControlPlaneMigrationTimeout = 2 * time.Hour
+	SecretName                   = "test-shoot-migration-secret"
+	SecretNamespace              = metav1.NamespaceDefault
+	ServiceAccountName           = "test-service-account"
+	ServiceAccountNamespace      = metav1.NamespaceDefault
+)
+
+var (
+	targetSeedName *string
+	shootName      *string
+	shootNamespace *string
+	gardenerConfig *GardenerConfig
+)
+
+func init() {
+	gardenerConfig = RegisterGardenerFrameworkFlags()
+	targetSeedName = flag.String("target-seed-name", "", "name of the seed to which the shoot will be migrated")
+	shootName = flag.String("shoot-name", "", "name of the shoot")
+	shootNamespace = flag.String("shoot-namespace", "", "namespace of the shoot")
+}
+
+var _ = ginkgo.Describe("Shoot migration testing", func() {
+	f := NewGardenerFramework(gardenerConfig)
+	t := NewShootMigrationTest(f, &ShootMigrationConfig{
+		ShootName:      *shootName,
+		ShootNamespace: *shootNamespace,
+		TargetSeedName: *targetSeedName,
+	})
+	guestBookApp := applications.GuestBookTest{}
+	testSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      SecretName,
+			Namespace: SecretNamespace,
+		},
+	}
+	testServiceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ServiceAccountName,
+			Namespace: ServiceAccountNamespace,
+		}}
+
+	CBeforeSuite(func(c context.Context) {
+		validateConfig()
+	}, 1*time.Minute)
+
+	CBeforeEach(func(ctx context.Context) {
+		if err := beforeMigration(ctx, t, &guestBookApp, testSecret, testServiceAccount); err != nil {
+			ginkgo.Fail("The Shoot CP Migration preparation steps failed with: " + err.Error())
+		}
+	}, 15*time.Minute)
+	CAfterEach(func(ctx context.Context) {
+		if err := afterMigration(ctx, t, guestBookApp, testSecret, testServiceAccount); err != nil {
+			ginkgo.Fail("The Shoot CP Migration health checks failed with: " + err.Error())
+		}
+	}, 15*time.Minute)
+
+	CIt("Migrate Shoot", func(ctx context.Context) {
+		if err := t.MigrateShoot(ctx); err != nil {
+			ginkgo.Fail("Shoot CP Migration failed with: " + err.Error())
+		}
+	}, ControlPlaneMigrationTimeout)
+})
+
+func validateConfig() {
+	if !StringSet(*targetSeedName) {
+		ginkgo.Fail("You should specify a name for the target Seed")
+	}
+	if !StringSet(*shootName) {
+		ginkgo.Fail("You should specify a name for the Shoot that will be migrated")
+	}
+	if !StringSet(*shootNamespace) {
+		ginkgo.Fail("You should specify a namespace of the Shoot that will be migrated")
+	}
+}
+
+func initShootAndClient(ctx context.Context, t *ShootMigrationTest) (err error) {
+	shoot := &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Name: t.Config.ShootName, Namespace: t.Config.ShootNamespace}}
+	if err = t.GardenerFramework.GetShoot(ctx, shoot); err != nil {
+		return err
+	}
+
+	kubecfgSecret := corev1.Secret{}
+	if err := t.GardenerFramework.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Name: shoot.Name + ".kubeconfig", Namespace: shoot.Namespace}, &kubecfgSecret); err != nil {
+		t.GardenerFramework.Logger.Errorf("Unable to get kubeconfig from secret: %s", err.Error())
+		return err
+	}
+	t.GardenerFramework.Logger.Info("Shoot kubeconfig secret was fetched successfully")
+
+	t.ShootClient, err = kubernetes.NewClientFromSecret(ctx, t.GardenerFramework.GardenClient.DirectClient(), kubecfgSecret.Namespace, kubecfgSecret.Name, kubernetes.WithClientOptions(client.Options{
+		Scheme: kubernetes.ShootScheme,
+	}))
+	t.Shoot = *shoot
+	return
+}
+
+func initSeedsAndClients(ctx context.Context, t *ShootMigrationTest) error {
+	t.Config.SourceSeedName = *t.Shoot.Spec.SeedName
+
+	if seed, seedClient, err := t.GardenerFramework.GetSeed(ctx, t.Config.TargetSeedName); err != nil {
+		return err
+	} else {
+		t.TargetSeedClient = seedClient
+		t.TargetSeed = seed
+	}
+
+	if seed, seedClient, err := t.GardenerFramework.GetSeed(ctx, t.Config.SourceSeedName); err != nil {
+		return err
+	} else {
+		t.SourceSeedClient = seedClient
+		t.SourceSeed = seed
+	}
+	return nil
+}
+
+func beforeMigration(ctx context.Context, t *ShootMigrationTest, guestBookApp *applications.GuestBookTest, testSecret *corev1.Secret, testServiceAccount *corev1.ServiceAccount) error {
+	ginkgo.By(fmt.Sprintf("Initializing Shoot %s/%s and its client", *shootNamespace, *shootName))
+	if err := initShootAndClient(ctx, t); err != nil {
+		return err
+	}
+	t.SeedShootNamespace = ComputeTechnicalID(t.GardenerFramework.ProjectNamespace, &t.Shoot)
+
+	ginkgo.By(fmt.Sprintf("Initializing source Seed %s, target Seed %s, and their Clients", *t.Shoot.Spec.SeedName, *targetSeedName))
+	if err := initSeedsAndClients(ctx, t); err != nil {
+		return err
+	}
+
+	ginkgo.By("Fetching the objects that will be used for comparison")
+	if err := t.PopulateBeforeMigrationComparisonElements(ctx); err != nil {
+		return err
+	}
+
+	ginkgo.By("Creating test Secret and Service Account")
+	if err := t.ShootClient.DirectClient().Create(ctx, testSecret); err != nil {
+		return err
+	}
+	t.GardenerFramework.Logger.Infof("Secret resource %s/%s was created!", testSecret.Namespace, testSecret.Name)
+	if err := t.ShootClient.DirectClient().Create(ctx, testServiceAccount); err != nil {
+		return err
+	}
+	t.GardenerFramework.Logger.Infof("ServiceAccount resource %s/%s was created!", testServiceAccount.Namespace, testServiceAccount.Name)
+
+	ginkgo.By("Deploying Guest Book Application")
+	initializedApp, err := initGuestBookTest(ctx, t)
+	if err != nil {
+		return err
+	}
+	*guestBookApp = *initializedApp
+	guestBookApp.DeployGuestBookApp(ctx)
+	guestBookApp.Test(ctx)
+
+	return nil
+}
+
+func afterMigration(ctx context.Context, t *ShootMigrationTest, guestBookApp applications.GuestBookTest, testSecret *corev1.Secret, testServiceAccount *corev1.ServiceAccount) error {
+	if ginkgo.CurrentGinkgoTestDescription().Failed {
+		t.GardenerFramework.DumpState(ctx)
+	}
+
+	ginkgo.By("Fetching the objects that will be used for comparison...")
+	if err := t.PopulateAfterMigrationComparisonElements(ctx); err != nil {
+		return err
+	}
+
+	ginkgo.By("Checking if the test Secret and Service Account are migrated and cleaning them up...")
+	if err := t.ShootClient.DirectClient().Delete(ctx, testSecret); err != nil {
+		return err
+	}
+	t.GardenerFramework.Logger.Infof("Secret resource %s/%s was deleted!", testSecret.Namespace, testSecret.Name)
+	if err := t.ShootClient.DirectClient().Delete(ctx, testServiceAccount); err != nil {
+		return err
+	}
+	t.GardenerFramework.Logger.Infof("ServiceAccount resource %s/%s was deleted!", testServiceAccount.Namespace, testServiceAccount.Name)
+
+	ginkgo.By("Comparing all Machines, Nodes and Pods after the migration...")
+	if err := t.CompareElementsAfterMigration(); err != nil {
+		return err
+	}
+
+	ginkgo.By("Testing the Guest Book Application and cleaning it up...")
+	guestBookApp.Test(ctx)
+	guestBookApp.Cleanup(ctx)
+
+	ginkgo.By("Checking timestamps of all resources...")
+	if err := t.CheckObjectsTimestamp(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func initGuestBookTest(ctx context.Context, t *ShootMigrationTest) (*applications.GuestBookTest, error) {
+	sFramework := ShootFramework{
+		GardenerFramework: t.GardenerFramework,
+		TestDescription:   NewTestDescription("Guestbook App for CP Migration test"),
+		Shoot:             &t.Shoot,
+		Seed:              t.SourceSeed,
+		ShootClient:       t.ShootClient,
+		SeedClient:        t.SourceSeedClient,
+	}
+	if !t.Shoot.Spec.Addons.NginxIngress.Enabled {
+		if err := t.GardenerFramework.UpdateShoot(ctx, &t.Shoot, func(shoot *gardencorev1beta1.Shoot) error {
+			if err := t.GardenerFramework.GetShoot(ctx, shoot); err != nil {
+				return err
+			}
+
+			shoot.Spec.Addons.NginxIngress.Enabled = true
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return applications.NewGuestBookTest(&sFramework)
+}


### PR DESCRIPTION
How to categorize this PR?

/area control-plane-migration
/area testing
/kind test
/priority normal

What this PR does / why we need it:
This PR introduces functionality in the integration tests suite that migrates shoot to existing seed. This integration test also makes sanity checks by comparing node details, machine details, the status of all pods and performs a test using the guestbook application onto the migrated shoot.
Which issue(s) this PR fixes:
Part of #1631

Special notes for your reviewer:
Release note:
