### PR TITLE
Fix statefulset name retrieval for etcd

### DIFF
--- a/pkg/operation/botanist/controlplane/etcd/etcd.go
+++ b/pkg/operation/botanist/controlplane/etcd/etcd.go
@@ -173,7 +173,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 	}
 
 	stsName := Name(e.role)
-	if foundEtcd {
+	if foundEtcd && existingEtcd.Status.Etcd.Name != "" {
 		stsName = existingEtcd.Status.Etcd.Name
 	}
 

--- a/pkg/operation/botanist/controlplane/etcd/etcd_test.go
+++ b/pkg/operation/botanist/controlplane/etcd/etcd_test.go
@@ -923,7 +923,7 @@ var _ = Describe("Etcd", func() {
 								},
 								Status: druidv1alpha1.EtcdStatus{
 									Etcd: druidv1alpha1.CrossVersionObjectReference{
-										Name: etcdName,
+										Name: "",
 									},
 								},
 							}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:
The etcd refactoring #3129 introduced a bug when retrieving the name of the statefulset, see https://github.com/gardener/gardener/blob/release-v1.12/pkg/operation/botanist/controlplane.go#L1502

**Which issue(s) this PR fixes**:
Fixes gardener/hvpa-controller#82

**Special notes for your reviewer**:
Thanks @ialidzhikov for spotting!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
