### PR TITLE
Auto-delete (Cluster)RoleBindings on invalid updates

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-actor.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-actor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: gardener.cloud:vpa:{{ .Values.clusterType }}:actor
   labels:
   {{ toYaml .Values.labels | indent 4 }}
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-admission-controller.yaml
@@ -5,6 +5,8 @@ metadata:
   name: gardener.cloud:vpa:{{ .Values.clusterType }}:admission-controller
   labels:
   {{ toYaml .Values.labels | indent 4 }}
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-checkpointer.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-checkpointer.yaml
@@ -5,6 +5,8 @@ metadata:
   name: gardener.cloud:vpa:{{ .Values.clusterType }}:checkpoint-actor
   labels:
   {{ toYaml .Values.labels | indent 4 }}
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-recommender.yaml
@@ -5,6 +5,8 @@ metadata:
   name: gardener.cloud:vpa:{{ .Values.clusterType }}:metrics-reader
   labels:
   {{ toYaml .Values.labels | indent 4 }}
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-target-reader.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-target-reader.yaml
@@ -5,6 +5,8 @@ metadata:
   name: gardener.cloud:vpa:{{ .Values.clusterType }}:target-reader
   labels:
   {{ toYaml .Values.labels | indent 4 }}
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-updater-evictioner.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-updater-evictioner.yaml
@@ -5,6 +5,8 @@ metadata:
   name: gardener.cloud:vpa:{{ .Values.clusterType }}:evictioner
   labels:
   {{ toYaml .Values.labels | indent 4 }}
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/rbac.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/rbac.yaml
@@ -68,6 +68,8 @@ metadata:
   namespace: {{ include "kubernetes-dashboard.namespace" . }}
   labels:
     k8s-app: kubernetes-dashboard
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -96,6 +98,8 @@ apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: kubernetes-dashboard
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-addons/charts/nginx-ingress/templates/clusterrolebinding.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/clusterrolebinding.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
   name: {{ template "nginx-ingress.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/shoot-addons/charts/nginx-ingress/templates/psp/nginx-ingress-rolebinding-privileged.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/psp/nginx-ingress-rolebinding-privileged.yaml
@@ -3,6 +3,8 @@ kind: RoleBinding
 metadata:
   name: gardener.cloud:psp:{{ template "nginx-ingress.fullname" . }}
   namespace: kube-system
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-addons/charts/nginx-ingress/templates/rolebinding.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/rolebinding.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
   name: {{ template "nginx-ingress.fullname" . }}
   namespace: kube-system
 roleRef:

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-rolebinding.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-rolebinding.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     gardener.cloud/role: system-component
     origin: gardener
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-core/components/charts/coredns/templates/coredns-rbac.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-rbac.yaml
@@ -24,6 +24,8 @@ apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: system:coredns
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-core/components/charts/konnectivity-agent/templates/psp/konnectivity-agent-rolebinding.yaml
+++ b/charts/shoot-core/components/charts/konnectivity-agent/templates/psp/konnectivity-agent-rolebinding.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: kube-system
   labels:
     app: konnectivity-agent
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-core/components/charts/konnectivity-agent/templates/rbac.yaml
+++ b/charts/shoot-core/components/charts/konnectivity-agent/templates/rbac.yaml
@@ -4,6 +4,8 @@ metadata:
   name: system:konnectivity-server
   labels:
     app: konnectivity-agent
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-core/components/charts/kube-apiserver-kubelet/templates/kube-apiserver-kubelet-rbac.yaml
+++ b/charts/shoot-core/components/charts/kube-apiserver-kubelet/templates/kube-apiserver-kubelet-rbac.yaml
@@ -22,6 +22,8 @@ apiVersion: {{ template "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: system:apiserver:kubelet
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-core/components/charts/kube-proxy/templates/psp/kube-proxy-rolebinding.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/psp/kube-proxy-rolebinding.yaml
@@ -3,6 +3,8 @@ kind: RoleBinding
 metadata:
   name: gardener.cloud:psp:kube-proxy
   namespace: kube-system
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-core/components/charts/metrics-server/templates/rbac.yaml
+++ b/charts/shoot-core/components/charts/metrics-server/templates/rbac.yaml
@@ -19,6 +19,8 @@ apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: system:metrics-server
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -33,6 +35,8 @@ kind: RoleBinding
 metadata:
   name: metrics-server-auth-reader
   namespace: kube-system
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -46,6 +50,8 @@ apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: metrics-server:system:auth-delegator
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-core/components/charts/monitoring/charts/kube-state-metrics-shoot/templates/rbac.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/kube-state-metrics-shoot/templates/rbac.yaml
@@ -53,6 +53,8 @@ metadata:
   name: gardener.cloud:monitoring:kube-state-metrics
   labels:
     component: kube-state-metrics
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-rolebinding.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-rolebinding.yaml
@@ -3,6 +3,8 @@ kind: RoleBinding
 metadata:
   name: gardener.cloud:psp:node-exporter
   namespace: kube-system
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-core/components/charts/monitoring/charts/prometheus-shoot/templates/rbac.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/prometheus-shoot/templates/rbac.yaml
@@ -31,6 +31,8 @@ apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: gardener.cloud:monitoring:prometheus
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-core/components/charts/node-problem-detector/templates/clusterrolebinding.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/templates/clusterrolebinding.yaml
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
     helm.sh/chart: {{ include "node-problem-detector.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 subjects:
 - kind: ServiceAccount
   name: node-problem-detector

--- a/charts/shoot-core/components/charts/node-problem-detector/templates/psp-clusterrolebinding.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/templates/psp-clusterrolebinding.yaml
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
     helm.sh/chart: {{ include "node-problem-detector.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-core/components/charts/nodelocal-dns/templates/psp/nodelocal-dns-rolebinding.yaml
+++ b/charts/shoot-core/components/charts/nodelocal-dns/templates/psp/nodelocal-dns-rolebinding.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: kube-system
   labels:
     app: node-local-dns
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-core/components/charts/podsecuritypolicies/templates/privileged-clusterrolebinding.yaml
+++ b/charts/shoot-core/components/charts/podsecuritypolicies/templates/privileged-clusterrolebinding.yaml
@@ -7,6 +7,7 @@ metadata:
       Allow all authenticated users to use the privileged PSP.
       The subject field is configured via .spec.kubernetes.allowPrivilegedContainers flag on the Shoot resource.
       Do not manually change it as it'll be reconciled back to the original state.
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-core/components/charts/podsecuritypolicies/templates/unprivileged-clusterrolebinding.yaml
+++ b/charts/shoot-core/components/charts/podsecuritypolicies/templates/unprivileged-clusterrolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     gardener.cloud/description: |
       Allow all authenticated users to use the unprivileged PSP.
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-core/components/charts/podsecuritypolicies/templates/unprivileged-kube-system-rolebinding.yaml
+++ b/charts/shoot-core/components/charts/podsecuritypolicies/templates/unprivileged-kube-system-rolebinding.yaml
@@ -3,6 +3,8 @@ kind: RoleBinding
 metadata:
   name: gardener.cloud:psp:unprivileged
   namespace: kube-system
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-core/components/charts/vpn-shoot/templates/psp/vpn-shoot-rolebinding.yaml
+++ b/charts/shoot-core/components/charts/vpn-shoot/templates/psp/vpn-shoot-rolebinding.yaml
@@ -3,6 +3,8 @@ kind: RoleBinding
 metadata:
   name: gardener.cloud:psp:vpn-shoot
   namespace: kube-system
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/shoot-core/components/charts/vpn-shoot/templates/vpn-seed-rbac.yaml
+++ b/charts/shoot-core/components/charts/vpn-shoot/templates/vpn-seed-rbac.yaml
@@ -17,6 +17,8 @@ apiVersion: {{ template "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: system:gardener.cloud:vpn-seed
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR we add `resources.gardener.cloud/delete-on-invalid-update=true` to all `(Cluster)RoleBindings` in the `shoot-core` and `shoot-addons` charts.
By this, gardener-resource-manager will delete rolebindings that were changed by the enduser and can't be updated (e.g. the `roleRef` field was changed by the enduser).
If endusers do such changes, operators will have to intervene and cleanup manually, which should not be necessary.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Gardener now deletes `(Cluster)RoleBindings` of system components or addons, that were changed to an invalid state by endusers to be able to reconcile them back to the desired state.
```
