### PR TITLE
Upgrade grafana

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -115,7 +115,7 @@ images:
 - name: grafana
   sourceRepository: github.com/grafana/grafana
   repository: grafana/grafana
-  tag: "7.0.3"
+  tag: "7.2.1"
 - name: blackbox-exporter
   sourceRepository: github.com/prometheus/blackbox_exporter
   repository: quay.io/prometheus/blackbox-exporter

--- a/charts/seed-bootstrap/dashboards/fluent-bit-dashboard.json
+++ b/charts/seed-bootstrap/dashboards/fluent-bit-dashboard.json
@@ -63,7 +63,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(fluentbit_input_bytes_total[5m])) by (pod, name)",
+          "expr": "sum(rate(fluentbit_input_bytes_total[$__rate_interval])) by (pod, name)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -166,7 +166,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(fluentbit_output_proc_bytes_total[5m])) by (pod, name)",
+          "expr": "sum(rate(fluentbit_output_proc_bytes_total[$__rate_interval])) by (pod, name)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -269,7 +269,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(fluentbit_input_records_total[5m])) by (pod, name)",
+          "expr": "sum(rate(fluentbit_input_records_total[$__rate_interval])) by (pod, name)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -374,7 +374,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(fluentbit_output_proc_records_total[5m])) by (pod, name)",
+          "expr": "sum(rate(fluentbit_output_proc_records_total[$__rate_interval])) by (pod, name)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -479,7 +479,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(fluentbit_output_retries_total[5m])) by (pod, name)",
+          "expr": "sum(rate(fluentbit_output_retries_total[$__rate_interval])) by (pod, name)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -488,7 +488,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(rate(fluentbit_output_retries_failed_total[5m])) by (pod, name)",
+          "expr": "sum(rate(fluentbit_output_retries_failed_total[$__rate_interval])) by (pod, name)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -593,7 +593,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(fluentbit_output_errors_total[5m])) by (pod, name)",
+          "expr": "sum(rate(fluentbit_output_errors_total[$__rate_interval])) by (pod, name)",
           "format": "time_series",
           "hide": false,
           "interval": "",

--- a/charts/seed-bootstrap/dashboards/systemd-logs.json
+++ b/charts/seed-bootstrap/dashboards/systemd-logs.json
@@ -263,7 +263,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "1 - avg(rate(seed:node_cpu_seconds_total:sum[5m]))",
+          "expr": "1 - avg(rate(seed:node_cpu_seconds_total:sum[$__rate_interval]))",
           "instant": false,
           "interval": "",
           "legendFormat": "",

--- a/charts/seed-bootstrap/templates/grafana/grafana-datasources-configmap.yaml
+++ b/charts/seed-bootstrap/templates/grafana/grafana-datasources-configmap.yaml
@@ -26,6 +26,8 @@ data:
       isDefault: true
       version: 1
       editable: false
