### PR TITLE
Expose apiserver envoy proxy metrics

### DIFF
--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
@@ -26,6 +26,7 @@ spec:
         role: apiserver-proxy
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-apiserver: allowed
+        networking.gardener.cloud/from-seed: allowed
     spec:
       serviceAccountName: apiserver-proxy
       priorityClassName: system-cluster-critical
@@ -93,12 +94,24 @@ spec:
             cpu: 20m
             memory: 20Mi
           limits:
-            cpu: 60m
-            memory: 40Mi
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - name: proxy
+          containerPort: 443
+          hostPort: 443
+          hostIP: {{ .Values.advertiseIPAddress }}
+        - name: metrics
+          containerPort: {{ .Values.metricsPort }}
+          hostPort: {{ .Values.metricsPort }}
         volumeMounts:
         - name: proxy-config
           mountPath: /etc/apiserver-proxy
+        - name: admin-uds
+          mountPath: /etc/admin-uds
       volumes:
       - name: proxy-config
         configMap:
           name: apiserver-proxy-config
+      - name: admin-uds
+        emptyDir: {}

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/proxy-configmap.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/proxy-configmap.yaml
@@ -33,13 +33,21 @@ data:
             envoy:
               resource_limits:
                 listener:
-                  listener_proxy:
+                  kube_apiserver:
                     connection_limit: 2000
             overload:
               global_downstream_max_connections: 10000
+    admin:
+      access_log_path: /dev/stout
+      address:
+        pipe:
+          # The admin interface should not be exposed as a TCP address.
+          # It's only used and exposed via the metrics lister that
+          # exposes only /stats/prometheus path for metrics scrape.
+          path: /etc/admin-uds/admin.socket
     static_resources:
       listeners:
-      - name: listener_proxy
+      - name: kube_apiserver
         address:
           socket_address:
             address: {{ .Values.advertiseIPAddress }}
@@ -52,6 +60,43 @@ data:
               "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
               stat_prefix: kube_apiserver
               cluster: kube_apiserver
+      - name: metrics
+        address:
+          socket_address:
+            address: 0.0.0.0
+            port_value: {{ .Values.metricsPort }}
+        filter_chains:
+        - filters:
+          - name: envoy.filters.network.http_connection_manager
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: ingress_http
+              use_remote_address: true
+              common_http_protocol_options:
+                idle_timeout: 8s
+                max_connection_duration: 10s
+                max_headers_count: 20
+                max_stream_duration: 8s
+                headers_with_underscores_action: REJECT_REQUEST
+              http2_protocol_options:
+                max_concurrent_streams: 5
+                initial_stream_window_size: 65536
+                initial_connection_window_size: 1048576
+              stream_idle_timeout: 8s
+              request_timeout: 9s
+              codec_type: AUTO
+              route_config:
+                name: local_route
+                virtual_hosts:
+                - name: local_service
+                  domains: ["*"]
+                  routes:
+                  - match:
+                      path: /stats/prometheus
+                    route:
+                      cluster: uds_admin
+              http_filters:
+              - name: envoy.filters.http.router
 
       clusters:
       - name: kube_apiserver
@@ -77,3 +122,17 @@ data:
               version: V2
             transport_socket:
               name: envoy.transport_sockets.raw_buffer
+      - name: uds_admin
+        connect_timeout: 0.25s
+        type: STATIC
+        lb_policy: ROUND_ROBIN
+        load_assignment:
+          cluster_name: uds_admin
+          endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    pipe:
+                      path: /etc/admin-uds/admin.socket
+        transport_socket:
+          name: envoy.transport_sockets.raw_buffer

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-psp.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-psp.yaml
@@ -10,10 +10,13 @@ spec:
   volumes:
   - secret
   - configMap
+  - emptyDir
   hostNetwork: true
   hostPorts:
   - min: 443
     max: 443
+  - min: {{ .Values.metricsPort }}
+    max: {{ .Values.metricsPort }}
   allowedHostPaths: []
   allowedCapabilities:
   - NET_ADMIN

--- a/charts/shoot-core/components/charts/apiserver-proxy/values.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/values.yaml
@@ -7,3 +7,5 @@ advertiseIPAddress: 1.1.1.1
 proxySeedServer:
   host: dummy.127.0.0.1.nip.io
   port: 8443
+# this is the nodeExporter port + 1
+metricsPort: 16910


### PR DESCRIPTION
On all Nodes `16910` (node-exporter port + 1) is now used for metrics scraping at `/stats/prometheus`

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area monitoring
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Allows for Prometheus to scrap this component (I'll do it in a separate PR).
**Which issue(s) this PR fixes**:

Part of #2942

**Special notes for your reviewer**:

Envoy's admin interface can be used to make some configuration changes by just calling the endpoint. Normally in container it'll listen on `127.0.0.1`, however in this case it's listening on the host network. To avoid the security issue, the admin management listens on unix socket and then it's exposed via http listener.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action user
`apiserver-proxy` now listens on port `16910` on all Nodes if `APIServerSNI` feature gate is enabled. It causes a conflict with workloads with `hostNetwork: true` and listening on `0.0.0.0:16910`, so it's required to change your workload's bind port.
```
