### PR TITLE
Add .mailmap aliases to identify authors uniquely

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,117 @@
+Adel Zaalouk <adel.zaalouk@sap.com>
+Adel Zaalouk <adel.zaalouk@sap.com> <adel.zalok.89@gmail.com>
+Amshuman K R <amshuman.rao.karaya@sap.com>
+Andreas Fritzler <andreas.fritzler@sap.com>
+Andreas Fritzler <andreas.fritzler@sap.com> <afritzler@users.noreply.github.com>
+Andreas Fritzler <andreas.fritzler@sap.com> <andreas.fritzler@gmail.com>
+Andreas Thaler <andreas.thaler01@sap.com>
+Avi Deitcher <avi@deitcher.net>
+Axel Christ <axel.christ@sap.com> <adracus@gmail.com>
+Aylei <rayingecho@gmail.com>
+Bekir Dogan <bdogan@ptc.com>
+Bekir Dogan <bdogan@ptc.com> <bekirdo@gmail.com>
+Bharath Suresh Kallur <bharath.suresh.kallur@sap.com>
+Bruno Klein <brunoklein99@gmail.com>
+Christian Berendt <berendt@23technologies.cloud>
+Christian Cwienk <christian.cwienk@sap.com>
+Cihangir Besiktas <cbesiktas@ptc.com>
+Daniel Föhr <daniel.foehr@sap.com>
+Daniel Pacrami <daniel.pacrami@sap.com>
+Daniel Sutton <daniel@ducksecops.uk>
+Maximilian Geberl <github@dergeberl.de>
+Dieter Guendisch <dieter.guendisch@sap.com>
+Dirk Marwinski <marwinski@users.noreply.github.com>
+Dominic Kistner <dominic.kistner@sap.com>
+Dominic Kistner <dominic.kistner@sap.com> <dominickistner@yahoo.de>
+Dr.Mo <57674787+Doctor-Mo@users.noreply.github.com>
+einfachnuralex <einfachnuralex@posteo.de>
+Emoin Lanyu <emoin.lanyu@sap.com>
+Fabian Ruff <fabian@progra.de>
+Frederik Thormaehlen <frederik.thormaehlen@sap.com>
+Gardener Development Community <gardener.opensource@sap.com>
+gardener-ci <gardener.ci.user@gmail.com>
+gardener-ci <gardener.ci.user@gmail.com> <35339986+gardener-ci@users.noreply.github.com>
+gardener-ci <gardener.ci.user@gmail.com> <gardener.ci.user2@gmail.com>
+gardener-ci <gardener.ci.user@gmail.com> <gardener.ci.user3@gmail.com>
+gardener-ci2 <gardener.ci.user@gmail.com>
+gardener-ci3 <gardener.ci.user@gmail.com>
+Gaurav Gupta <gaurav.gupta07@sap.com>
+George Kuruvilla <george.kuruvilla@sap.com>
+Georgi Pavlov <georgi.pavlov@sap.com>
+Gerrit Schwerthelm <gerrit.schwerthelm@f-i-ts.de>
+Guy Daich <guy.daich@sap.com>
+Hardik Dodiya <hardik.dodiya@sap.com>
+hassbert <45389730+hassbert@users.noreply.github.com>
+Holger Koser <holger.koser@sap.com>
+Holger Koser <holger.koser@sap.com> <holgerkoser@users.noreply.github.com>
+Huamin Chen <hchen@redhat.com>
+Ismail Alidzhikov <i.alidjikov@gmail.com>
+Jannick Fahlbusch <jannick.stephan.fahlbusch@sap.com>
+Jens Haley <jens.haley@sap.com>
+Jerry Jia <jerry.jia@sap.com>
+Johannes Aubart <johannes.aubart@sap.com>
+Johannes M. Scheuermann <joh.scheuer@gmail.com>
+Karthik Eyan <karthikeyan.net@gmail.com>
+Kay Diam <kay.diam@gmail.com>
+Konstantinos Angelopoulos <konstantinos.angelopoulos@sap.com>
+Kristian Zhelyazkov <k.zhelyazkov@sap.com>
+Kristian Zhelyazkov  <k.zhelyazkov@sap.com> <kristianzh@abv.bg>
+Kristiyan Gostev <kristiyan.gostev@sap.com>
+Liepold, Markus <markus.liepold@sap.com>
+Luis Davim <ldavim@ptc.com>
+Marin Koynov <marin.koynov@sap.com>
+Markus Liepold <markus.liepold@sap.com>
+Martin Vladev <martin.vladev@sap.com>
+Martin Weindel <martin.weindel@sap.com>
+Matthias Sohn <matthias.sohn@sap.com>
+Max Becker <max.becker@sap.com>
+Mehmet Onur Yalazi <oyalazi@ptc.com>
+Michael Engler <michael.engler@sap.com>
+Michael Schmidt <michael.j.schmidt@gmail.com>
+Minchao Wang <minchao.wang@sap.com>
+Neo Liang <neo.liang@sap.com>
+Nikhil Kumar Agrawal <nikhil.kumar.agrawal@sap.com>
+Nimrod Oron <nimrod.oron@sap.com>
+Nimrod Oron <nimrod.oron@sap.com> <nimrodoron@gmail.com>
+Oleg Loewen <oleg.loewen@sap.com>
+Onur Yalazı <oyalazi@ptc.com>
+Pablo Chacin <pchacin@suse.com>
+Padmashree B <padmashree.b@sap.com>
+Peter Sutter <peter.sutter@sap.com>
+Pieter du Toit <wpdutoit@gmail.com>
+Plamen Kokanov <plamen.kokanov@sap.com>
+Prashanth <prashanth@sap.com>
+Rafael Franzke <rafael.franzke@sap.com>
+Raphael Vogel <raphael.vogel@sap.com>
+Raphael Vogel <raphael.vogel@sap.com> <raphael.vogel@icloud.com>
+Roland Wilfer <roland.wilfer@sap.com>
+Saggi Raiter <saggi.raiter@sap.com>
+Sayak Mukhopadhyay <sayak@beezlabs.com>
+Sebastian Max Dusch <sedusch@microsoft.com>
+Sebastian Stauch <sebastian.stauch@sap.com>
+Shreyas Rao <shreyas.sriganesh.rao@sap.com>
+shturec <sthrakal@gmail.com>
+Stefan Majer <stefan.majer@f-i-ts.de>
+Stephan Spindler <stephan.spindler@device-insight.com>
+Stoyan Rachev <s.rachev@sap.com>
+Stoyan Rachev <s.rachev@sap.com> <stoyanr@gmail.com>
+Svetlina Shopova <svetlina.shopova@sap.com>
+Svilen Ivano <svilen.ivanov@sap.com> <49143264+swilen-iwanow@users.noreply.github.com>
+Svilen Ivanov <svilen.ivanov@sap.com>
+Swapnil Mhamane <swapnil.mhamane@sap.com>
+Tim Ebert <tim.ebert@sap.com>
+Tim Schrodi <tim.schrodi@sap.com>
+Tim Usner <tim.usner@sap.com>
+Tim Usner <tim.usner@sap.com> <timuthyu@gmail.com>
+Tim Usner <timuthyu@gmail.com> <40451181+timuthy@users.noreply.github.com>
+Tobias Wolf <wolf@b1-systems.de>
+Uwe Krueger <uwe.krueger@sap.com>
+Vasu Chandrasekhara <vasu.chandrasekhara@sap.com>
+Vasu Chandrasekhara <vasu.chandrasekhara@sap.com> <vasu1124@actvirtual.com>
+Vedran Lerenc <vedran.lerenc@sap.com>
+Vedran Lerenc <vedran.lerenc@sap.com> <vlerenc@gmail.com>
+Vedran Lerenc <vedran.lerenc@sap.com> <vlerenc@googlemail.com>
+Vladimir Nachev <vladimir.nachev@sap.com>
+Vladimir Panov <vladimir.panov@sap.com>
+Vladimir Vasilev <vladimir.vasilev@sap.com>
+Wesley Bermbach <wesley.bermbach@sap.com>


### PR DESCRIPTION
See https://git-scm.com/docs/git-check-mailmap#_mapping_authors

**How to categorize this PR?**
/area open-source
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Ensure authors are identified uniquely in git.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```improvement operator
NONE
```
