### PR TITLE
Fix missing user logs issue

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-configmap.yaml
@@ -15,6 +15,12 @@ data:
 {{- include "input.conf" . }}
 
   filter-kubernetes.conf: |-
+    [FILTER]
+        Name                lua
+        Match               kubernetes.*
+        script              add_tag_to_record.lua
+        call                add_tag_to_record
+
     # Systemd Filters
     [FILTER]
         Name record_modifier
@@ -241,12 +247,6 @@ data:
         Match               kubernetes.*
         script              modify_severity.lua
         call                cb_modify
-
-    [FILTER]
-        Name                lua
-        Match               kubernetes.*
-        script              add_tag_to_record.lua
-        call                add_tag_to_record
 
   output.conf: |-
     # Output section

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -394,7 +394,7 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 		loggingRewriteTagFilter := `[FILTER]
     Name          rewrite_tag
     Match         kubernetes.*
-    Rule          $kubernetes['pod_name'] ^(` + strings.Join(userAllowedComponents, "-?.+|") + `-?.+)$ ` + userExposedComponentTagPrefix + `.$TAG true
+    Rule          $tag ^kubernetes\.var\.log\.containers\.(` + strings.Join(userAllowedComponents, "-.+?|") + `-.+?)_ ` + userExposedComponentTagPrefix + `.$TAG true
     Emitter_Name  re_emitted
 `
 		filters.WriteString(fmt.Sprintln(loggingRewriteTagFilter))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug
/priority normal

**What this PR does / why we need it**:
After we removed k8s labels in Loki, the user logs can not be identified
This PR lets fluent-bit to take the needed `pod_name` from the tag and use it to determine the correct Loki ordID.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@rfranzke @vlvasilev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
