### PR TITLE
Re-evaluate shoot health status right after reconciliation

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot.go
+++ b/pkg/gardenlet/controller/shoot/shoot.go
@@ -138,7 +138,8 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 	shootInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister, config.SeedSelector),
 		Handler: cache.ResourceEventHandlerFuncs{
-			AddFunc: shootController.shootCareAdd,
+			AddFunc:    shootController.shootCareAdd,
+			UpdateFunc: shootController.shootCareUpdate,
 		},
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement
/priority normal

**What this PR does / why we need it**:
The shoot reconciler sets the conditions to `Progressing` after it finished a successful reconciliation, and the care controller starts to re-evaluate the health status after this happened. This helps end-users to better understand whether their cluster is indeed healthy after a reconciliation. Earlier, it could take up to 30s/1m (based on the configured care controller sync period) until the actual status is reflected.

Fixes #3238

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The shoot reconciler sets the conditions to `Progressing` after it finished a successful reconciliation, and the care controller starts to re-evaluate the health status after this happened. This helps end-users to better understand whether their cluster is indeed healthy after a reconciliation. Earlier, it could take up to `30s` / `1m` (based on the configured care controller sync period) until the actual status is reflected.
```