### PR TITLE
Refactor ControlPlane extension deployment into component

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -286,7 +286,7 @@ func (c *Controller) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		})
 		waitUntilControlPlaneReady = g.Add(flow.Task{
 			Name:         "Waiting until Shoot control plane has been reconciled",
-			Fn:           flow.TaskFn(botanist.WaitUntilControlPlaneReady).DoIf(cleanupShootResources && controlPlaneDeploymentNeeded),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.ControlPlane.Wait).DoIf(cleanupShootResources && controlPlaneDeploymentNeeded),
 			Dependencies: flow.NewTaskIDs(deployControlPlane),
 		})
 		generateEncryptionConfigurationMetaData = g.Add(flow.Task{
@@ -330,7 +330,7 @@ func (c *Controller) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		})
 		waitUntilControlPlaneExposureReady = g.Add(flow.Task{
 			Name:         "Waiting until Shoot control plane exposure has been reconciled",
-			Fn:           flow.TaskFn(botanist.WaitUntilControlPlaneExposureReady).SkipIf(useSNI).DoIf(cleanupShootResources),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.ControlPlaneExposure.Wait).SkipIf(useSNI).DoIf(cleanupShootResources),
 			Dependencies: flow.NewTaskIDs(deployControlPlaneExposure),
 		})
 		initializeShootClients = g.Add(flow.Task{
@@ -491,12 +491,12 @@ func (c *Controller) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		)
 		destroyControlPlane = g.Add(flow.Task{
 			Name:         "Destroying shoot control plane",
-			Fn:           flow.TaskFn(botanist.DestroyControlPlane).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.ControlPlane.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(syncPointCleaned),
 		})
 		waitUntilControlPlaneDeleted = g.Add(flow.Task{
 			Name:         "Waiting until shoot control plane has been destroyed",
-			Fn:           botanist.WaitUntilControlPlaneDeleted,
+			Fn:           botanist.Shoot.Components.Extensions.ControlPlane.WaitCleanup,
 			Dependencies: flow.NewTaskIDs(destroyControlPlane),
 		})
 
@@ -508,12 +508,12 @@ func (c *Controller) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 
 		destroyControlPlaneExposure = g.Add(flow.Task{
 			Name:         "Destroying shoot control plane exposure",
-			Fn:           flow.TaskFn(botanist.DestroyControlPlaneExposure),
+			Fn:           botanist.Shoot.Components.Extensions.ControlPlaneExposure.Destroy,
 			Dependencies: flow.NewTaskIDs(deleteKubeAPIServer),
 		})
 		waitUntilControlPlaneExposureDeleted = g.Add(flow.Task{
 			Name:         "Waiting until shoot control plane exposure has been destroyed",
-			Fn:           flow.TaskFn(botanist.WaitUntilControlPlaneExposureDeleted),
+			Fn:           botanist.Shoot.Components.Extensions.ControlPlaneExposure.WaitCleanup,
 			Dependencies: flow.NewTaskIDs(destroyControlPlaneExposure),
 		})
 

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -215,7 +215,7 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 		})
 		waitUntilControlPlaneReady = g.Add(flow.Task{
 			Name:         "Waiting until shoot control plane has been reconciled",
-			Fn:           flow.TaskFn(botanist.WaitUntilControlPlaneReady),
+			Fn:           botanist.Shoot.Components.Extensions.ControlPlane.Wait,
 			Dependencies: flow.NewTaskIDs(deployControlPlane),
 		})
 		generateEncryptionConfigurationMetaData = g.Add(flow.Task{
@@ -263,17 +263,17 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 		})
 		waitUntilControlPlaneExposureReady = g.Add(flow.Task{
 			Name:         "Waiting until Shoot control plane exposure has been reconciled",
-			Fn:           flow.TaskFn(botanist.WaitUntilControlPlaneExposureReady).SkipIf(useSNI),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.ControlPlaneExposure.Wait).SkipIf(useSNI),
 			Dependencies: flow.NewTaskIDs(deployControlPlaneExposure),
 		})
 		destroyControlPlaneExposure = g.Add(flow.Task{
 			Name:         "Destroying shoot control plane exposure",
-			Fn:           flow.TaskFn(botanist.DestroyControlPlaneExposure).DoIf(useSNI),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.ControlPlaneExposure.Destroy).DoIf(useSNI),
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady),
 		})
 		waitUntilControlPlaneExposureDeleted = g.Add(flow.Task{
 			Name:         "Waiting until shoot control plane exposure has been destroyed",
-			Fn:           flow.TaskFn(botanist.WaitUntilControlPlaneExposureDeleted).DoIf(useSNI),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.ControlPlaneExposure.WaitCleanup).DoIf(useSNI),
 			Dependencies: flow.NewTaskIDs(destroyControlPlaneExposure),
 		})
 		initializeShootClients = g.Add(flow.Task{

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -24,6 +24,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/botanist/clusteridentity"
 	"github.com/gardener/gardener/pkg/operation/botanist/controlplane/etcd"
@@ -73,6 +74,8 @@ func New(o *operation.Operation) (*Botanist, error) {
 	}
 
 	// extension components
+	o.Shoot.Components.Extensions.ControlPlane = b.DefaultControlPlane(b.K8sSeedClient.DirectClient(), extensionsv1alpha1.Normal)
+	o.Shoot.Components.Extensions.ControlPlaneExposure = b.DefaultControlPlane(b.K8sSeedClient.DirectClient(), extensionsv1alpha1.Exposure)
 	o.Shoot.Components.Extensions.DNS.ExternalProvider = b.DefaultExternalDNSProvider(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.DNS.ExternalOwner = b.DefaultExternalDNSOwner(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.DNS.ExternalEntry = b.DefaultExternalDNSEntry(b.K8sSeedClient.DirectClient())

--- a/pkg/operation/botanist/containerruntime.go
+++ b/pkg/operation/botanist/containerruntime.go
@@ -24,7 +24,7 @@ import (
 )
 
 // DefaultContainerRuntime creates the default deployer for the ContainerRuntime custom resource.
-func (b *Botanist) DefaultContainerRuntime(seedClient client.Client) shoot.ContainerRuntime {
+func (b *Botanist) DefaultContainerRuntime(seedClient client.Client) shoot.ExtensionContainerRuntime {
 	return containerruntime.New(
 		b.Logger,
 		seedClient,

--- a/pkg/operation/botanist/extensions/containerruntime/containerruntime.go
+++ b/pkg/operation/botanist/extensions/containerruntime/containerruntime.go
@@ -57,21 +57,21 @@ type Values struct {
 type containerruntime struct {
 	values              *Values
 	client              client.Client
-	logger              *logrus.Entry
+	logger              logrus.FieldLogger
 	waitInterval        time.Duration
 	waitSevereThreshold time.Duration
 	waitTimeout         time.Duration
 }
 
-// New creates a new instance of ContainerRuntime deployer.
+// New creates a new instance of ExtensionContainerRuntime deployer.
 func New(
-	logger *logrus.Entry,
+	logger logrus.FieldLogger,
 	client client.Client,
 	values *Values,
 	waitInterval time.Duration,
 	waitSevereThreshold time.Duration,
 	waitTimeout time.Duration,
-) shoot.ContainerRuntime {
+) shoot.ExtensionContainerRuntime {
 	return &containerruntime{
 		values:              values,
 		client:              client,
@@ -127,7 +127,7 @@ func (d *containerruntime) WaitCleanup(ctx context.Context) error {
 		d.logger,
 		&extensionsv1alpha1.ContainerRuntimeList{},
 		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ContainerRuntime{} },
-		"ContainerRuntime",
+		extensionsv1alpha1.ContainerRuntimeResource,
 		d.values.Namespace,
 		d.waitInterval,
 		d.waitTimeout,
@@ -135,7 +135,7 @@ func (d *containerruntime) WaitCleanup(ctx context.Context) error {
 	)
 }
 
-// Restore uses the seed client and the ShootState to create the ContainereRuntime resources and restore their state.
+// Restore uses the seed client and the ShootState to create the ContainerRuntime resources and restore their state.
 func (d *containerruntime) Restore(ctx context.Context, shootState *gardencorev1alpha1.ShootState) error {
 	fns := d.forEachContainerRuntime(func(ctx context.Context, workerName string, cr gardencorev1beta1.ContainerRuntime) error {
 		rd := resourceDeployer{d.values.Namespace, workerName, cr, d.client}

--- a/pkg/operation/botanist/extensions/containerruntime/containerruntime_test.go
+++ b/pkg/operation/botanist/extensions/containerruntime/containerruntime_test.go
@@ -60,9 +60,9 @@ var _ = Describe("#ContainerRuntimee", func() {
 		c        client.Client
 		expected []*extensionsv1alpha1.ContainerRuntime
 		values   *containerruntime.Values
-		log      *logrus.Entry
+		log      logrus.FieldLogger
 
-		defaultDepWaiter shoot.ContainerRuntime
+		defaultDepWaiter shoot.ExtensionContainerRuntime
 		workers          []gardencorev1beta1.Worker
 
 		mockNow *mocktime.MockNow
@@ -74,12 +74,10 @@ var _ = Describe("#ContainerRuntimee", func() {
 		mockNow = mocktime.NewMockNow(ctrl)
 
 		ctx = context.TODO()
-
-		log = logrus.NewEntry(logger.NewNopLogger())
+		log = logger.NewNopLogger()
 
 		s := runtime.NewScheme()
 		Expect(extensionsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())
-
 		c = fake.NewFakeClientWithScheme(s)
 
 		workers = make([]gardencorev1beta1.Worker, 0, len(workerNames))
@@ -192,7 +190,7 @@ var _ = Describe("#ContainerRuntimee", func() {
 	})
 
 	Describe("#Destroy", func() {
-		It("should not return erorr when not found", func() {
+		It("should not return error when not found", func() {
 			Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
 		})
 

--- a/pkg/operation/botanist/extensions/controlplane/controlplane.go
+++ b/pkg/operation/botanist/extensions/controlplane/controlplane.go
@@ -1,0 +1,246 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/operation/shoot"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	// DefaultInterval is the default interval for retry operations.
+	DefaultInterval = 5 * time.Second
+	// DefaultSevereThreshold is the default threshold until an error reported by another component is treated as
+	// 'severe'.
+	DefaultSevereThreshold = 30 * time.Second
+	// DefaultTimeout is the default timeout and defines how long Gardener should wait for a successful reconciliation
+	// of a ControlPlane resource.
+	DefaultTimeout = 3 * time.Minute
+)
+
+// TimeNow returns the current time. Exposed for testing.
+var TimeNow = time.Now
+
+// Values contains the values used to create an ControlPlane resources.
+type Values struct {
+	// Namespace is the Shoot namespace in the seed.
+	Namespace string
+	// Name is the name of the ControlPlane resource. Commonly the Shoot's name.
+	Name string
+	// Type is the type of the ControlPlane provider.
+	Type string
+	// ProviderConfig contains the provider config for the ControlPlane provider.
+	ProviderConfig *runtime.RawExtension
+	// Purpose is the purpose of the ControlPlane resource (normal/exposure).
+	Purpose extensionsv1alpha1.Purpose
+	// Region is the region of the shoot.
+	Region string
+	// InfrastructureProviderStatus is the provider status of the Infrastructure resource which might be relevant for
+	// the ControlPlane reconciliation.
+	InfrastructureProviderStatus *runtime.RawExtension
+}
+
+// New creates a new instance of an ControlPlane deployer.
+func New(
+	logger logrus.FieldLogger,
+	client client.Client,
+	values *Values,
+	waitInterval time.Duration,
+	waitSevereThreshold time.Duration,
+	waitTimeout time.Duration,
+) shoot.ExtensionControlPlane {
+	return &controlPlane{
+		client:              client,
+		logger:              logger,
+		values:              values,
+		waitInterval:        waitInterval,
+		waitSevereThreshold: waitSevereThreshold,
+		waitTimeout:         waitTimeout,
+	}
+}
+
+type controlPlane struct {
+	values              *Values
+	logger              logrus.FieldLogger
+	client              client.Client
+	waitInterval        time.Duration
+	waitSevereThreshold time.Duration
+	waitTimeout         time.Duration
+
+	providerStatus *runtime.RawExtension
+}
+
+func (i *controlPlane) name() string {
+	if i.values.Purpose == extensionsv1alpha1.Exposure {
+		return i.values.Name + "-exposure"
+	}
+	return i.values.Name
+}
+
+// Deploy uses the seed client to create or update the ControlPlane resource.
+func (i *controlPlane) Deploy(ctx context.Context) error {
+	_, err := i.deploy(ctx, v1beta1constants.GardenerOperationReconcile)
+	return err
+}
+
+func (i *controlPlane) deploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
+	var (
+		controlPlane = &extensionsv1alpha1.ControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      i.name(),
+				Namespace: i.values.Namespace,
+			},
+		}
+		providerConfig *runtime.RawExtension
+	)
+
+	if cfg := i.values.ProviderConfig; cfg != nil {
+		providerConfig = &runtime.RawExtension{Raw: cfg.Raw}
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, i.client, controlPlane, func() error {
+		metav1.SetMetaDataAnnotation(&controlPlane.ObjectMeta, v1beta1constants.GardenerOperation, operation)
+		metav1.SetMetaDataAnnotation(&controlPlane.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+
+		controlPlane.Spec = extensionsv1alpha1.ControlPlaneSpec{
+			DefaultSpec: extensionsv1alpha1.DefaultSpec{
+				Type:           i.values.Type,
+				ProviderConfig: providerConfig,
+			},
+			Region:  i.values.Region,
+			Purpose: &i.values.Purpose,
+			SecretRef: corev1.SecretReference{
+				Name:      v1beta1constants.SecretNameCloudProvider,
+				Namespace: controlPlane.Namespace,
+			},
+			InfrastructureProviderStatus: i.values.InfrastructureProviderStatus,
+		}
+
+		return nil
+	})
+
+	return controlPlane, err
+}
+
+// Restore uses the seed client and the ShootState to create the ControlPlane resources and restore their state.
+func (i *controlPlane) Restore(ctx context.Context, shootState *gardencorev1alpha1.ShootState) error {
+	return common.RestoreExtensionWithDeployFunction(
+		ctx,
+		shootState,
+		i.client,
+		extensionsv1alpha1.ControlPlaneResource,
+		i.values.Namespace,
+		i.deploy,
+	)
+}
+
+// Migrate migrates the ControlPlane resources.
+func (i *controlPlane) Migrate(ctx context.Context) error {
+	return common.MigrateExtensionCRs(
+		ctx,
+		i.client,
+		&extensionsv1alpha1.ControlPlaneList{},
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ControlPlane{} },
+		i.values.Namespace,
+	)
+}
+
+// Destroy deletes the ControlPlane resource.
+func (i *controlPlane) Destroy(ctx context.Context) error {
+	return common.DeleteExtensionCR(
+		ctx,
+		i.client,
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ControlPlane{} },
+		i.values.Namespace,
+		i.name(),
+	)
+}
+
+// Wait waits until the ControlPlane resource is ready.
+func (i *controlPlane) Wait(ctx context.Context) error {
+	return common.WaitUntilExtensionCRReady(
+		ctx,
+		i.client,
+		i.logger,
+		func() runtime.Object { return &extensionsv1alpha1.ControlPlane{} },
+		extensionsv1alpha1.ControlPlaneResource,
+		i.values.Namespace,
+		i.name(),
+		i.waitInterval,
+		i.waitSevereThreshold,
+		i.waitTimeout,
+		func(obj runtime.Object) error {
+			controlPlane, ok := obj.(*extensionsv1alpha1.ControlPlane)
+			if !ok {
+				return fmt.Errorf("expected extensionsv1alpha1.ControlPlane but got %T", controlPlane)
+			}
+
+			i.providerStatus = controlPlane.Status.ProviderStatus
+			return nil
+		},
+	)
+}
+
+// WaitMigrate waits until the ControlPlane resources are migrated successfully.
+func (i *controlPlane) WaitMigrate(ctx context.Context) error {
+	return common.WaitUntilExtensionCRMigrated(
+		ctx,
+		i.client,
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ControlPlane{} },
+		i.values.Namespace,
+		i.name(),
+		i.waitInterval,
+		i.waitTimeout,
+	)
+}
+
+// WaitCleanup waits until the ControlPlane resource is deleted.
+func (i *controlPlane) WaitCleanup(ctx context.Context) error {
+	return common.WaitUntilExtensionCRDeleted(
+		ctx,
+		i.client,
+		i.logger,
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ControlPlane{} },
+		extensionsv1alpha1.ControlPlaneResource,
+		i.values.Namespace,
+		i.name(),
+		i.waitInterval,
+		i.waitTimeout,
+	)
+}
+
+// SetInfrastructureProviderStatus sets the infrastructure provider status in the values.
+func (i *controlPlane) SetInfrastructureProviderStatus(status *runtime.RawExtension) {
+	i.values.InfrastructureProviderStatus = status
+}
+
+// ProviderStatus returns the generated status of the provider.
+func (i *controlPlane) ProviderStatus() *runtime.RawExtension {
+	return i.providerStatus
+}

--- a/pkg/operation/botanist/extensions/controlplane/controlplane_suite_test.go
+++ b/pkg/operation/botanist/extensions/controlplane/controlplane_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestControlPlane(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Botanist Extensions ControlPlane Suite")
+}

--- a/pkg/operation/botanist/extensions/controlplane/controlplane_test.go
+++ b/pkg/operation/botanist/extensions/controlplane/controlplane_test.go
@@ -1,0 +1,456 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/logger"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
+	"github.com/gardener/gardener/pkg/operation/botanist/extensions/controlplane"
+	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/operation/shoot"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("ControlPlane", func() {
+	var (
+		ctrl *gomock.Controller
+		c    client.Client
+
+		mockNow *mocktime.MockNow
+		now     time.Time
+
+		ctx = context.TODO()
+		log = logger.NewNopLogger()
+
+		name                         = "test"
+		namespace                    = "testnamespace"
+		extensionType                = "some-type"
+		purpose                      = extensionsv1alpha1.Purpose("foo")
+		region                       = "local"
+		providerConfig               = &runtime.RawExtension{Raw: []byte(`{"bar":"baz"}`)}
+		infrastructureProviderStatus = &runtime.RawExtension{Raw: []byte(`{"baz":"foo"}`)}
+
+		cp = &extensionsv1alpha1.ControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+		cpSpec extensionsv1alpha1.ControlPlaneSpec
+
+		defaultDepWaiter shoot.ExtensionControlPlane
+		values           *controlplane.Values
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockNow = mocktime.NewMockNow(ctrl)
+
+		s := runtime.NewScheme()
+		Expect(extensionsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())
+		c = fake.NewFakeClientWithScheme(s)
+
+		cpSpec = extensionsv1alpha1.ControlPlaneSpec{
+			DefaultSpec: extensionsv1alpha1.DefaultSpec{
+				Type:           extensionType,
+				ProviderConfig: providerConfig,
+			},
+			Region:  region,
+			Purpose: &purpose,
+			SecretRef: corev1.SecretReference{
+				Name:      "cloudprovider",
+				Namespace: namespace,
+			},
+			InfrastructureProviderStatus: infrastructureProviderStatus,
+		}
+
+		values = &controlplane.Values{
+			Name:                         name,
+			Namespace:                    namespace,
+			Type:                         extensionType,
+			ProviderConfig:               providerConfig,
+			Purpose:                      purpose,
+			Region:                       region,
+			InfrastructureProviderStatus: infrastructureProviderStatus,
+		}
+		defaultDepWaiter = controlplane.New(log, c, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#Deploy", func() {
+		It("should successfully deploy the ControlPlane resource (purpose != exposure)", func() {
+			defer test.WithVars(&controlplane.TimeNow, mockNow.Do)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+			obj := &extensionsv1alpha1.ControlPlane{}
+			err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(obj).To(DeepEqual(&extensionsv1alpha1.ControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: extensionsv1alpha1.SchemeGroupVersion.String(),
+					Kind:       extensionsv1alpha1.ControlPlaneResource,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"gardener.cloud/operation": "reconcile",
+						"gardener.cloud/timestamp": now.UTC().String(),
+					},
+					ResourceVersion: "1",
+				},
+				Spec: cpSpec,
+			}))
+		})
+
+		It("should successfully deploy the ControlPlane resource (purpose == exposure)", func() {
+			defer test.WithVars(&controlplane.TimeNow, mockNow.Do)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			values.Purpose = extensionsv1alpha1.Exposure
+			cpSpec.Purpose = &values.Purpose
+			defaultDepWaiter = controlplane.New(log, c, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
+
+			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+			obj := &extensionsv1alpha1.ControlPlane{}
+			err := c.Get(ctx, client.ObjectKey{Name: name + "-exposure", Namespace: namespace}, obj)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(obj).To(DeepEqual(&extensionsv1alpha1.ControlPlane{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: extensionsv1alpha1.SchemeGroupVersion.String(),
+					Kind:       extensionsv1alpha1.ControlPlaneResource,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name + "-exposure",
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"gardener.cloud/operation": "reconcile",
+						"gardener.cloud/timestamp": now.UTC().String(),
+					},
+					ResourceVersion: "1",
+				},
+				Spec: cpSpec,
+			}))
+		})
+	})
+
+	Describe("#Wait", func() {
+		It("should return error when no resources are found", func() {
+			Expect(defaultDepWaiter.Wait(ctx)).To(HaveOccurred())
+		})
+
+		It("should return error when resource is not ready", func() {
+			obj := cp.DeepCopy()
+			obj.Status.LastError = &gardencorev1beta1.LastError{
+				Description: "Some error",
+			}
+			Expect(c.Create(ctx, obj)).To(Succeed(), "creating controlplane succeeds")
+
+			Expect(defaultDepWaiter.Wait(ctx)).To(HaveOccurred(), "controlplane indicates error")
+		})
+
+		It("should return no error when it's ready (purpose != exposure)", func() {
+			obj := cp.DeepCopy()
+			obj.Annotations = nil
+			obj.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+			}
+			Expect(c.Create(ctx, obj)).To(Succeed(), "creating controlplane succeeds")
+
+			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed(), "controlplane is ready, should not return an error")
+		})
+
+		It("should return no error when it's ready (purpose == exposure)", func() {
+			values.Purpose = extensionsv1alpha1.Exposure
+			defaultDepWaiter = controlplane.New(log, c, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
+
+			obj := cp.DeepCopy()
+			obj.Name += "-exposure"
+			obj.Annotations = nil
+			obj.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+			}
+			Expect(c.Create(ctx, obj)).To(Succeed(), "creating controlplane succeeds")
+
+			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed(), "controlplane is ready, should not return an error")
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should not return error when not found", func() {
+			Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
+		})
+
+		It("should not return error when deleted successfully", func() {
+			Expect(c.Create(ctx, cp.DeepCopy())).To(Succeed(), "adding pre-existing controlplane succeeds")
+			Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
+		})
+
+		It("should return error if not deleted successfully (purpose != exposure)", func() {
+			defer test.WithVars(&common.TimeNow, mockNow.Do)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			values.Purpose = extensionsv1alpha1.Exposure
+			fakeErr := fmt.Errorf("some random error")
+			obj := cp.DeepCopy()
+			obj.Name += "-exposure"
+			obj.Annotations = map[string]string{
+				"confirmation.gardener.cloud/deletion": "true",
+				"gardener.cloud/timestamp":             now.UTC().String(),
+			}
+
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Get(ctx, kutil.Key(obj.Namespace, obj.Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.ControlPlane{}))
+			mc.EXPECT().Update(ctx, obj)
+			mc.EXPECT().Delete(ctx, obj).Return(fakeErr)
+
+			err := controlplane.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond).Destroy(ctx)
+			Expect(err).To(MatchError(fakeErr))
+		})
+
+		It("should return error if not deleted successfully (purpose == exposure)", func() {
+			defer test.WithVars(&common.TimeNow, mockNow.Do)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			fakeErr := fmt.Errorf("some random error")
+			obj := cp.DeepCopy()
+			obj.Annotations = map[string]string{
+				"confirmation.gardener.cloud/deletion": "true",
+				"gardener.cloud/timestamp":             now.UTC().String(),
+			}
+
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&extensionsv1alpha1.ControlPlane{}))
+			mc.EXPECT().Update(ctx, obj)
+			mc.EXPECT().Delete(ctx, obj).Return(fakeErr)
+
+			err := controlplane.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond).Destroy(ctx)
+			Expect(err).To(MatchError(fakeErr))
+		})
+	})
+
+	Describe("#WaitCleanup", func() {
+		It("should not return error when resources are removed", func() {
+			Expect(defaultDepWaiter.WaitCleanup(ctx)).To(Succeed())
+		})
+
+		It("should return error if resources with deletionTimestamp still exist (purpose != exposure)", func() {
+			timeNow := metav1.Now()
+			obj := cp.DeepCopy()
+			obj.DeletionTimestamp = &timeNow
+			Expect(c.Create(ctx, obj)).To(Succeed())
+
+			Expect(defaultDepWaiter.WaitCleanup(ctx)).To(HaveOccurred())
+		})
+
+		It("should return error if resources with deletionTimestamp still exist (purpose == exposure)", func() {
+			timeNow := metav1.Now()
+			obj := cp.DeepCopy()
+			obj.Name += "-exposure"
+			obj.DeletionTimestamp = &timeNow
+			Expect(c.Create(ctx, obj)).To(Succeed())
+
+			values.Purpose = extensionsv1alpha1.Exposure
+			defaultDepWaiter = controlplane.New(log, c, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
+			Expect(defaultDepWaiter.WaitCleanup(ctx)).To(HaveOccurred())
+		})
+	})
+
+	Describe("#Restore", func() {
+		var (
+			state      = &runtime.RawExtension{Raw: []byte("dummy state")}
+			shootState *gardencorev1alpha1.ShootState
+		)
+
+		BeforeEach(func() {
+			shootState = &gardencorev1alpha1.ShootState{
+				Spec: gardencorev1alpha1.ShootStateSpec{
+					Extensions: []gardencorev1alpha1.ExtensionResourceState{
+						{
+							Name:    &name,
+							Kind:    extensionsv1alpha1.ControlPlaneResource,
+							Purpose: pointer.StringPtr(string(purpose)),
+							State:   state,
+						},
+					},
+				},
+			}
+		})
+
+		It("should properly restore the controlplane state if it exists (purpose != exposure)", func() {
+			defer test.WithVars(
+				&controlplane.TimeNow, mockNow.Do,
+				&common.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			obj := cp.DeepCopy()
+			obj.Spec = cpSpec
+			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/operation", "wait-for-state")
+			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().String())
+			expectedWithState := obj.DeepCopy()
+			expectedWithState.Status.State = state
+			expectedWithRestore := expectedWithState.DeepCopy()
+			expectedWithRestore.Annotations["gardener.cloud/operation"] = "restore"
+
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&extensionsv1alpha1.ControlPlane{})).Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("ControlPlane"), name))
+			mc.EXPECT().Create(ctx, obj)
+			mc.EXPECT().Status().Return(mc)
+			mc.EXPECT().Update(ctx, expectedWithState)
+			mc.EXPECT().Patch(ctx, expectedWithRestore, client.MergeFrom(expectedWithState))
+
+			Expect(controlplane.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond).Restore(ctx, shootState)).To(Succeed())
+		})
+
+		It("should properly restore the controlplane state if it exists (purpose == exposure)", func() {
+			defer test.WithVars(
+				&controlplane.TimeNow, mockNow.Do,
+				&common.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			values.Purpose = extensionsv1alpha1.Exposure
+			obj := cp.DeepCopy()
+			obj.Name += "-exposure"
+			obj.Spec = cpSpec
+			obj.Spec.Purpose = &values.Purpose
+			shootState.Spec.Extensions[0].Name = &obj.Name
+			shootState.Spec.Extensions[0].Purpose = pointer.StringPtr(string(values.Purpose))
+			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/operation", "wait-for-state")
+			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().String())
+			expectedWithState := obj.DeepCopy()
+			expectedWithState.Status.State = state
+			expectedWithRestore := expectedWithState.DeepCopy()
+			expectedWithRestore.Annotations["gardener.cloud/operation"] = "restore"
+
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Get(ctx, kutil.Key(obj.Namespace, obj.Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.ControlPlane{})).Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("ControlPlane"), obj.Name))
+			mc.EXPECT().Create(ctx, obj)
+			mc.EXPECT().Status().Return(mc)
+			mc.EXPECT().Update(ctx, expectedWithState)
+			mc.EXPECT().Patch(ctx, expectedWithRestore, client.MergeFrom(expectedWithState))
+
+			defaultDepWaiter = controlplane.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
+			Expect(defaultDepWaiter.Restore(ctx, shootState)).To(Succeed())
+		})
+	})
+
+	Describe("#Migrate", func() {
+		It("should migrate the resources (purpose != exposure)", func() {
+			Expect(c.Create(ctx, cp.DeepCopy())).To(Succeed(), "creating controlplane succeeds")
+
+			Expect(defaultDepWaiter.Migrate(ctx)).To(Succeed())
+
+			result := &extensionsv1alpha1.ControlPlane{}
+			Expect(c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, result)).To(Succeed())
+			Expect(result.Annotations).To(HaveKeyWithValue("gardener.cloud/operation", "migrate"))
+		})
+
+		It("should migrate the resources (purpose == exposure)", func() {
+			values.Purpose = extensionsv1alpha1.Exposure
+			defaultDepWaiter = controlplane.New(log, c, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
+
+			Expect(c.Create(ctx, cp.DeepCopy())).To(Succeed(), "creating controlplane succeeds")
+
+			Expect(defaultDepWaiter.Migrate(ctx)).To(Succeed())
+
+			result := &extensionsv1alpha1.ControlPlane{}
+			Expect(c.Get(ctx, client.ObjectKey{Name: values.Name, Namespace: values.Namespace}, result)).To(Succeed())
+			Expect(result.Annotations).To(HaveKeyWithValue("gardener.cloud/operation", "migrate"))
+		})
+
+		It("should not return error if resource does not exist", func() {
+			Expect(defaultDepWaiter.Migrate(ctx)).To(Succeed())
+		})
+	})
+
+	Describe("#WaitMigrate", func() {
+		It("should not return error when resource is missing", func() {
+			Expect(defaultDepWaiter.WaitMigrate(ctx)).To(Succeed())
+		})
+
+		It("should return error if resource is not yet migrated successfully", func() {
+			obj := cp.DeepCopy()
+			obj.Status.LastError = &gardencorev1beta1.LastError{
+				Description: "Some error",
+			}
+			obj.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateError,
+				Type:  gardencorev1beta1.LastOperationTypeMigrate,
+			}
+
+			Expect(c.Create(ctx, obj)).To(Succeed(), "creating controlplane succeeds")
+			Expect(defaultDepWaiter.WaitMigrate(ctx)).To(HaveOccurred())
+		})
+
+		It("should not return error if resource gets migrated successfully (purpose != exposure)", func() {
+			values.Purpose = extensionsv1alpha1.Exposure
+			defaultDepWaiter = controlplane.New(log, c, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
+
+			obj := cp.DeepCopy()
+			obj.Name += "-exposure"
+			obj.Status.LastError = nil
+			obj.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+				Type:  gardencorev1beta1.LastOperationTypeMigrate,
+			}
+
+			Expect(c.Create(ctx, obj)).To(Succeed(), "creating controlplane succeeds")
+			Expect(defaultDepWaiter.WaitMigrate(ctx)).To(Succeed(), "controlplane is ready, should not return an error")
+		})
+
+		It("should not return error if resource gets migrated successfully (purpose == exposure)", func() {
+			obj := cp.DeepCopy()
+			obj.Status.LastError = nil
+			obj.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+				Type:  gardencorev1beta1.LastOperationTypeMigrate,
+			}
+
+			Expect(c.Create(ctx, obj)).To(Succeed(), "creating controlplane succeeds")
+			Expect(defaultDepWaiter.WaitMigrate(ctx)).To(Succeed(), "controlplane is ready, should not return an error")
+		})
+	})
+})

