### PR TITLE
Keep the Loki updates from the HVPA

### DIFF
--- a/charts/seed-bootstrap/charts/loki/values.yaml
+++ b/charts/seed-bootstrap/charts/loki/values.yaml
@@ -32,22 +32,22 @@ livenessProbe:
   httpGet:
     path: /ready
     port: metrics
-  initialDelaySeconds: 45
+  initialDelaySeconds: 120
 
 readinessProbe:
   httpGet:
     path: /ready
     port: metrics
-  initialDelaySeconds: 45
+  initialDelaySeconds: 120
 
 replicas: 1
 
 resources:
   limits:
-    cpu: 100m
-    memory: 256Mi
+    cpu: 450m
+    memory: 512Mi
   requests:
-    cpu: 20m
+    cpu: 200m
     memory: 64Mi
 
 securityContext:
@@ -67,8 +67,8 @@ hvpa:
     cpu: 800m
     memory: 2G
   minAllowed:
-    cpu: 20m
-    memory: 200M
+    cpu: 200m
+    memory: 64M
   targetAverageUtilizationCpu: 80
   targetAverageUtilizationMemory: 80
   scaleUpStabilization:
@@ -91,8 +91,8 @@ hvpa:
         percentage: 80
   limitsRequestsGapScaleParams:
     cpu:
-      value: "200m"
+      value: "300m"
       percentage: 40
     memory:
-      value: "300M"
+      value: "400M"
       percentage: 40

--- a/pkg/operation/common/utils_test.go
+++ b/pkg/operation/common/utils_test.go
@@ -39,8 +39,10 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -548,6 +550,107 @@ var _ = Describe("common", func() {
 
 				Expect(CheckIfDeletionIsConfirmed(obj)).To(Succeed())
 			})
+		})
+	})
+
+	Describe("#GetContainerResourcesInStatefulSet", func() {
+		var (
+			ctrl              *gomock.Controller
+			c                 *mockclient.MockClient
+			testNamespace     string
+			testStatefulset   string
+			statefulSet       *appsv1.StatefulSet
+			expectedResources *corev1.ResourceRequirements
+		)
+
+		BeforeEach(func() {
+			expectedResources = &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("300Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("3000Mi"),
+				},
+			}
+
+			ctrl = gomock.NewController(GinkgoT())
+			c = mockclient.NewMockClient(ctrl)
+			testNamespace = "test-namespace"
+			testStatefulset = "test-loki"
+
+			statefulSet = &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testStatefulset,
+					Namespace: testNamespace,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{},
+					},
+				},
+			}
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("should return container resources when statefulset contains one container", func() {
+			var (
+				ctx = context.TODO()
+			)
+
+			statefulSet.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:      "contaienr-1",
+					Resources: *expectedResources,
+				},
+			}
+
+			c.EXPECT().Get(ctx, kutil.Key(testNamespace, testStatefulset), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).SetArg(2, *statefulSet).Return(nil)
+
+			rr, err := GetContainerResourcesInStatefulSet(ctx, c, kutil.Key(testNamespace, testStatefulset))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rr).To(HaveLen(len(statefulSet.Spec.Template.Spec.Containers)))
+			Expect(rr[0]).To(Equal(expectedResources))
+		})
+
+		It("should return all container resources when statefulset contains two containers", func() {
+			var (
+				ctx = context.TODO()
+			)
+
+			statefulSet.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:      "container-1",
+					Resources: *expectedResources,
+				},
+				{
+					Name:      "container-2",
+					Resources: *expectedResources,
+				},
+			}
+
+			c.EXPECT().Get(ctx, kutil.Key(testNamespace, testStatefulset), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).SetArg(2, *statefulSet).Return(nil)
+
+			rr, err := GetContainerResourcesInStatefulSet(ctx, c, kutil.Key(testNamespace, testStatefulset))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rr).To(HaveLen(len(statefulSet.Spec.Template.Spec.Containers)))
+			Expect(rr[0]).To(Equal(expectedResources))
+			Expect(rr[1]).To(Equal(expectedResources))
+		})
+
+		It("should return error if statefulSet is not found", func() {
+			var (
+				ctx = context.TODO()
+			)
+
+			c.EXPECT().Get(ctx, kutil.Key(testNamespace, testStatefulset), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(errors.New("error"))
+
+			_, err := GetContainerResourcesInStatefulSet(ctx, c, kutil.Key(testNamespace, testStatefulset))
+			Expect(err).To(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug
/priority normal

**What this PR does / why we need it**:
Keep the Loki updates from the HVPA 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@ggaurav10 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug has been fixed that prevented the Loki HVPA recommendations from not being reverted.
```
