### PR TITLE
Switch to "gardener.cloud/role" label key for system components

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -5,7 +5,6 @@ kind: ClusterRole
 metadata:
   name: gardener.cloud:admin
   labels:
-    garden.sapcloud.io/role: admin
     gardener.cloud/role: admin
 rules:
 - apiGroups:
@@ -57,11 +56,7 @@ metadata:
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
-      garden.sapcloud.io/role: admin
-  - matchLabels:
       gardener.cloud/role: admin
-  - matchLabels:
-      garden.sapcloud.io/role: project-member
   - matchLabels:
       gardener.cloud/role: project-member
 rules: []
@@ -234,7 +229,6 @@ kind: ClusterRole
 metadata:
   name: gardener.cloud:system:project-viewer
   labels:
-    garden.sapcloud.io/role: project-viewer
     gardener.cloud/role: project-viewer
     app: gardener
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-dashboard.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-dashboard.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubernetes-dashboard
   namespace: {{ include "kubernetes-dashboard.namespace" . }}
   labels:
-    garden.sapcloud.io/role: optional-addon
+    gardener.cloud/role: optional-addon
     origin: gardener
     k8s-app: kubernetes-dashboard
 spec:
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        garden.sapcloud.io/role: optional-addon
+        gardener.cloud/role: optional-addon
         origin: gardener
         k8s-app: kubernetes-dashboard
     spec:

--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-metrics-scraper.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-metrics-scraper.yaml
@@ -6,7 +6,7 @@ metadata:
   name: dashboard-metrics-scraper
   namespace: kubernetes-dashboard
   labels:
-    garden.sapcloud.io/role: optional-addon
+    gardener.cloud/role: optional-addon
     origin: gardener
     k8s-app: dashboard-metrics-scraper
 spec:
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       labels:
-        garden.sapcloud.io/role: optional-addon
+        gardener.cloud/role: optional-addon
         k8s-app: dashboard-metrics-scraper
         origin: gardener
       annotations:

--- a/charts/shoot-addons/charts/nginx-ingress/templates/controller-daemonset.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/controller-daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: {{include "daemonsetversion" .}}
 kind: DaemonSet
 metadata:
   labels:
-    garden.sapcloud.io/role: optional-addon
+    gardener.cloud/role: optional-addon
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.controller.name }}"
@@ -22,7 +22,7 @@ spec:
 {{ toYaml .Values.controller.podAnnotations | indent 8}}
     {{- end }}
       labels:
-        garden.sapcloud.io/role: optional-addon
+        gardener.cloud/role: optional-addon
         origin: gardener
         app: {{ template "nginx-ingress.name" . }}
         component: "{{ .Values.controller.name }}"

--- a/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "deploymentversion" . }}
 kind: Deployment
 metadata:
   labels:
-    garden.sapcloud.io/role: optional-addon
+    gardener.cloud/role: optional-addon
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.controller.name }}"
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       labels:
         origin: gardener
-        garden.sapcloud.io/role: optional-addon
+        gardener.cloud/role: optional-addon
         app: {{ template "nginx-ingress.name" . }}
         component: "{{ .Values.controller.name }}"
         release: {{ .Release.Name }}

--- a/charts/shoot-addons/charts/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/default-backend-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "deploymentversion" . }}
 kind: Deployment
 metadata:
   labels:
