### PR TITLE
Clean up setting fake Shoot status in the Cluster

### DIFF
--- a/pkg/operation/common/extensions.go
+++ b/pkg/operation/common/extensions.go
@@ -84,20 +84,6 @@ func SyncClusterResourceToSeed(ctx context.Context, client client.Client, cluste
 			APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
 			Kind:       "Shoot",
 		}
-
-		// TODO: Workaround for the issue that was fixed with https://github.com/gardener/gardener/pull/2265. It adds a
-		//       fake "observed generation" and a fake "last operation" and in case it is not set yet. This prevents the
-		//       ShootNotFailed predicate in the extensions library from reacting false negatively. This fake status is only
-		//       internally and will not be reported in the Shoot object in the garden cluster.
-		//       This code can be removed in a future version after giving extension controllers enough time to revendor
-		//       Gardener's extensions library.
-		shootObj.Status.ObservedGeneration = shootObj.Generation
-		if shootObj.Status.LastOperation == nil {
-			shootObj.Status.LastOperation = &gardencorev1beta1.LastOperation{
-				Type:  gardencorev1beta1.LastOperationTypeCreate,
-				State: gardencorev1beta1.LastOperationStateSucceeded,
-			}
-		}
 	}
 
 	_, err := controllerutil.CreateOrUpdate(ctx, client, cluster, func() error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority normal

**What this PR does / why we need it**:
I believe we can now cleanup this workaround introduced with https://github.com/gardener/gardener/pull/2217 to prevent the ShootNotFailed predicate in the extensions library from reacting false negatively. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action developer
A temporary workaround during the Cluster resource sync to the Seed by setting a fake Shoot status to prevent ShootNotFailed predicate in the extensions library from reacting false negatively is now cleaned up. Before upgrading to this version of Gardener, make sure that all of the extensions in your environment that use the ShootNotFailed predicate vendor `github.com/gardener/gardener@v1.4.0` or above (that contains https://github.com/gardener/gardener/pull/2265).
```
