### PR TITLE
support providerConfig for shooted seeds

### DIFF
--- a/docs/usage/shooted_seed.md
+++ b/docs/usage/shooted_seed.md
@@ -72,3 +72,4 @@ Option | Description
 `apiServer.autoscaler.maxReplicas` | Controls the maximum number of `kube-apiserver` replicas for the shooted seed cluster.
 `apiServer.replicas` | Controls how many `kube-apiserver` replicas the shooted seed cluster gets by default.
 `use-serviceaccount-bootstrapping` | States that the gardenlet registers with the garden cluster using a temporary `ServiceAccount` instead of a `CertificateSigningRequest` (**default**)
+`providerConfig.*` | Sets `providerConfig` configuration parameters of the Seed resource. Each parameter is specified via its path, e.g. `providerConfig.param1=foo` or `providerConfig.sublevel1.sublevel2.param3=bar`

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -17,6 +17,8 @@ package helper_test
 import (
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
@@ -606,6 +608,24 @@ var _ = Describe("helper", func() {
 							MinReplicas: &two,
 							MaxReplicas: three,
 						},
+					},
+					Backup: &gardencorev1beta1.SeedBackup{},
+				}))
+			})
+
+			It("should return a filled seedprovider providerconfig", func() {
+				shoot.Annotations = map[string]string{
+					v1beta1constants.AnnotationShootUseAsSeed: "true,providerConfig.storagePolicyName=vSAN Default Storage Policy,providerConfig.param1=abc" +
+						",providerConfig.sub.param2=def,providerConfig.sub.param3=3,providerConfig.sub.param4=true,providerConfig.sub.param5=\"true\"",
+				}
+
+				shootedSeed, err := ReadShootedSeed(shoot)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shootedSeed).To(Equal(&ShootedSeed{
+					APIServer: &defaultAPIServer,
+					SeedProviderConfig: &runtime.RawExtension{
+						Raw: []byte(`{"param1":"abc","storagePolicyName":"vSAN Default Storage Policy","sub":{"param2":"def","param3":3,"param4":true,"param5":"true"}}`),
 					},
 					Backup: &gardencorev1beta1.SeedBackup{},
 				}))

--- a/pkg/gardenlet/controller/shoot/seed_registration_control.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control.go
@@ -331,8 +331,9 @@ func prepareSeedConfig(ctx context.Context, gardenClient client.Client, seedClie
 
 	return &gardencorev1beta1.SeedSpec{
 		Provider: gardencorev1beta1.SeedProvider{
-			Type:   shoot.Spec.Provider.Type,
-			Region: shoot.Spec.Region,
+			Type:           shoot.Spec.Provider.Type,
+			Region:         shoot.Spec.Region,
+			ProviderConfig: shootedSeedConfig.SeedProviderConfig,
 		},
 		DNS: gardencorev1beta1.SeedDNS{
 			IngressDomain: fmt.Sprintf("%s.%s", common.IngressPrefix, *(shoot.Spec.DNS.Domain)),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
The `providerConfig` of the Seed resource can be specified in the `shoot.gardener.cloud/use-as-seed` annotation of the shoot to be used as seed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
It is now possible to submit provider configuration (for the `.spec.provider.providerConfig` field in `Seed` resources) when creating shooted seeds. Please consult [the documentation](https://github.com/gardener/gardener/blob/v1.12.0/docs/usage/shooted_seed.md) for more information
```
