### PR TITLE
Add apiserver-proxy webhook to all SNI enabled clusters

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -253,3 +253,7 @@ images:
   sourceRepository: github.com/gardener/apiserver-proxy
   repository: eu.gcr.io/gardener-project/gardener/apiserver-proxy
   tag: "v0.1.0"
+- name: apiserver-proxy-pod-webhook
+  sourceRepository: github.com/gardener/apiserver-proxy
+  repository: eu.gcr.io/gardener-project/gardener/apiserver-proxy-pod-webhook
+  tag: "v0.2.0"

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -301,7 +301,7 @@ spec:
           readOnly: true
           {{- end }}
         {{- end }}
-      {{- if .Values.sni.enabled }}
+      {{- if .Values.sni.podMutatorEnabled }}
       - name: apiserver-proxy-pod-mutator
         image: {{ index .Values.images "apiserver-proxy-pod-webhook" }}
         args:

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -301,6 +301,20 @@ spec:
           readOnly: true
           {{- end }}
         {{- end }}
+      {{- if .Values.sni.enabled }}
+      - name: apiserver-proxy-pod-mutator
+        image: {{ index .Values.images "apiserver-proxy-pod-webhook" }}
+        args:
+        - --apiserver-fqdn={{ .Values.sni.apiserverFQDN }}
+        - --host=localhost
+        - --cert-dir=/srv/kubernetes/apiserver
+        - --cert-name=kube-apiserver.crt
+        - --key-name=kube-apiserver.key
+        - --port=9443
+        volumeMounts:
+        - name: kube-apiserver
+          mountPath: /srv/kubernetes/apiserver
+      {{- end }}
       {{- if .Values.konnectivityTunnel.enabled }}
       - name: konnectivity-server
         image: {{ index .Values.images "konnectivity-server" }}

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/hvpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/hvpa.yaml
@@ -76,6 +76,10 @@ spec:
               minAllowed:
                 memory: 400M
                 cpu: 300m
+            {{- if .Values.sni.podMutatorEnabled }}
+            - containerName: apiserver-proxy-pod-mutator
+              mode: "Off"
+            {{- end }}
             - containerName: vpn-seed
               mode: "Off"
   weightBasedScalingIntervals:

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -64,6 +64,7 @@ images:
   kube-apiserver: image-repository
   vpn-seed: image-repository:image-tag
   konnectivity-server: image-repository:image-tag
+  apiserver-proxy-pod-webhook: image-repository:image-tag
 
 blackboxExporterPort: 9115
 etcdServicePort: 2379
@@ -156,6 +157,7 @@ limitsRequestsGapScaleParams:
 sni:
   enabled: false
   advertiseIP: 1.1.1.1
+  # apiserverFQDN: foo.bar.
 
 mountHostCADirectories:
   enabled: false

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -157,6 +157,7 @@ limitsRequestsGapScaleParams:
 sni:
   enabled: false
   advertiseIP: 1.1.1.1
+  podMutatorEnabled: false
   # apiserverFQDN: foo.bar.
 
 mountHostCADirectories:

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-pod-mutatingwebhook.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-pod-mutatingwebhook.yaml
@@ -1,0 +1,45 @@
+apiVersion: {{ include "webhookadmissionregistration" . }}
+kind: MutatingWebhookConfiguration
+metadata:
+  name: apiserver-proxy.networking.gardener.cloud
+  annotations:
+    networking.gardener.cloud/description: |-
+      This webhook adds `KUBERNETES_SERVICE_HOST` environment variable
+      to all containers and init containers matched by it.
+  labels:
+    gardener.cloud/role: system-component
+    origin: gardener
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: {{ .Values.webhook.caBundle }}
+    url: https://127.0.0.1:9443/webhook/pod-apiserver-env
+  failurePolicy: Ignore
+  matchPolicy: Exact
+  name: apiserver-proxy.networking.gardener.cloud
+  namespaceSelector:
+    matchExpressions:
+    - key: apiserver-proxy.networking.gardener.cloud/inject
+      operator: NotIn
+      values:
+      - disable
+  objectSelector:
+    matchExpressions:
+    - key: apiserver-proxy.networking.gardener.cloud/inject
+      operator: NotIn
+      values:
+      - disable
+  reinvocationPolicy: Never
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 2

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-pod-mutatingwebhook.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-pod-mutatingwebhook.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.podMutatorEnabled }}
 apiVersion: {{ include "webhookadmissionregistration" . }}
 kind: MutatingWebhookConfiguration
 metadata:
