### PR TITLE
[release-1.13] Cherry-pick Use system-node-critical for apiserver-proxy Daemonset

### DIFF
--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         networking.gardener.cloud/from-seed: allowed
     spec:
       serviceAccountName: apiserver-proxy
-      priorityClassName: system-cluster-critical
+      priorityClassName: system-node-critical
       tolerations:
       - effect: NoSchedule
         operator: Exists
@@ -76,8 +76,8 @@ spec:
             cpu: 20m
             memory: 20Mi
           limits:
-            cpu: 60m
-            memory: 40Mi
+            cpu: 200m
+            memory: 200Mi
       - name: proxy
         image: {{ index .Values.images "apiserver-proxy" }}
         imagePullPolicy: IfNotPresent
@@ -94,8 +94,8 @@ spec:
             cpu: 20m
             memory: 20Mi
           limits:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 200m
+            memory: 300Mi
         readinessProbe:
           httpGet:
             path: /ready


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/area networking
/kind bug
/priority normal

**What this PR does / why we need it**:

- Use `system-node-critical` for apiserver-proxy Daemonset
- Increase memory limits to avoid OOM killer
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Cherry-pick of #3282 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
`apiserver-proxy` now uses `system-node-critical` priority class. Memory limit is also increased to avoid OOM killer.
```
