### PR TITLE
Fix coredns dashboard

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -55,14 +55,13 @@ allowedMetrics:
   coredns:
   - process_max_fds
   - process_open_fds
-  - coredns_dns_request_count_total
-  - coredns_dns_request_type_count_total
+  - coredns_cache_entries
   - coredns_cache_hits_total
   - coredns_cache_misses_total
-  - coredns_cache_size
-  - coredns_dns_response_rcode_count_total
-  - coredns_forward_request_count_total
-  - coredns_forward_response_rcode_count_total
+  - coredns_dns_request_duration_seconds_count
+  - coredns_dns_responses_total
+  - coredns_forward_requests_total
+  - coredns_forward_responses_total
   cloudControllerManager:
   - rest_client_requests_total
   - process_max_fds

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/coredns-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/coredns-dashboard.json
@@ -4,7 +4,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": 6,
   "iteration": 1588767609744,
   "links": [],
@@ -18,21 +18,28 @@
       "description": "Average rate of DNS requests (in packets per second) split by DNS record types, used protocol and DNS zone.\n\nNote: The `dot` zone is the local zone managed by the CoreDNS instance.",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "grid": {},
       "gridPos": {
         "h": 7,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 8,
       "legend": {
         "alignAsTable": true,
-        "avg": false,
+        "avg": true,
         "current": true,
-        "max": false,
+        "max": true,
         "min": false,
         "rightSide": true,
         "show": true,
@@ -58,23 +65,26 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(coredns_dns_request_type_count_total{pod=~\"$pod\"}[5m])) by (type)",
+          "expr": "sum(rate(coredns_dns_request_duration_seconds_count{pod=~\"$pod\"}[5m])) by (type)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "By Record: {{type}}",
           "refId": "A",
           "step": 60
         },
         {
-          "expr": "sum(rate(coredns_dns_request_count_total{pod=~\"$pod\"}[5m])) by (proto)",
+          "expr": "sum(rate(coredns_dns_request_duration_seconds_count{pod=~\"$pod\"}[5m])) by (proto)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "By Protocol: {{proto}}",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(coredns_dns_request_count_total{pod=~\"$pod\"}[5m])) by (zone)",
+          "expr": "sum(rate(coredns_dns_request_duration_seconds_count{pod=~\"$pod\"}[5m])) by (zone)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "By Zone: {{zone}}",
           "refId": "C"
@@ -124,7 +134,137 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": "prometheus",
+      "decimals": 0,
+      "description": "Count of DNS Requests received by CoreDNS.\n\nNote: The `dot` zone is the local zone managed by the CoreDNS instance.",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 3,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 20,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "expr": "sum(coredns_dns_request_duration_seconds_count{pod=~\"$pod\"} - coredns_dns_request_duration_seconds_count{pod=~\"$pod\"} offset 15s) by (type)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "By Record: {{type}}",
+          "refId": "A",
+          "step": 60
+        },
+        {
+          "expr": "sum(coredns_dns_request_duration_seconds_count{pod=~\"$pod\"} - coredns_dns_request_duration_seconds_count{pod=~\"$pod\"} offset 15s) by (proto)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "By Protocol: {{proto}}",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(coredns_dns_request_duration_seconds_count{pod=~\"$pod\"} - coredns_dns_request_duration_seconds_count{pod=~\"$pod\"} offset 15s) by (zone)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "By Zone: {{zone}}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "DNS Requests (Packets)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "packets",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "pps",
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
       "description": "The average per second rate of lookup requests split by their status codes (rcode).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -133,6 +273,7 @@
         "x": 0,
         "y": 7
       },
+      "hiddenSeries": false,
       "id": 16,
       "legend": {
         "avg": false,
@@ -160,8 +301,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(coredns_dns_response_rcode_count_total{pod=\"$pod\"}[5m])",
+          "expr": "rate(coredns_dns_responses_total{pod=\"$pod\"}[5m])",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "{{rcode}}",
           "refId": "A"
@@ -209,7 +351,108 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "description": "Lookup requests split by their status codes (rcode).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 21,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "expr": "sum(coredns_dns_responses_total{pod=\"$pod\"} - coredns_dns_responses_total{pod=\"$pod\"} offset $__interval) by (rcode)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{rcode}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "DNS Lookup Responses",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": true,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -224,9 +467,15 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "prometheus",
-          "description": "The `cache hits` rate describes how many DNS requests were answered due to a cached entry.\n\nThe `cache misses` rate describes how much DNS requests need to be looked up, because the requests entry does not exist in the local cache.\n\nThe rates are per second averages and displayed in packets per second.",
+          "description": "The `cache hits` describes how many DNS requests were answered due to a cached entry.\n\nThe `cache misses` describes how much DNS requests need to be looked up, because the requests entry does not exist in the local cache.\n\nThe rates are per second averages and displayed in packets per second.",
           "editable": true,
           "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "grid": {},
@@ -236,6 +485,7 @@
             "x": 0,
             "y": 15
           },
+          "hiddenSeries": false,
           "id": 6,
           "legend": {
             "avg": false,
@@ -299,7 +549,7 @@
           },
           "yaxes": [
             {
-              "format": "pps",
+              "format": "none",
               "logBase": 1,
               "max": null,
               "min": 0,
@@ -323,16 +573,135 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
+          "datasource": "prometheus",
           "decimals": 0,
-          "description": "Count of cached entries in the cache of the DNS.",
+          "description": "The `cache hits` describes how many DNS requests were answered due to a cached entry.\n\nThe `cache misses` describes how much DNS requests need to be looked up, because the requests entry does not exist in the local cache.\n\n",
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
+          "grid": {},
           "gridPos": {
             "h": 7,
             "w": 12,
             "x": 12,
             "y": 15
           },
+          "hiddenSeries": false,
+          "id": 22,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "expr": "sum(coredns_cache_hits_total{pod=~\"$pod\"} - coredns_cache_hits_total{pod=~\"$pod\"} offset $__interval)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "cache hits",
+              "refId": "A",
+              "step": 40
+            },
+            {
+              "expr": "sum(coredns_cache_misses_total{pod=~\"$pod\"} - coredns_cache_misses_total{pod=~\"$pod\"} offset $__interval)",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "cache misses",
+              "refId": "B",
+              "step": 40
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Cache Hits and Misses",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": 0,
+              "format": "none",
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "pps",
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "decimals": 0,
+          "description": "Count of cached entries in the cache of the DNS.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 22
+          },
+          "hiddenSeries": false,
           "id": 2,
           "legend": {
             "avg": false,
@@ -360,10 +729,11 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(coredns_cache_size{pod=\"$pod\"})",
+              "expr": "sum(coredns_cache_entries{pod=\"$pod\"}) by (type)",
               "format": "time_series",
+              "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "cache size",
+              "legendFormat": "cache size: {{ type }}",
               "refId": "A"
             }
           ],
@@ -415,6 +785,7 @@
     },
     {
       "collapsed": true,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -428,15 +799,23 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
+          "datasource": null,
           "description": "Average request (packets per second) rate made to upstream DNS.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 30
           },
+          "hiddenSeries": false,
           "id": 10,
           "legend": {
             "alignAsTable": false,
@@ -466,8 +845,9 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(coredns_forward_request_count_total{pod=\"$pod\"}[1h])) by (to)",
+              "expr": "sum(rate(coredns_forward_requests_total{pod=\"$pod\"}[5m])) by (to)",
               "format": "time_series",
+              "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{to}}",
               "refId": "A"
@@ -519,15 +899,23 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
+          "datasource": null,
           "description": "Average per second rate of responses from upstream DNS split by status code (rcode).",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
           "fill": 1,
           "fillGradient": 0,
           "gridPos": {
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 30
           },
+          "hiddenSeries": false,
           "id": 12,
           "legend": {
             "avg": false,
@@ -555,8 +943,9 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(coredns_forward_response_rcode_count_total{pod=\"$pod\"}[1h])",
+              "expr": "rate(coredns_forward_responses_total{pod=\"$pod\"}[5m])",
               "format": "time_series",
+              "interval": "",
               "intervalFactor": 1,
               "legendFormat": "{{rcode}} ({{to}})",
               "refId": "A"
@@ -609,7 +998,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 19,
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [
     "network",
@@ -619,17 +1008,21 @@
     "list": [
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "coredns-8774486d7-5cwd9",
+          "value": "coredns-8774486d7-5cwd9"
+        },
         "datasource": "prometheus",
-        "definition": "label_values(coredns_cache_size, pod)",
+        "definition": "label_values(coredns_build_info, pod)",
         "hide": 0,
         "includeAll": false,
         "label": "CoreDNS Pod",
         "multi": false,
         "name": "pod",
         "options": [],
-        "query": "label_values(coredns_cache_size, pod)",
-        "refresh": 1,
+        "query": "label_values(coredns_build_info, pod)",
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -647,7 +1040,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "5s",
       "10s",
       "30s",
       "1m",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug
/priority normal

**What this PR does / why we need it**:
Fix CoreDNS dashboard

Updated metrics were found here https://coredns.io/2020/06/15/coredns-1.7.0-release/


**Which issue(s) this PR fixes**:
Fixes #2966

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue causing CoreDNS dashboard to show always 'No Data' is now fixed.
```
