### PR TITLE
Fix Time_Format of some parsers

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-configmap.yaml
@@ -301,7 +301,7 @@ data:
         Name        extensionsParser
         Format      json
         Time_Key    ts
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
+        Time_Format %Y-%m-%dT%H:%M:%S.%Z
 
 {{ if .Values.additionalParsers }}
 {{- toString .Values.additionalParsers | indent 4 }}

--- a/pkg/operation/botanist/controlplane/etcd/logging.go
+++ b/pkg/operation/botanist/controlplane/etcd/logging.go
@@ -34,7 +34,7 @@ const (
     Format      regex
     Regex       ^time="(?<time>\d{4}-\d{2}-\d{2}T[^"]*)"\s+level=(?<severity>\w+)\smsg="(?<log>.*)"
     Time_Key    time
-    Time_Format %Y-%m-%dT%H:%M:%S.%L
+    Time_Format %Y-%m-%dT%H:%M:%S%Z
 `
 	loggingFilter = `[FILTER]
     Name                parser

--- a/pkg/operation/botanist/controlplane/etcd/logging_test.go
+++ b/pkg/operation/botanist/controlplane/etcd/logging_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Logging", func() {
     Format      regex
     Regex       ^time="(?<time>\d{4}-\d{2}-\d{2}T[^"]*)"\s+level=(?<severity>\w+)\smsg="(?<log>.*)"
     Time_Key    time
-    Time_Format %Y-%m-%dT%H:%M:%S.%L
+    Time_Format %Y-%m-%dT%H:%M:%S%Z
 `))
 
 			Expect(loggingConfig.Filters).To(Equal(`[FILTER]

--- a/pkg/operation/botanist/seedsystemcomponents/seedadmission/logging.go
+++ b/pkg/operation/botanist/seedsystemcomponents/seedadmission/logging.go
@@ -25,7 +25,7 @@ const (
     Format      regex
     Regex       ^time="(?<time>\d{4}-\d{2}-\d{2}T[^"]*)"\s+level=(?<severity>\w+)\smsg="(?<log>.*)"
     Time_Key    time
-    Time_Format %Y-%m-%dT%H:%M:%S.%L
+    Time_Format %Y-%m-%dT%H:%M:%S%Z
 `
 	loggingFilter = `[FILTER]
     Name                parser

--- a/pkg/operation/botanist/seedsystemcomponents/seedadmission/logging_test.go
+++ b/pkg/operation/botanist/seedsystemcomponents/seedadmission/logging_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Logging", func() {
     Format      regex
     Regex       ^time="(?<time>\d{4}-\d{2}-\d{2}T[^"]*)"\s+level=(?<severity>\w+)\smsg="(?<log>.*)"
     Time_Key    time
-    Time_Format %Y-%m-%dT%H:%M:%S.%L
+    Time_Format %Y-%m-%dT%H:%M:%S%Z
 `))
 
 			Expect(loggingConfig.Filters).To(Equal(`[FILTER]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug
/priority normal

**What this PR does / why we need it**:
Fix `Time_Format` of some parsers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@vlvasilev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
