### PR TITLE
Fix node-exporter configuration

### DIFF
--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -73,9 +73,9 @@ spec:
         - /bin/node_exporter
         - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
-        - --collector.filesystem.ignored-fs-types=^(tmpfs|cgroup|nsfs|fuse\.lxcfs|rpc_pipefs)$
-        - --collector.filesystem.ignored-mount-points=^/(rootfs/|host/)?(sys|proc|dev|host|etc|var/lib/docker)($|/)
+        - --collector.filesystem.ignored-mount-points=^/.+$
         - --web.listen-address=:{{ .Values.ports.metrics }}
+        - --path.rootfs=/host
         - --log.level=error
         - --no-collector.netclass
         ports:
@@ -108,24 +108,10 @@ spec:
             memory: 100Mi
           {{- end }}
         volumeMounts:
-        - name: proc
-          readOnly:  true
-          mountPath: /host/proc
-        - name: sys
+        - name: host
           readOnly: true
-          mountPath: /host/sys
-        # TODO(mvladev): Remove this once 0.17.X version of node exporter is released
-        - name: rootfs
-          readOnly: true
-          mountPath: /rootfs
+          mountPath: /host
       volumes:
-      - name: proc
-        hostPath:
-          path: /proc
-      - name: sys
-        hostPath:
-          path: /sys
-      # TODO(mvladev): Remove this once 0.17.X version of node exporter is released
-      - name: rootfs
+      - name: host
         hostPath:
           path: /


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug
/priority normal

**What this PR does / why we need it**:

* Use default values for ignored fs types.
* Fix ignored mount points
* Simplify mountpoints

On an xfs filesystem the reported size of the root volume was incorrect. This
change fixes the issue.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Node exporter properly reports filesystem size for operating systems that use an xfs filesystem
```
