### PR TITLE
[GEP-8] Deprecation warning for IGW AWS annotations

### DIFF
--- a/charts/istio/istio-ingress/templates/service.yaml
+++ b/charts/istio/istio-ingress/templates/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: istio-ingressgateway
   namespace: {{ .Release.Namespace }}
   annotations:
+    # Deprecated: These AWS-specific annotation are deprecated. You need to apply them via
+    # the '.spec.settings.loadBalancerServices.annotations' field of the Seed.
+    # TODO (mvladev): remove the annotations in v1.17.0
     service.alpha.kubernetes.io/aws-load-balancer-type: "nlb"
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 {{- if .Values.annotations }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup
/priority normal

**What this PR does / why we need it**:

Remove cloud-provider specific annotations from Istio Ingress Gateway service.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```doc operator
AWS-specific annotations set on the `istio-ingressgateway` Service are now **deprecated** and are going to be removed in the next release. Please use the `Seed`'s `spec.settings.loadBalancerServices.annotations` field to set or overwrite those annotations. For `shoot.gardener.cloud/use-as-seed` annotated `Shoot` clusters, see this [PR](https://github.com/gardener/gardener/pull/3344).
```
