### PR TITLE
Default kubelet.kubeReserved.pid only for k8s >= 1.15

### DIFF
--- a/pkg/apis/core/v1alpha1/defaults.go
+++ b/pkg/apis/core/v1alpha1/defaults.go
@@ -194,10 +194,16 @@ func SetDefaults_Shoot(obj *Shoot) {
 		kubeReservedMemory = resource.MustParse("1Gi")
 		kubeReservedCPU    = resource.MustParse("80m")
 		kubeReservedPID    = resource.MustParse("20k")
+
+		k8sVersionGreaterEqual115, _ = versionutils.CompareVersions(obj.Spec.Kubernetes.Version, ">=", "1.15")
 	)
 
 	if obj.Spec.Kubernetes.Kubelet.KubeReserved == nil {
-		obj.Spec.Kubernetes.Kubelet.KubeReserved = &KubeletConfigReserved{Memory: &kubeReservedMemory, CPU: &kubeReservedCPU, PID: &kubeReservedPID}
+		obj.Spec.Kubernetes.Kubelet.KubeReserved = &KubeletConfigReserved{Memory: &kubeReservedMemory, CPU: &kubeReservedCPU}
+
+		if k8sVersionGreaterEqual115 {
+			obj.Spec.Kubernetes.Kubelet.KubeReserved.PID = &kubeReservedPID
+		}
 	} else {
 		if obj.Spec.Kubernetes.Kubelet.KubeReserved.Memory == nil {
 			obj.Spec.Kubernetes.Kubelet.KubeReserved.Memory = &kubeReservedMemory
@@ -205,7 +211,7 @@ func SetDefaults_Shoot(obj *Shoot) {
 		if obj.Spec.Kubernetes.Kubelet.KubeReserved.CPU == nil {
 			obj.Spec.Kubernetes.Kubelet.KubeReserved.CPU = &kubeReservedCPU
 		}
-		if obj.Spec.Kubernetes.Kubelet.KubeReserved.PID == nil {
+		if obj.Spec.Kubernetes.Kubelet.KubeReserved.PID == nil && k8sVersionGreaterEqual115 {
 			obj.Spec.Kubernetes.Kubelet.KubeReserved.PID = &kubeReservedPID
 		}
 	}

--- a/pkg/apis/core/v1alpha1/defaults_test.go
+++ b/pkg/apis/core/v1alpha1/defaults_test.go
@@ -329,7 +329,20 @@ var _ = Describe("Defaults", func() {
 				kubeReservedPID           = resource.MustParse("10k")
 			)
 
-			It("should default all fields", func() {
+			It("should default all fields except PID for k8s < 1.15", func() {
+				obj.Spec.Kubernetes.Version = "1.13.1"
+
+				SetDefaults_Shoot(obj)
+
+				Expect(obj.Spec.Kubernetes.Kubelet.KubeReserved).To(PointTo(Equal(KubeletConfigReserved{
+					CPU:    &defaultKubeReservedCPU,
+					Memory: &defaultKubeReservedMemory,
+				})))
+			})
+
+			It("should default all fields for k8s >= 1.15", func() {
+				obj.Spec.Kubernetes.Version = "1.15.1"
+
 				SetDefaults_Shoot(obj)
 
 				Expect(obj.Spec.Kubernetes.Kubelet.KubeReserved).To(PointTo(Equal(KubeletConfigReserved{

--- a/pkg/apis/core/v1beta1/defaults.go
+++ b/pkg/apis/core/v1beta1/defaults.go
@@ -194,10 +194,16 @@ func SetDefaults_Shoot(obj *Shoot) {
 		kubeReservedMemory = resource.MustParse("1Gi")
 		kubeReservedCPU    = resource.MustParse("80m")
 		kubeReservedPID    = resource.MustParse("20k")
+
+		k8sVersionGreaterEqual115, _ = versionutils.CompareVersions(obj.Spec.Kubernetes.Version, ">=", "1.15")
 	)
 
 	if obj.Spec.Kubernetes.Kubelet.KubeReserved == nil {
-		obj.Spec.Kubernetes.Kubelet.KubeReserved = &KubeletConfigReserved{Memory: &kubeReservedMemory, CPU: &kubeReservedCPU, PID: &kubeReservedPID}
+		obj.Spec.Kubernetes.Kubelet.KubeReserved = &KubeletConfigReserved{Memory: &kubeReservedMemory, CPU: &kubeReservedCPU}
+
+		if k8sVersionGreaterEqual115 {
+			obj.Spec.Kubernetes.Kubelet.KubeReserved.PID = &kubeReservedPID
+		}
 	} else {
 		if obj.Spec.Kubernetes.Kubelet.KubeReserved.Memory == nil {
 			obj.Spec.Kubernetes.Kubelet.KubeReserved.Memory = &kubeReservedMemory
@@ -205,7 +211,7 @@ func SetDefaults_Shoot(obj *Shoot) {
 		if obj.Spec.Kubernetes.Kubelet.KubeReserved.CPU == nil {
 			obj.Spec.Kubernetes.Kubelet.KubeReserved.CPU = &kubeReservedCPU
 		}
-		if obj.Spec.Kubernetes.Kubelet.KubeReserved.PID == nil {
+		if obj.Spec.Kubernetes.Kubelet.KubeReserved.PID == nil && k8sVersionGreaterEqual115 {
 			obj.Spec.Kubernetes.Kubelet.KubeReserved.PID = &kubeReservedPID
 		}
 	}

--- a/pkg/apis/core/v1beta1/defaults_test.go
+++ b/pkg/apis/core/v1beta1/defaults_test.go
@@ -320,7 +320,20 @@ var _ = Describe("Defaults", func() {
 				kubeReservedPID           = resource.MustParse("10k")
 			)
 
-			It("should default all fields", func() {
+			It("should default all fields except PID for k8s < 1.15", func() {
+				obj.Spec.Kubernetes.Version = "1.13.1"
+
+				SetDefaults_Shoot(obj)
+
+				Expect(obj.Spec.Kubernetes.Kubelet.KubeReserved).To(PointTo(Equal(KubeletConfigReserved{
+					CPU:    &defaultKubeReservedCPU,
+					Memory: &defaultKubeReservedMemory,
+				})))
+			})
+
+			It("should default all fields for k8s >= 1.15", func() {
+				obj.Spec.Kubernetes.Version = "1.15.1"
+
 				SetDefaults_Shoot(obj)
 
 				Expect(obj.Spec.Kubernetes.Kubelet.KubeReserved).To(PointTo(Equal(KubeletConfigReserved{

--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -210,7 +210,7 @@ func (c *defaultControl) reconcileNamespaceForProject(ctx context.Context, garde
 				Annotations:     projectAnnotations,
 			},
 		}
-		err := gardenClient.Client().Create(context.TODO(), obj)
+		err := gardenClient.Client().Create(ctx, obj)
 		return obj, err
 	}
 
@@ -245,7 +245,7 @@ func (c *defaultControl) reconcileNamespaceForProject(ctx context.Context, garde
 				Annotations:     projectAnnotations,
 			},
 		}
-		err := gardenClient.Client().Create(context.TODO(), obj)
+		err := gardenClient.Client().Create(ctx, obj)
 		return obj, err
 	}
 

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -30,7 +30,6 @@ import (
 	corelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation/common"
-	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils"
 	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
 
@@ -238,7 +237,7 @@ func (d *DNS) Admit(ctx context.Context, a admission.Attributes, o admission.Obj
 // checkFunctionlessDNSProviders returns an error if a non-primary provider isn't configured correctly.
 func checkFunctionlessDNSProviders(dns *core.DNS) error {
 	for _, provider := range dns.Providers {
-		if !utils.IsTrue(provider.Primary) && (provider.Type == nil || provider.SecretName == nil) {
+		if !gardenerutils.IsTrue(provider.Primary) && (provider.Type == nil || provider.SecretName == nil) {
 			return apierrors.NewBadRequest("non-primary DNS providers in .spec.dns.providers must specify a `type` and `secretName`")
 		}
 	}

--- a/test/system/shoot_deletion/delete_test.go
+++ b/test/system/shoot_deletion/delete_test.go
@@ -32,7 +32,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -73,7 +72,7 @@ var _ = Describe("Shoot deletion testing", func() {
 			}
 		}
 
-		if err := f.DeleteShootAndWaitForDeletion(ctx, shoot); err != nil && !errors.IsNotFound(err) {
+		if err := f.DeleteShootAndWaitForDeletion(ctx, shoot); err != nil && !apierrors.IsNotFound(err) {
 			if shootFramework, err := f.NewShootFramework(shoot); err == nil {
 				shootFramework.DumpState(ctx)
 			}


### PR DESCRIPTION
kube-reserved pid requires the `SupportNodePidsLimit` feature gate to be enabled (it is beta since v1.15 and GA since v1.20). Ref https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/.

/kind bug

Fixes #3058

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
An issue causing `spec.kubernetes.kubelet.kubeReserved.pid` field of the Shoot to be set for Kubernetes versions that don't support the corresponding feature is now fixed.
```
