### PR TITLE
Add minAllowed for kcm VPA

### DIFF
--- a/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager.go
@@ -298,6 +298,15 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 		vpa.Spec.UpdatePolicy = &autoscalingv1beta2.PodUpdatePolicy{
 			UpdateMode: &vpaUpdateMode,
 		}
+		vpa.Spec.ResourcePolicy = &autoscalingv1beta2.PodResourcePolicy{
+			ContainerPolicies: []autoscalingv1beta2.ContainerResourcePolicy{{
+				ContainerName: kubeControllerManagerContainerName,
+				MinAllowed: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("25m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			}},
+		}
 		return nil
 	}); err != nil {
 		return err

--- a/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager_test.go
@@ -306,6 +306,15 @@ var _ = Describe("KubeControllerManager", func() {
 						UpdatePolicy: &autoscalingv1beta2.PodUpdatePolicy{
 							UpdateMode: &vpaUpdateMode,
 						},
+						ResourcePolicy: &autoscalingv1beta2.PodResourcePolicy{
+							ContainerPolicies: []autoscalingv1beta2.ContainerResourcePolicy{{
+								ContainerName: "kube-controller-manager",
+								MinAllowed: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("25m"),
+									corev1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+							}},
+						},
 					},
 				}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality robustness
/kind bug
/priority normal

**What this PR does / why we need it**:
I have seen multiple occurrences of VPA scaling down kcm too much, so it couldn't start up and was constantly getting OOMKilled.
This PR adds minAllowed values to kcm's VPA to prevent such situations in the future.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@amshuman-kr @ggaurav10 can you take a look at the values I put in and check if they are reasonable?

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `kube-controller-manager` VPA now has `minAllowed` values to prevent VPA from scaling it down too much.
```
