### PR TITLE
Show Service events when LoadBalancer cannot be ensured

### DIFF
--- a/pkg/operation/botanist/event.go
+++ b/pkg/operation/botanist/event.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist
+
+import corev1 "k8s.io/api/core/v1"
+
+// SortableEvents implements sort.Interface for []api.Event based on the Timestamp field.
+type SortableEvents []corev1.Event
+
+// Len implements sort.Interface.
+func (list SortableEvents) Len() int {
+	return len(list)
+}
+
+// Swap implements sort.Interface.
+func (list SortableEvents) Swap(i, j int) {
+	list[i], list[j] = list[j], list[i]
+}
+
+// Less implements sort.Interface.
+func (list SortableEvents) Less(i, j int) bool {
+	return list[i].LastTimestamp.Time.Before(list[j].LastTimestamp.Time)
+}

--- a/pkg/operation/botanist/event_test.go
+++ b/pkg/operation/botanist/event_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist_test
+
+import (
+	"sort"
+	"time"
+
+	"github.com/gardener/gardener/pkg/operation/botanist"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("event", func() {
+	Context("SortableEvents", func() {
+		It("should sort events", func() {
+			var (
+				event1 = corev1.Event{
+					Source:         corev1.EventSource{Component: "kubelet"},
+					Message:        "Item 1",
+					FirstTimestamp: metav1.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
+					LastTimestamp:  metav1.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
+					Count:          1,
+					Type:           corev1.EventTypeNormal,
+				}
+				event2 = corev1.Event{
+					Source:         corev1.EventSource{Component: "scheduler"},
+					Message:        "Item 2",
+					FirstTimestamp: metav1.NewTime(time.Date(1987, time.June, 17, 0, 0, 0, 0, time.UTC)),
+					LastTimestamp:  metav1.NewTime(time.Date(1987, time.June, 17, 0, 0, 0, 0, time.UTC)),
+					Count:          1,
+					Type:           corev1.EventTypeNormal,
+				}
+				event3 = corev1.Event{
+					Source:         corev1.EventSource{Component: "kubelet"},
+					Message:        "Item 3",
+					FirstTimestamp: metav1.NewTime(time.Date(2002, time.December, 25, 0, 0, 0, 0, time.UTC)),
+					LastTimestamp:  metav1.NewTime(time.Date(2002, time.December, 25, 0, 0, 0, 0, time.UTC)),
+					Count:          1,
+					Type:           corev1.EventTypeNormal,
+				}
+				events = []corev1.Event{
+					event1,
+					event2,
+					event3,
+				}
+			)
+
+			sort.Sort(botanist.SortableEvents(events))
+
+			Expect(events).To(Equal([]corev1.Event{event2, event3, event1}))
+		})
+	})
+})

--- a/pkg/operation/botanist/volumeattachments_test.go
+++ b/pkg/operation/botanist/volumeattachments_test.go
@@ -49,7 +49,7 @@ var _ = Describe("VolumeAttachments", func() {
 		ctrl.Finish()
 	})
 
-	Describe("#WaitUntilVolumeAttachmentsDeleted", func() {
+	Context("#WaitUntilVolumeAttachmentsDeleted", func() {
 		It("should return nil when there are no VolumeAttachments", func() {
 			c.EXPECT().List(context.TODO(), gomock.AssignableToTypeOf(&storagev1beta1.VolumeAttachmentList{})).Return(nil)
 

--- a/pkg/operation/botanist/waiter_test.go
+++ b/pkg/operation/botanist/waiter_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/gardener/gardener/pkg/logger"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	mock "github.com/gardener/gardener/pkg/mock/gardener/client/kubernetes"
+	"github.com/gardener/gardener/pkg/operation"
+	"github.com/gardener/gardener/pkg/operation/botanist"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("waiter", func() {
+
+	var (
+		ctrl                  *gomock.Controller
+		k8sShootClient        *mock.MockInterface
+		k8sShootRuntimeClient *mockclient.MockClient
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+
+		k8sShootClient = mock.NewMockInterface(ctrl)
+		k8sShootRuntimeClient = mockclient.NewMockClient(ctrl)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("#WaitUntilShootLoadBalancerIsReady", func() {
+		var (
+			key = client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "load-balancer"}
+			b   botanist.Botanist
+		)
+
+		BeforeEach(func() {
+			op := &operation.Operation{
+				K8sShootClient: k8sShootClient,
+				Logger:         logrus.NewEntry(logger.NewNopLogger()),
+			}
+			b = botanist.Botanist{Operation: op}
+		})
+
+		It("should return nil when the Service has .status.loadBalancer.ingress[]", func() {
+			var (
+				ctx = context.TODO()
+				svc = &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "load-balancer",
+						Namespace: metav1.NamespaceSystem,
+					},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{
+								{
+									Hostname: "cluster.local",
+								},
+							},
+						},
+					},
+				}
+			)
+
+			gomock.InOrder(
+				k8sShootClient.EXPECT().Client().Return(k8sShootRuntimeClient),
+				k8sShootRuntimeClient.EXPECT().Get(gomock.Any(), key, gomock.AssignableToTypeOf(&corev1.Service{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, obj *corev1.Service) error {
+						*obj = *svc
+						return nil
+					}),
+			)
+
+			actual, err := b.WaitUntilShootLoadBalancerIsReady(ctx, metav1.NamespaceSystem, "load-balancer", 1*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(actual).To(Equal("cluster.local"))
+		})
+
+		It("should return err when the Service has no .status.loadBalancer.ingress[]", func() {
+			var (
+				ctx = context.TODO()
+				svc = &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "load-balancer",
+						Namespace: metav1.NamespaceSystem,
+					},
+					Status: corev1.ServiceStatus{},
+				}
+				event = corev1.Event{
+					Source:         corev1.EventSource{Component: "service-controller"},
+					Message:        "Error syncing load balancer: an error occurred",
+					FirstTimestamp: metav1.NewTime(time.Date(2020, time.January, 15, 0, 0, 0, 0, time.UTC)),
+					LastTimestamp:  metav1.NewTime(time.Date(2020, time.January, 15, 0, 0, 0, 0, time.UTC)),
+					Count:          1,
+					Type:           corev1.EventTypeWarning,
+				}
+			)
+
+			gomock.InOrder(
+				k8sShootClient.EXPECT().Client().Return(k8sShootRuntimeClient),
+				k8sShootRuntimeClient.EXPECT().Get(gomock.Any(), key, gomock.AssignableToTypeOf(&corev1.Service{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, obj *corev1.Service) error {
+						*obj = *svc
+						return nil
+					}),
+				k8sShootClient.EXPECT().DirectClient().Return(k8sShootRuntimeClient),
+				k8sShootRuntimeClient.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.EventList{}), gomock.Any()).DoAndReturn(
+					func(_ context.Context, list *corev1.EventList, _ ...client.ListOption) error {
+						list.Items = append(list.Items, event)
+						return nil
+					}),
+			)
+
+			actual, err := b.WaitUntilShootLoadBalancerIsReady(ctx, metav1.NamespaceSystem, "load-balancer", 1*time.Second)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("-> Events:\n* service-controller reported"))
+			Expect(err.Error()).To(ContainSubstring("Error syncing load balancer: an error occurred"))
+			Expect(actual).To(BeEmpty())
+		})
+	})
+})

--- a/pkg/operation/common/extensions_test.go
+++ b/pkg/operation/common/extensions_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
-	"github.com/gardener/gardener/pkg/operation/common"
 	. "github.com/gardener/gardener/pkg/operation/common"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -259,7 +258,7 @@ var _ = Describe("extensions", func() {
 
 		It("should delete extension CR", func() {
 			defer test.WithVars(
-				&common.TimeNow, mockNow.Do,
+				&TimeNow, mockNow.Do,
 			)()
 
 			expected.Annotations = map[string]string{
@@ -389,7 +388,7 @@ var _ = Describe("extensions", func() {
 		Describe("#RestoreExtensionWithDeployFunction", func() {
 			It("should restore the extension CR state with the provided deploy fuction and annotate it for restoration", func() {
 				defer test.WithVars(
-					&common.TimeNow, mockNow.Do,
+					&TimeNow, mockNow.Do,
 				)()
 				mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 
@@ -415,7 +414,7 @@ var _ = Describe("extensions", func() {
 
 			It("should only annotate the resource with restore operation annotation if a corresponding state does not exist in the ShootState", func() {
 				defer test.WithVars(
-					&common.TimeNow, mockNow.Do,
+					&TimeNow, mockNow.Do,
 				)()
 				mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 
@@ -456,7 +455,7 @@ var _ = Describe("extensions", func() {
 
 			It("should update the state if the extension CR exists", func() {
 				defer test.WithVars(
-					&common.TimeNow, mockNow.Do,
+					&TimeNow, mockNow.Do,
 				)()
 				mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 
@@ -482,7 +481,7 @@ var _ = Describe("extensions", func() {
 
 		It("should properly annotate extension CR for migration", func() {
 			defer test.WithVars(
-				&common.TimeNow, mockNow.Do,
+				&TimeNow, mockNow.Do,
 			)()
 
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
@@ -658,7 +657,7 @@ var _ = Describe("extensions", func() {
 
 		It("should annotate extension object with operation", func() {
 			defer test.WithVars(
-				&common.TimeNow, mockNow.Do,
+				&TimeNow, mockNow.Do,
 			)()
 
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -338,7 +337,7 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 			clusterautoscaler.LoggingConfiguration,
 			kubescheduler.LoggingConfiguration,
 		}
-		userAllowedComponents := []string{constants.DeploymentNameKubeAPIServer, constants.DeploymentNameKubeControllerManager}
+		userAllowedComponents := []string{v1beta1constants.DeploymentNameKubeAPIServer, v1beta1constants.DeploymentNameKubeControllerManager}
 
 		// Fetch component specific logging configurations
 		for _, componentFn := range componentsFunctions {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/priority normal

**Which issue(s) this PR fixes**:
Fixes #2943

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
When a Shoot load balancer (vpn-shoot or addons-nginx-ingress-controller) cannot be ensured, gardenlet now fetches the involved object events (with type Warning) and adds them to the error message which is shown in the Shoot status. In this way users and operators will be able to identify better issues in which load balancer cannot be ensured because of invalid cloud provider credentials or another cloud provider issue.
```