-    garden.sapcloud.io/role: optional-addon
+    gardener.cloud/role: optional-addon
     app: {{ template "nginx-ingress.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     component: "{{ .Values.defaultBackend.name }}"
@@ -29,7 +29,7 @@ spec:
     {{- end }}
       labels:
         origin: gardener
-        garden.sapcloud.io/role: optional-addon
+        gardener.cloud/role: optional-addon
         app: {{ template "nginx-ingress.name" . }}
         component: "{{ .Values.defaultBackend.name }}"
         release: {{ .Release.Name }}

--- a/charts/shoot-core/components/charts/coredns/templates/coredns-deployment.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     origin: gardener
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
     k8s-app: kube-dns
 spec:
   revisionHistoryLimit: 0
@@ -22,7 +22,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
       labels:
         origin: gardener
-        garden.sapcloud.io/role: system-component
+        gardener.cloud/role: system-component
         k8s-app: kube-dns
       # we won't be using the checksum of the configmap since coredns provides the "reload" plugins that does the reload if config changes.
     spec:

--- a/charts/shoot-core/components/charts/konnectivity-agent/templates/daemonset.yaml
+++ b/charts/shoot-core/components/charts/konnectivity-agent/templates/daemonset.yaml
@@ -5,7 +5,6 @@ metadata:
     k8s-app: konnectivity-agent
     app: konnectivity-agent
     gardener.cloud/role: system-component
-    garden.sapcloud.io/role: system-component
     origin: gardener
   namespace: kube-system
   name: konnectivity-agent
@@ -22,7 +21,6 @@ spec:
         k8s-app: konnectivity-agent
         app: konnectivity-agent
         gardener.cloud/role: system-component
-        garden.sapcloud.io/role: system-component
         origin: gardener
       annotations:
 {{- if .Values.podAnnotations }}

--- a/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   name: kube-proxy
   namespace: kube-system
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
     origin: gardener
 spec:
   updateStrategy:
@@ -25,7 +25,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
-        garden.sapcloud.io/role: system-component
+        gardener.cloud/role: system-component
         origin: gardener
         app: kubernetes
         role: proxy

--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: blackbox-exporter
   namespace: kube-system
   labels:
-    garden.sapcloud.io/role: monitoring
+    gardener.cloud/role: monitoring
     component: blackbox-exporter
     origin: gardener
 spec:
@@ -19,7 +19,7 @@ spec:
         checksum/configmap-blackbox-exporter-config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
       labels:
         origin: gardener
-        garden.sapcloud.io/role: monitoring
+        gardener.cloud/role: monitoring
         component: blackbox-exporter
         networking.gardener.cloud/from-seed: allowed
         networking.gardener.cloud/to-dns: allowed

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -29,7 +29,7 @@ metadata:
   name: node-exporter
   namespace: kube-system
   labels:
-    garden.sapcloud.io/role: monitoring
+    gardener.cloud/role: monitoring
     component: node-exporter
     origin: gardener
 spec:
@@ -45,7 +45,7 @@ spec:
       labels:
         networking.gardener.cloud/to-public-networks: allowed
         networking.gardener.cloud/from-seed: allowed
-        garden.sapcloud.io/role: monitoring
+        gardener.cloud/role: monitoring
         origin: gardener
         component: node-exporter
     spec:

--- a/charts/shoot-core/components/charts/network-policies/templates/allow-from-seed.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-from-seed.yaml
@@ -20,5 +20,5 @@ spec:
     - podSelector:
         matchLabels:
           app: vpn-shoot
-          garden.sapcloud.io/role: system-component
+          gardener.cloud/role: system-component
           origin: gardener

--- a/charts/shoot-core/components/charts/node-problem-detector/templates/daemonset.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/templates/daemonset.yaml
@@ -3,7 +3,7 @@ kind: DaemonSet
 metadata:
   name: node-problem-detector
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
     app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
     helm.sh/chart: {{ include "node-problem-detector.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/name: {{ include "node-problem-detector.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app: {{ include "node-problem-detector.name" . }}
-        garden.sapcloud.io/role: system-component
+        gardener.cloud/role: system-component
         origin: gardener
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/custom-config-configmap.yaml") . | sha256sum }}

--- a/charts/shoot-core/components/charts/nodelocal-dns/templates/daemonset.yaml
+++ b/charts/shoot-core/components/charts/nodelocal-dns/templates/daemonset.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: kube-system
   labels:
     gardener.cloud/role: system-component
-    garden.sapcloud.io/role: system-component
     origin: gardener
     k8s-app: node-local-dns
 spec:

--- a/charts/shoot-core/components/charts/vpn-shoot/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/vpn-shoot/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: kube-system
   labels:
     gardener.cloud/role: system-component
+    # TODO (ialidzhikov): remove in a future version
     garden.sapcloud.io/role: system-component
     app: vpn-shoot
     origin: gardener
@@ -32,6 +33,7 @@ spec:
       labels:
         origin: gardener
         gardener.cloud/role: system-component
+        # TODO (ialidzhikov): remove in a future version
         garden.sapcloud.io/role: system-component
         app: vpn-shoot
         type: tunnel

--- a/docs/extensions/shoot-health-status-conditions.md
+++ b/docs/extensions/shoot-health-status-conditions.md
@@ -57,8 +57,7 @@ apiVersion: core.gardener.cloud/v1beta1
 kind: Shoot
 metadata:
   labels:
-    shoot.garden.sapcloud.io/status: unhealthy
-    shoot.garden.sapcloud.io/unhealthy: "true"
+    shoot.gardener.cloud/status: unhealthy
   name: some-shoot
   namespace: garden-core
 spec:

--- a/hack/local-development/local-garden/apply-rbac-garden-ns
+++ b/hack/local-development/local-garden/apply-rbac-garden-ns
@@ -14,7 +14,6 @@ kind: ClusterRole
 metadata:
   name: gardener.cloud:admin
   labels:
-    garden.sapcloud.io/role: admin
     gardener.cloud/role: admin
 rules:
 - apiGroups:

--- a/pkg/gardenlet/controller/federatedseed/networkpolicy/controller.go
+++ b/pkg/gardenlet/controller/federatedseed/networkpolicy/controller.go
@@ -80,8 +80,7 @@ func NewController(ctx context.Context, seedClient kubernetes.Interface, seedDef
 	)
 
 	shootNamespaceSelector := labels.SelectorFromSet(labels.Set{
-		v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleShoot,
-		v1beta1constants.GardenRole:           v1beta1constants.GardenRoleShoot,
+		v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot,
 	})
 
 	controller := &Controller{

--- a/pkg/gardenlet/controller/seed/seed.go
+++ b/pkg/gardenlet/controller/seed/seed.go
@@ -185,8 +185,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 
 		if _, err := controllerutil.CreateOrUpdate(ctx, gardenClient.Client(), seed, func() error {
 			seed.Labels = utils.MergeStringMaps(map[string]string{
-				v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleSeed,
-				v1beta1constants.GardenRole:           v1beta1constants.GardenRoleSeed,
+				v1beta1constants.GardenRole: v1beta1constants.GardenRoleSeed,
 			}, c.config.SeedConfig.Labels)
 			seed.Spec = c.config.SeedConfig.Seed.Spec
 			return nil

--- a/pkg/gardenlet/controller/shoot/seed_registration_control.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control.go
@@ -399,8 +399,7 @@ func registerAsSeed(ctx context.Context, gardenClient client.Client, seedClient 
 
 	_, err = controllerutil.CreateOrUpdate(ctx, gardenClient, seed, func() error {
 		seed.Labels = utils.MergeStringMaps(shoot.Labels, map[string]string{
-			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleSeed,
-			v1beta1constants.GardenRole:           v1beta1constants.GardenRoleSeed,
+			v1beta1constants.GardenRole: v1beta1constants.GardenRoleSeed,
 		})
 		seed.Spec = *seedSpec
 		return nil

--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -70,7 +70,7 @@ var (
 	GracePeriodFiveMinutes = utilclient.DeleteWith{client.GracePeriodSeconds(5 * 60)}
 
 	// NotSystemComponent is a requirement that something doesn't have the GardenRole GardenRoleSystemComponent.
-	NotSystemComponent = utils.MustNewRequirement(v1beta1constants.DeprecatedGardenRole, selection.NotEquals, v1beta1constants.GardenRoleSystemComponent)
+	NotSystemComponent = utils.MustNewRequirement(v1beta1constants.GardenRole, selection.NotEquals, v1beta1constants.GardenRoleSystemComponent)
 	// NoCleanupPrevention is a requirement that the ShootNoCleanup label of something is not true.
 	NoCleanupPrevention = utils.MustNewRequirement(common.ShootNoCleanup, selection.NotEquals, "true")
 	// NotKubernetesProvider is a requirement that the Provider label of something is not KubernetesProvider.

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -78,7 +78,6 @@ func (b *Botanist) DeployNamespace(ctx context.Context) error {
 			v1beta1constants.DeprecatedShootUID: string(b.Shoot.Info.Status.UID),
 		}
 		namespace.Labels = map[string]string{
-			v1beta1constants.DeprecatedGardenRole:    v1beta1constants.GardenRoleShoot,
 			v1beta1constants.GardenRole:              v1beta1constants.GardenRoleShoot,
 			v1beta1constants.LabelSeedProvider:       string(b.Seed.Info.Spec.Provider.Type),
 			v1beta1constants.LabelShootProvider:      string(b.Shoot.Info.Spec.Provider.Type),

--- a/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server.go
@@ -260,8 +260,8 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 				Name:      deploymentName,
 				Namespace: metav1.NamespaceSystem,
 				Labels: utils.MergeStringMaps(getLabels(), map[string]string{
-					common.ManagedResourceLabelKeyOrigin:  common.ManagedResourceLabelValueGardener,
-					v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleSystemComponent,
+					common.ManagedResourceLabelKeyOrigin: common.ManagedResourceLabelValueGardener,
+					v1beta1constants.GardenRole:          v1beta1constants.GardenRoleSystemComponent,
 				}),
 			},
 			Spec: appsv1.DeploymentSpec{
@@ -276,7 +276,7 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: utils.MergeStringMaps(getLabels(), map[string]string{
 							common.ManagedResourceLabelKeyOrigin:                common.ManagedResourceLabelValueGardener,
-							v1beta1constants.DeprecatedGardenRole:               v1beta1constants.GardenRoleSystemComponent,
+							v1beta1constants.GardenRole:                         v1beta1constants.GardenRoleSystemComponent,
 							v1beta1constants.LabelNetworkPolicyShootFromSeed:    v1beta1constants.LabelNetworkPolicyAllowed,
 							v1beta1constants.LabelNetworkPolicyShootToAPIServer: v1beta1constants.LabelNetworkPolicyAllowed,
 							v1beta1constants.LabelNetworkPolicyShootToKubelet:   v1beta1constants.LabelNetworkPolicyAllowed,

--- a/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server_test.go
@@ -198,7 +198,7 @@ kind: Deployment
 metadata:
   creationTimestamp: null
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
     k8s-app: metrics-server
     origin: gardener
   name: metrics-server
@@ -218,7 +218,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ""
       creationTimestamp: null
       labels:
-        garden.sapcloud.io/role: system-component
+        gardener.cloud/role: system-component
         k8s-app: metrics-server
         networking.gardener.cloud/from-seed: allowed
         networking.gardener.cloud/to-apiserver: allowed
@@ -288,7 +288,7 @@ kind: Deployment
 metadata:
   creationTimestamp: null
   labels:
-    garden.sapcloud.io/role: system-component
+    gardener.cloud/role: system-component
     k8s-app: metrics-server
     origin: gardener
   name: metrics-server
@@ -308,7 +308,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ""
       creationTimestamp: null
       labels:
-        garden.sapcloud.io/role: system-component
+        gardener.cloud/role: system-component
         k8s-app: metrics-server
         networking.gardener.cloud/from-seed: allowed
         networking.gardener.cloud/to-apiserver: allowed

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -370,8 +370,7 @@ func generateMonitoringSecret(k8sGardenClient kubernetes.Interface, gardenNamesp
 	}
 	if _, err := controllerutil.CreateOrUpdate(context.TODO(), k8sGardenClient.Client(), secret, func() error {
 		secret.Labels = map[string]string{
-			v1beta1constants.GardenRole:           common.GardenRoleGlobalMonitoring,
-			v1beta1constants.DeprecatedGardenRole: common.GardenRoleGlobalMonitoring,
+			v1beta1constants.GardenRole: common.GardenRoleGlobalMonitoring,
 		}
 		secret.Type = corev1.SecretTypeOpaque
 		secret.Data = basicAuth.SecretData()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority normal

**What this PR does / why we need it**:
As the system components and addons are managed via ManagedResource, we can adapt the role label key on the system-components. The healthchecks are performed via the ManagedResoure. There is also the `shoot.gardener.cloud/no-cleanup` label that is injected via the ManagedResource that prevents system-components to be deleted as part of the deletion flow - see also https://github.com/gardener/gardener-extension-networking-calico/pull/7.


**Which issue(s) this PR fixes**:
Ref #1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
The system components that were previous specifying label `garden.sapcloud.io/role: (optional-addon|monitoring|system-component)` are now adapted to specify `gardener.cloud/role: (optional-addon|monitoring|system-component)`.
```

```noteworthy operator
The Shoot namespace in the Seed no longer specifies label `garden.sapcloud.io/role: shoot`.
```
