### PR TITLE
Add konnectivity-server-reloader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,3 +72,17 @@ COPY --from=builder /go/bin/gardener-seed-admission-controller /gardener-seed-ad
 WORKDIR /
 
 ENTRYPOINT ["/gardener-seed-admission-controller"]
+
+############# konnectivity-server-base #############
+# Make sure to update Makefile when updating this version!!!
+FROM k8s.gcr.io/kas-network-proxy/proxy-server:v0.0.14 AS konnectivity-server-base
+
+############# konnectivity-server-reloader #############
+FROM base AS konnectivity-server-reloader
+
+COPY --from=builder /go/bin/konnectivity-server-reloader /konnectivity-server-reloader
+COPY --from=konnectivity-server-base /proxy-server /proxy-server
+
+WORKDIR /
+
+ENTRYPOINT ["/konnectivity-server-reloader"]

--- a/Makefile
+++ b/Makefile
@@ -12,22 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-REGISTRY                            := eu.gcr.io/gardener-project/gardener
-APISERVER_IMAGE_REPOSITORY          := $(REGISTRY)/apiserver
-CONTROLLER_MANAGER_IMAGE_REPOSITORY := $(REGISTRY)/controller-manager
-SCHEDULER_IMAGE_REPOSITORY          := $(REGISTRY)/scheduler
-ADMISSION_IMAGE_REPOSITORY          := $(REGISTRY)/admission-controller
-SEED_ADMISSION_IMAGE_REPOSITORY     := $(REGISTRY)/seed-admission-controller
-GARDENLET_IMAGE_REPOSITORY          := $(REGISTRY)/gardenlet
-PUSH_LATEST_TAG                     := false
-VERSION                             := $(shell cat VERSION)
-EFFECTIVE_VERSION                   := $(VERSION)-$(shell git rev-parse HEAD)
-REPO_ROOT                           := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-LOCAL_GARDEN_LABEL                  := local-garden
+REGISTRY                                  := eu.gcr.io/gardener-project/gardener
+APISERVER_IMAGE_REPOSITORY                := $(REGISTRY)/apiserver
+CONTROLLER_MANAGER_IMAGE_REPOSITORY       := $(REGISTRY)/controller-manager
+SCHEDULER_IMAGE_REPOSITORY                := $(REGISTRY)/scheduler
+ADMISSION_IMAGE_REPOSITORY                := $(REGISTRY)/admission-controller
+SEED_ADMISSION_IMAGE_REPOSITORY           := $(REGISTRY)/seed-admission-controller
+KONNECTIVIY_RELOADER_IMAGE_REPOSITORY     := $(REGISTRY)/konnectivity-server-reloader
+GARDENLET_IMAGE_REPOSITORY                := $(REGISTRY)/gardenlet
+PUSH_LATEST_TAG                           := false
+VERSION                                   := $(shell cat VERSION)
+EFFECTIVE_VERSION                         := $(VERSION)-$(shell git rev-parse HEAD)
+# Make sure to update Dockerfile as well when updating this version
+KONNECTIVITY_SERVER_VERSION               := v0.0.14
+KONNECTIVIY_RELOADER_IMAGE_VERION         := $(KONNECTIVITY_SERVER_VERSION)-$(EFFECTIVE_VERSION)
+REPO_ROOT                                 := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+LOCAL_GARDEN_LABEL                        := local-garden
 
 ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
-	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty
+	EFFECTIVE_VERSION                   := $(EFFECTIVE_VERSION)-dirty
+	KONNECTIVIY_RELOADER_IMAGE_VERION   := $(KONNECTIVITY_SERVER_VERSION)-$(EFFECTIVE_VERSION)
 endif
+
 
 #########################################
 # Rules for local development scenarios #
@@ -109,6 +115,14 @@ docker-images:
 	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(SEED_ADMISSION_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)     -t $(SEED_ADMISSION_IMAGE_REPOSITORY):latest     -f Dockerfile --target seed-admission-controller .
 	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(GARDENLET_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)          -t $(GARDENLET_IMAGE_REPOSITORY):latest          -f Dockerfile --target gardenlet .
 
