### PR TITLE
Remove Loki labels which come from metadata

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -198,9 +198,13 @@ images:
 
 # Logging
 - name: fluent-bit
+  sourceRepository: github.com/fluent/fluent-bit
+  repository: fluent/fluent-bit
+  tag: "1.5.4"
+- name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.26.0"
+  tag: "v0.27.0"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
@@ -93,13 +93,13 @@
         LogLevel info
         BatchWait 40
         BatchSize 30720
-        Labels {test="fluent-bit-go", lang="Golang"}
+        Labels {test="fluent-bit-go"}
         LineFormat json
         ReplaceOutOfOrderTS true
         DropSingleKey false
-        AutoKubernetesLabels true
+        AutoKubernetesLabels false
         LabelSelector gardener.cloud/role:shoot
-        RemoveKeys kubernetes,stream,type,time,tag
+        RemoveKeys kubernetes,stream,time,tag
         LabelMapPath /fluent-bit/etc/kubernetes_label_map.json
         DynamicHostPath {"kubernetes": {"namespace_name": "namespace"}}
         DynamicHostPrefix http://loki.
@@ -125,7 +125,7 @@
         LogLevel info
         BatchWait 60
         BatchSize 30720
-        Labels {test="fluent-bit-go", lang="Golang"}
+        Labels {test="fluent-bit-go"}
         LineFormat json
         ReplaceOutOfOrderTS true
         DropSingleKey false

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-configmap.yaml
@@ -238,18 +238,6 @@ data:
         Rename              msg    log
         Rename              logger source
 
-    # Kubernetes filter
-    [FILTER]
-        Name                kubernetes
-        Match               kubernetes.*
-        Kube_Tag_Prefix     kubernetes.var.log.containers.
-        Kube_URL            https://kubernetes.default.svc.cluster.local:443
-        Buffer_Size         1M
-        Labels              On
-        Annotations         On
-        tls.verify          Off
-        K8S-Logging.Exclude Off
-
     # Extensions
 {{ if .Values.additionalFilters }}
 {{- toString .Values.additionalFilters | indent 4 }}
@@ -421,16 +409,10 @@ data:
 
   kubernetes_label_map.json: |-
     {
-      "kubernetes": {
-        "container_name": "container_name",
-        "pod_name": "pod_name"
-      },
-      "type": "user",
+      "kubernetes": {{ toJson .Values.lokiLabels.kubernetesLabels }} ,
       "severity": "severity"
     }
 
   systemd_label_map.json: |-
-    {
-      "hostname": "hostname",
-      "unit": "unit"
-    }
+{{ toJson .Values.lokiLabels.systemdLabels | indent 4}}
+

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
@@ -19,6 +19,17 @@ spec:
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-seed-apiserver: allowed
     spec:
+      initContainers:
+      - name: install-plugin
+        image: {{ index .Values.global.images "fluent-bit-plugin-installer" }}
+        command:
+        - cp
+        - /source/plugins/.
+        - /plugins
+        - -fr
+        volumeMounts:
+        - name: plugins
+          mountPath: "/plugins"
       containers:
       - name: fluent-bit
         image: {{ index .Values.global.images "fluent-bit" }}
@@ -52,6 +63,8 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
+        - name: plugins
+          mountPath: /fluent-bit/plugins
       serviceAccount: fluent-bit
       serviceAccountName: fluent-bit
       automountServiceAccountToken: true
@@ -69,3 +82,5 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+      - name: plugins
+        emptyDir: {}

--- a/charts/seed-bootstrap/charts/fluent-bit/values.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/values.yaml
@@ -6,6 +6,7 @@ global:
       role: logging
   images:
     fluent-bit: image-repository:image-tag
+    fluent-bit-plugin-installer: image-repository:image-tag
 
 labels:
   gardener.cloud/role: logging
@@ -17,3 +18,12 @@ ports:
 additionalFilters: ""
 additionalParsers: ""
 fluentBitConfigurationsOverwrites: {}
+lokiLabels:
+  kubernetesLabels:
+    container_name: "container_name"
+    namespace_name: "namespace_name"
+    pod_name: "pod_name"
+    docker_id: "docker_id"
+  systemdLabels:
+    hostname: "host_name"
+    unit: "systemd_component"

--- a/charts/seed-bootstrap/dashboards/systemd-logs.json
+++ b/charts/seed-bootstrap/dashboards/systemd-logs.json
@@ -803,7 +803,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(count_over_time({unit=\"$unit\"} |~ \"$search\"[$__interval]))",
+          "expr": "sum(count_over_time({systemd_component=\"$systemd_component\"} |~ \"$search\"[$__interval]))",
           "refId": "A"
         }
       ],
@@ -872,7 +872,7 @@
       },
       "targets": [
         {
-          "expr": "{unit=\"$unit\"} |~ \"$search\"",
+          "expr": "{systemd_component=\"$systemd_component\"} |~ \"$search\"",
           "refId": "A"
         }
       ],
@@ -895,14 +895,14 @@
           "value": "containerd"
         },
         "datasource": "loki",
-        "definition": "label_values(unit)",
+        "definition": "label_values(systemd_component)",
         "hide": 0,
         "includeAll": false,
         "label": "Unit",
         "multi": false,
-        "name": "unit",
+        "name": "systemd_component",
         "options": [],
-        "query": "label_values(unit)",
+        "query": "label_values(systemd_component)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -439,6 +439,9 @@ const (
 	// FluentBitImageName is the image of Fluent-bit image
 	FluentBitImageName = "fluent-bit"
 
+	// FluentBitPluginInstaller is the image of Fluent-bit plugin installer image
+	FluentBitPluginInstaller = "fluent-bit-plugin-installer"
+
 	// AlpineImageName is the name of alpine image
 	AlpineImageName = "alpine"
 

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -275,6 +275,7 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 			common.ConfigMapReloaderImageName,
 			common.LokiImageName,
 			common.FluentBitImageName,
+			common.FluentBitPluginInstaller,
 			common.GardenerResourceManagerImageName,
 			common.GrafanaImageName,
 			common.PauseContainerImageName,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Upgrade custom plugin to version: v0.27.0
Remove Loki labels which come from metadata. In this way we expect to improve fluent-bit performance,
because it will no more need to call the Kube-apiserver for metadata.

**Which issue(s) this PR fixes**:
https://github.com/gardener/logging/issues/72

**Special notes for your reviewer**:
@vlvasilev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Loki labels which come from the metadata are removed
```
```improvement operator
Separate the fluent-bit-to-loki plugin build from a specific fluent-bit image.
```
```improvement operator
Extract `docker_id` from the log tag to the kubernetes metadata when `FallbackToTagWhenMetadataIsMissing` flag is set.
```