--- a/pkg/operation/botanist/extensions/infrastructure/infrastructure.go
+++ b/pkg/operation/botanist/extensions/infrastructure/infrastructure.go
@@ -72,12 +72,12 @@ type Values struct {
 	DeploymentRequested bool
 }
 
-// New creates a new instance of an Infrastructure deployer.
+// New creates a new instance of an ExtensionInfrastructure deployer.
 func New(
 	logger logrus.FieldLogger,
 	client client.Client,
 	values *Values,
-) shoot.Infrastructure {
+) shoot.ExtensionInfrastructure {
 	return &infrastructure{
 		client:              client,
 		logger:              logger,
@@ -166,7 +166,7 @@ func (i *infrastructure) Wait(ctx context.Context) error {
 		i.client,
 		i.logger,
 		func() runtime.Object { return &extensionsv1alpha1.Infrastructure{} },
-		"Infrastructure",
+		extensionsv1alpha1.InfrastructureResource,
 		i.values.Namespace,
 		i.values.Name,
 		i.waitInterval,
@@ -192,7 +192,7 @@ func (i *infrastructure) WaitCleanup(ctx context.Context) error {
 		i.client,
 		i.logger,
 		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Infrastructure{} },
-		"Infrastructure",
+		extensionsv1alpha1.InfrastructureResource,
 		i.values.Namespace,
 		i.values.Name,
 		i.waitInterval,

--- a/pkg/operation/botanist/extensions/infrastructure/infrastructure_test.go
+++ b/pkg/operation/botanist/extensions/infrastructure/infrastructure_test.go
@@ -47,7 +47,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("#Infrastructure", func() {
+var _ = Describe("#ExtensionInfrastructure", func() {
 	const (
 		namespace    = "test-namespace"
 		name         = "test-deploy"
@@ -69,7 +69,7 @@ var _ = Describe("#Infrastructure", func() {
 
 		infra        *extensionsv1alpha1.Infrastructure
 		values       *infrastructure.Values
-		deployWaiter shoot.Infrastructure
+		deployWaiter shoot.ExtensionInfrastructure
 		waiter       *retryfake.Ops
 
 		cleanupFunc func()

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -32,7 +32,7 @@ import (
 )
 
 // DefaultInfrastructure creates the default deployer for the Infrastructure custom resource.
-func (b *Botanist) DefaultInfrastructure(seedClient client.Client) shoot.Infrastructure {
+func (b *Botanist) DefaultInfrastructure(seedClient client.Client) shoot.ExtensionInfrastructure {
 	return infrastructure.New(
 		b.Logger,
 		seedClient,

--- a/pkg/operation/common/extensions.go
+++ b/pkg/operation/common/extensions.go
@@ -208,11 +208,7 @@ func DeleteExtensionCR(
 		return err
 	}
 
-	if err := client.IgnoreNotFound(c.Delete(ctx, obj, deleteOpts...)); err != nil {
-		return err
-	}
-
-	return nil
+	return client.IgnoreNotFound(c.Delete(ctx, obj, deleteOpts...))
 }
 
 // DeleteExtensionCRs lists all extension resources and loops over them. It executes the given <predicateFunc> for each
@@ -365,7 +361,7 @@ func RestoreExtensionWithDeployFunction(
 	return AnnotateExtensionObjectWithOperation(ctx, c, extensionObj, v1beta1constants.GardenerOperationRestore)
 }
 
-//RestoreExtensionObjectState restores the status.state field of the extension resources and deploys any required resources from the provided shoot state
+// RestoreExtensionObjectState restores the status.state field of the extension resources and deploys any required resources from the provided shoot state
 func RestoreExtensionObjectState(
 	ctx context.Context,
 	c client.Client,

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -108,10 +108,12 @@ type ControlPlane struct {
 
 // Extensions contains references to extension resources.
 type Extensions struct {
-	DNS              *DNS
-	Infrastructure   Infrastructure
-	Network          component.DeployMigrateWaiter
-	ContainerRuntime ContainerRuntime
+	ControlPlane         ExtensionControlPlane
+	ControlPlaneExposure ExtensionControlPlane
+	DNS                  *DNS
+	Infrastructure       ExtensionInfrastructure
+	Network              component.DeployMigrateWaiter
+	ContainerRuntime     ExtensionContainerRuntime
 }
 
 // SystemComponents contains references to system components.
@@ -132,17 +134,24 @@ type DNS struct {
 	NginxEntry          component.DeployWaiter
 }
 
-// Infrastructure contains references to an Infrastructure extension deployer and its generated
-// provider status.
-type Infrastructure interface {
+// ExtensionInfrastructure contains references to an Infrastructure extension deployer and its generated provider
+// status.
+type ExtensionInfrastructure interface {
 	component.DeployWaiter
 	SetSSHPublicKey([]byte)
 	ProviderStatus() *runtime.RawExtension
 	NodesCIDR() *string
 }
 
-// ContainerRuntime contains references to a ContainerRuntime extension deployer.
-type ContainerRuntime interface {
+// ExtensionControlPlane contains references to a ControlPlane extension deployer and its generated provider status.
+type ExtensionControlPlane interface {
+	component.DeployMigrateWaiter
+	SetInfrastructureProviderStatus(*runtime.RawExtension)
+	ProviderStatus() *runtime.RawExtension
+}
+
+// ExtensionContainerRuntime contains references to a ContainerRuntime extension deployer.
+type ExtensionContainerRuntime interface {
 	component.DeployMigrateWaiter
 	DeleteStaleResources(ctx context.Context) error
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity quality robustness
/kind technical-debt test
/priority normal
/topology seed
/platform all
/exp intermediate

**What this PR does / why we need it**:
This PR refactors the deployment for the `ControlPlane` extension resource and adopts the component concept. This improves several aspects and the overall code quality.

**Which issue(s) this PR fixes**:
Part of #2754

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
