### PR TITLE
Set DB sync to full mode

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
@@ -27,6 +27,7 @@
         Exclude_Path      *_garden_fluent-bit-*.log,*_garden_loki-*.log
         Parser            docker
         DB                /var/log/flb_kube.db
+        DB.sync           full
         read_from_head    true
         Skip_Long_Lines   On
         Mem_Buf_Limit     30MB

--- a/charts/seed-bootstrap/charts/loki/templates/loki-configmap.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/loki-configmap.yaml
@@ -9,6 +9,7 @@ data:
   loki.yaml: |-
     auth_enabled: {{ .Values.authEnabled }}
     ingester:
+      chunk_target_size: 1536000
       chunk_idle_period: 3m
       chunk_block_size: 262144
       chunk_retain_period: 3m


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR we set the fluent-bit tail plugin DB sync to `full` mode. The default was `normal` where the offsets of the currently processing files is not immediately written to the DB. In result when fluent-bit pod is restarted the log processor start from the last written offset which is not up to date and causing repetitions of logs. When the log aggregator has logic to eliminate the log duplication(Elasticsearch) this is not an issue, but when it doesn't like Loki this cause many log duplication and `Entry Out OF Order` warnings. Setting DB sync to full prevents this of happening.

Also we increase the `chunk_target_size` to `1536000` bytes as is recommended by [Grafana](https://grafana.com/docs/loki/latest/best-practices/current-best-practices/#7-use-chunk_target_size)  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fluent-bit tail plugin DB synchronization is set to FULL to avoid log duplication when fluent-bit pod is restarted.
```
```improvement operator
Loki chunk_target_size option is set to 1536000 bytes as recommended by Grafana 
```
