### PR TITLE
Prevent orphaned machine resources on worker deletion

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/interface.go
+++ b/extensions/pkg/controller/worker/genericactuator/interface.go
@@ -35,6 +35,8 @@ type WorkerDelegate interface {
 
 	// MachineClassKind yields the name of the provider specific machine class.
 	MachineClassKind() string
+	// MachineClass yields a newly initialized machine class object.
+	MachineClass() runtime.Object
 	// MachineClassList yields a newly initialized machine class list object.
 	MachineClassList() runtime.Object
 	// DeployMachineClasses generates and creates the provider specific machine classes.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity robustness quality
/kind bug
/priority normal

**What this PR does / why we need it**:
Most likely caused by stale caches, in rare situations it might happen that the generic worker actuator's deletion flow leaves orphaned machine classes and/or machine class secrets in the shoot namespace in the seed.
In order to prevent that, the flow is now improved as follows:

* Instead of first listing all classes/secrets/deployments we use a `DELETECOLLECTION` call and move the responsibility to the API server to list and delete individually.
* To be sure that we don't miss objects we use the API reader in the `waitUntilMachineResourcesDeleted` function instead of relying on the cache.

Extension controllers using the generic worker actuator have to implement a new function that returns an initialized machine class object (so far, only machine class list objects were required).

**Which issue(s) this PR fixes**:
Fixes #2453

**Special notes for your reviewer**:
/invite @timebertt @ialidzhikov @prashanth26 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action developer
The generic worker actuator interface does now include a new function `MachineClass() runtime.Object` that needs to be implemented. It is similar to `MachineClassList() runtime.Object` with the difference that it does not return the list object but the machine class object itself.
```
```noteworthy operator
A bug has been fixed that might led to orphaned machine resources in the shoot namespace in the seed that are stuck with the machine-controller-manager finalizer.
```
```action developer
The `CleanupLeakedClusterRoles` function has been removed from the generic worker actuator package. You can find more information about it [here](https://github.com/gardener-attic/gardener-extensions/pull/378) and [here](https://github.com/gardener/gardener/issues/2144).
```