### PR TITLE
Add restrictions in user's Grafana for logs

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
@@ -110,13 +110,47 @@
         MinBackoff 30
         Buffer true
         BufferType dque
-        QueueDir  /fluent-bit/buffers
+        QueueDir  /fluent-bit/buffers/operator
         QueueSegmentSize 300
         QueueSync normal
-        QueueName gardener-kubernetes
+        QueueName gardener-kubernetes-operator
         FallbackToTagWhenMetadataIsMissing true
         TagKey tag
         DropLogEntryWithoutK8sMetadata true
+        TenantID operator
+    
+    [Output]
+        Name loki
+        Match {{ .Values.exposedComponentsTagPrefix }}.kubernetes.*
+        Url http://loki.garden.svc:3100/loki/api/v1/push
+        LogLevel info
+        BatchWait 40
+        BatchSize 30720
+        Labels {test="fluent-bit-go", lang="Golang"}
+        LineFormat json
+        ReplaceOutOfOrderTS true
+        DropSingleKey false
+        AutoKubernetesLabels true
+        LabelSelector gardener.cloud/role:shoot
+        RemoveKeys kubernetes,stream,type,time,tag
+        LabelMapPath /fluent-bit/etc/kubernetes_label_map.json
+        DynamicHostPath {"kubernetes": {"namespace_name": "namespace"}}
+        DynamicHostPrefix http://loki.
+        DynamicHostSuffix .svc:3100/loki/api/v1/push
+        DynamicHostRegex shoot-
+        MaxRetries 3
+        Timeout 10
+        MinBackoff 30
+        Buffer true
+        BufferType dque
+        QueueDir  /fluent-bit/buffers/user
+        QueueSegmentSize 300
+        QueueSync normal
+        QueueName gardener-kubernetes-user
+        FallbackToTagWhenMetadataIsMissing true
+        TagKey tag
+        DropLogEntryWithoutK8sMetadata true
+        TenantID user
 
     [Output]
         Name loki

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-configmap.yaml
@@ -255,7 +255,6 @@ data:
         script              add_tag_to_record.lua
         call                add_tag_to_record
 
-
   output.conf: |-
     # Output section
 {{- include "output.conf" . }}
@@ -354,6 +353,7 @@ data:
   plugin.conf: |-
     [PLUGINS]
         Path /fluent-bit/plugins/out_loki.so
+
   modify_severity.lua: |-
     function cb_modify(tag, timestamp, record)
       local unified_severity = cb_modify_unify_severity(record)

--- a/charts/seed-bootstrap/charts/fluent-bit/values.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/values.yaml
@@ -27,3 +27,4 @@ lokiLabels:
   systemdLabels:
     hostname: "host_name"
     unit: "systemd_component"
+exposedComponentsTagPrefix: "user-exposed"

--- a/charts/seed-bootstrap/charts/loki/templates/loki-configmap.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/loki-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ toYaml .Values.labels | indent 4 }}
 data:
   loki.yaml: |-
-    auth_enabled: false
+    auth_enabled: {{ .Values.authEnabled }}
     ingester:
       chunk_idle_period: 3m
       chunk_block_size: 262144

--- a/charts/seed-bootstrap/charts/loki/values.yaml
+++ b/charts/seed-bootstrap/charts/loki/values.yaml
@@ -7,6 +7,8 @@ global:
       app: fluent-bit
       role: logging
 
+authEnabled: true
+
 annotations: {}
 
 labels:

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-ingress.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-ingress.yaml
@@ -6,6 +6,11 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: grafana-{{ .Values.role }}-basic-auth
     nginx.ingress.kubernetes.io/auth-type: basic
+{{- if eq .Values.role "users" }}
+    nginx.ingress.kubernetes.io/configuration-snippet: "proxy_set_header X-Scope-OrgID user;"
+{{- else }}
+    nginx.ingress.kubernetes.io/configuration-snippet: "proxy_set_header X-Scope-OrgID operator;"
+{{- end }}
   name: grafana-{{ .Values.role }}
   namespace: {{ .Release.Namespace }}
   labels:

--- a/pkg/operation/botanist/component/interfaces.go
+++ b/pkg/operation/botanist/component/interfaces.go
@@ -58,7 +58,7 @@ type MonitoringComponent interface {
 }
 
 // LoggingConfiguration is a function alias for returning logging parsers and filters.
-type LoggingConfiguration func() (string, string, error)
+type LoggingConfiguration func() (LoggingConfig, error)
 
 // BootstrapSeed is a function alias for components that require to bootstrap the seed cluster.
 type BootstrapSeed func(ctx context.Context, c client.Client, namespace, version string) error

--- a/pkg/operation/botanist/component/types.go
+++ b/pkg/operation/botanist/component/types.go
@@ -21,3 +21,15 @@ type Secret struct {
 	// Checksum is the checksum of the secret's data.
 	Checksum string
 }
