### PR TITLE
[GEP-7] Keep shoot managed resource objects during migration

### DIFF
--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -504,6 +504,14 @@ func (a *actuator) Migrate(
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 ) error {
+	// Keep objects for shoot managed resources so that they are not deleted from the shoot during the migration
+	if err := managedresources.KeepManagedResourceObjects(ctx, a.client, cp.Namespace, ControlPlaneShootChartResourceName, true); err != nil {
+		return errors.Wrapf(err, "could not keep objects of managed resource containing shoot chart for controlplane '%s'", kutil.ObjectName(cp))
+	}
+	if err := managedresources.KeepManagedResourceObjects(ctx, a.client, cp.Namespace, StorageClassesChartResourceName, true); err != nil {
+		return errors.Wrapf(err, "could not keep objects of managed resource containing storage classes chart for controlplane '%s'", kutil.ObjectName(cp))
+	}
+
 	return a.Delete(ctx, cp, cluster)
 }
 

--- a/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
@@ -22,6 +22,7 @@ import (
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/pkg/errors"
@@ -35,6 +36,11 @@ func (a *genericActuator) Migrate(ctx context.Context, worker *extensionsv1alpha
 	workerDelegate, err := a.delegateFactory.WorkerDelegate(ctx, worker, cluster)
 	if err != nil {
 		return errors.Wrap(err, "could not instantiate actuator context")
+	}
+
+	// Keep objects for shoot managed resources so that they are not deleted from the shoot during the migration
+	if err := managedresources.KeepManagedResourceObjects(ctx, a.client, worker.Namespace, McmShootResourceName, true); err != nil {
+		return errors.Wrapf(err, "could not keep objects of managed resource containing mcm chart for worker '%s'", kutil.ObjectName(worker))
 	}
 
 	// Make sure machine-controller-manager is deleted before deleting the machines.

--- a/pkg/utils/managedresources/managedresources_test.go
+++ b/pkg/utils/managedresources/managedresources_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedresources_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	. "github.com/gardener/gardener/pkg/utils/managedresources"
+
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	namespace = "test"
+	name      = "managed-resource"
+)
+
+func TestManagedResources(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ManagedResources Suite")
+}
+
+var _ = Describe("managedresources", func() {
+	var (
+		ctrl *gomock.Controller
+
+		c *mockclient.MockClient
+
+		managedResource = func(keepObjects bool) *resourcesv1alpha1.ManagedResource {
+			return &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					SecretRefs: []corev1.LocalObjectReference{
+						{
+							Name: name,
+						},
+					},
+					KeepObjects: &keepObjects,
+				},
+			}
+		}
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+
+		c = mockclient.NewMockClient(ctrl)
+	})
+
+	Describe("#KeepManagedResourceObjects", func() {
+		It("should update the managed resource if the value of keepObjects is different", func() {
+			c.EXPECT().Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).
+				DoAndReturn(clientGet(managedResource(false)))
+			c.EXPECT().Update(context.TODO(), managedResource(true)).Return(nil)
+
+			err := KeepManagedResourceObjects(context.TODO(), c, namespace, name, true)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not update the managed resource if the value of keepObjects is the same", func() {
+			c.EXPECT().Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).
+				DoAndReturn(clientGet(managedResource(true)))
+
+			err := KeepManagedResourceObjects(context.TODO(), c, namespace, name, true)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not fail if the managed resource is not found", func() {
+			c.EXPECT().Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).
+				Return(apierrors.NewNotFound(schema.GroupResource{}, name))
+
+			err := KeepManagedResourceObjects(context.TODO(), c, namespace, name, true)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should fail if the managed resource could not be updated", func() {
+			c.EXPECT().Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).
+				DoAndReturn(clientGet(managedResource(false)))
+			c.EXPECT().Update(context.TODO(), managedResource(true)).Return(errors.New("error"))
+
+			err := KeepManagedResourceObjects(context.TODO(), c, namespace, name, true)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+func clientGet(managedResource *resourcesv1alpha1.ManagedResource) interface{} {
+	return func(_ context.Context, _ client.ObjectKey, mr *resourcesv1alpha1.ManagedResource) error {
+		*mr = *managedResource
+		return nil
+	}
+}


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane-migration
/kind bug
/priority normal

**What this PR does / why we need it**:
Ensures that shoot managed resource objects are kept during migration by the generic controlplane and worker actuators. This is important in order to ensure that objects such as storage classes, cluster roles and rolebindings, and CSI node daemon sets are not deleted from the shoot during the migration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```improvement operator
NONE
```
