### PR TITLE
Sanitize webhook response

### DIFF
--- a/pkg/admissioncontroller/server/handlers/webhooks/utils_test.go
+++ b/pkg/admissioncontroller/server/handlers/webhooks/utils_test.go
@@ -22,6 +22,8 @@ import (
 	"net/http/httptest"
 	"reflect"
 
+	"github.com/gardener/gardener/pkg/logger"
+
 	. "github.com/gardener/gardener/pkg/admissioncontroller/server/handlers/webhooks"
 	core "github.com/gardener/gardener/pkg/apis/core/install"
 
@@ -72,7 +74,7 @@ var _ = Describe("Utils tests", func() {
 		DescribeTable("#DecodeAdmissionRequest",
 			func(r func() *http.Request, limit int64, objMatcher gomegatypes.GomegaMatcher, errMatcher gomegatypes.GomegaMatcher) {
 				into := &admissionv1beta1.AdmissionReview{}
-				err := DecodeAdmissionRequest(r(), decoder, into, limit)
+				err := DecodeAdmissionRequest(r(), decoder, into, limit, logger.NewNopLogger())
 				Expect(into).To(objMatcher)
 				Expect(err).To(errMatcher)
 			},
@@ -95,7 +97,7 @@ var _ = Describe("Utils tests", func() {
 				r.Header.Set("Content-Type", runtime.ContentTypeYAML)
 				return r
 			}, sizeRequest, Ignore(),
-				MatchError(fmt.Sprintf("contentType=%s, expect %s", runtime.ContentTypeYAML, runtime.ContentTypeJSON)),
+				MatchError(fmt.Sprintf("contentType not supported, expect %s", runtime.ContentTypeJSON)),
 			),
 		)
 	})

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -20,7 +20,10 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/gardener/gardener/pkg/utils"
+
 	"github.com/sirupsen/logrus"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 // Logger is the standard logger for the Gardener which is used for all messages which are not Shoot
@@ -79,6 +82,17 @@ func NewShootLogger(logger *logrus.Logger, shoot, project string) *logrus.Entry 
 
 // NewFieldLogger extends an existing logrus logger and adds the provided additional field.
 // Example output: time="2017-06-08T13:00:49+02:00" level=info msg="something" <fieldKey>=<fieldValue>.
-func NewFieldLogger(logger *logrus.Logger, fieldKey, fieldValue string) *logrus.Entry {
+func NewFieldLogger(logger logrus.FieldLogger, fieldKey, fieldValue string) *logrus.Entry {
 	return logger.WithField(fieldKey, fieldValue)
+}
+
+// IDFieldName is the name of the id field for a logger.
+const IDFieldName = "process_id"
+
+// NewIDLogger extends an existing logrus logger with a randomly generated id field.
+// Example output: time="2017-06-08T13:00:49+02:00" level=info msg="something" id=123abcde.
+func NewIDLogger(logger logrus.FieldLogger) logrus.FieldLogger {
+	id, err := utils.GenerateRandomString(8)
+	utilruntime.Must(err)
+	return NewFieldLogger(logger, IDFieldName, id)
 }

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -81,6 +81,17 @@ var _ = Describe("logger", func() {
 			})
 		})
 
+		Describe("#NewIDLogger", func() {
+			It("should return an Entry object an ID field", func() {
+				logger := NewLogger("info")
+
+				fieldLogger := NewIDLogger(logger)
+
+				entry, _ := fieldLogger.(*logrus.Entry)
+				Expect(entry.Data).To(HaveKeyWithValue(IDFieldName, Not(BeEmpty())))
+			})
+		})
+
 		Describe("#AddWriter", func() {
 			It("should return a pointer to a Test Logger object ('info' level)", func() {
 				logger := AddWriter(NewLogger(""), GinkgoWriter)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area ops-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR sanitizes webhook responses wrt findings from our static code analysis. It improves logging for the webhhoks along the way.

**Which issue(s) this PR fixes**:
Fixes #3252

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
