### PR TITLE
Add alerts for the custom metrics

### DIFF
--- a/charts/seed-bootstrap/aggregate-prometheus-rules-tests/fluent-bit.rules.test.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules-tests/fluent-bit.rules.test.yaml
@@ -4,6 +4,7 @@ rule_files:
 evaluation_interval: 30s
 
 tests:
+
 - interval: 30s
   external_labels:
     seed: aws
@@ -21,6 +22,99 @@ tests:
         type: seed
         visibility: operator
       exp_annotations:
-        description: "There are no fluent-bit pods running on seed: aws. No logs will be collected."
+        description: >
+          There are no fluent-bit pods running on seed: aws.
+          No logs will be collected.
         summary: Fluent-bit is down
 
+- interval: 1m
+  external_labels:
+    seed: aws
+  input_series:
+  # FluentBitReceivesLogsWithoutMetadata
+  - series: 'fluentbit_loki_gardener_logs_without_metadata_total{pod="fluent-bit-test"}'
+    values: '0+0x3 0+1x30'
+  alert_rule_test:
+  - eval_time: 22m
+    alertname: FluentBitReceivesLogsWithoutMetadata
+    exp_alerts:
+    - exp_labels:
+        pod: fluent-bit-test
+        service: logging
+        severity: warning
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: >
+          fluent-bit-test receives logs without metadata on seed:
+          aws. These logs will be dropped.
+        summary: Fluent-bit receives logs without metadata
+
+- interval: 1m
+  external_labels:
+    seed: aws
+  input_series:
+  # FluentBitSendsOoOLogs
+  - series: 'prometheus_target_scrapes_sample_out_of_order_total{pod="fluent-bit-test"}'
+    values: '0+0x3 0+1x30'
+  alert_rule_test:
+  - eval_time: 22m
+    alertname: FluentBitSendsOoOLogs
+    exp_alerts:
+    - exp_labels:
+        pod: fluent-bit-test
+        service: logging
+        severity: warning
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: >
+          fluent-bit-test on seed: aws sends OutOfOrder logs
+          to the Loki. These logs will be dropped.
+        summary: Fluent-bit sends OoO logs
+
+- interval: 1m
+  external_labels:
+    seed: aws
+  input_series:
+  # FluentBitGardenerLokiPluginErrors
+  - series: 'fluentbit_loki_gardener_errors_total{pod="fluent-bit-test"}'
+    values: '0+0x3 0+1x30'
+  alert_rule_test:
+  - eval_time: 22m
+    alertname: FluentBitGardenerLokiPluginErrors
+    exp_alerts:
+    - exp_labels:
+        pod: fluent-bit-test
+        service: logging
+        severity: warning
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: >
+          There are errors in the fluent-bit-test GardenerLoki plugin on seed:
+          aws.
+        summary: Errors in Fluent-bit GardenerLoki plugin
+
+- interval: 1m
+  external_labels:
+    seed: aws
+  input_series:
+  # FluentBitGardenerLokiPluginDoesNotSendLogs
+  - series: 'fluentbit_loki_gardener_forwarded_logs_total{pod="fluent-bit-test"}'
+    values: '1+1x3 4+0x30'
+  alert_rule_test:
+  - eval_time: 22m
+    alertname: FluentBitGardenerLokiPluginDoesNotSendLogs
+    exp_alerts:
+    - exp_labels:
+        pod: fluent-bit-test
+        service: logging
+        severity: warning
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: >
+          fluent-bit-test GardenerLoki plugin on seed: aws
+          does not send logs.
+        summary: Fluent-bit GardenerLoki plugin does not send logs

--- a/charts/seed-bootstrap/aggregate-prometheus-rules/fluent-bit.rules.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules/fluent-bit.rules.yaml
@@ -1,14 +1,94 @@
 groups:
