### PR TITLE
Add SeedChange feature gate for gardener-apiserver

### DIFF
--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -27,7 +27,6 @@ import (
 	settingsv1alpha1 "github.com/gardener/gardener/pkg/apis/settings/v1alpha1"
 	"github.com/gardener/gardener/pkg/apiserver"
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
-	"github.com/gardener/gardener/pkg/apiserver/features"
 	"github.com/gardener/gardener/pkg/apiserver/storage"
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/internalversion"
 	gardenversionedcoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
@@ -365,7 +364,7 @@ func (o *Options) ApplyTo(config *apiserver.Config) error {
 	}
 	if initializers, err := o.Recommended.ExtraAdmissionInitializers(gardenerAPIServerConfig); err != nil {
 		return err
-	} else if err := o.Recommended.Admission.ApplyTo(&gardenerAPIServerConfig.Config, gardenerAPIServerConfig.SharedInformerFactory, gardenerAPIServerConfig.ClientConfig, features.FeatureGate, initializers...); err != nil {
+	} else if err := o.Recommended.Admission.ApplyTo(&gardenerAPIServerConfig.Config, gardenerAPIServerConfig.SharedInformerFactory, gardenerAPIServerConfig.ClientConfig, utilfeature.DefaultFeatureGate, initializers...); err != nil {
 		return err
 	}
 

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -26,6 +26,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | ManagedIstio | `false` | `Alpha` | `1.5` | |
 | APIServerSNI | `false` | `Alpha` | `1.7` | |
 | MountHostCADirectories | `false` | `Alpha` | `1.11.0` | |
+| SeedChange | `false` | `Alpha` | `1.12.0` | |
 
 ## Using a feature
 
@@ -69,3 +70,4 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 * `ManagedIstio` enables a Gardener-tailored [Istio](https://istio.io) in each Seed cluster. Disable this feature if Istio is already installed in the cluster. Istio is not automatically removed if this feature is disabled. See the [detailed documentation](../usage/istio.md) for more information.
 * `APIServerSNI` enables only one LoadBalancer to be used for every Shoot cluster API server in a Seed. Enable this feature when `ManagedIstio` is enabled or Istio is manually deployed in Seed cluster. See [GEP-8](../proposals/08-shoot-apiserver-via-sni.md) for more details.
 * `MountHostCADirectories` enables mounting common CA certificate directories in the Shoot API server pod that might be required for webhooks or OIDC. 
+* `SeedChange` enables updating the `spec.seedName` field during shoot validation from a non-empty value in order to trigger shoot control plane migration.

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -33,6 +33,7 @@ apiserver_flags="
   --secure-port=8443 \
   --tls-cert-file $tls_dir/tls.crt \
   --tls-private-key-file $tls_dir/tls.key \
+  --feature-gates SeedChange=true \
   --v 2"
 
 if [[ "$(uname -s)" == "Linux" && "$(uname -r)" =~ "microsoft-standard" ]]; then

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/operation/botanist"
 	"github.com/gardener/gardener/pkg/utils"
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
@@ -43,6 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 var (
@@ -148,7 +150,7 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, deletionTimestamp
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Region, oldSpec.Region, fldPath.Child("region"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.CloudProfileName, oldSpec.CloudProfileName, fldPath.Child("cloudProfileName"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.SecretBindingName, oldSpec.SecretBindingName, fldPath.Child("secretBindingName"))...)
-	if oldSpec.SeedName != nil {
+	if oldSpec.SeedName != nil && !utilfeature.DefaultFeatureGate.Enabled(features.SeedChange) {
 		// allow initial seed assignment
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.SeedName, oldSpec.SeedName, fldPath.Child("seedName"))...)
 	}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -34,10 +34,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	. "github.com/gardener/gardener/pkg/apis/core/validation"
+	"github.com/gardener/gardener/pkg/features"
+	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -523,7 +526,9 @@ var _ = Describe("Shoot Validation Tests", func() {
 			))
 		})
 
