### PR TITLE
Add reference protection for audit policy ConfigMaps

### DIFF
--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -82,5 +82,6 @@ When an object is not actively referenced any more because the shoot specificati
 
 The Shoot Reference Controller inspects the following references:
 - DNS provider secrets (`.spec.dns.provider`)
+- Audit policy configmaps (`.spec.kubernetes.kubeAPIServer.auditConfig.auditPolicy.configMapRef`)
 
 Further checks might be added in the future.

--- a/pkg/controllermanager/controller/shoot/shoot_reference_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_reference_control.go
@@ -69,7 +69,15 @@ func (c *Controller) shootReferenceUpdate(oldObj, newObj interface{}) {
 }
 
 func refChange(oldShoot, newShoot *gardencorev1beta1.Shoot) bool {
+	return shootDNSFieldChanged(oldShoot, newShoot) || shootKubeAPIServerAuditConfigFieldChanged(oldShoot, newShoot)
+}
+
+func shootDNSFieldChanged(oldShoot, newShoot *gardencorev1beta1.Shoot) bool {
 	return !apiequality.Semantic.Equalities.DeepEqual(oldShoot.Spec.DNS, newShoot.Spec.DNS)
+}
+
+func shootKubeAPIServerAuditConfigFieldChanged(oldShoot, newShoot *gardencorev1beta1.Shoot) bool {
+	return !apiequality.Semantic.Equalities.DeepEqual(oldShoot.Spec.Kubernetes.KubeAPIServer.AuditConfig, newShoot.Spec.Kubernetes.KubeAPIServer.AuditConfig)
 }
 
 // FinalizerName is the name of the finalizer used for the reference protection.
@@ -78,13 +86,17 @@ const FinalizerName = "gardener.cloud/reference-protection"
 // SecretLister fetches secret objects with the given options.
 type SecretLister func(ctx context.Context, secretList *corev1.SecretList, options ...client.ListOption) error
 
+// ConfigMapLister fetches configmap objects with the given options.
+type ConfigMapLister func(ctx context.Context, configMapList *corev1.ConfigMapList, options ...client.ListOption) error
+
 // NewShootReferenceReconciler creates a new instance of a reconciler which checks object references from shoot objects.
 // A special `userSecretLister` serves as an option to retrieve secret objects which are not gardener managed.
