### PR TITLE
Special handling for central cadvisor scrape config relabel config

### DIFF
--- a/charts/seed-bootstrap/templates/prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/config.yaml
@@ -63,6 +63,9 @@ data:
       - source_labels: [ pod ]
         regex: ^.+\.tf-pod.+$
         action: drop
+{{- if .Values.prometheus.additionalCAdvisorScrapeConfigMetricRelabelConfigs }}
+{{ toString .Values.prometheus.additionalCAdvisorScrapeConfigMetricRelabelConfigs | indent 6 }}
+{{- end }}
 
     - job_name: kubelet
       honor_labels: false

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -5,6 +5,7 @@ prometheus:
   port: 9090
   storage: 10Gi
   additionalScrapeConfigs: ""
+  additionalCAdvisorScrapeConfigMetricRelabelConfigs: ""
 
 aggregatePrometheus:
   port: 9090

--- a/pkg/operation/botanist/component/types.go
+++ b/pkg/operation/botanist/component/types.go
@@ -28,6 +28,8 @@ type Secret struct {
 type CentralMonitoringConfig struct {
 	// ScrapeConfigs are the scrape configurations for central Prometheus.
 	ScrapeConfigs []string
+	// CAdvisorScrapeConfigMetricRelabelConfigs are metric_relabel_configs for the cadvisor scrape config job.
+	CAdvisorScrapeConfigMetricRelabelConfigs []string
 }
 
 // CentralLoggingConfig is a structure that contains configuration for the central logging stack.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug
/priority normal

**What this PR does / why we need it**:
The etcd component refactoring in #3129 introduced a new scrape config job for cadvisor just for etcd.
However, it seems that the cadvisor job in the central monitoring is so special that we should also handle it special, i.e., allow components to contribute metric relabel configs to it.

**Special notes for your reviewer**:
/cc @ialidzhikov @wyb1 @istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
