### PR TITLE
Promote 2 nonserial beta tests to default

### DIFF
--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package framework
 
 import (
@@ -403,7 +417,6 @@ func WaitUntilPodIsRunning(ctx context.Context, log *logrus.Logger, podName, pod
 			return retry.SevereError(err)
 		}
 		if !health.IsPodReady(pod) {
-			log.Infof("Waiting for %s to be ready!!", podName)
 			log.Infof("Waiting for %s to be ready!!", podName)
 			return retry.MinorError(fmt.Errorf(`pod "%s/%s" is not ready: %v`, podNamespace, podName, err))
 		}

--- a/test/integration/shoots/applications/metrics.go
+++ b/test/integration/shoots/applications/metrics.go
@@ -61,7 +61,7 @@ var _ = ginkgo.Describe("Shoot application metrics testing", func() {
 		name = "metrics-test"
 	)
 
-	f.Beta().CIt("should read runtime metrics", func(ctx context.Context) {
+	f.Default().CIt("should read runtime metrics", func(ctx context.Context) {
 		templateParams := map[string]string{
 			"name":      name,
 			"namespace": f.Namespace,

--- a/test/integration/shoots/applications/networking.go
+++ b/test/integration/shoots/applications/networking.go
@@ -60,7 +60,7 @@ var _ = ginkgo.Describe("Shoot network testing", func() {
 		name = "net-test"
 	)
 
-	f.Beta().CIt("should reach all webservers on all nodes", func(ctx context.Context) {
+	f.Default().CIt("should reach all webservers on all nodes", func(ctx context.Context) {
 		templateParams := map[string]string{
 			"name":      name,
 			"namespace": f.Namespace,

--- a/test/integration/shoots/operations/worker.go
+++ b/test/integration/shoots/operations/worker.go
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe("Shoot worker operation testing", func() {
 
 	}, scaleWorkerTimeout)
 
-	f.Beta().CIt("Shoot node's operating systems should differ if the the specified workers are different", func(ctx context.Context) {
+	f.Beta().CIt("Shoot node's operating systems should differ if the specified workers are different", func(ctx context.Context) {
 		ginkgo.By("Checking if shoot is compatible for testing")
 
 		if len(f.Shoot.Spec.Provider.Workers) >= 1 {


### PR DESCRIPTION
**How to categorize this PR?**
/area testing
/kind cleanup

**What this PR does / why we need it**:
As nonserial and beta tests currently we have:
- ✅  `Shoot application metrics testing [BETA] [SHOOT] should read runtime metrics` - according the tm data from the last 2,053 runs 30 failed -> promotion from beta to default
- ✅  `Shoot network testing [BETA] [SHOOT] should reach all webservers on all nodes` - according the tm data from the last 2,053 run 13 failed ->  promotion from beta to default
- ❌  `Seed logging testing [BETA] [SHOOT] should get container logs from loki by tenant` - it was added recently -> we need to observe the success rate
- ❌  `Shoot worker operation testing [BETA] [SHOOT] Shoot node's operating systems should differ if the specified workers are different` - this test is skipped when it is called with shoot with only 1 worker pool, hence it is always skipped in our flavors -> we need to follow up how we proceed with this test (whether we adapt/remove the test, adapt the flavor, something else?). 

This PR is about the nonserial beta tests. The serial beta test - I will try to address them in a separate PR.

Ref https://github.com/gardener/gardener/issues/1564#issuecomment-682406933

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
