### PR TITLE
Expose further configuration options for gardener-apiserver

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
@@ -84,6 +84,6 @@ webhooks:
       path: /webhooks/validate-resource-size
     {{- end }}
     caBundle: {{ required ".Values.global.admission.config.server.https.tls.caBundle is required" (b64enc .Values.global.admission.config.server.https.tls.caBundle) }}
-{{- end }}
   sideEffects: None
+{{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/_helpers.tpl
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/_helpers.tpl
@@ -22,3 +22,20 @@ true
 true
 {{- end -}}
 {{- end -}}
+
+{{- define "gardener-apiserver.watchCacheSizes" -}}
+{{- with .Values.global.apiserver.watchCacheSizes }}
+{{- if not (kindIs "invalid" .default) }}
+- --default-watch-cache-size={{ .default }}
+{{- end }}
+{{- with .resources }}
+- --watch-cache-sizes={{ include "gardener-apiserver.resourceWatchCacheSize" . | trimSuffix "," }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "gardener-apiserver.resourceWatchCacheSize" -}}
+{{- range . }}
+{{- required ".resource is required" .resource }}{{ if .apiGroup }}.{{ .apiGroup }}{{ end }}#{{ .size }},
+{{- end -}}
+{{- end -}}

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -201,14 +201,38 @@ spec:
         {{- end }}
         {{- end }}
         {{- include "gardener-apiserver.featureGates" . | trimSuffix "," | indent 8 }}
+        {{- if .Values.global.apiserver.goAwayChance }}
+        - --goaway-chance={{ .Values.global.apiserver.goAwayChance }}
+        {{- end }}
+        {{- if .Values.global.apiserver.http2MaxStreamsPerConnection }}
+        - --http2-max-streams-per-connection={{ .Values.global.apiserver.http2MaxStreamsPerConnection }}
+        {{- end }}
         {{- if .Values.global.apiserver.kubeconfig }}
         - --authentication-kubeconfig=/etc/gardener-apiserver/kubeconfig/kubeconfig
         - --authorization-kubeconfig=/etc/gardener-apiserver/kubeconfig/kubeconfig
         - --kubeconfig=/etc/gardener-apiserver/kubeconfig/kubeconfig
         {{- end }}
+        {{- if .Values.global.apiserver.requests }}
+        {{- if .Values.global.apiserver.requests.maxMutatingInflight }}
+        - --max-mutating-requests-inflight={{ .Values.global.apiserver.requests.maxMutatingInflight }}
+        {{- end }}
+        {{- if .Values.global.apiserver.requests.maxNonMutatingInflight }}
+        - --max-requests-inflight={{ .Values.global.apiserver.requests.maxNonMutatingInflight }}
+        {{- end }}
+        {{- if .Values.global.apiserver.requests.minTimeout }}
+        - --min-request-timeout={{ .Values.global.apiserver.requests.minTimeout }}
+        {{- end }}
+        {{- if .Values.global.apiserver.requests.timeout }}
+        - --request-timeout={{ .Values.global.apiserver.requests.timeout }}
+        {{- end }}
+        {{- end }}
         - --secure-port=443
+        {{- if .Values.global.apiserver.shutdownDelayDuration }}
+        - --shutdown-delay-duration={{ .Values.global.apiserver.shutdownDelayDuration }}
+        {{- end }}
         - --tls-cert-file=/etc/gardener-apiserver/srv/gardener-apiserver.crt
         - --tls-private-key-file=/etc/gardener-apiserver/srv/gardener-apiserver.key
+        {{- include "gardener-apiserver.watchCacheSizes" . | indent 8 }}
         - --v=2
         lifecycle:
           preStop:

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -163,6 +163,21 @@ global:
           value: "1G"
           percentage: 70
 
+ #  goAwayChance: 0.1
+ #  http2MaxStreamsPerConnection: 1000
+ #  shutdownDelayDuration: 20s
+ #  requests:
+ #    maxNonMutatingInflight: 400
+ #    maxMutatingInflight: 200
+ #    minTimeout: 1m0s
+ #    timeout: 1m0s
+ #  watchCacheSizes:
+ #    default: 100
+ #    resources:
+ #    - apiGroup: core.gardener.cloud
+ #      resource: shoots
+ #      size: 500
+
     audit:
  #    dynamicConfiguration: false                             Enables dynamic audit configuration. This feature also requires the DynamicAuditing feature flag
       log:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR we expose a bunch of more options for the gardener-apiserver related to scalability:

```
diff /tmp/old /tmp/new
6a7
>       --advertise-address ip                                    The IP address on which to advertise the apiserver to members of the cluster. This address must be reachable by the rest of the cluster. If blank, the --bind-address will be used. If --bind-address is unspecified, the host's default interface will be used.
51a53
>       --cors-allowed-origins strings                            List of allowed origins for CORS, comma separated.  An allowed origin can be a regular expression to support subdomain matching. If this list is empty CORS will not be enabled.
57a60
>       --enable-priority-and-fairness                            If true and the APIPriorityAndFairness feature gate is enabled, replace the max-in-flight handler with an enhanced one that queues and dispatches with priority and fairness (default true)
66a70
>       --external-hostname string                                The hostname to use when generating externalized URLs for this master (e.g. Swagger API Docs or OpenID Discovery).
83a88
>       --goaway-chance float                                     To prevent HTTP/2 clients from getting stuck on a single apiserver, randomly close a connection (GOAWAY). The client's other in-flight requests won't be affected, and the client will reconnect, likely landing on a different apiserver after going through the load balancer again. This argument sets the fraction of requests that will be sent a GOAWAY. Clusters with single apiservers, or which don't use a load balancer, should NOT enable this. Min is 0 (off), Max is .02 (1/50 requests); .001 (1/1000) is a recommended starting point.
86a92
>       --livez-grace-period duration                             This option represents the maximum amount of time it should take for apiserver to complete its startup sequence and become live. From apiserver's start time to when this amount of time has elapsed, /livez will assume that unfinished post-start hooks will complete successfully and therefore return true.
93a100,103
>       --master-service-namespace string                         DEPRECATED: the namespace from which the Kubernetes master services should be injected into pods. (default "default")
>       --max-mutating-requests-inflight int                      The maximum number of mutating requests in flight at a given time. When the server exceeds this, it rejects requests. Zero for no limit. (default 200)
>       --max-requests-inflight int                               The maximum number of non-mutating requests in flight at a given time. When the server exceeds this, it rejects requests. Zero for no limit. (default 400)
>       --min-request-timeout int                                 An optional field indicating the minimum number of seconds a handler must keep a request open before timing it out. Currently only honored by the watch request handler, which picks a randomized value above this number as the connection timeout, to spread out load. (default 1800)
94a105
>       --request-timeout duration                                An optional field indicating the duration a handler must keep a request open before timing it out. This is the default request timeout for requests but may be overridden by flags such as --min-request-timeout for specific types of requests. (default 1m0s)
100a112
>       --shutdown-delay-duration duration                        Time to delay the termination. During that time the server keeps serving requests normally and /healthz returns success, but /readyz immediately returns failure. Graceful termination starts after this delay has elapsed. This can be used to allow load balancer to stop sending traffic to this server.
105a118
>       --target-ram-mb int                                       Memory limit for apiserver in MB (used to configure sizes of caches, etc.)
```

Not all of them are exposed in the Helm chart right now, but I exposed those related to scalability and request rates.

**Special notes for your reviewer**:
/assign @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The `controlplane` Helm chart for Gardener does now expose a few more configuration options for the gardener-apiserver:
* `.Values.global.apiserver.goAwayChance` configures the `--goaway-chance` flag.
* `.Values.global.apiserver.http2MaxStreamsPerConnection` configures the `--http2-max-streams-per-connection` flag.
* `.Values.global.apiserver.shutdownDelayDuration` configures the `--shutdown-delay-duration` flag.
* `.Values.global.requests.maxNonMutatingInflight` configures the `--max-requests-inflight` flag.
* `.Values.global.requests.maxMutatingInflight` configures the `--max-mutating-requests-inflight` flag.
* `.Values.global.requests.minTimeout` configures the `--min-request-timeout` flag.
* `.Values.global.requests.timeout` configures the `--request-timeout` flag.
* `.Values.global.watchCacheSizes.default` configures the `--default-watch-cache-size` flag.
* `.Values.global.watchCacheSizes.resources[]` configures the `--watch-cache-size` flag.
```
