### PR TITLE
Allow gcr copy of golang to be specified

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.15.5 AS builder
+FROM eu.gcr.io/gardener-project/3rd/golang:1.15.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .

--- a/hack/.ci/prepare_release
+++ b/hack/.ci/prepare_release
@@ -35,7 +35,7 @@ apk add --no-cache \
     gcc \
     sed
 
-GOLANG_VERSION="$(sed -rn 's/FROM golang:([^ ]+).*/\1/p' < "$repo_root_dir/Dockerfile")"
+GOLANG_VERSION="$(sed -rn 's/FROM (eu\.gcr\.io\/gardener-project\/3rd\/golang|golang):([^ ]+).*/\2/p' < "$repo_root_dir/Dockerfile")"
 
 export \
     GOROOT="$(go env GOROOT)" \


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows specifying also `eu.gcr.io/gardener-project/3rd/golang` image as base image in the `Dockerfile`s of the extension repositories.
Currently if `eu.gcr.io/gardener-project/3rd/golang` is set, the release script would fail with something similar to:

```
subprocess.CalledProcessError: Command '['/tmp/build/01f561ac/git-gardener.gardener-extension-os-gardenlinux-master.master/.ci/prepare_release']' returned non-zero exit status 2.
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
