### PR TITLE
Fetch guestbook tests redis chart from bitnami

### DIFF
--- a/test/framework/resources/repository/repositories.yaml
+++ b/test/framework/resources/repository/repositories.yaml
@@ -5,5 +5,5 @@ repositories:
     keyFile: ""
     name: stable
     password: ""
-    url: https://kubernetes-charts.storage.googleapis.com
+    url: https://charts.bitnami.com/bitnami
     username: ""


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup
/priority critical

**What this PR does / why we need it**:
We currently utilise redis for the guestbook integration test, however it seems like helm stable repos got deprecated: https://helm.sh/blog/charts-repo-deprecation/
Hence as a short-term mitigation we need to switch to bitnami repos.
In the long-term we should probably clone the required chart and upload to gcr instead.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
Guestbook integration test dependencies are now fetched from bitnami repo instead of deprecated/shutdown helm repo.
```
