### PR TITLE
Do not reconcile shoots multiple times during their maintenance time windows

### DIFF
--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -695,6 +695,13 @@ const (
 // Maintenance relevant types                                                                   //
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
+const (
+	// MaintenanceTimeWindowDurationMinimum is the minimum duration for a maintenance time window.
+	MaintenanceTimeWindowDurationMinimum = 30 * time.Minute
+	// MaintenanceTimeWindowDurationMaximum is the maximum duration for a maintenance time window.
+	MaintenanceTimeWindowDurationMaximum = 6 * time.Hour
+)
+
 // Maintenance contains information about the time window for maintenance operations and which
 // operations should be performed.
 type Maintenance struct {

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -870,6 +870,13 @@ const (
 // Maintenance relevant types                                                                   //
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
+const (
+	// MaintenanceTimeWindowDurationMinimum is the minimum duration for a maintenance time window.
+	MaintenanceTimeWindowDurationMinimum = 30 * time.Minute
+	// MaintenanceTimeWindowDurationMaximum is the maximum duration for a maintenance time window.
+	MaintenanceTimeWindowDurationMaximum = 6 * time.Hour
+)
+
 // Maintenance contains information about the time window for maintenance operations and which
 // operations should be performed.
 type Maintenance struct {

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -867,6 +867,13 @@ const (
 // Maintenance relevant types                                                                   //
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
+const (
+	// MaintenanceTimeWindowDurationMinimum is the minimum duration for a maintenance time window.
+	MaintenanceTimeWindowDurationMinimum = 30 * time.Minute
+	// MaintenanceTimeWindowDurationMaximum is the maximum duration for a maintenance time window.
+	MaintenanceTimeWindowDurationMaximum = 6 * time.Hour
+)
+
 // Maintenance contains information about the time window for maintenance operations and which
 // operations should be performed.
 type Maintenance struct {

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -823,12 +823,12 @@ func validateMaintenance(maintenance *core.Maintenance, fldPath *field.Path) fie
 
 		if err == nil {
 			duration := maintenanceTimeWindow.Duration()
-			if duration > 6*time.Hour {
-				allErrs = append(allErrs, field.Forbidden(fldPath.Child("timeWindow"), "time window must not be greater than 6 hours"))
+			if duration > core.MaintenanceTimeWindowDurationMaximum {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("timeWindow"), fmt.Sprintf("time window must not be greater than %s", core.MaintenanceTimeWindowDurationMaximum)))
 				return allErrs
 			}
-			if duration < 30*time.Minute {
-				allErrs = append(allErrs, field.Forbidden(fldPath.Child("timeWindow"), "time window must not be smaller than 30 minutes"))
+			if duration < core.MaintenanceTimeWindowDurationMinimum {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("timeWindow"), fmt.Sprintf("time window must not be smaller than %s", core.MaintenanceTimeWindowDurationMinimum)))
 				return allErrs
 			}
 		}

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -112,7 +112,7 @@ func (c *Controller) shootMaintenanceRequeue(key string, shoot *gardencorev1beta
 	var (
 		now             = time.Now()
 		window          = common.EffectiveShootMaintenanceTimeWindow(shoot)
-		duration        = window.RandomDurationUntilNext(now)
+		duration        = window.RandomDurationUntilNext(now, false)
 		nextMaintenance = time.Now().UTC().Add(duration)
 	)
 

--- a/pkg/gardenlet/controller/shoot/shoot.go
+++ b/pkg/gardenlet/controller/shoot/shoot.go
@@ -58,6 +58,7 @@ type Controller struct {
 	recorder                      record.EventRecorder
 	secrets                       map[string]*corev1.Secret
 	imageVector                   imagevector.ImageVector
+	shootReconciliationDueTracker *reconciliationDueTracker
 
 	controllerInstallationLister gardencorelisters.ControllerInstallationLister
 	seedLister                   gardencorelisters.SeedLister
@@ -108,6 +109,7 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 		recorder:                      recorder,
 		secrets:                       secrets,
 		imageVector:                   imageVector,
+		shootReconciliationDueTracker: newReconciliationDueTracker(),
 
 		seedLister:                   seedLister,
 		shootLister:                  shootLister,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/priority critical

**What this PR does / why we need it**:
Today, the shoot controller has various problems that lead to scalability issues in very large landscapes:
1. It is reconciling shoots multiple times during their maintenance time windows (if the gardenlet's component config sets "reconcile in maintenance only" to `true`) based on the sync period. This also happens even if the reconciliation has already happened before for the current time window.
1. When the gardenlet restarts then all shoots whose maintenance time window is met will be enqueued and reconciled immediately. If many shoots have the same maintenance time window then this will produce a lot of load.

This PR adapts the behaviour in the following ways:
1. When the gardenlet has already reconciled a shoot in its maintenance time window then it doesn't do it again. Instead, it computes a random duration for the next time window and requeues the shoot. Already reconciled shoots are those whose last reconciliation was less then `24h` ago.
1. When the gardenlet is (re)started then it does no longer reconcile all shoots whose maintenance time windows are met immediately. Instead, it computes a random time for the current time window and requeues the shoot ("jittering"). This will have the effect that not all shoots are getting reconciled at the same time right after startup.

Both changes will lead to a lot of less load on the seeds, the garden cluster (apiservers), and to less network I/O.

/cc @vpnachev 

**Special notes for your reviewer**:
The implementation introduces a so called "reconciliationDueTracker" in the shoot controller. Its purpose is to distinguish the two cases:
1. gardenlet starts and checks if shoot whose maintenance time window is met must be reconciled
1. gardenlet runs and checks if a shoot whose maintenance time window is met must be reconciled but was already delayed/jittered before

A better implementation is probably to handle this situation in the `shootAdd()` function, i.e., right in the event handler for `CREATE SHOOT` events. However, this would require some duplication of the logic that is already part of `reconcileShoot()`, and it even might have other side effects. The logic is quite complex at the moment, so I was reluctant do follow this approach (and risking to break something). I guess the `reconciliationDueTracker` approach is easier to understand/review for now, it's more lightweight and has less duplication/complexity. Nevertheless, we should clean up this shoot control logic when possible so that the whole flow/logic and different cases become better understandable and readable.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The shoot controller inside the gardenlet has been adapted to cater with large Gardener landscapes:
1. When the gardenlet has already reconciled a shoot cluster during its maintenance time window then it doesn't reconcile it again. Instead, it computes a random duration for the next time window and requeues the shoot. Already reconciled shoots are those whose last reconciliation was less then `24h` ago.
1. When the gardenlet is (re)started then it does no longer reconcile all shoots immediately whose maintenance time windows are met. Instead, it computes a random time for the current time window and requeues the shoot ("jittering", i.e., spreading the load). This will have the effect that not all shoots are getting reconciled at the same time right after startup.
```
