### PR TITLE
Increase severe threshold timeout for etcd to 3m

### DIFF
--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -63,7 +63,7 @@ func (b *Botanist) WaitUntilEtcdReady(ctx context.Context) error {
 	var (
 		retryCountUntilSevere int
 		interval              = 5 * time.Second
-		severeThreshold       = 30 * time.Second
+		severeThreshold       = 3 * time.Minute
 		timeout               = 5 * time.Minute
 	)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:
The etcd-druid waits for 1m for the statefulset backing etcd pods to be ready. Then it errors and writes this error into the `Etcd` resource's `.status.lastError` field. When Gardener detects this then it considers it as severe after `30s`. In the end, it might take some time (depending on the underlying infrastructure) to provision a volume, attach and mount it, and start etcd, so let's give the whole process a bit more time.

Ref #2397 

**Special notes for your reviewer**:
/cc @amshuman-kr @shreyas-s-rao @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
