### PR TITLE
Fix node local dns issue for control plane pods

### DIFF
--- a/charts/global-network-policies/templates/allow-to-dns.yaml
+++ b/charts/global-network-policies/templates/allow-to-dns.yaml
@@ -15,6 +15,16 @@ spec:
       networking.gardener.cloud/to-dns: allowed
   egress:
   - to:
+    {{- if .Values.nodeLocalDNSEnabled }}
+    {{- if .Values.dnsServer }}
+    - ipBlock:
+        cidr: {{ .Values.dnsServer }}/32 # required for node local dns feature, allows egress traffic to kube-dns
+    {{- end }}
+    {{- if .Values.nodeLocalIPVSAddress }}
+    - ipBlock:
+        cidr: {{ .Values.nodeLocalIPVSAddress }}/32 # required for node local dns feature, allows egress traffic to node local dns cache
+    {{- end }}
+    {{- end }}
     - namespaceSelector:
         matchLabels:
           role: kube-system

--- a/charts/global-network-policies/values.yaml
+++ b/charts/global-network-policies/values.yaml
@@ -20,3 +20,7 @@ privateNetworks:
 - network: 100.64.0.0/10
   except:
   - 100.64.1.0/24
+
+dnsServer:  ""
+nodeLocalIPVSAddress: ""
+nodeLocalDNSEnabled: false

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -729,8 +729,11 @@ func getResourcesForAPIServer(nodeCount int32, scalingClass string) (string, str
 func (b *Botanist) deployNetworkPolicies(ctx context.Context, denyAll bool) error {
 	var (
 		globalNetworkPoliciesValues = map[string]interface{}{
-			"blockedAddresses": b.Seed.Info.Spec.Networks.BlockCIDRs,
-			"denyAll":          denyAll,
+			"blockedAddresses":     b.Seed.Info.Spec.Networks.BlockCIDRs,
+			"denyAll":              denyAll,
+			"dnsServer":            b.Shoot.Networks.CoreDNS.String(),
+			"nodeLocalIPVSAddress": NodeLocalIPVSAddress,
+			"nodeLocalDNSEnabled":  b.Shoot.NodeLocalDNSEnabled,
 		}
 		excludeNets = []string{}
 		values      = map[string]interface{}{}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/priority normal

**What this PR does / why we need it**:
Traffic is now allowed to `cluster dns` and the `node local ipvs address` to resolve a dns resolution issue with the `NodeLocalDNS` feature for dns names in control plane pods.

**Which issue(s) this PR fixes**:
Fixes #2745

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Traffic is now allowed to `cluster dns` and the `node local ipvs address` to resolve a dns resolution issue with the `NodeLocalDNS` feature for dns names in control plane pods.
```
