### PR TITLE
Add ownerRef to infra configmap and secret

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG EFFECTIVE_VERSION
 RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
 
 ############# base
-FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.1 AS base
+FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.3 AS base
 
 #############      apiserver     #############
 FROM base AS apiserver

--- a/extensions/pkg/event/event_test.go
+++ b/extensions/pkg/event/event_test.go
@@ -20,6 +20,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestEvent(t *testing.T) {
@@ -37,5 +39,24 @@ var _ = Describe("Event", func() {
 			Expect(event.Object).To(BeIdenticalTo(obj))
 			Expect(event.Meta).To(BeIdenticalTo(obj))
 		})
+
+		It("should not use object metadata and return a generic event", func() {
+			obj := noMeta{}
+
+			event := NewFromObject(obj)
+
+			Expect(event.Object).To(BeIdenticalTo(obj))
+			Expect(event.Meta).To(BeNil())
+		})
 	})
 })
+
+type noMeta struct {
+}
+
+func (noMeta) GetObjectKind() schema.ObjectKind {
+	return nil
+}
+func (noMeta) DeepCopyObject() runtime.Object {
+	return nil
+}

--- a/extensions/pkg/terraformer/terraform_test.go
+++ b/extensions/pkg/terraformer/terraform_test.go
@@ -369,13 +369,17 @@ var _ = Describe("terraformer", func() {
 					variablesNotFound = apierrors.NewNotFound(secretGroupResource, variablesName)
 
 					runInitializer = func(ctx context.Context, initializeState bool) error {
-						return DefaultInitializer(c, mainName, variablesName, tfVars, StateConfigMapInitializerFunc(CreateState), nil).Initialize(ctx, &InitializerConfig{
-							Namespace:         namespace,
-							ConfigurationName: configurationName,
-							VariablesName:     variablesName,
-							StateName:         stateName,
-							InitializeState:   initializeState,
-						})
+						return DefaultInitializer(c, mainName, variablesName, tfVars, StateConfigMapInitializerFunc(CreateState)).Initialize(
+							ctx,
+							&InitializerConfig{
+								Namespace:         namespace,
+								ConfigurationName: configurationName,
+								VariablesName:     variablesName,
+								StateName:         stateName,
+								InitializeState:   initializeState,
+							},
+							nil,
+						)
 					}
 				})
 
@@ -433,13 +437,17 @@ var _ = Describe("terraformer", func() {
 					stateNotFound = apierrors.NewNotFound(configMapGroupResource, stateName)
 
 					runInitializer = func(ctx context.Context, initializeState bool) error {
-						return DefaultInitializer(c, mainName, variablesName, tfVars, &CreateOrUpdateState{State: &state}, nil).Initialize(ctx, &InitializerConfig{
-							Namespace:         namespace,
-							ConfigurationName: configurationName,
-							VariablesName:     variablesName,
-							StateName:         stateName,
-							InitializeState:   initializeState,
-						})
+						return DefaultInitializer(c, mainName, variablesName, tfVars, &CreateOrUpdateState{State: &state}).Initialize(
+							ctx,
+							&InitializerConfig{
+								Namespace:         namespace,
+								ConfigurationName: configurationName,
+								VariablesName:     variablesName,
+								StateName:         stateName,
+								InitializeState:   initializeState,
+							},
+							nil,
+						)
 					}
 				})
 

--- a/extensions/pkg/terraformer/terraform_test.go
+++ b/extensions/pkg/terraformer/terraform_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
@@ -39,13 +40,31 @@ var (
 	secretGroupResource    = schema.GroupResource{Resource: "Secrets"}
 )
 
