### PR TITLE
WorkerDelegate: factor out optional interface WorkerCredentialsDelegate

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -64,13 +64,15 @@ func (a *genericActuator) Delete(ctx context.Context, worker *extensionsv1alpha1
 		return errors.Wrapf(err, "failed to deploy the machine classes")
 	}
 
-	// Update cloud credentials for all existing machine class secrets
-	cloudCredentials, err := workerDelegate.GetMachineControllerManagerCloudCredentials(ctx)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get the cloud credentials in namespace %s", worker.Namespace)
-	}
-	if err = a.updateCloudCredentialsInAllMachineClassSecrets(ctx, logger, cloudCredentials, worker.Namespace); err != nil {
-		return errors.Wrapf(err, "failed to update cloud credentials in machine class secrets for namespace %s", worker.Namespace)
+	if workerCredentialsDelegate, ok := workerDelegate.(WorkerCredentialsDelegate); ok {
+		// Update cloud credentials for all existing machine class secrets
+		cloudCredentials, err := workerCredentialsDelegate.GetMachineControllerManagerCloudCredentials(ctx)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get the cloud credentials in namespace %s", worker.Namespace)
+		}
+		if err = a.updateCloudCredentialsInAllMachineClassSecrets(ctx, logger, cloudCredentials, worker.Namespace); err != nil {
+			return errors.Wrapf(err, "failed to update cloud credentials in machine class secrets for namespace %s", worker.Namespace)
+		}
 	}
 
 	// Mark all existing machines to become forcefully deleted.

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -110,13 +110,15 @@ func (a *genericActuator) Reconcile(ctx context.Context, worker *extensionsv1alp
 		return errors.Wrapf(err, "failed to deploy the machine classes")
 	}
 
-	// Update cloud credentials for all existing machine class secrets
-	cloudCredentials, err := workerDelegate.GetMachineControllerManagerCloudCredentials(ctx)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get the cloud credentials in namespace %s", worker.Namespace)
-	}
-	if err = a.updateCloudCredentialsInAllMachineClassSecrets(ctx, logger, cloudCredentials, worker.Namespace); err != nil {
-		return errors.Wrapf(err, "failed to update cloud credentials in machine class secrets for namespace %s", worker.Namespace)
+	if workerCredentialsDelegate, ok := workerDelegate.(WorkerCredentialsDelegate); ok {
+		// Update cloud credentials for all existing machine class secrets
+		cloudCredentials, err := workerCredentialsDelegate.GetMachineControllerManagerCloudCredentials(ctx)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get the cloud credentials in namespace %s", worker.Namespace)
+		}
+		if err = a.updateCloudCredentialsInAllMachineClassSecrets(ctx, logger, cloudCredentials, worker.Namespace); err != nil {
+			return errors.Wrapf(err, "failed to update cloud credentials in machine class secrets for namespace %s", worker.Namespace)
+		}
 	}
 
 	// Update the machine images in the worker provider status.

--- a/extensions/pkg/controller/worker/genericactuator/interface.go
+++ b/extensions/pkg/controller/worker/genericactuator/interface.go
@@ -32,9 +32,6 @@ type WorkerDelegate interface {
 	// GetMachineControllerManagerShootChartValues should return the values to render the chart containing resources
 	// that are required by the machine-controller-manager inside the shoot cluster itself.
 	GetMachineControllerManagerShootChartValues(context.Context) (map[string]interface{}, error)
-	// GetMachineControllerManagerCloudCredentials should return the IaaS credentials
-	// with the secret keys used by the machine-controller-manager.
-	GetMachineControllerManagerCloudCredentials(context.Context) (map[string][]byte, error)
 
 	// MachineClassKind yields the name of the provider specific machine class.
 	MachineClassKind() string
@@ -59,6 +56,18 @@ type WorkerDelegate interface {
 
 	// CleanupMachineDependencies is a hook to cleanup external machine dependencies.
 	CleanupMachineDependencies(context.Context) error
+}
+
+// WorkerCredentialsDelegate is an interface that can optionally be implemented to be
+// used during the Worker reconciliation to keep all machine class secrets up to date.
+// DEPRECATED: extensions should instead provide credentials only (!) via the machine class field .spec.credentialsSecretRef
+// referencing the Worker's secret reference (spec.SecretRef). This way all machine classes
+// reference the same secret - there is no need anymore to update all machine class secrets.
+// please see [here](https://github.com/gardener/machine-controller-manager/pull/578) for more details
+type WorkerCredentialsDelegate interface {
+	// GetMachineControllerManagerCloudCredentials should return the IaaS credentials
+	// with the secret keys used by the machine-controller-manager.
+	GetMachineControllerManagerCloudCredentials(context.Context) (map[string][]byte, error)
 }
 
 // DelegateFactory acts upon Worker resources.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup
/priority normal

**What this PR does / why we need it**:

Making the update of all machine class secrets in the generic worker actuator optional.
It is only performed if the actuator implements the deprecated WorkerCredentialsDelegate interface.

Alternatively, extensions  can now use the field in the machine class spec.CredentialsSecretRef so that [all refer to the same "cloudprovider" secret in the shoot namespace in the Seed](https://github.com/gardener/gardener-extension-provider-aws/pull/238).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
Making the implementation of the function `GetMachineControllerManagerCloudCredentials` in the `WorkerDelegate` optional. Alternatively, extensions  can now use the field in the machine class `spec.credentialsSecretRef` so that all machine classes refer to the same secret from the `Worker` field `spec.secretRef`. See [here for more details](https://github.com/gardener/machine-controller-manager/pull/578).
```
