### PR TITLE
Fix Dynamic Host Regex

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
@@ -104,7 +104,7 @@
         DynamicHostPath {"kubernetes": {"namespace_name": "namespace"}}
         DynamicHostPrefix http://loki.
         DynamicHostSuffix .svc:3100/loki/api/v1/push
-        DynamicHostRegex shoot-
+        DynamicHostRegex ^shoot-
         MaxRetries 3
         Timeout 10
         MinBackoff 30
@@ -137,7 +137,7 @@
         DynamicHostPath {"kubernetes": {"namespace_name": "namespace"}}
         DynamicHostPrefix http://loki.
         DynamicHostSuffix .svc:3100/loki/api/v1/push
-        DynamicHostRegex shoot-
+        DynamicHostRegex ^shoot-
         MaxRetries 3
         Timeout 10
         MinBackoff 30


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug
/priority normal

**What this PR does / why we need it**:
Current regex matches logs for `extension-extension-shoot-cert-service-x9hw6` and `extension-extension-shoot-dns-service-ztx52` but it cannot create client for them and skips their logs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@vlvasilev

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue has been fixed which caused the logging stack to skip logs for certain extension pods.
```
