### PR TITLE
Fix error during seed bootstrapping for fresh seeds

### DIFF
--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -51,6 +51,7 @@ import (
 	"github.com/Masterminds/semver"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -370,7 +371,7 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 		}
 
 		lokiVpa := &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "loki-vpa", Namespace: v1beta1constants.GardenNamespace}}
-		if err := k8sSeedClient.Client().Delete(ctx, lokiVpa); client.IgnoreNotFound(err) != nil {
+		if err := k8sSeedClient.Client().Delete(ctx, lokiVpa); client.IgnoreNotFound(err) != nil && !meta.IsNoMatchError(err) {
 			return err
 		}
 


### PR DESCRIPTION
/kind  bug
/priority critical

**What this PR does / why we need it**:
I deployed a fresh shooted Seed from g/g master and ran into the below error:
```
time="xxx" level=error msg="Seed bootstrapping failed: no matches for kind \"VerticalPodAutoscaler\" in version \"autoscaling.k8s.io/v1beta2\"" seed=my-seed
```
Applying the change fixed it. During the time the [delete](https://github.com/gardener/gardener/blame/5ef926b0acc35ddeedb587b75f0ee632b93ec6db/pkg/operation/seed/seed.go#L373) is executed there are no vpa crds in the garden namespace of the Seed.

```bugfix operator
Fix an error during bootstrapping of fresh Seeds
```
