### PR TITLE
Add missing admission plugin image definition in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ REGISTRY                            := eu.gcr.io/gardener-project/gardener
 APISERVER_IMAGE_REPOSITORY          := $(REGISTRY)/apiserver
 CONTROLLER_MANAGER_IMAGE_REPOSITORY := $(REGISTRY)/controller-manager
 SCHEDULER_IMAGE_REPOSITORY          := $(REGISTRY)/scheduler
+ADMISSION_IMAGE_REPOSITORY          := $(REGISTRY)/admission-controller
 SEED_ADMISSION_IMAGE_REPOSITORY     := $(REGISTRY)/seed-admission-controller
 GARDENLET_IMAGE_REPOSITORY          := $(REGISTRY)/gardenlet
 PUSH_LATEST_TAG                     := false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/priority normal

**What this PR does / why we need it**:
When trying to build the gardener images with `make docker-images`, the build fails for the admission controller as the used variable [ADMISSION_IMAGE_REPOSITORY](https://github.com/gardener/gardener/blob/master/Makefile#L107) is not defined.

```
Successfully tagged eu.gcr.io/gardener-project/gardener/scheduler:latest
invalid argument ":v1.12.0-dev-9c3980a3e74b25b9dac3be838db49e5ba81f3a8a" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.
make: *** [docker-images] Error 125
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
