### PR TITLE
Remove preStop hook for >= 1.16 clusters

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -155,7 +155,7 @@ spec:
         - --service-cluster-ip-range={{ .Values.shootNetworks.services }}
         - --service-account-key-file=/srv/kubernetes/service-account-key/id_rsa
         {{- if semverCompare ">= 1.16" .Values.kubernetesVersion }}
-        - --shutdown-delay-duration=20s
+        - --shutdown-delay-duration=15s
         {{- end }}
         - --token-auth-file=/srv/kubernetes/token/static_tokens.csv
         - --tls-cert-file=/srv/kubernetes/apiserver/kube-apiserver.crt
@@ -164,6 +164,7 @@ spec:
         {{- include "kube-apiserver.apiAudiences" . | indent 8 }}
         {{- include "kube-apiserver.serviceAccountConfig" . | indent 8 }}
         - --v=2
+        {{- if semverCompare "< 1.16" .Values.kubernetesVersion }}
         lifecycle:
           preStop:
             exec:
@@ -171,6 +172,7 @@ spec:
               - sh
               - -c
               - sleep 5
+        {{- end }}
         livenessProbe:
           httpGet:
             scheme: HTTPS


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/priority normal

**What this PR does / why we need it**:
Because of the streamlining of KAS 1.19.x images and the `shutdown-delay-duration`, we can remove the `preStop` hook for the API server deployment (see linked issue). `shutdown-delay-duration` has been increased to `15s` to circumvent kubernetes/kubernetes#88293.

**Which issue(s) this PR fixes**:
Fixes #3278

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fixed that prevented the execution of the Kube-API-Server's configured `preStop` hooks for `>=1.19.x` clusters.
```
