### PR TITLE
Fix test namespace dump accidentally reusing a potentially expired context

### DIFF
--- a/test/framework/shootframework.go
+++ b/test/framework/shootframework.go
@@ -141,7 +141,9 @@ func (f *ShootFramework) AfterEach(ctx context.Context) {
 		}
 		err = f.WaitUntilNamespaceIsDeleted(ctx, f.ShootClient, f.Namespace)
 		if err != nil {
-			err2 := f.DumpDefaultResourcesInNamespace(ctx, fmt.Sprintf("[SHOOT %s] [NAMESPACE %s]", f.Shoot.Name, f.Namespace), f.ShootClient, f.Namespace)
+			ctx2, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			defer cancel()
+			err2 := f.DumpDefaultResourcesInNamespace(ctx2, fmt.Sprintf("[SHOOT %s] [NAMESPACE %s]", f.Shoot.Name, f.Namespace), f.ShootClient, f.Namespace)
 			ExpectNoError(err2)
 		}
 		ExpectNoError(err)


### PR DESCRIPTION
**How to categorize this PR?**

/area testing
/kind bug
/priority normal

**What this PR does / why we need it**:

In case of errors during test namespace deletion some k8s resources of the namespace are dumped. This dumping however reused the given context which at this point in time might already have been expired.
Therefore a new context with 1min is created to allow resource dumping.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

