### PR TITLE
Adapt terraformer library

### DIFF
--- a/extensions/pkg/terraformer/config.go
+++ b/extensions/pkg/terraformer/config.go
@@ -65,6 +65,18 @@ func (t *terraformer) SetDeadlinePod(d time.Duration) Terraformer {
 	return t
 }
 
+// UseV2 configures if it should use flags compatible with terraformer@v2.
+func (t *terraformer) UseV2(v2 bool) Terraformer {
+	t.useV2 = v2
+	return t
+}
+
+// SetLogLevel sets the log level of the Terraformer pod. It only takes effect when UseV2 is set to true.
+func (t *terraformer) SetLogLevel(level string) Terraformer {
+	t.logLevel = level
+	return t
+}
+
 // InitializerConfig is the configuration about the location and naming of the resources the
 // Terraformer expects.
 type InitializerConfig struct {

--- a/extensions/pkg/terraformer/config.go
+++ b/extensions/pkg/terraformer/config.go
@@ -21,12 +21,13 @@ import (
 	"strings"
 	"time"
 
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 const (

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -21,10 +21,6 @@ import (
 	"strings"
 	"time"
 
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -32,8 +28,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/retry"
 )
 
 const (
@@ -139,7 +141,7 @@ func (t *terraformer) Destroy() error {
 
 // execute creates a Terraform Pod which runs the provided scriptName (apply or destroy), waits for the Pod to be completed
 // (either successful or not), prints its logs, deletes it and returns whether it was successful or not.
-func (t *terraformer) execute(ctx context.Context, scriptName string) error {
+func (t *terraformer) execute(ctx context.Context, command string) error {
 	var (
 		succeeded             = true  // Success status of the Terraform apply/destroy pod
 		execute               = false // Should we skip the rest of the function depending on whether all ConfigMaps/Secrets exist/do not exist?
@@ -153,14 +155,14 @@ func (t *terraformer) execute(ctx context.Context, scriptName string) error {
 			return retry.SevereError(err)
 		}
 		if numberOfExistingResources == 0 {
-			t.logger.Debugf("All ConfigMaps/Secrets do not exist, can not execute the Terraform %s Pod.", scriptName)
+			t.logger.Debugf("All ConfigMaps/Secrets do not exist, can not execute the Terraform %s Pod.", command)
 			return retry.Ok()
 		} else if numberOfExistingResources == numberOfConfigResources {
-			t.logger.Debugf("All ConfigMaps/Secrets exist, will execute the Terraform %s Pod.", scriptName)
+			t.logger.Debugf("All ConfigMaps/Secrets exist, will execute the Terraform %s Pod.", command)
 			execute = true
 			return retry.Ok()
 		} else {
-			t.logger.Errorf("Can not execute Terraform %s Pod as ConfigMaps/Secrets are missing!", scriptName)
+			t.logger.Errorf("Can not execute Terraform %s Pod as ConfigMaps/Secrets are missing!", command)
 			return retry.MinorError(fmt.Errorf("%d/%d terraform resources are missing", numberOfConfigResources-numberOfExistingResources, numberOfConfigResources))
 		}
 	}); err != nil {
@@ -170,18 +172,18 @@ func (t *terraformer) execute(ctx context.Context, scriptName string) error {
 		return nil
 	}
 
-	// In case of scriptName == 'destroy', we need to first check whether the Terraform state contains
+	// In case of command == 'destroy', we need to first check whether the Terraform state contains
 	// something at all. If it does not contain anything, then the 'apply' could never be executed, probably
 	// because of syntax errors. In this case, we want to skip the Terraform destroy pod (as it wouldn't do anything
 	// anyway) and just delete the related ConfigMaps/Secrets.
-	if scriptName == "destroy" {
+	if command == "destroy" {
 		skipApplyOrDestroyPod = t.IsStateEmpty()
 	}
 
 	if !skipApplyOrDestroyPod {
-		// Create Terraform Pod which executes the provided scriptName
-		generateName := t.computePodGenerateName(scriptName)
-		pod, err := t.deployTerraformerPod(ctx, generateName, scriptName)
+		// Create Terraform Pod which executes the provided command
+		generateName := t.computePodGenerateName(command)
+		pod, err := t.deployTerraformerPod(ctx, generateName, command)
 		if err != nil {
 			return fmt.Errorf("failed to deploy the Terraformer Pod with .meta.generateName '%s': %s", generateName, err.Error())
 		}
@@ -218,9 +220,9 @@ func (t *terraformer) execute(ctx context.Context, scriptName string) error {
 	}
 
 	// Evaluate whether the execution was successful or not
-	t.logger.Infof("Terraformer '%s' execution for command '%s' has been completed.", t.name, scriptName)
+	t.logger.Infof("Terraformer '%s' execution for command '%s' has been completed.", t.name, command)
 	if !succeeded {
-		errorMessage := fmt.Sprintf("Terraform execution for command '%s' could not be completed.", scriptName)
+		errorMessage := fmt.Sprintf("Terraform execution for command '%s' could not be completed.", command)
 		if terraformErrors := retrieveTerraformErrors(logList); terraformErrors != nil {
 			errorMessage += fmt.Sprintf(" The following issues have been found in the logs:\n\n%s", strings.Join(terraformErrors, "\n\n"))
 		}
@@ -245,18 +247,11 @@ func (t *terraformer) createOrUpdateServiceAccount(ctx context.Context) error {
 func (t *terraformer) createOrUpdateRole(ctx context.Context) error {
 	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Namespace: t.namespace, Name: rbacName}}
 	_, err := controllerutil.CreateOrUpdate(ctx, t.client, role, func() error {
-		role.Rules = []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"configmaps"},
-				Verbs:     []string{"*"},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"secrets"},
-				Verbs:     []string{"*"},
-			},
-		}
+		role.Rules = []rbacv1.PolicyRule{{
+			APIGroups: []string{""},
+			Resources: []string{"configmaps", "secrets"},
+			Verbs:     []string{"*"},
+		}}
 		return nil
 	})
 	return err
@@ -270,13 +265,11 @@ func (t *terraformer) createOrUpdateRoleBinding(ctx context.Context) error {
 			Kind:     "Role",
 			Name:     rbacName,
 		}
-		roleBinding.Subjects = []rbacv1.Subject{
-			{
-				Kind:      rbacv1.ServiceAccountKind,
-				Name:      terraformerName,
-				Namespace: t.namespace,
-			},
-		}
+		roleBinding.Subjects = []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      terraformerName,
+			Namespace: t.namespace,
+		}}
 		return nil
 	})
 	return err
@@ -298,7 +291,6 @@ func (t *terraformer) deployTerraformerPod(ctx context.Context, generateName, co
 	}
 
 	t.logger.Infof("Deploying Terraformer Pod with .meta.generateName '%s'.", generateName)
-	podSpec := *t.podSpec(command)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: generateName,
@@ -314,34 +306,8 @@ func (t *terraformer) deployTerraformerPod(ctx context.Context, generateName, co
 				v1beta1constants.LabelNetworkPolicyToSeedAPIServer:   v1beta1constants.LabelNetworkPolicyAllowed,
 			},
 		},
-		Spec: podSpec,
-	}
-
-	err := t.client.Create(ctx, pod)
-	return pod, err
-}
-
-func (t *terraformer) env() []corev1.EnvVar {
-	envVars := []corev1.EnvVar{
-		{Name: "MAX_BACKOFF_SEC", Value: "60"},
-		{Name: "MAX_TIME_SEC", Value: "1800"},
-		{Name: "TF_CONFIGURATION_CONFIG_MAP_NAME", Value: t.configName},
-		{Name: "TF_STATE_CONFIG_MAP_NAME", Value: t.stateName},
-		{Name: "TF_VARIABLES_SECRET_NAME", Value: t.variablesName},
-	}
-	for k, v := range t.variablesEnvironment {
-		envVars = append(envVars, corev1.EnvVar{Name: k, Value: v})
-	}
-	return envVars
-}
-
-func (t *terraformer) podSpec(command string) *corev1.PodSpec {
-	terminationGracePeriodSeconds := t.terminationGracePeriodSeconds
-
-	return &corev1.PodSpec{
-		RestartPolicy: corev1.RestartPolicyNever,
-		Containers: []corev1.Container{
-			{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
 				Name:            "terraform",
 				Image:           t.image,
 				ImagePullPolicy: corev1.PullIfNotPresent,
@@ -360,11 +326,29 @@ func (t *terraformer) podSpec(command string) *corev1.PodSpec {
 					},
 				},
 				Env: t.env(),
-			},
+			}},
+			RestartPolicy:                 corev1.RestartPolicyNever,
+			ServiceAccountName:            terraformerName,
+			TerminationGracePeriodSeconds: pointer.Int64Ptr(t.terminationGracePeriodSeconds),
 		},
