### PR TITLE
 Upgrade to fluent-bit 1.6.4 and set liveness and readiness probe to the fluent-bit DaemonSet

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -200,11 +200,11 @@ images:
 - name: fluent-bit
   sourceRepository: github.com/fluent/fluent-bit
   repository: fluent/fluent-bit
-  tag: "1.5.4"
+  tag: "1.6.4"
 - name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.27.0"
+  tag: "v0.28.0"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
@@ -87,7 +87,7 @@
 {{ .Values.fluentBitConfigurationsOverwrites.output | indent 4 }}
 {{ else }}
     [Output]
-        Name loki
+        Name gardenerloki
         Match kubernetes.*
         Url http://loki.garden.svc:3100/loki/api/v1/push
         LogLevel info
@@ -120,7 +120,7 @@
         TenantID operator
     
     [Output]
-        Name loki
+        Name gardenerloki
         Match {{ .Values.exposedComponentsTagPrefix }}.kubernetes.*
         Url http://loki.garden.svc:3100/loki/api/v1/push
         LogLevel info
@@ -153,7 +153,7 @@
         TenantID user
 
     [Output]
-        Name loki
+        Name gardenerloki
         Match journald.*
         Url http://loki.garden.svc:3100/loki/api/v1/push
         LogLevel info

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
@@ -55,6 +55,14 @@ spec:
         - name: metrics
           containerPort: 2020
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /api/v1/metrics/prometheus
+            port: 2020
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 2020
         volumeMounts:
         - name: config
           mountPath: /fluent-bit/etc


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR we upgrade the fluent-bit version to 1.6.4 and also we add readiness and liveness probe to the fluent-bit DaemonSet. From now on the gardener fluent-bit-to-loki-plugin is named `gardenerloki` , because from fluent-bit version 1.6.4 there is native plugin named `loki` which leads to collisions.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Fluent-bit version upgraded to 1.6.4.
```
```improvement operator
Add Readiness and Liveness probe to the fluent-bit DaemonSet.
```
```improvement operator
Change the name of the gardener custom fluent-bit-to-loki plugin from `loki` to `gardenerloki` to avoid any plugin collisions with future version of the fluent-bit.
```