### PR TITLE
Pin sigs.k8s.io/structured-merge-diff/v3 back to upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,5 +74,5 @@ replace (
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.18.10
 	k8s.io/kube-openapi => github.com/gardener/kube-openapi v0.0.0-20200831104310-b5db060350c7
 	sigs.k8s.io/controller-runtime => github.com/gardener/controller-runtime v0.6.3-gardener.1
-	sigs.k8s.io/structured-merge-diff/v3 => github.com/gardener/structured-merge-diff/v3 v3.0.0-gardener.1
+	sigs.k8s.io/structured-merge-diff/v3 => sigs.k8s.io/structured-merge-diff/v3 v3.0.1-0.20201124164700-f5fd4ea1e4c9
 )

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,6 @@ github.com/gardener/kube-openapi v0.0.0-20200831104310-b5db060350c7/go.mod h1:GR
 github.com/gardener/machine-controller-manager v0.27.0/go.mod h1:zlIxuLQMtRO+aXOFsG6qtYkBmggbWY82K7MSO051ARU=
 github.com/gardener/machine-controller-manager v0.33.0 h1:58Gh4MW7Yv9XoARKhP4wORDcn2Hofbuv/1OlMe9y1eY=
 github.com/gardener/machine-controller-manager v0.33.0/go.mod h1:jxxE+mGgXwg4iPlCHTG4GtUfK2CcHA6yYoIIowoxOZU=
-github.com/gardener/structured-merge-diff/v3 v3.0.0-gardener.1 h1:LC+Y/9O1ZiEKlTb79B6XStLlb7UU/xUky6QkpSQd3A0=
-github.com/gardener/structured-merge-diff/v3 v3.0.0-gardener.1/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -921,6 +919,8 @@ sigs.k8s.io/controller-tools v0.2.0-beta.4/go.mod h1:8t/X+FVWvk6TaBcsa+UKUBbn7GM
 sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
 sigs.k8s.io/controller-tools v0.2.9/go.mod h1:ArP7w60JQKkZf7UU2oWTVnEhoNGA+sOMyuSuS+JFNDQ=
 sigs.k8s.io/kind v0.7.0/go.mod h1:An/AbWHT6pA/Lm0Og8j3ukGhfJP3RiVN/IBU6Lo3zl8=
+sigs.k8s.io/structured-merge-diff/v3 v3.0.1-0.20201124164700-f5fd4ea1e4c9 h1:aQn+bP3hsnER21VpkPthyiJQGGPA1LuxV2r3dXMkQEI=
+sigs.k8s.io/structured-merge-diff/v3 v3.0.1-0.20201124164700-f5fd4ea1e4c9/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1251,7 +1251,7 @@ sigs.k8s.io/controller-runtime/pkg/webhook/admission
 sigs.k8s.io/controller-runtime/pkg/webhook/conversion
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/certwatcher
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
-# sigs.k8s.io/structured-merge-diff/v3 v3.0.0 => github.com/gardener/structured-merge-diff/v3 v3.0.0-gardener.1
+# sigs.k8s.io/structured-merge-diff/v3 v3.0.0 => sigs.k8s.io/structured-merge-diff/v3 v3.0.1-0.20201124164700-f5fd4ea1e4c9
 sigs.k8s.io/structured-merge-diff/v3/fieldpath
 sigs.k8s.io/structured-merge-diff/v3/merge
 sigs.k8s.io/structured-merge-diff/v3/schema
@@ -1273,4 +1273,4 @@ sigs.k8s.io/yaml
 # k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.18.10
 # k8s.io/kube-openapi => github.com/gardener/kube-openapi v0.0.0-20200831104310-b5db060350c7
 # sigs.k8s.io/controller-runtime => github.com/gardener/controller-runtime v0.6.3-gardener.1
-# sigs.k8s.io/structured-merge-diff/v3 => github.com/gardener/structured-merge-diff/v3 v3.0.0-gardener.1
+# sigs.k8s.io/structured-merge-diff/v3 => sigs.k8s.io/structured-merge-diff/v3 v3.0.1-0.20201124164700-f5fd4ea1e4c9

--- a/vendor/sigs.k8s.io/structured-merge-diff/v3/value/reflectcache.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/v3/value/reflectcache.go
@@ -70,14 +70,11 @@ func (f *FieldCacheEntry) CanOmit(fieldVal reflect.Value) bool {
 	return f.isOmitEmpty && (safeIsNil(fieldVal) || isZero(fieldVal))
 }
 
-// GetUsing returns the field identified by this FieldCacheEntry from the provided struct.
+// GetFrom returns the field identified by this FieldCacheEntry from the provided struct.
 func (f *FieldCacheEntry) GetFrom(structVal reflect.Value) reflect.Value {
 	// field might be nested within 'inline' structs
 	for _, elem := range f.fieldPath {
-		if structVal.Kind() == reflect.Ptr {
-			structVal = structVal.Elem()
-		}
-		structVal = structVal.FieldByIndex(elem)
+		structVal = dereference(structVal).FieldByIndex(elem)
 	}
 	return structVal
 }
@@ -153,11 +150,11 @@ func buildStructCacheEntry(t reflect.Type, infos map[string]*FieldCacheEntry, fi
 			continue
 		}
 		if isInline {
-			fieldType := field.Type
+			e := field.Type
 			if field.Type.Kind() == reflect.Ptr {
-				fieldType = field.Type.Elem()
+				e = field.Type.Elem()
 			}
-			buildStructCacheEntry(fieldType, infos, append(fieldPath, field.Index))
+			buildStructCacheEntry(e, infos, append(fieldPath, field.Index))
 			continue
 		}
 		info := &FieldCacheEntry{JsonName: jsonName, isOmitEmpty: isOmitempty, fieldPath: append(fieldPath, field.Index), fieldType: field.Type}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority normal

**What this PR does / why we need it**:
I believe we can pin back to the upstream of `sigs.k8s.io/structured-merge-diff/v3` as https://github.com/kubernetes-sigs/structured-merge-diff/pull/180 is now merged into `release-3.0` branch of `sigs.k8s.io/structured-merge-diff`

Follow up on https://github.com/gardener/gardener/pull/2985

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
