### PR TITLE
Only consider effective shoot for health checks

### DIFF
--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -1126,3 +1126,11 @@ func (s *ShootItems) Union(shootItems *ShootItems) []gardencorev1beta1.Shoot {
 func objectKey(namesapce, name string) string {
 	return fmt.Sprintf("%s/%s", namesapce, name)
 }
+
+// GetPurpose returns the purpose of the shoot or 'evaluation' if it's nil.
+func GetPurpose(s *gardencorev1beta1.Shoot) gardencorev1beta1.ShootPurpose {
+	if v := s.Spec.Purpose; v != nil {
+		return *v
+	}
+	return gardencorev1beta1.ShootPurposeEvaluation
+}

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -753,6 +753,11 @@ func ShootIgnoresAlerts(shoot *gardencorev1beta1.Shoot) bool {
 	return ignore
 }
 
+// ShootWantsAlertManager checks if the given shoot specification requires an alert manager.
+func ShootWantsAlertManager(shoot *gardencorev1beta1.Shoot) bool {
+	return !ShootIgnoresAlerts(shoot) && shoot.Spec.Monitoring != nil && shoot.Spec.Monitoring.Alerting != nil && len(shoot.Spec.Monitoring.Alerting.EmailReceivers) > 0
+}
+
 // ShootWantsBasicAuthentication returns true if basic authentication is not configured or
 // if it is set explicitly to 'true'.
 func ShootWantsBasicAuthentication(shoot *gardencorev1beta1.Shoot) bool {

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -1641,4 +1641,64 @@ var _ = Describe("helper", func() {
 		})
 	})
 
+	Context("Shoot Alerts", func() {
+		var shoot *gardencorev1beta1.Shoot
+
+		BeforeEach(func() {
+			shoot = &gardencorev1beta1.Shoot{}
+		})
+
+		Describe("#ShootIgnoresAlerts", func() {
+			It("should not ignore alerts because no annotations given", func() {
+				Expect(ShootIgnoresAlerts(shoot)).To(BeFalse())
+			})
+			It("should not ignore alerts because annotation is not given", func() {
+				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "foo", "bar")
+				Expect(ShootIgnoresAlerts(shoot)).To(BeFalse())
+			})
+			It("should not ignore alerts because annotation value is false", func() {
+				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, v1beta1constants.AnnotationShootIgnoreAlerts, "false")
+				Expect(ShootIgnoresAlerts(shoot)).To(BeFalse())
+			})
+			It("should ignore alerts because annotation value is true", func() {
+				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, v1beta1constants.AnnotationShootIgnoreAlerts, "true")
+				Expect(ShootIgnoresAlerts(shoot)).To(BeTrue())
+			})
+		})
+
+		Describe("#ShootWantsAlertManager", func() {
+			It("should not want alert manager because alerts are ignored", func() {
+				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, v1beta1constants.AnnotationShootIgnoreAlerts, "true")
+				Expect(ShootWantsAlertManager(shoot)).To(BeFalse())
+			})
+			It("should not want alert manager because of missing monitoring configuration", func() {
+				Expect(ShootWantsAlertManager(shoot)).To(BeFalse())
+			})
+			It("should not want alert manager because of missing alerting configuration", func() {
+				shoot.Spec = gardencorev1beta1.ShootSpec{
+					Monitoring: &gardencorev1beta1.Monitoring{},
+				}
+				Expect(ShootWantsAlertManager(shoot)).To(BeFalse())
+			})
+			It("should not want alert manager because of missing email configuration", func() {
+				shoot.Spec = gardencorev1beta1.ShootSpec{
+					Monitoring: &gardencorev1beta1.Monitoring{
+						Alerting: &gardencorev1beta1.Alerting{},
+					},
+				}
+				Expect(ShootWantsAlertManager(shoot)).To(BeFalse())
+			})
+			It("should want alert manager", func() {
+				shoot.Spec = gardencorev1beta1.ShootSpec{
+					Monitoring: &gardencorev1beta1.Monitoring{
+						Alerting: &gardencorev1beta1.Alerting{
+							EmailReceivers: []string{"operators@gardener.clou"},
+						},
+					},
+				}
+				Expect(ShootWantsAlertManager(shoot)).To(BeTrue())
+			})
+		})
+	})
+
 })

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -1619,4 +1619,26 @@ var _ = Describe("helper", func() {
 
 	})
 