@@ -43,3 +44,4 @@ webhooks:
     scope: '*'
   sideEffects: None
   timeoutSeconds: 2
+{{- end }}

--- a/charts/shoot-core/components/charts/apiserver-proxy/values.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/values.yaml
@@ -3,6 +3,8 @@ images:
   apiserver-proxy: image-repository
   apiserver-proxy-sidecar: image-repository
 
+# webhook:
+  # caBundle: LS0tLS1C
 advertiseIPAddress: 1.1.1.1
 proxySeedServer:
   host: dummy.127.0.0.1.nip.io

--- a/charts/shoot-core/components/charts/apiserver-proxy/values.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/values.yaml
@@ -11,3 +11,4 @@ proxySeedServer:
   port: 8443
 # this is the nodeExporter port + 1
 adminPort: 16910
+podMutatorEnabled: false

--- a/charts/shoot-core/components/values.yaml
+++ b/charts/shoot-core/components/values.yaml
@@ -8,6 +8,8 @@ apiserver-proxy:
     apiserver-proxy: image-repository
     apiserver-proxy-sidecar: image-repository
   advertiseIPAddress: 1.1.1.1
+  # webhook:
+    # caBundle: LS0tLS1C
   proxySeedServer:
     host: dummy.127.0.0.1.nip.io
     port: 8443

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@
 * [Trigger shoot operations](usage/shoot_operations.md)
 * [Troubleshooting guide](usage/trouble_shooting_guide.md)
 * [Trusted TLS certificate for shoot control planes](usage/trusted-tls-for-control-planes.md)
+* [APIServerSNI environment variable injection](usage/apiserver-sni-injection.md)
 
 ## Proposals
 

--- a/docs/usage/apiserver-sni-injection.md
+++ b/docs/usage/apiserver-sni-injection.md
@@ -11,7 +11,7 @@ In some cases it's desirable to opt-out of Pod injection:
 - DNS is disabled on that individual Pod, but it still needs to talk to the kube-apiserver.
 - Want to test the `kube-proxy` and `kubelet` in-cluster discovery.
 
-### Opt-out of pod injection for specific pods.
+### Opt-out of pod injection for specific pods
 
 To opt out of the injection, the Pod should be labeled with `apiserver-proxy.networking.gardener.cloud/inject: disable` e.g.:
 
