### PR TITLE
Update konnectivity server config

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -315,6 +315,7 @@ spec:
         - --agent-port={{ .Values.konnectivityTunnel.agentPort }}
         - --admin-port={{ .Values.konnectivityTunnel.adminPort }}
         - --health-port={{ .Values.konnectivityTunnel.healthPort }}
+        - --delete-existing-uds-file=true
         resources:
 {{ toYaml .Values.konnectivityTunnelResources | indent 10 }}
         livenessProbe:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Set `delete-existing-uds-file=true`.

**Which issue(s) this PR fixes**:
When the connectivity server container crashes and restarts it runs in an error if the UDS file already exists.
With this flag  set it cleans up the UDS file before listening.
See: #https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/69


```improvement operator
None
```
