### PR TITLE
Fix flaky tests in hostname resolver

### DIFF
--- a/pkg/gardenlet/controller/federatedseed/networkpolicy/hostnameresolver/resolver.go
+++ b/pkg/gardenlet/controller/federatedseed/networkpolicy/hostnameresolver/resolver.go
@@ -95,14 +95,11 @@ func (l *resolver) Start(stopCtx context.Context) {
 
 		sort.Strings(addresses)
 
-		l.lock.RLock()
+		l.lock.Lock()
 		updated := !equal(addresses, l.addrs)
-		l.lock.RUnlock()
 
 		if updated {
-			l.lock.Lock()
 			l.addrs = addresses
-			l.lock.Unlock()
 
 			l.log.WithField("resolvedIPs", l.addrs).Infoln("updated resolved addresses")
 
@@ -110,6 +107,8 @@ func (l *resolver) Start(stopCtx context.Context) {
 				l.onUpdate()
 			}
 		}
+
+		l.lock.Unlock()
 	}
 
 	// start the update in the beginning


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake
/priority normal

**What this PR does / why we need it**:

The hostnameresolver tests could occasionally fail with timeout errors due to improper timeouts.

**Which issue(s) this PR fixes**:
Fixes n/a

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