@@ -60,3 +60,24 @@ kubectl label namespace my-namespace apiserver-proxy.networking.gardener.cloud/i
 ```
 
 > NOTE: Please be aware that it's not possible to disable injection on namespace level and enable it for individual pods in it.
+
+### Opt-out of pod injection for the entire cluster
+
+If the injection is causing problems for different workloads and ignoring individual pods or namespaces is not possible, then the feature could be disabled for the entire cluster with the `alpha.featuregates.shoot.gardener.cloud/apiserver-sni-pod-injector` annotation with value `disable` on the `Shoot` resource itself:
+
+```yaml
+apiVersion: core.gardener.cloud/v1beta1
+kind: Shoot
+metadata:
+  annotations:
+    alpha.featuregates.shoot.gardener.cloud/apiserver-sni-pod-injector: 'disable'
+  name: my-cluster
+```
+
+or via `kubectl` for existing shoot cluster:
+
+```console
+kubectl label shoot my-cluster alpha.featuregates.shoot.gardener.cloud/apiserver-sni-pod-injector=disable
+```
+
+> NOTE: Please be aware that it's not possible to disable injection on cluster level and enable it for individual pods in it.

--- a/docs/usage/apiserver-sni-injection.md
+++ b/docs/usage/apiserver-sni-injection.md
@@ -1,0 +1,62 @@
+# APIServerSNI environment variable injection
+
+If the Gardener administrator has enabled `APIServerSNI` feature gate for a particular Seed cluster, then in each Shoot cluster's `kube-system` namespace a `DaemonSet` called `apiserver-proxy` is deployed. It routes traffic to the upstream Shoot Kube APIServer. See the [APIServer SNI GEP](../proposals/08-shoot-apiserver-via-sni.md) for more details.
+
+To skip this extra network hop, a [mutating webhook](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook) called `apiserver-proxy.networking.gardener.cloud` is deployed next to the API server in the Seed. It adds `KUBERNETES_SERVICE_HOST` environment variable to each container and init container that do not specify it. See the webhook [repository](https://github.com/gardener/apiserver-proxy/) for more information.
+
+## Opt-out of pod injection
+
+In some cases it's desirable to opt-out of Pod injection:
+
+- DNS is disabled on that individual Pod, but it still needs to talk to the kube-apiserver.
+- Want to test the `kube-proxy` and `kubelet` in-cluster discovery.
+
+### Opt-out of pod injection for specific pods.
+
+To opt out of the injection, the Pod should be labeled with `apiserver-proxy.networking.gardener.cloud/inject: disable` e.g.:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+        apiserver-proxy.networking.gardener.cloud/inject: disable
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+```
+
+### Opt-out of pod injection on namespace level
+
+To opt out of the injection of **all** Pods in a namespace, you should label your namespace with `apiserver-proxy.networking.gardener.cloud/inject: disable` e.g.:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    apiserver-proxy.networking.gardener.cloud/inject: disable
+  name: my-namespace
+```
+
+or via `kubectl` for existing namespace:
+
+```console
+kubectl label namespace my-namespace apiserver-proxy.networking.gardener.cloud/inject=disable
+```
+
+> NOTE: Please be aware that it's not possible to disable injection on namespace level and enable it for individual pods in it.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -259,6 +259,15 @@ const (
 	// if a konnectivity-tunnel should be deployed into the shoot cluster or not.
 	AnnotationShootKonnectivityTunnel = "alpha.featuregates.shoot.gardener.cloud/konnectivity-tunnel"
 
+	// AnnotationShootAPIServerSNIPodInjector is the key for an annotation of a Shoot cluster whose value indicates
+	// if pod injection of 'KUBERNETES_SERVICE_HOST' environment variable should happen for clusters where APIServerSNI
+	// featuregate is enabled.
+	// Any value than 'disable' enables this feature.
+	AnnotationShootAPIServerSNIPodInjector = "alpha.featuregates.shoot.gardener.cloud/apiserver-sni-pod-injector"
+	// AnnotationShootAPIServerSNIPodInjectorDisableValue is the value of the
+	// `alpha.featuregates.shoot.gardener.cloud/apiserver-sni-pod-injector` annotation that disables the pod injection.
+	AnnotationShootAPIServerSNIPodInjectorDisableValue = "disable"
+
 	// OperatingSystemConfigUnitNameKubeletService is a constant for a unit in the operating system config that contains the kubelet service.
 	OperatingSystemConfigUnitNameKubeletService = "kubelet.service"
 	// OperatingSystemConfigUnitNameDockerService is a constant for a unit in the operating system config that contains the docker service.

--- a/pkg/gardenlet/controller/federatedseed/networkpolicy/controller.go
+++ b/pkg/gardenlet/controller/federatedseed/networkpolicy/controller.go
@@ -17,6 +17,8 @@ package networkpolicy
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"sync"
 	"time"
 
@@ -24,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/federatedseed/networkpolicy/helper"
+	"github.com/gardener/gardener/pkg/gardenlet/controller/federatedseed/networkpolicy/hostnameresolver"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -41,26 +44,20 @@ import (
 // Controller watching the endpoints resource "kubernetes" of the Seeds's kube-apiserver in the default namespace
 // to keep the NetworkPolicy "allow-to-seed-apiserver" in sync.
 type Controller struct {
-	ctx      context.Context
-	log      *logrus.Entry
-	recorder record.EventRecorder
-
-	seedClient client.Client
-
-	namespaceReconciler reconcile.Reconciler
-
-	endpointsInformer cache.SharedInformer
-
+	ctx                     context.Context
+	log                     *logrus.Entry
+	recorder                record.EventRecorder
+	seedClient              client.Client
+	namespaceReconciler     reconcile.Reconciler
+	endpointsInformer       cache.SharedInformer
 	networkPoliciesInformer runtimecache.Informer
-
-	namespaceQueue    workqueue.RateLimitingInterface
-	namespaceInformer runtimecache.Informer
-
-	shootNamespaceSelector labels.Selector
-
-	workerCh               chan int
-	numberOfRunningWorkers int
-	waitGroup              sync.WaitGroup
+	namespaceQueue          workqueue.RateLimitingInterface
+	namespaceInformer       runtimecache.Informer
+	hostnameProvider        hostnameresolver.Provider
+	shootNamespaceSelector  labels.Selector
+	workerCh                chan int
+	numberOfRunningWorkers  int
+	waitGroup               sync.WaitGroup
 }
 
 // NewController instantiates a new controller.
@@ -81,28 +78,70 @@ func NewController(ctx context.Context, seedClient kubernetes.Interface, seedDef
 
 	shootNamespaceSelector := labels.SelectorFromSet(labels.Set{
 		v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleShoot,
-		v1beta1constants.GardenRole:           v1beta1constants.GardenRoleShoot})
+		v1beta1constants.GardenRole:           v1beta1constants.GardenRoleShoot,
+	})
+
+	u, err := url.Parse(seedClient.RESTConfig().Host)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		provider       = hostnameresolver.NewNoOpProvider()
+		serverHostname = u.Hostname()
+		providerLogger = seedLogger.WithField("hostname", serverHostname)
+	)
+
+	// If the hostname is not an IP address, then it should be resolved.
+	if net.ParseIP(serverHostname) == nil {
+		var (
+			port = "443"
+			host = serverHostname
+		)
+
+		if p := u.Port(); p != "" {
+			port = p
+		}
+
+		providerLogger.Infoln("using hostname resolver")
+
+		provider = hostnameresolver.NewProvider(
+			host,
+			port,
+			providerLogger,
+			time.Second*30,
+		)
+	} else {
+		providerLogger.Infoln("using no-op hostname resolver")
+	}
 
 	controller := &Controller{
-		ctx:                 ctx,
-		log:                 seedLogger,
-		namespaceReconciler: newNamespaceReconciler(ctx, seedLogger, seedClient.Client(), endpointsInformer.Lister(), seedName, shootNamespaceSelector),
-		recorder:            recorder,
-
-		seedClient: seedClient.Client(),
-
+		ctx: ctx,
+		log: seedLogger,
+		namespaceReconciler: newNamespaceReconciler(
+			ctx,
+			seedLogger,
+			seedClient.Client(),
+			endpointsInformer.Lister(),
+			seedName,
+			shootNamespaceSelector,
+			provider,
+		),
+		recorder:                recorder,
+		seedClient:              seedClient.Client(),
 		endpointsInformer:       endpointsInformer.Informer(),
 		namespaceInformer:       namespaceInformer,
 		networkPoliciesInformer: networkPoliciesInformer,
 		namespaceQueue:          namespaceQueue,
-
-		shootNamespaceSelector: shootNamespaceSelector,
-
-		workerCh: make(chan int),
+		shootNamespaceSelector:  shootNamespaceSelector,
+		workerCh:                make(chan int),
+		hostnameProvider:        provider,
 	}
 
 	// start informer & sync caches
 	seedDefaultNamespaceKubeInformer.Start(ctx.Done())
+
+	go controller.hostnameProvider.Start(ctx)
 
 	return controller, nil
 }
@@ -112,9 +151,19 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute*2)
 	defer cancel()
 
-	if !cache.WaitForCacheSync(timeoutCtx.Done(), c.endpointsInformer.HasSynced, c.namespaceInformer.HasSynced, c.networkPoliciesInformer.HasSynced) {
-		return fmt.Errorf("timeout waiting for endpoints informers to sync")
+	if !cache.WaitForCacheSync(
+		timeoutCtx.Done(),
+		c.endpointsInformer.HasSynced,
+		c.namespaceInformer.HasSynced,
+		c.networkPoliciesInformer.HasSynced,
+		c.hostnameProvider.HasSynced,
+	) {
+		return fmt.Errorf("timeout waiting for informers to sync")
 	}
+
+	c.hostnameProvider.WithCallback(func() {
+		c.enqueueNamespaces()
+	})
 
 	c.endpointsInformer.AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
@@ -161,6 +210,7 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 	}
 
 	c.log.Info("Seed API server network policy controller initialized.")
+
 	return nil
 }
 

--- a/pkg/gardenlet/controller/federatedseed/networkpolicy/hostnameresolver/resolver.go
+++ b/pkg/gardenlet/controller/federatedseed/networkpolicy/hostnameresolver/resolver.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostnameresolver
+
+import (
+	"context"
+	"net"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type resolver struct {
+	lock          sync.RWMutex
+	upstreamFQDN  string
+	upstreamPort  int32
+	refreshTicker *time.Ticker
+	onUpdate      func()
+	log           logrus.FieldLogger
+	addrs         []string
+	// used for testing
+	lookup lookup
+}
+
+type noOpResover struct{}
+
+type lookup interface {
+	LookupHost(ctx context.Context, host string) (addrs []string, err error)
+}
+
+// Provider allows to start and attach callbacks for a specific host
+// resolution updates.
+type Provider interface {
+	HasSynced() bool
+	Start(ctx context.Context)
+	WithCallback(onUpdate func())
+	HostResolver
+}
+
+// HostResolver is used for getting endpoint subsets with resolved IPs.
+type HostResolver interface {
+	Subset() []corev1.EndpointSubset
+}
+
+// NewProvider returns a Provider for a specific host and port with resync
+// indicating how often the hostname resolution is happening.
+func NewProvider(host string, port string, log logrus.FieldLogger, resync time.Duration) Provider {
+	return &resolver{
+		upstreamFQDN:  host,
+		upstreamPort:  intstr.Parse(port).IntVal,
+		refreshTicker: time.NewTicker(resync),
+		log:           log,
+		lookup:        net.DefaultResolver,
+	}
+}
+
+// HasSynced returns true if ip addresses are exposed.
+func (l *resolver) HasSynced() bool {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	return len(l.addrs) > 0
+}
+
+// Start waits for stopCtx to be done and resolves the upstream
+// hostname every resync period.
+// Updates are send if returned hosts are changed.
+func (l *resolver) Start(stopCtx context.Context) {
+	updateFunc := func() {
+		addresses, err := l.lookup.LookupHost(stopCtx, l.upstreamFQDN)
+		if err != nil {
+			l.log.WithField("error", err).Errorln("could not resolve upstream hostname")
+
+			return
+		}
+
+		sort.Strings(addresses)
+
+		l.lock.RLock()
+		updated := !equal(addresses, l.addrs)
+		l.lock.RUnlock()
+
+		if updated {
+			l.lock.Lock()
+			l.addrs = addresses
+			l.lock.Unlock()
+
+			l.log.WithField("resolvedIPs", l.addrs).Infoln("updated resolved addresses")
+
+			if l.onUpdate != nil {
+				l.onUpdate()
+			}
+		}
+	}
+
+	// start the update in the beginning
+	updateFunc()
+
+	for {
+		select {
+		case <-l.refreshTicker.C:
+			updateFunc()
+		case <-stopCtx.Done():
+			l.refreshTicker.Stop()
+			l.log.Infoln("stopping periodic hostname resolution")
+
+			return
+		}
+	}
+}
+
+// Resolved returns a slice of resolved ip addresses.
+func (l *resolver) Subset() []corev1.EndpointSubset {
+	l.lock.RLock()
+	defer l.lock.RUnlock()
+
+	subset := []corev1.EndpointSubset{}
+
+	if len(l.addrs) > 0 {
+		s := corev1.EndpointSubset{
+			Ports: []corev1.EndpointPort{
+				{
+					Port:     l.upstreamPort,
+					Protocol: corev1.ProtocolTCP,
+				},
+			},
+			Addresses: make([]corev1.EndpointAddress, 0, len(l.addrs)),
+		}
+		for _, addr := range l.addrs {
+			s.Addresses = append(s.Addresses, corev1.EndpointAddress{IP: addr})
+		}
+
+		subset = append(subset, s)
+	}
+
+	return subset
+}
+
+// WithCallback calls onUpdate function when resolved IPs are changed.
+func (l *resolver) WithCallback(onUpdate func()) {
+	l.onUpdate = onUpdate
+}
+
+func NewNoOpProvider() Provider { return &noOpResover{} }
+
+// HasSynced always returns true.
+func (*noOpResover) HasSynced() bool { return true }
+
+// Start does nothing.
+func (*noOpResover) Start(_ context.Context) {}
+
+// Resolved returns a slice of resolved ip addresses.
+func (*noOpResover) Subset() []corev1.EndpointSubset { return []corev1.EndpointSubset{} }
+
+// WithCallback does nothing.
+func (*noOpResover) WithCallback(_ func()) {}
+
+func equal(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/gardenlet/controller/federatedseed/networkpolicy/hostnameresolver/resolver_test.go
+++ b/pkg/gardenlet/controller/federatedseed/networkpolicy/hostnameresolver/resolver_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostnameresolver
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gardener/gardener/pkg/logger"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestHostnameresolver(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Hostnameresolver Suite")
+}
+
+type fakeLookup struct {
+	addrs []string
+	err   error
+	lock  sync.Mutex
+}
+
+func (f *fakeLookup) LookupHost(ctx context.Context, host string) ([]string, error) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	return f.addrs, f.err
+}
+
+func (f *fakeLookup) setAddrs(addrs []string) {
+	f.lock.Lock()
+	f.addrs = addrs
+	f.lock.Unlock()
+}
+
+func (f *fakeLookup) setErr(err error) {
+	f.lock.Lock()
+	f.err = err
+	f.lock.Unlock()
+}
+
+var _ = Describe("resolver", func() {
+	var (
+		updateCalled bool
+		r            *resolver
+		ctx          context.Context
+		cancelFunc   context.CancelFunc
+		f            *fakeLookup
+		lock         sync.Mutex
+	)
+	BeforeEach(func() {
+		updateCalled = false
+		lock = sync.Mutex{}
+		f = &fakeLookup{
+			addrs: []string{"5.6.7.8", "1.2.3.4"}, // sorting check
+		}
+		r = &resolver{
+			lookup:        f,
+			upstreamPort:  1234,
+			refreshTicker: time.NewTicker(time.Millisecond * 3),
+			log:           logger.NewNopLogger(),
+			onUpdate: func() {
+				lock.Lock()
+				updateCalled = true
+				cancelFunc()
+				lock.Unlock()
+			},
+		}
+	})
+
+	It("should return correct subset", func(done Done) {
+		ctx, cancelFunc = context.WithTimeout(context.Background(), time.Millisecond*2)
+
+		Expect(r.HasSynced()).To(BeFalse(), "HasSync should be false before starting")
+
+		r.Start(ctx)
+
+		Expect(r.HasSynced()).To(BeTrue(), "HasSync should be true after start")
+		Expect(updateCalled).To(BeTrue(), "update should be called")
+
+		Expect(r.Subset()).To(ConsistOf(corev1.EndpointSubset{
+			Addresses: []corev1.EndpointAddress{
+				{IP: "1.2.3.4"}, {IP: "5.6.7.8"},
+			},
+			Ports: []corev1.EndpointPort{{Protocol: corev1.ProtocolTCP, Port: 1234}},
+		}))
+
+		close(done)
+	}, 0.2)
+
+	It("should not return that it has synced", func(done Done) {
+		ctx, cancelFunc = context.WithTimeout(context.Background(), time.Millisecond*2)
+
+		Expect(updateCalled).To(BeFalse(), "update should not be called")
+		Expect(r.HasSynced()).To(BeFalse(), "HasSync should be false")
+
+		close(done)
+	}, 0.2)
+
+	It("should not return that it has synced if error occurs", func(done Done) {
+		ctx, cancelFunc = context.WithTimeout(context.Background(), time.Millisecond*2)
+
+		f.setAddrs(nil)
+		f.setErr(errors.New("some-error"))
+
+		r.Start(ctx)
+
+		Expect(updateCalled).To(BeFalse(), "update should not be called")
+		Expect(r.HasSynced()).To(BeFalse(), "HasSync should be false")
+
+		close(done)
+	}, 0.2)
+
+	It("should return correct subset after resync", func(done Done) {
+		ctx, cancelFunc = context.WithTimeout(context.Background(), time.Millisecond*10)
+		r.onUpdate = func() {
+			lock.Lock()
+			updateCalled = true
+			lock.Unlock()
+		}
+
+		Expect(r.HasSynced()).To(BeFalse(), "HasSync should be false before starting")
+
+		go r.Start(ctx)
+
+		Eventually(func() bool { //nolint:unlambda
+			return r.HasSynced()
+		}, time.Millisecond*3, time.Millisecond).Should(BeTrue(), "HasSync should be true after start")
+
+		Eventually(func() bool { //nolint:unlambda
+			lock.Lock()
+			defer lock.Unlock()
+			return updateCalled
+		}, time.Millisecond*3, time.Millisecond).Should(BeTrue(), "update should be called")
+
+		Consistently(func() []corev1.EndpointSubset { //nolint:unlambda
+			return r.Subset()
+		}, time.Millisecond*3, time.Millisecond).Should(ConsistOf(corev1.EndpointSubset{
+			Addresses: []corev1.EndpointAddress{
+				{IP: "1.2.3.4"}, {IP: "5.6.7.8"},
+			},
+			Ports: []corev1.EndpointPort{{Protocol: corev1.ProtocolTCP, Port: 1234}},
+		}))
+
+		f.setAddrs([]string{"5.6.7.8"})
+
+		Eventually(func() []corev1.EndpointSubset { //nolint:unlambda
+			return r.Subset()
+		}, time.Millisecond*3, time.Millisecond).Should(ConsistOf(corev1.EndpointSubset{
+			Addresses: []corev1.EndpointAddress{{IP: "5.6.7.8"}},
+			Ports:     []corev1.EndpointPort{{Protocol: corev1.ProtocolTCP, Port: 1234}},
+		}))
+
+		cancelFunc()
+		close(done)
+	}, 0.2)
+})

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -471,6 +471,9 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 			"host": kasFQDN,
 			"port": "8443",
 		},
+		"webhook": map[string]interface{}{
+			"caBundle": b.Secrets[v1beta1constants.SecretNameCACluster].Data[secrets.DataKeyCertificateCA],
+		},
 	}
 
 	apiserverProxy, err := b.InjectShootShootImages(apiserverProxyConfig, common.APIServerProxySidecarImageName, common.APIServerProxyImageName)
@@ -501,7 +504,7 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 		"cluster-identity":        map[string]interface{}{"clusterIdentity": b.Shoot.Info.Status.ClusterIdentity},
 	}
 
-	var shootClient = b.K8sShootClient.Client()
+	shootClient := b.K8sShootClient.Client()
 
 	if b.Shoot.KonnectivityTunnelEnabled {
 		konnectivityAgentConfig := map[string]interface{}{

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -474,6 +474,7 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 		"webhook": map[string]interface{}{
 			"caBundle": b.Secrets[v1beta1constants.SecretNameCACluster].Data[secrets.DataKeyCertificateCA],
 		},
+		"podMutatorEnabled": b.APIServerSNIPodMutatorEnabled(),
 	}
 
 	apiserverProxy, err := b.InjectShootShootImages(apiserverProxyConfig, common.APIServerProxySidecarImageName, common.APIServerProxyImageName)

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -857,8 +857,9 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 
 	if b.APIServerSNIEnabled() {
 		defaultValues["sni"] = map[string]interface{}{
-			"enabled":     true,
-			"advertiseIP": b.APIServerClusterIP,
+			"enabled":       true,
+			"advertiseIP":   b.APIServerClusterIP,
+			"apiserverFQDN": b.outOfClusterAPIServerFQDN(),
 		}
 	}
 
@@ -1052,6 +1053,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 		tunnelComponentImageName,
 		common.KubeAPIServerImageName,
 		common.AlpineIptablesImageName,
+		common.APIServerProxyPodMutatorWebhookImageName,
 	)
 	if err != nil {
 		return err

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -857,9 +857,10 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 
 	if b.APIServerSNIEnabled() {
 		defaultValues["sni"] = map[string]interface{}{
-			"enabled":       true,
-			"advertiseIP":   b.APIServerClusterIP,
-			"apiserverFQDN": b.outOfClusterAPIServerFQDN(),
+			"enabled":           true,
+			"advertiseIP":       b.APIServerClusterIP,
+			"apiserverFQDN":     b.outOfClusterAPIServerFQDN(),
+			"podMutatorEnabled": b.APIServerSNIPodMutatorEnabled(),
 		}
 	}
 

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -387,6 +387,23 @@ func (b *Botanist) APIServerSNIEnabled() bool {
 	return gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI) && b.NeedsInternalDNS() && b.NeedsExternalDNS()
 }
 
+// APIServerSNIPodMutatorEnabled returns false if the value of the Shoot annotation
+// 'alpha.featuregates.shoot.gardener.cloud/apiserver-sni-pod-injector' is 'disable' or
+// APIServereSNI feature is disabled.
+func (b *Botanist) APIServerSNIPodMutatorEnabled() bool {
+	sniEnabled := b.APIServerSNIEnabled()
+	if !sniEnabled {
+		return false
+	}
+
+	vs, ok := b.Shoot.Info.GetAnnotations()[v1beta1constants.AnnotationShootAPIServerSNIPodInjector]
+	if !ok {
+		return true
+	}
+
+	return vs != v1beta1constants.AnnotationShootAPIServerSNIPodInjectorDisableValue
+}
+
 // DeleteDNSProviders deletes all DNS providers in the shoot namespace of the seed.
 func (b *Botanist) DeleteDNSProviders(ctx context.Context) error {
 	if err := b.K8sSeedClient.Client().DeleteAllOf(

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -469,8 +469,11 @@ const (
 	// APIServerProxyImageName is the image of apiserver-proxy
 	APIServerProxyImageName = "apiserver-proxy"
 
-	// APIServerProxySidecarImageName is the image of apiserver-proxy sidecar
+	// APIServerProxySidecarImageName is the image of apiserver-proxy sidecar.
 	APIServerProxySidecarImageName = "apiserver-proxy-sidecar"
+
+	// APIServerProxyPodMutatorWebhookImageName is the image of apiserver-proxy pod mutator webhook.
+	APIServerProxyPodMutatorWebhookImageName = "apiserver-proxy-pod-webhook"
 
 	// ServiceAccountSigningKeySecretDataKey is the data key of a signing key Kubernetes secret.
 	ServiceAccountSigningKeySecretDataKey = "signing-key"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement 
/priority normal

**What this PR does / why we need it**:

The API Server proxy webhook adds `KUBERNETES_SERVICE_HOST` environment variable to all SNI enabled Shoot clusters. It skips additional network
hop.

It can be disabled for individual Pods or entire namespaces.

See more details at https://github.com/gardener/apiserver-proxy

**Which issue(s) this PR fixes**:

Part of #2942

**Special notes for your reviewer**:

~This a draft until gardener/apiserver-proxy#8 is merged.~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
A new webhook `mutatingwebhookconfigurations.admissionregistration.k8s.io` is deployed for all `APIServerSNI`-enabled clusters. It's running as a sidecar to the KubeAPI Server.
```