-- name: fluent-bit.rules
-  rules:
-  - alert: FluentBitDown
-    expr: absent(up{job="fluent-bit"} == 1)
-    for: 15m
-    labels:
-      service: logging
-      severity: warning
-      type: seed
-      visibility: operator
-    annotations:
-      description: "There are no fluent-bit pods running on seed: {{ .ExternalLabels.seed }}. No logs will be collected."
-      summary: Fluent-bit is down
+  - name: fluent-bit.rules
+    rules:
+  
+    - alert: FluentBitDown
+      expr: |
+        absent(
+          up{job="fluent-bit"}
+          == 1
+        )
+      for: 15m
+      labels:
+        severity: warning
+        service: logging
+        type: seed
+        visibility: operator
+      annotations:
+        summary: Fluent-bit is down
+        description: >
+          There are no fluent-bit pods running on seed: {{$externalLabels.seed}}.
+          No logs will be collected.
+  
+    - alert: FluentBitReceivesLogsWithoutMetadata
+      expr: |
+        sum by (pod) (
+          increase(
+            fluentbit_loki_gardener_logs_without_metadata_total[4m]
+          )
+        ) > 0
+      labels:
+        severity: warning
+        service: logging
+        type: seed
+        visibility: operator
+      annotations:
+        summary: Fluent-bit receives logs without metadata
+        description: >
+          {{$labels.pod}} receives logs without metadata on seed:
+          {{$externalLabels.seed}}. These logs will be dropped.
+  
+    - alert: FluentBitSendsOoOLogs
+      expr: |
+        sum by (pod) (
+          increase(
+            prometheus_target_scrapes_sample_out_of_order_total[4m]
+          )
+        ) > 0
+      labels:
+        severity: warning
+        service: logging
+        type: seed
+        visibility: operator
+      annotations:
+        summary: Fluent-bit sends OoO logs
+        description: >
+          {{$labels.pod}} on seed: {{$externalLabels.seed}} sends OutOfOrder logs
+          to the Loki. These logs will be dropped.
+  
+    - alert: FluentBitGardenerLokiPluginErrors
+      expr: |
+        sum by (pod) (
+          increase(
+            fluentbit_loki_gardener_errors_total[4m]
+          )
+        ) > 0
+      labels:
+        severity: warning
+        service: logging
+        type: seed
+        visibility: operator
+      annotations:
+        summary: Errors in Fluent-bit GardenerLoki plugin
+        description: >
+          There are errors in the {{$labels.pod}} GardenerLoki plugin on seed:
+          {{$externalLabels.seed}}.
+  
+    - alert: FluentBitGardenerLokiPluginDoesNotSendLogs
+      expr: |
+        sum by (pod) (
+          rate(
+            fluentbit_loki_gardener_forwarded_logs_total[4m]
+          )
+        ) == 0
+      for: 15m
+      labels:
+        severity: warning
+        service: logging
+        type: seed
+        visibility: operator
+      annotations:
+        summary: Fluent-bit GardenerLoki plugin does not send logs
+        description: >
+          {{$labels.pod}} GardenerLoki plugin on seed: {{$externalLabels.seed}}
+          does not send logs.

--- a/charts/seed-bootstrap/dashboards/fluent-bit-dashboard.json
+++ b/charts/seed-bootstrap/dashboards/fluent-bit-dashboard.json
@@ -498,17 +498,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(fluentbit_loki_gardener_incoming_logs_total[$__rate_interval]))",
+          "expr": "sum(rate(fluentbit_loki_gardener_incoming_logs_total[$__rate_interval])) by (pod)",
           "instant": false,
           "interval": "",
-          "legendFormat": "Incoming Logs",
+          "legendFormat": "Incoming Logs-{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(fluentbit_loki_gardener_forwarded_logs_total[$__rate_interval]))",
+          "expr": "sum(rate(fluentbit_loki_gardener_forwarded_logs_total[$__rate_interval])) by (pod)",
           "instant": false,
           "interval": "",
-          "legendFormat": "Transferred to Promtail",
+          "legendFormat": "Transferred to Promtail-{{pod}}",
           "refId": "B"
         }
       ],
@@ -605,33 +605,33 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(fluentbit_loki_gardener_dropped_logs_total[$__rate_interval]))",
+          "expr": "sum(rate(fluentbit_loki_gardener_dropped_logs_total[$__rate_interval])) by (pod)",
           "interval": "",
-          "legendFormat": "Dropt Logs",
+          "legendFormat": "Dropped Logs-{{pod}}",
           "refId": "C"
         },
         {
-          "expr": "sum(rate(prometheus_target_scrapes_sample_out_of_order_total[$__rate_interval]))",
+          "expr": "sum(rate(prometheus_target_scrapes_sample_out_of_order_total[$__rate_interval])) by (pod)",
           "interval": "",
-          "legendFormat": "OutOfOrder Logs",
+          "legendFormat": "OutOfOrder Logs-{{pod}}",
           "refId": "D"
         },
         {
-          "expr": "sum(rate(fluentbit_loki_gardener_logs_without_metadata_total[$__rate_interval]))",
+          "expr": "sum(rate(fluentbit_loki_gardener_logs_without_metadata_total[$__rate_interval])) by (pod)",
           "interval": "",
-          "legendFormat": "Missing Metadata",
+          "legendFormat": "Missing Metadata-{{pod}}",
           "refId": "E"
         },
         {
-          "expr": "sum(rate(fluentbit_loki_gardener_errors_total[$__rate_interval]))",
+          "expr": "sum(rate(fluentbit_loki_gardener_errors_total[$__rate_interval])) by (pod)",
           "interval": "",
-          "legendFormat": "Errors",
+          "legendFormat": "Errors-{{pod}}",
           "refId": "F"
         },
         {
-          "expr": "sum(rate(promtail_dropped_entries_total[$__rate_interval]))",
+          "expr": "sum(rate(promtail_dropped_entries_total[$__rate_interval])) by (pod)",
           "interval": "",
-          "legendFormat": "Promtail Dropped",
+          "legendFormat": "Promtail Dropped-{{pod}}",
           "refId": "G"
         }
       ],


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Graphs in the fluent-bit dashboard show `podName`.
Add alerts for the custom metrics.

**Which issue(s) this PR fixes**:
https://github.com/gardener/logging/issues/72

**Special notes for your reviewer**:
@wyb1 
@istvanballok 
@vlvasilev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Alerts are added for the custom metrics for fluent-bit `GardenerLoki` plugin
```