+      jsonData:
+        timeInterval: 1m
     - name: loki
       type: loki
       access: proxy

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/cluster-overview-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/cluster-overview-dashboard.json
@@ -897,7 +897,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(increase(kube_pod_container_status_restarts[1h]) > 5)",
+          "expr": "count(increase(kube_pod_container_status_restarts[$__rate_interval]) > 5)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -981,7 +981,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate (apiserver_audit_error_total{plugin=\"webhook\"} [5m])) by (app ,role) / ignoring(plugin) sum(rate(apiserver_audit_event_total [5m])) by (app, role)",
+          "expr": "sum(rate (apiserver_audit_error_total{plugin=\"webhook\"} [$__rate_interval])) by (app ,role) / ignoring(plugin) sum(rate(apiserver_audit_event_total [$__rate_interval])) by (app, role)",
           "format": "time_series",
           "instant": false,
           "interval": "",

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-backup-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-backup-dashboard.json
@@ -775,7 +775,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_snapshot_duration_seconds_bucket{role=\"main\",kind=\"Full\"}[2h])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_snapshot_duration_seconds_bucket{role=\"main\",kind=\"Full\"}[$__rate_interval])) by (le))",
           "hide": false,
           "instant": false,
           "intervalFactor": 1,
@@ -785,7 +785,7 @@
           "step": 4
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_snapshot_duration_seconds_bucket{role=\"main\",kind=\"Incr\"}[10m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcdbr_snapshot_duration_seconds_bucket{role=\"main\",kind=\"Incr\"}[$__rate_interval])) by (le))",
           "hide": false,
           "instant": false,
           "legendFormat": "Delta",
@@ -1219,7 +1219,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "rate(process_cpu_seconds_total{role=\"main\",job=\"kube-etcd3-backup-restore\"}[5m]) * 100",
+          "expr": "rate(process_cpu_seconds_total{role=\"main\",job=\"kube-etcd3-backup-restore\"}[$__rate_interval]) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "CPU",

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-dashboard.json
@@ -149,7 +149,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(grpc_server_started_total{role=~\"$cluster\",grpc_type=\"unary\"}[5m]))",
+          "expr": "sum(rate(grpc_server_started_total{role=~\"$cluster\",grpc_type=\"unary\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "RPC Rate",
@@ -158,7 +158,7 @@
           "step": 2
         },
         {
-          "expr": "sum(rate(grpc_server_handled_total{role=~\"$cluster\",grpc_type=\"unary\",grpc_code!=\"OK\"}[5m]))",
+          "expr": "sum(rate(grpc_server_handled_total{role=~\"$cluster\",grpc_type=\"unary\",grpc_code!=\"OK\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "RPC Failed Rate",
@@ -530,7 +530,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{role=~\"$cluster\"}[5m])) by (instance, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{role=~\"$cluster\"}[$__rate_interval])) by (instance, le))",
           "hide": false,
           "intervalFactor": 2,
           "legendFormat": "{{instance}} WAL fsync",
@@ -539,7 +539,7 @@
           "step": 4
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{role=~\"$cluster\"}[5m])) by (instance, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{role=~\"$cluster\"}[$__rate_interval])) by (instance, le))",
           "intervalFactor": 2,
           "legendFormat": "{{instance}} DB fsync",
           "metric": "etcd_disk_backend_commit_duration_seconds_bucket",
@@ -627,7 +627,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(etcd_network_client_grpc_received_bytes_total{role=~\"$cluster\"}[5m])",
+          "expr": "rate(etcd_network_client_grpc_received_bytes_total{role=~\"$cluster\"}[$__rate_interval])",
           "intervalFactor": 2,
           "legendFormat": "{{instance}} Client Traffic In",
           "metric": "etcd_network_client_grpc_received_bytes_total",
@@ -717,7 +717,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(etcd_network_client_grpc_sent_bytes_total{role=~\"$cluster\"}[5m])",
+          "expr": "rate(etcd_network_client_grpc_sent_bytes_total{role=~\"$cluster\"}[$__rate_interval])",
           "intervalFactor": 2,
           "legendFormat": "{{instance}} Client Traffic Out",
           "metric": "etcd_network_client_grpc_sent_bytes_total",
@@ -816,7 +816,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_fs_reads_bytes_total{namespace=\"kube-system\", pod=~\"etcd-(${cluster:pipe}).*\"}[2m])) by(pod, container)",
+          "expr": "sum(rate(container_fs_reads_bytes_total{namespace=\"kube-system\", pod=~\"etcd-(${cluster:pipe}).*\"}[$__rate_interval])) by(pod, container)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} / {{container}}",
@@ -900,7 +900,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_fs_writes_bytes_total{namespace=\"kube-system\", pod=~\"etcd-(${cluster:pipe}).*\"}[2m])) by(pod, container)",
+          "expr": "sum(rate(container_fs_writes_bytes_total{namespace=\"kube-system\", pod=~\"etcd-(${cluster:pipe}).*\"}[$__rate_interval])) by(pod, container)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}} / {{container}}",
@@ -1092,7 +1092,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(etcd_network_peer_received_bytes_total{role=~\"$cluster\"}[5m])) by (instance)",
+              "expr": "sum(rate(etcd_network_peer_received_bytes_total{role=~\"$cluster\"}[$__rate_interval])) by (instance)",
               "intervalFactor": 2,
               "legendFormat": "{{instance}} Peer Traffic In",
               "metric": "etcd_network_peer_received_bytes_total",
@@ -1183,7 +1183,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(etcd_network_peer_sent_bytes_total{role=~\"$cluster\"}[5m])) by (instance)",
+              "expr": "sum(rate(etcd_network_peer_sent_bytes_total{role=~\"$cluster\"}[$__rate_interval])) by (instance)",
               "hide": false,
               "interval": "",
               "intervalFactor": 2,
@@ -1273,7 +1273,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(etcd_server_proposals_failed_total{role=~\"$cluster\"}[5m]))",
+              "expr": "sum(rate(etcd_server_proposals_failed_total{role=~\"$cluster\"}[$__rate_interval]))",
               "intervalFactor": 2,
               "legendFormat": "Proposal Failure Rate",
               "metric": "etcd_server_proposals_failed_total",
@@ -1289,7 +1289,7 @@
               "step": 2
             },
             {
-              "expr": "sum(rate(etcd_server_proposals_committed_total{role=~\"$cluster\"}[5m]))",
+              "expr": "sum(rate(etcd_server_proposals_committed_total{role=~\"$cluster\"}[$__rate_interval]))",
               "intervalFactor": 2,
               "legendFormat": "Proposal Commit Rate",
               "metric": "etcd_server_proposals_committed_total",
@@ -1297,7 +1297,7 @@
               "step": 2
             },
             {
-              "expr": "sum(rate(etcd_server_proposals_applied_total{role=~\"$cluster\"}[5m]))",
+              "expr": "sum(rate(etcd_server_proposals_applied_total{role=~\"$cluster\"}[$__rate_interval]))",
               "intervalFactor": 2,
               "legendFormat": "Proposal Apply Rate",
               "refId": "D",

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-daemonsets-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-daemonsets-dashboard.json
@@ -72,7 +72,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$daemonset_name.*\"}[3m])) ",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$daemonset_name.*\"}[$__rate_interval])) ",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -238,7 +238,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"$daemonset_name.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{pod=~\"$daemonset_name.*\"}[3m])) ",
+          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"$daemonset_name.*\"}[$__rate_interval])) + sum(rate(container_network_receive_bytes_total{pod=~\"$daemonset_name.*\"}[$__rate_interval])) ",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-deployments-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-deployments-dashboard.json
@@ -77,7 +77,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$deployment_name.*\"}[3m])) ",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$deployment_name.*\"}[$__rate_interval])) ",
           "intervalFactor": 2,
           "refId": "A",
           "step": 600
@@ -253,7 +253,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"$deployment_name.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{pod=~\"$deployment_name.*\"}[3m])) ",
+          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"$deployment_name.*\"}[$__rate_interval])) + sum(rate(container_network_receive_bytes_total{pod=~\"$deployment_name.*\"}[$__rate_interval])) ",
           "intervalFactor": 2,
           "refId": "A",
           "step": 600

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
@@ -171,7 +171,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{container=~\"$container\",pod=~\"$pod\"}[2m]))",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{container=~\"$container\",pod=~\"$pod\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -286,7 +286,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"$pod\"}[2m])) by (pod)",
+          "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"$pod\"}[$__rate_interval])) by (pod)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Received",
@@ -294,7 +294,7 @@
           "step": 20
         },
         {
-          "expr": "- sum(rate(container_network_transmit_bytes_total{pod=~\"$pod\"}[2m])) by (pod)",
+          "expr": "- sum(rate(container_network_transmit_bytes_total{pod=~\"$pod\"}[$__rate_interval])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Sent",

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-statefulsets-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-statefulsets-dashboard.json
@@ -77,7 +77,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$statefulset_name.*\"}[3m])) ",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$statefulset_name.*\"}[$__rate_interval])) ",
           "intervalFactor": 2,
           "refId": "A",
           "step": 600
@@ -253,7 +253,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"$statefulset_name.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{pod=~\"$statefulset_name.*\"}[3m])) ",
+          "expr": "sum(rate(container_network_transmit_bytes_total{pod=~\"$statefulset_name.*\"}[$__rate_interval])) + sum(rate(container_network_receive_bytes_total{pod=~\"$statefulset_name.*\"}[$__rate_interval])) ",
           "intervalFactor": 2,
           "refId": "A",
           "step": 600

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/prometheus-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/prometheus-dashboard.json
@@ -57,7 +57,7 @@
           "stack": false,
           "steppedLine": false,
           "targets": [{
-            "expr": "sum(irate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus\"}[5m]))",
+            "expr": "sum(irate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus\"}[$__rate_interval]))",
             "format": "time_series",
             "hide": false,
             "interval": "",
@@ -624,7 +624,7 @@
               "step": 20
             },
             {
-              "expr": "irate(prometheus_tsdb_head_gc_duration_seconds_count{job=\"prometheus\"}[5m])",
+              "expr": "irate(prometheus_tsdb_head_gc_duration_seconds_count{job=\"prometheus\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "collections",
@@ -714,7 +714,7 @@
           "stack": false,
           "steppedLine": false,
           "targets": [{
-              "expr": "histogram_quantile(0.99, sum(rate(prometheus_tsdb_compaction_duration_bucket{job=\"prometheus\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(prometheus_tsdb_compaction_duration_bucket{job=\"prometheus\"}[$__rate_interval])) by (le))",
               "format": "time_series",
               "hide": false,
               "interval": "",
@@ -724,7 +724,7 @@
               "step": 20
             },
             {
-              "expr": "irate(prometheus_tsdb_compactions_total{job=\"prometheus\"}[5m])",
+              "expr": "irate(prometheus_tsdb_compactions_total{job=\"prometheus\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "compactions",
@@ -732,7 +732,7 @@
               "step": 20
             },
             {
-              "expr": "irate(prometheus_tsdb_compactions_failed_total{job=\"prometheus\"}[5m])",
+              "expr": "irate(prometheus_tsdb_compactions_failed_total{job=\"prometheus\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "failed",
@@ -740,7 +740,7 @@
               "step": 20
             },
             {
-              "expr": "irate(prometheus_tsdb_compactions_triggered_total{job=\"prometheus\"}[5m])",
+              "expr": "irate(prometheus_tsdb_compactions_triggered_total{job=\"prometheus\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "triggered",
@@ -814,7 +814,7 @@
           "stack": false,
           "steppedLine": false,
           "targets": [{
-              "expr": "rate(prometheus_tsdb_reloads_total{job=\"prometheus\"}[5m])",
+              "expr": "rate(prometheus_tsdb_reloads_total{job=\"prometheus\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "reloads",
@@ -822,7 +822,7 @@
               "step": 20
             },
             {
-              "expr": "rate(prometheus_tsdb_reloads_failures_total{job=\"prometheus\"}[5m])",
+              "expr": "rate(prometheus_tsdb_reloads_failures_total{job=\"prometheus\"}[$__rate_interval])",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -1060,7 +1060,7 @@
           "stack": true,
           "steppedLine": false,
           "targets": [{
-              "expr": "rate(prometheus_rule_group_iterations_missed_total{job=\"prometheus\"}[5m])",
+              "expr": "rate(prometheus_rule_group_iterations_missed_total{job=\"prometheus\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "missed",
@@ -1068,7 +1068,7 @@
               "step": 10
             },
             {
-              "expr": "rate(prometheus_rule_group_iterations_total{job=\"prometheus\"}[5m])",
+              "expr": "rate(prometheus_rule_group_iterations_total{job=\"prometheus\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "iterations",

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/vpa-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/vpa-dashboard.json
@@ -236,7 +236,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$targetName-(.+)\"}[5m])) by (container)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$targetName-(.+)\"}[$__rate_interval])) by (container)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ container }} actual usage",

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/vpn-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/vpn-dashboard.json
@@ -170,7 +170,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sort_desc(sum by (pod) (rate (container_network_receive_bytes_total{pod=~\"vpn-shoot-.*\"}[2m]) ))",
+          "expr": "sort_desc(sum by (pod) (rate (container_network_receive_bytes_total{pod=~\"vpn-shoot-.*\"}[$__rate_interval]) ))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Received",
@@ -178,7 +178,7 @@
           "step": 20
         },
         {
-          "expr": "-sort_desc(sum by (pod) (rate (container_network_transmit_bytes_total{pod=~\"vpn-shoot-.*\"}[2m]) ))",
+          "expr": "-sort_desc(sum by (pod) (rate (container_network_transmit_bytes_total{pod=~\"vpn-shoot-.*\"}[$__rate_interval]) ))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Transmitted",
@@ -274,7 +274,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"vpn-shoot-.*\"}[2m]))",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"vpn-shoot-.*\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -518,7 +518,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_cpu_usage_seconds_total{pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}[2m])",
+          "expr": "rate(container_cpu_usage_seconds_total{pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
           "interval": "10s",

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/coredns-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/coredns-dashboard.json
@@ -65,7 +65,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(coredns_dns_request_duration_seconds_count{pod=~\"$pod\"}[5m])) by (type)",
+          "expr": "sum(rate(coredns_dns_request_duration_seconds_count{pod=~\"$pod\"}[$__rate_interval])) by (type)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -74,7 +74,7 @@
           "step": 60
         },
         {
-          "expr": "sum(rate(coredns_dns_request_duration_seconds_count{pod=~\"$pod\"}[5m])) by (proto)",
+          "expr": "sum(rate(coredns_dns_request_duration_seconds_count{pod=~\"$pod\"}[$__rate_interval])) by (proto)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -82,7 +82,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(rate(coredns_dns_request_duration_seconds_count{pod=~\"$pod\"}[5m])) by (zone)",
+          "expr": "sum(rate(coredns_dns_request_duration_seconds_count{pod=~\"$pod\"}[$__rate_interval])) by (zone)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -301,7 +301,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(coredns_dns_responses_total{pod=\"$pod\"}[5m])",
+          "expr": "rate(coredns_dns_responses_total{pod=\"$pod\"}[$__rate_interval])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -513,7 +513,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(coredns_cache_hits_total{pod=~\"$pod\"}[5m])",
+              "expr": "rate(coredns_cache_hits_total{pod=~\"$pod\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "cache hits",
@@ -521,7 +521,7 @@
               "step": 40
             },
             {
-              "expr": "rate(coredns_cache_misses_total{pod=~\"$pod\"}[5m])",
+              "expr": "rate(coredns_cache_misses_total{pod=~\"$pod\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "cache misses",
@@ -845,7 +845,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(coredns_forward_requests_total{pod=\"$pod\"}[5m])) by (to)",
+              "expr": "sum(rate(coredns_forward_requests_total{pod=\"$pod\"}[$__rate_interval])) by (to)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -943,7 +943,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(coredns_forward_responses_total{pod=\"$pod\"}[5m])",
+              "expr": "rate(coredns_forward_responses_total{pod=\"$pod\"}[$__rate_interval])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-control-plane-status-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-control-plane-status-dashboard.json
@@ -404,7 +404,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(sum by(instance) (rate(apiserver_request_total{code=~\"5..\"}[5m])) / sum by(instance) (rate(apiserver_request_total[5m]))) * 100",
+          "expr": "max(sum by(instance) (rate(apiserver_request_total{code=~\"5..\"}[$__rate_interval])) / sum by(instance) (rate(apiserver_request_total[$__rate_interval]))) * 100",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -583,7 +583,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"kube-apiserver-(.+)\"}[5m])) by (pod)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"kube-apiserver-(.+)\"}[$__rate_interval])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}}-current",
@@ -798,7 +798,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apiserver_request_total{code!~\"2..\"}[5m]))",
+          "expr": "sum(rate(apiserver_request_total{code!~\"2..\"}[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Error Rate",
@@ -806,7 +806,7 @@
           "step": 60
         },
         {
-          "expr": "sum(rate(apiserver_request_total[5m]))",
+          "expr": "sum(rate(apiserver_request_total[$__rate_interval]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Request Rate",
@@ -903,7 +903,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by(verb) (rate(apiserver_latency_seconds:quantile[5m]) >= 0)",
+          "expr": "sum by(verb) (rate(apiserver_latency_seconds:quantile[$__rate_interval]) >= 0)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{verb}}",
@@ -1297,7 +1297,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(container_cpu_usage_seconds_total{pod=~\"kube-controller-manager-(.+)\"}[5m])",
+              "expr": "rate(container_cpu_usage_seconds_total{pod=~\"kube-controller-manager-(.+)\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "current",
@@ -1499,7 +1499,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(rest_client_requests_total{host=~\".*kube-apiserver.*\", job=\"kube-controller-manager\"}[5m])) by(code)",
+              "expr": "sum(rate(rest_client_requests_total{host=~\".*kube-apiserver.*\", job=\"kube-controller-manager\"}[$__rate_interval])) by(code)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{code}}",
@@ -1600,7 +1600,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(container_cpu_usage_seconds_total{pod=~\"kube-scheduler-(.+)\"}[5m])",
+              "expr": "rate(container_cpu_usage_seconds_total{pod=~\"kube-scheduler-(.+)\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "current",
@@ -1898,7 +1898,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(rest_client_requests_total{host=~\".*kube-apiserver.*\", job=\"kube-scheduler\"}[5m])) by(code)",
+              "expr": "sum(rate(rest_client_requests_total{host=~\".*kube-apiserver.*\", job=\"kube-scheduler\"}[$__rate_interval])) by(code)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{code}}",

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
@@ -46,7 +46,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m])) by (node) + on (node) group_right sum(kube_node_labels{label_worker_garden_sapcloud_io_group=~\"$worker_group\"}) by (label_worker_garden_sapcloud_io_group, node) - 1) by (label_worker_garden_sapcloud_io_group)",
+          "expr": "avg(sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[$__rate_interval])) by (node) + on (node) group_right sum(kube_node_labels{label_worker_garden_sapcloud_io_group=~\"$worker_group\"}) by (label_worker_garden_sapcloud_io_group, node) - 1) by (label_worker_garden_sapcloud_io_group)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{label_worker_garden_sapcloud_io_group}}",
@@ -553,7 +553,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[2m])) by (node) + on (node) group_right sum(kube_node_labels{label_worker_garden_sapcloud_io_group=~\"$worker_group\"}) by (label_worker_garden_sapcloud_io_group, node) - 1",
+          "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[$__rate_interval])) by (node) + on (node) group_right sum(kube_node_labels{label_worker_garden_sapcloud_io_group=~\"$worker_group\"}) by (label_worker_garden_sapcloud_io_group, node) - 1",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -568,7 +568,7 @@
           "refId": "C"
         },
         {
-          "expr": "(sum(kube_node_status_allocatable_cpu_cores) by (node) - sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m])) by (node)) + on (node) group_right sum(kube_node_labels{label_worker_garden_sapcloud_io_group=~\"$worker_group\"}) by (label_worker_garden_sapcloud_io_group, node) - 1",
+          "expr": "(sum(kube_node_status_allocatable_cpu_cores) by (node) - sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[$__rate_interval])) by (node)) + on (node) group_right sum(kube_node_labels{label_worker_garden_sapcloud_io_group=~\"$worker_group\"}) by (label_worker_garden_sapcloud_io_group, node) - 1",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/shoot-vpa-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/shoot-vpa-dashboard.json
@@ -199,7 +199,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{type=\"shoot\", container=~\"$container\"}[5m])) by (container)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{type=\"shoot\", container=~\"$container\"}[$__rate_interval])) by (container)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-datasources-configmap.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-datasources-configmap.yaml
@@ -27,6 +27,8 @@ data:
       isDefault: true
       version: 1
       editable: false
+      jsonData:
+        timeInterval: 1m
     - name: loki
       type: loki
       access: proxy

--- a/charts/seed-monitoring/charts/grafana/templates/logging-dashboard.tpl
+++ b/charts/seed-monitoring/charts/grafana/templates/logging-dashboard.tpl
@@ -147,8 +147,8 @@
         "stack": false,
         "steppedLine": false,
         "targets": [
-          {                                                     
-            "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"{{ $.podPrefix }}-(.+)\"}[5m])) by (pod)",
+          {
+            "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"{{ $.podPrefix }}-(.+)\"}[$__rate_interval])) by (pod)",
             "format": "time_series",
             "intervalFactor": 1,
             "legendFormat": "{{ "{{" }}pod}}-current",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Grafana dashboards now use `$__rate_interval` instead of hard coded intervals. This should improve dashboard performance when selecting large time ranges.

**Which issue(s) this PR fixes**:
Fixes #3001 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Upgrade grafana to version 7.2.1
```
```improvement operator
Grafana dashboards now use `$__rate_interval` instead of hard coded intervals. This should improve dashboard performance when selecting large time ranges.
```