+	@echo "Building konnectivity-server-reloader image with version and tag $(KONNECTIVIY_RELOADER_IMAGE_VERION)"
+	@docker build \
+		--build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) \
+		-t $(KONNECTIVIY_RELOADER_IMAGE_REPOSITORY):$(KONNECTIVIY_RELOADER_IMAGE_VERION) \
+		-t $(KONNECTIVIY_RELOADER_IMAGE_REPOSITORY):latest \
+		-f Dockerfile \
+		--target konnectivity-server-reloader .
+
 .PHONY: docker-login
 docker-login:
 	@gcloud auth activate-service-account --key-file .kube-secrets/gcr/gcr-readwrite.json
@@ -121,6 +135,7 @@ docker-push:
 	@if ! docker images $(ADMISSION_IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(EFFECTIVE_VERSION); then echo "$(ADMISSION_IMAGE_REPOSITORY) version $(EFFECTIVE_VERSION) is not yet built. Please run 'make docker-images'"; false; fi
 	@if ! docker images $(SEED_ADMISSION_IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(EFFECTIVE_VERSION); then echo "$(SEED_ADMISSION_IMAGE_REPOSITORY) version $(EFFECTIVE_VERSION) is not yet built. Please run 'make docker-images'"; false; fi
 	@if ! docker images $(GARDENLET_IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(EFFECTIVE_VERSION); then echo "$(GARDENLET_IMAGE_REPOSITORY) version $(EFFECTIVE_VERSION) is not yet built. Please run 'make docker-images'"; false; fi
+	@if ! docker images $(KONNECTIVIY_RELOADER_IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(KONNECTIVIY_RELOADER_IMAGE_VERION); then echo "$(KONNECTIVIY_RELOADER_IMAGE_REPOSITORY) version $(KONNECTIVIY_RELOADER_IMAGE_VERION) is not yet built. Please run 'make docker-images'"; false; fi
 	@gcloud docker -- push $(APISERVER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)
 	@if [[ "$(PUSH_LATEST_TAG)" == "true" ]]; then gcloud docker -- push $(APISERVER_IMAGE_REPOSITORY):latest; fi
 	@gcloud docker -- push $(CONTROLLER_MANAGER_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)
@@ -133,6 +148,8 @@ docker-push:
 	@if [[ "$(PUSH_LATEST_TAG)" == "true" ]]; then gcloud docker -- push $(SEED_ADMISSION_IMAGE_REPOSITORY):latest; fi
 	@gcloud docker -- push $(GARDENLET_IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)
 	@if [[ "$(PUSH_LATEST_TAG)" == "true" ]]; then gcloud docker -- push $(GARDENLET_IMAGE_REPOSITORY):latest; fi
+	@gcloud docker -- push $(KONNECTIVIY_RELOADER_IMAGE_REPOSITORY):$(KONNECTIVIY_RELOADER_IMAGE_VERION)
+	@if [[ "$(PUSH_LATEST_TAG)" == "true" ]]; then gcloud docker -- push $(KONNECTIVIY_RELOADER_IMAGE_REPOSITORY):latest; fi
 
 #####################################################################
 # Rules for verification, formatting, linting, testing and cleaning #

--- a/cmd/konnectivity-server-reloader/cmd/controller.go
+++ b/cmd/konnectivity-server-reloader/cmd/controller.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func (o *options) start(ctx context.Context) error {
+	conf, err := ctrl.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	client, err := kubernetes.NewForConfig(conf)
+	if err != nil {
+		return err
+	}
+
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		client,
+		0,
+		informers.WithNamespace(o.namespace),
+		informers.WithTweakListOptions(func(lo *metav1.ListOptions) {
+			lo.FieldSelector = fields.OneTermEqualSelector("metadata.name", o.deploymentName).String()
+			lo.Limit = 1
+		}))
+
+	c := &controller{
+		opts:        o,
+		actualCount: 0,
+		queue:       workqueue.New(),
+		getter:      factory.Apps().V1().Deployments().Lister().Deployments(o.namespace).Get,
+	}
+
+	inf := factory.Apps().V1().Deployments().Informer()
+	inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(_ interface{}) {
+			klog.V(6).Info("Add event")
+
+			c.queue.Add(o.deploymentName)
+		},
+		UpdateFunc: func(_, _ interface{}) {
+			klog.V(6).Info("Update event")
+
+			c.queue.Add(o.deploymentName)
+		},
+	})
+
+	klog.V(1).Info("Starting cache...")
+	factory.Start(ctx.Done())
+
+	if !cache.WaitForCacheSync(ctx.Done(), inf.HasSynced) {
+		return errors.New("waiting for caches failed")
+	}
+
+	klog.V(1).Info("Caches are synced")
+
+	go c.start(ctx)
+
+	<-ctx.Done()
+	c.queue.ShutDown()
+
+	klog.V(1).Info("Shutdown called. Bye...")
+
+	return nil
+}
+
+type options struct {
+	command        []string
+	namespace      string
+	deploymentName string
+	jitter         time.Duration
+	jitterFactor   float64
+}
+
+type controller struct {
+	opts *options
+	sync.Mutex
+	actualCount int32
+	lastCommand *exec.Cmd
+	queue       *workqueue.Type
+	getter      func(name string) (*v1.Deployment, error)
+}
+
+func (c *controller) start(ctx context.Context) {
+	wait.UntilWithContext(ctx, c.runWorker, time.Second)
+}
+
+func (c *controller) runWorker(ctx context.Context) {
+	for c.processNextWorkItem(ctx) {
+	}
+}
+
+func (c *controller) processNextWorkItem(ctx context.Context) bool {
+	obj, shutdown := c.queue.Get()
+	if shutdown {
+		klog.V(2).Info("Queue is shutdown")
+
+		return false
+	}
+
+	defer c.queue.Done(obj)
+
+	if err := c.reconcile(ctx); err != nil {
+		return false
+	}
+
+	return false
+}
+
+func (c *controller) reconcile(ctx context.Context) error {
+	c.Lock()
+	defer c.Unlock()
+
+	klog.V(4).InfoS("Reconciling deployment", "name", c.opts.deploymentName, "namespace", c.opts.namespace)
+
+	dep, err := c.getter(c.opts.deploymentName)
+	if err != nil {
+		return err
+	}
+
+	if *dep.Spec.Replicas == c.actualCount {
+		klog.V(4).InfoS("Servercount is the same. Skipping...", "oldReplica", c.actualCount)
+
+		return nil
+	}
+
+	if c.lastCommand != nil {
+		jitter := wait.Jitter(c.opts.jitter, c.opts.jitterFactor)
+
+		klog.V(2).InfoS(
+			"Deployment replica count changed. Restarting server.",
+			"oldReplica", c.actualCount,
+			"newReplica", *dep.Spec.Replicas,
+			"jitter", jitter,
+		)
+
+		if jitter > 0 {
+			time.Sleep(jitter)
+		}
+
+		if err := c.lastCommand.Process.Signal(os.Interrupt); err != nil {
+			return err
+		}
+
+		ps, err := c.lastCommand.Process.Wait()
+		if err != nil {
+			return err
+		}
+
+		klog.V(4).InfoS("Previous command exited", "existed", ps.Exited(), "code", ps.ExitCode())
+
+	}
+
+	fullCmd := append(c.opts.command, strconv.FormatInt(int64(*dep.Spec.Replicas), 10))
+	c.actualCount = *dep.Spec.Replicas
+
+	klog.V(4).InfoS("Starting command", "command", fullCmd[0], "args", fullCmd[1:])
+
+	c.lastCommand = exec.CommandContext(ctx, fullCmd[0], fullCmd[1:]...)
+
+	c.lastCommand.Stdout = os.Stdout
+	c.lastCommand.Stderr = os.Stderr
+
+	return c.lastCommand.Start()
+}

--- a/cmd/konnectivity-server-reloader/cmd/controller_test.go
+++ b/cmd/konnectivity-server-reloader/cmd/controller_test.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controller tests")
+}
+
+var _ = Describe("controller", func() {
+	var (
+		c          *controller
+		ctx        context.Context
+		cancelFunc context.CancelFunc
+		deploy     *appsv1.Deployment
+		getErr     error
+	)
+
+	BeforeEach(func() {
+		deploy = &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Replicas: pointer.Int32Ptr(40),
+			},
+		}
+		getErr = nil
+		c = &controller{
+			opts: &options{
+				command:        []string{"sleep"},
+				namespace:      "foo",
+				deploymentName: "bar",
+			},
+			actualCount: 0,
+			lastCommand: nil,
+			getter:      func(name string) (*appsv1.Deployment, error) { return deploy, getErr },
+		}
+		ctx, cancelFunc = context.WithCancel(context.Background())
+	})
+
+	Context("get of deployment succeeds", func() {
+		AfterEach(func() {
+			cancelFunc()
+
+			Eventually(func() error {
+				_, err := c.lastCommand.Process.Wait()
+				// when the process is killed it by the context above
+				// Wait should return error
+				return err
+			}, time.Millisecond*40, time.Millisecond).Should(HaveOccurred(), "process should be killed by cancelFunc")
+		})
+
+		It("starts a sleep process", func() {
+			Expect(c.reconcile(ctx)).ToNot(HaveOccurred())
+
+			Expect(c.lastCommand).NotTo(BeNil())
+			Expect(c.lastCommand.Args).To(ConsistOf("sleep", "40"))
+		})
+
+		It("restarts a sleep process when replica count is changed", func() {
+			Expect(c.reconcile(ctx)).ToNot(HaveOccurred())
+
+			Expect(c.lastCommand).NotTo(BeNil())
+			Expect(c.lastCommand.Args).To(ConsistOf("sleep", "40"))
+
+			oldProcess := c.lastCommand
+
+			deploy.Spec.Replicas = pointer.Int32Ptr(60)
+			Expect(c.reconcile(ctx)).ToNot(HaveOccurred())
+
+			Eventually(func() error {
+				_, err := oldProcess.Process.Wait()
+				return err
+			}, time.Millisecond*40, time.Millisecond).Should(HaveOccurred(), "old process should be interupted")
+
+			Expect(c.lastCommand).NotTo(BeNil())
+			Expect(c.lastCommand.Args).To(ConsistOf("sleep", "60"))
+		})
+
+		It("do not restart a sleep process when replica count is not changed", func() {
+			Expect(c.reconcile(ctx)).ToNot(HaveOccurred())
+
+			Expect(c.lastCommand).NotTo(BeNil())
+			Expect(c.lastCommand.Args).To(ConsistOf("sleep", "40"))
+
+			oldProcess := c.lastCommand
+
+			Expect(c.reconcile(ctx)).ToNot(HaveOccurred())
+
+			Expect(c.lastCommand).NotTo(BeNil())
+			Expect(c.lastCommand).To(BeIdenticalTo(oldProcess), "old process must not be changed")
+			Expect(c.lastCommand.Args).To(ConsistOf("sleep", "40"))
+		})
+
+		It("do not restart a process that was killed after reconcile", func() {
+			Expect(c.reconcile(ctx)).ToNot(HaveOccurred())
+
+			Expect(c.lastCommand).NotTo(BeNil())
+			Expect(c.lastCommand.Args).To(ConsistOf("sleep", "40"))
+
+			Expect(c.lastCommand.Process.Signal(os.Interrupt)).NotTo(HaveOccurred())
+
+			Expect(c.reconcile(ctx)).ToNot(HaveOccurred())
+
+			Expect(c.lastCommand).NotTo(BeNil())
+			Expect(c.lastCommand.Args).To(ConsistOf("sleep", "40"))
+
+			Eventually(func() error {
+				_, err := c.lastCommand.Process.Wait()
+				return err
+			}, time.Millisecond*40, time.Millisecond).Should(HaveOccurred(), "process should be started again")
+		})
+	})
+
+	Context("get of deployment fails", func() {
+		BeforeEach(func() {
+			getErr = errors.New("some error")
+		})
+
+		It("returns error", func() {
+			Expect(c.reconcile(ctx)).Should(HaveOccurred())
+
+			Expect(c.lastCommand).To(BeNil())
+		})
+	})
+})

