### PR TITLE
Add --version flag for components

### DIFF
--- a/cmd/gardener-admission-controller/app/gardener_admission_controller.go
+++ b/cmd/gardener-admission-controller/app/gardener_admission_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/healthz"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/server"
+	"github.com/gardener/gardener/pkg/version/verflag"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -221,6 +222,8 @@ func NewCommandStartGardenerAdmissionController() *cobra.Command {
 		Short: "Launch the Gardener admission controller",
 		Long:  `The Gardener admission controller serves a validation webhook endpoint for resources in the garden cluster.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			verflag.PrintAndExitIfRequested()
+
 			if err := opts.configFileSpecified(); err != nil {
 				return err
 			}
@@ -231,6 +234,8 @@ func NewCommandStartGardenerAdmissionController() *cobra.Command {
 		},
 	}
 
-	opts.addFlags(cmd.Flags())
+	flags := cmd.Flags()
+	verflag.AddFlags(flags)
+	opts.addFlags(flags)
 	return cmd
 }

--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -37,6 +37,7 @@ import (
 	settingsinformer "github.com/gardener/gardener/pkg/client/settings/informers/externalversions"
 	"github.com/gardener/gardener/pkg/openapi"
 	"github.com/gardener/gardener/pkg/version"
+	"github.com/gardener/gardener/pkg/version/verflag"
 	controllerregistrationresources "github.com/gardener/gardener/plugin/pkg/controllerregistration/resources"
 	"github.com/gardener/gardener/plugin/pkg/global/customverbauthorizer"
 	"github.com/gardener/gardener/plugin/pkg/global/deletionconfirmation"
@@ -90,6 +91,8 @@ the main components of a Kubernetes cluster (etcd, API server, controller manage
 These so-called control plane components are hosted in Kubernetes clusters themselves
 (which are called Seed clusters).`,
 		RunE: func(c *cobra.Command, args []string) error {
+			verflag.PrintAndExitIfRequested()
+
 			if err := opts.complete(); err != nil {
 				return err
 			}
@@ -101,6 +104,7 @@ These so-called control plane components are hosted in Kubernetes clusters thems
 	}
 
 	flags := cmd.Flags()
+	verflag.AddFlags(flags)
 	utilfeature.DefaultMutableFeatureGate.AddFlag(flags)
 	opts.Recommended.AddFlags(flags)
 	opts.ExtraOptions.AddFlags(flags)

--- a/cmd/gardener-controller-manager/app/gardener_controller_manager.go
+++ b/cmd/gardener-controller-manager/app/gardener_controller_manager.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gardener/gardener/pkg/healthz"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/server"
+	"github.com/gardener/gardener/pkg/version/verflag"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -164,6 +165,8 @@ the main components of a Kubernetes cluster (etcd, API server, controller manage
 These so-called control plane components are hosted in Kubernetes clusters themselves
 (which are called Seed clusters).`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			verflag.PrintAndExitIfRequested()
+
 			if err := opts.configFileSpecified(); err != nil {
 				return err
 			}
@@ -174,7 +177,9 @@ These so-called control plane components are hosted in Kubernetes clusters thems
 		},
 	}
 
-	opts.AddFlags(cmd.Flags())
+	flags := cmd.Flags()
+	verflag.AddFlags(flags)
+	opts.AddFlags(flags)
 	return cmd
 }
 

--- a/cmd/gardener-scheduler/app/gardener_scheduler.go
+++ b/cmd/gardener-scheduler/app/gardener_scheduler.go
@@ -35,6 +35,7 @@ import (
 	shootcontroller "github.com/gardener/gardener/pkg/scheduler/controller/shoot"
 	schedulerfeatures "github.com/gardener/gardener/pkg/scheduler/features"
 	"github.com/gardener/gardener/pkg/server"
+	"github.com/gardener/gardener/pkg/version/verflag"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -104,6 +105,8 @@ func NewCommandStartGardenerScheduler(ctx context.Context) *cobra.Command {
 		Short: "Launch the Gardener scheduler",
 		Long:  `The Gardener scheduler is a controller that tries to find the best matching seed cluster for a shoot. The scheduler takes the cloud provider and the distance between the seed (hosting the control plane) and the shoot cluster region into account.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			verflag.PrintAndExitIfRequested()
+
 			if err := opts.validate(args); err != nil {
 				return err
 			}
@@ -111,7 +114,9 @@ func NewCommandStartGardenerScheduler(ctx context.Context) *cobra.Command {
 		},
 	}
 
-	opts.AddFlags(cmd.Flags())
+	flags := cmd.Flags()
+	verflag.AddFlags(flags)
+	opts.AddFlags(flags)
 	return cmd
 }
 

--- a/cmd/gardener-seed-admission-controller/app/gardener_seed_admission_controller.go
+++ b/cmd/gardener-seed-admission-controller/app/gardener_seed_admission_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerlogger "github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/seedadmission"
+	"github.com/gardener/gardener/pkg/version/verflag"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -102,6 +103,8 @@ func NewCommandStartGardenerSeedAdmissionController(ctx context.Context) *cobra.
 		Short: "Launch the Gardener seed admission controller",
 		Long:  `The Gardener seed admission controller serves a validation webhook endpoint for resources in the seed clusters.`,
 		Run: func(cmd *cobra.Command, args []string) {
+			verflag.PrintAndExitIfRequested()
+
 			utilruntime.Must(opts.validate(args))
 
 			logger.Infof("Starting Gardener seed admission controller...")
@@ -113,7 +116,9 @@ func NewCommandStartGardenerSeedAdmissionController(ctx context.Context) *cobra.
 		},
 	}
 
