### PR TITLE
Default kubeReserved PID to 20k

### DIFF
--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -4263,7 +4263,7 @@ KubeletConfigReserved
 <em>(Optional)</em>
 <p>KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime).
 When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
-Default: cpu=80m,memory=1Gi</p>
+Default: cpu=80m,memory=1Gi,pid=20k</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -590,7 +590,7 @@ type KubeletConfig struct {
 	FailSwapOn *bool
 	// KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime).
 	// When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
-	// Default: cpu=80m,memory=1Gi
+	// Default: cpu=80m,memory=1Gi,pid=20k
 	KubeReserved *KubeletConfigReserved
 	// SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald).
 	// When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.

--- a/pkg/apis/core/v1alpha1/defaults.go
+++ b/pkg/apis/core/v1alpha1/defaults.go
@@ -207,16 +207,20 @@ func SetDefaults_Shoot(obj *Shoot) {
 	var (
 		kubeReservedMemory = resource.MustParse("1Gi")
 		kubeReservedCPU    = resource.MustParse("80m")
+		kubeReservedPID    = resource.MustParse("20k")
 	)
 
 	if obj.Spec.Kubernetes.Kubelet.KubeReserved == nil {
-		obj.Spec.Kubernetes.Kubelet.KubeReserved = &KubeletConfigReserved{Memory: &kubeReservedMemory, CPU: &kubeReservedCPU}
+		obj.Spec.Kubernetes.Kubelet.KubeReserved = &KubeletConfigReserved{Memory: &kubeReservedMemory, CPU: &kubeReservedCPU, PID: &kubeReservedPID}
 	} else {
 		if obj.Spec.Kubernetes.Kubelet.KubeReserved.Memory == nil {
 			obj.Spec.Kubernetes.Kubelet.KubeReserved.Memory = &kubeReservedMemory
 		}
 		if obj.Spec.Kubernetes.Kubelet.KubeReserved.CPU == nil {
 			obj.Spec.Kubernetes.Kubelet.KubeReserved.CPU = &kubeReservedCPU
+		}
+		if obj.Spec.Kubernetes.Kubelet.KubeReserved.PID == nil {
+			obj.Spec.Kubernetes.Kubelet.KubeReserved.PID = &kubeReservedPID
 		}
 	}
 

--- a/pkg/apis/core/v1alpha1/defaults_test.go
+++ b/pkg/apis/core/v1alpha1/defaults_test.go
@@ -339,8 +339,10 @@ var _ = Describe("Defaults", func() {
 			var (
 				defaultKubeReservedMemory = resource.MustParse("1Gi")
 				defaultKubeReservedCPU    = resource.MustParse("80m")
+				defaultKubeReservedPID    = resource.MustParse("20k")
 				kubeReservedMemory        = resource.MustParse("2Gi")
 				kubeReservedCPU           = resource.MustParse("20m")
+				kubeReservedPID           = resource.MustParse("10k")
 			)
 
 			It("should default all fields", func() {
@@ -349,42 +351,16 @@ var _ = Describe("Defaults", func() {
 				Expect(obj.Spec.Kubernetes.Kubelet.KubeReserved).To(PointTo(Equal(KubeletConfigReserved{
 					CPU:    &defaultKubeReservedCPU,
 					Memory: &defaultKubeReservedMemory,
+					PID:    &defaultKubeReservedPID,
 				})))
 			})
 
-			It("should default memory", func() {
-				obj.Spec.Kubernetes.Kubelet = &KubeletConfig{
-					KubeReserved: &KubeletConfigReserved{
-						CPU: &kubeReservedCPU,
-					},
-				}
-				SetDefaults_Shoot(obj)
-
-				Expect(obj.Spec.Kubernetes.Kubelet.KubeReserved).To(PointTo(Equal(KubeletConfigReserved{
-					CPU:    &kubeReservedCPU,
-					Memory: &defaultKubeReservedMemory,
-				})))
-			})
-
-			It("should default CPU", func() {
-				obj.Spec.Kubernetes.Kubelet = &KubeletConfig{
-					KubeReserved: &KubeletConfigReserved{
-						Memory: &kubeReservedMemory,
-					},
-				}
-				SetDefaults_Shoot(obj)
-
-				Expect(obj.Spec.Kubernetes.Kubelet.KubeReserved).To(PointTo(Equal(KubeletConfigReserved{
-					CPU:    &defaultKubeReservedCPU,
-					Memory: &kubeReservedMemory,
-				})))
-			})
-
-			It("should not default kubeReserved", func() {
+			It("should not overwrite manually set kubeReserved", func() {
 				obj.Spec.Kubernetes.Kubelet = &KubeletConfig{
 					KubeReserved: &KubeletConfigReserved{
 						CPU:    &kubeReservedCPU,
 						Memory: &kubeReservedMemory,
+						PID:    &kubeReservedPID,
 					},
 				}
 				SetDefaults_Shoot(obj)
@@ -392,6 +368,7 @@ var _ = Describe("Defaults", func() {
 				Expect(obj.Spec.Kubernetes.Kubelet.KubeReserved).To(PointTo(Equal(KubeletConfigReserved{
 					CPU:    &kubeReservedCPU,
 					Memory: &kubeReservedMemory,
+					PID:    &kubeReservedPID,
 				})))
 			})
 		})

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -874,7 +874,7 @@ message KubeletConfig {
   // KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime).
   // When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
   // +optional
-  // Default: cpu=80m,memory=1Gi
+  // Default: cpu=80m,memory=1Gi,pid=20k
   optional KubeletConfigReserved kubeReserved = 14;
 
   // SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald).

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -737,7 +737,7 @@ type KubeletConfig struct {
 	// KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime).
 	// When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
 	// +optional
-	// Default: cpu=80m,memory=1Gi
+	// Default: cpu=80m,memory=1Gi,pid=20k
 	KubeReserved *KubeletConfigReserved `json:"kubeReserved,omitempty" protobuf:"bytes,14,opt,name=kubeReserved"`
 	// SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald).
 	// When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.

--- a/pkg/apis/core/v1beta1/defaults.go
+++ b/pkg/apis/core/v1beta1/defaults.go
@@ -207,16 +207,20 @@ func SetDefaults_Shoot(obj *Shoot) {
 	var (
 		kubeReservedMemory = resource.MustParse("1Gi")
 		kubeReservedCPU    = resource.MustParse("80m")
+		kubeReservedPID    = resource.MustParse("20k")
 	)
 
 	if obj.Spec.Kubernetes.Kubelet.KubeReserved == nil {
-		obj.Spec.Kubernetes.Kubelet.KubeReserved = &KubeletConfigReserved{Memory: &kubeReservedMemory, CPU: &kubeReservedCPU}
+		obj.Spec.Kubernetes.Kubelet.KubeReserved = &KubeletConfigReserved{Memory: &kubeReservedMemory, CPU: &kubeReservedCPU, PID: &kubeReservedPID}
 	} else {
 		if obj.Spec.Kubernetes.Kubelet.KubeReserved.Memory == nil {
 			obj.Spec.Kubernetes.Kubelet.KubeReserved.Memory = &kubeReservedMemory
 		}
 		if obj.Spec.Kubernetes.Kubelet.KubeReserved.CPU == nil {
 			obj.Spec.Kubernetes.Kubelet.KubeReserved.CPU = &kubeReservedCPU
+		}
+		if obj.Spec.Kubernetes.Kubelet.KubeReserved.PID == nil {
+			obj.Spec.Kubernetes.Kubelet.KubeReserved.PID = &kubeReservedPID
 		}
 	}
 

--- a/pkg/apis/core/v1beta1/defaults_test.go
+++ b/pkg/apis/core/v1beta1/defaults_test.go
@@ -330,8 +330,10 @@ var _ = Describe("Defaults", func() {
 			var (
 				defaultKubeReservedMemory = resource.MustParse("1Gi")
 				defaultKubeReservedCPU    = resource.MustParse("80m")
+				defaultKubeReservedPID    = resource.MustParse("20k")
 				kubeReservedMemory        = resource.MustParse("2Gi")
 				kubeReservedCPU           = resource.MustParse("20m")
+				kubeReservedPID           = resource.MustParse("10k")
 			)
 
 			It("should default all fields", func() {
@@ -340,42 +342,16 @@ var _ = Describe("Defaults", func() {
 				Expect(obj.Spec.Kubernetes.Kubelet.KubeReserved).To(PointTo(Equal(KubeletConfigReserved{
 					CPU:    &defaultKubeReservedCPU,
 					Memory: &defaultKubeReservedMemory,
+					PID:    &defaultKubeReservedPID,
 				})))
 			})
 
-			It("should default memory", func() {
-				obj.Spec.Kubernetes.Kubelet = &KubeletConfig{
-					KubeReserved: &KubeletConfigReserved{
-						CPU: &kubeReservedCPU,
-					},
-				}
-				SetDefaults_Shoot(obj)
-
-				Expect(obj.Spec.Kubernetes.Kubelet.KubeReserved).To(PointTo(Equal(KubeletConfigReserved{
-					CPU:    &kubeReservedCPU,
-					Memory: &defaultKubeReservedMemory,
-				})))
-			})
-
-			It("should default CPU", func() {
-				obj.Spec.Kubernetes.Kubelet = &KubeletConfig{
-					KubeReserved: &KubeletConfigReserved{
-						Memory: &kubeReservedMemory,
-					},
-				}
-				SetDefaults_Shoot(obj)
-
-				Expect(obj.Spec.Kubernetes.Kubelet.KubeReserved).To(PointTo(Equal(KubeletConfigReserved{
-					CPU:    &defaultKubeReservedCPU,
-					Memory: &kubeReservedMemory,
-				})))
-			})
-
-			It("should not default kubeReserved", func() {
+			It("should not overwrite manually set kubeReserved", func() {
 				obj.Spec.Kubernetes.Kubelet = &KubeletConfig{
 					KubeReserved: &KubeletConfigReserved{
 						CPU:    &kubeReservedCPU,
 						Memory: &kubeReservedMemory,
+						PID:    &kubeReservedPID,
 					},
 				}
 				SetDefaults_Shoot(obj)
@@ -383,6 +359,7 @@ var _ = Describe("Defaults", func() {
 				Expect(obj.Spec.Kubernetes.Kubelet.KubeReserved).To(PointTo(Equal(KubeletConfigReserved{
 					CPU:    &kubeReservedCPU,
 					Memory: &kubeReservedMemory,
+					PID:    &kubeReservedPID,
 				})))
 			})
 		})

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -838,7 +838,7 @@ message KubeletConfig {
   // KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime).
   // When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
   // +optional
-  // Default: cpu=80m,memory=1Gi
+  // Default: cpu=80m,memory=1Gi,pid=20k
   optional KubeletConfigReserved kubeReserved = 14;
 
   // SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald).

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -734,7 +734,7 @@ type KubeletConfig struct {
 	// KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime).
 	// When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
 	// +optional
-	// Default: cpu=80m,memory=1Gi
+	// Default: cpu=80m,memory=1Gi,pid=20k
 	KubeReserved *KubeletConfigReserved `json:"kubeReserved,omitempty" protobuf:"bytes,14,opt,name=kubeReserved"`
 	// SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald).
 	// When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2850,7 +2850,7 @@ func schema_pkg_apis_core_v1alpha1_KubeletConfig(ref common.ReferenceCallback) c
 					},
 					"kubeReserved": {
 						SchemaProps: spec.SchemaProps{
-							Description: "KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime). When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied. Default: cpu=80m,memory=1Gi",
+							Description: "KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime). When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied. Default: cpu=80m,memory=1Gi,pid=20k",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.KubeletConfigReserved"),
 						},
 					},
@@ -8806,7 +8806,7 @@ func schema_pkg_apis_core_v1beta1_KubeletConfig(ref common.ReferenceCallback) co
 					},
 					"kubeReserved": {
 						SchemaProps: spec.SchemaProps{
-							Description: "KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime). When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied. Default: cpu=80m,memory=1Gi",
+							Description: "KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime). When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied. Default: cpu=80m,memory=1Gi,pid=20k",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.KubeletConfigReserved"),
 						},
 					},


### PR DESCRIPTION
Protect kubelet from being starved out of PIDs by workload.

/area availability
/area security
/priority normal

**What this PR does / why we need it**:

Currently a kubelet, the container runtime or other system daemons can be starved out of processes if a pod on a node creates excessive amount of processes.
Setting this flag will guarantee that all processes outside of pods will have 20k pids guaranteed.

I checked on large Shooted Seeds and PIDs used in the system.slice(includes container runtime and kubelet) were ~4k so I multiplied it by 5 to be on the safe side.

Verified that it works:

```
# Before:
$ cat /sys/fs/cgroup/pids/kubepods/pids.max
4194304

# After (20k less)
$ cat /sys/fs/cgroup/pids/kubepods/pids.max
4174304

# Total available pids:
cat /proc/sys/kernel/pid_max
4194304
```

This change does not require a restart of the nodes or the pods. Only the kubelet gets restarted.

I also removed some tests in the defaults_test that I did not think added meaningful test coverage.

**Release note**:
```noteworthy user
Defaults reserved PIDs for kubelet and container runtime to 20k.
```
