### PR TITLE
Fix allow-to-dns network policy when nodeLocalDNS is enabled

### DIFF
--- a/charts/shoot-core/components/charts/network-policies/templates/allow-to-dns.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-to-dns.yaml
@@ -19,7 +19,11 @@ spec:
   - to:
     - podSelector:
         matchExpressions:
-        - {key: k8s-app, operator: In, values: [kube-dns,coredns]}
+        - {key: k8s-app, operator: In, values: [kube-dns]}
+    {{- if .Values.nodeLocalDNS.enabled }}
+    - ipBlock:
+        cidr: {{ .Values.nodeLocalDNS.kubeDNSClusterIP }}/32
+    {{- end }}
     ports:
     - protocol: UDP
       port: 53

--- a/charts/shoot-core/components/charts/network-policies/values.yaml
+++ b/charts/shoot-core/components/charts/network-policies/values.yaml
@@ -1,0 +1,3 @@
+nodeLocalDNS:
+  enabled: false
+  kubeDNSClusterIP: 1.1.1.1

--- a/pkg/operation/botanist/addons/networkpolicy/shoot_network_policy.go
+++ b/pkg/operation/botanist/addons/networkpolicy/shoot_network_policy.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+// ShootNetworkPolicyValues contain NodeLocalDNS configuration for
+// network-policy charts used in the kube-system namespace in the Shoot
+// cluster.
+type ShootNetworkPolicyValues struct {
+	Enabled      bool               `json:"enabled,omitempty"`
+	NodeLocalDNS NodeLocalDNSValues `json:"nodeLocalDNS,omitempty"`
+}
+
+// NodeLocalDNSValues contain optional IP address of the kube-dns
+// which should be allowed in the network policies.
+type NodeLocalDNSValues struct {
+	Enabled          bool   `json:"enabled,omitempty"`
+	KubeDNSClusterIP string `json:"kubeDNSClusterIP,omitempty"`
+}

