### PR TITLE
Components in kube-system use FQDN of the APIServer if SNI is enabled

### DIFF
--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-dashboard.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-dashboard.yaml
@@ -47,6 +47,11 @@ spec:
         {{- if semverCompare ">= 1.16" .Capabilities.KubeVersion.GitVersion }}
         - --namespace={{ include "kubernetes-dashboard.namespace" . }}
         {{- end }}
+        {{- if .Values.kubeAPIServerHost }}
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ .Values.kubeAPIServerHost}}
+        {{- end }}
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/charts/shoot-addons/charts/kubernetes-dashboard/values.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/values.yaml
@@ -8,3 +8,4 @@ images:
   kubernetes-dashboard-metrics-scraper: image-repository:image-tag
 
 authenticationMode: basic
+# kubeAPIServerHost: foo.bar

--- a/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -81,6 +81,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        {{- if .Values.kubeAPIServerHost }}
+          - name: KUBERNETES_SERVICE_HOST
+            value: {{ .Values.kubeAPIServerHost}}
+        {{- end }}
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/charts/shoot-addons/charts/nginx-ingress/values.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/values.yaml
@@ -224,3 +224,5 @@ tcp: {}
 ##
 udp: {}
   # 53: "kube-system/kube-dns:53"
+
+# kubeAPIServerHost: foo.bar

--- a/charts/shoot-core/components/charts/coredns/templates/coredns-deployment.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-deployment.yaml
@@ -55,6 +55,11 @@ spec:
         args:
         - -conf
         - /etc/coredns/Corefile
+        {{- if .Values.kubeAPIServerHost }}
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ .Values.kubeAPIServerHost}}
+        {{- end }}
         {{- if .Values.deployment.spec.containers.resources }}
         resources:
 {{ .Values.deployment.spec.containers.resources | toYaml | trimSuffix "\n"| indent 10 }}

--- a/charts/shoot-core/components/charts/coredns/values.yaml
+++ b/charts/shoot-core/components/charts/coredns/values.yaml
@@ -74,3 +74,4 @@ horizontalPodAutoScaler:
     minReplicas: 2
     metrics:
       targetAverageUtilization: 70
+# kubeAPIServerHost: foo.bar

--- a/charts/shoot-core/components/charts/metrics-server/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/metrics-server/templates/deployment.yaml
@@ -59,6 +59,11 @@ spec:
         - --tls-cert-file=/srv/metrics-server/tls/tls.crt
         - --tls-private-key-file=/srv/metrics-server/tls/tls.key
         - --v=2
+        {{- if .Values.kubeAPIServerHost }}
+        env:
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ .Values.kubeAPIServerHost}}
+        {{- end }}
         readinessProbe:
           tcpSocket:
             port: 8443

--- a/charts/shoot-core/components/charts/metrics-server/values.yaml
+++ b/charts/shoot-core/components/charts/metrics-server/values.yaml
@@ -7,3 +7,4 @@ secret:
   data:
     tls.crt: server-cert-of-metrics-server
     tls.key: server-key-of-metrics-server
+# kubeAPIServerHost: foo.bar

--- a/charts/shoot-core/components/charts/node-problem-detector/values.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/values.yaml
@@ -92,3 +92,5 @@ env:
 #    valueFrom:
 #      fieldRef:
 #        fieldPath: metadata.name
+#  - name: KUBERNETES_SERVICE_HOST
+#    value: foo.bar


### PR DESCRIPTION
This allows for system components

- kubernetes-dasboard
- nginx-ingress
- coredns
- metrics-server
- node-problem-detector

to directly access the API server and not go through the kubernetes service in default namespace. The Fully Qualified Domain Name is used to prevent multiple queries to DNS in case the record is not found.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Part of #2942 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
If `APIServerSNI` featuregate is enabled, system components in the `kube-system` namespace are talking to their kube-apiserver via its FQDN.
```
