### PR TITLE
Clean up more migration logic

### DIFF
--- a/extensions/pkg/controller/csimigration/reconciler_test.go
+++ b/extensions/pkg/controller/csimigration/reconciler_test.go
@@ -56,7 +56,7 @@ var _ = Describe("reconciler", func() {
 			storageClassName              = "foo"
 			storageClassProvisioner       = "bar"
 
-			emptyPatch                      = client.ConstantPatch(types.StrategicMergePatchType, []byte("{}"))
+			emptyPatch                      = client.RawPatch(types.StrategicMergePatchType, []byte("{}"))
 			kubeAPIServerDeployment         = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: clusterName}}
 			kubeControllerManagerDeployment = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeControllerManager, Namespace: clusterName}}
 			kubeSchedulerDeployment         = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeScheduler, Namespace: clusterName}}

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -35,7 +35,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -220,23 +219,7 @@ func (b *Botanist) DeployManagedResources(ctx context.Context) error {
 		}
 	}
 
-	if err := b.deployCloudConfigExecutionManagedResource(ctx); err != nil {
-		return err
-	}
-
-	// TODO: remove in a future release
-	// Clean up the stale vpa-webhook-config MutatingWebhookConfiguration.
-	// We can delete vpa-webhook-config as the new vpa-webhook-config-shoot will be created by the shoot-core ManagedResource.
-	if b.Shoot.WantsVerticalPodAutoscaler {
-		webhook := &admissionregistrationv1beta1.MutatingWebhookConfiguration{
-			ObjectMeta: metav1.ObjectMeta{Name: "vpa-webhook-config"},
-		}
-		if err := b.K8sShootClient.Client().Delete(ctx, webhook); client.IgnoreNotFound(err) != nil {
-			return err
-		}
-	}
-
-	return nil
+	return b.deployCloudConfigExecutionManagedResource(ctx)
 }
 
 // deployCloudConfigExecutionManagedResource creates the cloud config managed resource that contains:

--- a/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager.go
@@ -504,7 +504,6 @@ func (k *kubeControllerManager) getHorizontalPodAutoscalerConfig() gardencorev1b
 }
 
 var (
-	versionConstraintK8sEqual113        *semver.Constraints
 	versionConstraintK8sGreaterEqual112 *semver.Constraints
 	versionConstraintK8sSmaller112      *semver.Constraints
 	versionConstraintK8sGreaterEqual113 *semver.Constraints
@@ -520,8 +519,6 @@ func init() {
 	versionConstraintK8sSmaller112, err = semver.NewConstraint("< 1.12")
 	utilruntime.Must(err)
 	versionConstraintK8sGreaterEqual112, err = semver.NewConstraint(">= 1.12")
-	utilruntime.Must(err)
-	versionConstraintK8sEqual113, err = semver.NewConstraint("~ 1.13")
 	utilruntime.Must(err)
 	versionConstraintK8sGreaterEqual113, err = semver.NewConstraint(">= 1.13")
 	utilruntime.Must(err)

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -47,7 +47,6 @@ import (
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	"github.com/gardener/gardener/pkg/version"
 
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -325,11 +324,6 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 	images[common.GardenerSeedAdmissionControllerImageName] = &imagevector.Image{
 		Repository: repository,
 		Tag:        &tag,
-	}
-	// TODO: Remove in future release
-	// Delete the mutatingwebhookconfigoration
-	if err := deleteMutatingWebHookConfiguration(ctx, k8sSeedClient.Client()); err != nil {
-		return err
 	}
 
 	// HVPA feature gate
@@ -928,15 +922,4 @@ func determineClusterIdentity(ctx context.Context, c client.Client) (string, err
 		return string(gardenNamespace.UID), nil
 	}
 	return clusterIdentity.Data[v1beta1constants.ClusterIdentity], nil
-}
-
-func deleteMutatingWebHookConfiguration(ctx context.Context, k8sSeedClient client.Client) error {
-	a := &admissionregistrationv1beta1.MutatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "gardener-seed-admission-controller",
-		},
-	}
-
-	err := k8sSeedClient.Delete(ctx, a)
-	return client.IgnoreNotFound(err)
 }

--- a/pkg/operation/types.go
+++ b/pkg/operation/types.go
@@ -16,9 +16,6 @@ package operation
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"net/http"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -31,7 +28,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 
-	prometheusapi "github.com/prometheus/client_golang/api"
 	prometheusclient "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -79,15 +75,4 @@ type Operation struct {
 
 	// ControlPlaneWildcardCert is a wildcard tls certificate which is issued for the seed's ingress domain.
 	ControlPlaneWildcardCert *corev1.Secret
-}
-
-type prometheusRoundTripper struct {
-	authHeader string
-	ca         *x509.CertPool
-}
-
-func (r prometheusRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("Authorization", r.authHeader)
-	prometheusapi.DefaultRoundTripper.(*http.Transport).TLSClientConfig = &tls.Config{RootCAs: r.ca}
-	return prometheusapi.DefaultRoundTripper.RoundTrip(req)
 }

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -66,16 +66,6 @@ func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Obje
 	if mustIncreaseGeneration(oldShoot, newShoot) {
 		newShoot.Generation = oldShoot.Generation + 1
 	}
