### PR TITLE
Add minAllowed resource limits for hvpa controller

### DIFF
--- a/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
@@ -79,3 +79,9 @@ spec:
     name: hvpa-controller
   updatePolicy:
     updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        minAllowed:
+          cpu: 100m
+          memory: 128Mi


### PR DESCRIPTION
Prevent hvpa controller to be OOM killed.
As this is deployed per Seed the resource consumption widely varies. We tried to find a good trade-off between availability and cost.
Very large Seeds can use up to 600 Mib of memory and 2 CPU but we think that this is the resource usage under load and with this PR we just want to provide enough resources for the container to start up.

cc @vpnachev 

  /area control-plane
  /area auto-scaling
/area availability
/kind enhancement

```improvement operator
Add minimum resource limit for the hvpa controller vpa
```
