### PR TITLE
Fix shoot constraints to not contain duplicates

### DIFF
--- a/pkg/operation/botanist/constraints_check.go
+++ b/pkg/operation/botanist/constraints_check.go
@@ -82,13 +82,13 @@ func (b *Botanist) constraintsChecks(
 
 	var newHibernationConstraint, newMaintenancePreconditionsSatisfiedConstraint *gardencorev1beta1.Condition
 
-	status, reason, message, err := b.CheckForProblematicWebhooks(ctx, hibernationPossibleConstraint)
+	status, reason, message, err := b.CheckForProblematicWebhooks(ctx)
 	if err == nil {
-		c := gardencorev1beta1helper.UpdatedCondition(hibernationPossibleConstraint, status, reason, message)
-		newHibernationConstraint = &c
+		updatedHibernationCondition := gardencorev1beta1helper.UpdatedCondition(hibernationPossibleConstraint, status, reason, message)
+		newHibernationConstraint = &updatedHibernationCondition
 
-		c = gardencorev1beta1helper.UpdatedCondition(maintenancePreconditionsSatisfiedConstraint, status, reason, message)
-		newMaintenancePreconditionsSatisfiedConstraint = &c
+		updatedMaintenanceCondition := gardencorev1beta1helper.UpdatedCondition(maintenancePreconditionsSatisfiedConstraint, status, reason, message)
+		newMaintenancePreconditionsSatisfiedConstraint = &updatedMaintenanceCondition
 	}
 
 	hibernationPossibleConstraint = newConditionOrError(hibernationPossibleConstraint, newHibernationConstraint, err)
@@ -99,7 +99,7 @@ func (b *Botanist) constraintsChecks(
 
 // CheckForProblematicWebhooks checks the Shoot for problematic webhooks which could prevent shoot worker nodes from
 // joining the cluster.
-func (b *Botanist) CheckForProblematicWebhooks(ctx context.Context, constraint gardencorev1beta1.Condition) (gardencorev1beta1.ConditionStatus, string, string, error) {
+func (b *Botanist) CheckForProblematicWebhooks(ctx context.Context) (gardencorev1beta1.ConditionStatus, string, string, error) {
 	validatingWebhookConfigs := &admissionregistrationv1beta1.ValidatingWebhookConfigurationList{}
 	if err := b.K8sShootClient.Client().List(ctx, validatingWebhookConfigs); err != nil {
 		return "", "", "", fmt.Errorf("could not get ValidatingWebhookConfigurations of Shoot cluster to check for problematic webhooks")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug
/priority normal

**What this PR does / why we need it**:
There was a bug introduced in #3173 that resulted in duplicate constraints:

```yaml
    constraints:
    - lastTransitionTime: "2020-11-23T09:35:23Z"
      lastUpdateTime: "2020-11-23T09:35:23Z"
      message: All webhooks are properly configured.
      reason: NoProblematicWebhooks
      status: "True"
      type: MaintenancePreconditionsSatisfied
    - lastTransitionTime: "2020-11-23T09:35:23Z"
      lastUpdateTime: "2020-11-23T09:35:23Z"
      message: All webhooks are properly configured.
      reason: NoProblematicWebhooks
      status: "True"
      type: MaintenancePreconditionsSatisfied
```

With this PR it's fixed and looks like this:

```yaml
    constraints:
    - lastTransitionTime: "2020-11-23T09:54:35Z"
      lastUpdateTime: "2020-11-23T09:54:35Z"
      message: All webhooks are properly configured.
      reason: NoProblematicWebhooks
      status: "True"
      type: HibernationPossible
    - lastTransitionTime: "2020-11-23T09:35:23Z"
      lastUpdateTime: "2020-11-23T09:35:23Z"
      message: All webhooks are properly configured.
      reason: NoProblematicWebhooks
      status: "True"
      type: MaintenancePreconditionsSatisfied
```

**Special notes for your reviewer**:
Thanks @mvladev for reporting!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
