### PR TITLE
[release-1.12] Cherry-pick Fix coredns network policies.

### DIFF
--- a/charts/shoot-core/components/charts/coredns/templates/coredns-networkpolicy.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-networkpolicy.yaml
@@ -34,6 +34,8 @@ spec:
     from:
     - namespaceSelector: {}
       podSelector: {}
+    - ipBlock:
+        cidr: {{ .Values.global.podNetwork }}
   policyTypes:
   - Egress
   - Ingress

--- a/charts/shoot-core/components/charts/coredns/values.yaml
+++ b/charts/shoot-core/components/charts/coredns/values.yaml
@@ -1,6 +1,8 @@
 # The values here match the ones on the upstream deployment repo (https://github.com/coredns/deployment/blob/master/kubernetes/coredns.yaml.sed).
 # They may need to be updated in the future
 
+global:
+  podNetwork: 1.2.3.4/24
 service:
   type: "ClusterIP"
   clusterDNS: 100.64.0.10


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area neworking
/kind bug
/priority normal

**What this PR does / why we need it**:

Now they allow traffic from the Pod network. This is needed because traffic might come from the calico tunnel IP which is part of the Pod network.

Before this, Pods with `hostNetwork: true` and `dnsPolicy: ClusterFirstWithHostNet` could not talk to coredns if they are running on a different Node than CoreDNS.


**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

Cherry-pick of https://github.com/gardener/gardener/pull/3162

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Fixed NetworkPolicy `gardener.cloud--allow-dns` to allow traffic from Pods with `hostNetwork: true` and `dnsPolicy: ClusterFirstWithHostNet`. 
```