-		ServiceAccountName:            terraformerName,
-		TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 	}
+
+	err := t.client.Create(ctx, pod)
+	return pod, err
+}
+
+func (t *terraformer) env() []corev1.EnvVar {
+	envVars := []corev1.EnvVar{
+		{Name: "MAX_BACKOFF_SEC", Value: "60"},
+		{Name: "MAX_TIME_SEC", Value: "1800"},
+		{Name: "TF_CONFIGURATION_CONFIG_MAP_NAME", Value: t.configName},
+		{Name: "TF_STATE_CONFIG_MAP_NAME", Value: t.stateName},
+		{Name: "TF_VARIABLES_SECRET_NAME", Value: t.variablesName},
+	}
+	for k, v := range t.variablesEnvironment {
+		envVars = append(envVars, corev1.EnvVar{Name: k, Value: v})
+	}
+	return envVars
 }
 
 // listTerraformerPods lists all pods in the Terraformer namespace which have labels 'terraformer.gardener.cloud/name'

--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -25,6 +25,7 @@ import (
 )
 
 // terraformer is a struct containing configuration parameters for the Terraform script it acts on.
+// * useV2 indicates if it should use flags compatible with terraformer@v2 (defaults to false)
 // * purpose is a one-word description depicting what the Terraformer does (e.g. 'infrastructure').
 // * namespace is the namespace in which the Terraformer will act.
 // * image is the Docker image name of the Terraformer image.
