### PR TITLE
Add hack scripts for etcdctl in local-garden

### DIFF
--- a/hack/local-development/local-garden/etcdctl-gardener-etcd.sh
+++ b/hack/local-development/local-garden/etcdctl-gardener-etcd.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+docker exec -i --env ETCDCTL_API=3 g-etcd etcdctl \
+ --endpoints http://localhost:22379 \
+ $@

--- a/hack/local-development/local-garden/etcdctl-kube-etcd.sh
+++ b/hack/local-development/local-garden/etcdctl-kube-etcd.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+docker exec -i --env ETCDCTL_API=3 etcd etcdctl \
+ --endpoints https://localhost:12379 \
+ --key /keys/kube-etcd.key --cert /certs/kube-etcd.crt --cacert /certs/ca.crt \
+ $@


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR add two hack scripts for talking to the etcds running in the local-garden using etcdctl.
They can be helpful when interacting with etcd directly for debugging and development purposes and save the time of building up all command line parameters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Two hack scripts have been added (`hack/local-development/local-garden/etcdctl-{gardener,kube}-etcd.sh`) for talking to the etcds running in the `local-garden`.
```
