### PR TITLE
Fix cluster-autoscaler seed bootstrapping

### DIFF
--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -67,6 +67,11 @@ var (
 		client.GracePeriodSeconds(0),
 	}
 
+	// SeedSerializer is a YAML serializer using the Seed scheme.
+	SeedSerializer = json.NewSerializerWithOptions(json.DefaultMetaFactory, SeedScheme, SeedScheme, json.SerializerOptions{Yaml: true, Pretty: false, Strict: false})
+	// SeedCodec is a codec factory using the Seed scheme.
+	SeedCodec = serializer.NewCodecFactory(SeedScheme)
+
 	// ShootSerializer is a YAML serializer using the Shoot scheme.
 	ShootSerializer = json.NewSerializerWithOptions(json.DefaultMetaFactory, ShootScheme, ShootScheme, json.SerializerOptions{Yaml: true, Pretty: false, Strict: false})
 	// ShootCodec is a codec factory using the Shoot scheme.

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -206,7 +206,7 @@ func (b *Botanist) DeployManagedResources(ctx context.Context) error {
 			return fmt.Errorf("error rendering %q chart: %+v", name, err)
 		}
 
-		if err := common.DeployManagedResource(ctx, b.K8sSeedClient.Client(), name, b.Shoot.SeedNamespace, options.keepObjects, renderedChart.AsSecretData()); err != nil {
+		if err := common.DeployManagedResourceForShoot(ctx, b.K8sSeedClient.Client(), name, b.Shoot.SeedNamespace, options.keepObjects, renderedChart.AsSecretData()); err != nil {
 			return err
 		}
 	}
@@ -257,7 +257,7 @@ func (b *Botanist) deployCloudConfigExecutionManagedResource(ctx context.Context
 		cloudConfigCharts[name] = b.getGenerateCloudConfigExecutionChartFunc(name, worker, bootstrapTokenSecret)
 	}
 
-	cloudConfigManagedResource := common.NewManagedResource(b.K8sSeedClient.Client(), managedResourceName, b.Shoot.SeedNamespace, false)
+	cloudConfigManagedResource := common.NewManagedResourceForShoot(b.K8sSeedClient.Client(), managedResourceName, b.Shoot.SeedNamespace, false)
 
 	// reconcile secrets and reference them to the ManagedResource
 	fns := make([]flow.TaskFn, 0, len(cloudConfigCharts))

--- a/pkg/operation/botanist/controlplane/clusterautoscaler/bootstrap.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/bootstrap.go
@@ -37,7 +37,7 @@ const (
 func BootstrapSeed(ctx context.Context, c client.Client, namespace, _ string) error {
 	var (
 		versions = schema.GroupVersions([]schema.GroupVersion{rbacv1.SchemeGroupVersion})
-		codec    = kubernetes.ShootCodec.CodecForVersions(kubernetes.ShootSerializer, kubernetes.ShootSerializer, versions, versions)
+		codec    = kubernetes.ShootCodec.CodecForVersions(kubernetes.SeedSerializer, kubernetes.SeedSerializer, versions, versions)
 
 		clusterRole = &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
@@ -54,7 +54,7 @@ func BootstrapSeed(ctx context.Context, c client.Client, namespace, _ string) er
 		clusterRoleYAML, _ = runtime.Encode(codec, clusterRole)
 	)
 
-	return common.DeployManagedResource(ctx, c, managedResourceControlName, namespace, false, map[string][]byte{
+	return common.DeployManagedResourceForSeed(ctx, c, managedResourceControlName, namespace, false, map[string][]byte{
 		"clusterrole.yaml": clusterRoleYAML,
 	})
 }

--- a/pkg/operation/botanist/controlplane/clusterautoscaler/bootstrap_test.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/bootstrap_test.go
@@ -93,14 +93,13 @@ rules:
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      managedResourceName,
 					Namespace: namespace,
-					Labels:    map[string]string{"origin": "gardener"},
 				},
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
 					SecretRefs: []corev1.LocalObjectReference{
 						{Name: managedResourceSecretName},
 					},
-					InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
-					KeepObjects:  pointer.BoolPtr(false),
+					Class:       pointer.StringPtr("seed"),
+					KeepObjects: pointer.BoolPtr(false),
 				},
 			}
 		)

