### PR TITLE
Add another special case to set_dependency_version script

### DIFF
--- a/hack/.ci/set_dependency_version
+++ b/hack/.ci/set_dependency_version
@@ -109,6 +109,8 @@ elif name == 'external-dns-management':
     names = ['dns-controller-manager']
 elif name == 'logging':
     names = ['fluent-bit-plugin-installer']
+elif name == 'etcd-custom-image':
+    names = ['etcd']
 else:
     names = [name]
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/priority normal

**What this PR does / why we need it**:
The script at `hack/.ci/set_dependency_version` is vendored in to and used by most of our components. There was a recent change to the etcd-druid component that requires another special case to be handled properly.

Also pinging @shreyas-s-rao since he'll need to revendor eventually.
