### PR TITLE
Check if shoot is no longer managed by this gardenlet before reconcilation

### DIFF
--- a/pkg/controllerutils/seedfilter.go
+++ b/pkg/controllerutils/seedfilter.go
@@ -19,6 +19,8 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	confighelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -69,6 +71,16 @@ func ShootFilterFunc(seedName string, seedLister gardencorelisters.SeedLister, l
 		}
 		return SeedLabelsMatch(seedLister, *shoot.Status.SeedName, labelSelector)
 	}
+}
+
+// ShootIsManagedByThisGardenlet checks if the given shoot is managed by this gardenlet by comparing it with the seed name from the GardenletConfiguration
+// or by checking whether the seed labels mathes the seed seoector from the GardenletConfiguration.
+func ShootIsManagedByThisGardenlet(shoot *gardencorev1beta1.Shoot, gc *config.GardenletConfiguration, seedLister gardencorelisters.SeedLister) bool {
+	seedName := confighelper.SeedNameFromSeedConfig(gc.SeedConfig)
+	if len(seedName) > 0 {
+		return *shoot.Spec.SeedName == seedName
+	}
+	return SeedLabelsMatch(seedLister, *shoot.Spec.SeedName, gc.SeedSelector)
 }
 
 // SeedLabelsMatch fetches the given seed via a lister by its name and then checks whether the given label selector matches

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -36,7 +36,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	confighelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/operation/botanist"
@@ -121,7 +120,7 @@ func (c *Controller) reconcileShootCareKey(key string) error {
 	}
 
 	// if shoot is no longer managed by this gardenlet (e.g., due to migration to another seed) then don't requeue
-	if seedName := confighelper.SeedNameFromSeedConfig(c.config.SeedConfig); (len(seedName) > 0 && *shoot.Spec.SeedName != seedName) || (len(seedName) == 0 && !controllerutils.SeedLabelsMatch(c.seedLister, *shoot.Spec.SeedName, c.config.SeedSelector)) {
+	if !controllerutils.ShootIsManagedByThisGardenlet(shoot, c.config, c.seedLister) {
 		return nil
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR adds additional check before the start of the reconciliation process if the whether is managed by this gardenlet or not. If the shoot is no longer managed by this gardenlet (e.g., due to migration to another seed) it should no longer be requeued.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
