### PR TITLE
Keep project namespaces after deletion if they existed already

### DIFF
--- a/example/00-namespace-garden-dev.yaml
+++ b/example/00-namespace-garden-dev.yaml
@@ -6,3 +6,5 @@ metadata:
   labels:
     gardener.cloud/role: project
     project.gardener.cloud/name: dev
+  annotations:
+    namespace.gardener.cloud/keep-after-project-deletion: "true"

--- a/example/00-namespace-garden.yaml
+++ b/example/00-namespace-garden.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: garden
+  annotations:
+    namespace.gardener.cloud/keep-after-project-deletion: "true"

--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -257,6 +257,12 @@ func (c *defaultControl) reconcileNamespaceForProject(ctx context.Context, garde
 			delete(ns.Labels, deprecatedLabel)
 		}
 
+		// If the project is reconciled for the first time then its observed generation is 0. Only in this case we want
+		// to add the "keep-after-project-deletion" annotation to the namespace when we adopt it.
+		if project.Status.ObservedGeneration == 0 {
+			ns.Annotations[common.NamespaceKeepAfterProjectDeletion] = "true"
+		}
+
 		return ns, nil
 	})
 	if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
When existing `Namespace`s are adopted for `Project`s then they will now be configured to remain even after the `Project` is being deleted later again. Earlier, such namespaces were also deleted together with the `Project`.

**Which issue(s) this PR fixes**:
Fixes #2978

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
When existing `Namespace`s are adopted for `Project`s then they will now be configured to remain even after the `Project` is being deleted later again. Earlier, such namespaces were also deleted together with the `Project`. Please note that this only takes effect for newly adopted project namespaces.
```
