### PR TITLE
Reduce Garden cluster connections for Gardenlet

### DIFF
--- a/pkg/client/kubernetes/clientmap/internal/generic_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/generic_clientmap.go
@@ -212,6 +212,12 @@ func (cm *GenericClientMap) InvalidateClient(key clientmap.ClientSetKey) error {
 
 	delete(cm.clientSets, key)
 
+	if invalidate, ok := cm.factory.(clientmap.Invalidate); ok {
+		if err := invalidate.InvalidateClient(key); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/client/kubernetes/clientmap/types.go
+++ b/pkg/client/kubernetes/clientmap/types.go
@@ -20,20 +20,23 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 )
 
+// Invalidate is an interface used to invalidate client specific information.
+type Invalidate interface {
+	// InvalidateClient removes cached client information identified by the given `ClientSetKey`.
+	InvalidateClient(key ClientSetKey) error
+}
+
 // A ClientMap is a collection of kubernetes ClientSets, which can be used to dynamically create and lookup different
 // ClientSets during runtime. ClientSets are identified by a ClientSetKey, which can have different forms, as there
 // are different kinds of ClientMaps (for example one for Seed clients and one for Shoot clients).
 // Implementations will provide suitable mechanisms to create a ClientSet for a given key and should come with some
 // easy ways of constructing ClientSetKeys that their callers can use to lookup ClientSets in the map.
 type ClientMap interface {
+	Invalidate
 	// GetClient returns the corresponding ClientSet for the given key in the ClientMap or creates a new ClientSet for
 	// it if the map does not contain a corresponding ClientSet. If the ClientMap was started before by a call to Start,
 	// newly created ClientSets will be started automatically using the stop channel provided to Start.
 	GetClient(ctx context.Context, key ClientSetKey) (kubernetes.Interface, error)
-
-	// InvalidateClient stops the ClientSet identified by the given key and removes it from the map. If the map doesn't
-	// contain a corresponding ClientSet, it does nothing.
-	InvalidateClient(key ClientSetKey) error
 
 	// Start starts the ClientMap, i.e. starts all ClientSets already contained in the map and saves the stop channel
 	// for starting new ClientSets, when they are created.

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -146,7 +146,8 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	}
 
 	gardenNamespace := &corev1.Namespace{}
-	runtime.Must(k8sGardenClient.Client().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace), gardenNamespace))
+	// Use direct client here since we don't want to cache all namespaces of the Garden cluster.
+	runtime.Must(k8sGardenClient.DirectClient().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace), gardenNamespace))
 
 	// Initialize the workqueue metrics collection.
 	gardenmetrics.RegisterWorkqueMetrics()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR adds two improvements which reduces the amount of calls from Gardenlet -> Gardener/Kubernetes API Server:
- Retrieving shoot clients from a `clientMap` is now possible w/o requesting the `Shoot` resource every time. This becomes especially important if the Gardenlet cache is disabled (`CachedRuntimeClients: false`) in combination with regular shoot care operations.
- Garden cluster `Namespaces` are not list/wach-ed any more.

**Special notes for your reviewer**:
Caching the `seedName` and `shoot-namespace` should be safe, also for migration use-cases since the migration logic will [invalidate](https://github.com/gardener/gardener/blob/f120f2c74a503ab4a388aa055cd08d4081eaf5ed/pkg/operation/botanist/controlplane.go#L125) this cached information, once the API Server has removed from the old seed.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Required connections from Gardenlet to the Garden cluster has been reduced which will have positive effects on scalability and costs.
```
