### PR TITLE
Improve seed VPA handling

### DIFF
--- a/charts/seed-bootstrap/templates/aggregate-prometheus/vpa.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/vpa.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.vpa.enabled }}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
@@ -11,4 +10,3 @@ spec:
     name: aggregate-prometheus
   updatePolicy:
     updateMode: "Auto"
-{{ end }}

--- a/docs/usage/seed_settings.md
+++ b/docs/usage/seed_settings.md
@@ -58,3 +58,5 @@ By default, the seed controller deploys the VPA components into the `garden` nam
 In case you want to manage the VPA deployment on your own or have a custom one then you might want to disable the automatic deployment of Gardener.
 Otherwise, you might end up with two VPAs which will cause erratic behaviour.
 By setting the `.spec.settings.verticalPodAutoscaler.enabled=false` you can disable the automatic deployment.
+
+⚠️ In any case, there must be a VPA available for your seed cluster. Using a seed without VPA is not supported.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR improves VPA handling for seed clusters:
- Aggregated Prometheus VPA was not deployed if seed VPA was disabled (/cc @wyb1)
- Seed bootstrap now checks for an existing VPA (CRD) if VPA is disabled via the seed spec

I moved the VPA handling to the top of `BootstrapCluster` since it is a prerequisite required for many following components.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fixed which did not enable VPA for the aggregate Prometheus Pod in new seed clusters.
```
```other operator
Gardener will now check seed clusters for VPA functionality as a prerequisite.
```