### PR TITLE
Merge duplicate project members

### DIFF
--- a/pkg/apis/core/validation/project.go
+++ b/pkg/apis/core/validation/project.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/validation/path"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 )
 
 // ValidateProject validates a Project object.
@@ -72,8 +73,23 @@ func ValidateProjectSpec(projectSpec *core.ProjectSpec, fldPath *field.Path) fie
 	}
 	ownerFound := false
 
+	members := make(map[string]struct{}, len(projectSpec.Members))
+
 	for i, member := range projectSpec.Members {
 		idxPath := fldPath.Child("members").Index(i)
+
+		apiGroup, kind, namespace, name, err := ProjectMemberProperties(member)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(idxPath.Child("name"), member.Name, err.Error()))
+			continue
+		}
+		id := ProjectMemberId(apiGroup, kind, namespace, name)
+
+		if _, ok := members[id]; ok {
+			allErrs = append(allErrs, field.Duplicate(idxPath, member))
+		} else {
+			members[id] = struct{}{}
+		}
 
 		allErrs = append(allErrs, ValidateProjectMember(member, idxPath)...)
 
@@ -242,4 +258,33 @@ func ValidateProjectStatusUpdate(newProject, oldProject *core.Project) field.Err
 	}
 
 	return allErrs
+}
+
+// ProjectMemberProperties returns the properties for the given project member.
+func ProjectMemberProperties(member core.ProjectMember) (string, string, string, string, error) {
+	var (
+		apiGroup  = member.APIGroup
+		kind      = member.Kind
+		namespace = member.Namespace
+		name      = member.Name
+	)
+
+	if member.Kind == rbacv1.UserKind && strings.HasPrefix(member.Name, serviceaccount.ServiceAccountUsernamePrefix) {
+		user := strings.Split(member.Name, serviceaccount.ServiceAccountUsernameSeparator)
+		if len(user) < 4 {
+			return "", "", "", "", fmt.Errorf("unsupported service account user name: %q", member.Name)
+		}
+
+		apiGroup = ""
+		kind = rbacv1.ServiceAccountKind
+		namespace = user[2]
+		name = user[3]
+	}
+
+	return apiGroup, kind, namespace, name, nil
+}
+
+// ProjectMemberId returns an internal ID for the project member.
+func ProjectMemberId(apiGroup, kind, namespace, name string) string {
+	return fmt.Sprintf("%s_%s_%s_%s", apiGroup, kind, namespace, name)
 }

--- a/pkg/registry/core/project/project_suite_test.go
+++ b/pkg/registry/core/project/project_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestProject(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Registry Core Project Suite")
+}

--- a/pkg/registry/core/project/strategy.go
+++ b/pkg/registry/core/project/strategy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/validation"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -39,14 +40,16 @@ func (projectStrategy) NamespaceScoped() bool {
 	return false
 }
 
