### PR TITLE
Fix missing metrics-server RBAC roles

### DIFF
--- a/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server_test.go
@@ -129,6 +129,8 @@ rules:
   - pods
   - nodes
   - nodes/stats
+  - namespaces
+  - configmaps
   verbs:
   - get
   - list
@@ -206,7 +208,9 @@ spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
-  strategy: {}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
   template:
     metadata:
       annotations:
@@ -225,6 +229,7 @@ spec:
       containers:
       - command:
         - /metrics-server
+        - --authorization-always-allow-paths=/livez,/readyz
         - --profiling=false
         - --cert-dir=/home/certdir
         - --secure-port=8443
@@ -292,7 +297,9 @@ spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
-  strategy: {}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
   template:
     metadata:
       annotations:
@@ -311,6 +318,7 @@ spec:
       containers:
       - command:
         - /metrics-server
+        - --authorization-always-allow-paths=/livez,/readyz
         - --profiling=false
         - --cert-dir=/home/certdir
         - --secure-port=8443


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/priority normal

**What this PR does / why we need it**:
After #3174 the metrics-server lacks some RBAC permissions which make him fail to start. See also https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.4.1/components.yaml.

**Special notes for your reviewer**:
/invite @ialidzhikov @vpnachev 
/cc @dguendisch @mvladev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
