### PR TITLE
Remove ShootState sync controller events

### DIFF
--- a/pkg/gardenlet/controller/federatedseed/extensions/shootstate_control.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/shootstate_control.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -121,13 +120,11 @@ func (s *shootStateControl) createShootStateSyncReconcileFunc(ctx context.Contex
 		}); err != nil {
 			message := fmt.Sprintf("Shoot's %s %s extension state with name %s and purpose %s was NOT successfully synced: %v", shoot.Name, kind, name, purposeToString(purpose), err)
 			s.log.Error(message)
-			s.recorder.Event(shootState, corev1.EventTypeNormal, "ScheduledNextSync", message)
 			return reconcile.Result{}, err
 		}
 
 		message := fmt.Sprintf("Shoot's %s %s extension state with name %s and purpose %s was successfully synced", shoot.Name, kind, name, purposeToString(purpose))
 		s.log.Info(message)
-		s.recorder.Event(shootState, corev1.EventTypeNormal, "ScheduledNextSync", message)
 		return reconcile.Result{}, nil
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
The federated seed controller syncing the `ShootState` is no longer sends events for `ShootState` resources as they are not evaluated in a meaningful way anyways.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The federated seed controller syncing the `ShootState` is no longer sends events for `ShootState` resources as they are not evaluated in a meaningful way anyways.
```