-		It("should forbid updating the seed, if it has been set previously", func() {
+		It("should forbid updating the seed if it has been set previously and the SeedChange feature gate is not enabled", func() {
+			defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SeedChange, false)()
+
 			newShoot := prepareShootForUpdate(shoot)
 			newShoot.Spec.SeedName = pointer.StringPtr("another-seed")
 			shoot.Spec.SeedName = pointer.StringPtr("first-seed")
@@ -536,6 +541,18 @@ var _ = Describe("Shoot Validation Tests", func() {
 					"Field": Equal("spec.seedName"),
 				}))),
 			)
+		})
+
+		It("should allow updating the seed if it has been set previously and the SeedChange feature gate is enabled", func() {
+			defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SeedChange, true)()
+
+			newShoot := prepareShootForUpdate(shoot)
+			newShoot.Spec.SeedName = pointer.StringPtr("another-seed")
+			shoot.Spec.SeedName = pointer.StringPtr("first-seed")
+
+			errorList := ValidateShootUpdate(newShoot, shoot)
+
+			Expect(errorList).To(BeEmpty())
 		})
 
 		It("should forbid passing an extension w/o type information", func() {

--- a/pkg/apis/core/validation/validation_suite_test.go
+++ b/pkg/apis/core/validation/validation_suite_test.go
@@ -15,13 +15,16 @@
 package validation_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"testing"
+	"github.com/gardener/gardener/pkg/apiserver/features"
 )
 
 func TestValidation(t *testing.T) {
+	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Core API Validation Suite")
 }

--- a/pkg/apiserver/features/features.go
+++ b/pkg/apiserver/features/features.go
@@ -16,17 +16,19 @@ package features
 
 import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/featuregate"
+
+	"github.com/gardener/gardener/pkg/features"
 )
 
 var (
-	// FeatureGate is a shared global FeatureGate for Gardener APIServer flags.
-	// right now the Generic API server uses this feature gate as default
-	FeatureGate  = featuregate.NewFeatureGate()
-	featureGates = map[featuregate.Feature]featuregate.FeatureSpec{}
+	featureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+		features.SeedChange: {Default: false, PreRelease: featuregate.Alpha},
+	}
 )
 
 // RegisterFeatureGates registers the feature gates of the Gardener API Server.
 func RegisterFeatureGates() {
-	utilruntime.Must(FeatureGate.Add(featureGates))
+	utilruntime.Must(utilfeature.DefaultMutableFeatureGate.Add(featureGates))
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -77,4 +77,10 @@ const (
 	// owner @danielfoehrKn
 	// alpha: v1.11.0
 	MountHostCADirectories featuregate.Feature = "MountHostCADirectories"
+
+	// SeedChange enables updating the `spec.seedName` field during shoot validation from a non-empty value
+	// in order to trigger shoot control plane migration.
+	// owner: @stoyanr
+	// alpha: v1.12.0
+	SeedChange featuregate.Feature = "SeedChange"
 )


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Adds `SeedChange` feature gate for `gardener-apiserver`. If set, this feature gate enables updating the `spec.seedName` field during shoot validation from a non-empty value in order to trigger shoot control plane migration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Unlike other Gardener components, `gardener-apiserver` is not configured via a `componentconfig` but instead relies on passing the feature gates via the command line and uses the `	DefaultMutableFeatureGate` during startup. Therefore, I am simply adding the new feature gate to the `DefaultMutableFeatureGate` and making sure it's used instead of the (empty) `FeatureGate` when calling `o.Recommended.Admission.ApplyTo`.

**Release note**:

```noteworthy operator
`gardener-apiserver` now has a new feature gate `SeedChange`. If set, this feature gate enables updating the `spec.seedName` field during shoot validation from a non-empty value in order to trigger shoot control plane migration.
```
