### PR TITLE
Skip certain tasks in shoot deletion flow if namespace is terminating

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -283,7 +283,7 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 		})
 		deleteNamespace = g.Add(flow.Task{
 			Name:         "Deleting shoot namespace in Seed",
-			Fn:           flow.TaskFn(botanist.DeleteNamespace).Retry(defaultInterval),
+			Fn:           flow.TaskFn(botanist.DeleteNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deleteAllExtensionCRs, destroyDNSProviders, deleteBackupEntryFromSeed, waitForManagedResourcesDeletion, scaleETCDToZero),
 		})
 		_ = g.Add(flow.Task{

--- a/pkg/utils/flow/taskfn.go
+++ b/pkg/utils/flow/taskfn.go
@@ -61,19 +61,6 @@ func (t TaskFn) DoIf(condition bool) TaskFn {
 	return t.SkipIf(!condition)
 }
 
-// Retry returns a TaskFn that is retried until the timeout is reached.
-// Deprecated: Retry handling should be done in the function itself, if necessary.
-func (t TaskFn) Retry(interval time.Duration) TaskFn {
-	return func(ctx context.Context) error {
-		return retry.Until(ctx, interval, func(ctx context.Context) (done bool, err error) {
-			if err := t(ctx); err != nil {
-				return retry.MinorError(err)
-			}
-			return retry.Ok()
-		})
-	}
-}
-
 // Timeout returns a TaskFn that is bound to a context which times out.
 func (t TaskFn) Timeout(timeout time.Duration) TaskFn {
 	return func(ctx context.Context) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability ops-productivity
/kind bug
/priority normal

**What this PR does / why we need it**:
Certain tasks should be skipped when the namespace is already terminating (because no new resources can be created in such namespaces anyways).

**Special notes for your reviewer**:
On the way, I cleaned up some duplication and replaced usage of deprecated functions.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
