### PR TITLE
Reconcile Infrastructure for hibernated clusters

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -195,9 +195,7 @@ func (c *defaultMaintenanceControl) Maintain(shootObj *gardencorev1beta1.Shoot, 
 			metav1.SetMetaDataAnnotation(&s.ObjectMeta, v1beta1constants.GardenerOperation, common.ShootOperationRetry)
 		}
 
-		if !gardencorev1beta1helper.HibernationIsEnabled(s) {
-			controllerutils.AddTasks(s.Annotations, common.ShootTaskDeployInfrastructure)
-		}
+		controllerutils.AddTasks(s.Annotations, common.ShootTaskDeployInfrastructure)
 		if utils.IsTrue(c.config.EnableShootControlPlaneRestarter) {
 			controllerutils.AddTasks(s.Annotations, common.ShootTaskRestartControlPlanePods)
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
https://github.com/gardener/gardener/commit/29b45ab868a5e5ba3c80f9da4c020241350292ee skipped infrastructure reconciliation during maintenance to save infrastructure calls as well as our previous logging stack couldn't deal with Terraformer logs while the logging endpoint was not available. We can now enable infrastructure reconciliation again for these clusters, since the current logging implementation just disregards component logs while the cluster is hibernated (/cc @vlvasilev). Furthermore, regular infra reconciliation is especially necessary for long-term hibernated clusters because only certain versions of Gardener and Extensions may contain important migration logic.

**Special notes for your reviewer**:
/cc @ialidzhikov @dkistner 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Gardener triggers an infrastructure reconciliation during maintenance also for hibernated clusters. This ensures that the infrastructure is always up-to-date, even for long-term hibernated clusters.
```