@@ -36,10 +37,14 @@ import (
 //   with TF_VAR_).
 // * configurationDefined indicates whether the required configuration ConfigMaps/Secrets have been
 //   successfully defined.
+// * logLevel configures the log level for the Terraformer Pod (only compatible with terraformer@v2,
+//   defaults to "info")
 // * terminationGracePeriodSeconds is the respective Pod spec field passed to Terraformer Pods.
 // * deadlineCleaning is the timeout to wait Terraformer Pods to be cleaned up.
 // * deadlinePod is the time to wait apply/destroy Pod to be completed.
 type terraformer struct {
+	useV2 bool
+
 	logger       logrus.FieldLogger
 	client       client.Client
 	coreV1Client corev1client.CoreV1Interface
@@ -55,6 +60,7 @@ type terraformer struct {
 	variablesEnvironment map[string]string
 	configurationDefined bool
 
+	logLevel                      string
 	terminationGracePeriodSeconds int64
 
 	deadlineCleaning time.Duration
@@ -88,6 +94,8 @@ const (
 
 // Terraformer is the Terraformer interface.
 type Terraformer interface {
+	UseV2(bool) Terraformer
+	SetLogLevel(string) Terraformer
 	SetVariablesEnvironment(tfVarsEnvironment map[string]string) Terraformer
 	SetTerminationGracePeriodSeconds(int64) Terraformer
 	SetDeadlineCleaning(time.Duration) Terraformer

--- a/pkg/mock/gardener/extensions/terraformer/mocks.go
+++ b/pkg/mock/gardener/extensions/terraformer/mocks.go
@@ -231,6 +231,20 @@ func (mr *MockTerraformerMockRecorder) SetDeadlinePod(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDeadlinePod", reflect.TypeOf((*MockTerraformer)(nil).SetDeadlinePod), arg0)
 }
 
+// SetLogLevel mocks base method.
+func (m *MockTerraformer) SetLogLevel(arg0 string) terraformer.Terraformer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetLogLevel", arg0)
+	ret0, _ := ret[0].(terraformer.Terraformer)
+	return ret0
+}
+
+// SetLogLevel indicates an expected call of SetLogLevel.
+func (mr *MockTerraformerMockRecorder) SetLogLevel(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogLevel", reflect.TypeOf((*MockTerraformer)(nil).SetLogLevel), arg0)
+}
+
 // SetTerminationGracePeriodSeconds mocks base method.
 func (m *MockTerraformer) SetTerminationGracePeriodSeconds(arg0 int64) terraformer.Terraformer {
 	m.ctrl.T.Helper()
@@ -257,6 +271,20 @@ func (m *MockTerraformer) SetVariablesEnvironment(arg0 map[string]string) terraf
 func (mr *MockTerraformerMockRecorder) SetVariablesEnvironment(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVariablesEnvironment", reflect.TypeOf((*MockTerraformer)(nil).SetVariablesEnvironment), arg0)
+}
+
+// UseV2 mocks base method.
+func (m *MockTerraformer) UseV2(arg0 bool) terraformer.Terraformer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UseV2", arg0)
+	ret0, _ := ret[0].(terraformer.Terraformer)
+	return ret0
+}
+
+// UseV2 indicates an expected call of UseV2.
+func (mr *MockTerraformerMockRecorder) UseV2(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseV2", reflect.TypeOf((*MockTerraformer)(nil).UseV2), arg0)
 }
 
 // WaitForCleanEnvironment mocks base method.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR changes the terraformer library in the following ways:
- minor cleanups (first commit)
- adapt the library to terraformer v2, ref https://github.com/gardener/terraformer/pull/48 (second commit)

terraformer v2 is still in the works and not yet released. But this change here is made in a backwards-compatible manner.
Controllers using it, have to set `UseV2(true)` in order to get the PodSpec compatible to v2, otherwise the old PodSpec is used.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/terraformer/issues/40

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
The [terraformer library](https://github.com/gardener/gardener/tree/master/extensions/pkg/terraformer) can now be used to deploy `terraformer@v2` Pods. To enable this, you have to set `UseV2(true)` on the `Terraformer` instance, otherwise the old `PodSpec`, that is compatible with v1, will be used.
```
