### PR TITLE
Add KEEPALIVE to apiserver-proxy

### DIFF
--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/proxy-configmap.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/proxy-configmap.yaml
@@ -109,6 +109,10 @@ data:
               version: V2
             transport_socket:
               name: envoy.transport_sockets.raw_buffer
+        upstream_connection_options:
+          tcp_keepalive:
+            keepalive_time: 7200
+            keepalive_interval: 55
       - name: uds_admin
         connect_timeout: 0.25s
         type: STATIC


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/priority normal

**What this PR does / why we need it**:

Some upstream LoadBalancers have low idle connection timeouts and reset the connection. For AWS NLBs its 350sec (unconfigurable).

If a controller is watching the API server via the proxy, AWS NLB might simply silently terminate the connection if no data is send between the client and the API server.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`apiserver-proxy` now uses tcp keepalive every 55 seconds to prevent idle timeouts between it and the SNI LoadBalancer.
```
