### PR TITLE
Upgrade konnectivity components to v0.0.14

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -87,9 +87,9 @@ images:
   repository: eu.gcr.io/gardener-project/gardener/vpn-seed
   tag: "0.19.0"
 - name: konnectivity-server
-  sourceRepository: github.com/kubernetes-sigs/apiserver-network-proxy
-  repository: k8s.gcr.io/kas-network-proxy/proxy-server
-  tag: "v0.0.12"
+  sourceRepository: github.com/gardener/replica-reloader
+  repository: eu.gcr.io/gardener-project/gardener/replica-reloader
+  tag: "v0.1.0"
 
 # Monitoring
 - name: alertmanager
@@ -139,7 +139,7 @@ images:
 - name: konnectivity-agent
   sourceRepository: github.com/kubernetes-sigs/apiserver-network-proxy
   repository: k8s.gcr.io/kas-network-proxy/proxy-agent
-  tag: "v0.0.12"
+  tag: "v0.0.14"
 - name: coredns
   sourceRepository: github.com/coredns/coredns
   repository: coredns/coredns

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
         networking.gardener.cloud/to-shoot-networks: allowed
         networking.gardener.cloud/from-prometheus: allowed
     spec:
+      {{- if .Values.konnectivityTunnel.enabled }}
+      serviceAccountName: kube-apiserver
+      {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -321,8 +324,15 @@ spec:
       - name: konnectivity-server
         image: {{ index .Values.images "konnectivity-server" }}
         command:
-          - /proxy-server
+        - /replica-reloader
         args:
+        - --namespace={{ .Release.Namespace }}
+        - --deployment-name=kube-apiserver
+        - --jitter=10s
+        - --jitter-factor=5
+        - --v=2
+        - --
+        - /proxy-server
         - --uds-name=/etc/srv/kubernetes/konnectivity-server/konnectivity-server.socket
         - --logtostderr=true
         - --cluster-cert=/certs/konnectivity-server/konnectivity-server.crt
@@ -331,39 +341,45 @@ spec:
         - --agent-service-account=konnectivity-agent
         - --kubeconfig=/etc/srv/kubernetes/konnectivity-server-kubeconfig/kubeconfig
         - --authentication-audience=system:konnectivity-server
+        - --keepalive-time=1h
+        - --log-file-max-size=0
+        - --delete-existing-uds-file=true
         - --mode=http-connect
-        - --server-count={{ .Values.konnectivityTunnel.serverCount }}
         - --server-port={{ .Values.konnectivityTunnel.serverPort }}
         - --agent-port={{ .Values.konnectivityTunnel.agentPort }}
         - --admin-port={{ .Values.konnectivityTunnel.adminPort }}
         - --health-port={{ .Values.konnectivityTunnel.healthPort }}
-        - --delete-existing-uds-file=true
+        - --v=2
+        # the last argument should be server-count - the reloader injects the actual count after it
+        - --server-count
         resources:
 {{ toYaml .Values.konnectivityTunnelResources | indent 10 }}
         livenessProbe:
           httpGet:
             scheme: HTTP
+            host: 127.0.0.1
             port: {{ .Values.konnectivityTunnel.healthPort }}
             path: /healthz
-          initialDelaySeconds: 10
-          periodSeconds: 10
+          initialDelaySeconds: 30
           timeoutSeconds: 60
         ports:
-          - name: agentport
-            containerPort: {{ .Values.konnectivityTunnel.agentPort }}
-          - name: adminport
-            containerPort: {{ .Values.konnectivityTunnel.adminPort }}
-          - name: healthport
-            containerPort: {{ .Values.konnectivityTunnel.healthPort }}
+        - name: agentport
+          containerPort: {{ .Values.konnectivityTunnel.agentPort }}
+        - name: adminport
+          containerPort: {{ .Values.konnectivityTunnel.adminPort }}
+          hostPort: {{ .Values.konnectivityTunnel.adminPort }}
+        - name: healthport
+          containerPort: {{ .Values.konnectivityTunnel.healthPort }}
+          hostPort: {{ .Values.konnectivityTunnel.healthPort }}
         volumeMounts:
-          - name: konnectivity-server-certs
-            mountPath: /certs/konnectivity-server
-            readOnly: true
-          - name: konnectivity-server-kubeconfig
-            mountPath: /etc/srv/kubernetes/konnectivity-server-kubeconfig
-          - name: konnectivity-uds
-            mountPath: /etc/srv/kubernetes/konnectivity-server
-            readOnly: false
+        - name: konnectivity-server-certs
+          mountPath: /certs/konnectivity-server
+          readOnly: true
+        - name: konnectivity-server-kubeconfig
+          mountPath: /etc/srv/kubernetes/konnectivity-server-kubeconfig
+        - name: konnectivity-uds
+          mountPath: /etc/srv/kubernetes/konnectivity-server
+          readOnly: false
       {{- else }}
       - name: vpn-seed
         image: {{ index .Values.images "vpn-seed" }}

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/rbac.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/rbac.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.konnectivityTunnel.enabled }}
+apiVersion: {{ include "rbacversion" . }}
+kind: Role
+metadata:
+  name: konnectivity-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    gardener.cloud/role: controlplane
+    app: kubernetes
+    role: apiserver
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - watch
+  - list
+  resourceNames:
+  - kube-apiserver
+---
+
+apiVersion: {{ include "rbacversion" . }}
+kind: RoleBinding
+metadata:
+  name: konnectivity-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    gardener.cloud/role: controlplane
+    app: kubernetes
+    role: apiserver
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: konnectivity-server
+subjects:
+- kind: ServiceAccount
+  name: kube-apiserver
+{{- end }}

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/serviceaccount.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.konnectivityTunnel.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-apiserver
+  namespace: {{ .Release.Namespace }}
+  labels:
+    gardener.cloud/role: controlplane
+    garden.sapcloud.io/role: controlplane
+    app: kubernetes
+    role: apiserver
+{{- end }}

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -5,7 +5,6 @@ securePort: 443
 konnectivityTunnel:
   enabled: true
   serverPort: 0
