### PR TITLE
Reference in CONTRIBUTING.md to the Contributor Guide on gardener.cloud

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please refer to the [Gardener contributor guide](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md).
+Please refer to the [Gardener contributor guide](https://gardener.cloud/documentation/contribute/).


### PR DESCRIPTION
Related to gardener/documentation#144. The single source of trust is the contributor guide on gardener.cloud. All CONTRIBUTING.md files should refer to this guide