### PR TITLE
Remove apiserver-proxy overload manager

### DIFF
--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/proxy-configmap.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/proxy-configmap.yaml
@@ -8,24 +8,6 @@ metadata:
     origin: gardener
 data:
   envoy.yaml: |-
-    overload_manager:
-      refresh_interval: 0.25s
-      resource_monitors:
-      - name: "envoy.resource_monitors.fixed_heap"
-        typed_config:
-          "@type": type.googleapis.com/envoy.config.resource_monitor.fixed_heap.v2alpha.FixedHeapConfig
-          max_heap_size_bytes: 20971520 # 20 MiB
-      actions:
-      - name: "envoy.overload_actions.shrink_heap"
-        triggers:
-        - name: "envoy.resource_monitors.fixed_heap"
-          threshold:
-            value: 0.95
-      - name: "envoy.overload_actions.stop_accepting_requests"
-        triggers:
-        - name: "envoy.resource_monitors.fixed_heap"
-          threshold:
-            value: 0.98
     layered_runtime:
       layers:
         - name: static_layer_0
@@ -34,7 +16,7 @@ data:
               resource_limits:
                 listener:
                   kube_apiserver:
-                    connection_limit: 2000
+                    connection_limit: 10000
             overload:
               global_downstream_max_connections: 10000
     admin:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area scalability
/kind regression
/priority normal

**What this PR does / why we need it**:

Depending on the workload, it can cause the readiness check to return - 503 envoy overloaded

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
`apiserver-proxy` overload's manager is removed.
```