--- a/cmd/konnectivity-server-reloader/cmd/konnectivity_server_reloader.go
+++ b/cmd/konnectivity-server-reloader/cmd/konnectivity_server_reloader.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"errors"
+
+	goflag "flag"
+
+	"github.com/gardener/gardener/pkg/version/verflag"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	"k8s.io/klog/v2"
+)
+
+// NewKonnectivityServerReloaderCommand creates the root command of the konnectivity-server-reloader.
+func NewKonnectivityServerReloaderCommand(ctx context.Context) *cobra.Command {
+	opts := &options{}
+
+	cmd := &cobra.Command{
+		Use:   "konnectivity-server-reloader [flags] -- COMMAND [args...] INJECTED-REPLICA-COUNT",
+		Short: "Executes a command depending on the deployment's replica count",
+		Example: `
+    $(terminal-1) kubectl create deployment --image=nginx nginx
+    deployment.apps/nginx created
+
+and running
+
+    $(terminal-2) konnectivity-server-reloader --namespace=default --deployment-name=nginx -- sleep
+
+would start a "sleep 1" process.
+If the watched deployment is scaled, then the controller stops the previous process and
+starts a new one:
+
+    $(terminal-1) kubectl scale deployment my-dep --replicas=10
+    deployment.apps/my-dep scaled
+
+    $(terminal-1) ps | grep sleep
+    61191 ttys003    0:00.00 sleep 10`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			verflag.PrintAndExitIfRequested()
+
+			argsLenAtDash := cmd.ArgsLenAtDash()
+
+			if argsLenAtDash > -1 && len(args[argsLenAtDash:]) > 0 {
+				opts.command = args[argsLenAtDash:]
+			} else {
+				return errors.New("COMMAND should be passed e.g. konnectivity-server-reloader --namespace=default -- sleep")
+			}
+
+			if opts.namespace == "" {
+				return errors.New("namespace is required")
+			}
+
+			if opts.deploymentName == "" {
+				return errors.New("deployment-name is required")
+			}
+
+			if opts.jitter < 0 {
+				return errors.New("jitter cannot be negative")
+			}
+
+			if opts.jitterFactor < 0 {
+				return errors.New("jitter-factor cannot be negative")
+			}
+
+			if opts.jitterFactor > 0 && opts.jitter == 0 {
+				return errors.New("jitter must be set when specifying jitter-factor")
+			}
+
+			return opts.start(ctx)
+		},
+	}
+
+	flags := cmd.Flags()
+
+	klog.InitFlags(goflag.CommandLine)
+	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	verflag.AddFlags(flags)
+
+	flags.StringVarP(&opts.namespace, "namespace", "n", "", "namespace of the deployment")
+	flags.StringVar(&opts.deploymentName, "deployment-name", "kube-apiserver", "name of the deployment")
+	flags.DurationVar(&opts.jitter, "jitter", 0, "duration between receiving a scale event and process restart")
+	flags.Float64Var(&opts.jitterFactor, "jitter-factor", 0.0, "adds random factor to jitter. Requires jitter to be set")
+
+	return cmd
+}

