### PR TITLE
Refactor seed bootstrapping to DeployWaiter components

### DIFF
--- a/pkg/operation/botanist/component/interfaces.go
+++ b/pkg/operation/botanist/component/interfaces.go
@@ -18,8 +18,6 @@ import (
 	"context"
 
 	"github.com/gardener/gardener/pkg/apis/core/v1alpha1"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Deployer is used to control the life-cycle of a component.
@@ -65,13 +63,6 @@ type CentralLoggingConfiguration func() (CentralLoggingConfig, error)
 
 // DependencyWatchdogConfiguration is a function alias for returning configuration for the dependency-watchdog.
 type DependencyWatchdogConfiguration func() (string, error)
-
-// BootstrapSeed is a function alias for components that require to bootstrap the seed cluster.
-type BootstrapSeed func(ctx context.Context, c client.Client, namespace, version string) error
-
-// DebootstrapSeed is a function alias for components that need to delete resources from the seed cluster that were
-// created during seed bootstrapping.
-type DebootstrapSeed func(ctx context.Context, c client.Client, namespace string) error
 
 // DeployWaiter controls and waits for life-cycle operations of a component.
 type DeployWaiter interface {

--- a/pkg/operation/botanist/controlplane/clusterautoscaler/bootstrap.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/bootstrap.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 
@@ -33,12 +34,20 @@ const (
 	managedResourceControlName = "cluster-autoscaler"
 )
 
-// TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy
-// or deleted.
-var TimeoutWaitForManagedResource = 2 * time.Minute
+// NewBootstrapper creates a new instance of DeployWaiter for the cluster-autoscaler bootstrapper.
+func NewBootstrapper(client client.Client, namespace string) component.DeployWaiter {
+	return &bootstrapper{
+		client:    client,
+		namespace: namespace,
+	}
+}
 
-// BootstrapSeed deploys the RBAC configuration for the control cluster.
-func BootstrapSeed(ctx context.Context, c client.Client, namespace, _ string) error {
+type bootstrapper struct {
+	client    client.Client
+	namespace string
+}
+
+func (b *bootstrapper) Deploy(ctx context.Context) error {
 	var (
 		registry = managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 
@@ -61,24 +70,27 @@ func BootstrapSeed(ctx context.Context, c client.Client, namespace, _ string) er
 		return err
 	}
 
-	if err := common.DeployManagedResourceForSeed(ctx, c, managedResourceControlName, namespace, false, resources); err != nil {
-		return err
-	}
-
-	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
-	defer cancel()
-
-	return managedresources.WaitUntilManagedResourceHealthy(timeoutCtx, c, namespace, managedResourceControlName)
+	return common.DeployManagedResourceForSeed(ctx, b.client, managedResourceControlName, b.namespace, false, resources)
 }
 
-// DebootstrapSeed deletes all the resources deployed during the seed bootstrapping.
-func DebootstrapSeed(ctx context.Context, c client.Client, namespace string) error {
-	if err := common.DeleteManagedResourceForSeed(ctx, c, managedResourceControlName, namespace); err != nil {
-		return err
-	}
+func (b *bootstrapper) Destroy(ctx context.Context) error {
+	return common.DeleteManagedResourceForSeed(ctx, b.client, managedResourceControlName, b.namespace)
+}
 
+// TimeoutWaitForManagedResource is the timeout used while waiting for the ManagedResources to become healthy
+// or deleted.
+var TimeoutWaitForManagedResource = 2 * time.Minute
+
+func (b *bootstrapper) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
 	defer cancel()
 
-	return managedresources.WaitUntilManagedResourceDeleted(timeoutCtx, c, namespace, managedResourceControlName)
+	return managedresources.WaitUntilManagedResourceHealthy(timeoutCtx, b.client, b.namespace, managedResourceControlName)
+}
+
+func (b *bootstrapper) WaitCleanup(ctx context.Context) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
+	defer cancel()
+
+	return managedresources.WaitUntilManagedResourceDeleted(timeoutCtx, b.client, b.namespace, managedResourceControlName)
 }

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -769,30 +769,16 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 	}
 
 	// Deploy component specific resources
+	bootstrapComponents, err := bootstrapComponents(k8sSeedClient, v1beta1constants.GardenNamespace, imageVector, imageVectorOverwrites)
+	if err != nil {
+		return err
+	}
+
 	var bootstrapFunctions []flow.TaskFn
-	for _, componentFn := range []component.BootstrapSeed{
-		clusterautoscaler.BootstrapSeed,
-		func(ctx context.Context, c client.Client, namespace, version string) error {
-			image, err := imageVector.FindImage(
-				common.EtcdDruidImageName,
-				imagevector.RuntimeVersion(k8sSeedClient.Version()),
-				imagevector.TargetVersion(k8sSeedClient.Version()),
-			)
-			if err != nil {
-				return err
-			}
-
-			var imageVectorOverwrite *string
-			if val, ok := imageVectorOverwrites[etcd.Druid]; ok {
-				imageVectorOverwrite = &val
-			}
-
-			return etcd.BootstrapSeed(ctx, c, namespace, version, image.String(), imageVectorOverwrite)
-		},
-	} {
+	for _, componentFn := range bootstrapComponents {
 		fn := componentFn
 		bootstrapFunctions = append(bootstrapFunctions, func(ctx context.Context) error {
-			return fn(ctx, k8sSeedClient.Client(), v1beta1constants.GardenNamespace, k8sSeedClient.Version())
+			return component.OpWaiter(fn).Deploy(ctx)
 		})
 	}
 
@@ -801,18 +787,49 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 
 // DebootstrapCluster deletes certain resources from the seed cluster.
 func DebootstrapCluster(ctx context.Context, k8sSeedClient kubernetes.Interface) error {
+	bootstrapComponents, err := bootstrapComponents(k8sSeedClient, v1beta1constants.GardenNamespace, nil, nil)
+	if err != nil {
+		return err
+	}
+
 	// Delete component specific resources
 	var debootstrapFunctions []flow.TaskFn
-	for _, componentFn := range []component.DebootstrapSeed{
-		clusterautoscaler.DebootstrapSeed,
-		etcd.DebootstrapSeed,
-	} {
+	for _, componentFn := range bootstrapComponents {
+		fn := componentFn
 		debootstrapFunctions = append(debootstrapFunctions, func(ctx context.Context) error {
-			return componentFn(ctx, k8sSeedClient.Client(), v1beta1constants.GardenNamespace)
+			return component.OpDestroyAndWait(fn).Destroy(ctx)
 		})
 	}
 
 	return flow.Parallel(debootstrapFunctions...)(ctx)
+}
+
+func bootstrapComponents(c kubernetes.Interface, namespace string, imageVector imagevector.ImageVector, imageVectorOverwrites map[string]string) ([]component.DeployWaiter, error) {
+	var components []component.DeployWaiter
+
+	// cluster-autoscaler
+	components = append(components, clusterautoscaler.NewBootstrapper(c.Client(), namespace))
+
+	// etcd
+	var (
+		etcdImage                string
+		etcdImageVectorOverwrite *string
+	)
+	if imageVector != nil {
+		image, err := imageVector.FindImage(common.EtcdDruidImageName, imagevector.RuntimeVersion(c.Version()), imagevector.TargetVersion(c.Version()))
+		if err != nil {
+			return nil, err
+		}
+		etcdImage = image.String()
+	}
+	if imageVectorOverwrites != nil {
+		if val, ok := imageVectorOverwrites[etcd.Druid]; ok {
+			etcdImageVectorOverwrite = &val
+		}
+	}
+	components = append(components, etcd.NewBootstrapper(c.Client(), namespace, etcdImage, c.Version(), etcdImageVectorOverwrite))
+
+	return components, nil
 }
 
 // DesiredExcessCapacity computes the required resources (CPU and memory) required to deploy new shoot control planes


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality dev-productivity
/kind cleanup
/priority normal

**What this PR does / why we need it**:
This PR refactors the (de-)bootstrap functions for components by using the `DeployWaiter` interface instead of function aliases as suggested by @timuthy.

Part of #2754

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
