### PR TITLE
Fix namespace not resetting on deletion failures and beautify dump output

### DIFF
--- a/test/framework/dump.go
+++ b/test/framework/dump.go
@@ -302,6 +302,18 @@ func (f *CommonFramework) dumpDaemonSetInfoForNamespace(ctx context.Context, ctx
 	return nil
 }
 
+// dumpNamespaceResource prints information about the Namespace itself
+func (f *CommonFramework) dumpNamespaceResource(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string) error {
+	f.Logger.Infof("%s [NAMESPACE RESOURCE %s]", ctxIdentifier, namespace)
+	ns := &corev1.Namespace{}
+	if err := k8sClient.DirectClient().Get(ctx, client.ObjectKey{Name: namespace}, ns); err != nil {
+		return err
+	}
+	f.Logger.Printf("Namespace %s - Spec %+v - Status %+v", namespace, ns.Spec, ns.Status)
+	f.Logger.Println()
+	return nil
+}
+
 // dumpServiceInfoForNamespace prints information about all Services of a namespace
 func (f *CommonFramework) dumpServiceInfoForNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string) error {
 	f.Logger.Infof("%s [NAMESPACE %s] [SERVICES]", ctxIdentifier, namespace)
@@ -310,7 +322,7 @@ func (f *CommonFramework) dumpServiceInfoForNamespace(ctx context.Context, ctxId
 		return err
 	}
 	for _, service := range services.Items {
-		f.Logger.Printf("Service %s - Spec %v - Status %v", service.Name, service.Spec, service.Status)
+		f.Logger.Printf("Service %s - Spec %+v - Status %+v", service.Name, service.Spec, service.Status)
 	}
 	f.Logger.Println()
 	return nil
@@ -324,7 +336,7 @@ func (f *CommonFramework) dumpVolumeInfoForNamespace(ctx context.Context, ctxIde
 		return err
 	}
 	for _, pvc := range pvcs.Items {
-		f.Logger.Printf("PVC %s - Spec %v - Status %v", pvc.Name, pvc.Spec, pvc.Status)
+		f.Logger.Printf("PVC %s - Spec %+v - Status %+v", pvc.Name, pvc.Spec, pvc.Status)
 	}
 	f.Logger.Println()
 
@@ -334,7 +346,7 @@ func (f *CommonFramework) dumpVolumeInfoForNamespace(ctx context.Context, ctxIde
 		return err
 	}
 	for _, pv := range pvs.Items {
-		f.Logger.Printf("PV %s - Spec %v - Status %v", pv.Name, pv.Spec, pv.Status)
+		f.Logger.Printf("PV %s - Spec %+v - Status %+v", pv.Name, pv.Spec, pv.Status)
 	}
 	f.Logger.Println()
 	return nil

--- a/test/framework/shootframework.go
+++ b/test/framework/shootframework.go
@@ -133,22 +133,24 @@ func (f *ShootFramework) AfterEach(ctx context.Context) {
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: f.Namespace},
 		}
+		f.Namespace = ""
 		err := f.ShootClient.DirectClient().Delete(ctx, ns)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
 				ExpectNoError(err)
 			}
 		}
-		err = f.WaitUntilNamespaceIsDeleted(ctx, f.ShootClient, f.Namespace)
+		err = f.WaitUntilNamespaceIsDeleted(ctx, f.ShootClient, ns.Name)
 		if err != nil {
 			ctx2, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 			defer cancel()
-			err2 := f.DumpDefaultResourcesInNamespace(ctx2, fmt.Sprintf("[SHOOT %s] [NAMESPACE %s]", f.Shoot.Name, f.Namespace), f.ShootClient, f.Namespace)
+			err2 := f.dumpNamespaceResource(ctx2, fmt.Sprintf("[SHOOT %s] [NAMESPACE %s]", f.Shoot.Name, ns.Name), f.ShootClient, ns.Name)
+			ExpectNoError(err2)
+			err2 = f.DumpDefaultResourcesInNamespace(ctx2, fmt.Sprintf("[SHOOT %s] [NAMESPACE %s]", f.Shoot.Name, ns.Name), f.ShootClient, ns.Name)
 			ExpectNoError(err2)
 		}
 		ExpectNoError(err)
-		f.Namespace = ""
-		ginkgo.By(fmt.Sprintf("deleted test namespace %s", f.Namespace))
+		ginkgo.By(fmt.Sprintf("deleted test namespace %s", ns.Name))
 	}
 }
 


### PR DESCRIPTION
**How to categorize this PR?**

/area testing
/kind bug
/kind enhancement
/priority normal

**What this PR does / why we need it**:

- test namespaces were not reset on `AfterEach` if the ns deletion failed, resulting in subsequent tests accidentally trying to cleanup this namespace later again.
- added a dump of the namespace itself (spec and status) if ns deletion fails
- beautified dumps of other resources (i.e. services) as their field names were missing, which made it hard to debug their output