### PR TITLE
Add timeout for the cloud-config-downloader service

### DIFF
--- a/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
+++ b/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
@@ -35,6 +35,7 @@ spec:
       [Service]
       Restart=always
       RestartSec=30
+      RuntimeMaxSec=1200
       EnvironmentFile=/etc/environment
       ExecStart=/var/lib/cloud-config-downloader/download-cloud-config.sh
       [Install]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity quality
/kind bug
/priority normal

**What this PR does / why we need it**:
The cloud-config-downloader service is now allowed to finish its job in 20 minutes. 20 minutes should be safe because usually it needs less then 1 minute. Also considering that last years the default timeout of MCM for a machine to join is 20 minutes and this is working fine last several years.

**Which issue(s) this PR fixes**:
Fixes #2981 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
For newly created machines, `cloud-config-downloader` systemd service is now configured with maximum allowed time of 20 minutes to do its job. This change is needed, to mitigate issues where the execution of the service got stuck and in-place changes might not be applied, for example kubelet patch update.
```
