### PR TITLE
Nit: Cleanup deprecated predicate.Or

### DIFF
--- a/extensions/pkg/predicate/predicate.go
+++ b/extensions/pkg/predicate/predicate.go
@@ -88,12 +88,6 @@ func ShootNotFailed() predicate.Predicate {
 		CreateTrigger, UpdateNewTrigger, DeleteTrigger, GenericTrigger)
 }
 
-// Or builds a logical OR gate of passed predicates.
-// Deprecated: Use sigs.k8s.io/controller-runtime/pkg/predicate.Or directly. Will be removed in gardener version v1.12.
-func Or(predicates ...predicate.Predicate) predicate.Predicate {
-	return predicate.Or(predicates...)
-}
-
 // HasType filters the incoming OperatingSystemConfigs for ones that have the same type
 // as the given type.
 func HasType(typeName string) predicate.Predicate {


### PR DESCRIPTION
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
`github.com/gardener/gardener/extensions/pkg/predicate.Or` (which was deprecated in favor of `sigs.k8s.io/controller-runtime/pkg/predicate.Or`) is now removed.
```
