### PR TITLE
Reset shoot rate limiting on deletion

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot.go
+++ b/pkg/gardenlet/controller/shoot/shoot.go
@@ -125,7 +125,9 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 	shootInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister, config.SeedSelector),
 		Handler: cache.ResourceEventHandlerFuncs{
-			AddFunc:    shootController.shootAdd,
+			AddFunc: func(obj interface{}) {
+				shootController.shootAdd(obj, false)
+			},
 			UpdateFunc: shootController.shootUpdate,
 			DeleteFunc: shootController.shootDelete,
 		},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
The gardenlet's shoot controller does now forget about the rate limiting when a shoot's deletion timestamp is set. This is to make starting deletion operations faster.

**Which issue(s) this PR fixes**:
Fixes #3050

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The gardenlet's shoot controller does now forget about the rate limiting when a shoot's deletion timestamp is set. This is to make starting deletion operations faster.
```
