### PR TITLE
Fix flaky test in managed resource registry utility

### DIFF
--- a/pkg/utils/managedresources/registry_test.go
+++ b/pkg/utils/managedresources/registry_test.go
@@ -148,10 +148,10 @@ roleRef:
 			Expect(registry.Add(secret)).To(Succeed())
 			Expect(registry.Add(roleBinding)).To(Succeed())
 
-			Expect(registry.String()).To(Equal(`* ` + secretFilename + `:
-` + string(secretSerialized) + `
-
-* ` + roleBindingFilename + `:
+			result := registry.String()
+			Expect(result).To(ContainSubstring(`* ` + secretFilename + `:
+` + string(secretSerialized)))
+			Expect(result).To(ContainSubstring(`* ` + roleBindingFilename + `:
 ` + string(roleBindingSerialized)))
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake
/priority normal

**What this PR does / why we need it**:
The test is flaky because the implementation iterates over the registry `map` which does not have a stable order, see https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-pull-request-job/builds/23.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