--- a/pkg/operation/botanist/addons/networkpolicy/shoot_network_policy_suite_test.go
+++ b/pkg/operation/botanist/addons/networkpolicy/shoot_network_policy_suite_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	cr "github.com/gardener/gardener/pkg/chartrenderer"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/gardener/gardener/pkg/operation/botanist/addons/networkpolicy"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/version"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestNetworkPolicy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Shoot NetworkPolicy Suite")
+}
+
+const (
+	chartsRootPath = "../../../../../charts"
+)
+
+var _ = Describe("Shoot NetworkPolicy Chart", func() {
+
+	var (
+		c            client.Client
+		ctx          context.Context
+		np, expected *networkingv1.NetworkPolicy
+		val          ShootNetworkPolicyValues
+	)
+
+	BeforeEach(func() {
+		var (
+			tcp      = corev1.ProtocolTCP
+			udp      = corev1.ProtocolUDP
+			port53   = intstr.FromInt(53)
+			port8053 = intstr.FromInt(8053)
+			s        = runtime.NewScheme()
+		)
+
+		ctx = context.TODO()
+		np = &networkingv1.NetworkPolicy{}
+		val = ShootNetworkPolicyValues{Enabled: true}
+		expected = &networkingv1.NetworkPolicy{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "NetworkPolicy",
+				APIVersion: "networking.k8s.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener.cloud--allow-to-dns",
+				Namespace: "kube-system",
+				Labels:    map[string]string{"origin": "gardener"},
+				Annotations: map[string]string{
+					"gardener.cloud/description": "Allows Egress from pods labeled with 'networking.gardener.cloud/to-dns=allowed'\nto DNS running in the 'kube-system' namespace.\n",
+				},
+				ResourceVersion: "1",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"networking.gardener.cloud/to-dns": "allowed",
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+				Egress: []networkingv1.NetworkPolicyEgressRule{{
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &udp, Port: &port53},
+						{Protocol: &tcp, Port: &port53},
+						{Protocol: &udp, Port: &port8053},
+						{Protocol: &tcp, Port: &port8053},
+					},
+					To: []networkingv1.NetworkPolicyPeer{{
+						PodSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{{
+								Key:      "k8s-app",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"kube-dns"},
+							}},
+						},
+					},
+					},
+				},
+				},
+			},
+		}
+
+		Expect(networkingv1.AddToScheme(s)).NotTo(HaveOccurred(), "adding to schema succeeds")
+		c = fakeclient.NewFakeClientWithScheme(s)
+	})
+
+	JustBeforeEach(func() {
+		ca := kubernetes.NewChartApplier(
+			cr.NewWithServerVersion(&version.Info{}),
+			kubernetes.NewApplier(c, meta.NewDefaultRESTMapper([]schema.GroupVersion{})),
+		)
+
+		Expect(ca.Apply(
+			ctx,
+			filepath.Join(chartsRootPath, "shoot-core", "components", "charts", "network-policies"),
+			"kube-system",
+			"bar",
+			kubernetes.Values(val),
+		)).NotTo(HaveOccurred(), "can apply chart")
+
+		err := c.Get(ctx, client.ObjectKey{Name: "gardener.cloud--allow-to-dns", Namespace: "kube-system"}, np)
+		Expect(err).ToNot(HaveOccurred(), "get succeeds")
+	})
+
+	Context("nodelocaldns is disabled", func() {
+		BeforeEach(func() {
+			val.NodeLocalDNS.Enabled = false
+		})
+
+		It("allows traffic only to coredns", func() {
+			Expect(np).To(Equal(expected))
+		})
+	})
+
+	Context("nodelocaldns is enabled", func() {
+		BeforeEach(func() {
+			val.NodeLocalDNS.Enabled = true
+			val.NodeLocalDNS.KubeDNSClusterIP = "1.2.3.4"
+		})
+
+		It("allows traffic only to coredns", func() {
+			expected.Spec.Egress[0].To = append(expected.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
+				IPBlock: &networkingv1.IPBlock{
+					CIDR: "1.2.3.4/32",
+				},
+			})
+			Expect(np).To(Equal(expected))
+		})
+	})
+})

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -137,7 +137,7 @@ func (b *Botanist) generateOriginalConfig() (map[string]interface{}, error) {
 	// if IPVS is enabled, instruct the kubelet to create pods resolving DNS to the `nodelocaldns` network interface link-local ip address
 	// for more information checkout the [usage documentation](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/)
 	if b.Shoot.NodeLocalDNSEnabled && b.Shoot.IPVSEnabled() {
-		kubernetesConfig["clusterDNS"] = "169.254.20.10"
+		kubernetesConfig["clusterDNS"] = NodeLocalIPVSAddress
 	}
 
 	var (

--- a/pkg/operation/botanist/types.go
+++ b/pkg/operation/botanist/types.go
@@ -28,3 +28,6 @@ type Botanist struct {
 	DefaultDomainSecret *corev1.Secret
 	mutex               sync.RWMutex
 }
+
+// NodeLocalIPVSAddress is the IPv4 address used by node local dns when IPVS is used.
+const NodeLocalIPVSAddress = "169.254.20.10"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/priority normal

**What this PR does / why we need it**:

`gardener.cloud--allow-to-dns` network policy in the Shoot cluster now allows communication to the cluster ip of kube-dns

**Which issue(s) this PR fixes**:

Before this change on a pod labeled with `networking.gardener.cloud/to-dns=allowed`:

```console
root@busybox:/# nslookup example.com.
;; connection timed out; no servers could be reached
```

After the change:

```console
root@busybox:/#  nslookup example.com.
Server:         10.252.0.10
Address:        10.252.0.10#53

Non-authoritative answer:
Name:   example.com
Address: 93.184.216.34
Name:   example.com
Address: 2606:2800:220:1:248:1893:25c8:1946
```

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fix a bug where `gardener.cloud--allow-to-dns`  network policy do not allow traffic to DNS when `NodeLocalDNS` feature gate is enabled.
```
