### PR TITLE
Change PodAntiAffinity to PreferredDuringSchedulingIgnoredDuringExecution for seed-admission-controller

### DIFF
--- a/pkg/operation/botanist/seedsystemcomponents/seedadmission/seedadmission.go
+++ b/pkg/operation/botanist/seedsystemcomponents/seedadmission/seedadmission.go
@@ -182,10 +182,15 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 					Spec: corev1.PodSpec{
 						Affinity: &corev1.Affinity{
 							PodAntiAffinity: &corev1.PodAntiAffinity{
-								RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
-									TopologyKey:   corev1.LabelHostname,
-									LabelSelector: &metav1.LabelSelector{MatchLabels: getLabels()},
-								}},
+								PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+									{
+										Weight: 100,
+										PodAffinityTerm: corev1.PodAffinityTerm{
+											TopologyKey:   corev1.LabelHostname,
+											LabelSelector: &metav1.LabelSelector{MatchLabels: getLabels()},
+										},
+									},
+								},
 							},
 						},
 						ServiceAccountName: serviceAccount.Name,

--- a/pkg/operation/botanist/seedsystemcomponents/seedadmission/seedadmission_test.go
+++ b/pkg/operation/botanist/seedsystemcomponents/seedadmission/seedadmission_test.go
@@ -127,12 +127,14 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchLabels:
-                app: gardener
-                role: seed-admission-controller
-            topologyKey: kubernetes.io/hostname
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: gardener
+                  role: seed-admission-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
       - command:
         - /gardener-seed-admission-controller


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:  Changing PodAntiAffinity to `PreferredDuringSchedulingIgnoredDuringExecution` for seed-admission-controller. `RequiredDuringSchedulingIgnoredDuringExecution` would block the bootstrapping of the seed clusters with less than 3 machines, due to failing health-check of seed-admission-controller deployment in the seed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Change pod anti-affinity to `preferredDuringSchedulingIgnoredDuringExecution` for `gardener-seed-admission-controller` deployment in the `garden` namespaces of seed clusters.
```
