### PR TITLE
Log checkAPIServerAvailability errors

### DIFF
--- a/pkg/controllermanager/controller/plant/plant_health.go
+++ b/pkg/controllermanager/controller/plant/plant_health.go
@@ -20,6 +20,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 
 	corev1 "k8s.io/api/core/v1"
@@ -57,11 +58,13 @@ func (h *HealthChecker) CheckPlantClusterNodes(ctx context.Context, condition ga
 	return updatedCondition
 }
 
+var nopLogger = logger.NewNopLogger()
+
 // CheckAPIServerAvailability checks if the API server of a Plant cluster is reachable and measure the response time.
 func (h *HealthChecker) CheckAPIServerAvailability(ctx context.Context, condition gardencorev1beta1.Condition) gardencorev1beta1.Condition {
 	return health.CheckAPIServerAvailability(ctx, condition, h.discoveryClient.RESTClient(), func(conditionType, message string) gardencorev1beta1.Condition {
 		return gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionFalse, conditionType, message)
-	})
+	}, nopLogger)
 }
 
 func (h *HealthChecker) checkNodes(condition gardencorev1beta1.Condition, nodeList *corev1.NodeList) (gardencorev1beta1.Condition, error) {

--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -401,7 +401,7 @@ func (b *HealthChecker) FailedCondition(condition gardencorev1beta1.Condition, r
 func (b *Botanist) checkAPIServerAvailability(ctx context.Context, checker *HealthChecker, condition gardencorev1beta1.Condition) gardencorev1beta1.Condition {
 	return health.CheckAPIServerAvailability(ctx, condition, b.K8sShootClient.RESTClient(), func(conditionType, message string) gardencorev1beta1.Condition {
 		return checker.FailedCondition(condition, conditionType, message)
-	})
+	}, b.Logger)
 }
 
 // CheckClusterNodes checks whether cluster nodes in the given listers are healthy and within the desired range.

--- a/pkg/utils/kubernetes/health/health.go
+++ b/pkg/utils/kubernetes/health/health.go
@@ -35,6 +35,7 @@ import (
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
+	"github.com/sirupsen/logrus"
 )
 
 func requiredConditionMissing(conditionType string) error {
@@ -340,7 +341,7 @@ var Now = time.Now
 type conditionerFunc func(conditionType string, message string) gardencorev1beta1.Condition
 
 // CheckAPIServerAvailability checks if the API server of a cluster is reachable and measure the response time.
-func CheckAPIServerAvailability(ctx context.Context, condition gardencorev1beta1.Condition, restClient rest.Interface, conditioner conditionerFunc) gardencorev1beta1.Condition {
+func CheckAPIServerAvailability(ctx context.Context, condition gardencorev1beta1.Condition, restClient rest.Interface, conditioner conditionerFunc, log logrus.FieldLogger) gardencorev1beta1.Condition {
 	now := Now()
 	response := restClient.Get().AbsPath("/healthz").Do(ctx)
 	responseDurationText := fmt.Sprintf("[response_time:%dms]", Now().Sub(now).Nanoseconds()/time.Millisecond.Nanoseconds())
@@ -362,6 +363,7 @@ func CheckAPIServerAvailability(ctx context.Context, condition gardencorev1beta1
 			body = string(bodyRaw)
 		}
 		message := fmt.Sprintf("API server /healthz endpoint check returned a non ok status code %d. (%s)", statusCode, body)
+		log.Error(message)
 		return conditioner("HealthzRequestError", message)
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR make the `checkAPIServerAvailability` health check log the actual error (HTTP response code + body) that happened when calling the `/healthz` endpoint of the API server.

**Special notes for your reviewer**:
/cc @wyb1 @istvanballok

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Gardenlet now logs the HTTP response of failed shoot health checks for `checkAPIServerAvailability`.
```