+	Describe("#GetPurpose", func() {
+		var shoot *gardencorev1beta1.Shoot
+
+		BeforeEach(func() {
+			shoot = &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{},
+			}
+		})
+
+		It("should get default purpose if not defined", func() {
+			purpose := GetPurpose(shoot)
+			Expect(purpose).To(Equal(gardencorev1beta1.ShootPurposeEvaluation))
+		})
+
+		It("should get purpose", func() {
+			shootPurpose := gardencorev1beta1.ShootPurposeProduction
+			shoot.Spec.Purpose = &shootPurpose
+			purpose := GetPurpose(shoot)
+			Expect(purpose).To(Equal(shootPurpose))
+		})
+	})
+
 })

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -473,7 +473,7 @@ func (b *Botanist) generateCoreAddonsChart() (*chartrenderer.RenderedChart, erro
 		"monitoring": common.GenerateAddonConfig(map[string]interface{}{
 			"node-exporter":     nodeExporter,
 			"blackbox-exporter": blackboxExporter,
-		}, b.Shoot.GetPurpose() != gardencorev1beta1.ShootPurposeTesting),
+		}, b.Shoot.Purpose != gardencorev1beta1.ShootPurposeTesting),
 		"network-policies":        networkPolicyConfig,
 		"node-problem-detector":   common.GenerateAddonConfig(nodeProblemDetector, true),
 		"podsecuritypolicies":     common.GenerateAddonConfig(podSecurityPolicies, true),

--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -525,7 +525,7 @@ func (b *Botanist) checkControlPlane(
 		return exitCondition, err
 	}
 
-	wantsAlertmanager := !gardencorev1beta1helper.ShootIgnoresAlerts(effectiveShoot) && effectiveShoot.Spec.Monitoring != nil && effectiveShoot.Spec.Monitoring.Alerting != nil && len(effectiveShoot.Spec.Monitoring.Alerting.EmailReceivers) > 0
+	wantsAlertmanager := gardencorev1beta1helper.ShootWantsAlertManager(effectiveShoot)
 	if exitCondition, err := checker.CheckMonitoringControlPlane(b.Shoot.SeedNamespace, gardencorev1beta1helper.GetPurpose(effectiveShoot) == gardencorev1beta1.ShootPurposeTesting, wantsAlertmanager, condition, seedDeploymentLister, seedStatefulSetLister); err != nil || exitCondition != nil {
 		return exitCondition, err
 	}

