### PR TITLE
Exclude garden namespace from ValidatingWebhookConfig

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/namespace-garden.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/namespace-garden.yaml
@@ -3,4 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: garden
+  labels:
+    app: gardener
 {{- end }}

--- a/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
@@ -41,8 +41,9 @@ webhooks:
     - secrets
   failurePolicy: Fail
   namespaceSelector:
-    matchLabels:
-      gardener.cloud/role: project
+    matchExpressions:
+    - {key: gardener.cloud/role, operator: In, values: [project]}
+    - {key: app, operator: NotIn, values: [gardener]}
   clientConfig:
     {{- if .Values.global.deployment.virtualGarden.enabled }}
     url: https://gardener-admission-controller.garden/webhooks/validate-kubeconfig-secrets
@@ -70,8 +71,9 @@ webhooks:
     {{- end }}
   failurePolicy: Fail
   namespaceSelector:
-    matchLabels:
-      gardener.cloud/role: project
+    matchExpressions:
+      - {key: gardener.cloud/role, operator: In, values: [project]}
+      - {key: app, operator: NotIn, values: [gardener]}
   clientConfig:
     {{- if .Values.global.deployment.virtualGarden.enabled }}
     url: https://gardener-admission-controller.garden/webhooks/validate-resource-size

--- a/docs/deployment/setup_gardener.md
+++ b/docs/deployment/setup_gardener.md
@@ -7,11 +7,15 @@ Please note that it is possible to use the garden cluster as seed cluster by sim
 We are providing [Helm charts](../../charts/gardener) in order to manage the various resources of the components.
 Please always make sure that you use the Helm chart version that matches the Gardener version you want to deploy.
 
-## Deploying the Gardener control plane (API server, controller manager, scheduler)
+## Deploying the Gardener control plane (API server, admission controller, controller manager, scheduler)
 
 The [configuration values](../../charts/gardener/controlplane/values.yaml) depict the various options to configure the different components.
 Please consult [this document](../usage/configuration.md) to get a detailed explanation of what can be configured for which component.
+
 Also note that all resources and deployments need to be created in the `garden` namespace (not overrideable).
+If you enable the Gardener admission controller as part of you setup, please make sure the `garden` namespace is labelled with `app: gardener`.
+Otherwise, the backing service account for the admission controller Pod might not be created successfully.
+No action is necessary, if you deploy the `garden` namespace with the Gardener control plane Helm chart.
 
 After preparing your values in a separate `controlplane-values.yaml` file, you can run the following command against your garden cluster:
 

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -12,16 +12,22 @@ This document describes the
 ## Configuration and Usage of Gardener as Operator/Administrator
 
 When we use the terms "operator/administrator" we refer to both the people deploying and operating Gardener.
-Gardener consists out of four components:
+Gardener consists of the following components:
 
 1. `gardener-apiserver`, a Kubernetes-native API extension that serves custom resources in the Kubernetes-style (like `Seed`s and `Shoot`s), and a component that contains multiple admission plugins.
+1. `gardener-admission-controller`, an HTTP(S) server with several handlers to be used in a [ValidatingWebhookConfiguration](../../charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml).
 1. `gardener-controller-manager`, a component consisting out of multiple controllers that implement reconciliation and deletion flows for some of the custom resources (e.g., it contains the logic for maintaining `Shoot`s, reconciling `Plant`s, etc.).
 1. `gardener-scheduler`, a component that assigns newly created `Shoot` clusters to appropriate `Seed` clusters.
 1. `gardenlet`, a component running in seed clusters and consisting out of multiple controllers that implement reconciliation and deletion flows for some of the custom resources (e.g., it contains the logic for reconciliation and deletion of `Shoot`s).
 
 Each of these components have various configuration options.
 The `gardener-apiserver` uses the standard API server library maintained by the Kubernetes community, and as such it mainly supports command line flags.
-The two other components are using so-called componentconfig files that describe their configuration in a Kubernetes-style versioned object.
+Other components use so-called componentconfig files that describe their configuration in a Kubernetes-style versioned object.
+
+### Configuration file for Gardener admission controller
+
+The Gardener admission controller does only support one command line flag which should be a path to a valid admission-controller configuration file.
+Please take a look at [this](../../example/20-componentconfig-gardener-admission-controller.yaml) example configuration.
 
 ### Configuration file for Gardener controller manager
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR excludes `app: gardener` labelled `Namespaces` from the `ValidatingWebhookConfiguration` which is used for the Gardener-Admission-Controller. The `garden` namespaces, now getting the same label, is consequently excluded from any admission validation and thus prevents race conditions with `ServiceAccounts`, described in #2983.

/invite @rfranzke
/cc @Diaphteiros

**Which issue(s) this PR fixes**:
Fixes #2983

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A race condition in Gardener's helm chart (`/charts/gardener/controlplane`) has been fixed. Earlier, the deployed `ValidatingWebhookConfiguration` potentially blocked the creation of Gardener `ServiceAccounts`. The validation is now excluded from namespaces with the label `app: gardener`. 
ℹ️ Please make sure you either let `/charts/gardener/controlplane` also deploy the `garden` namespace, or add the label `app=gardener` to the namespace yourself.
```
