### PR TITLE
Metrics server to use http healthchecks

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -123,7 +123,7 @@ images:
 - name: metrics-server
   sourceRepository: github.com/kubernetes-incubator/metrics-server
   repository: k8s.gcr.io/metrics-server/metrics-server
-  tag: v0.3.7
+  tag: v0.4.1
   targetVersion: ">= 1.11"
 - name: metrics-server
   sourceRepository: github.com/kubernetes-incubator/metrics-server

--- a/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server.go
@@ -312,12 +312,13 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 								"--kubelet-preferred-address-types=[Hostname,InternalDNS,InternalIP,ExternalDNS,ExternalIP]",
 								fmt.Sprintf("--tls-cert-file=%s/%s", volumeMountPathServer, secrets.DataKeyCertificate),
 								fmt.Sprintf("--tls-private-key-file=%s/%s", volumeMountPathServer, secrets.DataKeyPrivateKey),
-								"--v=2",
 							},
 							ReadinessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
-									TCPSocket: &corev1.TCPSocketAction{
-										Port: intstr.FromInt(int(containerPort)),
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/readyz",
+										Port:   intstr.FromInt(int(containerPort)),
+										Scheme: corev1.URISchemeHTTPS,
 									},
 								},
 								InitialDelaySeconds: 5,
@@ -326,8 +327,10 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 							},
 							LivenessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
-									TCPSocket: &corev1.TCPSocketAction{
-										Port: intstr.FromInt(int(containerPort)),
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/livez",
+										Port:   intstr.FromInt(int(containerPort)),
+										Scheme: corev1.URISchemeHTTPS,
 									},
 								},
 								InitialDelaySeconds: 30,

--- a/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server_test.go
@@ -232,22 +232,25 @@ spec:
         - --kubelet-preferred-address-types=[Hostname,InternalDNS,InternalIP,ExternalDNS,ExternalIP]
         - --tls-cert-file=/srv/metrics-server/tls/tls.crt
         - --tls-private-key-file=/srv/metrics-server/tls/tls.key
-        - --v=2
         image: ` + image + `
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 1
+          httpGet:
+            path: /livez
+            port: 8443
+            scheme: HTTPS
           initialDelaySeconds: 30
           periodSeconds: 30
-          tcpSocket:
-            port: 8443
         name: metrics-server
         readinessProbe:
           failureThreshold: 1
+          httpGet:
+            path: /readyz
+            port: 8443
+            scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
-          tcpSocket:
-            port: 8443
         resources:
           limits:
             cpu: 100m
@@ -315,7 +318,6 @@ spec:
         - --kubelet-preferred-address-types=[Hostname,InternalDNS,InternalIP,ExternalDNS,ExternalIP]
         - --tls-cert-file=/srv/metrics-server/tls/tls.crt
         - --tls-private-key-file=/srv/metrics-server/tls/tls.key
-        - --v=2
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: ` + kubeAPIServerHost + `
@@ -323,17 +325,21 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 1
+          httpGet:
+            path: /livez
+            port: 8443
+            scheme: HTTPS
           initialDelaySeconds: 30
           periodSeconds: 30
-          tcpSocket:
-            port: 8443
         name: metrics-server
         readinessProbe:
           failureThreshold: 1
+          httpGet:
+            path: /readyz
+            port: 8443
+            scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
-          tcpSocket:
-            port: 8443
         resources:
           limits:
             cpu: 80m


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement 
/priority normal

**What this PR does / why we need it**:

The metric server was logging tcp errors when the health checks are tcp.

The version is upgraded to `v0.4.1`

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

This is on hold until `v0.4.1` is released. See https://github.com/kubernetes-sigs/metrics-server/issues/638

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`metrics-server` is upgraded to `v0.4.1` and readiness and liveness probes now use http instead of tcp.
```

/hold
