### PR TITLE
Clean up unnecessary get call during seed bootstrap

### DIFF
--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -518,11 +518,6 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 		}
 	}
 
-	nodes := &corev1.NodeList{}
-	if err = k8sSeedClient.Client().List(ctx, nodes); err != nil {
-		return err
-	}
-
 	chartApplier := k8sSeedClient.ChartApplier()
 
 	var (


### PR DESCRIPTION
/kind cleanup

It should be a leftover from the times before the introduction of vpa when the Seed nodes count was used for computing requests and limits for several components.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
