### PR TITLE
Collect relevant cadvisor metrics for all pods

### DIFF
--- a/pkg/operation/botanist/controlplane/etcd/monitoring_test.go
+++ b/pkg/operation/botanist/controlplane/etcd/monitoring_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/gardener/gardener/pkg/operation/botanist/controlplane/etcd"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Monitoring", func() {
@@ -74,19 +73,6 @@ var _ = Describe("Monitoring", func() {
 					filepath.Join("testdata", "monitoring_alertingrules_important_with_backup.yaml"),
 				)
 			})
-		})
-	})
-
-	Describe("#CentralMonitoringConfiguration", func() {
-		It("should return the expected central monitoring configuration", func() {
-			config, err := CentralMonitoringConfiguration()
-			Expect(config.ScrapeConfigs).To(BeNil())
-			Expect(config.CAdvisorScrapeConfigMetricRelabelConfigs).To(ConsistOf(
-				expectedCentralCAdvisorRelabelConfig1,
-				expectedCentralCAdvisorRelabelConfig2,
-				expectedCentralCAdvisorRelabelConfig3,
-			))
-			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })
@@ -297,20 +283,4 @@ metric_relabel_configs:
 	expectedAlertingRulesImportantWithoutBackup = alertingRulesImportant + alertingRulesDefault
 	expectedAlertingRulesNormalWithBackup       = alertingRulesNormal + alertingRulesDefault + alertingRulesBackup
 	expectedAlertingRulesImportantWithBackup    = alertingRulesImportant + alertingRulesDefault + alertingRulesBackup
-
-	expectedCentralCAdvisorRelabelConfig1 = `target_label: __name__
-source_labels:
-- container
-- __name__
-regex: etcd;(container_fs_writes_bytes_total|container_fs_reads_bytes_total)
-replacement: 'GARDEN_TMP_${1}'
-action: replace`
-	expectedCentralCAdvisorRelabelConfig2 = `source_labels: [ __name__ ]
-regex: (container_fs_writes_bytes_total|container_fs_reads_bytes_total)
-action: drop`
-	expectedCentralCAdvisorRelabelConfig3 = `target_label: __name__
-source_labels: [ __name__ ]
-regex: GARDEN_TMP_(.*)
-replacement: $1
-action: replace`
 )

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -335,9 +335,7 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 		centralCAdvisorScrapeConfigMetricRelabelConfigs = strings.Builder{}
 	)
 
-	for _, componentFn := range []component.CentralMonitoringConfiguration{
-		etcd.CentralMonitoringConfiguration,
-	} {
+	for _, componentFn := range []component.CentralMonitoringConfiguration{} {
 		centralMonitoringConfig, err := componentFn()
 		if err != nil {
 			return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement
/priority normal

**What this PR does / why we need it**:

The metrics `container_fs_writes_bytes_total` and `container_fs_reads_bytes_total` are now collected by the `prometheus` in the `garden` ns for all pods. Previously these metrics were only collected for etcd pods, but this complicates the Prometheus configuration. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
