### PR TITLE
Add minAllowed VPA ResourcePolicy for Cluster Autoscaler

### DIFF
--- a/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler.go
@@ -255,6 +255,17 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 		vpa.Spec.UpdatePolicy = &autoscalingv1beta2.PodUpdatePolicy{
 			UpdateMode: &vpaUpdateMode,
 		}
+		vpa.Spec.ResourcePolicy = &autoscalingv1beta2.PodResourcePolicy{
+			ContainerPolicies: []autoscalingv1beta2.ContainerResourcePolicy{
+				{
+					ContainerName: autoscalingv1beta2.DefaultContainerResourcePolicy,
+					MinAllowed: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("20m"),
+						corev1.ResourceMemory: resource.MustParse("50Mi"),
+					},
+				},
+			},
+		}
 		return nil
 	}); err != nil {
 		return err

--- a/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler_test.go
@@ -107,6 +107,17 @@ var _ = Describe("ClusterAutoscaler", func() {
 				UpdatePolicy: &autoscalingv1beta2.PodUpdatePolicy{
 					UpdateMode: &vpaUpdateMode,
 				},
+				ResourcePolicy: &autoscalingv1beta2.PodResourcePolicy{
+					ContainerPolicies: []autoscalingv1beta2.ContainerResourcePolicy{
+						{
+							ContainerName: autoscalingv1beta2.DefaultContainerResourcePolicy,
+							MinAllowed: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("20m"),
+								corev1.ResourceMemory: resource.MustParse("50Mi"),
+							},
+						},
+					},
+				},
 			},
 		}
 		clusterRoleBinding = &rbacv1.ClusterRoleBinding{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/area robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR adds minAllowed VPA ResourcePolicy values for Cluster Autoscaler based on observed and analyzed values on our landscapes.

We experienced cases in which the VPA recommender only recommended `10Mi` and this again led to OOM kills. `10Mi` with a request:limit ration of 1:10 is too low wrt our observation. Hence, we want to prevent such outliers. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
