### PR TITLE
Fix seed bootstrap

### DIFF
--- a/pkg/operation/botanist/controlplane/kube_apiserver_sni.go
+++ b/pkg/operation/botanist/controlplane/kube_apiserver_sni.go
@@ -98,7 +98,7 @@ func AnyDeployedSNI(ctx context.Context, c client.Client) (bool, error) {
 		},
 	}
 
-	if err := c.List(ctx, l, client.MatchingField("metadata.name", "kube-apiserver"), client.Limit(1)); err != nil {
+	if err := c.List(ctx, l, client.MatchingFields{"metadata.name": "kube-apiserver"}, client.Limit(1)); err != nil && !meta.IsNoMatchError(err) {
 		return false, err
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority blocker

**What this PR does / why we need it**:
This PR fixes an error during seed bootstrap if `ManagedIstio` is not enabled.

```
time="2020-11-10T09:55:21+01:00" level=error msg="Seed bootstrapping failed: no matches for kind \"VirtualService\" in version \"networking.istio.io/v1beta1\""
```

**Special notes for your reviewer**:
Thanks for reporting @Diaphteiros 
/cc @mvladev @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An error has been fixed which caused the seed reconciliation (bootstrap) to fail if `ManagedIstio` is not enabled.
```
