### PR TITLE
Increase `KubeEtcdFullBackupFailed` Alert to 2 days

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/kube-etcd3.rules.test.yaml
@@ -32,9 +32,9 @@ tests:
     values: '1+0x62'
   # KubeEtcdFullBackupFailed
   - series: 'etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore",role="main",kind="Full"}'
-    values: '0+0x2912'
+    values: '0+0x5790'
   - series: 'etcdbr_snapshot_required{job="kube-etcd3-backup-restore",role="main",kind="Full"}'
-    values: '1+0x2912'
+    values: '1+0x5790'
   # KubeEtcdRestorationFailed
   - series: 'etcdbr_restoration_duration_seconds_count{job="kube-etcd3-backup-restore",role="main",succeeded="false"}'
     values: '0+0x7 1 2 2'
@@ -136,7 +136,7 @@ tests:
       exp_annotations:
         description: No delta snapshot for the past at least 30 minutes.
         summary: Etcd delta snapshot failure.
-  - eval_time: 1456m
+  - eval_time: 2896m # 2 days + 16 minutes
     alertname: KubeEtcdFullBackupFailed
     exp_alerts:
     - exp_labels:
@@ -148,7 +148,7 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: No full snapshot taken in the past day.
+        description: No full snapshot taken in the past 2 days.
         summary: Etcd full snapshot failure.
   - eval_time: 5m
     alertname: KubeEtcdRestorationFailed

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-etcd3.rules.yaml
@@ -102,8 +102,10 @@ groups:
     annotations:
       description: No delta snapshot for the past at least 30 minutes.
       summary: Etcd delta snapshot failure.
+
+  # TODO (wyb1): change back to 86400 (1 day) once logic in B&R is fixed
   - alert: KubeEtcdFullBackupFailed
-    expr: (time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore",kind="Full",role="main"} > bool 86400) + (etcdbr_snapshot_required{kind="Full", role="main"} >= bool 1) == 2
+    expr: (time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore",kind="Full",role="main"} > bool 172800) + (etcdbr_snapshot_required{kind="Full", role="main"} >= bool 1) == 2
     for: 15m
     labels:
         service: etcd
@@ -111,7 +113,7 @@ groups:
         type: seed
         visibility: operator
     annotations:
-        description: No full snapshot taken in the past day.
+        description: No full snapshot taken in the past 2 days.
         summary: Etcd full snapshot failure.
 
   # etcd data restoration failure alert


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Increase time until `KubeEtcdFullBackupFailed` alert fires to 2 days. Previously this alert would fire after 1 day, but this causes many false positive alerts.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This change should be reverted once the cause of false positives is fixed.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fire `KubeEtcdFullBackupFailed` alert after 2 days instead of 1 day
```
