### PR TITLE
Collect metric `coredns_build_info`

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -53,8 +53,7 @@ allowedMetrics:
   - container_network_receive_bytes_total
   - container_network_transmit_bytes_total
   coredns:
-  - process_max_fds
-  - process_open_fds
+  - coredns_build_info
   - coredns_cache_entries
   - coredns_cache_hits_total
   - coredns_cache_misses_total
@@ -62,6 +61,8 @@ allowedMetrics:
   - coredns_dns_responses_total
   - coredns_forward_requests_total
   - coredns_forward_responses_total
+  - process_max_fds
+  - process_open_fds
   cloudControllerManager:
   - rest_client_requests_total
   - process_max_fds


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug
/priority normal

**What this PR does / why we need it**:
Add `coredns_build_info` to the prometheus metric allow list for coredns. Currently the coredns dashboard is broken because this metric is missing.

**Which issue(s) this PR fixes**:
Fixes #2966

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
An issue causing CoreDNS dashboard to show always 'No Data' is now fixed.
```
