### PR TITLE
Promote several serial beta tests to default

### DIFF
--- a/test/integration/shoots/care/shoot_care.go
+++ b/test/integration/shoots/care/shoot_care.go
@@ -49,7 +49,7 @@ var _ = ginkgo.Describe("Shoot Care testing", func() {
 		err          error
 	)
 
-	f.Beta().Serial().CIt("Should observe failed health condition in the Shoot when scaling down the API Server of the Shoot", func(ctx context.Context) {
+	f.Default().Serial().CIt("Should observe failed health condition in the Shoot when scaling down the API Server of the Shoot", func(ctx context.Context) {
 		cond := helper.GetCondition(f.Shoot.Status.Conditions, gardencorev1beta1.ShootAPIServerAvailable)
 		gomega.Expect(cond).ToNot(gomega.BeNil())
 		gomega.Expect(cond.Status).To(gomega.Equal(gardencorev1beta1.ConditionTrue))

--- a/test/integration/shoots/operatingsystem/os.go
+++ b/test/integration/shoots/operatingsystem/os.go
@@ -49,8 +49,7 @@ var _ = ginkgo.Describe("Operating system testing", func() {
 
 		var rootPodExecutor framework.RootPodExecutor
 
-		f.Beta().Serial().CIt("should not segfault", func(ctx context.Context) {
-
+		f.Default().Serial().CIt("should not segfault", func(ctx context.Context) {
 			// choose random node
 			nodes := &corev1.NodeList{}
 			err := f.ShootClient.DirectClient().List(ctx, nodes)

--- a/test/integration/shoots/operations/clusterautoscaler.go
+++ b/test/integration/shoots/operations/clusterautoscaler.go
@@ -71,7 +71,7 @@ var _ = ginkgo.Describe("Shoot clusterautoscaler testing", func() {
 		origMaxWorkers              int32
 	)
 
-	f.Beta().Serial().CIt("should autoscale a single worker group", func(ctx context.Context) {
+	f.Default().Serial().CIt("should autoscale a single worker group", func(ctx context.Context) {
 		var (
 			shoot = f.Shoot
 
@@ -153,7 +153,7 @@ var _ = ginkgo.Describe("Shoot clusterautoscaler testing", func() {
 		framework.ExpectNoError(err)
 	}, cleanupTimeout))
 
-	f.Beta().Serial().CIt("should autoscale a single worker group to/from zero", func(ctx context.Context) {
+	f.Default().Serial().CIt("should autoscale a single worker group to/from zero", func(ctx context.Context) {
 		var shoot = f.Shoot
 
 		origClusterAutoscalerConfig = shoot.Spec.Kubernetes.ClusterAutoscaler.DeepCopy()

--- a/test/integration/shoots/operations/containerruntime.go
+++ b/test/integration/shoots/operations/containerruntime.go
@@ -31,7 +31,7 @@ var _ = ginkgo.Describe("Shoot container runtime testing", func() {
 
 	f := framework.NewShootFramework(nil)
 
-	f.Beta().Serial().CIt("should add worker pool with containerd", func(ctx context.Context) {
+	f.Default().Serial().CIt("should add worker pool with containerd", func(ctx context.Context) {
 		var (
 			shoot       = f.Shoot
 			worker      = shoot.Spec.Provider.Workers[0]

--- a/test/integration/shoots/operations/operations.go
+++ b/test/integration/shoots/operations/operations.go
@@ -91,7 +91,7 @@ var _ = ginkgo.Describe("Shoot operation testing", func() {
 
 	}, hibernationTestTimeout)
 
-	f.Beta().Serial().CIt("should fully maintain and reconcile a shoot cluster", func(ctx context.Context) {
+	f.Default().Serial().CIt("should fully maintain and reconcile a shoot cluster", func(ctx context.Context) {
 		ginkgo.By("maintain shoot")
 		err := f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
 			shoot.Annotations[v1beta1constants.GardenerOperation] = common.ShootOperationMaintain
@@ -107,7 +107,7 @@ var _ = ginkgo.Describe("Shoot operation testing", func() {
 		framework.ExpectNoError(err)
 	}, reconcileTimeout)
 
-	f.Beta().Serial().CIt("should rotate kubeconfig for a shoot cluster", func(ctx context.Context) {
+	f.Default().Serial().CIt("should rotate kubeconfig for a shoot cluster", func(ctx context.Context) {
 		ginkgo.By("rotate kubeconfig")
 		var (
 			oldKubeconfigPath = "old.kubeconfig"

--- a/test/integration/shoots/operations/worker.go
+++ b/test/integration/shoots/operations/worker.go
@@ -53,7 +53,7 @@ var _ = ginkgo.Describe("Shoot worker operation testing", func() {
 
 	f := framework.NewShootFramework(nil)
 
-	f.Beta().Serial().CIt("should add one machine to the worker pool and remove it again", func(ctx context.Context) {
+	f.Default().Serial().CIt("should add one machine to the worker pool and remove it again", func(ctx context.Context) {
 		shoot := f.Shoot
 		if len(shoot.Spec.Provider.Workers) == 0 {
 			ginkgo.Skip("no workers defined")

--- a/test/suites/shoot/run_suite_test.go
+++ b/test/suites/shoot/run_suite_test.go
@@ -18,14 +18,13 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"testing"
 
 	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/framework/config"
 	"github.com/gardener/gardener/test/framework/reporter"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 
 	_ "github.com/gardener/gardener/test/integration/plants"
 	_ "github.com/gardener/gardener/test/integration/shoots/applications"


### PR DESCRIPTION
/area testing
/kind cleanup

**What this PR does / why we need it**:
As serial and beta tests currently we have:
- ✅ `Shoot Care testing [BETA] [SERIAL] [SHOOT] Should observe failed health condition in the Shoot when scaling down the API Server of the Shoot` - 0 failures from last 129 runs -> promotion from beta to default
- ❌ `Seed logging testing  [BETA] [SHOOT] should get container logs from loki by tenant` -> recently added and there are some failures
- ❌ `Machine image maintenance tests` - the maintenance suite is currently not part of the suite and it is not being executed
- ❌ `Kubernetes version maintenance tests` - the maintenance suite is currently not part of the suite and it is not being executed
- ✅ `Operating system testing OperatingSystem load [BETA] [SERIAL] [SHOOT] should not segfault` - 7 failures from the last 282 runs -> promotion from beta to default
- ✅ `Shoot clusterautoscaler testing  [BETA] [SERIAL] [SHOOT] should autoscale a single worker group` - 8 failures from the last 282 runs -> promotion from beta to default
- ✅ `Shoot clusterautoscaler testing  [BETA] [SERIAL] [SHOOT] should autoscale a single worker group to/from zero` - 10 failures from last 178 runs -> promotion from beta to default
- ✅ `Shoot container runtime testing [BETA] [SERIAL] [SHOOT] should add worker pool with containerd` - 1 failure in last 106 runs -> promotion from beta to default
- ❌ `Shoot operation testing [BETA] [SERIAL] [SHOOT] Testing if Shoot can be hibernated successfully` - to be rechecked after https://github.com/gardener/gardener/pull/3289 
- ✅  `Shoot operation testing [BETA] [SERIAL] [SHOOT] should fully maintain and reconcile a shoot cluster` - 14 failures in the last 258 runs -> promotion to default
- ✅ `Shoot operation testing [BETA] [SERIAL] [SHOOT] should rotate kubeconfig for a shoot cluster` - 14 failures from the last 258 runs -> promotion to default
- ✅ `Shoot worker operation testing -> should add one machine to the worker pool and remove it again` - 3 failures from the last 89 runs - > promotion to default

In general most of the failures are caused by https://github.com/gardener/gardener/pull/3289 as hibernation test is executed at first, then fails and leaves the Shoot in broken wake up state and the following beta tests fail also because they can't each the apiserver.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