-func (projectStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+func (projectStrategy) PrepareForCreate(_ context.Context, obj runtime.Object) {
 	project := obj.(*core.Project)
 
 	project.Generation = 1
 	project.Status = core.ProjectStatus{}
+
+	mergeDuplicateMembers(project)
 }
 
-func (projectStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+func (projectStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Object) {
 	newProject := obj.(*core.Project)
 	oldProject := old.(*core.Project)
 	newProject.Status = oldProject.Status
@@ -54,6 +57,61 @@ func (projectStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Ob
 	if !apiequality.Semantic.DeepEqual(oldProject.Spec, newProject.Spec) {
 		newProject.Generation = oldProject.Generation + 1
 	}
+
+	mergeDuplicateMembers(newProject)
+}
+
+// TODO: This code is needed now that we have introduced validation that forbids specifying duplicates in the
+// spec.members list (this code wasn't there before). Hence, we have to remove the duplicates now to not break the API
+// incompatibly.
+// This code can be removed in a future version.
+func mergeDuplicateMembers(project *core.Project) {
+	var (
+		oldMembersToRoles = make(map[string]map[string]struct{})
+		memberToNewRoles  = make(map[string][]string)
+		newMembers        []core.ProjectMember
+	)
+
+	for _, member := range project.Spec.Members {
+		apiGroup, kind, namespace, name, err := validation.ProjectMemberProperties(member)
+		if err != nil {
+			// No meaningful way to handle the error here
+			continue
+		}
+		id := validation.ProjectMemberId(apiGroup, kind, namespace, name)
+
+		if _, ok := oldMembersToRoles[id]; !ok {
+			newMembers = append(newMembers, core.ProjectMember{
+				Subject: rbacv1.Subject{
+					APIGroup:  apiGroup,
+					Kind:      kind,
+					Namespace: namespace,
+					Name:      name,
+				},
+			})
+			oldMembersToRoles[id] = make(map[string]struct{})
+		}
+
+		for _, role := range member.Roles {
+			if _, ok := oldMembersToRoles[id][role]; !ok {
+				memberToNewRoles[id] = append(memberToNewRoles[id], role)
+			}
+			oldMembersToRoles[id][role] = struct{}{}
+		}
+	}
+
+	for i, member := range newMembers {
+		apiGroup, kind, namespace, name, err := validation.ProjectMemberProperties(member)
+		if err != nil {
+			// No meaningful way to handle the error here
+			continue
+		}
+		id := validation.ProjectMemberId(apiGroup, kind, namespace, name)
+
+		newMembers[i].Roles = memberToNewRoles[id]
+	}
+
+	project.Spec.Members = newMembers
 }
 
 func (projectStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {

--- a/pkg/registry/core/project/strategy_test.go
+++ b/pkg/registry/core/project/strategy_test.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project_test
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	. "github.com/gardener/gardener/pkg/registry/core/project"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("Strategy", func() {
+	var (
+		ctx = context.TODO()
+	)
+
+	Context("member duplicates", func() {
+		var (
+			duplicateMembers = []core.ProjectMember{
+				{
+					Subject: rbacv1.Subject{
+						APIGroup: rbacv1.GroupName,
+						Kind:     rbacv1.UserKind,
+						Name:     "system:serviceaccount:foo:bar",
+					},
+					Roles: []string{
+						"role1",
+						"role2",
+					},
+				},
+				{
+					Subject: rbacv1.Subject{
+						Kind:      rbacv1.ServiceAccountKind,
+						Name:      "bar",
+						Namespace: "foo",
+					},
+					Roles: []string{
+						"role2",
+						"role3",
+						"role4",
+						"role5",
+					},
+				},
+				{
+					Subject: rbacv1.Subject{
+						APIGroup: rbacv1.GroupName,
+						Kind:     rbacv1.GroupKind,
+						Name:     "baz",
+					},
+				},
+				{
+					Subject: rbacv1.Subject{
+						APIGroup: rbacv1.GroupName,
+						Kind:     rbacv1.GroupKind,
+						Name:     "baz",
+					},
+					Roles: []string{
+						"role0",
+					},
+				},
+				{
+					Subject: rbacv1.Subject{
+						APIGroup: rbacv1.GroupName,
+						Kind:     rbacv1.UserKind,
+						Name:     "bazz",
+					},
+					Roles: []string{
+						"role-1",
+					},
+				},
+				{
+					Subject: rbacv1.Subject{
+						APIGroup: rbacv1.GroupName,
+						Kind:     rbacv1.UserKind,
+						Name:     "bazz",
+					},
+				},
+			}
+
+			expectedMembers = []core.ProjectMember{
+				{
+					Subject: rbacv1.Subject{
+						Kind:      rbacv1.ServiceAccountKind,
+						Name:      "bar",
+						Namespace: "foo",
+					},
+					Roles: []string{
+						"role1",
+						"role2",
+						"role3",
+						"role4",
+						"role5",
+					},
+				},
+				{
+					Subject: rbacv1.Subject{
+						APIGroup: rbacv1.GroupName,
+						Kind:     rbacv1.GroupKind,
+						Name:     "baz",
+					},
+					Roles: []string{
+						"role0",
+					},
+				},
+				{
+					Subject: rbacv1.Subject{
+						APIGroup: rbacv1.GroupName,
+						Kind:     rbacv1.UserKind,
+						Name:     "bazz",
+					},
+					Roles: []string{
+						"role-1",
+					},
+				},
+			}
+		)
+
+		Describe("#PrepareForCreate", func() {
+			It("should merge duplicate members", func() {
+				obj := &core.Project{
+					Spec: core.ProjectSpec{
+						Members: duplicateMembers,
+					},
+				}
+
+				Strategy.PrepareForCreate(ctx, obj)
+
+				Expect(obj.Generation).To(Equal(int64(1)))
+				Expect(obj.Status).To(Equal(core.ProjectStatus{}))
+				Expect(obj.Spec.Members).To(Equal(expectedMembers))
+			})
+		})
+
+		Describe("#PrepareForUpdate", func() {
+			It("should merge duplicate members", func() {
+				obj := &core.Project{
+					Spec: core.ProjectSpec{
+						Members: duplicateMembers,
+					},
+					Status: core.ProjectStatus{ObservedGeneration: 123},
+				}
+
+				newObj := obj.DeepCopy()
+				newObj.Spec.Description = pointer.StringPtr("new description")
+				newObj.Status = core.ProjectStatus{}
+
+				Strategy.PrepareForUpdate(ctx, newObj, obj)
+
+				Expect(newObj.Generation).To(Equal(int64(1)))
+				Expect(newObj.Status).To(Equal(obj.Status))
+				Expect(newObj.Spec.Members).To(Equal(expectedMembers))
+			})
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability 
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR we prevent duplicates in the `Project`'s `.spec.members[]` list. In order to be backwards compatible we are now merging such duplicates in before writing them to etcd.

**Which issue(s) this PR fixes**:
Fixes #2849

**Special notes for your reviewer**:
After a couple of releases this merging code can be removed again.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action user
We are preparing a change that will lead to validation errors when the `Project` resource contains duplicates in the `.spec.members[]` list. For the time being, duplicates in this list are merged into a single member automatically by the Gardener API Server. In the future, this will no longer happen, instead, a validation error will be returned if a user sends a `Project` resource with duplicate members. Please adapt your API usage to not send any of such resources.
```
