### PR TITLE
Remove GardenerID and GardenerName checks from CheckSeed method

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -205,7 +205,7 @@ func (c *Controller) reconcileShootRequest(req reconcile.Request) (reconcile.Res
 	log = log.WithField("operation", "reconcile")
 
 	if shouldPrepareShootForMigration(shoot) {
-		if err := c.isSeedAvailable(seed); err != nil {
+		if err := c.isSeedReadyForMigration(seed); err != nil {
 			return reconcile.Result{}, fmt.Errorf("target Seed is not available to host the Control Plane of Shoot %s: %v", shoot.GetName(), err)
 		}
 
@@ -365,12 +365,12 @@ func (c *Controller) finalizeShootDeletion(ctx context.Context, gardenClient kub
 	return reconcile.Result{}, c.removeFinalizerFrom(ctx, gardenClient, shoot)
 }
 
-func (c *Controller) isSeedAvailable(seed *gardencorev1beta1.Seed) error {
+func (c *Controller) isSeedReadyForMigration(seed *gardencorev1beta1.Seed) error {
 	if seed.DeletionTimestamp != nil {
 		return fmt.Errorf("seed is set for deletion")
 	}
 
-	return health.CheckSeed(seed, c.identity)
+	return health.CheckSeedForMigration(seed, c.identity)
 }
 
 func (c *Controller) reconcileShoot(logger *logrus.Entry, shoot *gardencorev1beta1.Shoot, project *gardencorev1beta1.Project, cloudProfile *gardencorev1beta1.CloudProfile, seed *gardencorev1beta1.Seed) (reconcile.Result, error) {

--- a/pkg/utils/kubernetes/health/health.go
+++ b/pkg/utils/kubernetes/health/health.go
@@ -246,11 +246,26 @@ var (
 
 // CheckSeed checks if the Seed is up-to-date and if its extensions have been successfully bootstrapped.
 func CheckSeed(seed *gardencorev1beta1.Seed, identity *gardencorev1beta1.Gardener) error {
-	if seed.Status.ObservedGeneration < seed.Generation {
-		return fmt.Errorf("observed generation outdated (%d/%d)", seed.Status.ObservedGeneration, seed.Generation)
-	}
 	if !apiequality.Semantic.DeepEqual(seed.Status.Gardener, identity) {
 		return fmt.Errorf("observing Gardener version not up to date (%v/%v)", seed.Status.Gardener, identity)
+	}
+
+	return checkSeed(seed, identity)
+}
+
+// CheckSeedForMigration checks if the Seed is up-to-date (comparing only the versions) and if its extensions have been successfully bootstrapped.
+func CheckSeedForMigration(seed *gardencorev1beta1.Seed, identity *gardencorev1beta1.Gardener) error {
+	if seed.Status.Gardener.Version != identity.Version {
+		return fmt.Errorf("observing Gardener version not up to date (%s/%s)", seed.Status.Gardener.Version, identity.Version)
+	}
+
+	return checkSeed(seed, identity)
+}
+
+// checkSeed checks if the seed.Status.ObservedGeneration ObservedGeneration is not outdated and if its extensions have been successfully bootstrapped.
+func checkSeed(seed *gardencorev1beta1.Seed, identity *gardencorev1beta1.Gardener) error {
+	if seed.Status.ObservedGeneration < seed.Generation {
+		return fmt.Errorf("observed generation outdated (%d/%d)", seed.Status.ObservedGeneration, seed.Generation)
 	}
 
 	for _, trueConditionType := range trueSeedConditionTypes {


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane-migration
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Remove GardenerID and GardenerName checks Seed is healthy as those values are defined for each gardenlet and will most likely be different when CP migration is triggered. Otherwise the error below will occur and the migration process will not start.
`Shoot cannot be synced with Seed: seed is not yet ready: observing Gardener version not up to date (&Gardener{ID:3180e2fe4ad646e011c35e7faf68a5f10e2837407feaa9b876d1e25257f86014,Name:gardenlet-7dfc58f57f-dfxdp,Version:v1.12.8,}/&Gardener{ID:543c33e44050deeeaa2175342764563559021950f1d567f6ee6c859b05342341,Name:gardenlet-5c84bbc686-d82p6,Version:v1.12.8,})`
**Which issue(s) this PR fixes**:
Part of [Issue 1631](https://github.com/gardener/gardener/issues/1631)


**Special notes for your reviewer**:

**Release note**:
```
NONE
```
