### PR TITLE
Update VPA pod autoscaler from 0.8.0 to 0.9.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -214,15 +214,15 @@ images:
 - name: vpa-admission-controller
   sourceRepository: github.com/kubernetes/autoscaler
   repository: k8s.gcr.io/autoscaling/vpa-admission-controller
-  tag: "0.8.0"
+  tag: "0.9.0"
 - name: vpa-recommender
   sourceRepository: github.com/kubernetes/autoscaler
   repository: k8s.gcr.io/autoscaling/vpa-recommender
-  tag: "0.8.0"
+  tag: "0.9.0"
 - name: vpa-updater
   sourceRepository: github.com/kubernetes/autoscaler
   repository: k8s.gcr.io/autoscaling/vpa-updater
-  tag: "0.8.0"
+  tag: "0.9.0"
 - name: vpa-exporter
   sourceRepository: github.com/gardener/vpa-exporter
   repository: eu.gcr.io/gardener-project/gardener/vpa-exporter


### PR DESCRIPTION
Updating the version of each of vpa-admission-controller,
vpa-recommender and vpa-updater to 0.9.0 from 0.8.0

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.

  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
The PR updates the release of VPA to vpa-pod-autoscaler-0.9.0.
This is an attempt at a version upgrade from 0.8.0 to tackle the issues mentioned in
The following components of vpa are updated
vpa-admission-controller
vpa-recommender
vpa-updater


**Which issue(s) this PR fixes**:
Fixes #2961

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```
Updating the vpa pod autoscaler components vpa-admission-controller, vpa-recommender and vpa-updater from 0.8.0 to 0.9.0.
```