-  serverCount: 2
   agentPort: 8132
   adminPort: 8133
   healthPort: 8134

--- a/charts/shoot-core/components/charts/konnectivity-agent/templates/daemonset.yaml
+++ b/charts/shoot-core/components/charts/konnectivity-agent/templates/daemonset.yaml
@@ -43,13 +43,12 @@ spec:
           command:
             - /proxy-agent
           args:
-            - --log-file=/var/log/konnectivity-agent/info.log
-            - --logtostderr=false
-            - --log-file-max-size=12
+            - --logtostderr=true
             - --ca-cert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
             - --proxy-server-host={{ .Values.proxyHost }}
             - --proxy-server-port=8132
             - --service-account-token-path=/var/run/secrets/tokens/konnectivity-agent-token
+            - --v=2
           resources:
             requests:
               cpu: 100m
@@ -70,14 +69,9 @@ spec:
             initialDelaySeconds: 15
             timeoutSeconds: 15
           volumeMounts:
-            - name: konnectivity-agent-log
-              mountPath: /var/log/konnectivity-agent
-              readOnly: false
             - mountPath: /var/run/secrets/tokens
               name: konnectivity-agent-token
       volumes:
-        - name: konnectivity-agent-log
-          emptyDir: {}
         - name: konnectivity-agent-token
           projected:
             sources:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area networking
/kind enhancement 
/priority normal

**What this PR does / why we need it**:

Use the new `replica-reloader` to handle dynamic scaling of the `kube-apiserver`.

**Which issue(s) this PR fixes**:

Part of #2956
Fixes #3208 

**Special notes for your reviewer**:
 
In another PR I'll move the `konnectivity-server` to a dedicated `Deployment` that would greatly reduce the need of restarting the `konnectivity-server`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`KonnectivityTunnel`'s stability is improved and now handles `kube-apiserver` autoscaling. It properly sets `--server-count` of `konnectivity-server` on such event.
```

/assign @DockToFuture