--- a/cmd/konnectivity-server-reloader/main.go
+++ b/cmd/konnectivity-server-reloader/main.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gardener/gardener/cmd/konnectivity-server-reloader/cmd"
+	"github.com/gardener/gardener/cmd/utils"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+)
+
+func main() {
+	ctx := utils.ContextFromStopChannel(signals.SetupSignalHandler())
+
+	reloader := cmd.NewKonnectivityServerReloaderCommand(ctx)
+	if err := reloader.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac
 	k8s.io/helm v2.16.1+incompatible
 	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.0.0
 	k8s.io/kube-aggregator v0.18.10
 	k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29 // release-1.18
 	k8s.io/kubelet v0.18.10

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1159,6 +1159,7 @@ k8s.io/helm/pkg/version
 ## explicit
 k8s.io/klog
 # k8s.io/klog/v2 v2.0.0
+## explicit
 k8s.io/klog/v2
 # k8s.io/kube-aggregator v0.18.10 => k8s.io/kube-aggregator v0.18.10
 ## explicit


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:

This new component solves the problem with dynamic scaling of kube-apiservers where the konnectivity-server needs to be restarted with new `--server-count`.

`konnectivity-server-reloader` watches for Deployments and whenever the `spec.replicas` changes, it restarts the process with the replica count as last argument e.g.:

```
konnectivity-server-reloader [flags] -- COMMAND [args...] INJECTED-REPLICA-COUNT
```

**Which issue(s) this PR fixes**:

Part of https://github.com/gardener/gardener/issues/2956

**Special notes for your reviewer**:

This PR does not include integration of this new image in the actual `kube-apiserver` as a sidecar as it would require this image first.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
New `konnectivity-server-reloader` is added that watches for changes on the `kube-apiserver`'s replica count and restarts assigned processes. It's main purpose is to restart the `konnectivity-server` with new `--server-count` whenever the apiserver is scaled dynamically.
```

/cc @DockToFuture 