--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -26,7 +26,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardenerextensions "github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/logger"
@@ -43,7 +42,6 @@ import (
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -514,6 +512,7 @@ func (b *HealthChecker) CheckExtensionCondition(condition gardencorev1beta1.Cond
 // checkControlPlane checks whether the control plane of the Shoot cluster is healthy.
 func (b *Botanist) checkControlPlane(
 	ctx context.Context,
+	effectiveShoot *gardencorev1beta1.Shoot,
 	checker *HealthChecker,
 	condition gardencorev1beta1.Condition,
 	seedDeploymentLister kutil.DeploymentLister,
@@ -522,30 +521,16 @@ func (b *Botanist) checkControlPlane(
 	seedWorkerLister kutil.WorkerLister,
 	extensionConditions []ExtensionCondition,
 ) (*gardencorev1beta1.Condition, error) {
-	cluster, err := gardenerextensions.GetCluster(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			c := checker.FailedCondition(condition, "ControlPlaneNotReady", "Control plane is not yet ready because of missing cluster resource.")
-			return &c, nil
-		}
-		b.Logger.Errorf("Failed to execute control plane health checks: %v", err)
-		return nil, err
-	}
-	// Use shoot from cluster resource here because it reflects the actual or "active" spec to determine which health checks are required.
-	// With the "confineSpecUpdateRollout" feature enabled, shoot resources have a spec which is not yet active.
-	shoot := cluster.Shoot
-	if shoot == nil {
-		return nil, errors.New("failed to execute control plane health checks because shoot is missing in cluster resource")
-	}
-
-	if exitCondition, err := checker.CheckControlPlane(shoot, b.Shoot.SeedNamespace, condition, seedDeploymentLister, seedEtcdLister, seedWorkerLister); err != nil || exitCondition != nil {
+	if exitCondition, err := checker.CheckControlPlane(effectiveShoot, b.Shoot.SeedNamespace, condition, seedDeploymentLister, seedEtcdLister, seedWorkerLister); err != nil || exitCondition != nil {
 		return exitCondition, err
 	}
-	if exitCondition, err := checker.CheckMonitoringControlPlane(b.Shoot.SeedNamespace, b.Shoot.GetPurpose() == gardencorev1beta1.ShootPurposeTesting, b.Shoot.WantsAlertmanager, condition, seedDeploymentLister, seedStatefulSetLister); err != nil || exitCondition != nil {
+
+	wantsAlertmanager := !gardencorev1beta1helper.ShootIgnoresAlerts(effectiveShoot) && effectiveShoot.Spec.Monitoring != nil && effectiveShoot.Spec.Monitoring.Alerting != nil && len(effectiveShoot.Spec.Monitoring.Alerting.EmailReceivers) > 0
+	if exitCondition, err := checker.CheckMonitoringControlPlane(b.Shoot.SeedNamespace, gardencorev1beta1helper.GetPurpose(effectiveShoot) == gardencorev1beta1.ShootPurposeTesting, wantsAlertmanager, condition, seedDeploymentLister, seedStatefulSetLister); err != nil || exitCondition != nil {
 		return exitCondition, err
 	}
 	if gardenletfeatures.FeatureGate.Enabled(features.Logging) {
-		if exitCondition, err := checker.CheckLoggingControlPlane(b.Shoot.SeedNamespace, b.Shoot.GetPurpose() == gardencorev1beta1.ShootPurposeTesting, condition, seedStatefulSetLister); err != nil || exitCondition != nil {
+		if exitCondition, err := checker.CheckLoggingControlPlane(b.Shoot.SeedNamespace, gardencorev1beta1helper.GetPurpose(effectiveShoot) == gardencorev1beta1.ShootPurposeTesting, condition, seedStatefulSetLister); err != nil || exitCondition != nil {
 			return exitCondition, err
 		}
 	}
@@ -629,12 +614,13 @@ func (b *Botanist) checkSystemComponents(
 // checkClusterNodes checks whether every node registered at the Shoot cluster is in "Ready" state, that
 // as many nodes are registered as desired, and that every machine is running.
 func (b *Botanist) checkClusterNodes(
+	effectiveShoot *gardencorev1beta1.Shoot,
 	checker *HealthChecker,
 	condition gardencorev1beta1.Condition,
 	shootNodeLister kutil.NodeLister,
 	extensionConditions []ExtensionCondition,
 ) (*gardencorev1beta1.Condition, error) {
-	if exitCondition, err := checker.CheckClusterNodes(b.Shoot.Info.Spec.Provider.Workers, condition, shootNodeLister); err != nil || exitCondition != nil {
+	if exitCondition, err := checker.CheckClusterNodes(effectiveShoot.Spec.Provider.Workers, condition, shootNodeLister); err != nil || exitCondition != nil {
 		return exitCondition, err
 	}
 	if exitCondition := checker.CheckExtensionCondition(condition, extensionConditions); exitCondition != nil {
@@ -788,6 +774,7 @@ var (
 
 func (b *Botanist) healthChecks(
 	ctx context.Context,
+	effectiveShoot *gardencorev1beta1.Shoot,
 	initializeShootClients func() (bool, error),
 	thresholdMappings map[gardencorev1beta1.ConditionType]time.Duration,
 	healthCheckOutdatedThreshold *metav1.Duration,
@@ -802,7 +789,7 @@ func (b *Botanist) healthChecks(
 	gardencorev1beta1.Condition,
 	gardencorev1beta1.Condition,
 ) {
-	if b.Shoot.HibernationEnabled || b.Shoot.Info.Status.IsHibernated {
+	if gardencorev1beta1helper.HibernationIsEnabled(effectiveShoot) || b.Shoot.Info.Status.IsHibernated {
 		return shootHibernatedCondition(apiserverAvailability), shootHibernatedCondition(controlPlane), shootHibernatedCondition(nodes), shootHibernatedCondition(systemComponents)
 	}
 
@@ -831,7 +818,7 @@ func (b *Botanist) healthChecks(
 		nodes = gardencorev1beta1helper.UpdatedConditionUnknownErrorMessage(nodes, message)
 		systemComponents = gardencorev1beta1helper.UpdatedConditionUnknownErrorMessage(systemComponents, message)
 
-		newControlPlane, err := b.checkControlPlane(ctx, checker, controlPlane, seedDeploymentLister, seedStatefulSetLister, seedEtcdLister, seedWorkerLister, extensionConditionsControlPlaneHealthy)
+		newControlPlane, err := b.checkControlPlane(ctx, effectiveShoot, checker, controlPlane, seedDeploymentLister, seedStatefulSetLister, seedEtcdLister, seedWorkerLister, extensionConditionsControlPlaneHealthy)
 		controlPlane = newConditionOrError(controlPlane, newControlPlane, err)
 		return apiserverAvailability, controlPlane, nodes, systemComponents
 	}
@@ -840,11 +827,11 @@ func (b *Botanist) healthChecks(
 		apiserverAvailability = b.checkAPIServerAvailability(ctx, checker, apiserverAvailability)
 		return nil
 	}, func(ctx context.Context) error {
-		newControlPlane, err := b.checkControlPlane(ctx, checker, controlPlane, seedDeploymentLister, seedStatefulSetLister, seedEtcdLister, seedWorkerLister, extensionConditionsControlPlaneHealthy)
+		newControlPlane, err := b.checkControlPlane(ctx, effectiveShoot, checker, controlPlane, seedDeploymentLister, seedStatefulSetLister, seedEtcdLister, seedWorkerLister, extensionConditionsControlPlaneHealthy)
 		controlPlane = newConditionOrError(controlPlane, newControlPlane, err)
 		return nil
 	}, func(ctx context.Context) error {
-		newNodes, err := b.checkClusterNodes(checker, nodes, makeNodeLister(ctx, b.K8sShootClient.Client()), extensionConditionsEveryNodeReady)
+		newNodes, err := b.checkClusterNodes(effectiveShoot, checker, nodes, makeNodeLister(ctx, b.K8sShootClient.Client()), extensionConditionsEveryNodeReady)
 		nodes = newConditionOrError(nodes, newNodes, err)
 		return nil
 	}, func(ctx context.Context) error {
@@ -882,6 +869,7 @@ func PardonCondition(condition gardencorev1beta1.Condition, lastOp *gardencorev1
 // HealthChecks conducts the health checks on all the given conditions.
 func (b *Botanist) HealthChecks(
 	ctx context.Context,
+	effectiveShoot *gardencorev1beta1.Shoot,
 	initializeShootClients func() (bool, error),
 	thresholdMappings map[gardencorev1beta1.ConditionType]time.Duration,
 	healthCheckOutdatedThreshold *metav1.Duration,
@@ -896,7 +884,7 @@ func (b *Botanist) HealthChecks(
 	gardencorev1beta1.Condition,
 	gardencorev1beta1.Condition,
 ) {
-	apiServerAvailable, controlPlaneHealthy, everyNodeReady, systemComponentsHealthy := b.healthChecks(ctx, initializeShootClients, thresholdMappings, healthCheckOutdatedThreshold, gardenerVersion, apiserverAvailability, controlPlane, nodes, systemComponents)
+	apiServerAvailable, controlPlaneHealthy, everyNodeReady, systemComponentsHealthy := b.healthChecks(ctx, effectiveShoot, initializeShootClients, thresholdMappings, healthCheckOutdatedThreshold, gardenerVersion, apiserverAvailability, controlPlane, nodes, systemComponents)
 	lastOp := b.Shoot.Info.Status.LastOperation
 	lastErrors := b.Shoot.Info.Status.LastErrors
 	return PardonCondition(apiServerAvailable, lastOp, lastErrors),

--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -39,7 +39,7 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 		return err
 	}
 
-	if b.Shoot.GetPurpose() == gardencorev1beta1.ShootPurposeTesting || !gardenletfeatures.FeatureGate.Enabled(features.Logging) {
+	if b.Shoot.Purpose == gardencorev1beta1.ShootPurposeTesting || !gardenletfeatures.FeatureGate.Enabled(features.Logging) {
 		return common.DeleteLoggingStack(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace)
 	}
 

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -46,7 +46,7 @@ import (
 // DeploySeedMonitoring will install the Helm release "seed-monitoring" in the Seed clusters. It comprises components
 // to monitor the Shoot cluster whose control plane runs in the Seed cluster.
 func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
-	if b.Shoot.GetPurpose() == gardencorev1beta1.ShootPurposeTesting {
+	if b.Shoot.Purpose == gardencorev1beta1.ShootPurposeTesting {
 		return b.DeleteSeedMonitoring(ctx)
 	}
 

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -160,7 +160,7 @@ func (b *Builder) Build(ctx context.Context, c client.Client) (*Shoot, error) {
 	shoot.InternalClusterDomain = ConstructInternalClusterDomain(shootObject.Name, b.projectName, b.internalDomain)
 	shoot.ExternalClusterDomain = ConstructExternalClusterDomain(shootObject)
 	shoot.IgnoreAlerts = gardencorev1beta1helper.ShootIgnoresAlerts(shootObject)
-	shoot.WantsAlertmanager = !shoot.IgnoreAlerts && shootObject.Spec.Monitoring != nil && shootObject.Spec.Monitoring.Alerting != nil && len(shootObject.Spec.Monitoring.Alerting.EmailReceivers) > 0
+	shoot.WantsAlertmanager = gardencorev1beta1helper.ShootWantsAlertManager(shootObject)
 	shoot.WantsVerticalPodAutoscaler = gardencorev1beta1helper.ShootWantsVerticalPodAutoscaler(shootObject)
 	shoot.Components = &Components{
 		Extensions: &Extensions{

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -221,6 +221,7 @@ func (b *Builder) Build(ctx context.Context, c client.Client) (*Shoot, error) {
 
 	shoot.ResourceRefs = getResourceRefs(shootObject)
 	shoot.NodeLocalDNSEnabled = gardenletfeatures.FeatureGate.Enabled(features.NodeLocalDNS)
+	shoot.Purpose = gardencorev1beta1helper.GetPurpose(shootObject)
 
 	return shoot, nil
 }
@@ -240,14 +241,6 @@ func (s *Shoot) GetIngressFQDN(subDomain string) string {
 		return ""
 	}
 	return fmt.Sprintf("%s.%s.%s", subDomain, common.IngressPrefix, *(s.Info.Spec.DNS.Domain))
-}
-
-// GetPurpose returns the purpose of the shoot or 'evaluation' if it's nil.
-func (s *Shoot) GetPurpose() gardencorev1beta1.ShootPurpose {
-	if v := s.Info.Spec.Purpose; v != nil {
-		return *v
-	}
-	return gardencorev1beta1.ShootPurposeEvaluation
 }
 
 // GetWorkerNames returns a list of names of the worker groups in the Shoot manifest.

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -64,6 +64,7 @@ type Shoot struct {
 	ExternalClusterDomain *string
 	ExternalDomain        *garden.Domain
 
+	Purpose                    gardencorev1beta1.ShootPurpose
 	WantsClusterAutoscaler     bool
 	WantsVerticalPodAutoscaler bool
 	WantsAlertmanager          bool


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR changes the care controller in a way that health checks to be executed now consider only the effective shoot spec, i.e. respecting the `.spec.maintenance.confineSpecRollout` option. More information can be found in the linked issue.

**Which issue(s) this PR fixes**:
Fixes #2706

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Gardener health checks now take the effective Shoot specification into consideration if `.spec.maintenance.confineSpecRollout` is used. Earlier, `EveryNodeReady` or `ControlPlaneHealthy` conditions reported an invalid state if the specification was changed but not yet effective due to a rollout during shoot maintenance (`confineSpecRollout: true`).
```
