### PR TITLE
Trivial fix for the "default-admin.conf" path used for local-garden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ local-garden-up:
 	@./hack/local-development/local-garden/run-gardener-etcd $(LOCAL_GARDEN_LABEL)
 
 	# Applying proxy RBAC for the extension controller
-	# After this step, you can start using the cluster at hack/local-garden/kubeconfigs/admin.conf
+	# After this step, you can start using the cluster at KUBECONFIG=hack/local-development/local-garden/kubeconfigs/default-admin.conf
 	@./hack/local-development/local-garden/apply-rbac-garden-ns
 
 	# Now you can start using the cluster at with `export KUBECONFIG=hack/local-development/local-garden/kubeconfigs/default-admin.conf`


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind cleanup
/priority normal

**What this PR does / why we need it**:
This PR simply changes a left-over (non-existent) path in the "Makefile" to point to the `default-admin.conf` used at `hack/local-development/local-garden/apply-rbac-garden-ns`.