### PR TITLE
Fix IGW ports when SNI is being disabled

### DIFF
--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/operation/botanist/controlplane"
 	"github.com/gardener/gardener/pkg/operation/botanist/controlplane/clusterautoscaler"
 	"github.com/gardener/gardener/pkg/operation/botanist/controlplane/kubecontrollermanager"
 	"github.com/gardener/gardener/pkg/operation/botanist/controlplane/kubescheduler"
@@ -356,7 +357,6 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 		lokiVpa := &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "loki-vpa", Namespace: v1beta1constants.GardenNamespace}}
 		if err := k8sSeedClient.Client().Delete(ctx, lokiVpa); client.IgnoreNotFound(err) != nil {
 			return err
-
 		}
 
 		if hvpaEnabled {
@@ -561,6 +561,11 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 		imageVectorOverwrites[name] = data
 	}
 
+	anySNI, err := controlplane.AnyDeployedSNI(ctx, k8sSeedClient.Client())
+	if err != nil {
+		return err
+	}
+
 	if gardenletfeatures.FeatureGate.Enabled(features.ManagedIstio) {
 		istiodImage, err := imageVector.FindImage(common.IstioIstiodImageName)
 		if err != nil {
@@ -590,19 +595,24 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 			Image:           igwImage.String(),
 			IstiodNamespace: common.IstioNamespace,
 			Annotations:     seed.LoadBalancerServiceAnnotations,
+			Ports:           []corev1.ServicePort{},
 		}
 
-		if gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI) {
-			ports := []corev1.ServicePort{
-				{Name: "proxy", Port: 8443, TargetPort: intstr.FromInt(8443)},
-				{Name: "tcp", Port: 443, TargetPort: intstr.FromInt(9443)},
-			}
+		// even if SNI is being disabled, the existing ports must stay the same
+		// until all APIServer SNI resources are removed.
+		if gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI) || anySNI {
+			igwConfig.Ports = append(
+				igwConfig.Ports,
+				corev1.ServicePort{Name: "proxy", Port: 8443, TargetPort: intstr.FromInt(8443)},
+				corev1.ServicePort{Name: "tcp", Port: 443, TargetPort: intstr.FromInt(9443)},
+			)
 
 			if gardenletfeatures.FeatureGate.Enabled(features.KonnectivityTunnel) {
-				ports = append(ports, corev1.ServicePort{Name: "tls-tunnel", Port: 8132, TargetPort: intstr.FromInt(8132)})
+				igwConfig.Ports = append(
+					igwConfig.Ports,
+					corev1.ServicePort{Name: "tls-tunnel", Port: 8132, TargetPort: intstr.FromInt(8132)},
+				)
 			}
-
-			igwConfig.Ports = ports
 		}
 
 		igw := istio.NewIngressGateway(
@@ -700,7 +710,7 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 		"global-network-policies": map[string]interface{}{
 			"denyAll":         false,
 			"privateNetworks": privateNetworks,
-			"sniEnabled":      gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI),
+			"sniEnabled":      gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI) || anySNI,
 		},
 		"gardenerResourceManager": map[string]interface{}{
 			"resourceClass": v1beta1constants.SeedResourceManagerClass,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/priority normal

**What this PR does / why we need it**:

When APIServerSNI feature gate is turned off and there are still existing SNI resources available in the cluster, the ports on the Istio Ingress Gateway are not changed to allow not yet SNI disabled Shoot clusters to work.

**Which issue(s) this PR fixes**:

Part of #2942

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
When disabling `APIServerSNI` feature gate, existing LoadBalancer ports from `ManagedIstio` are not removed until all existing SNI-enabled Shoot clusters are migrated.
```
