### PR TITLE
ConfigMap checksum in annotation for etcd-druid deployment

### DIFF
--- a/pkg/operation/botanist/controlplane/etcd/bootstrap.go
+++ b/pkg/operation/botanist/controlplane/etcd/bootstrap.go
@@ -243,7 +243,7 @@ func BootstrapSeed(ctx context.Context, c client.Client, namespace, seedVersion,
 		configMapImageVectorOverwrite.Data = map[string]string{druidConfigMapImageVectorOverwriteDataKey: *imageVectorOverwrite}
 		resourcesToAdd = append(resourcesToAdd, configMapImageVectorOverwrite)
 
-		deployment.Spec.Template.Labels["checksum/configmap-imagevector-overwrite"] = utils.ComputeChecksum(configMapImageVectorOverwrite.Data)
+		metav1.SetMetaDataAnnotation(&deployment.Spec.Template.ObjectMeta, "checksum/configmap-imagevector-overwrite", utils.ComputeChecksum(configMapImageVectorOverwrite.Data))
 		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: druidDeploymentVolumeNameImageVectorOverwrite,
 			VolumeSource: corev1.VolumeSource{

--- a/pkg/operation/botanist/controlplane/etcd/bootstrap_test.go
+++ b/pkg/operation/botanist/controlplane/etcd/bootstrap_test.go
@@ -262,9 +262,10 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        checksum/configmap-imagevector-overwrite: a131f53775a6f537386a63d22cf474b338bbab6d55e439b884c7dea9e148933d
       creationTimestamp: null
       labels:
-        checksum/configmap-imagevector-overwrite: a131f53775a6f537386a63d22cf474b338bbab6d55e439b884c7dea9e148933d
         gardener.cloud/role: etcd-druid
     spec:
       containers:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/priority normal

**What this PR does / why we need it**:
Without this PR it can lead to 

```yaml
  - lastTransitionTime: "2020-11-23T14:04:29Z"
    lastUpdateTime: "2020-11-23T14:00:39Z"
    message: 'Could not apply all new resources: 1 error occurred: error during apply
      of object "apps/v1/Deployment/garden/etcd-druid": Deployment.apps "etcd-druid"
      is invalid: spec.template.labels: Invalid value: "646cbdd3e64e99a57f583af8674805171fad76d18dc3e7e375c973136c59a589":
      must be no more than 63 characters'
    reason: ApplyFailed
    status: "False"
    type: ResourcesApplied
```

condition when the image vector overwrite for etcd-druid is used. Actually, the checksum should be an annotation and not a label. This was wrong even before #3099, however, the Helm chart truncated the value to 63 characters which worked around the potential issue that we hit now.

**Special notes for your reviewer**:
/invite @ialidzhikov @timebertt 
This needs to be cherry-picked to v1.13 and a hotfix needs to be released.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bugfix operator
A bug has been fixed which can lead to `Seed`s not getting ready when an image vector overwrite for the etcd-druid is configured.
```
