### PR TITLE
Gardenlet does not use self-generated TLS cert during self-deployment

### DIFF
--- a/pkg/utils/secrets/certificates.go
+++ b/pkg/utils/secrets/certificates.go
@@ -422,12 +422,16 @@ func GenerateCertificateAuthorities(k8sClusterClient kubernetes.Interface, exist
 	return generatedSecrets, certificateAuthorities, nil
 }
 
+// TemporaryDirectoryForSelfGeneratedTLSCertificatesPattern is a constant for the pattern used when creating a temporary
+// directory for self-generated certificates.
+const TemporaryDirectoryForSelfGeneratedTLSCertificatesPattern = "self-generated-server-certificates-"
+
 // SelfGenerateTLSServerCertificate generates a new CA certificate and signs a server certificate with it. It'll store
 // the generated CA + server certificate bytes into a temporary directory with the default filenames, e.g. `DataKeyCertificateCA`.
 // The function will return the *Certificate object as well as the path of the temporary directory where the
 // certificates are stored.
 func SelfGenerateTLSServerCertificate(name string, dnsNames []string) (*Certificate, string, error) {
-	tempDir, err := ioutil.TempDir("", "self-generated-server-certificates-")
+	tempDir, err := ioutil.TempDir("", TemporaryDirectoryForSelfGeneratedTLSCertificatesPattern)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security scalability
/kind bug
/priority normal

**What this PR does / why we need it**:
Without this PR, the gardenlet deploys further instances of itself with the same self-generated certificate. This is bad in two ways:
1. Security-wise, the same certificate is used multiple times.
1. Any re-deployment of the gardenlet leads to rollouts of all further instances because a new certificate was generated and needs to be populated.

**Special notes for your reviewer**:
/cc @prashanth26 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug has been fixed that caused the gardenlet to deploy further instances of itself with its own self-generated server certificate. It prevents undesired redeployments of these further instances.
```
