### PR TITLE
add event on BackupBucket if referred secret is missing

### DIFF
--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
@@ -107,7 +107,9 @@ func (r *reconciler) reconcileBackupBucket(gardenClient kubernetes.Interface, ba
 
 	secret, err := common.GetSecretFromSecretRef(r.ctx, gardenClient.Client(), &backupBucket.Spec.SecretRef)
 	if err != nil {
-		backupBucketLogger.Errorf("Failed to get referred secret: %+v", err)
+		msg := fmt.Sprintf("Failed to get backup secret (%s/%s): %+v", backupBucket.Spec.SecretRef.Namespace, backupBucket.Spec.SecretRef.Name, err)
+		backupBucketLogger.Error(msg)
+		r.recorder.Eventf(backupBucket, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, "%s", msg)
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Adds an event on BackupBucket if referred secret is missing.
Otherwise there is no indication in the BB itself why the reconciliation is hanging at 2 percent.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```