+
+// LoggingConfig is a structure that contains additional Fluentbit filters and parsers
+type LoggingConfig struct {
+	// Filters contains the filters for specific component
+	Filters string
+	// Parser contains the parsers for specific component
+	Parsers string
+	// PodPrefix is the prefix of the pod name
+	PodPrefix string
+	// UserExposed defines if the component is exposed to the end-user
+	UserExposed bool
+}

--- a/pkg/operation/botanist/controlplane/clusterautoscaler/logging.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/logging.go
@@ -16,6 +16,7 @@ package clusterautoscaler
 
 import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
 )
 
 const (
@@ -37,6 +38,6 @@ const (
 )
 
 // LoggingConfiguration returns a fluent-bit parser and filter for the cluster-autoscaler logs.
-func LoggingConfiguration() (string, string, error) {
-	return loggingParser, loggingFilter, nil
+func LoggingConfiguration() (component.LoggingConfig, error) {
+	return component.LoggingConfig{Filters: loggingFilter, Parsers: loggingParser, PodPrefix: v1beta1constants.DeploymentNameClusterAutoscaler, UserExposed: true}, nil
 }

--- a/pkg/operation/botanist/controlplane/clusterautoscaler/logging_test.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/logging_test.go
@@ -24,10 +24,10 @@ import (
 var _ = Describe("Logging", func() {
 	Describe("#LoggingConfiguration", func() {
 		It("should return the expected logging parser and filter", func() {
-			parser, filter, err := LoggingConfiguration()
+			loggingConfig, err := LoggingConfiguration()
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(parser).To(Equal(`[PARSER]
+			Expect(loggingConfig.Parsers).To(Equal(`[PARSER]
     Name        clusterAutoscalerParser
     Format      regex
     Regex       ^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<log>.*)$
@@ -35,13 +35,15 @@ var _ = Describe("Logging", func() {
     Time_Format %m%d %H:%M:%S.%L
 `))
 
-			Expect(filter).To(Equal(`[FILTER]
+			Expect(loggingConfig.Filters).To(Equal(`[FILTER]
     Name                parser
     Match               kubernetes.*cluster-autoscaler*cluster-autoscaler*
     Key_Name            log
     Parser              clusterAutoscalerParser
     Reserve_Data        True
 `))
+			Expect(loggingConfig.PodPrefix).To(Equal("cluster-autoscaler"))
+			Expect(loggingConfig.UserExposed).To(Equal(true))
 		})
 	})
 })

--- a/pkg/operation/botanist/controlplane/kubescheduler/logging.go
+++ b/pkg/operation/botanist/controlplane/kubescheduler/logging.go
@@ -16,6 +16,7 @@ package kubescheduler
 
 import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
 )
 
 const (
@@ -37,6 +38,6 @@ const (
 )
 
 // LoggingConfiguration returns a fluent-bit parser and filter for the kube-scheduler logs.
-func LoggingConfiguration() (string, string, error) {
-	return loggingParser, loggingFilter, nil
+func LoggingConfiguration() (component.LoggingConfig, error) {
+	return component.LoggingConfig{Filters: loggingFilter, Parsers: loggingParser, PodPrefix: v1beta1constants.DeploymentNameKubeScheduler, UserExposed: true}, nil
 }

--- a/pkg/operation/botanist/controlplane/kubescheduler/logging_test.go
+++ b/pkg/operation/botanist/controlplane/kubescheduler/logging_test.go
@@ -24,10 +24,10 @@ import (
 var _ = Describe("Logging", func() {
 	Describe("#LoggingConfiguration", func() {
 		It("should return the expected logging parser and filter", func() {
-			parser, filter, err := LoggingConfiguration()
+			loggingConfig, err := LoggingConfiguration()
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(parser).To(Equal(`[PARSER]
+			Expect(loggingConfig.Parsers).To(Equal(`[PARSER]
     Name        kubeSchedulerParser
     Format      regex
     Regex       ^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<log>.*)$
@@ -35,13 +35,16 @@ var _ = Describe("Logging", func() {
     Time_Format %m%d %H:%M:%S.%L
 `))
 
-			Expect(filter).To(Equal(`[FILTER]
+			Expect(loggingConfig.Filters).To(Equal(`[FILTER]
     Name                parser
     Match               kubernetes.*kube-scheduler*kube-scheduler*
     Key_Name            log
     Parser              kubeSchedulerParser
     Reserve_Data        True
 `))
+			Expect(loggingConfig.PodPrefix).To(Equal("kube-scheduler"))
+			Expect(loggingConfig.UserExposed).To(Equal(true))
+
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR will be created two tenants in the Loki. `user` and `operator`. Two datasources will be created also for these two tenants. The users will no have permissions to access logs stored in the operator's tenant

**Which issue(s) this PR fixes**:
https://github.com/gardener/logging/issues/72

**Special notes for your reviewer**:
@wyb1 @vlvasilev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
port-forwarding of the operator's and user's grafana will not work anymore for accessing logs.
The only way to access logs is by using the Ingress, because it attaches a new header with the tenantID in the request.
```