-
-	// Remove the conflicting "SecurityContextDeny" admission plugin if present
-	// TODO: This can be removed in a future release.
-	if newShoot.Spec.Kubernetes.KubeAPIServer != nil {
-		for i := len(newShoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins) - 1; i >= 0; i-- {
-			if newShoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins[i].Name == "SecurityContextDeny" {
-				newShoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = append(newShoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins[:i], newShoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins[i+1:]...)
-			}
-		}
-	}
 }
 
 func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -349,28 +349,6 @@ var _ = Describe("Strategy", func() {
 				Expect(newShoot.Generation).To(Equal(oldShoot.Generation + 1))
 			})
 		})
-
-		Context("admission plugin migration", func() {
-			It("should remove conflicting admission plugins", func() {
-				oldShoot := &core.Shoot{}
-				newShoot := oldShoot.DeepCopy()
-				newShoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{
-					AdmissionPlugins: []core.AdmissionPlugin{
-						{Name: "foo"},
-						{Name: "bar"},
-						{Name: "SecurityContextDeny"},
-						{Name: "baz"},
-					},
-				}
-
-				shootregistry.Strategy.PrepareForUpdate(context.TODO(), newShoot, oldShoot)
-				Expect(newShoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins).To(ConsistOf(
-					Equal(core.AdmissionPlugin{Name: "foo"}),
-					Equal(core.AdmissionPlugin{Name: "bar"}),
-					Equal(core.AdmissionPlugin{Name: "baz"}),
-				))
-			})
-		})
 	})
 })
 

--- a/pkg/utils/kubernetes/patch.go
+++ b/pkg/utils/kubernetes/patch.go
@@ -121,5 +121,5 @@ func IsEmptyPatch(patch []byte) bool {
 
 // SubmitEmptyPatch submits an empty patch to the given `obj` with the given `client` instance.
 func SubmitEmptyPatch(ctx context.Context, c client.Client, obj runtime.Object) error {
-	return c.Patch(ctx, obj, client.ConstantPatch(types.StrategicMergePatchType, []byte("{}")))
+	return c.Patch(ctx, obj, client.RawPatch(types.StrategicMergePatchType, []byte("{}")))
 }

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -28,12 +28,10 @@ import (
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	corelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation/common"
 	gardenerutils "github.com/gardener/gardener/pkg/utils"
 	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
 
-	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/admission"
@@ -46,13 +44,6 @@ const (
 	// PluginName is the name of this admission plugin.
 	PluginName = "ShootDNS"
 )
-
-var log = logger.NewLogger("").WithField("admission", PluginName)
-
-// SetLogger sets the logger for this admission plugin.
-func SetLogger(logger *logrus.Entry) {
-	log = logger
-}
 
 // Register registers a plugin.
 func Register(plugins *admission.Plugins) {

--- a/plugin/pkg/shoot/dns/admission_test.go
+++ b/plugin/pkg/shoot/dns/admission_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation/common"
 	. "github.com/gardener/gardener/plugin/pkg/shoot/dns"
 
@@ -38,9 +37,7 @@ import (
 )
 
 var _ = Describe("dns", func() {
-	BeforeSuite(func() {
-		SetLogger(logger.NewNopLogger().WithField("test", "dns"))
-	})
+
 	Describe("#Admit", func() {
 		var (
 			admissionHandler    *DNS

--- a/test/framework/dump.go
+++ b/test/framework/dump.go
@@ -393,23 +393,6 @@ func (f *CommonFramework) dumpPodInfoForNamespace(ctx context.Context, ctxIdenti
 }
 
 // dumpEventsInNamespace prints all events of a namespace
-func (f *CommonFramework) dumpEventsInAllNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, filters ...EventFilterFunc) error {
-	namespaces := &corev1.NamespaceList{}
-	if err := k8sClient.DirectClient().List(ctx, namespaces); err != nil {
-		return err
-	}
-
-	var result error
-
-	for _, ns := range namespaces.Items {
-		if err := f.dumpEventsInNamespace(ctx, ctxIdentifier, k8sClient, ns.Name); err != nil {
-			result = multierror.Append(result, err)
-		}
-	}
-	return result
-}
-
-// dumpEventsInNamespace prints all events of a namespace
 func (f *CommonFramework) dumpEventsInNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string, filters ...EventFilterFunc) error {
 	f.Logger.Infof("%s [NAMESPACE %s] [EVENTS]", ctxIdentifier, namespace)
 	events := &corev1.EventList{}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority normal

**What this PR does / why we need it**:
This PR removes:
- the cleanup logic that deletes the stale `gardener-seed-admission-controller` mutatingwebhook - ref https://github.com/gardener/gardener/pull/2735
- the cleanup logic that deletes the stale `vpa-webhook-config-shoot` mutatingwebhook - ref https://github.com/gardener/gardener/pull/2937
- the logic that removes the `SecurityContextDeny` admission plugin from existing Shoots (if it is present) - ref https://github.com/gardener/gardener/pull/2346
- and few golangci-lint finding (reported by the `unused` linter or deprecated var usage)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
