### PR TITLE
Support containerd sandbox image overwrite

### DIFF
--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.flags
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.flags
@@ -32,5 +32,7 @@
 {{- else }}
 --pod-infra-container-image={{ index .Values.images "pause-container" }}
 {{- end -}}
+{{- else }}
+--pod-infra-container-image={{ index .Values.images "pause-container" }}
 {{- end -}}
 {{- end -}}

--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.flags
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet.flags
@@ -16,7 +16,6 @@
 {{- if semverCompare "< 1.14" .Values.kubernetes.version }}
 --feature-gates=SupportPodPidsLimit=true
 {{- end }}
---pod-infra-container-image={{ index .Values.images "pause-container" }}
 --kubeconfig=/var/lib/kubelet/kubeconfig-real
 --network-plugin=cni
 {{- if semverCompare "< 1.11" .Values.kubernetes.version }}
@@ -30,6 +29,8 @@
 {{- if eq .Values.worker.cri.name .Values.osc.cri.names.containerd }}
 --container-runtime=remote
 --container-runtime-endpoint=unix:///run/containerd/containerd.sock
+{{- else }}
+--pod-infra-container-image={{ index .Values.images "pause-container" }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/seed-operatingsystemconfig/original/templates/scripts/_init-containerd.sh
+++ b/charts/seed-operatingsystemconfig/original/templates/scripts/_init-containerd.sh
@@ -16,7 +16,7 @@
         # use injected image as sandbox image
         sandbox_image_line="$(grep sandbox_image $FILE | sed -e 's/^[ ]*//')"
         pause_image={{ index .Values.images "pause-container" }}
-        sed -i  "s|$sandbox_image_line|sandbox_image = $pause_image|g" $FILE
+        sed -i  "s|$sandbox_image_line|sandbox_image = \"$pause_image\"|g" $FILE
 
         BIN_PATH={{ .Values.osc.cri.containerRuntimesBinaryPath }}
         mkdir -p $BIN_PATH

--- a/charts/seed-operatingsystemconfig/original/templates/scripts/_init-containerd.sh
+++ b/charts/seed-operatingsystemconfig/original/templates/scripts/_init-containerd.sh
@@ -13,6 +13,11 @@
           containerd config default > "$FILE"
         fi
 
+        # use injected image as sandbox image
+        sandbox_image_line="$(grep sandbox_image $FILE | sed -e 's/^[ ]*//')"
+        pause_image={{ index .Values.images "pause-container" }}
+        sed -i  "s|$sandbox_image_line|sandbox_image = $pause_image|g" $FILE
+
         BIN_PATH={{ .Values.osc.cri.containerRuntimesBinaryPath }}
         mkdir -p $BIN_PATH
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement
/priority blocker

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #3161

**Special notes for your reviewer**:
I removed `--pod-infra-container-image` option for kubelet. It is not needed when `--container-runtime=remote`.  https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/server.go#L190 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Containerd is supported in regions where gcr.io container registry can't be accessed.
```
