### PR TITLE
Remove egress restrictions

### DIFF
--- a/charts/shoot-core/components/charts/vpn-shoot/templates/vpn-networkpolicy.yaml
+++ b/charts/shoot-core/components/charts/vpn-shoot/templates/vpn-networkpolicy.yaml
@@ -9,15 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   egress:
-  - to:
-    - ipBlock:
-        cidr: {{ .Values.serviceNetwork }}
-    - ipBlock:
-        cidr: {{ .Values.podNetwork }}
-{{- if .Values.nodeNetwork }}
-    - ipBlock:
-        cidr: {{ .Values.nodeNetwork }}
-{{- end }}
+  - {}
   ingress:
   - {}
   podSelector:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/priority normal

**What this PR does / why we need it**:
Remove egress restrictions for `vpn-shoot` pod introduced by https://github.com/gardener/gardener/pull/2859 as it currently breaks our setup when running with cilium as network plugin.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Remove egress restrictions for vpn-shoot pod as it was incompatible with the cilium network plugin.
```