-	opts.AddFlags(cmd.Flags())
+	flags := cmd.Flags()
+	verflag.AddFlags(flags)
+	opts.AddFlags(flags)
 	return cmd
 }
 

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -51,6 +51,7 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/version"
+	"github.com/gardener/gardener/pkg/version/verflag"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -182,6 +183,8 @@ the main components of a Kubernetes cluster (etcd, API server, controller manage
 These so-called control plane components are hosted in Kubernetes clusters themselves
 (which are called Seed clusters).`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			verflag.PrintAndExitIfRequested()
+
 			if err := opts.configFileSpecified(); err != nil {
 				return err
 			}
@@ -192,8 +195,9 @@ These so-called control plane components are hosted in Kubernetes clusters thems
 		},
 	}
 
-	opts.AddFlags(cmd.Flags())
-
+	flags := cmd.Flags()
+	verflag.AddFlags(flags)
+	opts.AddFlags(flags)
 	return cmd
 }
 

--- a/pkg/version/verflag/verflag.go
+++ b/pkg/version/verflag/verflag.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verflag
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/gardener/gardener/pkg/version"
+
+	flag "github.com/spf13/pflag"
+)
+
+// TODO (ialidzhikov): When we vendor kubernetes-1.19, replace usage of github.com/gardener/gardener/pkg/version and
+// github.com/gardener/gardener/pkg/version/verflag with k8s.io/component-base/version and k8s.io/component-base/version/verflag.
+// With kubernetes-1.19 the programName is configurable (https://github.com/kubernetes/kubernetes/pull/90139).
+
+type versionValue int
+
+const (
+	// VersionFalse represents 'false' value for the version flag
+	VersionFalse versionValue = 0
+	// VersionTrue represents 'true' value for the version flag
+	VersionTrue versionValue = 1
+	// VersionRaw represents 'raw' value for the version flag
+	VersionRaw versionValue = 2
+)
+
+const strRawVersion string = "raw"
+
+// IsBoolFlag is defined to allow the flag to be defined without an argument
+func (v *versionValue) IsBoolFlag() bool {
+	return true
+}
+
+// Get gets the version value for the flag.Getter interface.
+func (v *versionValue) Get() interface{} {
+	return versionValue(*v)
+}
+
+// Set sets the version value for the flag.Value interface.
+func (v *versionValue) Set(s string) error {
+	if s == strRawVersion {
+		*v = VersionRaw
+		return nil
+	}
+	boolVal, err := strconv.ParseBool(s)
+	if boolVal {
+		*v = VersionTrue
+	} else {
+		*v = VersionFalse
+	}
+	return err
+}
+
+// String returns a string representation of the version value.
+func (v *versionValue) String() string {
+	if *v == VersionRaw {
+		return strRawVersion
+	}
+	return fmt.Sprintf("%v", bool(*v == VersionTrue))
+}
+
+// Type returns the type of the flag as required by the pflag.Value interface
+func (v *versionValue) Type() string {
+	return "version"
+}
+
+// VersionVar defines the given version flag
+func VersionVar(p *versionValue, name string, value versionValue, usage string) {
+	*p = value
+	flag.Var(p, name, usage)
+	// "--version" will be treated as "--version=true"
+	flag.Lookup(name).NoOptDefVal = "true"
+}
+
+// Version returns a new version flag
+func Version(name string, value versionValue, usage string) *versionValue {
+	p := new(versionValue)
+	VersionVar(p, name, value, usage)
+	return p
+}
+
+const versionFlagName = "version"
+
+var (
+	versionFlag = Version(versionFlagName, VersionFalse, "Print version information and quit")
+	programName = "Gardener"
+)
+
+// AddFlags registers this package's flags on arbitrary FlagSets, such that they point to the
+// same value as the global flags.
+func AddFlags(fs *flag.FlagSet) {
+	fs.AddFlag(flag.Lookup(versionFlagName))
+}
+
+// PrintAndExitIfRequested will check if the --version flag was passed
+// and, if so, print the version and exit.
+func PrintAndExitIfRequested() {
+	if *versionFlag == VersionRaw {
+		fmt.Printf("%#v\n", version.Get())
+		os.Exit(0)
+	} else if *versionFlag == VersionTrue {
+		fmt.Printf("%s %s\n", programName, version.Get())
+		os.Exit(0)
+	}
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/area ops-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:

```
$ docker run k8s.gcr.io/kube-apiserver:v1.18.6 kube-apiserver --version
Kubernetes v1.18.6

$ docker run k8s.gcr.io/kube-apiserver:v1.18.6 kube-apiserver --version=raw
version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.6", GitCommit:"dff82dc0de47299ab66c83c626e08b245ab19037", GitTreeState:"clean", BuildDate:"2020-07-15T16:51:04Z", GoVersion:"go1.13.9", Compiler:"gc", Platform:"linux/amd64"}

$ docker run eu.gcr.io/gardener-project/gardener/apiserver:v1.12.0-dev-d7744404ae9b0b01b374e60ec7b6525fe9357c2d --version
Gardener v1.12.0-dev-d7744404ae9b0b01b374e60ec7b6525fe9357c2d

$ docker run eu.gcr.io/gardener-project/gardener/apiserver:v1.12.0-dev-d7744404ae9b0b01b374e60ec7b6525fe9357c2d --version=raw
version.Info{Major:"1", Minor:"12", GitVersion:"v1.12.0-dev-d7744404ae9b0b01b374e60ec7b6525fe9357c2d", GitCommit:"d7744404ae9b0b01b374e60ec7b6525fe9357c2d", GitTreeState:"dirty", BuildDate:"2020-10-24T21:15:51+00:00", GoVersion:"go1.14.7", Compiler:"gc", Platform:"linux/amd64"}
```

**Which issue(s) this PR fixes**:
Ref #2703

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
Gardener components now support `--version` flag that prints the component version information and useful metadata.
```
