### PR TITLE
Delete disabled subcharts when applying a chart

### DIFF
--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -204,7 +204,7 @@ func (a *actuator) reconcileControlPlaneExposure(
 	// Apply control plane exposure chart
 	a.logger.Info("Applying control plane exposure chart", "controlplaneexposure", kutil.ObjectName(cp), "values", values)
 	version := cluster.Shoot.Spec.Kubernetes.Version
-	if err := a.controlPlaneExposureChart.Apply(ctx, a.chartApplier, cp.Namespace, a.imageVector, a.gardenerClientset.Version(), version, values); err != nil {
+	if err := a.controlPlaneExposureChart.Apply(ctx, a.chartApplier, a.client, cp.Namespace, a.imageVector, a.gardenerClientset.Version(), version, values); err != nil {
 		return false, errors.Wrapf(err, "could not apply control plane exposure chart for controlplane '%s'", kutil.ObjectName(cp))
 	}
 
@@ -241,7 +241,7 @@ func (a *actuator) reconcileControlPlane(
 
 		// Apply config chart
 		a.logger.Info("Applying configuration chart", "controlplane", kutil.ObjectName(cp))
-		if err := a.configChart.Apply(ctx, a.chartApplier, cp.Namespace, nil, "", "", values); err != nil {
+		if err := a.configChart.Apply(ctx, a.chartApplier, a.client, cp.Namespace, nil, "", "", values); err != nil {
 			return false, errors.Wrapf(err, "could not apply configuration chart for controlplane '%s'", kutil.ObjectName(cp))
 		}
 	}
@@ -291,7 +291,7 @@ func (a *actuator) reconcileControlPlane(
 	// Apply control plane chart
 	version := cluster.Shoot.Spec.Kubernetes.Version
 	a.logger.Info("Applying control plane chart", "controlplane", kutil.ObjectName(cp))
-	if err := a.controlPlaneChart.Apply(ctx, a.chartApplier, cp.Namespace, a.imageVector, a.gardenerClientset.Version(), version, values); err != nil {
+	if err := a.controlPlaneChart.Apply(ctx, a.chartApplier, a.client, cp.Namespace, a.imageVector, a.gardenerClientset.Version(), version, values); err != nil {
 		return false, errors.Wrapf(err, "could not apply control plane chart for controlplane '%s'", kutil.ObjectName(cp))
 	}
 

--- a/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -71,7 +71,7 @@ func (a *genericActuator) deployMachineControllerManager(ctx context.Context, lo
 	}
 	mcmValues["replicas"] = replicaCount
 
-	if err := a.mcmSeedChart.Apply(ctx, a.chartApplier, workerObj.Namespace,
+	if err := a.mcmSeedChart.Apply(ctx, a.chartApplier, a.client, workerObj.Namespace,
 		a.imageVector, a.gardenerClientset.Version(), cluster.Shoot.Spec.Kubernetes.Version, mcmValues); err != nil {
 		return errors.Wrapf(err, "could not apply MCM chart in seed for worker '%s'", kutil.ObjectName(workerObj))
 	}

--- a/pkg/mock/gardener/utils/chart/mocks.go
+++ b/pkg/mock/gardener/utils/chart/mocks.go
@@ -39,17 +39,17 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // Apply mocks base method.
-func (m *MockInterface) Apply(arg0 context.Context, arg1 kubernetes.ChartApplier, arg2 string, arg3 imagevector.ImageVector, arg4, arg5 string, arg6 map[string]interface{}) error {
+func (m *MockInterface) Apply(arg0 context.Context, arg1 kubernetes.ChartApplier, arg2 client.Client, arg3 string, arg4 imagevector.ImageVector, arg5, arg6 string, arg7 map[string]interface{}) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Apply", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "Apply", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Apply indicates an expected call of Apply.
-func (mr *MockInterfaceMockRecorder) Apply(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Apply(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockInterface)(nil).Apply), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockInterface)(nil).Apply), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 // Delete mocks base method.


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Enhances the `Chart` `Apply` method do delete disabled subcharts when applying a chart. Needed in order to fix https://github.com/gardener/gardener-extension-provider-azure/issues/218.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Tested this change successfully with https://github.com/gardener/gardener-extension-provider-azure/pull/223.

**Release note**:
```other developer
The `Apply` method of `chart.Interface` now includes one additional `client.Client` argument. This is needed in order to delete the disabled subcharts when applying a chart.
The type of the `SubCharts` field in the `chart.Chart` type has been changed to the new type `chart.SubChart` in order to add a `Condition` field that is only relevant for subcharts.
```