### PR TITLE
Force ca-certs activation on the nodes.

### DIFF
--- a/charts/seed-operatingsystemconfig/original/templates/ssl/_update-ca-certs.service
+++ b/charts/seed-operatingsystemconfig/original/templates/ssl/_update-ca-certs.service
@@ -14,7 +14,7 @@
     ConditionPathExists=!/var/lib/kubelet/kubeconfig-real
     [Service]
     Type=oneshot
-    ExecStart=/usr/sbin/update-ca-certificates
+    ExecStart=/usr/sbin/update-ca-certificates --fresh
     ExecStartPost=/bin/systemctl restart docker
     [Install]
     WantedBy=multi-user.target


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind bug
/priority normal

**What this PR does / why we need it**:
Force ca-certs activation on the nodes.

**Which issue(s) this PR fixes**:
Fixes #3112

**Special notes for your reviewer**:
I will need some time next days to validate the change on all supported OSes. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
A bug that was preventing custom CA certificates to be installed on the shoot nodes is now fixed.
```
