### PR TITLE
[rel-1.12] Fix bug in secret generation caused by usage of shared memory

### DIFF
--- a/pkg/apis/core/v1alpha1/helper/shootstate_list.go
+++ b/pkg/apis/core/v1alpha1/helper/shootstate_list.go
@@ -36,8 +36,8 @@ func (e *ExtensionResourceStateList) Get(kind string, name, purpose *string) *ga
 
 // Delete removes an ExtensionResourceState from the list by kind, name and purpose
 func (e *ExtensionResourceStateList) Delete(kind string, name, purpose *string) {
-	for i, obj := range *e {
-		if matchesExtensionResourceState(&obj, kind, name, purpose) {
+	for i := len(*e) - 1; i >= 0; i-- {
+		if matchesExtensionResourceState(&(*e)[i], kind, name, purpose) {
 			*e = append((*e)[:i], (*e)[i+1:]...)
 			return
 		}
@@ -68,9 +68,10 @@ type GardenerResourceDataList []gardencorev1alpha1.GardenerResourceData
 
 // Delete deletes an item from the list
 func (g *GardenerResourceDataList) Delete(name string) {
-	for i, e := range *g {
-		if e.Name == name {
+	for i := len(*g) - 1; i >= 0; i-- {
+		if (*g)[i].Name == name {
 			*g = append((*g)[:i], (*g)[i+1:]...)
+			return
 		}
 	}
 }
@@ -97,14 +98,24 @@ func (g *GardenerResourceDataList) Upsert(data *gardencorev1alpha1.GardenerResou
 	*g = append(*g, *data)
 }
 
+// DeepCopy makes a deep copy of a GardenerResourceDataList
+func (g GardenerResourceDataList) DeepCopy() GardenerResourceDataList {
+	res := GardenerResourceDataList{}
+	for _, obj := range g {
+		res = append(res, *obj.DeepCopy())
+	}
+	return res
+}
+
 // ResourceDataList is a list of ResourceData
 type ResourceDataList []gardencorev1alpha1.ResourceData
 
 // Delete deletes an item from the list
 func (r *ResourceDataList) Delete(ref *autoscalingv1.CrossVersionObjectReference) {
-	for i, obj := range *r {
-		if apiequality.Semantic.DeepEqual(obj.CrossVersionObjectReference, *ref) {
+	for i := len(*r) - 1; i >= 0; i-- {
+		if apiequality.Semantic.DeepEqual((*r)[i].CrossVersionObjectReference, *ref) {
 			*r = append((*r)[:i], (*r)[i+1:]...)
+			return
 		}
 	}
 }

--- a/pkg/apis/core/v1alpha1/helper/shootstate_list_test.go
+++ b/pkg/apis/core/v1alpha1/helper/shootstate_list_test.go
@@ -213,6 +213,50 @@ var _ = Describe("ShootStateList", func() {
 				Expect(list[0].Data).To(Equal(newData))
 			})
 		})
+
+		Context("#DeepCopy", func() {
+			It("should reuse the slice of shootState", func() {
+				list := GardenerResourceDataList(shootState.Spec.Gardener)
+				shootStateResourceName := shootState.Spec.Gardener[0].Name
+
+				newResource := &gardencorev1alpha1.GardenerResourceData{
+					Name: shootStateResourceName + "bar",
+					Type: "bar",
+					Data: runtime.RawExtension{Raw: []byte("data")},
+				}
+
+				list.Delete(shootStateResourceName)
+				Expect(list).To(HaveLen(0))
+				Expect(shootState.Spec.Gardener[0].Name).To(Equal(shootStateResourceName))
+
+				list.Upsert(newResource)
+				Expect(list).To(HaveLen(1))
+				Expect(shootState.Spec.Gardener[0].Name).ToNot(Equal(shootStateResourceName))
+				Expect(shootState.Spec.Gardener[0].Name).To(Equal(shootStateResourceName + "bar"))
+
+			})
+
+			It("should not reuse the slice of shootState", func() {
+				list := GardenerResourceDataList(shootState.Spec.Gardener).DeepCopy()
+				shootStateResourceName := shootState.Spec.Gardener[0].Name
+
+				newResource := &gardencorev1alpha1.GardenerResourceData{
+					Name: shootStateResourceName + "bar",
+					Type: "bar",
+					Data: runtime.RawExtension{Raw: []byte("data")},
+				}
+
+				list.Delete(shootStateResourceName)
+				Expect(list).To(HaveLen(0))
+				Expect(shootState.Spec.Gardener[0].Name).To(Equal(shootStateResourceName))
+
+				list.Upsert(newResource)
+				Expect(list).To(HaveLen(1))
+				Expect(shootState.Spec.Gardener[0].Name).To(Equal(shootStateResourceName))
+				Expect(shootState.Spec.Gardener[0].Name).ToNot(Equal(shootStateResourceName + "bar"))
+
+			})
+		})
 	})
 
 	Describe("ResourceDataList", func() {

--- a/pkg/controllerutils/miscellaneous.go
+++ b/pkg/controllerutils/miscellaneous.go
@@ -62,10 +62,9 @@ func AddTasks(annotations map[string]string, tasksToAdd ...string) {
 func RemoveTasks(annotations map[string]string, tasksToRemove ...string) {
 	tasks := GetTasks(annotations)
 
-	for i := 0; i < len(tasks); i++ {
+	for i := len(tasks) - 1; i >= 0; i-- {
 		if utils.ValueExists(tasks[i], tasksToRemove) {
-			tasks = append(tasks[:i], tasks[i+1:]...)
-			i--
+			tasks = append((tasks)[:i], (tasks)[i+1:]...)
 		}
 	}
 

--- a/pkg/controllerutils/miscellaneous_test.go
+++ b/pkg/controllerutils/miscellaneous_test.go
@@ -84,13 +84,11 @@ var _ = Describe("controller", func() {
 
 			Entry("task from absent annotation", map[string]string{},
 				[]string{common.ShootTaskDeployInfrastructure}, nil),
-			Entry("tasks from empty list", map[string]string{},
-				[]string{common.ShootTaskDeployInfrastructure}, nil),
 			Entry("task from empty list", map[string]string{"foo": "bar"},
 				[]string{common.ShootTaskDeployInfrastructure}, nil),
 			Entry("no task from empty list", map[string]string{},
 				[]string{}, nil),
-			Entry("no task from empty list", map[string]string{"foo": "bar"},
+			Entry("task from empty list", map[string]string{"foo": "bar"},
 				[]string{}, nil),
 			Entry("task from empty list twice", map[string]string{},
 				[]string{common.ShootTaskDeployInfrastructure, common.ShootTaskDeployInfrastructure}, nil),
@@ -100,6 +98,8 @@ var _ = Describe("controller", func() {
 				[]string{common.ShootTaskDeployInfrastructure}, []string{"foo"}),
 			Entry("all existing tasks from filled list", map[string]string{common.ShootTasks: common.ShootTaskDeployInfrastructure + ",foo"},
 				[]string{"foo", common.ShootTaskDeployInfrastructure}, nil),
+			Entry("all occurances of a task", map[string]string{common.ShootTasks: common.ShootTaskDeployInfrastructure + "," + common.ShootTaskDeployInfrastructure},
+				[]string{common.ShootTaskDeployInfrastructure}, nil),
 		)
 
 		DescribeTable("#HasTask",

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -44,7 +44,7 @@ import (
 // credentials are computed which will be used to secure the Ingress resources and the kube-apiserver itself.
 // Server certificates for the exposed monitoring endpoints (via Ingress) are generated as well.
 func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
-	gardenerResourceDataList := gardencorev1alpha1helper.GardenerResourceDataList(b.ShootState.Spec.Gardener)
+	gardenerResourceDataList := gardencorev1alpha1helper.GardenerResourceDataList(b.ShootState.Spec.Gardener).DeepCopy()
 
 	if val, ok := common.GetShootOperationAnnotation(b.Shoot.Info.Annotations); ok && val == common.ShootOperationRotateKubeconfigCredentials {
 		if err := b.rotateKubeconfigSecrets(ctx, &gardenerResourceDataList); err != nil {

--- a/pkg/operation/shootsecrets/secrets_manager.go
+++ b/pkg/operation/shootsecrets/secrets_manager.go
@@ -61,7 +61,7 @@ func NewSecretsManager(
 	secretConfigGenerator SecretConfigGeneratorFunc,
 ) *SecretsManager {
 	return &SecretsManager{
-		GardenerResourceDataList:    gardenerResourceDataList,
+		GardenerResourceDataList:    gardenerResourceDataList.DeepCopy(),
 		staticTokenConfig:           staticTokenConfig,
 		certificateAuthorityConfigs: certificateAuthorityConfigs,
 		secretConfigGenerator:       secretConfigGenerator,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/priority normal

**What this PR does / why we need it**:
cherry-pick of #3069 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug that was preventing the `ShootState` resource to be updated with newly generated secrets is now fixed.
```
