### PR TITLE
Force gardenlet restart if SNI is enabled in the Seed cluster

### DIFF
--- a/pkg/gardenlet/controller/shoot/seed_registration_control_test.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("gardenletAnnotations", func() {
+	BeforeEach(func() {
+		gardenletfeatures.RegisterFeatureGates()
+	})
+
+	DescribeTable("with different values annotation", func(added bool, version string, SNIEnabled bool) {
+		Expect(gardenletfeatures.FeatureGate.SetFromMap(map[string]bool{"APIServerSNI": SNIEnabled})).NotTo(HaveOccurred())
+
+		s := &gardencorev1beta1.Shoot{
+			Status: gardencorev1beta1.ShootStatus{
+				Gardener: gardencorev1beta1.Gardener{
+					Version: version,
+				},
+			},
+		}
+
+		actualAnnotations := gardenletAnnotations(s)
+
+		if added {
+			Expect(actualAnnotations).To(HaveKeyWithValue("networking.gardener.cloud/seed-sni-enabled", "true"))
+			Expect(actualAnnotations).To(HaveLen(1))
+		} else {
+			Expect(actualAnnotations).To(BeEmpty())
+		}
+	},
+		Entry("should be added for SNIEnabled release 1.14.1", true, "1.14.1", true),
+		Entry("should be added for SNIEnabled pre-release 1.14", true, "1.14-dev", true),
+		Entry("should be added for SNIEnabled pre-release 1.14.0", true, "1.14.0-dev", true),
+		Entry("should be added for SNIEnabled release 1.13.3", true, "1.13.3", true),
+		Entry("should be added for SNIEnabled pre-release 1.13", true, "1.13-dev", true),
+		Entry("should be added for SNIEnabled pre-release 1.13.0", true, "1.13.0-dev", true),
+		Entry("should not be added for SNIEnabled release 1.12.8", false, "1.12.8", true),
+		Entry("should not be added for SNIEnabled unparsable version", false, "not a semver", true),
+
+		Entry("should not be added for SNIDisabled release 1.14.1", false, "1.14.1", false),
+		Entry("should not be added for SNIDisabled pre-release 1.14", false, "1.14-dev", false),
+		Entry("should not be added for SNIDisabled pre-release 1.14.0", false, "1.14.0-dev", false),
+		Entry("should not be added for SNIDisabled release 1.13.3", false, "1.13.3", false),
+		Entry("should not be added for SNIDisabled pre-release 1.13", false, "1.13-dev", false),
+		Entry("should not be added for SNIDisabled pre-release 1.13.0", false, "1.13.0-dev", false),
+		Entry("should not be added for SNIDisabled release 1.12.8", false, "1.12.8", false),
+		Entry("should not be added for SNIDisabled unparsable version", false, "not a semver", false),
+	)
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/priority normal

**What this PR does / why we need it**:

For seed clusters created from Shoot clusters, make sure to restart the `gardenlet` so the `KUBERNETES_SERVICE_HOST` environment variable is injected and federated network policy controller is working correctly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
`gardenlet` is now restarted if `APIServerSNI` is enabled on the Seed cluster.
```
