### PR TITLE
Update cloud credentials even for unwanted machine deployments.

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -213,6 +213,27 @@ func (a *genericActuator) cleanupMachineClassSecrets(ctx context.Context, logger
 	return nil
 }
 
+// updateCloudCredentialsInAllMachineClassSecrets updates the cloud credentials
+// for all existing machine class secrets.
+func (a *genericActuator) updateCloudCredentialsInAllMachineClassSecrets(ctx context.Context, logger logr.Logger, cloudCredentials map[string][]byte, namespace string) error {
+	logger.Info("Updating cloud credentials for existing machine class secrets")
+	secretList, err := a.listMachineClassSecrets(ctx, namespace)
+	if err != nil {
+		return errors.Wrapf(err, "failed to list machine class secrets in namespace %s", namespace)
+	}
+
+	for _, secret := range secretList.Items {
+		secretCopy := secret.DeepCopy()
+		for key, value := range cloudCredentials {
+			secretCopy.Data[key] = value
+		}
+		if err := a.client.Patch(ctx, secretCopy, client.MergeFrom(&secret)); err != nil {
+			return errors.Wrapf(err, "failed to patch secret %s/%s with cloud credentials", namespace, secret.Name)
+		}
+	}
+	return nil
+}
+
 // shallowDeleteMachineClassSecrets deletes all unused machine class secrets (i.e., those which are not part
 // of the provided list <usedSecrets>) without waiting for MCM to do this.
 func (a *genericActuator) shallowDeleteMachineClassSecrets(ctx context.Context, logger logr.Logger, namespace string, wantedMachineDeployments worker.MachineDeployments) error {

--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -64,6 +64,15 @@ func (a *genericActuator) Delete(ctx context.Context, worker *extensionsv1alpha1
 		return errors.Wrapf(err, "failed to deploy the machine classes")
 	}
 
+	// Update cloud credentials for all existing machine class secrets
+	cloudCredentials, err := workerDelegate.GetMachineControllerManagerCloudCredentials(ctx)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get the cloud credentials in namespace %s", worker.Namespace)
+	}
+	if err = a.updateCloudCredentialsInAllMachineClassSecrets(ctx, logger, cloudCredentials, worker.Namespace); err != nil {
+		return errors.Wrapf(err, "failed to update cloud credentials in machine class secrets for namespace %s", worker.Namespace)
+	}
+
 	// Mark all existing machines to become forcefully deleted.
 	logger.Info("Marking all machines to become forcefully deleted")
 	if err := a.markAllMachinesForcefulDeletion(ctx, logger, worker.Namespace); err != nil {

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -110,6 +110,15 @@ func (a *genericActuator) Reconcile(ctx context.Context, worker *extensionsv1alp
 		return errors.Wrapf(err, "failed to deploy the machine classes")
 	}
 
+	// Update cloud credentials for all existing machine class secrets
+	cloudCredentials, err := workerDelegate.GetMachineControllerManagerCloudCredentials(ctx)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get the cloud credentials in namespace %s", worker.Namespace)
+	}
+	if err = a.updateCloudCredentialsInAllMachineClassSecrets(ctx, logger, cloudCredentials, worker.Namespace); err != nil {
+		return errors.Wrapf(err, "failed to update cloud credentials in machine class secrets for namespace %s", worker.Namespace)
+	}
+
 	// Update the machine images in the worker provider status.
 	if err := workerDelegate.UpdateMachineImagesStatus(ctx); err != nil {
 		return errors.Wrapf(err, "failed to update the machine image status")

--- a/extensions/pkg/controller/worker/genericactuator/interface.go
+++ b/extensions/pkg/controller/worker/genericactuator/interface.go
@@ -26,12 +26,15 @@ import (
 
 // WorkerDelegate is used for the Worker reconciliation.
 type WorkerDelegate interface {
-	// GetMachineControllerManagerChart should return the the chart and the values for the machine-controller-manager
+	// GetMachineControllerManagerChartValues should return the the chart and the values for the machine-controller-manager
 	// deployment.
 	GetMachineControllerManagerChartValues(context.Context) (map[string]interface{}, error)
-	// GetMachineControllerManagerShootChart should return the values to render the chart containing resources
+	// GetMachineControllerManagerShootChartValues should return the values to render the chart containing resources
 	// that are required by the machine-controller-manager inside the shoot cluster itself.
 	GetMachineControllerManagerShootChartValues(context.Context) (map[string]interface{}, error)
+	// GetMachineControllerManagerCloudCredentials should return the IaaS credentials
+	// with the secret keys used by the machine-controller-manager.
+	GetMachineControllerManagerCloudCredentials(context.Context) (map[string][]byte, error)
 
 	// MachineClassKind yields the name of the provider specific machine class.
 	MachineClassKind() string


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority normal

**What this PR does / why we need it**:
The worker controller will now update the cloud credentials also for machine deployments that are not referenced by the worker resource, e.g. they are in deletion. 

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3023

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bugfix dependency
The generic worker actuator is now ensuring that all machine class secrets have up-to-date cloud credentials.
```

```breaking dependency
The `WorkerDelegate` must implement method `GetMachineControllerManagerCloudCredentials` returning map with cloud credential keys and values just like they are used by the machine-controller-manager.
```
