### PR TITLE
Clean up the usage of deprecated role label under charts/seed-bootstrap

### DIFF
--- a/charts/seed-bootstrap/charts/dependency-watchdog/templates/endpoint-deployment.yaml
+++ b/charts/seed-bootstrap/charts/dependency-watchdog/templates/endpoint-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     role: dependency-watchdog-endpoint
-    garden.sapcloud.io/role: controlplane
 spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: 0

--- a/charts/seed-bootstrap/charts/dependency-watchdog/templates/probe-deployment.yaml
+++ b/charts/seed-bootstrap/charts/dependency-watchdog/templates/probe-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     role: dependency-watchdog-probe
-    garden.sapcloud.io/role: controlplane
 spec:
   replicas: {{ .Values.replicas }}
   revisionHistoryLimit: 0

--- a/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kube-state-metrics
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: monitoring
+    role: monitoring
     component: kube-state-metrics
     type: seed
 spec:
@@ -21,7 +21,7 @@ spec:
   template:
     metadata:
       labels:
-        garden.sapcloud.io/role: monitoring
+        role: monitoring
         component: kube-state-metrics
         type: seed
         networking.gardener.cloud/to-dns: allowed

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
@@ -18,7 +18,6 @@ spec:
   selector:
     matchLabels:
       app: vpa-admission-controller
-{{ toYaml .Values.labels | indent 6 }}
   template:
     metadata:
 {{- if .Values.admissionController.podAnnotations }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
@@ -18,7 +18,6 @@ spec:
   selector:
     matchLabels:
       app: vpa-recommender
-{{ toYaml .Values.labels | indent 6 }}
   template:
     metadata:
 {{- if .Values.recommender.podAnnotations }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
@@ -17,7 +17,6 @@ spec:
   selector:
     matchLabels:
       app: vpa-updater
-{{ toYaml .Values.labels | indent 6 }}
   template:
     metadata:
 {{- if .Values.updater.podAnnotations }}

--- a/charts/seed-bootstrap/charts/vpa/values.yaml
+++ b/charts/seed-bootstrap/charts/vpa/values.yaml
@@ -6,7 +6,7 @@ global:
     vpa-exporter: image-repository:image-tag
 
 labels:
-  garden.sapcloud.io/role: vpa
+  gardener.cloud/role: vpa
 
 clusterType: seed
 

--- a/charts/seed-bootstrap/templates/alertmanager/alertmanager.yaml
+++ b/charts/seed-bootstrap/templates/alertmanager/alertmanager.yaml
@@ -41,7 +41,6 @@ metadata:
   name: alertmanager
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: monitoring
     component: alertmanager
     role: monitoring
 spec:
@@ -55,7 +54,6 @@ spec:
   template:
     metadata:
       labels:
-        garden.sapcloud.io/role: monitoring
         component: alertmanager
         role: monitoring
     spec:

--- a/charts/seed-bootstrap/templates/grafana/grafana-deployment.yaml
+++ b/charts/seed-bootstrap/templates/grafana/grafana-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   name: grafana
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: monitoring
+    role: monitoring
     component: grafana
 spec:
   revisionHistoryLimit: 0
@@ -20,7 +20,7 @@ spec:
         checksum/configmap-datasources: {{ include (print $.Template.BasePath "/grafana/grafana-datasources-configmap.yaml") . | sha256sum }}
         checksum/configmap-dashboard-providers: {{ include (print $.Template.BasePath "/grafana/grafana-dashboard-providers-configmap.yaml") . | sha256sum }}
       labels:
-        garden.sapcloud.io/role: monitoring
+        role: monitoring
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-aggregate-prometheus: allowed
         networking.gardener.cloud/to-loki: allowed

--- a/charts/seed-bootstrap/templates/grafana/grafana-service.yaml
+++ b/charts/seed-bootstrap/templates/grafana/grafana-service.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     component: grafana
-    garden.sapcloud.io/role: monitoring
+    role: monitoring
 spec:
   type: ClusterIP
   ports:

--- a/charts/seed-bootstrap/templates/vpa-exporter/deployment-exporter.yaml
+++ b/charts/seed-bootstrap/templates/vpa-exporter/deployment-exporter.yaml
@@ -13,7 +13,6 @@ spec:
   selector:
     matchLabels:
       app: vpa-exporter
-      garden.sapcloud.io/role: vpa
   template:
     metadata:
       labels:

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -283,7 +283,7 @@ vpa:
     port: 9570
     servicePort: 9570
     labels:
-      garden.sapcloud.io/role: vpa
+      gardener.cloud/role: vpa
 
 istio:
   enabled: false

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -667,6 +667,23 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 		}
 	}
 
+	// .spec.selector of a Deployment is immutable. If Deployment's .spec.selector contains
+	// the deprecated role label key, we delete it and let it to be re-created below with the chart apply.
+	// TODO: remove in a future version
+	deploymentKeys := []client.ObjectKey{
+		kutil.Key(v1beta1constants.GardenNamespace, "vpa-exporter"),
+	}
+	if vpaEnabled {
+		deploymentKeys = append(deploymentKeys,
+			kutil.Key(v1beta1constants.GardenNamespace, "vpa-updater"),
+			kutil.Key(v1beta1constants.GardenNamespace, "vpa-recommender"),
+			kutil.Key(v1beta1constants.GardenNamespace, "vpa-admission-controller"),
+		)
+	}
+	if err := common.DeleteDeploymentsHavingDeprecatedRoleLabelKey(ctx, k8sSeedClient.Client(), deploymentKeys); err != nil {
+		return err
+	}
+
 	values := kubernetes.Values(map[string]interface{}{
 		"cloudProvider":     seed.Info.Spec.Provider.Type,
 		"priorityClassName": v1beta1constants.PriorityClassNameShootControlPlane,


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
This PR cleans up most of the usage of the `garden.sapcloud.io/role` label key under `charts/seed-bootstrap`:
- for the monitoring components I switched `garden.sapcloud.io/role` usage to `role` to harmonise the labels in the monitoring chars. Almost all components in the garden ns use the `role` label instead of gardener.cloud/role (garden.sapcloud.io/role). I also believe that some of the usage of garden.sapcloud.io/role=controlplane|monitoring is because of legacy reason as some of the charts were moved from controlplane to the seed bootstrap - for example the dependency-watchdog, the kube-state-metrics
- the vpa components adaptation requires an additional step as the `.spec.selector` of a Deployment is immutable

Ref #1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
