### PR TITLE
Prepare for label key switch in the health check selector

### DIFF
--- a/charts/seed-bootstrap/charts/loki/values.yaml
+++ b/charts/seed-bootstrap/charts/loki/values.yaml
@@ -12,7 +12,7 @@ authEnabled: true
 annotations: {}
 
 labels:
-  # depricated label only for the health check
+  # deprecated label only for the health check
   garden.sapcloud.io/role: logging
   gardener.cloud/role: logging
   app: loki

--- a/charts/seed-controlplane/charts/gardener-resource-manager/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: gardener-resource-manager
   namespace: {{ .Release.Namespace }}
   labels:
+    gardener.cloud/role: controlplane
     garden.sapcloud.io/role: controlplane
     app: gardener-resource-manager
 spec:

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kube-apiserver
   namespace: {{ .Release.Namespace }}
   labels:
+    gardener.cloud/role: controlplane
     garden.sapcloud.io/role: controlplane
     app: kubernetes
     role: apiserver

--- a/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
@@ -40,6 +40,7 @@ metadata:
   name: alertmanager
   namespace: {{ .Release.Namespace }}
   labels:
+    gardener.cloud/role: monitoring
     garden.sapcloud.io/role: monitoring
     component: alertmanager
     role: monitoring

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/deployment.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kube-state-metrics
   namespace: {{ .Release.Namespace }}
   labels:
+    gardener.cloud/role: monitoring
     garden.sapcloud.io/role: monitoring
     component: kube-state-metrics
     type: shoot

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -33,6 +33,7 @@ metadata:
   name: prometheus
   namespace: {{ .Release.Namespace }}
   labels:
+    gardener.cloud/role: monitoring
     garden.sapcloud.io/role: monitoring
     app: prometheus
     role: monitoring

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: grafana-{{ .Values.role }}
   namespace: {{ .Release.Namespace }}
   labels:
+    gardener.cloud/role: monitoring
     garden.sapcloud.io/role: monitoring
     component: grafana
     role: {{ .Values.role }}

--- a/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler.go
@@ -166,6 +166,7 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, c.client, deployment, func() error {
 		deployment.Labels = utils.MergeStringMaps(getLabels(), map[string]string{
+			v1beta1constants.GardenRole:           v1beta1constants.GardenRoleControlPlane,
 			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
 		})
 		deployment.Spec.Replicas = &c.replicas

--- a/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler_test.go
@@ -217,6 +217,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 					Labels: map[string]string{
 						"app":                     "kubernetes",
 						"role":                    "cluster-autoscaler",
+						"gardener.cloud/role":     "controlplane",
 						"garden.sapcloud.io/role": "controlplane",
 					},
 				},

--- a/pkg/operation/botanist/controlplane/etcd/etcd.go
+++ b/pkg/operation/botanist/controlplane/etcd/etcd.go
@@ -279,7 +279,11 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
 			v1beta1constants.GardenerTimestamp: TimeNow().UTC().String(),
 		}
-		etcd.Labels = e.getLabels()
+		etcd.Labels = map[string]string{
+			v1beta1constants.LabelRole:            e.role,
+			v1beta1constants.GardenRole:           v1beta1constants.GardenRoleControlPlane,
+			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
+		}
 		etcd.Spec.Replicas = replicas
 		etcd.Spec.PriorityClassName = pointer.StringPtr(v1beta1constants.PriorityClassNameShootControlPlane)
 		etcd.Spec.Annotations = annotations

--- a/pkg/operation/botanist/controlplane/etcd/etcd_test.go
+++ b/pkg/operation/botanist/controlplane/etcd/etcd_test.go
@@ -215,6 +215,7 @@ var _ = Describe("Etcd", func() {
 						"gardener.cloud/timestamp": now.String(),
 					},
 					Labels: map[string]string{
+						"gardener.cloud/role":     "controlplane",
 						"garden.sapcloud.io/role": "controlplane",
 						"role":                    testRole,
 					},

--- a/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager.go
@@ -169,6 +169,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, k.seedClient, deployment, func() error {
 		deployment.Labels = utils.MergeStringMaps(getLabels(), map[string]string{
+			v1beta1constants.GardenRole:           v1beta1constants.GardenRoleControlPlane,
 			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
 		})
 		deployment.Spec.Replicas = &k.replicas

--- a/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager_test.go
@@ -357,6 +357,7 @@ var _ = Describe("KubeControllerManager", func() {
 							Labels: map[string]string{
 								"app":                     "kubernetes",
 								"role":                    "controller-manager",
+								"gardener.cloud/role":     "controlplane",
 								"garden.sapcloud.io/role": "controlplane",
 							},
 						},

--- a/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler.go
+++ b/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler.go
@@ -165,6 +165,7 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, k.client, deployment, func() error {
 		deployment.Labels = utils.MergeStringMaps(getLabels(), map[string]string{
+			v1beta1constants.GardenRole:           v1beta1constants.GardenRoleControlPlane,
 			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
 		})
 		deployment.Spec.Replicas = &k.replicas

--- a/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler_test.go
+++ b/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler_test.go
@@ -143,6 +143,7 @@ var _ = Describe("KubeScheduler", func() {
 					Labels: map[string]string{
 						"app":                     "kubernetes",
 						"role":                    "scheduler",
+						"gardener.cloud/role":     "controlplane",
 						"garden.sapcloud.io/role": "controlplane",
 					},
 				},

--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -54,6 +54,7 @@ import (
 )
 
 func mustGardenRoleLabelSelector(gardenRoles ...string) labels.Selector {
+	// TODO (ialidzhikov): switch to v1beta1constants.GardenRole in a future version.
 	if len(gardenRoles) == 1 {
 		return labels.SelectorFromSet(map[string]string{v1beta1constants.DeprecatedGardenRole: gardenRoles[0]})
 	}

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/helper"
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
@@ -899,7 +898,7 @@ func ensureMachineImage(oldWorkers []core.Worker, worker core.Worker, images []c
 }
 
 func (v ValidateShoot) validateShootedSeed(a admission.Attributes, shoot, oldShoot *core.Shoot) error {
-	if shoot.Namespace != constants.GardenNamespace {
+	if shoot.Namespace != v1beta1constants.GardenNamespace {
 		return nil
 	}
 
@@ -917,12 +916,12 @@ func (v ValidateShoot) validateShootedSeed(a admission.Attributes, shoot, oldSho
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return apierrors.NewInternalError(fmt.Errorf("could not get seed '%s' to verify that annotation '%s' can be removed: %v", shoot.Name, constants.AnnotationShootUseAsSeed, err))
+		return apierrors.NewInternalError(fmt.Errorf("could not get seed '%s' to verify that annotation '%s' can be removed: %v", shoot.Name, v1beta1constants.AnnotationShootUseAsSeed, err))
 	}
 
 	shoots, err := v.shootLister.List(labels.Everything())
 	if err != nil {
-		return apierrors.NewInternalError(fmt.Errorf("could not list shoots to verify that annotation '%s' can be removed: %v", constants.AnnotationShootUseAsSeed, err))
+		return apierrors.NewInternalError(fmt.Errorf("could not list shoots to verify that annotation '%s' can be removed: %v", v1beta1constants.AnnotationShootUseAsSeed, err))
 	}
 
 	if admissionutils.IsSeedUsedByShoot(shoot.Name, shoots) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority normal

**What this PR does / why we need it**:
This PR adds the `gardener.cloud/role` label key to the controlplane components. This will allows us to switch the health check label selector to use `gardener.cloud/role` in a future version.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
