### PR TITLE
Extension enhancements

### DIFF
--- a/extensions/pkg/controller/cmd/options.go
+++ b/extensions/pkg/controller/cmd/options.go
@@ -360,7 +360,11 @@ func NewSwitchOptions(pairs ...NameToAddToManagerFunc) *SwitchOptions {
 
 // AddFlags implements Option.
 func (d *SwitchOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.StringSliceVar(&d.Disabled, DisableFlag, d.Disabled, "List of controllers to disable")
+	controllerNames := make([]string, 0, len(d.nameToAddToManager))
+	for name := range d.nameToAddToManager {
+		controllerNames = append(controllerNames, name)
+	}
+	fs.StringSliceVar(&d.Disabled, DisableFlag, d.Disabled, fmt.Sprintf("List of controllers to disable %v", controllerNames))
 }
 
 // Complete implements Option.

--- a/extensions/pkg/controller/healthcheck/actuator.go
+++ b/extensions/pkg/controller/healthcheck/actuator.go
@@ -24,7 +24,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 /*
@@ -115,10 +114,6 @@ func (h *Result) GetDetails() string {
 type HealthCheck interface {
 	// Check is the function that executes the actual health check
 	Check(context.Context, types.NamespacedName) (*SingleCheckResult, error)
-	// InjectSeedClient injects the seed client
-	InjectSeedClient(client.Client)
-	// InjectShootClient injects the shoot client
-	InjectShootClient(client.Client)
 	// SetLoggerSuffix injects the logger
 	SetLoggerSuffix(string, string)
 	// DeepCopy clones the healthCheck

--- a/extensions/pkg/controller/healthcheck/general/managed_resource.go
+++ b/extensions/pkg/controller/healthcheck/general/managed_resource.go
@@ -33,7 +33,6 @@ import (
 type ManagedResourceHealthChecker struct {
 	logger              logr.Logger
 	seedClient          client.Client
-	shootClient         client.Client
 	managedResourceName string
 }
 
@@ -47,11 +46,6 @@ func CheckManagedResource(managedResourceName string) healthcheck.HealthCheck {
 // InjectSeedClient injects the seed client
 func (healthChecker *ManagedResourceHealthChecker) InjectSeedClient(seedClient client.Client) {
 	healthChecker.seedClient = seedClient
-}
-
-// InjectShootClient injects the shoot client
-func (healthChecker *ManagedResourceHealthChecker) InjectShootClient(shootClient client.Client) {
-	healthChecker.shootClient = shootClient
 }
 
 // SetLoggerSuffix injects the logger

--- a/extensions/pkg/controller/healthcheck/inject.go
+++ b/extensions/pkg/controller/healthcheck/inject.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ShootClient is an interface to be used to receive a shoot client.
+type ShootClient interface {
+	// InjectShootClient injects the shoot client
+	InjectShootClient(client.Client)
+}
+
+// ShootClient is an interface to be used to receive a seed client.
+type SeedClient interface {
+	// InjectSeedClient injects the seed client
+	InjectSeedClient(client.Client)
+}
+
+// ShootClientInto will set the shoot client on i if i implements ShootClient.
+func ShootClientInto(client client.Client, i interface{}) bool {
+	if s, ok := i.(ShootClient); ok {
+		s.InjectShootClient(client)
+		return true
+	}
+	return false
+}
+
+// SeedClientInto will set the seed client on i if i implements SeedClient.
+func SeedClientInto(client client.Client, i interface{}) bool {
+	if s, ok := i.(SeedClient); ok {
+		s.InjectSeedClient(client)
+		return true
+	}
+	return false
+}

--- a/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/extensions/pkg/controller/healthcheck/reconciler.go
@@ -117,15 +117,17 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	if controller.IsHibernated(cluster) {
+		var conditions []condition
 		for _, healthConditionType := range r.registeredExtension.healthConditionTypes {
 			conditionBuilder, err := gardencorev1beta1helper.NewConditionBuilder(gardencorev1beta1.ConditionType(healthConditionType))
 			if err != nil {
 				return reconcile.Result{}, err
 			}
 
-			if err := r.updateExtensionConditionHibernated(r.ctx, conditionBuilder, healthConditionType, extension); err != nil {
-				return reconcile.Result{}, err
-			}
+			conditions = append(conditions, extensionConditionHibernated(conditionBuilder, healthConditionType))
+		}
+		if err := r.updateExtensionConditions(r.ctx, extension, conditions...); err != nil {
+			return reconcile.Result{}, err
 		}
 
 		r.logger.V(6).Info("Do not perform HealthCheck for extension resource. Shoot is hibernated.", "name", acc.GetName(), "namespace", acc.GetNamespace(), "kind", acc.GetObjectKind().GroupVersionKind().Kind)
@@ -139,6 +141,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 func (r *reconciler) performHealthCheck(ctx context.Context, request reconcile.Request, extension extensionsv1alpha1.Object) (reconcile.Result, error) {
 	healthCheckResults, err := r.actuator.ExecuteHealthCheckFunctions(ctx, types.NamespacedName{Namespace: request.Namespace, Name: request.Name})
 	if err != nil {
+		var conditions []condition
 		r.logger.Info("Failed to execute healthChecks. Updating each HealthCheckCondition for the extension resource to ConditionCheckError.", "kind", r.registeredExtension.groupVersionKind.Kind, "health condition types", r.registeredExtension.healthConditionTypes, "name", request.Name, "namespace", request.Namespace, "error", err.Error())
 		for _, healthConditionType := range r.registeredExtension.healthConditionTypes {
 			conditionBuilder, buildErr := gardencorev1beta1helper.NewConditionBuilder(gardencorev1beta1.ConditionType(healthConditionType))
@@ -146,13 +149,15 @@ func (r *reconciler) performHealthCheck(ctx context.Context, request reconcile.R
 				return reconcile.Result{}, buildErr
 			}
 
-			if updateErr := r.updateExtensionConditionFailedToExecute(ctx, conditionBuilder, healthConditionType, extension, r.registeredExtension.groupVersionKind.Kind, err); updateErr != nil {
-				return reconcile.Result{}, updateErr
-			}
+			conditions = append(conditions, extensionConditionFailedToExecute(conditionBuilder, healthConditionType, r.registeredExtension.groupVersionKind.Kind, err))
+		}
+		if updateErr := r.updateExtensionConditions(ctx, extension, conditions...); updateErr != nil {
+			return reconcile.Result{}, updateErr
 		}
 		return r.resultWithRequeue(), nil
 	}
 
+	conditions := make([]condition, 0, len(*healthCheckResults))
 	for _, healthCheckResult := range *healthCheckResults {
 		conditionBuilder, err := gardencorev1beta1helper.NewConditionBuilder(gardencorev1beta1.ConditionType(healthCheckResult.HealthConditionType))
 		if err != nil {
@@ -169,45 +174,49 @@ func (r *reconciler) performHealthCheck(ctx context.Context, request reconcile.R
 		if healthCheckResult.Status == gardencorev1beta1.ConditionProgressing || healthCheckResult.Status == gardencorev1beta1.ConditionFalse {
 			if healthCheckResult.FailedChecks > 0 {
 				r.logger.Info("Updating HealthCheckCondition for extension resource to ConditionCheckError.", "kind", r.registeredExtension.groupVersionKind.Kind, "health condition type", healthCheckResult.HealthConditionType, "name", request.Name, "namespace", request.Namespace)
-				if err := r.updateExtensionConditionToConditionCheckError(ctx, conditionBuilder, healthCheckResult.HealthConditionType, extension, r.registeredExtension.groupVersionKind.Kind, healthCheckResult); err != nil {
-					return reconcile.Result{}, err
-				}
+				conditions = append(conditions, extensionConditionCheckError(conditionBuilder, healthCheckResult.HealthConditionType, r.registeredExtension.groupVersionKind.Kind, healthCheckResult))
 				continue
 			}
 
 			logger.Info("Health check for extension resource progressing or unsuccessful.", "kind", fmt.Sprintf("%s.%s.%s", r.registeredExtension.groupVersionKind.Kind, r.registeredExtension.groupVersionKind.Group, r.registeredExtension.groupVersionKind.Version), "name", request.Name, "namespace", request.Namespace, "failed", healthCheckResult.FailedChecks, "progressing", healthCheckResult.ProgressingChecks, "successful", healthCheckResult.SuccessfulChecks, "details", healthCheckResult.GetDetails())
-			if err := r.updateExtensionConditionToUnsuccessful(ctx, conditionBuilder, healthCheckResult.HealthConditionType, extension, healthCheckResult); err != nil {
-				return reconcile.Result{}, err
-			}
+			conditions = append(conditions, extensionConditionUnsuccessful(conditionBuilder, healthCheckResult.HealthConditionType, extension, healthCheckResult))
 			continue
 		}
 
 		logger.Info("Health check for extension resource successful.", "kind", r.registeredExtension.groupVersionKind.Kind, "health condition type", healthCheckResult.HealthConditionType, "name", request.Name, "namespace", request.Namespace)
-		if err := r.updateExtensionConditionToSuccessful(ctx, conditionBuilder, healthCheckResult.HealthConditionType, extension, healthCheckResult); err != nil {
-			return reconcile.Result{}, err
-		}
+		conditions = append(conditions, extensionConditionSuccessful(conditionBuilder, healthCheckResult.HealthConditionType, healthCheckResult))
+	}
+
+	if err := r.updateExtensionConditions(ctx, extension, conditions...); err != nil {
+		return reconcile.Result{}, err
 	}
 
 	return r.resultWithRequeue(), nil
 }
 
-func (r *reconciler) updateExtensionConditionFailedToExecute(ctx context.Context, conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, extension extensionsv1alpha1.Object, kind string, executionError error) error {
+func extensionConditionFailedToExecute(conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, kind string, executionError error) condition {
 	conditionBuilder.
 		WithStatus(gardencorev1beta1.ConditionUnknown).
 		WithReason(gardencorev1beta1.ConditionCheckError).
 		WithMessage(fmt.Sprintf("failed to execute health checks for '%s': %v", kind, executionError.Error()))
-	return r.updateExtensionCondition(ctx, conditionBuilder, healthConditionType, extension)
+	return condition{
+		builder:             conditionBuilder,
+		healthConditionType: healthConditionType,
+	}
 }
 
-func (r *reconciler) updateExtensionConditionToConditionCheckError(ctx context.Context, conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, extension extensionsv1alpha1.Object, kind string, healthCheckResult Result) error {
+func extensionConditionCheckError(conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, kind string, healthCheckResult Result) condition {
 	conditionBuilder.
 		WithStatus(gardencorev1beta1.ConditionUnknown).
 		WithReason(gardencorev1beta1.ConditionCheckError).
 		WithMessage(fmt.Sprintf("failed to execute %d/%d health checks for '%s': %v", healthCheckResult.FailedChecks, healthCheckResult.SuccessfulChecks+healthCheckResult.UnsuccessfulChecks+healthCheckResult.FailedChecks, kind, healthCheckResult.GetDetails()))
-	return r.updateExtensionCondition(ctx, conditionBuilder, healthConditionType, extension)
+	return condition{
+		builder:             conditionBuilder,
+		healthConditionType: healthConditionType,
+	}
 }
 
-func (r *reconciler) updateExtensionConditionToUnsuccessful(ctx context.Context, conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, extension extensionsv1alpha1.Object, healthCheckResult Result) error {
+func extensionConditionUnsuccessful(conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, extension extensionsv1alpha1.Object, healthCheckResult Result) condition {
 	var (
 		numberOfChecks = healthCheckResult.UnsuccessfulChecks + healthCheckResult.ProgressingChecks + healthCheckResult.SuccessfulChecks
 		detail         = fmt.Sprintf("Health check summary: %d/%d unsuccessful, %d/%d progressing, %d/%d successful. %v", healthCheckResult.UnsuccessfulChecks, numberOfChecks, healthCheckResult.ProgressingChecks, numberOfChecks, healthCheckResult.SuccessfulChecks, numberOfChecks, healthCheckResult.GetDetails())
@@ -233,36 +242,51 @@ func (r *reconciler) updateExtensionConditionToUnsuccessful(ctx context.Context,
 		WithReason(reason).
 		WithCodes(healthCheckResult.Codes...).
 		WithMessage(detail)
-	return r.updateExtensionCondition(ctx, conditionBuilder, healthConditionType, extension)
+	return condition{
+		builder:             conditionBuilder,
+		healthConditionType: healthConditionType,
+	}
 }
 
-func (r *reconciler) updateExtensionConditionToSuccessful(ctx context.Context, conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, extension extensionsv1alpha1.Object, healthCheckResult Result) error {
+func extensionConditionSuccessful(conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, healthCheckResult Result) condition {
 	conditionBuilder.
 		WithStatus(gardencorev1beta1.ConditionTrue).
 		WithReason(ReasonSuccessful).
 		WithMessage(fmt.Sprintf("(%d/%d) Health checks successful", healthCheckResult.SuccessfulChecks, healthCheckResult.SuccessfulChecks))
-	return r.updateExtensionCondition(ctx, conditionBuilder, healthConditionType, extension)
+	return condition{
+		builder:             conditionBuilder,
+		healthConditionType: healthConditionType,
+	}
 }
 
-func (r *reconciler) updateExtensionConditionHibernated(ctx context.Context, conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, extension extensionsv1alpha1.Object) error {
+func extensionConditionHibernated(conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string) condition {
 	conditionBuilder.
 		WithStatus(gardencorev1beta1.ConditionTrue).
 		WithReason(ReasonSuccessful).
 		WithMessage("Shoot is hibernated")
-	return r.updateExtensionCondition(ctx, conditionBuilder, healthConditionType, extension)
+	return condition{
+		builder:             conditionBuilder,
+		healthConditionType: healthConditionType,
+	}
 }
 
-func (r *reconciler) updateExtensionCondition(ctx context.Context, conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, extension extensionsv1alpha1.Object) error {
+type condition struct {
+	builder             gardencorev1beta1helper.ConditionBuilder
+	healthConditionType string
+}
+
+func (r *reconciler) updateExtensionConditions(ctx context.Context, extension extensionsv1alpha1.Object, conditions ...condition) error {
 	return extensionscontroller.TryPatchStatus(ctx, retry.DefaultBackoff, r.client, extension, func() error {
-		if c := gardencorev1beta1helper.GetCondition(extension.GetExtensionStatus().GetConditions(), gardencorev1beta1.ConditionType(healthConditionType)); c != nil {
-			conditionBuilder.WithOldCondition(*c)
+		for _, cond := range conditions {
+			now := metav1.Now()
+			if c := gardencorev1beta1helper.GetCondition(extension.GetExtensionStatus().GetConditions(), gardencorev1beta1.ConditionType(cond.healthConditionType)); c != nil {
+				cond.builder.WithOldCondition(*c)
+			}
+			updatedCondition, _ := cond.builder.WithNowFunc(func() metav1.Time { return now }).Build()
+			// always update - the Gardenlet expects a recent health check
+			updatedCondition.LastUpdateTime = now
+			extension.GetExtensionStatus().SetConditions(gardencorev1beta1helper.MergeConditions(extension.GetExtensionStatus().GetConditions(), updatedCondition))
 		}
-
-		updatedCondition, _ := conditionBuilder.WithNowFunc(metav1.Now).Build()
-		// always update - the Gardenlet expects a recent health check
-		updatedCondition.LastUpdateTime = metav1.Now()
-
-		extension.GetExtensionStatus().SetConditions(gardencorev1beta1helper.MergeConditions(extension.GetExtensionStatus().GetConditions(), updatedCondition))
 		return nil
 	})
 }

--- a/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/extensions/pkg/controller/healthcheck/reconciler.go
@@ -253,7 +253,7 @@ func (r *reconciler) updateExtensionConditionHibernated(ctx context.Context, con
 }
 
 func (r *reconciler) updateExtensionCondition(ctx context.Context, conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, extension extensionsv1alpha1.Object) error {
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, extension, func() error {
+	return extensionscontroller.TryPatchStatus(ctx, retry.DefaultBackoff, r.client, extension, func() error {
 		if c := gardencorev1beta1helper.GetCondition(extension.GetExtensionStatus().GetConditions(), gardencorev1beta1.ConditionType(healthConditionType)); c != nil {
 			conditionBuilder.WithOldCondition(*c)
 		}

--- a/extensions/pkg/controller/utils.go
+++ b/extensions/pkg/controller/utils.go
@@ -206,6 +206,51 @@ func GetSecretByReference(ctx context.Context, c client.Client, ref *corev1.Secr
 	return secret, nil
 }
 
+// TryPatch tries to apply the given transformation function onto the given object, and to patch it afterwards with optimistic locking.
+// It retries the patch with an exponential backoff.
+func TryPatch(ctx context.Context, backoff wait.Backoff, c client.Client, obj runtime.Object, transform func() error) error {
+	return tryPatch(ctx, backoff, c, obj, c.Patch, transform)
+}
+
+// TryPatchStatus tries to apply the given transformation function onto the given object, and to patch its
+// status afterwards with optimistic locking. It retries the status patch with an exponential backoff.
+func TryPatchStatus(ctx context.Context, backoff wait.Backoff, c client.Client, obj runtime.Object, transform func() error) error {
+	return tryPatch(ctx, backoff, c, obj, c.Status().Patch, transform)
+}
+
+func tryPatch(ctx context.Context, backoff wait.Backoff, c client.Client, obj runtime.Object, patchFunc func(context.Context, runtime.Object, client.Patch, ...client.PatchOption) error, transform func() error) error {
+	key, err := client.ObjectKeyFromObject(obj)
+	if err != nil {
+		return err
+	}
+
+	resetCopy := obj.DeepCopyObject()
+	return exponentialBackoff(ctx, backoff, func() (bool, error) {
+		if err := c.Get(ctx, key, obj); err != nil {
+			return false, err
+		}
+		beforeTransform := obj.DeepCopyObject()
+		if err := transform(); err != nil {
+			return false, err
+		}
+
+		if reflect.DeepEqual(obj, beforeTransform) {
+			return true, nil
+		}
+
+		patch := client.MergeFromWithOptions(beforeTransform, client.MergeFromWithOptimisticLock{})
+
+		if err := patchFunc(ctx, obj, patch); err != nil {
+			if apierrors.IsConflict(err) {
+				reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(resetCopy).Elem())
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+}
+
 // TryUpdate tries to apply the given transformation function onto the given object, and to update it afterwards.
 // It retries the update with an exponential backoff.
 func TryUpdate(ctx context.Context, backoff wait.Backoff, c client.Client, obj runtime.Object, transform func() error) error {

--- a/extensions/pkg/controller/utils.go
+++ b/extensions/pkg/controller/utils.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"time"
 
 	controllererror "github.com/gardener/gardener/extensions/pkg/controller/error"
 	"github.com/gardener/gardener/pkg/api/extensions"
@@ -31,14 +30,12 @@ import (
 	resourcemanagerv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/retry"
@@ -208,118 +205,19 @@ func GetSecretByReference(ctx context.Context, c client.Client, ref *corev1.Secr
 
 // TryPatch tries to apply the given transformation function onto the given object, and to patch it afterwards with optimistic locking.
 // It retries the patch with an exponential backoff.
-func TryPatch(ctx context.Context, backoff wait.Backoff, c client.Client, obj runtime.Object, transform func() error) error {
-	return tryPatch(ctx, backoff, c, obj, c.Patch, transform)
-}
+var TryPatch = kutil.TryPatch
 
 // TryPatchStatus tries to apply the given transformation function onto the given object, and to patch its
 // status afterwards with optimistic locking. It retries the status patch with an exponential backoff.
-func TryPatchStatus(ctx context.Context, backoff wait.Backoff, c client.Client, obj runtime.Object, transform func() error) error {
-	return tryPatch(ctx, backoff, c, obj, c.Status().Patch, transform)
-}
-
-func tryPatch(ctx context.Context, backoff wait.Backoff, c client.Client, obj runtime.Object, patchFunc func(context.Context, runtime.Object, client.Patch, ...client.PatchOption) error, transform func() error) error {
-	key, err := client.ObjectKeyFromObject(obj)
-	if err != nil {
-		return err
-	}
-
-	resetCopy := obj.DeepCopyObject()
-	return exponentialBackoff(ctx, backoff, func() (bool, error) {
-		if err := c.Get(ctx, key, obj); err != nil {
-			return false, err
-		}
-		beforeTransform := obj.DeepCopyObject()
-		if err := transform(); err != nil {
-			return false, err
-		}
-
-		if reflect.DeepEqual(obj, beforeTransform) {
-			return true, nil
-		}
-
-		patch := client.MergeFromWithOptions(beforeTransform, client.MergeFromWithOptimisticLock{})
-
-		if err := patchFunc(ctx, obj, patch); err != nil {
-			if apierrors.IsConflict(err) {
-				reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(resetCopy).Elem())
-				return false, nil
-			}
-			return false, err
-		}
-		return true, nil
-	})
-}
+var TryPatchStatus = kutil.TryPatchStatus
 
 // TryUpdate tries to apply the given transformation function onto the given object, and to update it afterwards.
 // It retries the update with an exponential backoff.
-func TryUpdate(ctx context.Context, backoff wait.Backoff, c client.Client, obj runtime.Object, transform func() error) error {
-	return tryUpdate(ctx, backoff, c, obj, c.Update, transform)
-}
+var TryUpdate = kutil.TryUpdate
 
 // TryUpdateStatus tries to apply the given transformation function onto the given object, and to update its
 // status afterwards. It retries the status update with an exponential backoff.
-func TryUpdateStatus(ctx context.Context, backoff wait.Backoff, c client.Client, obj runtime.Object, transform func() error) error {
-	return tryUpdate(ctx, backoff, c, obj, c.Status().Update, transform)
-}
-
-func tryUpdate(ctx context.Context, backoff wait.Backoff, c client.Client, obj runtime.Object, updateFunc func(context.Context, runtime.Object, ...client.UpdateOption) error, transform func() error) error {
-	key, err := client.ObjectKeyFromObject(obj)
-	if err != nil {
-		return err
-	}
-
-	resetCopy := obj.DeepCopyObject()
-	return exponentialBackoff(ctx, backoff, func() (bool, error) {
-		if err := c.Get(ctx, key, obj); err != nil {
-			return false, err
-		}
-
-		beforeTransform := obj.DeepCopyObject()
-		if err := transform(); err != nil {
-			return false, err
-		}
-
-		if reflect.DeepEqual(obj, beforeTransform) {
-			return true, nil
-		}
-
-		if err := updateFunc(ctx, obj); err != nil {
-			if apierrors.IsConflict(err) {
-				reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(resetCopy).Elem())
-				return false, nil
-			}
-			return false, err
-		}
-		return true, nil
-	})
-}
-
-func exponentialBackoff(ctx context.Context, backoff wait.Backoff, condition wait.ConditionFunc) error {
-	duration := backoff.Duration
-
-	for i := 0; i < backoff.Steps; i++ {
-		if ok, err := condition(); err != nil || ok {
-			return err
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			adjusted := duration
-			if backoff.Jitter > 0.0 {
-				adjusted = wait.Jitter(duration, backoff.Jitter)
-			}
-			time.Sleep(adjusted)
-			duration = time.Duration(float64(duration) * backoff.Factor)
-		}
-
-		i++
-	}
-
-	return wait.ErrWaitTimeout
-}
+var TryUpdateStatus = kutil.TryUpdateStatus
 
 // WatchBuilder holds various functions which add watch controls to the passed Controller.
 type WatchBuilder []func(controller.Controller) error

--- a/pkg/utils/kubernetes/patch_test.go
+++ b/pkg/utils/kubernetes/patch_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("#tryPatch", func() {
+	It("should set state to obj, when conflict occurs", func() {
+		s := runtime.NewScheme()
+		Expect(extensionsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())
+		objInFakeClient := newInfraObj()
+		objInFakeClient.SetResourceVersion("1")
+		objInFakeClient.Status.Conditions = []v1beta1.Condition{
+			{Type: "Health", Reason: "reason", Message: "messages", Status: "status", LastUpdateTime: metav1.Now()},
+		}
+
+		c := fake.NewFakeClientWithScheme(s, objInFakeClient)
+		infraObj := objInFakeClient.DeepCopy()
+		transform := func() error {
+			infraState, _ := json.Marshal(state{"someState"})
+			infraObj.GetExtensionStatus().SetState(&runtime.RawExtension{Raw: infraState})
+			return nil
+		}
+
+		u := &conflictErrManager{
+			conflictsBeforeUpdate: 2,
+			client:                c,
+		}
+
+		tryPatchErr := tryPatch(context.Background(), retry.DefaultRetry, c, infraObj, u.patchFunc, transform)
+		Expect(tryPatchErr).NotTo(HaveOccurred())
+
+		objFromFakeClient := &extensionsv1alpha1.Infrastructure{}
+		err := c.Get(context.Background(), Key("infraNamespace", "infraName"), objFromFakeClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(objFromFakeClient).To(Equal(infraObj))
+	})
+})
+
+func (c *conflictErrManager) patchFunc(ctx context.Context, obj runtime.Object, patch client.Patch, o ...client.PatchOption) error {
+	if c.conflictsBeforeUpdate == c.conflictsOccured {
+		return c.client.Status().Patch(ctx, obj, patch, o...)
+	}
+
+	c.conflictsOccured++
+	return apierrors.NewConflict(schema.GroupResource{}, "", nil)
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area cost
/area performance
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR contains several usability, performance and cost improvements for the `/extensions` library, mainly used by Gardener extensions
- List all controller names that can be disabled via `--disable-controllers` in the cmd help.
- Only inject shoot client into health check if requested which mainly saves API discovery calls every check period.
- Patch conditions instead of updating them to save network traffic, especially if the extension holds `.status.state`.
- Patch results of health checks in bulk instead of updating every condition type individually.

**Special notes for your reviewer**:
/cc @danielfoehrKn 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Several improvements for extension health checks have been implemented which increase the runtime performance and reduce network traffic.
```
```improvement developer
Several improvements for extension health checks (lib `github.com/gardener/gardener/extensions`) have been implemented which increase the runtime performance and reduce network traffic. Please update your `github.com/gardener/gardener` to the latest version to profit from these changes.
```
