### PR TITLE
Wait for apiserver Service to be deleted on hibernation

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -305,6 +305,10 @@ func (b *Botanist) HibernateControlPlane(ctx context.Context) error {
 		if err := b.Shoot.Components.ControlPlane.KubeAPIServerService.Destroy(ctx); err != nil {
 			return err
 		}
+
+		if err := b.Shoot.Components.ControlPlane.KubeAPIServerService.WaitCleanup(ctx); err != nil {
+			return err
+		}
 	}
 
 	if err := b.Shoot.Components.ControlPlane.KubeAPIServerSNI.Destroy(ctx); err != nil {

--- a/pkg/operation/botanist/controlplane/kube_apiserver_service.go
+++ b/pkg/operation/botanist/controlplane/kube_apiserver_service.go
@@ -167,10 +167,9 @@ func (d *kubeAPIService) Wait(ctx context.Context) error {
 }
 
 func (d *kubeAPIService) WaitCleanup(ctx context.Context) error {
-	return nil
+	return kutil.WaitUntilResourceDeleted(ctx, d.client, d.getService(), 5*time.Second)
 }
 
-// entry returns an empty DNSEntry used for deletion.
 func (d *kubeAPIService) getService() *corev1.Service {
 	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: d.service.Name, Namespace: d.service.Namespace}}
 }


### PR DESCRIPTION
/kind bug

We see often Shoots failing to wake up with err:
```yaml
  lastErrors:
  - codes:
    - ERR_CONFIGURATION_PROBLEM
    description: 'task "Waiting until Shoot control plane exposure has been reconciled"
      failed: Error while waiting for ControlPlane shoot--foo--bar/bar-exposure
      to become ready: extension encountered error during reconciliation: Error reconciling
      controlplane: could not get kube-apiserver service load balancer address: Service
      "kube-apiserver" not found'
    lastUpdateTime: "2020-12-10T11:59:47Z"
    taskID: Waiting until Shoot control plane exposure has been reconciled
```

The reason is that in `HibernateControlPlane` we delete the apiserver svc but we don't wait for it be completed. In some cases when the svc is not gone after hibernation (Seed cloud-controller-manager is unavailable for short period of time, or the LB deletion is taking time on cloud provider side) an immediate wake up can fail with this err.

Also the hibernation integration test is quite often failing with the reason. This PR should deflake it.

I tried to add a test but I think whole test suite should be reworked to use mock client instead of fake client. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An race issue causing immediate wake up after hibernation to fail is now fixed. The hibernation is now waiting until the kube-apiserver Service is cleaned up.
```