--- a/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler.go
@@ -266,7 +266,7 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	return common.DeployManagedResource(ctx, c.client, managedResourceTargetName, c.namespace, false, c.computeShootResourcesData())
+	return common.DeployManagedResourceForShoot(ctx, c.client, managedResourceTargetName, c.namespace, false, c.computeShootResourcesData())
 }
 
 func (c *clusterAutoscaler) Destroy(ctx context.Context) error {

--- a/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler.go
+++ b/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler.go
@@ -326,7 +326,7 @@ func (k *kubeScheduler) emptyManagedResourceSecret() *corev1.Secret {
 
 func (k *kubeScheduler) reconcileShootResources(ctx context.Context) error {
 	if versionConstraintK8sEqual113.Check(k.version) {
-		return common.DeployManagedResource(ctx, k.client, managedResourceName, k.namespace, false, k.computeShootResourcesData())
+		return common.DeployManagedResourceForShoot(ctx, k.client, managedResourceName, k.namespace, false, k.computeShootResourcesData())
 	}
 
 	return kutil.DeleteObjects(ctx, k.client, k.emptyManagedResource(), k.emptyManagedResourceSecret())

--- a/pkg/operation/common/managedresources.go
+++ b/pkg/operation/common/managedresources.go
@@ -31,16 +31,23 @@ const (
 	ManagedResourceSecretPrefix = "managedresource-"
 )
 
-// DeployManagedResource deploys a ManagedResource CR for the gardener-resource-manager.
-func DeployManagedResource(ctx context.Context, c client.Client, name, namespace string, keepObjects bool, data map[string][]byte) error {
-	var (
-		secretName, secret = NewManagedResourceSecret(c, name, namespace, data)
-		managedResource    = NewManagedResource(c, name, namespace, keepObjects)
-	)
+// DeployManagedResourceForShoot deploys a ManagedResource CR for the shoot's gardener-resource-manager.
+func DeployManagedResourceForShoot(ctx context.Context, c client.Client, name, namespace string, keepObjects bool, data map[string][]byte) error {
+	return deployManagedResource(ctx, c, name, namespace, data, NewManagedResourceForShoot(c, name, namespace, keepObjects))
+}
+
+// DeployManagedResourceForSeed deploys a ManagedResource CR for the seed's gardener-resource-manager.
+func DeployManagedResourceForSeed(ctx context.Context, c client.Client, name, namespace string, keepObjects bool, data map[string][]byte) error {
+	return deployManagedResource(ctx, c, name, namespace, data, NewManagedResourceForSeed(c, name, namespace, keepObjects))
+}
+
+func deployManagedResource(ctx context.Context, c client.Client, name, namespace string, data map[string][]byte, managedResource *manager.ManagedResource) error {
+	secretName, secret := NewManagedResourceSecret(c, name, namespace, data)
 
 	if err := secret.Reconcile(ctx); err != nil {
 		return err
 	}
+
 	return managedResource.WithSecretRef(secretName).Reconcile(ctx)
 }
 
@@ -53,8 +60,8 @@ func NewManagedResourceSecret(c client.Client, name, namespace string, data map[
 		WithKeyValues(data)
 }
 
-// NewManagedResource constructs a new ManagedResource object for the Gardener-Resource-Manager.
-func NewManagedResource(c client.Client, name, namespace string, keepObjects bool) *manager.ManagedResource {
+// NewManagedResourceForShoot constructs a new ManagedResource object for the shoot's Gardener-Resource-Manager.
+func NewManagedResourceForShoot(c client.Client, name, namespace string, keepObjects bool) *manager.ManagedResource {
 	var (
 		injectedLabels = map[string]string{ShootNoCleanup: "true"}
 		labels         = map[string]string{ManagedResourceLabelKeyOrigin: ManagedResourceLabelValueGardener}
@@ -64,6 +71,14 @@ func NewManagedResource(c client.Client, name, namespace string, keepObjects boo
 		WithNamespacedName(namespace, name).
 		WithLabels(labels).
 		WithInjectedLabels(injectedLabels).
+		KeepObjects(keepObjects)
+}
+
+// NewManagedResourceForSeed constructs a new ManagedResource object for the seed's Gardener-Resource-Manager.
+func NewManagedResourceForSeed(c client.Client, name, namespace string, keepObjects bool) *manager.ManagedResource {
+	return manager.NewManagedResource(c).
+		WithNamespacedName(namespace, name).
+		WithClass("seed").
 		KeepObjects(keepObjects)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR fixes the seed bootstrapping of the `cluster-autoscaler` component by configuring the `ManagedResource` properly so that the seed's GRM picks it up and reconciles the objects.

**Special notes for your reviewer**:
The bug has been introduced with the refactoring PR #2858.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug has been fixed that prevented the correct cluster-autoscaler seed bootstrapping (concretely, for new seeds the central cluster-autoscaler RBAC `ClusterRole` was not created), which, as a consequence, led to broken/non-working cluster-autoscaler pods for all shoots on that seed.
```
