### PR TITLE
Garbage collect OutOf* Pods

### DIFF
--- a/pkg/operation/botanist/garbage_collection.go
+++ b/pkg/operation/botanist/garbage_collection.go
@@ -67,7 +67,7 @@ func (b *Botanist) deleteStalePods(ctx context.Context, c client.Client, podList
 	var result error
 
 	for _, pod := range podList.Items {
-		if strings.Contains(pod.Status.Reason, "Evicted") {
+		if strings.Contains(pod.Status.Reason, "Evicted") || strings.HasPrefix(pod.Status.Reason, "OutOf") {
 			b.Logger.Debugf("Deleting pod %s as its reason is %s.", pod.Name, pod.Status.Reason)
 			if err := c.Delete(ctx, &pod, kubernetes.DefaultDeleteOptions...); client.IgnoreNotFound(err) != nil {
 				result = multierror.Append(result, err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:

With this PR the shoot garbage collector also deletes failed Pods with the reason `OutOf*` in the Seed namespace and the `kube-system` namespace of the Shoot.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The kubelet sets the status reason in Pods to `OutOf{cpu,memory,...}`, if a Pod is assigned to a node, but the requested resources cannot be acquired / exceed the Node's capacity.
This can happen for example because of manual scheduling, but we have also observed such occurrences after a longer period of API server downtime.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The Shoot garbage collector now also deletes failed Pods with the reason `OutOf*` in the Seed namespace and the `kube-system` namespace of the Shoot.
```
