### PR TITLE
Cleanup terraformer library

### DIFF
--- a/extensions/pkg/controller/worker/reconciler.go
+++ b/extensions/pkg/controller/worker/reconciler.go
@@ -145,9 +145,7 @@ func (r *reconciler) removeFinalizerFromWorker(logger logr.Logger, worker *exten
 
 func (r *reconciler) removeAnnotation(logger logr.Logger, worker *extensionsv1alpha1.Worker) error {
 	logger.Info("Removing operation annotation")
-	withOpAnnotation := worker.DeepCopyObject()
-	delete(worker.Annotations, v1beta1constants.GardenerOperation)
-	return r.client.Patch(r.ctx, worker, client.MergeFrom(withOpAnnotation))
+	return extensionscontroller.RemoveAnnotation(r.ctx, r.client, worker, v1beta1constants.GardenerOperation)
 }
 
 func (r *reconciler) migrate(logger logr.Logger, worker *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
@@ -192,7 +190,6 @@ func (r *reconciler) delete(logger logr.Logger, worker *extensionsv1alpha1.Worke
 
 	if err := r.actuator.Delete(r.ctx, worker, cluster); err != nil {
 		r.updateStatusError(err, worker, gardencorev1beta1.LastOperationTypeDelete, "Error deleting worker")
-
 		return extensionscontroller.ReconcileErr(err)
 	}
 

--- a/extensions/pkg/terraformer/errors.go
+++ b/extensions/pkg/terraformer/errors.go
@@ -27,7 +27,7 @@ import (
 func retrieveTerraformErrors(logList map[string]string) []string {
 	var (
 		foundErrors = map[string]string{}
-		errorList   = []string{}
+		errorList   []string
 	)
 
 	for podName, output := range logList {
@@ -58,7 +58,7 @@ func findTerraformErrors(output string) string {
 		regexMultiNewline   = regexp.MustCompile(`\n{2,}`)
 
 		errorMessage = output
-		valid        = []string{}
+		valid        []string
 	)
 
 	// Strip optional explanation how Terraform behaves in case of errors.

--- a/extensions/pkg/terraformer/state.go
+++ b/extensions/pkg/terraformer/state.go
@@ -44,8 +44,7 @@ type terraformStateV4 struct {
 }
 
 // GetState returns the Terraform state as byte slice.
-func (t *terraformer) GetState() ([]byte, error) {
-	ctx := context.TODO()
+func (t *terraformer) GetState(ctx context.Context) ([]byte, error) {
 	configMap := &corev1.ConfigMap{}
 	if err := t.client.Get(ctx, kutil.Key(t.namespace, t.stateName), configMap); err != nil {
 		return nil, err
@@ -56,7 +55,7 @@ func (t *terraformer) GetState() ([]byte, error) {
 
 // GetStateOutputVariables returns the given <variable> from the given Terraform <stateData>.
 // In case the variable was not found, an error is returned.
-func (t *terraformer) GetStateOutputVariables(variables ...string) (map[string]string, error) {
+func (t *terraformer) GetStateOutputVariables(ctx context.Context, variables ...string) (map[string]string, error) {
 	var (
 		output = make(map[string]string)
 
@@ -64,7 +63,7 @@ func (t *terraformer) GetStateOutputVariables(variables ...string) (map[string]s
 		foundVariables  = sets.NewString()
 	)
 
-	stateConfigMap, err := t.GetState()
+	stateConfigMap, err := t.GetState(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -93,8 +92,8 @@ func (t *terraformer) GetStateOutputVariables(variables ...string) (map[string]s
 }
 
 // IsStateEmpty returns true if the Terraform state is empty, and false otherwise.
-func (t *terraformer) IsStateEmpty() bool {
-	state, err := t.GetState()
+func (t *terraformer) IsStateEmpty(ctx context.Context) bool {
+	state, err := t.GetState(ctx)
 	if err != nil {
 		return apierrors.IsNotFound(err)
 	}
@@ -164,7 +163,7 @@ func sniffJSONStateVersion(stateConfigMap []byte) (uint64, error) {
 	return *sniff.Version, nil
 }
 
-// Initialize implements
+// Initialize implements StateConfigMapInitializer
 func (f StateConfigMapInitializerFunc) Initialize(ctx context.Context, c client.Client, namespace, name string) error {
 	return f(ctx, c, namespace, name)
 }

--- a/extensions/pkg/terraformer/terraform_test.go
+++ b/extensions/pkg/terraformer/terraform_test.go
@@ -19,9 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -30,6 +27,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 var (
@@ -41,11 +41,14 @@ var _ = Describe("terraformer", func() {
 	var (
 		ctrl *gomock.Controller
 		c    *mockclient.MockClient
+		ctx  context.Context
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		c = mockclient.NewMockClient(ctrl)
+
+		ctx = context.Background()
 	})
 
 	AfterEach(func() {
@@ -81,7 +84,7 @@ var _ = Describe("terraformer", func() {
 					Create(gomock.Any(), expected.DeepCopy()),
 			)
 
-			actual, err := CreateOrUpdateConfigurationConfigMap(context.TODO(), c, namespace, name, main, variables)
+			actual, err := CreateOrUpdateConfigurationConfigMap(ctx, c, namespace, name, main, variables)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(actual).To(Equal(expected))
 		})
@@ -106,13 +109,13 @@ var _ = Describe("terraformer", func() {
 						StateKey: "",
 					},
 				}
-				stateConfigMapInitializer = StateConfigMapInitializerFunc(CreateState)
+				stateConfigMapInitializer = CreateState
 			})
 
 			It("should create the ConfigMap", func() {
 				c.EXPECT().Create(gomock.Any(), expected.DeepCopy())
 
-				err := stateConfigMapInitializer.Initialize(context.TODO(), c, namespace, name)
+				err := stateConfigMapInitializer.Initialize(ctx, c, namespace, name)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -121,7 +124,7 @@ var _ = Describe("terraformer", func() {
 					Create(gomock.Any(), expected.DeepCopy()).
 					Return(apierrors.NewAlreadyExists(configMapGroupResource, name))
 
-				err := stateConfigMapInitializer.Initialize(context.TODO(), c, namespace, name)
+				err := stateConfigMapInitializer.Initialize(ctx, c, namespace, name)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -130,7 +133,7 @@ var _ = Describe("terraformer", func() {
 					Create(gomock.Any(), expected.DeepCopy()).
 					Return(apierrors.NewForbidden(configMapGroupResource, name, fmt.Errorf("not allowed to create ConfigMap")))
 
-				err := stateConfigMapInitializer.Initialize(context.TODO(), c, namespace, name)
+				err := stateConfigMapInitializer.Initialize(ctx, c, namespace, name)
 				Expect(err).To(HaveOccurred())
 				Expect(apierrors.IsForbidden(err)).To(BeTrue())
 			})
@@ -159,7 +162,7 @@ var _ = Describe("terraformer", func() {
 					c.EXPECT().Create(gomock.Any(), expected.DeepCopy()),
 				)
 
-				err := stateConfigMapInitializer.Initialize(context.TODO(), c, namespace, name)
+				err := stateConfigMapInitializer.Initialize(ctx, c, namespace, name)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -191,7 +194,7 @@ var _ = Describe("terraformer", func() {
 					Create(gomock.Any(), expected.DeepCopy()),
 			)
 
-			actual, err := CreateOrUpdateTFVarsSecret(context.TODO(), c, namespace, name, tfVars)
+			actual, err := CreateOrUpdateTFVarsSecret(ctx, c, namespace, name, tfVars)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(actual).To(Equal(expected))
 		})
@@ -261,7 +264,7 @@ var _ = Describe("terraformer", func() {
 				state                                                   string
 				createState                                             *corev1.ConfigMap
 				configurationNotFound, variablesNotFound, stateNotFound *apierrors.StatusError
-				runInitializer                                          func(initializeState bool) error
+				runInitializer                                          func(ctx context.Context, initializeState bool) error
 			)
 
 			Context("When there is no init state", func() {
@@ -276,8 +279,8 @@ var _ = Describe("terraformer", func() {
 					configurationNotFound = apierrors.NewNotFound(configMapGroupResource, configurationName)
 					variablesNotFound = apierrors.NewNotFound(secretGroupResource, variablesName)
 
-					runInitializer = func(initializeState bool) error {
-						return DefaultInitializer(c, main, variables, tfVars, StateConfigMapInitializerFunc(CreateState)).Initialize(&InitializerConfig{
+					runInitializer = func(ctx context.Context, initializeState bool) error {
+						return DefaultInitializer(c, main, variables, tfVars, StateConfigMapInitializerFunc(CreateState)).Initialize(ctx, &InitializerConfig{
 							Namespace:         namespace,
 							ConfigurationName: configurationName,
 							VariablesName:     variablesName,
@@ -305,7 +308,7 @@ var _ = Describe("terraformer", func() {
 							Create(gomock.Any(), createState.DeepCopy()),
 					)
 
-					Expect(runInitializer(true)).NotTo(HaveOccurred())
+					Expect(runInitializer(ctx, true)).NotTo(HaveOccurred())
 				})
 
 				It("should not initialize state when initializeState is false", func() {
@@ -323,7 +326,7 @@ var _ = Describe("terraformer", func() {
 							Create(gomock.Any(), createVariables.DeepCopy()),
 					)
 
-					Expect(runInitializer(false)).NotTo(HaveOccurred())
+					Expect(runInitializer(ctx, false)).NotTo(HaveOccurred())
 				})
 			})
 
@@ -340,8 +343,8 @@ var _ = Describe("terraformer", func() {
 					variablesNotFound = apierrors.NewNotFound(secretGroupResource, variablesName)
 					stateNotFound = apierrors.NewNotFound(configMapGroupResource, stateName)
 
-					runInitializer = func(initializeState bool) error {
-						return DefaultInitializer(c, main, variables, tfVars, &CreateOrUpdateState{State: &state}).Initialize(&InitializerConfig{
+					runInitializer = func(ctx context.Context, initializeState bool) error {
+						return DefaultInitializer(c, main, variables, tfVars, &CreateOrUpdateState{State: &state}).Initialize(ctx, &InitializerConfig{
 							Namespace:         namespace,
 							ConfigurationName: configurationName,
 							VariablesName:     variablesName,
@@ -372,7 +375,7 @@ var _ = Describe("terraformer", func() {
 							Create(gomock.Any(), createState.DeepCopy()),
 					)
 
-					Expect(runInitializer(true)).NotTo(HaveOccurred())
+					Expect(runInitializer(ctx, true)).NotTo(HaveOccurred())
 				})
 
 				It("should not initialize state when initializeState is false", func() {
@@ -390,7 +393,7 @@ var _ = Describe("terraformer", func() {
 							Create(gomock.Any(), createVariables.DeepCopy()),
 					)
 
-					Expect(runInitializer(false)).NotTo(HaveOccurred())
+					Expect(runInitializer(ctx, false)).NotTo(HaveOccurred())
 				})
 			})
 		})
@@ -400,8 +403,8 @@ var _ = Describe("terraformer", func() {
 		It("should return err when config is not defined", func() {
 			tf := New(nil, c, nil, "purpose", "namespace", "name", "image")
 
-			err := tf.Apply()
-			Expect(err).To((HaveOccurred()))
+			err := tf.Apply(ctx)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 
@@ -423,7 +426,7 @@ var _ = Describe("terraformer", func() {
 				"version": 1,
 			}
 			stateJSON, err := json.Marshal(state)
-			Expect(err).NotTo((HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 
 			c.EXPECT().
 				Get(gomock.Any(), stateKey, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).
@@ -435,7 +438,7 @@ var _ = Describe("terraformer", func() {
 				})
 
 			terraformer := New(nil, c, nil, purpose, namespace, name, image)
-			actual, err := terraformer.GetStateOutputVariables("variableV1")
+			actual, err := terraformer.GetStateOutputVariables(ctx, "variableV1")
 
 			Expect(actual).To(BeNil())
 			Expect(err).To(HaveOccurred())
@@ -455,7 +458,7 @@ var _ = Describe("terraformer", func() {
 				},
 			}
 			stateJSON, err := json.Marshal(state)
-			Expect(err).NotTo((HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 
 			c.EXPECT().
 				Get(gomock.Any(), stateKey, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).
@@ -467,7 +470,7 @@ var _ = Describe("terraformer", func() {
 				})
 
 			terraformer := New(nil, c, nil, purpose, namespace, name, image)
-			actual, err := terraformer.GetStateOutputVariables("variableV3")
+			actual, err := terraformer.GetStateOutputVariables(ctx, "variableV3")
 
 			expected := map[string]string{
 				"variableV3": "valueV3",
@@ -486,7 +489,7 @@ var _ = Describe("terraformer", func() {
 				},
 			}
 			stateJSON, err := json.Marshal(state)
-			Expect(err).NotTo((HaveOccurred()))
+			Expect(err).NotTo(HaveOccurred())
 
 			c.EXPECT().
 				Get(gomock.Any(), stateKey, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).
@@ -498,7 +501,7 @@ var _ = Describe("terraformer", func() {
 				})
 
 			terraformer := New(nil, c, nil, purpose, namespace, name, image)
-			actual, err := terraformer.GetStateOutputVariables("variableV4")
+			actual, err := terraformer.GetStateOutputVariables(ctx, "variableV4")
 
 			expected := map[string]string{
 				"variableV4": "valueV4",

--- a/extensions/pkg/terraformer/terraform_test.go
+++ b/extensions/pkg/terraformer/terraform_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -27,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -42,6 +44,8 @@ var _ = Describe("terraformer", func() {
 		ctrl *gomock.Controller
 		c    *mockclient.MockClient
 		ctx  context.Context
+
+		log logr.Logger
 	)
 
 	BeforeEach(func() {
@@ -49,6 +53,8 @@ var _ = Describe("terraformer", func() {
 		c = mockclient.NewMockClient(ctrl)
 
 		ctx = context.Background()
+
+		log = logzap.New(logzap.WriteTo(GinkgoWriter))
 	})
 
 	AfterEach(func() {
@@ -401,7 +407,7 @@ var _ = Describe("terraformer", func() {
 
 	Describe("#Apply", func() {
 		It("should return err when config is not defined", func() {
-			tf := New(nil, c, nil, "purpose", "namespace", "name", "image")
+			tf := New(log, c, nil, "purpose", "namespace", "name", "image")
 
 			err := tf.Apply(ctx)
 			Expect(err).To(HaveOccurred())
@@ -437,7 +443,7 @@ var _ = Describe("terraformer", func() {
 					return nil
 				})
 
-			terraformer := New(nil, c, nil, purpose, namespace, name, image)
+			terraformer := New(log, c, nil, purpose, namespace, name, image)
 			actual, err := terraformer.GetStateOutputVariables(ctx, "variableV1")
 
 			Expect(actual).To(BeNil())
@@ -469,7 +475,7 @@ var _ = Describe("terraformer", func() {
 					return nil
 				})
 
-			terraformer := New(nil, c, nil, purpose, namespace, name, image)
+			terraformer := New(log, c, nil, purpose, namespace, name, image)
 			actual, err := terraformer.GetStateOutputVariables(ctx, "variableV3")
 
 			expected := map[string]string{
@@ -500,7 +506,7 @@ var _ = Describe("terraformer", func() {
 					return nil
 				})
 
-			terraformer := New(nil, c, nil, purpose, namespace, name, image)
+			terraformer := New(log, c, nil, purpose, namespace, name, image)
 			actual, err := terraformer.GetStateOutputVariables(ctx, "variableV4")
 
 			expected := map[string]string{

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -35,6 +35,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	kutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
 )
 
@@ -47,11 +48,11 @@ const (
 
 type factory struct{}
 
-func (factory) NewForConfig(logger logrus.FieldLogger, config *rest.Config, purpose, namespace, name, image string) (Terraformer, error) {
+func (factory) NewForConfig(logger logr.Logger, config *rest.Config, purpose, namespace, name, image string) (Terraformer, error) {
 	return NewForConfig(logger, config, purpose, namespace, name, image)
 }
 
-func (f factory) New(logger logrus.FieldLogger, client client.Client, coreV1Client corev1client.CoreV1Interface, purpose, namespace, name, image string) Terraformer {
+func (f factory) New(logger logr.Logger, client client.Client, coreV1Client corev1client.CoreV1Interface, purpose, namespace, name, image string) Terraformer {
 	return New(logger, client, coreV1Client, purpose, namespace, name, image)
 }
 
@@ -66,7 +67,7 @@ func DefaultFactory() Factory {
 
 // NewForConfig creates a new Terraformer and its dependencies from the given configuration.
 func NewForConfig(
-	logger logrus.FieldLogger,
+	logger logr.Logger,
 	config *rest.Config,
 	purpose,
 	namespace,
@@ -92,8 +93,8 @@ func NewForConfig(
 // values for the namespace and the names which will be used for all the stored resources like
 // ConfigMaps/Secrets.
 func New(
-	logger logrus.FieldLogger,
-	client client.Client,
+	logger logr.Logger,
+	c client.Client,
 	coreV1Client corev1client.CoreV1Interface,
 	purpose,
 	namespace,
@@ -103,8 +104,8 @@ func New(
 	var prefix = fmt.Sprintf("%s.%s", name, purpose)
 
 	return &terraformer{
-		logger:       logger,
-		client:       client,
+		logger:       logger.WithName("terraformer"),
+		client:       c,
 		coreV1Client: coreV1Client,
 
 		name:      name,
@@ -127,7 +128,7 @@ func New(
 // Apply executes a Terraform Pod by running the 'terraform apply' command.
 func (t *terraformer) Apply(ctx context.Context) error {
 	if !t.configurationDefined {
-		return errors.New("terraformer configuration has not been defined, cannot execute the Terraform scripts")
+		return errors.New("terraformer configuration has not been defined, cannot execute Terraformer")
 	}
 	return t.execute(ctx, "apply")
 }
@@ -144,10 +145,14 @@ func (t *terraformer) Destroy(ctx context.Context) error {
 // (either successful or not), prints its logs, deletes it and returns whether it was successful or not.
 func (t *terraformer) execute(ctx context.Context, command string) error {
 	var (
+		logger = t.logger.WithValues("command", command)
+
 		succeeded             = true  // Success status of the Terraform apply/destroy pod
 		execute               = false // Should we skip the rest of the function depending on whether all ConfigMaps/Secrets exist/do not exist?
 		skipApplyOrDestroyPod = false // Should we skip the execution of the Terraform apply/destroy command (actual execution of the Terraform config)?
 	)
+
+	logger.V(1).Info("Waiting until all configuration resources exist")
 
 	// We should retry the preparation check in order to allow the kube-apiserver to actually create the ConfigMaps.
 	if err := retry.UntilTimeout(ctx, 5*time.Second, 30*time.Second, func(ctx context.Context) (done bool, err error) {
@@ -156,14 +161,14 @@ func (t *terraformer) execute(ctx context.Context, command string) error {
 			return retry.SevereError(err)
 		}
 		if numberOfExistingResources == 0 {
-			t.logger.Debugf("All ConfigMaps/Secrets do not exist, can not execute the Terraform %s Pod.", command)
+			logger.Info("All ConfigMaps and Secrets missing, can not execute Terraformer Pod")
 			return retry.Ok()
 		} else if numberOfExistingResources == numberOfConfigResources {
-			t.logger.Debugf("All ConfigMaps/Secrets exist, will execute the Terraform %s Pod.", command)
+			logger.Info("All ConfigMaps and Secrets exist, will execute Terraformer Pod")
 			execute = true
 			return retry.Ok()
 		} else {
-			t.logger.Errorf("Can not execute Terraform %s Pod as ConfigMaps/Secrets are missing!", command)
+			logger.Error(fmt.Errorf("ConfigMaps or Secrets are missing"), "Cannot execute Terraformer Pod")
 			return retry.MinorError(fmt.Errorf("%d/%d terraform resources are missing", numberOfConfigResources-numberOfExistingResources, numberOfConfigResources))
 		}
 	}); err != nil {
@@ -184,44 +189,50 @@ func (t *terraformer) execute(ctx context.Context, command string) error {
 	if !skipApplyOrDestroyPod {
 		// Create Terraform Pod which executes the provided command
 		generateName := t.computePodGenerateName(command)
+
+		logger.Info("Deploying Terraformer Pod", "generateName", generateName)
 		pod, err := t.deployTerraformerPod(ctx, generateName, command)
 		if err != nil {
-			return fmt.Errorf("failed to deploy the Terraformer Pod with .meta.generateName '%s': %s", generateName, err.Error())
+			return fmt.Errorf("failed to deploy the Terraformer Pod with .meta.generateName %q: %w", generateName, err)
 		}
 
-		t.logger.Infof("Successfully created Terraformer Pod '%s'.", pod.Name)
+		logger.Info("Successfully created Terraformer Pod", "pod", kutils.KeyFromObject(pod))
 
 		// Wait for the Terraform apply/destroy Pod to be completed
-		exitCode := t.waitForPod(ctx, pod.Name, t.deadlinePod)
+		exitCode := t.waitForPod(ctx, logger, pod, t.deadlinePod)
 		succeeded = exitCode == 0
-		t.logger.Infof("Terraform Pod '%s' finished with exit code %d.", pod.Name, exitCode)
+		if succeeded {
+			logger.Info("Terraformer Pod finished successfully")
+		} else {
+			logger.Info("Terraformer Pod finished with error", "exitCode", exitCode)
+		}
 	}
 
 	// Retrieve the logs of the apply/destroy Pods
 	podList, err := t.listTerraformerPods(ctx)
 	if err != nil {
-		t.logger.Errorf("Could not retrieve list of pods belonging to Terraformer '%s': %s", t.name, err.Error())
+		logger.Error(err, "Could not retrieve list of Terraformer pods")
 		podList = &corev1.PodList{}
 	}
 
-	t.logger.Infof("Fetching the logs for all pods belonging to Terraformer '%s'...", t.name)
-	logList, err := t.retrievePodLogs(ctx, podList)
+	logger.V(1).Info("Fetching the logs for all Terraformer pods")
+	logList, err := t.retrievePodLogs(ctx, logger, podList)
 	if err != nil {
-		t.logger.Errorf("Could not retrieve the logs of the pods belonging to Terraformer '%s': %s", t.name, err.Error())
+		logger.Error(err, "Could not retrieve the logs of the Terraformer pods")
 		logList = map[string]string{}
 	}
 	for podName, podLogs := range logList {
-		t.logger.Infof("Logs of Pod '%s' belonging to Terraformer '%s':\n%s", podName, t.name, podLogs)
+		logger.V(1).Info("Logs of Terraformer Pod: "+podLogs, "pod", client.ObjectKey{Namespace: t.namespace, Name: podName})
 	}
 
 	// Delete the Terraformer Pods
-	t.logger.Infof("Cleaning up pods created by Terraformer '%s'...", t.name)
+	logger.Info("Cleaning up pods created by Terraformer")
 	if err := t.deleteTerraformerPods(ctx, podList); err != nil {
 		return err
 	}
 
 	// Evaluate whether the execution was successful or not
-	t.logger.Infof("Terraformer '%s' execution for command '%s' has been completed.", t.name, command)
+	logger.Info("Terraformer execution has been completed")
 	if !succeeded {
 		errorMessage := fmt.Sprintf("Terraform execution for command '%s' could not be completed.", command)
 		if terraformErrors := retrieveTerraformErrors(logList); terraformErrors != nil {
@@ -291,7 +302,6 @@ func (t *terraformer) deployTerraformerPod(ctx context.Context, generateName, co
 		return nil, err
 	}
 
-	t.logger.Infof("Deploying Terraformer Pod with .meta.generateName '%s'.", generateName)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: generateName,
@@ -390,7 +400,7 @@ func (t *terraformer) listTerraformerPods(ctx context.Context) (*corev1.PodList,
 
 // retrievePodLogs fetches the logs of the created Pods by the Terraformer and returns them as a map whose
 // keys are pod names and whose values are the corresponding logs.
-func (t *terraformer) retrievePodLogs(ctx context.Context, podList *corev1.PodList) (map[string]string, error) {
+func (t *terraformer) retrievePodLogs(ctx context.Context, logger logr.Logger, podList *corev1.PodList) (map[string]string, error) {
 	logChan := make(chan map[string]string, 1)
 	go func() {
 		var logList = map[string]string{}
@@ -398,7 +408,7 @@ func (t *terraformer) retrievePodLogs(ctx context.Context, podList *corev1.PodLi
 			name := pod.Name
 			logs, err := kubernetes.GetPodLogs(ctx, t.coreV1Client.Pods(pod.Namespace), name, &corev1.PodLogOptions{})
 			if err != nil {
-				t.logger.Warnf("Could not retrieve the logs of Terraform pod %s: '%v'", name, err)
+				logger.Error(err, "Could not retrieve the logs of Terraformer pod", "pod", kutils.KeyFromObject(&pod))
 				continue
 			}
 			logList[name] = string(logs)
@@ -410,7 +420,7 @@ func (t *terraformer) retrievePodLogs(ctx context.Context, podList *corev1.PodLi
 	case result := <-logChan:
 		return result, nil
 	case <-time.After(2 * time.Minute):
-		return nil, fmt.Errorf("timeout when reading the logs of all pods created by Terraformer '%s'", t.name)
+		return nil, fmt.Errorf("timeout when reading the logs of all pods created by Terraformer")
 	}
 }
 
@@ -419,10 +429,7 @@ func (t *terraformer) deleteTerraformerPods(ctx context.Context, podList *corev1
 		if err := t.client.Delete(ctx, &pod); client.IgnoreNotFound(err) != nil {
 			return err
 		}
-
-		t.logger.Infof("Deleted Terraform Pod '%s'", pod.Name)
 	}
-
 	return nil
 }
 

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -125,19 +125,19 @@ func New(
 }
 
 // Apply executes a Terraform Pod by running the 'terraform apply' command.
-func (t *terraformer) Apply() error {
+func (t *terraformer) Apply(ctx context.Context) error {
 	if !t.configurationDefined {
 		return errors.New("terraformer configuration has not been defined, cannot execute the Terraform scripts")
 	}
-	return t.execute(context.TODO(), "apply")
+	return t.execute(ctx, "apply")
 }
 
 // Destroy executes a Terraform Pod by running the 'terraform destroy' command.
-func (t *terraformer) Destroy() error {
-	if err := t.execute(context.TODO(), "destroy"); err != nil {
+func (t *terraformer) Destroy(ctx context.Context) error {
+	if err := t.execute(ctx, "destroy"); err != nil {
 		return err
 	}
-	return t.CleanupConfiguration(context.TODO())
+	return t.CleanupConfiguration(ctx)
 }
 
 // execute creates a Terraform Pod which runs the provided scriptName (apply or destroy), waits for the Pod to be completed
@@ -178,7 +178,7 @@ func (t *terraformer) execute(ctx context.Context, command string) error {
 	// because of syntax errors. In this case, we want to skip the Terraform destroy pod (as it wouldn't do anything
 	// anyway) and just delete the related ConfigMaps/Secrets.
 	if command == "destroy" {
-		skipApplyOrDestroyPod = t.IsStateEmpty()
+		skipApplyOrDestroyPod = t.IsStateEmpty(ctx)
 	}
 
 	if !skipApplyOrDestroyPod {

--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -97,8 +97,6 @@ const (
 type Terraformer interface {
 	UseV2(bool) Terraformer
 	SetLogLevel(string) Terraformer
-	// Deprecated: use SetEnvVars instead
-	SetVariablesEnvironment(tfVarsEnvironment map[string]string) Terraformer
 	SetEnvVars(envVars ...corev1.EnvVar) Terraformer
 	SetTerminationGracePeriodSeconds(int64) Terraformer
 	SetDeadlineCleaning(time.Duration) Terraformer

--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
@@ -46,7 +46,7 @@ import (
 type terraformer struct {
 	useV2 bool
 
-	logger       logrus.FieldLogger
+	logger       logr.Logger
 	client       client.Client
 	coreV1Client corev1client.CoreV1Interface
 
@@ -122,8 +122,8 @@ type Initializer interface {
 
 // Factory is a factory that can produce Terraformer and Initializer.
 type Factory interface {
-	NewForConfig(logger logrus.FieldLogger, config *rest.Config, purpose, namespace, name, image string) (Terraformer, error)
-	New(logger logrus.FieldLogger, client client.Client, coreV1Client corev1client.CoreV1Interface, purpose, namespace, name, image string) Terraformer
+	NewForConfig(logger logr.Logger, config *rest.Config, purpose, namespace, name, image string) (Terraformer, error)
+	New(logger logr.Logger, client client.Client, coreV1Client corev1client.CoreV1Interface, purpose, namespace, name, image string) Terraformer
 	DefaultInitializer(c client.Client, main, variables string, tfVars []byte, stateInitializer StateConfigMapInitializer) Initializer
 }
 

--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -101,23 +101,23 @@ type Terraformer interface {
 	SetTerminationGracePeriodSeconds(int64) Terraformer
 	SetDeadlineCleaning(time.Duration) Terraformer
 	SetDeadlinePod(time.Duration) Terraformer
-	InitializeWith(initializer Initializer) Terraformer
-	Apply() error
-	Destroy() error
-	GetRawState(context.Context) (*RawState, error)
-	GetState() ([]byte, error)
-	IsStateEmpty() bool
+	InitializeWith(ctx context.Context, initializer Initializer) Terraformer
+	Apply(ctx context.Context) error
+	Destroy(ctx context.Context) error
+	GetRawState(ctx context.Context) (*RawState, error)
+	GetState(ctx context.Context) ([]byte, error)
+	IsStateEmpty(ctx context.Context) bool
 	CleanupConfiguration(ctx context.Context) error
-	GetStateOutputVariables(variables ...string) (map[string]string, error)
-	ConfigExists() (bool, error)
-	NumberOfResources(context.Context) (int, error)
+	GetStateOutputVariables(ctx context.Context, variables ...string) (map[string]string, error)
+	ConfigExists(ctx context.Context) (bool, error)
+	NumberOfResources(ctx context.Context) (int, error)
 	EnsureCleanedUp(ctx context.Context) error
 	WaitForCleanEnvironment(ctx context.Context) error
 }
 
 // Initializer can initialize a Terraformer.
 type Initializer interface {
-	Initialize(config *InitializerConfig) error
+	Initialize(ctx context.Context, config *InitializerConfig) error
 }
 
 // Factory is a factory that can produce Terraformer and Initializer.

--- a/pkg/mock/gardener/extensions/terraformer/mocks.go
+++ b/pkg/mock/gardener/extensions/terraformer/mocks.go
@@ -10,8 +10,8 @@ import (
 	time "time"
 
 	terraformer "github.com/gardener/gardener/extensions/pkg/terraformer"
+	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
-	logrus "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	v10 "k8s.io/client-go/kubernetes/typed/core/v1"
 	rest "k8s.io/client-go/rest"
@@ -382,7 +382,7 @@ func (mr *MockFactoryMockRecorder) DefaultInitializer(arg0, arg1, arg2, arg3, ar
 }
 
 // New mocks base method.
-func (m *MockFactory) New(arg0 logrus.FieldLogger, arg1 client.Client, arg2 v10.CoreV1Interface, arg3, arg4, arg5, arg6 string) terraformer.Terraformer {
+func (m *MockFactory) New(arg0 logr.Logger, arg1 client.Client, arg2 v10.CoreV1Interface, arg3, arg4, arg5, arg6 string) terraformer.Terraformer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "New", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(terraformer.Terraformer)
@@ -396,7 +396,7 @@ func (mr *MockFactoryMockRecorder) New(arg0, arg1, arg2, arg3, arg4, arg5, arg6 
 }
 
 // NewForConfig mocks base method.
-func (m *MockFactory) NewForConfig(arg0 logrus.FieldLogger, arg1 *rest.Config, arg2, arg3, arg4, arg5 string) (terraformer.Terraformer, error) {
+func (m *MockFactory) NewForConfig(arg0 logr.Logger, arg1 *rest.Config, arg2, arg3, arg4, arg5 string) (terraformer.Terraformer, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewForConfig", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(terraformer.Terraformer)

--- a/pkg/mock/gardener/extensions/terraformer/mocks.go
+++ b/pkg/mock/gardener/extensions/terraformer/mocks.go
@@ -278,20 +278,6 @@ func (mr *MockTerraformerMockRecorder) SetTerminationGracePeriodSeconds(arg0 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTerminationGracePeriodSeconds", reflect.TypeOf((*MockTerraformer)(nil).SetTerminationGracePeriodSeconds), arg0)
 }
 
-// SetVariablesEnvironment mocks base method.
-func (m *MockTerraformer) SetVariablesEnvironment(arg0 map[string]string) terraformer.Terraformer {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetVariablesEnvironment", arg0)
-	ret0, _ := ret[0].(terraformer.Terraformer)
-	return ret0
-}
-
-// SetVariablesEnvironment indicates an expected call of SetVariablesEnvironment.
-func (mr *MockTerraformerMockRecorder) SetVariablesEnvironment(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVariablesEnvironment", reflect.TypeOf((*MockTerraformer)(nil).SetVariablesEnvironment), arg0)
-}
-
 // UseV2 mocks base method.
 func (m *MockTerraformer) UseV2(arg0 bool) terraformer.Terraformer {
 	m.ctrl.T.Helper()

--- a/pkg/mock/gardener/extensions/terraformer/mocks.go
+++ b/pkg/mock/gardener/extensions/terraformer/mocks.go
@@ -42,17 +42,17 @@ func (m *MockTerraformer) EXPECT() *MockTerraformerMockRecorder {
 }
 
 // Apply mocks base method.
-func (m *MockTerraformer) Apply() error {
+func (m *MockTerraformer) Apply(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Apply")
+	ret := m.ctrl.Call(m, "Apply", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Apply indicates an expected call of Apply.
-func (mr *MockTerraformerMockRecorder) Apply() *gomock.Call {
+func (mr *MockTerraformerMockRecorder) Apply(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockTerraformer)(nil).Apply))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockTerraformer)(nil).Apply), arg0)
 }
 
 // CleanupConfiguration mocks base method.
@@ -70,32 +70,32 @@ func (mr *MockTerraformerMockRecorder) CleanupConfiguration(arg0 interface{}) *g
 }
 
 // ConfigExists mocks base method.
-func (m *MockTerraformer) ConfigExists() (bool, error) {
+func (m *MockTerraformer) ConfigExists(arg0 context.Context) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConfigExists")
+	ret := m.ctrl.Call(m, "ConfigExists", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConfigExists indicates an expected call of ConfigExists.
-func (mr *MockTerraformerMockRecorder) ConfigExists() *gomock.Call {
+func (mr *MockTerraformerMockRecorder) ConfigExists(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigExists", reflect.TypeOf((*MockTerraformer)(nil).ConfigExists))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigExists", reflect.TypeOf((*MockTerraformer)(nil).ConfigExists), arg0)
 }
 
 // Destroy mocks base method.
-func (m *MockTerraformer) Destroy() error {
+func (m *MockTerraformer) Destroy(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Destroy")
+	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Destroy indicates an expected call of Destroy.
-func (mr *MockTerraformerMockRecorder) Destroy() *gomock.Call {
+func (mr *MockTerraformerMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockTerraformer)(nil).Destroy))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockTerraformer)(nil).Destroy), arg0)
 }
 
 // EnsureCleanedUp mocks base method.
@@ -128,25 +128,25 @@ func (mr *MockTerraformerMockRecorder) GetRawState(arg0 interface{}) *gomock.Cal
 }
 
 // GetState mocks base method.
-func (m *MockTerraformer) GetState() ([]byte, error) {
+func (m *MockTerraformer) GetState(arg0 context.Context) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetState")
+	ret := m.ctrl.Call(m, "GetState", arg0)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetState indicates an expected call of GetState.
-func (mr *MockTerraformerMockRecorder) GetState() *gomock.Call {
+func (mr *MockTerraformerMockRecorder) GetState(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetState", reflect.TypeOf((*MockTerraformer)(nil).GetState))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetState", reflect.TypeOf((*MockTerraformer)(nil).GetState), arg0)
 }
 
 // GetStateOutputVariables mocks base method.
-func (m *MockTerraformer) GetStateOutputVariables(arg0 ...string) (map[string]string, error) {
+func (m *MockTerraformer) GetStateOutputVariables(arg0 context.Context, arg1 ...string) (map[string]string, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{}
-	for _, a := range arg0 {
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetStateOutputVariables", varargs...)
@@ -156,37 +156,38 @@ func (m *MockTerraformer) GetStateOutputVariables(arg0 ...string) (map[string]st
 }
 
 // GetStateOutputVariables indicates an expected call of GetStateOutputVariables.
-func (mr *MockTerraformerMockRecorder) GetStateOutputVariables(arg0 ...interface{}) *gomock.Call {
+func (mr *MockTerraformerMockRecorder) GetStateOutputVariables(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStateOutputVariables", reflect.TypeOf((*MockTerraformer)(nil).GetStateOutputVariables), arg0...)
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStateOutputVariables", reflect.TypeOf((*MockTerraformer)(nil).GetStateOutputVariables), varargs...)
 }
 
 // InitializeWith mocks base method.
-func (m *MockTerraformer) InitializeWith(arg0 terraformer.Initializer) terraformer.Terraformer {
+func (m *MockTerraformer) InitializeWith(arg0 context.Context, arg1 terraformer.Initializer) terraformer.Terraformer {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitializeWith", arg0)
+	ret := m.ctrl.Call(m, "InitializeWith", arg0, arg1)
 	ret0, _ := ret[0].(terraformer.Terraformer)
 	return ret0
 }
 
 // InitializeWith indicates an expected call of InitializeWith.
-func (mr *MockTerraformerMockRecorder) InitializeWith(arg0 interface{}) *gomock.Call {
+func (mr *MockTerraformerMockRecorder) InitializeWith(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializeWith", reflect.TypeOf((*MockTerraformer)(nil).InitializeWith), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializeWith", reflect.TypeOf((*MockTerraformer)(nil).InitializeWith), arg0, arg1)
 }
 
 // IsStateEmpty mocks base method.
-func (m *MockTerraformer) IsStateEmpty() bool {
+func (m *MockTerraformer) IsStateEmpty(arg0 context.Context) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsStateEmpty")
+	ret := m.ctrl.Call(m, "IsStateEmpty", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // IsStateEmpty indicates an expected call of IsStateEmpty.
-func (mr *MockTerraformerMockRecorder) IsStateEmpty() *gomock.Call {
+func (mr *MockTerraformerMockRecorder) IsStateEmpty(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsStateEmpty", reflect.TypeOf((*MockTerraformer)(nil).IsStateEmpty))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsStateEmpty", reflect.TypeOf((*MockTerraformer)(nil).IsStateEmpty), arg0)
 }
 
 // NumberOfResources mocks base method.
@@ -330,17 +331,17 @@ func (m *MockInitializer) EXPECT() *MockInitializerMockRecorder {
 }
 
 // Initialize mocks base method.
-func (m *MockInitializer) Initialize(arg0 *terraformer.InitializerConfig) error {
+func (m *MockInitializer) Initialize(arg0 context.Context, arg1 *terraformer.InitializerConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Initialize", arg0)
+	ret := m.ctrl.Call(m, "Initialize", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Initialize indicates an expected call of Initialize.
-func (mr *MockInitializerMockRecorder) Initialize(arg0 interface{}) *gomock.Call {
+func (mr *MockInitializerMockRecorder) Initialize(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockInitializer)(nil).Initialize), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockInitializer)(nil).Initialize), arg0, arg1)
 }
 
 // MockFactory is a mock of Factory interface.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging quality
/kind cleanup
/priority normal

**What this PR does / why we need it**:

This PR cleans up several things related to the terraformer library:
- removes deprecated functions: `Terraformer.SetVariablesEnvironment` and `GenerateVariablesEnvironment` (⚠️ breaking change)
- cleans up `context.TODO`s and replace them by proper contexts passed by callers (⚠️ breaking change)
- improve the logs in the infrastructure controller/reconciler similar to https://github.com/gardener/gardener/pull/2807
- switch to `logr` in the terraformer, as all the extensions use it everywhere and using `logrus` only there makes the logs inconsistent and hard to read (⚠️ breaking change)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```breaking dependency
The deprecated functions in the terraformer library (`SetVariablesEnvironment` and `GenerateVariablesEnvironment`) have been removed.
```
```breaking dependency
The `Terraformer` functions have been changed to allow passing proper contexts. Please adapt your usage accordingly.
```
```breaking dependency
The terraformer library was switched to `logr` instead of `logrus` in order to have more consistent and readable logging in the infrastructure controllers of provider extensions. Please adapt your usage accordingly.
```
