### PR TITLE
Do not use FQDN for KUBERNETES_SERVICE_HOST injection

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -861,7 +861,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 		defaultValues["sni"] = map[string]interface{}{
 			"enabled":           true,
 			"advertiseIP":       b.APIServerClusterIP,
-			"apiserverFQDN":     b.outOfClusterAPIServerFQDN(),
+			"apiserverFQDN":     b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
 			"podMutatorEnabled": b.APIServerSNIPodMutatorEnabled(),
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/priority normal

**What this PR does / why we need it**:

Some Kubernetes clients are not respecting the [TLS extension specification][1] and are not removing the trailing dot. They request server name which is not recognized by envoy and TLS handshake fails.

[1]: https://tools.ietf.org/html/rfc6066#section-3

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The `KUBERNETES_SERVICE_HOST` environment variable injected when `APIServerSNI` is enabled no longer includes a trailing dot (being a Fully Qualified Domain Name) due to several homebrew kubernetes clients not properly handling it and sending wrong server name when initiating a TLS conneciton.
```
