### PR TITLE
Allow injecting arbitrary EnvVars into terraformer pods

### DIFF
--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -357,19 +357,16 @@ func (t *terraformer) env() []corev1.EnvVar {
 	var envVars []corev1.EnvVar
 
 	if !t.useV2 {
-		envVars = []corev1.EnvVar{
+		envVars = append(envVars, []corev1.EnvVar{
 			{Name: "MAX_BACKOFF_SEC", Value: "60"},
 			{Name: "MAX_TIME_SEC", Value: "1800"},
 			{Name: "TF_CONFIGURATION_CONFIG_MAP_NAME", Value: t.configName},
 			{Name: "TF_STATE_CONFIG_MAP_NAME", Value: t.stateName},
 			{Name: "TF_VARIABLES_SECRET_NAME", Value: t.variablesName},
-		}
+		}...)
 	}
 
-	for k, v := range t.variablesEnvironment {
-		envVars = append(envVars, corev1.EnvVar{Name: k, Value: v})
-	}
-	return envVars
+	return append(envVars, t.envVars...)
 }
 
 // listTerraformerPods lists all pods in the Terraformer namespace which have labels 'terraformer.gardener.cloud/name'

--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,8 +33,8 @@ import (
 // * configName is the name of the ConfigMap containing the main Terraform file ('main.tf').
 // * variablesName is the name of the Secret containing the Terraform variables ('terraform.tfvars').
 // * stateName is the name of the ConfigMap containing the Terraform state ('terraform.tfstate').
-// * variablesEnvironment is a map of environment variables which will be injected in the resulting
-//   Terraform job/pod. These variables should contain Terraform variables (i.e., must be prefixed
+// * envVars is a list of environment variables which will be injected in the resulting
+//   Terraform pod. These variables can contain Terraform variables (i.e., must be prefixed
 //   with TF_VAR_).
 // * configurationDefined indicates whether the required configuration ConfigMaps/Secrets have been
 //   successfully defined.
@@ -57,7 +58,7 @@ type terraformer struct {
 	configName           string
 	variablesName        string
 	stateName            string
-	variablesEnvironment map[string]string
+	envVars              []corev1.EnvVar
 	configurationDefined bool
 
 	logLevel                      string
@@ -96,7 +97,9 @@ const (
 type Terraformer interface {
 	UseV2(bool) Terraformer
 	SetLogLevel(string) Terraformer
+	// Deprecated: use SetEnvVars instead
 	SetVariablesEnvironment(tfVarsEnvironment map[string]string) Terraformer
+	SetEnvVars(envVars ...corev1.EnvVar) Terraformer
 	SetTerminationGracePeriodSeconds(int64) Terraformer
 	SetDeadlineCleaning(time.Duration) Terraformer
 	SetDeadlinePod(time.Duration) Terraformer

--- a/pkg/mock/gardener/extensions/terraformer/mocks.go
+++ b/pkg/mock/gardener/extensions/terraformer/mocks.go
@@ -12,7 +12,8 @@ import (
 	terraformer "github.com/gardener/gardener/extensions/pkg/terraformer"
 	gomock "github.com/golang/mock/gomock"
 	logrus "github.com/sirupsen/logrus"
-	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	v1 "k8s.io/api/core/v1"
+	v10 "k8s.io/client-go/kubernetes/typed/core/v1"
 	rest "k8s.io/client-go/rest"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -231,6 +232,24 @@ func (mr *MockTerraformerMockRecorder) SetDeadlinePod(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDeadlinePod", reflect.TypeOf((*MockTerraformer)(nil).SetDeadlinePod), arg0)
 }
 
+// SetEnvVars mocks base method.
+func (m *MockTerraformer) SetEnvVars(arg0 ...v1.EnvVar) terraformer.Terraformer {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SetEnvVars", varargs...)
+	ret0, _ := ret[0].(terraformer.Terraformer)
+	return ret0
+}
+
+// SetEnvVars indicates an expected call of SetEnvVars.
+func (mr *MockTerraformerMockRecorder) SetEnvVars(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEnvVars", reflect.TypeOf((*MockTerraformer)(nil).SetEnvVars), arg0...)
+}
+
 // SetLogLevel mocks base method.
 func (m *MockTerraformer) SetLogLevel(arg0 string) terraformer.Terraformer {
 	m.ctrl.T.Helper()
@@ -376,7 +395,7 @@ func (mr *MockFactoryMockRecorder) DefaultInitializer(arg0, arg1, arg2, arg3, ar
 }
 
 // New mocks base method.
-func (m *MockFactory) New(arg0 logrus.FieldLogger, arg1 client.Client, arg2 v1.CoreV1Interface, arg3, arg4, arg5, arg6 string) terraformer.Terraformer {
+func (m *MockFactory) New(arg0 logrus.FieldLogger, arg1 client.Client, arg2 v10.CoreV1Interface, arg3, arg4, arg5, arg6 string) terraformer.Terraformer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "New", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(terraformer.Terraformer)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security quality
/kind cleanup
/priority normal

**What this PR does / why we need it**:

Currently, the terraformer library offers only one mechanism for injecting environment variables into terraformer pods:
setting the plain values directly in the `PodSpec` via `Terraformer.SetVariablesEnvironment`.
This is not desirable or acceptable for some cases, especially from a security point-of-view, e.g. for setting terraform variables (i.e. infrastructure credentials) via env vars (`TF_VAR_*`) like most provider extensions hosted under the gardener org do.

This PR deprecates the old `Terraformer.SetVariablesEnvironment` function in favor of the newly added and more flexible `Terraformer.SetEnvVars` function.
The new function allows to inject arbitrary `corev1.EnvVars` into the `PodSpec` (e.g. with a `secretKeyRef`).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action developer
`Terraformer.SetVariablesEnvironment` has been deprecated in favor of `Terraformer.SetEnvVars`. Please adapt your usage of the terraformer library accordingly.
```
