### PR TITLE
Improve infrastructure reconciliation

### DIFF
--- a/pkg/operation/botanist/extensions/infrastructure/infrastructure.go
+++ b/pkg/operation/botanist/extensions/infrastructure/infrastructure.go
@@ -40,7 +40,7 @@ const (
 	DefaultSevereThreshold = 30 * time.Second
 	// DefaultTimeout is the default timeout and defines how long Gardener should wait
 	// for a successful reconciliation of an infrastructure resource.
-	DefaultTimeout = 5 * time.Minute
+	DefaultTimeout = 10 * time.Minute
 )
 
 // TimeNow returns the current time. Exposed for testing.
@@ -60,10 +60,6 @@ type Values struct {
 	Region string
 	// SSHPublicKey is the to-be-used SSH public key of the shoot.
 	SSHPublicKey []byte
-	// IsInCreationPhase indicates if the Shoot is in the creation phase.
-	IsInCreationPhase bool
-	// IsWakingUp indicates if the Shoot is being waked up.
-	IsWakingUp bool
 	// IsInRestorePhaseOfControlPlaneMigration indicates if the Shoot is in the restoration
 	// phase of the ControlPlane migration.
 	IsInRestorePhaseOfControlPlaneMigration bool
@@ -105,7 +101,7 @@ func (i *infrastructure) Deploy(ctx context.Context) error {
 	var (
 		operation        = v1beta1constants.GardenerOperationReconcile
 		restorePhase     = i.values.IsInRestorePhaseOfControlPlaneMigration
-		requestOperation = i.values.IsInCreationPhase || i.values.IsWakingUp || i.values.IsInRestorePhaseOfControlPlaneMigration || i.values.DeploymentRequested
+		requestOperation = i.values.DeploymentRequested || restorePhase
 		infrastructure   = &extensionsv1alpha1.Infrastructure{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      i.values.Name,

--- a/pkg/operation/botanist/extensions/infrastructure/infrastructure_test.go
+++ b/pkg/operation/botanist/extensions/infrastructure/infrastructure_test.go
@@ -155,20 +155,6 @@ var _ = Describe("#ExtensionInfrastructure", func() {
 				values.ProviderConfig = nil
 				infra.Spec.ProviderConfig = nil
 			}),
-			Entry("creation phase", func() {
-				values.IsInCreationPhase = true
-				infra.Annotations = map[string]string{
-					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-					v1beta1constants.GardenerTimestamp: now.UTC().String(),
-				}
-			}),
-			Entry("wake up phase", func() {
-				values.IsWakingUp = true
-				infra.Annotations = map[string]string{
-					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-					v1beta1constants.GardenerTimestamp: now.UTC().String(),
-				}
-			}),
 			Entry("deployment task", func() {
 				values.DeploymentRequested = true
 				infra.Annotations = map[string]string{

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -17,9 +17,7 @@ package botanist
 import (
 	"context"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/botanist/extensions/infrastructure"
@@ -42,8 +40,6 @@ func (b *Botanist) DefaultInfrastructure(seedClient client.Client) shoot.Extensi
 			Type:                                    b.Shoot.Info.Spec.Provider.Type,
 			ProviderConfig:                          b.Shoot.Info.Spec.Provider.InfrastructureConfig,
 			Region:                                  b.Shoot.Info.Spec.Region,
-			IsInCreationPhase:                       b.Shoot.Info.Status.LastOperation != nil && b.Shoot.Info.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeCreate,
-			IsWakingUp:                              !gardencorev1beta1helper.HibernationIsEnabled(b.Shoot.Info) && b.Shoot.Info.Status.IsHibernated,
 			IsInRestorePhaseOfControlPlaneMigration: b.isRestorePhase(),
 			DeploymentRequested:                     controllerutils.HasTask(b.Shoot.Info.Annotations, common.ShootTaskDeployInfrastructure),
 		},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR improves the reconciliation cycles for infrastructure resources. Earlier, when a cluster was created or waking up from hibernation, the infrastructure was reconciled every time the shoot reconciliation flow stopped at a later point, e.g. timeout while waiting for workers to become ready. With this change, the infrastructure resource is not reconciled again if once done successfully.

Additionally, the infrastructure timeout has been increased from `5 minutes` -> `10 minutes`. The infrastructure extension already has proper error handling in place, i.e. it enqueues the resource automatically in case of an error. Re-triggering an infra reconciliation prematurely (because of low timeouts) isn't necessary and doesn't improve such situations. 

Even on the contrary:
1. Extension waits [15 minutes](https://github.com/gardener/gardener-extension-provider-gcp/blob/0706f81a5929278f63741420240c6d2f03fa087b/pkg/internal/terraform.go#L67) for the Terraformer Pod which is much longer than the entire infra timeout from Gardener (5 minutes)
2. Gardener times out and restarts shoot reconcile flow -> adds `gardener.cloud/operation: reconcile` to infra resource **BUT** cannot stop active reconciliation from step 1.
3. Extension enqueues infra while still in reconciliation (step 1.)
4. After successful reconciliation from step 1., the infra is reconciled again

--> 1 "unnecessary" reconciliation

Please note, a shorter timeout used to be reasonable because one might solved an occurring issue by changing the shoot spec accordingly. Since we have [early exists](https://github.com/gardener/gardener/blob/1de02bc33bdf924f7a7739fdd31fc565595a2651/pkg/operation/common/extensions.go#L170) in place for these scenarios, user experience shouldn't suffer from a higher timeout.
 
**Special notes for your reviewer**:
I decided to completely make use of the `deployInfrastructure` task, now even for creations and wake ups to keep it simple. Alternatively, we could have used the infrastructure `.status` sub-resource to deduce if we need to reconcile or not.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardener has improved infrastructure processing procedures in oder to avoid unnecessary reconciliation cycles.
```
