### PR TITLE
Parse the time zones from logs and set the tail plugin to read from head

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
@@ -27,6 +27,7 @@
         Exclude_Path      *_garden_fluent-bit-*.log,*_garden_loki-*.log
         Parser            docker
         DB                /var/log/flb_kube.db
+        read_from_head    true
         Skip_Long_Lines   On
         Mem_Buf_Limit     30MB
         Refresh_Interval  10

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-configmap.yaml
@@ -237,7 +237,7 @@ data:
         Name        docker
         Format      json
         Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
         Time_Keep   On
         # Command      |  Decoder | Field | Optional Action
         # =============|==================|=================

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
@@ -60,10 +60,13 @@ spec:
           httpGet:
             path: /api/v1/metrics/prometheus
             port: 2020
+          periodSeconds: 10
         livenessProbe:
           httpGet:
             path: /
             port: 2020
+          initialDelaySeconds: 90
+          periodSeconds: 10
         volumeMounts:
         - name: config
           mountPath: /fluent-bit/etc

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-role.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-role.yaml
@@ -5,10 +5,6 @@ metadata:
   labels:
     {{- toYaml .Values.labels | nindent 4 }}
 rules:
-- apiGroups: [""]
-  resources:
-  - pods
-  verbs: ["get", "list", "watch"]
 - apiGroups:
   - extensions.gardener.cloud
   resources:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR we:
- parse the time zone of a log when reading it from the node /var/log/containers directory.
- when fluent-bit containers runs the tail plugin starts to read a file from the head(like it was prior fluent-bit 1.6).
- make the readiness and liveness probe fail after 30 seconds and the liveness probes starts after 90 seconds.
- `get`, `list` and `watch` for Pods are removed from the fluent-bit RBAC as no log needed.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```other operator
Parse the time zone of a log when reading it from the node /var/log/containers directory.
```
```other operator
When fluent-bit containers runs the tail plugin starts to read a file from the head(like it was prior fluent-bit 1.6).
```
```other operator
Make the readiness and liveness probe fail after 30 seconds and the liveness probes starts after 90 seconds.
```
```other operator
`get`, `list` and `watch` for Pods are removed from the fluent-bit RBAC as no longer needed.
```