### PR TITLE
Ignore missing audit configmaps when deploying KAPI in shoot deletion

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -1027,12 +1027,19 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 		if apiServerConfig.AuditConfig != nil &&
 			apiServerConfig.AuditConfig.AuditPolicy != nil &&
 			apiServerConfig.AuditConfig.AuditPolicy.ConfigMapRef != nil {
+
 			auditPolicy, err := b.getAuditPolicy(apiServerConfig.AuditConfig.AuditPolicy.ConfigMapRef.Name, b.Shoot.Info.Namespace)
 			if err != nil {
-				return fmt.Errorf("retrieving audit policy from the ConfigMap '%v' failed with reason '%v'", apiServerConfig.AuditConfig.AuditPolicy.ConfigMapRef.Name, err)
-			}
-			defaultValues["auditConfig"] = map[string]interface{}{
-				"auditPolicy": auditPolicy,
+				// Ignore missing audit configuration on shoot deletion to prevent failing redeployments of the
+				// kube-apiserver in case the end-user deleted the configmap before/simultaneously to the shoot
+				// deletion.
+				if !apierrors.IsNotFound(err) || b.Shoot.Info.DeletionTimestamp == nil {
+					return fmt.Errorf("retrieving audit policy from the ConfigMap '%v' failed with reason '%v'", apiServerConfig.AuditConfig.AuditPolicy.ConfigMapRef.Name, err)
+				}
+			} else {
+				defaultValues["auditConfig"] = map[string]interface{}{
+					"auditPolicy": auditPolicy,
+				}
 			}
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability open-source
/kind task
/priority normal

**What this PR does / why we need it**:
#2967 introduced an incompatible change because the shoot deletion flow is now trying to redeploy the kube-apiserver deployment. This fails when the end-user has already deleted the audit policy configmap. As Gardener did not protect this configmap with a finalizer earlier the configmap was removed from the system immediately. (This was improved with #3071, but still, Gardener v1.12 is introducing an incompatible change initially caused by #2967.
Let's ignore missing configmaps for the time being to give all end-users enough time to adapt their workflows.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Missing audit policy `ConfigMap`s for `Shoot`s are now ignored when trying to redeploy the kube-apiserver in the shoot deletion flow.
```
