### PR TITLE
Add liveness probe to konnectivity-server

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -314,13 +314,24 @@ spec:
         - --server-port={{ .Values.konnectivityTunnel.serverPort }}
         - --agent-port={{ .Values.konnectivityTunnel.agentPort }}
         - --admin-port={{ .Values.konnectivityTunnel.adminPort }}
+        - --health-port={{ .Values.konnectivityTunnel.healthPort }}
         resources:
 {{ toYaml .Values.konnectivityTunnelResources | indent 10 }}
+        livenessProbe:
+          httpGet:
+            scheme: HTTP
+            port: {{ .Values.konnectivityTunnel.healthPort }}
+            path: /healthz
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 60
         ports:
           - name: agentport
             containerPort: {{ .Values.konnectivityTunnel.agentPort }}
           - name: adminport
             containerPort: {{ .Values.konnectivityTunnel.adminPort }}
+          - name: healthport
+            containerPort: {{ .Values.konnectivityTunnel.healthPort }}
         volumeMounts:
           - name: konnectivity-server-certs
             mountPath: /certs/konnectivity-server

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -7,6 +7,7 @@ konnectivityTunnel:
   serverCount: 2
   agentPort: 8132
   adminPort: 8133
+  healthPort: 8134
   agentNamespace: kube-system
 probeCredentials: base64(user:pass)
 shootNetworks:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Add liveness probe to konnectivity-server

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Liveness probe added to konnectivity-server
```
