### PR TITLE
Set dnsPolicy to Deault for Shoot system components

### DIFF
--- a/charts/shoot-core/components/charts/network-policies/templates/allow-to-dns.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-to-dns.yaml
@@ -26,10 +26,16 @@ spec:
     {{- end }}
     ports:
     - protocol: UDP
-      port: 53
+      port: 8053
     - protocol: TCP
-      port: 53
+      port: 8053
+  # this allows Pods with 'dnsPolicy: Default' to talk to
+  # the node's DNS provider.
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
     - protocol: UDP
-      port: 8053
+      port: 53
     - protocol: TCP
-      port: 8053
+      port: 53

--- a/charts/shoot-core/components/charts/node-problem-detector/templates/daemonset.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/templates/daemonset.yaml
@@ -30,6 +30,7 @@ spec:
 {{ toYaml .Values.annotations | indent 8 }}
 {{- end }}
     spec:
+      dnsPolicy: Default # make sure to not use the coredns for DNS resolution.
       serviceAccountName: node-problem-detector
       hostNetwork: {{ .Values.hostNetwork }}
       terminationGracePeriodSeconds: 30

--- a/charts/shoot-core/components/charts/vpn-shoot/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/vpn-shoot/templates/deployment.yaml
@@ -39,6 +39,7 @@ spec:
       automountServiceAccountToken: false
       serviceAccountName: vpn-shoot
       priorityClassName: system-cluster-critical
+      dnsPolicy: Default # make sure to not use the coredns for DNS resolution.
       nodeSelector:
         worker.gardener.cloud/system-components: "true"
       tolerations:

--- a/pkg/operation/botanist/addons/networkpolicy/shoot_network_policy_suite_test.go
+++ b/pkg/operation/botanist/addons/networkpolicy/shoot_network_policy_suite_test.go
@@ -48,7 +48,6 @@ const (
 )
 
 var _ = Describe("Shoot NetworkPolicy Chart", func() {
-
 	var (
 		c            client.Client
 		ctx          context.Context
@@ -89,24 +88,35 @@ var _ = Describe("Shoot NetworkPolicy Chart", func() {
 					},
 				},
 				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
-				Egress: []networkingv1.NetworkPolicyEgressRule{{
-					Ports: []networkingv1.NetworkPolicyPort{
-						{Protocol: &udp, Port: &port53},
-						{Protocol: &tcp, Port: &port53},
-						{Protocol: &udp, Port: &port8053},
-						{Protocol: &tcp, Port: &port8053},
-					},
-					To: []networkingv1.NetworkPolicyPeer{{
-						PodSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{{
-								Key:      "k8s-app",
-								Operator: metav1.LabelSelectorOpIn,
-								Values:   []string{"kube-dns"},
-							}},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{Protocol: &udp, Port: &port8053},
+							{Protocol: &tcp, Port: &port8053},
+						},
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{{
+										Key:      "k8s-app",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"kube-dns"},
+									}},
+								},
+							},
 						},
 					},
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{Protocol: &udp, Port: &port53},
+							{Protocol: &tcp, Port: &port53},
+						},
+						To: []networkingv1.NetworkPolicyPeer{{
+							IPBlock: &networkingv1.IPBlock{
+								CIDR: "0.0.0.0/0",
+							},
+						}},
 					},
-				},
 				},
 			},
 		}

--- a/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server.go
@@ -300,6 +300,7 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 							RunAsUser: pointer.Int64Ptr(65534),
 							FSGroup:   pointer.Int64Ptr(65534),
 						},
+						DNSPolicy:          corev1.DNSDefault, // make sure to not use the coredns for DNS resolution.
 						ServiceAccountName: serviceAccount.Name,
 						Containers: []corev1.Container{{
 							Name:            containerName,

--- a/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server_test.go
@@ -266,6 +266,7 @@ spec:
         volumeMounts:
         - mountPath: /srv/metrics-server/tls
           name: metrics-server
+      dnsPolicy: Default
       nodeSelector:
         worker.gardener.cloud/system-components: "true"
       priorityClassName: system-cluster-critical
@@ -358,6 +359,7 @@ spec:
         volumeMounts:
         - mountPath: /srv/metrics-server/tls
           name: metrics-server
+      dnsPolicy: Default
       nodeSelector:
         worker.gardener.cloud/system-components: "true"
       priorityClassName: system-cluster-critical


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/priority normal

**What this PR does / why we need it**:

The following components only talk to their respective API server and do not need any DNS resolution other than the API server:

- metrics-server
- node-problem-detector
- vpn-shoot

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`metrics-server`, `node-problem-detector` and `vpn-shoot` now have `dnsPolicy: Default` set to them to remove dependency to `coredns`.
```

/cc @DockToFuture 
