### PR TITLE
Prevent successfully deleted shoots from getting stuck

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -606,7 +606,7 @@ func (c *Controller) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 }
 
 func (c *Controller) removeFinalizerFrom(ctx context.Context, gardenClient kubernetes.Interface, shoot *gardencorev1beta1.Shoot) error {
-	newShoot, err := c.updateShootStatusOperationSuccess(ctx, gardenClient.GardenCore(), shoot, "", "", gardencorev1beta1.LastOperationTypeDelete)
+	newShoot, err := c.updateShootStatusOperationSuccess(ctx, gardenClient.GardenCore(), shoot, "", nil, gardencorev1beta1.LastOperationTypeDelete)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity usability
/kind bug
/priority normal

**What this PR does / why we need it**:
Shoots can become stuck in `Delete Succeeded` state because the `removeFinalizerFrom` function is updating the shoot's `.status.seedName` to `""`, i.e., an empty string ([ref](https://github.com/gardener/gardener/blob/24275d2bd50419304850f77bfd5074313d4f30c5/pkg/gardenlet/controller/shoot/shoot_control_delete.go#L609)).
In some corner cases, when a gardenlet successfully deletes a shoot but fails to remove the finalizer and gets restarted/redeployed afterwards, the `ShootFilterFunc` function prevents any gardenlet from feeling responsible ([ref](https://github.com/gardener/gardener/blob/9f94ead0cbbe15e04e2c5798d7222f173dcfdf65/pkg/controllerutils/seedfilter.go#L52-L72)) because the `.status.seedName=""`.

This PR fixes the problem by setting the `.status.seedName` to `nil` as intended. It also includes a small cosmetic improvement for the logger and a shortcut for finalization of successfully deleted shoots.

**Which issue(s) this PR fixes**:
Fixes #3152

**Special notes for your reviewer**:
We should use PATCH for the finalizer handling, though, there can be also other errors than `409 Conflict` which can lead to failed calls.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
A bug has been fixed that can cause `Shoot` resources from being stuck in `Delete Succeeded` state.
```