```action user
A new webhook `mutatingwebhookconfigurations.admissionregistration.k8s.io` is deployed for all `APIServerSNI`- enabled clusters. It adds `KUBERNETES_SERVICE_HOST` environment variable pointing to the upstream Kube API Server. To disable this behavior:

- label your Pods with `apiserver-proxy.networking.gardener.cloud/inject: disable`
- or label the entire namespace with `apiserver-proxy.networking.gardener.cloud/inject: disable`
- or label your Shoot resource with `alpha.featuregates.shoot.gardener.cloud/apiserver-sni-pod-injector: disable` to disable it cluster-wide.
```

```action user
For `APIServerSNI`-enabled clusters, Pods talking to the Kube API Server need to be allowed to connect to  `coredns` running in `kube-system` namespace in order to resolve the hostname of the Kube API server. It also needs to have access to the IP from the `default/kubernetes` endpoint and the upstream IP of of the kube-apiserver. 

If the Pod:

- is not matched by any `NetworkPolicy` - no action is required. 
- is not injected with `KUBERNETES_SERVICE_HOST`, because the feature is disabled - no action is required.
- is matched by `NetworkPolicies` allowing ingress to `coredns` in `kube-system` and allows traffic top the `default/kubernetes` endpoint and the upstream upstream IP of of the kube-apiserver - no action is required.
- is matched by `NetworkPolicies` that do not allow access to `coredns` in `kube-system` and/or do not allows traffic top the `default/kubernetes` endpoint and/or the upstream upstream IP of of the kube-apiserver - a `NetworkPolicy` allowing such egress must be added e.g.:

  > apiVersion: networking.k8s.io/v1
  > kind: NetworkPolicy
  > metadata:
  >   name: allow-to-apiserver
  > spec:
  >   podSelector: {}
  >   egress:
  >   - to:
  >     - ipBlock:
  >         cidr: <IP from default/kubernetes endpoint>/32
  >     - ipBlock:
  >         cidr: <ip from apiserver FQDN e.g. nslookup api.foo.bar>/32
  >   - ports:
  >     - port: 8053
  >       protocol: UDP
  >     - port: 8053
  >       protocol: TCP
  >     to:
  >     - podSelector:
  >         matchExpressions:
  >         - key: k8s-app
  >           operator: In
  >           values:
  >           - kube-dns
  >       namespaceSelector:
  >         matchLabels:
  >           gardener.cloud/purpose: kube-system
  >   policyTypes:
  >   - Egress
  >   - Ingress
```
