### PR TITLE
Add apiserver-proxy readiness check

### DIFF
--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
@@ -96,14 +96,22 @@ spec:
           limits:
             cpu: 100m
             memory: 100Mi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: {{ .Values.adminPort }}
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         ports:
         - name: proxy
           containerPort: 443
           hostPort: 443
           hostIP: {{ .Values.advertiseIPAddress }}
         - name: metrics
-          containerPort: {{ .Values.metricsPort }}
-          hostPort: {{ .Values.metricsPort }}
+          containerPort: {{ .Values.adminPort }}
+          hostPort: {{ .Values.adminPort }}
         volumeMounts:
         - name: proxy-config
           mountPath: /etc/apiserver-proxy

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/proxy-configmap.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/proxy-configmap.yaml
@@ -64,7 +64,7 @@ data:
         address:
           socket_address:
             address: 0.0.0.0
-            port_value: {{ .Values.metricsPort }}
+            port_value: {{ .Values.adminPort }}
         filter_chains:
         - filters:
           - name: envoy.filters.network.http_connection_manager
@@ -93,6 +93,10 @@ data:
                   routes:
                   - match:
                       path: /stats/prometheus
+                    route:
+                      cluster: uds_admin
+                  - match:
+                      path: /ready
                     route:
                       cluster: uds_admin
               http_filters:

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-psp.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-psp.yaml
@@ -15,8 +15,8 @@ spec:
   hostPorts:
   - min: 443
     max: 443
-  - min: {{ .Values.metricsPort }}
-    max: {{ .Values.metricsPort }}
+  - min: {{ .Values.adminPort }}
+    max: {{ .Values.adminPort }}
   allowedHostPaths: []
   allowedCapabilities:
   - NET_ADMIN

--- a/charts/shoot-core/components/charts/apiserver-proxy/values.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/values.yaml
@@ -8,4 +8,4 @@ proxySeedServer:
   host: dummy.127.0.0.1.nip.io
   port: 8443
 # this is the nodeExporter port + 1
-metricsPort: 16910
+adminPort: 16910


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Make sure to have readiness probes for the envoy proxy. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
