### PR TITLE
[release-v1.14] Correct order of admission plugins 

### DIFF
--- a/pkg/apiserver/apiserver_suite_test.go
+++ b/pkg/apiserver/apiserver_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAPIServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gardener API Server Suite")
+}

--- a/pkg/apiserver/plugins.go
+++ b/pkg/apiserver/plugins.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle"
+	mutatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/mutating"
+	validatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/validating"
+
+	controllerregistrationresources "github.com/gardener/gardener/plugin/pkg/controllerregistration/resources"
+	"github.com/gardener/gardener/plugin/pkg/global/customverbauthorizer"
+	"github.com/gardener/gardener/plugin/pkg/global/deletionconfirmation"
+	"github.com/gardener/gardener/plugin/pkg/global/extensionvalidation"
+	"github.com/gardener/gardener/plugin/pkg/global/resourcereferencemanager"
+	plantvalidator "github.com/gardener/gardener/plugin/pkg/plant"
+	seedvalidator "github.com/gardener/gardener/plugin/pkg/seed/validator"
+	shootdns "github.com/gardener/gardener/plugin/pkg/shoot/dns"
+	"github.com/gardener/gardener/plugin/pkg/shoot/oidc/clusteropenidconnectpreset"
+	"github.com/gardener/gardener/plugin/pkg/shoot/oidc/openidconnectpreset"
+	shootquotavalidator "github.com/gardener/gardener/plugin/pkg/shoot/quotavalidator"
+	shoottolerationrestriction "github.com/gardener/gardener/plugin/pkg/shoot/tolerationrestriction"
+	shootvalidator "github.com/gardener/gardener/plugin/pkg/shoot/validator"
+	shootstatedeletionvalidator "github.com/gardener/gardener/plugin/pkg/shootstate/validator"
+	"github.com/gardener/gardener/third_party/forked/kubernetes/plugin/pkg/admission/resourcequota"
+)
+
+// AllOrderedPlugins is the list of all the plugins in order.
+var AllOrderedPlugins = []string{
+	lifecycle.PluginName, // NamespaceLifecycle
+	resourcereferencemanager.PluginName,
+	extensionvalidation.PluginName,
+	shoottolerationrestriction.PluginName,
+	shootdns.PluginName,
+	shootquotavalidator.PluginName,
+	shootvalidator.PluginName,
+	seedvalidator.PluginName,
+	controllerregistrationresources.PluginName,
+	plantvalidator.PluginName,
+	deletionconfirmation.PluginName,
+	openidconnectpreset.PluginName,
+	clusteropenidconnectpreset.PluginName,
+	shootstatedeletionvalidator.PluginName,
+	customverbauthorizer.PluginName,
+
+	// new admission plugins should generally be inserted above here
+	// webhook, and resourcequota plugins must go at the end
+
+	mutatingwebhook.PluginName,   // MutatingAdmissionWebhook
+	validatingwebhook.PluginName, // ValidatingAdmissionWebhook
+
+	// This plugin must remain the last one in the list since it updates the quota usage
+	// which can only happen reliably if previous plugins permitted the request.
+	resourcequota.PluginName, // ResourceQuota
+}
+
+// RegisterAllAdmissionPlugins registers all admission plugins.
+func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
+	resourcereferencemanager.Register(plugins)
+	deletionconfirmation.Register(plugins)
+	extensionvalidation.Register(plugins)
+	shoottolerationrestriction.Register(plugins)
+	shootquotavalidator.Register(plugins)
+	shootdns.Register(plugins)
+	shootvalidator.Register(plugins)
+	seedvalidator.Register(plugins)
+	controllerregistrationresources.Register(plugins)
+	plantvalidator.Register(plugins)
+	openidconnectpreset.Register(plugins)
+	clusteropenidconnectpreset.Register(plugins)
+	shootstatedeletionvalidator.Register(plugins)
+	customverbauthorizer.Register(plugins)
+	resourcequota.Register(plugins)
+}

--- a/pkg/apiserver/plugins_test.go
+++ b/pkg/apiserver/plugins_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver_test
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	genericoptions "k8s.io/apiserver/pkg/server/options"
+
+	"github.com/gardener/gardener/pkg/apiserver"
+)
+
+var _ = Describe("AllOrderedPlugins", func() {
+	It("must end with specific plugins", func() {
+		// it's important for these admission plugins to be invoked at the end, ensure correct order here
+		Expect(strings.Join(apiserver.AllOrderedPlugins, ",")).To(HaveSuffix(",MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"))
+	})
+
+	It("expects default plugins", func() {
+		// if this test breaks, the default admission plugins in the API server library have changed
+		admissionOpts := genericoptions.NewAdmissionOptions()
+		// we can't automatically insert our admission plugins in the right order
+		// we should reevaluate, what's the correct order for the plugins, when the default list of plugins changes
+		Expect(strings.Join(admissionOpts.RecommendedPluginOrder, ",")).To(Equal("NamespaceLifecycle,MutatingAdmissionWebhook,ValidatingAdmissionWebhook"))
+		Expect(strings.Join(admissionOpts.Plugins.Registered(), ",")).To(Equal("MutatingAdmissionWebhook,NamespaceLifecycle,ValidatingAdmissionWebhook"))
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/priority normal

**What this PR does / why we need it**:
Before this PR, `gardener-apiserver` was calling the in-tree admission plugins after the webhook plugins.
However, the correct behaviour would be to invoke all in-tree plugins first (for example including defaulting and so on) and then invoking the webhook plugins (that can further default/validate/...).

This PR corrects this bug.

**Which issue(s) this PR fixes**:
ref #3298

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
By default, gardener-apiserver now invokes in-tree admission plugins before invoking the webhook plugins.
```
