### PR TITLE
Configuration option for feature gates for shooted seeds

### DIFF
--- a/docs/usage/shooted_seed.md
+++ b/docs/usage/shooted_seed.md
@@ -73,3 +73,4 @@ Option | Description
 `apiServer.replicas` | Controls how many `kube-apiserver` replicas the shooted seed cluster gets by default.
 `use-serviceaccount-bootstrapping` | States that the gardenlet registers with the garden cluster using a temporary `ServiceAccount` instead of a `CertificateSigningRequest` (**default**)
 `providerConfig.*` | Sets `providerConfig` configuration parameters of the Seed resource. Each parameter is specified via its path, e.g. `providerConfig.param1=foo` or `providerConfig.sublevel1.sublevel2.param3=bar`
+`featureGates.*={true,false}` | Overwrites the `.featureGates` in the gardenlet configuration (only applicable when the `no-gardenlet` setting is **not** set), e.g. `featureGates.APIServerSNI=true`

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -631,6 +631,25 @@ var _ = Describe("helper", func() {
 				}))
 			})
 
+			It("should return a filled feature gates map", func() {
+				shoot.Annotations = map[string]string{
+					v1beta1constants.AnnotationShootUseAsSeed: "true,featureGates.Foo=bar,featureGates.Bar=true,featureGates.Baz=false",
+				}
+
+				shootedSeed, err := ReadShootedSeed(shoot)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shootedSeed).To(Equal(&ShootedSeed{
+					APIServer: &defaultAPIServer,
+					FeatureGates: map[string]bool{
+						"Foo": false,
+						"Bar": true,
+						"Baz": false,
+					},
+					Backup: &gardencorev1beta1.SeedBackup{},
+				}))
+			})
+
 			It("should fail due to maxReplicas not being specified", func() {
 				shoot.Annotations = map[string]string{
 					v1beta1constants.AnnotationShootUseAsSeed: "true,apiServer.autoscaler.minReplicas=2",

--- a/pkg/gardenlet/controller/shoot/seed_registration_control.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control.go
@@ -635,6 +635,15 @@ func deployGardenlet(ctx context.Context, gardenClient, seedClient, shootedSeedC
 		}
 	}
 
+	featureGates := externalConfig.FeatureGates
+	if featureGates == nil {
+		featureGates = shootedSeedConfig.FeatureGates
+	} else {
+		for feature, enabled := range shootedSeedConfig.FeatureGates {
+			featureGates[feature] = enabled
+		}
+	}
+
 	values := map[string]interface{}{
 		"global": map[string]interface{}{
 			"gardenlet": map[string]interface{}{
@@ -665,7 +674,7 @@ func deployGardenlet(ctx context.Context, gardenClient, seedClient, shootedSeedC
 					"leaderElection":        externalConfig.LeaderElection,
 					"logLevel":              externalConfig.LogLevel,
 					"kubernetesLogLevel":    externalConfig.KubernetesLogLevel,
-					"featureGates":          externalConfig.FeatureGates,
+					"featureGates":          featureGates,
 					"server":                serverConfig,
 					"seedConfig": &configv1alpha1.SeedConfig{
 						Seed: gardencorev1beta1.Seed{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR allows to overwrite the feature gates for self-deployed gardenlets for shooted seeds by extending the respective shooted-seed annotation with `featureGates.<name>={true,false}`.

**Special notes for your reviewer**:
/cc @mvladev @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
It is now possible to overwrite the feature gates in the gardenlet configuration for shooted seeds without the `no-gardenlet` option by setting `featureGates.<name>={true,false}`.
```
