### PR TITLE
Introduce MaintenancePreconditionsSatisfied shoot constraint

### DIFF
--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -50,11 +50,15 @@ Let's check the following example to get better understanding. Let's say that th
 
 Constraints represent conditions of a Shoot’s current state that constraint some operations on it.
 
-Currently there is only one Shoot constraint:
+Currently there are two constraints:
 
 - `HibernationPossible`
 
   This constraint indicates whether a Shoot is allowed to be hibernated. The rationale behind this constraint is that a Shoot can have `ValidatingWebhookConfiguration`s or `MutatingWebhookConfiguration`s with rules for CREATE Pods or Nodes and `failurePolicy=Fail`. Such webhooks are preventing wake up for a Shoot cluster as new Nodes cannot be created or new system component Pods cannot be created because the webhook is not running. To prevent such deadlock situation, the gardener-apiserver does not allow Shoot to be hibernated when the `HibernationPossible` has status `False`.
+
+- `MaintenancePreconditionsSatisfied`
+
+  This constraint indicates whether all preconditions for a safe maintenance operation are satisfied (see also [this document](shoot_maintenance.md) for more information about what happens during a shoot maintenance). As of today, the same checks as in the `HibernationPossible` constraint are being performed (user-deployed webhooks that might interfere with potential rolling updates of shoot worker nodes). There is no further action being performed on this constraint's status (maintenance is still being performed). It is meant to make the user aware of potential problems that might occur due to his configurations. 
 
 ### Last Operation
 

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -921,6 +921,9 @@ const (
 	ShootSystemComponentsHealthy ConditionType = "SystemComponentsHealthy"
 	// ShootHibernationPossible is a constant for a condition type indicating whether the Shoot can be hibernated.
 	ShootHibernationPossible ConditionType = "HibernationPossible"
+	// ShootMaintenancePreconditionsSatisfied is a constant for a condition type indicating whether all preconditions
+	// for a shoot maintenance operation are satisfied.
+	ShootMaintenancePreconditionsSatisfied ConditionType = "MaintenancePreconditionsSatisfied"
 )
 
 // DNSUnmanaged is a constant for the 'unmanaged' DNS provider.

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -1134,6 +1134,9 @@ const (
 	ShootSystemComponentsHealthy ConditionType = "SystemComponentsHealthy"
 	// ShootHibernationPossible is a constant for a condition type indicating whether the Shoot can be hibernated.
 	ShootHibernationPossible ConditionType = "HibernationPossible"
+	// ShootMaintenancePreconditionsSatisfied is a constant for a condition type indicating whether all preconditions
+	// for a shoot maintenance operation are satisfied.
+	ShootMaintenancePreconditionsSatisfied ConditionType = "MaintenancePreconditionsSatisfied"
 )
 
 // ShootPurpose is a type alias for string.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1132,6 +1132,9 @@ const (
 	ShootSystemComponentsHealthy ConditionType = "SystemComponentsHealthy"
 	// ShootHibernationPossible is a constant for a condition type indicating whether the Shoot can be hibernated.
 	ShootHibernationPossible ConditionType = "HibernationPossible"
+	// ShootMaintenancePreconditionsSatisfied is a constant for a condition type indicating whether all preconditions
+	// for a shoot maintenance operation are satisfied.
+	ShootMaintenancePreconditionsSatisfied ConditionType = "MaintenancePreconditionsSatisfied"
 )
 
 // ShootPurpose is a type alias for string.

--- a/pkg/controllermanager/controller/seed/seed_lifecycle_control.go
+++ b/pkg/controllermanager/controller/seed/seed_lifecycle_control.go
@@ -206,7 +206,8 @@ func setShootStatusToUnknown(ctx context.Context, g gardencore.Interface, shoot 
 		}
 
 		constraints = map[gardencorev1beta1.ConditionType]gardencorev1beta1.Condition{
-			gardencorev1beta1.ShootHibernationPossible: {},
+			gardencorev1beta1.ShootHibernationPossible:               {},
+			gardencorev1beta1.ShootMaintenancePreconditionsSatisfied: {},
 		}
 	)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
The `Shoot` now has a new constraint with type `MaintenancePreconditionsSatisfied` which indicates whether it's safe to maintain a shoot (see [this document](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_maintenance.md) to get an overview what happens during maintenance). End-users should check this information to properly configure their clusters in order to avoid problems.

**Which issue(s) this PR fixes**:
Fixes #3122

**Special notes for your reviewer**:
/cc @gardener/dashboard-maintainers 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
The `Shoot` now has a new constraint with type `MaintenancePreconditionsSatisfied` which indicates whether it's safe to maintain a shoot (see [this document](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_maintenance.md) to get an overview what happens during maintenance). End-users should check this information to properly configure their clusters in order to avoid problems.
```
