### PR TITLE
Remove deprecated label key in networkpolicy test expectations

### DIFF
--- a/extensions/test/e2e/framework/networkpolicies/agnostic.go
+++ b/extensions/test/e2e/framework/networkpolicies/agnostic.go
@@ -168,9 +168,8 @@ func (a *Agnostic) CloudControllerManagerNotSecured() *SourcePod {
 	return &SourcePod{
 		Ports: NewSinglePort(10253),
 		Pod: NewPod("cloud-controller-manager-http", labels.Set{
-			v1beta1constants.LabelApp:             v1beta1constants.LabelKubernetes,
-			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
-			v1beta1constants.LabelRole:            "cloud-controller-manager",
+			v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
+			v1beta1constants.LabelRole: "cloud-controller-manager",
 		}, "< 1.13"),
 		ExpectedPolicies: sets.NewString(
 			"allow-from-prometheus",
@@ -187,9 +186,8 @@ func (a *Agnostic) CloudControllerManagerSecured() *SourcePod {
 	return &SourcePod{
 		Ports: NewSinglePort(10258),
 		Pod: NewPod("cloud-controller-manager-https", labels.Set{
-			v1beta1constants.LabelApp:             v1beta1constants.LabelKubernetes,
-			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
-			v1beta1constants.LabelRole:            "cloud-controller-manager",
+			v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
+			v1beta1constants.LabelRole: "cloud-controller-manager",
 		}, ">= 1.13"),
 		ExpectedPolicies: sets.NewString(
 			"allow-from-prometheus",
@@ -259,9 +257,8 @@ func (a *Agnostic) MachineControllerManager() *SourcePod {
 	return &SourcePod{
 		Ports: NewSinglePort(10258),
 		Pod: NewPod("machine-controller-manager", labels.Set{
-			v1beta1constants.LabelApp:             v1beta1constants.LabelKubernetes,
-			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
-			v1beta1constants.LabelRole:            "machine-controller-manager",
+			v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
+			v1beta1constants.LabelRole: "machine-controller-manager",
 		}),
 		ExpectedPolicies: sets.NewString(
 			"allow-from-prometheus",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority normal

**What this PR does / why we need it**:
This PR is prerequisite for https://github.com/gardener/gardener-extension-provider-aws/pull/230. Without this prerequisite, the network policy test would fail with:

```
Failure [15.728 seconds]
[BeforeSuite] BeforeSuite
/go/src/github.com/gardener/gardener-extension-provider-aws/test/e2e/networkpolicies/networkpolicy_test.go:638

  Couldn't find running Pod shoot--foo--bar/machine-controller-manager with labels: app=kubernetes,garden.sapcloud.io/role=controlplane,role=machine-controller-manager

  /go/src/github.com/gardener/gardener-extension-provider-aws/test/e2e/networkpolicies/networkpolicy_test.go:799
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