+const (
+	namespace         = "namespace"
+	name              = "name"
+	mainName          = "main"
+	configurationName = "configuration"
+	variablesName     = "variables"
+	stateName         = "state"
+	infraUID          = "2a540a5c-1b8c-11e8-b291-0a580a2c025a"
+)
+
 var _ = Describe("terraformer", func() {
 	var (
 		ctrl *gomock.Controller
 		c    *mockclient.MockClient
 		ctx  context.Context
+		log  logr.Logger
 
-		log logr.Logger
+		infra = extensionsv1alpha1.Infrastructure{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      name,
+				UID:       infraUID,
+			},
+		}
+		ownerRef = metav1.NewControllerRef(&infra.ObjectMeta, extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.InfrastructureResource))
 	)
 
 	BeforeEach(func() {
@@ -62,22 +81,14 @@ var _ = Describe("terraformer", func() {
 	})
 
 	Describe("#CreateOrUpdateConfigurationConfigMap", func() {
-		It("Should create the config map", func() {
-			const (
-				namespace = "namespace"
-				name      = "name"
-
-				main      = "main"
-				variables = "variables"
-			)
-
+		It("Should create the config map without owner reference", func() {
 			var (
 				objectMeta = metav1.ObjectMeta{Namespace: namespace, Name: name}
 				expected   = &corev1.ConfigMap{
 					ObjectMeta: objectMeta,
 					Data: map[string]string{
-						MainKey:      main,
-						VariablesKey: variables,
+						MainKey:      mainName,
+						VariablesKey: variablesName,
 					},
 				}
 			)
@@ -90,30 +101,69 @@ var _ = Describe("terraformer", func() {
 					Create(gomock.Any(), expected.DeepCopy()),
 			)
 
-			actual, err := CreateOrUpdateConfigurationConfigMap(ctx, c, namespace, name, main, variables)
+			actual, err := CreateOrUpdateConfigurationConfigMap(ctx, c, namespace, name, mainName, variablesName, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(actual).To(Equal(expected))
+		})
+
+		It("Should create the config map with owner reference", func() {
+			var (
+				objectMeta = metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				}
+				objectMetaWithOwnerRef = metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+					OwnerReferences: []metav1.OwnerReference{
+						*ownerRef,
+					},
+				}
+				expected = &corev1.ConfigMap{
+					ObjectMeta: objectMetaWithOwnerRef,
+					Data: map[string]string{
+						MainKey:      mainName,
+						VariablesKey: variablesName,
+					},
+				}
+			)
+
+			gomock.InOrder(
+				c.EXPECT().
+					Get(gomock.Any(), kutil.Key(namespace, name), &corev1.ConfigMap{ObjectMeta: objectMeta}).
+					Return(apierrors.NewNotFound(configMapGroupResource, name)),
+				c.EXPECT().
+					Create(gomock.Any(), expected.DeepCopy()),
+			)
+
+			actual, err := CreateOrUpdateConfigurationConfigMap(ctx, c, namespace, name, mainName, variablesName, ownerRef)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(actual).To(Equal(expected))
 		})
 	})
 
 	Describe("#StateConfigMapInitializer", func() {
-		const (
-			namespace = "namespace"
-			name      = "name"
-		)
 
 		Describe("#CreateState", func() {
 			var (
+				stateConfigMap            *corev1.ConfigMap
 				expected                  *corev1.ConfigMap
 				stateConfigMapInitializer StateConfigMapInitializerFunc
 			)
 
 			BeforeEach(func() {
-				expected = &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+				stateConfigMap = &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      name,
+					},
 					Data: map[string]string{
 						StateKey: "",
 					},
+				}
+				expected = stateConfigMap.DeepCopy()
+				expected.OwnerReferences = []metav1.OwnerReference{
+					*ownerRef,
 				}
 				stateConfigMapInitializer = CreateState
 			})
@@ -121,16 +171,16 @@ var _ = Describe("terraformer", func() {
 			It("should create the ConfigMap", func() {
 				c.EXPECT().Create(gomock.Any(), expected.DeepCopy())
 
-				err := stateConfigMapInitializer.Initialize(ctx, c, namespace, name)
+				err := stateConfigMapInitializer.Initialize(ctx, c, namespace, name, ownerRef)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should return nil when the ConfigMap already exists", func() {
 				c.EXPECT().
-					Create(gomock.Any(), expected.DeepCopy()).
+					Create(gomock.Any(), stateConfigMap.DeepCopy()).
 					Return(apierrors.NewAlreadyExists(configMapGroupResource, name))
 
-				err := stateConfigMapInitializer.Initialize(ctx, c, namespace, name)
+				err := stateConfigMapInitializer.Initialize(ctx, c, namespace, name, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -139,7 +189,7 @@ var _ = Describe("terraformer", func() {
 					Create(gomock.Any(), expected.DeepCopy()).
 					Return(apierrors.NewForbidden(configMapGroupResource, name, fmt.Errorf("not allowed to create ConfigMap")))
 
-				err := stateConfigMapInitializer.Initialize(ctx, c, namespace, name)
+				err := stateConfigMapInitializer.Initialize(ctx, c, namespace, name, ownerRef)
 				Expect(err).To(HaveOccurred())
 				Expect(apierrors.IsForbidden(err)).To(BeTrue())
 			})
@@ -150,9 +200,20 @@ var _ = Describe("terraformer", func() {
 				var (
 					state      = "state"
 					stateKey   = kutil.Key(namespace, name)
-					objectMeta = metav1.ObjectMeta{Namespace: namespace, Name: name}
-					getState   = &corev1.ConfigMap{ObjectMeta: objectMeta}
-					expected   = &corev1.ConfigMap{
+					objectMeta = metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      name,
+						OwnerReferences: []metav1.OwnerReference{
+							*ownerRef,
+						},
+					}
+					getState = &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace,
+							Name:      name,
+						},
+					}
+					expected = &corev1.ConfigMap{
 						ObjectMeta: objectMeta,
 						Data: map[string]string{
 							StateKey: state,
@@ -168,18 +229,14 @@ var _ = Describe("terraformer", func() {
 					c.EXPECT().Create(gomock.Any(), expected.DeepCopy()),
 				)
 
-				err := stateConfigMapInitializer.Initialize(ctx, c, namespace, name)
+				err := stateConfigMapInitializer.Initialize(ctx, c, namespace, name, ownerRef)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})
 
 	Describe("#CreateOrUpdateTFVarsSecret", func() {
-		It("Should create the secret", func() {
-			const (
-				namespace = "namespace"
-				name      = "name"
-			)
+		It("Should create the secret without owner reference", func() {
 
 			var (
 				tfVars     = []byte("tfvars")
@@ -200,22 +257,48 @@ var _ = Describe("terraformer", func() {
 					Create(gomock.Any(), expected.DeepCopy()),
 			)
 
-			actual, err := CreateOrUpdateTFVarsSecret(ctx, c, namespace, name, tfVars)
+			actual, err := CreateOrUpdateTFVarsSecret(ctx, c, namespace, name, tfVars, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(actual).To(Equal(expected))
+		})
+
+		It("Should create the secret with owner reference", func() {
+			var (
+				tfVars     = []byte("tfvars")
+				objectMeta = metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				}
+				objectMetaWithOwnerRef = metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+					OwnerReferences: []metav1.OwnerReference{
+						*ownerRef,
+					},
+				}
+				expected = &corev1.Secret{
+					ObjectMeta: objectMetaWithOwnerRef,
+					Data: map[string][]byte{
+						TFVarsKey: tfVars,
+					},
+				}
+			)
+
+			gomock.InOrder(
+				c.EXPECT().
+					Get(gomock.Any(), kutil.Key(namespace, name), &corev1.Secret{ObjectMeta: objectMeta}).
+					Return(apierrors.NewNotFound(secretGroupResource, name)),
+				c.EXPECT().
+					Create(gomock.Any(), expected.DeepCopy()),
+			)
+
+			actual, err := CreateOrUpdateTFVarsSecret(ctx, c, namespace, name, tfVars, ownerRef)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(actual).To(Equal(expected))
 		})
 	})
 
 	Describe("#Initializers", func() {
-		const (
-			namespace         = "namespace"
-			configurationName = "configuration"
-			variablesName     = "variables"
-			stateName         = "state"
-
-			main      = "main"
-			variables = "variables"
-		)
 		var (
 			tfVars []byte
 
@@ -253,8 +336,8 @@ var _ = Describe("terraformer", func() {
 			createConfiguration = &corev1.ConfigMap{
 				ObjectMeta: configurationObjectMeta,
 				Data: map[string]string{
-					MainKey:      main,
-					VariablesKey: variables,
+					MainKey:      mainName,
+					VariablesKey: variablesName,
 				},
 			}
 			createVariables = &corev1.Secret{
@@ -286,7 +369,7 @@ var _ = Describe("terraformer", func() {
 					variablesNotFound = apierrors.NewNotFound(secretGroupResource, variablesName)
 
 					runInitializer = func(ctx context.Context, initializeState bool) error {
-						return DefaultInitializer(c, main, variables, tfVars, StateConfigMapInitializerFunc(CreateState)).Initialize(ctx, &InitializerConfig{
+						return DefaultInitializer(c, mainName, variablesName, tfVars, StateConfigMapInitializerFunc(CreateState), nil).Initialize(ctx, &InitializerConfig{
 							Namespace:         namespace,
 							ConfigurationName: configurationName,
 							VariablesName:     variablesName,
@@ -350,7 +433,7 @@ var _ = Describe("terraformer", func() {
 					stateNotFound = apierrors.NewNotFound(configMapGroupResource, stateName)
 
 					runInitializer = func(ctx context.Context, initializeState bool) error {
-						return DefaultInitializer(c, main, variables, tfVars, &CreateOrUpdateState{State: &state}).Initialize(ctx, &InitializerConfig{
+						return DefaultInitializer(c, mainName, variablesName, tfVars, &CreateOrUpdateState{State: &state}, nil).Initialize(ctx, &InitializerConfig{
 							Namespace:         namespace,
 							ConfigurationName: configurationName,
 							VariablesName:     variablesName,
@@ -416,10 +499,8 @@ var _ = Describe("terraformer", func() {
 
 	Describe("#GetStateOutputVariables", func() {
 		const (
-			namespace = "namespace"
-			name      = "name"
-			purpose   = "purpose"
-			image     = "image"
+			purpose = "purpose"
+			image   = "image"
 		)
 
 		var (

--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -124,16 +125,16 @@ type Initializer interface {
 type Factory interface {
 	NewForConfig(logger logr.Logger, config *rest.Config, purpose, namespace, name, image string) (Terraformer, error)
 	New(logger logr.Logger, client client.Client, coreV1Client corev1client.CoreV1Interface, purpose, namespace, name, image string) Terraformer
-	DefaultInitializer(c client.Client, main, variables string, tfVars []byte, stateInitializer StateConfigMapInitializer) Initializer
+	DefaultInitializer(c client.Client, main, variables string, tfVars []byte, stateInitializer StateConfigMapInitializer, ownerRef *metav1.OwnerReference) Initializer
 }
 
 // StateConfigMapInitializer initialize terraformer state ConfigMap
 type StateConfigMapInitializer interface {
-	Initialize(ctx context.Context, c client.Client, namespace, name string) error
+	Initialize(ctx context.Context, c client.Client, namespace, name string, ownerRef *metav1.OwnerReference) error
 }
 
 // StateConfigMapInitializerFunc implements StateConfigMapInitializer
-type StateConfigMapInitializerFunc func(ctx context.Context, c client.Client, namespace, name string) error
+type StateConfigMapInitializerFunc func(ctx context.Context, c client.Client, namespace, name string, ownerRef *metav1.OwnerReference) error
 
 // CreateOrUpdateState implements StateConfigMapInitializer.
 // It use it field state for creating or updating the state ConfigMap

--- a/hack/hook-me.sh
+++ b/hack/hook-me.sh
@@ -27,7 +27,7 @@ providerName=${2:-}
 [[ -z $providerName ]] && echo "Please specify the provider name (aws,gcp,azure,..etc.)!" && exit 1
 
 tmpService=$(mktemp)
-kubectl get svc gardener-extension-provider-$providerName -o yaml --export > $tmpService
+kubectl get svc gardener-extension-provider-$providerName -o yaml > $tmpService
 
     cat <<EOF | kubectl apply -f -
 ---
@@ -238,8 +238,8 @@ usage(){
   echo ""
 
   echo "========================================================USAGE======================================================================"
-  echo "> ./hack/hook-me.sh <extension namespace e.g. extension-provider-aws-fpr6w> <provider e.g., aws>  <webhookserver port e.g., 8443>"
-  echo "> \`make EXTENSION_NAMESPACE=<extension namespace e.g. extension-provider-aws-fpr6w> start\`"
+  echo "> ./hack/hook-me.sh <provider e.g., aws> <extension namespace e.g. extension-provider-aws-fpr6w> <webhookserver port e.g., 8443>"
+  echo "> \`make EXTENSION_NAMESPACE=<extension namespace e.g. extension-provider-aws-fpr6w> WEBHOOK_CONFIG_MODE=service start\`"
   echo "=================================================================================================================================="
 
   echo ""
@@ -294,7 +294,7 @@ if [[ "${BASH_SOURCE[0]}" = "$0" ]]; then
             createOrUpdateWebhookSVC $namespace $providerName
 
             echo "[STEP 7] Initializing the inlets client";
-            echo "[Info] Inlets initialized, you are ready to go ahead and run \"make EXTENSION_NAMESPACE=$namespace start\""
+            echo "[Info] Inlets initialized, you are ready to go ahead and run \"make EXTENSION_NAMESPACE=$namespace WEBHOOK_CONFIG_MODE=service start\""
             echo "[Info] It will take about 5 seconds for the connection to succeeed!"
 
             inlets client --remote ws://$loadbalancerIPOrHostName:8000 --upstream https://localhost:$webhookServerPort --token=21d809ed61915c9177fbceeaa87e307e766be5f2

--- a/pkg/mock/gardener/extensions/terraformer/mocks.go
+++ b/pkg/mock/gardener/extensions/terraformer/mocks.go
@@ -266,6 +266,20 @@ func (mr *MockTerraformerMockRecorder) SetLogLevel(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogLevel", reflect.TypeOf((*MockTerraformer)(nil).SetLogLevel), arg0)
 }
 
+// SetOwnerRef mocks base method.
+func (m *MockTerraformer) SetOwnerRef(arg0 *v10.OwnerReference) terraformer.Terraformer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetOwnerRef", arg0)
+	ret0, _ := ret[0].(terraformer.Terraformer)
+	return ret0
+}
+
+// SetOwnerRef indicates an expected call of SetOwnerRef.
+func (mr *MockTerraformerMockRecorder) SetOwnerRef(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOwnerRef", reflect.TypeOf((*MockTerraformer)(nil).SetOwnerRef), arg0)
+}
+
 // SetTerminationGracePeriodSeconds mocks base method.
 func (m *MockTerraformer) SetTerminationGracePeriodSeconds(arg0 int64) terraformer.Terraformer {
 	m.ctrl.T.Helper()
@@ -332,17 +346,17 @@ func (m *MockInitializer) EXPECT() *MockInitializerMockRecorder {
 }
 
 // Initialize mocks base method.
-func (m *MockInitializer) Initialize(arg0 context.Context, arg1 *terraformer.InitializerConfig) error {
+func (m *MockInitializer) Initialize(arg0 context.Context, arg1 *terraformer.InitializerConfig, arg2 *v10.OwnerReference) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Initialize", arg0, arg1)
+	ret := m.ctrl.Call(m, "Initialize", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Initialize indicates an expected call of Initialize.
-func (mr *MockInitializerMockRecorder) Initialize(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockInitializerMockRecorder) Initialize(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockInitializer)(nil).Initialize), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockInitializer)(nil).Initialize), arg0, arg1, arg2)
 }
 
 // MockFactory is a mock of Factory interface.
@@ -369,17 +383,17 @@ func (m *MockFactory) EXPECT() *MockFactoryMockRecorder {
 }
 
 // DefaultInitializer mocks base method.
-func (m *MockFactory) DefaultInitializer(arg0 client.Client, arg1, arg2 string, arg3 []byte, arg4 terraformer.StateConfigMapInitializer, arg5 *v10.OwnerReference) terraformer.Initializer {
+func (m *MockFactory) DefaultInitializer(arg0 client.Client, arg1, arg2 string, arg3 []byte, arg4 terraformer.StateConfigMapInitializer) terraformer.Initializer {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DefaultInitializer", arg0, arg1, arg2, arg3, arg4, arg5)
+	ret := m.ctrl.Call(m, "DefaultInitializer", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(terraformer.Initializer)
 	return ret0
 }
 
 // DefaultInitializer indicates an expected call of DefaultInitializer.
-func (mr *MockFactoryMockRecorder) DefaultInitializer(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+func (mr *MockFactoryMockRecorder) DefaultInitializer(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultInitializer", reflect.TypeOf((*MockFactory)(nil).DefaultInitializer), arg0, arg1, arg2, arg3, arg4, arg5)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultInitializer", reflect.TypeOf((*MockFactory)(nil).DefaultInitializer), arg0, arg1, arg2, arg3, arg4)
 }
 
 // New mocks base method.

--- a/pkg/mock/gardener/extensions/terraformer/mocks.go
+++ b/pkg/mock/gardener/extensions/terraformer/mocks.go
@@ -13,7 +13,8 @@ import (
 	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
-	v10 "k8s.io/client-go/kubernetes/typed/core/v1"
+	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v11 "k8s.io/client-go/kubernetes/typed/core/v1"
 	rest "k8s.io/client-go/rest"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -368,21 +369,21 @@ func (m *MockFactory) EXPECT() *MockFactoryMockRecorder {
 }
 
 // DefaultInitializer mocks base method.
-func (m *MockFactory) DefaultInitializer(arg0 client.Client, arg1, arg2 string, arg3 []byte, arg4 terraformer.StateConfigMapInitializer) terraformer.Initializer {
+func (m *MockFactory) DefaultInitializer(arg0 client.Client, arg1, arg2 string, arg3 []byte, arg4 terraformer.StateConfigMapInitializer, arg5 *v10.OwnerReference) terraformer.Initializer {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DefaultInitializer", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "DefaultInitializer", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(terraformer.Initializer)
 	return ret0
 }
 
 // DefaultInitializer indicates an expected call of DefaultInitializer.
-func (mr *MockFactoryMockRecorder) DefaultInitializer(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockFactoryMockRecorder) DefaultInitializer(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultInitializer", reflect.TypeOf((*MockFactory)(nil).DefaultInitializer), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultInitializer", reflect.TypeOf((*MockFactory)(nil).DefaultInitializer), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // New mocks base method.
-func (m *MockFactory) New(arg0 logr.Logger, arg1 client.Client, arg2 v10.CoreV1Interface, arg3, arg4, arg5, arg6 string) terraformer.Terraformer {
+func (m *MockFactory) New(arg0 logr.Logger, arg1 client.Client, arg2 v11.CoreV1Interface, arg3, arg4, arg5, arg6 string) terraformer.Terraformer {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "New", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(terraformer.Terraformer)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Ensures that the configmap and secrets, used by terraform, have owner reference to the Infrastructure resource.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature dependency
The `ConfigMaps` and `Secrets` used to store the config and state of terraform now have owner reference to the Infrastructure resource.
```
