### PR TITLE
Replace nginx with envoy

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -246,9 +246,9 @@ images:
 
 # API Server SNI
 - name: apiserver-proxy
-  sourceRepository: github.com/nginxinc/docker-nginx
-  repository: nginx
-  tag: "1.17.8"
+  sourceRepository: github.com/envoyproxy/envoy
+  repository: envoyproxy/envoy
+  tag: "v1.16.0"
 - name: apiserver-proxy-sidecar
   sourceRepository: github.com/gardener/apiserver-proxy
   repository: eu.gcr.io/gardener-project/gardener/apiserver-proxy

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
@@ -81,9 +81,9 @@ spec:
         image: {{ index .Values.images "apiserver-proxy" }}
         imagePullPolicy: IfNotPresent
         command:
-        - nginx
+        - envoy
         - -c
-        - /etc/apiserver-proxy/proxy.conf
+        - /etc/apiserver-proxy/envoy.yaml
         securityContext:
           capabilities:
             add:

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/proxy-configmap.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/proxy-configmap.yaml
@@ -74,6 +74,6 @@ data:
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.transport_sockets.proxy_protocol.v3.ProxyProtocolUpstreamTransport
             config:
-              version: V1
+              version: V2
             transport_socket:
               name: envoy.transport_sockets.raw_buffer

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/proxy-configmap.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/proxy-configmap.yaml
@@ -7,21 +7,73 @@ metadata:
     gardener.cloud/role: system-component
     origin: gardener
 data:
-  proxy.conf: |-
-    daemon off;
-    error_log {{ .Values.errorLog }};
-    stream {
-        log_format basic '[client $remote_addr:$remote_port] [server $server_addr:$server_port]';
-        server {
-            access_log {{ .Values.accessLog }};
-            listen {{ .Values.advertiseIPAddress }}:443;
-            proxy_pass {{ .Values.proxySeedServer }};
-            proxy_protocol on;
+  envoy.yaml: |-
+    overload_manager:
+      refresh_interval: 0.25s
+      resource_monitors:
+      - name: "envoy.resource_monitors.fixed_heap"
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.resource_monitor.fixed_heap.v2alpha.FixedHeapConfig
+          max_heap_size_bytes: 20971520 # 20 MiB
+      actions:
+      - name: "envoy.overload_actions.shrink_heap"
+        triggers:
+        - name: "envoy.resource_monitors.fixed_heap"
+          threshold:
+            value: 0.95
+      - name: "envoy.overload_actions.stop_accepting_requests"
+        triggers:
+        - name: "envoy.resource_monitors.fixed_heap"
+          threshold:
+            value: 0.98
+    layered_runtime:
+      layers:
+        - name: static_layer_0
+          static_layer:
+            envoy:
+              resource_limits:
+                listener:
+                  listener_proxy:
+                    connection_limit: 2000
+            overload:
+              global_downstream_max_connections: 10000
+    static_resources:
+      listeners:
+      - name: listener_proxy
+        address:
+          socket_address:
+            address: {{ .Values.advertiseIPAddress }}
+            port_value: 443
+        per_connection_buffer_limit_bytes: 32768 # 32 KiB
+        filter_chains:
+        - filters:
+          - name: envoy.filters.network.tcp_proxy
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+              stat_prefix: kube_apiserver
+              cluster: kube_apiserver
 
-            proxy_protocol_timeout 5s;
-            resolver_timeout 5s;
-            proxy_connect_timeout 5s;
-        }
-    }
-
-    events {}
+      clusters:
+      - name: kube_apiserver
+        connect_timeout: 5s
+        per_connection_buffer_limit_bytes: 32768 # 32 KiB
+        type: LOGICAL_DNS
+        dns_lookup_family: V4_ONLY
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: kube_apiserver
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: {{ .Values.proxySeedServer.host }}
+                    port_value: {{ .Values.proxySeedServer.port }}
+        transport_socket:
+          name: envoy.transport_sockets.upstream_proxy_protocol
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.transport_sockets.proxy_protocol.v3.ProxyProtocolUpstreamTransport
+            config:
+              version: V1
+            transport_socket:
+              name: envoy.transport_sockets.raw_buffer

--- a/charts/shoot-core/components/charts/apiserver-proxy/values.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/values.yaml
@@ -4,8 +4,6 @@ images:
   apiserver-proxy-sidecar: image-repository
 
 advertiseIPAddress: 1.1.1.1
-proxySeedServer: dummy.127.0.0.1.nip.io
-accessLog: "off"
-# accessLog: /dev/stdout basic
-errorLog: "/dev/stdout notice"
-# errorLog: "/dev/stdout debug"
+proxySeedServer:
+  host: dummy.127.0.0.1.nip.io
+  port: 8443

--- a/charts/shoot-core/components/values.yaml
+++ b/charts/shoot-core/components/values.yaml
@@ -8,7 +8,9 @@ apiserver-proxy:
     apiserver-proxy: image-repository
     apiserver-proxy-sidecar: image-repository
   advertiseIPAddress: 1.1.1.1
-  proxySeedServer: dummy.127.0.0.1.nip.io
+  proxySeedServer:
+    host: dummy.127.0.0.1.nip.io
+    port: 8443
 coredns:
   enabled: true
 konnectivity-agent:

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -478,7 +478,10 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 
 	apiserverProxyConfig := map[string]interface{}{
 		"advertiseIPAddress": b.APIServerClusterIP,
-		"proxySeedServer":    fmt.Sprintf("%s:8443", b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true)),
+		"proxySeedServer": map[string]interface{}{
+			"host": kasFQDN,
+			"port": "8443",
+		},
 	}
 
 	apiserverProxy, err := b.InjectShootShootImages(apiserverProxyConfig, common.APIServerPorxySidecarImageName, common.APIServerProxyImageName)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/priority normal

**What this PR does / why we need it**:

`nginx` is replaced with `envoy` for `apiserver-proxy`. This allows to have the same proxy for both the client and the server.

PROXY Protocol v2 is now used by `apiserver-proxy`. 

**Which issue(s) this PR fixes**:

Part of #2942

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`nginx` is replaced with `envoy` for `apiserver-proxy`. This allows to have the same proxy for both the client and the server.
```

```improvement operator
`apiserver-proxy` now uses `PROXY Protocol` v2 when talking to the upstream kube-apiserver.
```
