### PR TITLE
Use vpa-admission-controller runtime namespace only in seed

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
@@ -53,15 +53,16 @@ spec:
         image: {{ index .Values.global.images "vpa-admission-controller" }}
         imagePullPolicy: IfNotPresent
         env:
-        - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
 {{- if not .Values.admissionController.enableServiceAccount }}
         - name: KUBERNETES_SERVICE_HOST
           value: kube-apiserver
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
+{{- else }}
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
 {{- end }}
         volumeMounts:
           - name: vpa-tls-certs


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR fixes a bug that causes the vpa-admission-controller not being able to update its status (inside `Lease` object) when its enabled for shoots.
Usually, the vpa-ac maintains a `Lease` object in the `kube-system` namespace of its cluster. When its ran in the seed then we override this namespace by setting the `NAMESPACE` environment variable to its runtime namespace (i.e., `garden`). This only works because the target cluster is the same like the runtime cluster.
In the shoot case it still runs in the seed, however, in a `shoot--foo--bar` namespace. In this case it cannot talk to the seed in anyway. Still, the `NAMESPACE` environment variable was set to a namespace in a seed which causes failures like this:

```
E1204 06:55:14.581193       1 status_updater.go:56] Status update by vpa-admission-controller-58bd747ff7-jrbs5 failed: namespaces "shoot--foo--bar" not found
```

With this fix we only override it when the vpa-ac is ran in the seed. Otherwise, if enabled for shoots, it will use the `kube-system` namespace for its `Lease` object.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed that caused the `vpa-admission-controller` to not being able to update its status (inside `Lease` object) when its enabled for shoot clusters.
```