-func NewShootReferenceReconciler(l logrus.FieldLogger, clientMap clientmap.ClientMap, userSecretLister SecretLister) reconcile.Reconciler {
+func NewShootReferenceReconciler(l logrus.FieldLogger, clientMap clientmap.ClientMap, userSecretLister SecretLister, configMapLister ConfigMapLister) reconcile.Reconciler {
 	return &shootReferenceReconciler{
-		clientMap:    clientMap,
-		secretLister: userSecretLister,
-		logger:       l,
+		clientMap:       clientMap,
+		secretLister:    userSecretLister,
+		configMapLister: configMapLister,
+		logger:          l,
 	}
 }
 
@@ -92,8 +104,9 @@ type shootReferenceReconciler struct {
 	ctx context.Context
 
 	// secretLister is supposed to be the most performant option to retrieve secret objects in this controller.
-	secretLister SecretLister
-	clientMap    clientmap.ClientMap
+	secretLister    SecretLister
+	configMapLister ConfigMapLister
+	clientMap       clientmap.ClientMap
 
 	logger logrus.FieldLogger
 }
@@ -136,16 +149,28 @@ func (r *shootReferenceReconciler) reconcileShootReferences(c client.Client, sho
 		return err
 	}
 
+	// Iterate over all user configmaps in project namespace and check if they can be released.
+	if err := r.releaseUnreferencedConfigMaps(c, shoot); err != nil {
+		return err
+	}
+
 	// Remove finalizer from shoot in case it's being deleted and not handled by Gardener any more.
 	if shoot.DeletionTimestamp != nil && !controllerutils.HasFinalizer(shoot, gardencorev1beta1.GardenerName) {
 		return controllerutils.PatchRemoveFinalizers(r.ctx, c, shoot, FinalizerName)
 	}
 
 	// Add finalizer to referenced secrets that are not managed by Gardener.
-	needsFinalizer, err := r.handleReferencedSecrets(c, shoot)
+	addedFinalizerToSecret, err := r.handleReferencedSecrets(c, shoot)
 	if err != nil {
 		return err
 	}
+
+	addedFinalizerToConfigMap, err := r.handleReferencedConfigMap(c, shoot)
+	if err != nil {
+		return err
+	}
+
+	needsFinalizer := addedFinalizerToSecret || addedFinalizerToConfigMap
 
 	// Manage finalizers on shoot.
 	hasFinalizer := controllerutils.HasFinalizer(shoot, FinalizerName)
@@ -192,6 +217,25 @@ func (r *shootReferenceReconciler) handleReferencedSecrets(c client.Client, shoo
 	return added != 0, err
 }
 
+func (r *shootReferenceReconciler) handleReferencedConfigMap(c client.Client, shoot *gardencorev1beta1.Shoot) (bool, error) {
+	apiServerConfig := shoot.Spec.Kubernetes.KubeAPIServer
+	configMapRef := getAuditPolicyConfigMapRef(apiServerConfig)
+	if configMapRef != nil {
+		configMap := &corev1.ConfigMap{}
+		if err := c.Get(r.ctx, kutil.Key(shoot.Namespace, configMapRef.Name), configMap); err != nil {
+			return false, err
+		}
+
+		if controllerutils.HasFinalizer(configMap, FinalizerName) {
+			return true, nil
+		}
+
+		return true, controllerutils.PatchFinalizers(r.ctx, c, configMap, FinalizerName)
+	}
+
+	return false, nil
+}
+
 func (r *shootReferenceReconciler) releaseUnreferencedSecrets(c client.Client, shoot *gardencorev1beta1.Shoot) error {
 	secrets, err := r.getUnreferencedSecrets(c, shoot)
 	if err != nil {
@@ -203,6 +247,23 @@ func (r *shootReferenceReconciler) releaseUnreferencedSecrets(c client.Client, s
 		s := secret
 		fns = append(fns, func(ctx context.Context) error {
 			return client.IgnoreNotFound(controllerutils.PatchRemoveFinalizers(r.ctx, c, &s, FinalizerName))
+		})
+
+	}
+	return flow.Parallel(fns...)(r.ctx)
+}
+
+func (r *shootReferenceReconciler) releaseUnreferencedConfigMaps(c client.Client, shoot *gardencorev1beta1.Shoot) error {
+	configMaps, err := r.getUnreferencedConfigMaps(c, shoot)
+	if err != nil {
+		return err
+	}
+
+	var fns []flow.TaskFn
+	for _, configMap := range configMaps {
+		cm := configMap
+		fns = append(fns, func(ctx context.Context) error {
+			return client.IgnoreNotFound(controllerutils.PatchRemoveFinalizers(r.ctx, c, &cm, FinalizerName))
 		})
 
 	}
@@ -252,6 +313,52 @@ func (r *shootReferenceReconciler) getUnreferencedSecrets(c client.Client, shoot
 	return secretsToRelease, nil
 }
 
+func (r *shootReferenceReconciler) getUnreferencedConfigMaps(c client.Client, shoot *gardencorev1beta1.Shoot) ([]corev1.ConfigMap, error) {
+	namespace := shoot.Namespace
+
+	configMaps := &corev1.ConfigMapList{}
+	if err := r.configMapLister(r.ctx, configMaps, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+
+	// Exit early if there are no ConfigMaps at all in the namespace
+	if len(configMaps.Items) == 0 {
+		return nil, nil
+	}
+
+	shoots := &gardencorev1beta1.ShootList{}
+	if err := c.List(r.ctx, shoots, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+
+	referencedConfigMaps := sets.NewString()
+	for _, s := range shoots.Items {
+		// Ignore own references if shoot is in deletion and references are not needed any more by Gardener.
+		if s.Name == shoot.Name && shoot.DeletionTimestamp != nil && !controllerutils.HasFinalizer(&s, gardencorev1beta1.GardenerName) {
+			continue
+		}
+
+		apiServerConfig := s.Spec.Kubernetes.KubeAPIServer
+		configMapRef := getAuditPolicyConfigMapRef(apiServerConfig)
+		if configMapRef != nil {
+			referencedConfigMaps.Insert(configMapRef.Name)
+		}
+	}
+
+	var configMapsToRelease []corev1.ConfigMap
+	for _, configMap := range configMaps.Items {
+		if !controllerutils.HasFinalizer(&configMap, FinalizerName) {
+			continue
+		}
+		if referencedConfigMaps.Has(configMap.Name) {
+			continue
+		}
+		configMapsToRelease = append(configMapsToRelease, configMap)
+	}
+
+	return configMapsToRelease, nil
+}
+
 func secretNamesForDNSProviders(shoot *gardencorev1beta1.Shoot) []string {
 	if shoot.Spec.DNS == nil {
 		return nil
@@ -265,4 +372,16 @@ func secretNamesForDNSProviders(shoot *gardencorev1beta1.Shoot) []string {
 	}
 
 	return names
+}
+
+func getAuditPolicyConfigMapRef(apiServerConfig *gardencorev1beta1.KubeAPIServerConfig) *corev1.ObjectReference {
+	if apiServerConfig != nil &&
+		apiServerConfig.AuditConfig != nil &&
+		apiServerConfig.AuditConfig.AuditPolicy != nil &&
+		apiServerConfig.AuditConfig.AuditPolicy.ConfigMapRef != nil {
+
+		return apiServerConfig.AuditConfig.AuditPolicy.ConfigMapRef
+	}
+
+	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/priority normal

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/2967, the components are being redeployed in the deletion flow. Currently if Shoot with audit policy is deleted and afterwards the policy ConfigMap is also deleted, the Shoot deletion will be stuck with reason:

```yaml
  lastErrors:
    - description: >-
        task "Deploying Kubernetes API server" failed: retry failed with context
        deadline exceeded, last error: retrieving audit policy from the
        ConfigMap 'auditpolicy' failed with reason 'configmaps
        "auditpolicy" not found'
```

This PR adds a finalizer on audit policy ConfigMap until there is a Shoot that reference it.


**Special notes for your reviewer**:
Well, with this PR we have code duplication in the reference controller tests and controller itself. We should check if we can improve that and avoid the code duplication.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
gardener-controller-manager's Shoot reference controller now also handles audit policy ConfigMap references.
```
