### PR TITLE
Set KEEPALIVE on istio-ingressgateway listeners

### DIFF
--- a/charts/istio/istio-ingress/templates/envoy-filter.yaml
+++ b/charts/istio/istio-ingress/templates/envoy-filter.yaml
@@ -27,6 +27,39 @@ spec:
       operation: MERGE
       value:
         per_connection_buffer_limit_bytes: 32768 # 32 KiB
+  # Some LoadBalancers do not set KEEPALIVE when they open a TCP connection
+  # to the Istio Ingress Gateway. For long living connections it can cause
+  # silent timeouts.
+  # Therefore envoy must be configured to send KEEPALIVE to downstream (LB).
+  # See https://github.com/envoyproxy/envoy/issues/3634
+  - applyTo: LISTENER
+    match:
+      context: GATEWAY
+      listener:
+        name: 0.0.0.0_{{ .targetPort }}
+        portNumber: {{ .targetPort }}
+    patch:
+      operation: MERGE
+      value:
+        socket_options:
+        # SOL_SOCKET = 1
+        # SO_KEEPALIVE = 9
+        - level: 1
+          name: 9
+          int_value: 1
+          state: STATE_LISTENING
+        # IPPROTO_TCP = 6
+        # TCP_KEEPIDLE = 4
+        - level: 6
+          name: 4
+          int_value: 55
+          state: STATE_LISTENING
+        # IPPROTO_TCP = 6
+        # TCP_KEEPINTVL = 5
+        - level: 6
+          name: 5
+          int_value: 55
+          state: STATE_LISTENING
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/priority normal

**What this PR does / why we need it**:

Some LoadBalancers (AWS NLB) do not set KEEPALIVE when they open a TCP connection to the Istio Ingress Gateway. For long living connections it can cause silent timeouts when idle timeouts are hit.

Therefore envoy must be configured to send KEEPALIVE to downstream (LB).

See https://github.com/envoyproxy/envoy/issues/3634

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`istio-ingressgateway` now uses KEEPALIVE to downstream LoadBalancers to prevent idle timeout issues.
```
