### PR TITLE
Refactor BackupEntry handling into components

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -208,21 +208,6 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 			Fn:           botanist.WaitForExtensionsOperationMigrateToSucceed,
 			Dependencies: flow.NewTaskIDs(annotateExtensionCRsForMigration),
 		})
-		annotateBackupEntryInSeedForMigration = g.Add(flow.Task{
-			Name:         "Annotating BackupEntry in Seed with operation - migration",
-			Fn:           botanist.AnnotateBackupEntryInSeedForMigration,
-			Dependencies: flow.NewTaskIDs(ensureResourceManagerScaledUp),
-		})
-		waitForBackupEntryOperationMigrateToSucceed = g.Add(flow.Task{
-			Name:         "Waiting until BackupEntry in Seed has lastOperation Status Migrate = Succeeded",
-			Fn:           botanist.WaitForBackupEntryOperationMigrateToSucceed,
-			Dependencies: flow.NewTaskIDs(annotateBackupEntryInSeedForMigration),
-		})
-		deleteBackupEntryFromSeed = g.Add(flow.Task{
-			Name:         "Deleting BackupEntry from Seed",
-			Fn:           botanist.DeleteBackupEntryFromSeed,
-			Dependencies: flow.NewTaskIDs(waitForBackupEntryOperationMigrateToSucceed),
-		})
 		deleteAllExtensionCRs = g.Add(flow.Task{
 			Name:         "Deleting all extension CRs from the Shoot namespace",
 			Dependencies: flow.NewTaskIDs(waitForExtensionCRsOperationMigrateToSucceed),
@@ -286,7 +271,7 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 		deleteNamespace = g.Add(flow.Task{
 			Name:         "Deleting shoot namespace in Seed",
 			Fn:           flow.TaskFn(botanist.DeleteSeedNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(deleteAllExtensionCRs, destroyDNSProviders, deleteBackupEntryFromSeed, waitForManagedResourcesDeletion, scaleETCDToZero),
+			Dependencies: flow.NewTaskIDs(deleteAllExtensionCRs, destroyDNSProviders, waitForManagedResourcesDeletion, scaleETCDToZero),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until shoot namespace in Seed has been deleted",

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -191,11 +191,11 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 		})
 		deployBackupEntryInGarden = g.Add(flow.Task{
 			Name: "Deploying backup entry",
-			Fn:   flow.TaskFn(botanist.DeployBackupEntryInGarden).DoIf(allowBackup),
+			Fn:   flow.TaskFn(botanist.Shoot.Components.BackupEntry.Deploy).DoIf(allowBackup),
 		})
 		waitUntilBackupEntryInGardenReconciled = g.Add(flow.Task{
 			Name:         "Waiting until the backup entry has been reconciled",
-			Fn:           flow.TaskFn(botanist.WaitUntilBackupEntryInGardenReconciled).DoIf(allowBackup),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.BackupEntry.Wait).DoIf(allowBackup),
 			Dependencies: flow.NewTaskIDs(deployBackupEntryInGarden),
 		})
 		deployETCD = g.Add(flow.Task{

--- a/pkg/operation/botanist/backupentry.go
+++ b/pkg/operation/botanist/backupentry.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	corebackupentry "github.com/gardener/gardener/pkg/operation/botanist/backupentry"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	extensionsbackupentry "github.com/gardener/gardener/pkg/operation/botanist/extensions/backupentry"
+	"github.com/gardener/gardener/pkg/operation/common"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DefaultCoreBackupEntry creates the default deployer for the core.gardener.cloud/v1beta1.BackupEntry resource.
+func (b *Botanist) DefaultCoreBackupEntry(gardenClient client.Client) component.DeployWaiter {
+	ownerRef := metav1.NewControllerRef(b.Shoot.Info, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"))
+	ownerRef.BlockOwnerDeletion = pointer.BoolPtr(false)
+
+	return corebackupentry.New(
+		b.Logger,
+		gardenClient,
+		&corebackupentry.Values{
+			Namespace:         b.Shoot.Info.Namespace,
+			Name:              common.GenerateBackupEntryName(b.Shoot.Info.Status.TechnicalID, b.Shoot.Info.Status.UID),
+			OwnerReference:    ownerRef,
+			SeedName:          pointer.StringPtr(b.Seed.Info.Name),
+			OverwriteSeedName: b.isRestorePhase(),
+			BucketName:        string(b.Seed.Info.UID),
+		},
+		corebackupentry.DefaultInterval,
+		corebackupentry.DefaultTimeout,
+	)
+}
+
+// DefaultExtensionsBackupEntry creates the default deployer for the extensions.gardener.cloud/v1alpha1.BackupEntry
+// custom resource.
+func (b *Botanist) DefaultExtensionsBackupEntry(seedClient client.Client) extensionsbackupentry.BackupEntry {
+	return extensionsbackupentry.New(
+		b.Logger,
+		seedClient,
+		&extensionsbackupentry.Values{
+			Name: common.GenerateBackupEntryName(b.Shoot.Info.Status.TechnicalID, b.Shoot.Info.Status.UID),
+		},
+		extensionsbackupentry.DefaultInterval,
+		extensionsbackupentry.DefaultSevereThreshold,
+		extensionsbackupentry.DefaultTimeout,
+	)
+}

--- a/pkg/operation/botanist/backupentry/backupentry.go
+++ b/pkg/operation/botanist/backupentry/backupentry.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupentry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/retry"
+
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	// DefaultInterval is the default interval for retry operations.
+	DefaultInterval = 5 * time.Second
+	// DefaultTimeout is the default timeout and defines how long Gardener should wait
+	// for a successful reconciliation of a BackupEntry resource.
+	DefaultTimeout = 10 * time.Minute
+)
+
+// TimeNow returns the current time. Exposed for testing.
+var TimeNow = time.Now
+
+// Values contains the values used to create a BackupEntry resource.
+type Values struct {
+	// Namespace is the namespace of the BackupEntry resource.
+	Namespace string
+	// Name is the name of the BackupEntry resource.
+	Name string
+	// OwnerReference is a reference to an owner for BackupEntry resource.
+	OwnerReference *metav1.OwnerReference
+	// SeedName is the name of the seed to which the BackupEntry shall be scheduled.
+	SeedName *string
+	// OverwriteSeedName indicates whether the provided SeedName in the values shall be used even if the BackupEntry
+	// already exists (if this is false then the existing `.spec.seedName` will be kept even if the SeedName in these
+	// values differs.
+	OverwriteSeedName bool
+	// BucketName is the name of the bucket in which the BackupEntry shall be reconciled. This value is only used if the
+	// BackupEntry does not exist yet. Otherwise, the existing `.spec.bucketName` will be kept even if the BucketName in
+	// these values differs.
+	BucketName string
+}
+
+// New creates a new instance of DeployWaiter for a BackupEntry.
+func New(
+	logger logrus.FieldLogger,
+	client client.Client,
+	values *Values,
+	waitInterval time.Duration,
+	waitTimeout time.Duration,
+) component.DeployWaiter {
+	return &backupEntry{
+		client:       client,
+		logger:       logger,
+		values:       values,
+		waitInterval: waitInterval,
+		waitTimeout:  waitTimeout,
+	}
+}
+
+type backupEntry struct {
+	values       *Values
+	logger       logrus.FieldLogger
+	client       client.Client
+	waitInterval time.Duration
+	waitTimeout  time.Duration
+}
+
+// Deploy uses the garden client to create or update the BackupEntry resource in the project namespace in the Garden.
+func (b *backupEntry) Deploy(ctx context.Context) error {
+	var (
+		backupEntry = &gardencorev1beta1.BackupEntry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      b.values.Name,
+				Namespace: b.values.Namespace,
+			},
+		}
+		bucketName = b.values.BucketName
+		seedName   = b.values.SeedName
+	)
+
+	if err := b.client.Get(ctx, kutil.Key(b.values.Namespace, b.values.Name), backupEntry); err == nil {
+		bucketName = backupEntry.Spec.BucketName
+		seedName = backupEntry.Spec.SeedName
+	} else if client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	if b.values.OverwriteSeedName {
+		seedName = b.values.SeedName
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, b.client, backupEntry, func() error {
+		metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+		metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+
+		finalizers := sets.NewString(backupEntry.GetFinalizers()...)
+		finalizers.Insert(gardencorev1beta1.GardenerName)
+		backupEntry.SetFinalizers(finalizers.UnsortedList())
+
+		if b.values.OwnerReference != nil {
+			backupEntry.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*b.values.OwnerReference}
+		}
+
+		backupEntry.Spec.BucketName = bucketName
+		backupEntry.Spec.SeedName = seedName
+
+		return nil
+	})
+
+	return err
+}
+
+// Wait waits until the BackupEntry resource is ready.
+func (b *backupEntry) Wait(ctx context.Context) error {
+	return retry.UntilTimeout(ctx, b.waitInterval, b.waitTimeout, func(ctx context.Context) (done bool, err error) {
+		be := &gardencorev1beta1.BackupEntry{}
+		if err := b.client.Get(ctx, kutil.Key(b.values.Namespace, b.values.Name), be); err != nil {
+			return retry.SevereError(err)
+		}
+
+		if be.Status.LastOperation != nil {
+			if be.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
+				b.logger.Info("Backup entry has been successfully reconciled.")
+				return retry.Ok()
+			}
+			if be.Status.LastOperation.State == gardencorev1beta1.LastOperationStateError {
+				b.logger.Info("Backup entry has been reconciled with error.")
+				return retry.SevereError(errors.New(be.Status.LastError.Description))
+			}
+		}
+
+		b.logger.Info("Waiting until the backup entry has been reconciled in the Garden cluster...")
+		return retry.MinorError(fmt.Errorf("backup entry %q has not yet been reconciled", be.Name))
+	})
+}
+
+// Destroy is not implemented yet.
+func (b *backupEntry) Destroy(_ context.Context) error { return nil }
+
+// WaitCleanup is not implemented yet.
+func (b *backupEntry) WaitCleanup(_ context.Context) error { return nil }

--- a/pkg/operation/botanist/backupentry/backupentry_suite_test.go
+++ b/pkg/operation/botanist/backupentry/backupentry_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupentry_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBackupEntry(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Botanist BackupEntry Suite")
+}

--- a/pkg/operation/botanist/backupentry/backupentry_test.go
+++ b/pkg/operation/botanist/backupentry/backupentry_test.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupentry_test
+
+import (
+	"context"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/logger"
+	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
+	. "github.com/gardener/gardener/pkg/operation/botanist/backupentry"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("BackupEntry", func() {
+	var (
+		ctrl *gomock.Controller
+
+		ctx              context.Context
+		c                client.Client
+		expected         *gardencorev1beta1.BackupEntry
+		values           *Values
+		log              logrus.FieldLogger
+		defaultDepWaiter component.DeployWaiter
+
+		mockNow *mocktime.MockNow
+		now     time.Time
+
+		name      = "be"
+		namespace = "namespace"
+		ownerRef  = metav1.NewControllerRef(&corev1.Namespace{}, corev1.SchemeGroupVersion.WithKind("Namespace"))
+
+		seedName            = "seed"
+		bucketName          = "bucket"
+		differentBucketName = "different-bucketname"
+		differentSeedName   = "different-seedname"
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+
+		mockNow = mocktime.NewMockNow(ctrl)
+
+		ctx = context.TODO()
+		log = logger.NewNopLogger()
+
+		s := runtime.NewScheme()
+		Expect(gardencorev1beta1.AddToScheme(s)).NotTo(HaveOccurred())
+
+		c = fake.NewFakeClientWithScheme(s)
+
+		values = &Values{
+			Name:           name,
+			Namespace:      namespace,
+			OwnerReference: ownerRef,
+			SeedName:       &seedName,
+			BucketName:     bucketName,
+		}
+
+		expected = &gardencorev1beta1.BackupEntry{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+				Kind:       "BackupEntry",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				},
+				Finalizers:      []string{"gardener"},
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+			Spec: gardencorev1beta1.BackupEntrySpec{
+				BucketName: bucketName,
+				SeedName:   &seedName,
+			},
+		}
+
+		defaultDepWaiter = New(log, c, values, time.Millisecond, 500*time.Millisecond)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#Deploy", func() {
+		BeforeEach(func() {
+			expected.ResourceVersion = "1"
+		})
+
+		Context("do not overwrite seed name", func() {
+			It("should create correct BackupEntry (newly created)", func() {
+				defer test.WithVars(&TimeNow, mockNow.Do)()
+				mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+				actual := &gardencorev1beta1.BackupEntry{}
+				Expect(c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, actual)).To(Succeed())
+
+				Expect(actual).To(DeepEqual(expected))
+			})
+
+			It("should create correct BackupEntry (reconciling/updating)", func() {
+				defer test.WithVars(&TimeNow, mockNow.Do)()
+				mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+				existing := expected.DeepCopy()
+				existing.ResourceVersion = ""
+				existing.Spec.BucketName = differentBucketName
+				existing.Spec.SeedName = &differentSeedName
+				Expect(c.Create(ctx, existing)).To(Succeed(), "creating BackupEntry succeeds")
+
+				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+				actual := &gardencorev1beta1.BackupEntry{}
+				Expect(c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, actual)).To(Succeed())
+
+				expected.Spec.BucketName = differentBucketName
+				expected.Spec.SeedName = &differentSeedName
+				Expect(actual).To(DeepEqual(expected))
+			})
+		})
+
+		Context("overwrite seed name", func() {
+			BeforeEach(func() {
+				values.OverwriteSeedName = true
+				defaultDepWaiter = New(log, c, values, time.Millisecond, 500*time.Millisecond)
+			})
+
+			It("should create correct BackupEntry (newly created)", func() {
+				defer test.WithVars(&TimeNow, mockNow.Do)()
+				mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+				actual := &gardencorev1beta1.BackupEntry{}
+				Expect(c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, actual)).To(Succeed())
+
+				Expect(actual).To(DeepEqual(expected))
+			})
+
+			It("should create correct BackupEntry (reconciling/updating)", func() {
+				defer test.WithVars(&TimeNow, mockNow.Do)()
+				mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+				existing := expected.DeepCopy()
+				existing.ResourceVersion = ""
+				existing.Spec.BucketName = differentBucketName
+				existing.Spec.SeedName = &differentSeedName
+				Expect(c.Create(ctx, existing)).To(Succeed(), "creating BackupEntry succeeds")
+
+				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+				actual := &gardencorev1beta1.BackupEntry{}
+				Expect(c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, actual)).To(Succeed())
+
+				expected.ResourceVersion = "2"
+				expected.Spec.BucketName = differentBucketName
+				Expect(actual).To(DeepEqual(expected))
+			})
+		})
+	})
+
+	Describe("#Wait", func() {
+		It("should return error when it's not found", func() {
+			Expect(defaultDepWaiter.Wait(ctx)).To(HaveOccurred())
+		})
+
+		It("should return error when it's not ready", func() {
+			expected.Status.LastError = &gardencorev1beta1.LastError{
+				Description: "Some error",
+			}
+
+			Expect(c.Create(ctx, expected)).To(Succeed(), "creating BackupEntry succeeds")
+			Expect(defaultDepWaiter.Wait(ctx)).To(MatchError(ContainSubstring("has not yet been reconciled")), "BackupEntry indicates error")
+		})
+
+		It("should return no error when is ready", func() {
+			expected.Status.LastError = nil
+			expected.ObjectMeta.Annotations = map[string]string{}
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+			}
+
+			Expect(c.Create(ctx, expected)).To(Succeed(), "creating BackupEntry succeeds")
+			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed(), "BackupEntry is ready, should not return an error")
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should be nil because it's not implemented", func() {
+			Expect(defaultDepWaiter.Destroy(ctx)).To(BeNil())
+		})
+	})
+
+	Describe("#WaitCleanup", func() {
+		It("should be nil because it's not implemented", func() {
+			Expect(defaultDepWaiter.WaitCleanup(ctx)).To(BeNil())
+		})
+	})
+})

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -73,6 +73,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	}
 
 	// extension components
+	o.Shoot.Components.Extensions.BackupEntry = b.DefaultExtensionsBackupEntry(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.ContainerRuntime = b.DefaultContainerRuntime(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.ControlPlane = b.DefaultControlPlane(b.K8sSeedClient.DirectClient(), extensionsv1alpha1.Normal)
 	o.Shoot.Components.Extensions.ControlPlaneExposure = b.DefaultControlPlane(b.K8sSeedClient.DirectClient(), extensionsv1alpha1.Exposure)
@@ -131,6 +132,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	}
 
 	// other components
+	o.Shoot.Components.BackupEntry = b.DefaultCoreBackupEntry(b.K8sGardenClient.DirectClient())
 	o.Shoot.Components.ClusterIdentity = clusteridentity.New(o.Shoot.Info.Status.ClusterIdentity, o.GardenClusterIdentity, o.Shoot.Info.Name, o.Shoot.Info.Namespace, o.Shoot.SeedNamespace, string(o.Shoot.Info.Status.UID), b.K8sGardenClient.DirectClient(), b.K8sSeedClient.DirectClient(), b.Logger)
 
 	return b, nil

--- a/pkg/operation/botanist/extensions/backupentry/backupentry.go
+++ b/pkg/operation/botanist/extensions/backupentry/backupentry.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupentry
+
+import (
+	"context"
+	"time"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/operation/common"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	// DefaultInterval is the default interval for retry operations.
+	DefaultInterval = 5 * time.Second
+	// DefaultSevereThreshold is the default threshold until an error reported by another component is treated as 'severe'.
+	DefaultSevereThreshold = 30 * time.Second
+	// DefaultTimeout is the default timeout and defines how long Gardener should wait
+	// for a successful reconciliation of a BackupEntry resource.
+	DefaultTimeout = 10 * time.Minute
+)
+
+// TimeNow returns the current time. Exposed for testing.
+var TimeNow = time.Now
+
+// BackupEntry is an interface for managing BackupEntries.
+type BackupEntry interface {
+	component.DeployMigrateWaiter
+	SetType(string)
+	SetProviderConfig(*runtime.RawExtension)
+	SetRegion(string)
+	SetBackupBucketProviderStatus(*runtime.RawExtension)
+}
+
+// Values contains the values used to create a BackupEntry CRD
+type Values struct {
+	// Name is the name of the BackupEntry extension.
+	Name string
+	// Type is the type of BackupEntry plugin/extension.
+	Type string
+	// ProviderConfig contains the provider config for the BackupEntry extension.
+	ProviderConfig *runtime.RawExtension
+	// Region is the infrastructure region of the BackupEntry.
+	Region string
+	// SecretRef is a reference to a secret with the infrastructure credentials.
+	SecretRef corev1.SecretReference
+	// BucketName is the name of the bucket in which the entry shall be created.
+	BucketName string
+	// BackupBucketProviderStatus is the optional provider status of the BackupBucket.
+	BackupBucketProviderStatus *runtime.RawExtension
+}
+
+// New creates a new instance of DeployWaiter for a BackupEntry.
+func New(
+	logger logrus.FieldLogger,
+	client client.Client,
+	values *Values,
+	waitInterval time.Duration,
+	waitSevereThreshold time.Duration,
+	waitTimeout time.Duration,
+) BackupEntry {
+	return &backupEntry{
+		client:              client,
+		logger:              logger,
+		values:              values,
+		waitInterval:        waitInterval,
+		waitSevereThreshold: waitSevereThreshold,
+		waitTimeout:         waitTimeout,
+	}
+}
+
+type backupEntry struct {
+	values              *Values
+	logger              logrus.FieldLogger
+	client              client.Client
+	waitInterval        time.Duration
+	waitSevereThreshold time.Duration
+	waitTimeout         time.Duration
+}
+
+// Deploy uses the seed client to create or update the BackupEntry custom resource in the Seed.
+func (b *backupEntry) Deploy(ctx context.Context) error {
+	backupEntry := &extensionsv1alpha1.BackupEntry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: b.values.Name,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, b.client, backupEntry, func() error {
+		metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+		metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+
+		backupEntry.Spec = extensionsv1alpha1.BackupEntrySpec{
+			DefaultSpec: extensionsv1alpha1.DefaultSpec{
+				Type:           b.values.Type,
+				ProviderConfig: b.values.ProviderConfig,
+			},
+			Region:                     b.values.Region,
+			SecretRef:                  b.values.SecretRef,
+			BucketName:                 b.values.BucketName,
+			BackupBucketProviderStatus: b.values.BackupBucketProviderStatus,
+		}
+
+		return nil
+	})
+
+	return err
+}
+
+// Restore uses the seed client and the ShootState to create the BackupEntry custom resource in the Seed and restore its
+// state.
+func (b *backupEntry) Restore(ctx context.Context, _ *gardencorev1alpha1.ShootState) error {
+	return b.Deploy(ctx)
+}
+
+// Migrate migrates the BackupEntry custom resource
+func (b *backupEntry) Migrate(ctx context.Context) error {
+	return common.MigrateExtensionCR(
+		ctx,
+		b.client,
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.BackupEntry{} },
+		"",
+		b.values.Name,
+	)
+}
+
+// WaitMigrate waits until the BackupEntry custom resource has been successfully migrated.
+func (b *backupEntry) WaitMigrate(ctx context.Context) error {
+	return common.WaitUntilExtensionCRMigrated(
+		ctx,
+		b.client,
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.BackupEntry{} },
+		"",
+		b.values.Name,
+		b.waitInterval,
+		b.waitTimeout,
+	)
+}
+
+// Destroy deletes the BackupEntry CRD
+func (b *backupEntry) Destroy(ctx context.Context) error {
+	return common.DeleteExtensionCR(
+		ctx,
+		b.client,
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.BackupEntry{} },
+		"",
+		b.values.Name,
+	)
+}
+
+// Wait waits until the BackupEntry CRD is ready (deployed or restored)
+func (b *backupEntry) Wait(ctx context.Context) error {
+	return common.WaitUntilExtensionCRReady(
+		ctx,
+		b.client,
+		b.logger,
+		func() runtime.Object { return &extensionsv1alpha1.BackupEntry{} },
+		extensionsv1alpha1.BackupEntryResource,
+		"",
+		b.values.Name,
+		b.waitInterval,
+		b.waitSevereThreshold,
+		b.waitTimeout,
+		nil,
+	)
+}
+
+// WaitCleanup waits until the BackupEntry CRD is deleted
+func (b *backupEntry) WaitCleanup(ctx context.Context) error {
+	return common.WaitUntilExtensionCRDeleted(
+		ctx,
+		b.client,
+		b.logger,
+		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.BackupEntry{} },
+		extensionsv1alpha1.BackupEntryResource,
+		"",
+		b.values.Name,
+		b.waitInterval,
+		b.waitTimeout,
+	)
+}
+
+func (b *backupEntry) SetType(t string) {
+	b.values.Type = t
+}
+
+func (b *backupEntry) SetProviderConfig(providerConfig *runtime.RawExtension) {
+	b.values.ProviderConfig = providerConfig
+}
+
+func (b *backupEntry) SetRegion(region string) {
+	b.values.Region = region
+}
+
+func (b *backupEntry) SetBackupBucketProviderStatus(providerStatus *runtime.RawExtension) {
+	b.values.BackupBucketProviderStatus = providerStatus
+}

--- a/pkg/operation/botanist/extensions/backupentry/backupentry_suite_test.go
+++ b/pkg/operation/botanist/extensions/backupentry/backupentry_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupentry_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestBackupEntry(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Botanist Extensions BackupEntry Suite")
+}

--- a/pkg/operation/botanist/extensions/backupentry/backupentry_test.go
+++ b/pkg/operation/botanist/extensions/backupentry/backupentry_test.go
@@ -1,0 +1,290 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupentry_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/logger"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/operation/botanist/extensions/backupentry"
+	"github.com/gardener/gardener/pkg/operation/common"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("#BackupEntry", func() {
+	var (
+		ctrl *gomock.Controller
+
+		ctx              context.Context
+		c                client.Client
+		expected         *extensionsv1alpha1.BackupEntry
+		values           *backupentry.Values
+		log              logrus.FieldLogger
+		fakeErr          error
+		defaultDepWaiter component.DeployMigrateWaiter
+
+		mockNow *mocktime.MockNow
+		now     time.Time
+
+		name                       = "test-deploy"
+		region                     = "region"
+		bucketName                 = "bucketname"
+		providerType               = "foo"
+		providerConfig             = &runtime.RawExtension{Raw: []byte(`{"bar":"foo"}`)}
+		backupBucketProviderStatus = &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)}
+		secretRef                  = corev1.SecretReference{
+			Name:      "secretname",
+			Namespace: "secretnamespace",
+		}
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+
+		mockNow = mocktime.NewMockNow(ctrl)
+
+		ctx = context.TODO()
+		log = logger.NewNopLogger()
+		fakeErr = fmt.Errorf("some random error")
+
+		s := runtime.NewScheme()
+		Expect(extensionsv1alpha1.AddToScheme(s)).To(Succeed())
+
+		c = fake.NewFakeClientWithScheme(s)
+
+		values = &backupentry.Values{
+			Name:                       name,
+			Type:                       providerType,
+			ProviderConfig:             providerConfig,
+			Region:                     region,
+			SecretRef:                  secretRef,
+			BucketName:                 bucketName,
+			BackupBucketProviderStatus: backupBucketProviderStatus,
+		}
+
+		expected = &extensionsv1alpha1.BackupEntry{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: extensionsv1alpha1.SchemeGroupVersion.String(),
+				Kind:       extensionsv1alpha1.BackupEntryResource,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				Annotations: map[string]string{
+					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				},
+			},
+			Spec: extensionsv1alpha1.BackupEntrySpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type:           providerType,
+					ProviderConfig: providerConfig,
+				},
+				Region:                     region,
+				SecretRef:                  secretRef,
+				BucketName:                 bucketName,
+				BackupBucketProviderStatus: backupBucketProviderStatus,
+			},
+		}
+
+		defaultDepWaiter = backupentry.New(log, c, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#Deploy", func() {
+		BeforeEach(func() {
+			expected.ResourceVersion = "1"
+		})
+
+		It("should create correct BackupEntry", func() {
+			defer test.WithVars(&backupentry.TimeNow, mockNow.Do)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+			actual := &extensionsv1alpha1.BackupEntry{}
+			Expect(c.Get(ctx, client.ObjectKey{Name: name}, actual)).To(Succeed())
+
+			Expect(actual).To(DeepEqual(expected))
+		})
+	})
+
+	Describe("#Wait", func() {
+		It("should return error when it's not found", func() {
+			Expect(defaultDepWaiter.Wait(ctx)).To(MatchError(ContainSubstring("not found")))
+		})
+
+		It("should return error when it's not ready", func() {
+			expected.Status.LastError = &gardencorev1beta1.LastError{
+				Description: "Some error",
+			}
+
+			Expect(c.Create(ctx, expected)).To(Succeed(), "creating backupentry succeeds")
+			Expect(defaultDepWaiter.Wait(ctx)).To(MatchError(ContainSubstring("error during reconciliation: Some error")), "backupentry indicates error")
+		})
+
+		It("should return no error when is ready", func() {
+			expected.Status.LastError = nil
+			expected.ObjectMeta.Annotations = map[string]string{}
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+			}
+
+			Expect(c.Create(ctx, expected)).To(Succeed(), "creating backupentry succeeds")
+			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed(), "backupentry is ready, should not return an error")
+		})
+	})
+
+	Describe("#Destroy", func() {
+		It("should not return error when it's not found", func() {
+			Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
+		})
+
+		It("should not return error when it's deleted successfully", func() {
+			Expect(c.Create(ctx, expected)).To(Succeed(), "adding pre-existing backupentry succeeds")
+			Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
+		})
+
+		It("should return error when it's not deleted successfully", func() {
+			defer test.WithVars(&common.TimeNow, mockNow.Do)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			expected := extensionsv1alpha1.BackupEntry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+					Annotations: map[string]string{
+						common.ConfirmationDeletion:        "true",
+						v1beta1constants.GardenerTimestamp: now.UTC().String(),
+					},
+				}}
+
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Get(ctx, kutil.Key(name), gomock.AssignableToTypeOf(&extensionsv1alpha1.BackupEntry{}))
+
+			// add deletion confirmation and timestamp annotation
+			mc.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.BackupEntry{})).Return(nil)
+			mc.EXPECT().Delete(ctx, &expected).Times(1).Return(fakeErr)
+
+			defaultDepWaiter = backupentry.New(log, mc, &backupentry.Values{Name: name}, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
+			Expect(defaultDepWaiter.Destroy(ctx)).To(MatchError(fakeErr))
+		})
+	})
+
+	Describe("#WaitCleanup", func() {
+		It("should not return error when it's already removed", func() {
+			Expect(defaultDepWaiter.WaitCleanup(ctx)).To(Succeed())
+		})
+	})
+
+	Describe("#Restore", func() {
+		BeforeEach(func() {
+			expected.ResourceVersion = "1"
+		})
+
+		It("should perform a normal deployment", func() {
+			defer test.WithVars(&backupentry.TimeNow, mockNow.Do)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			Expect(defaultDepWaiter.Restore(ctx, nil)).To(Succeed())
+
+			actual := &extensionsv1alpha1.BackupEntry{}
+			Expect(c.Get(ctx, client.ObjectKey{Name: name}, actual)).To(Succeed())
+
+			Expect(actual).To(DeepEqual(expected))
+		})
+	})
+
+	Describe("#Migrate", func() {
+		It("should migrate the resource", func() {
+			defer test.WithVars(
+				&backupentry.TimeNow, mockNow.Do,
+				&common.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			expectedCopy := expected.DeepCopy()
+			expectedCopy.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationMigrate
+
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Get(ctx, kutil.Key(name), gomock.AssignableToTypeOf(&extensionsv1alpha1.BackupEntry{})).SetArg(2, *expected)
+			mc.EXPECT().Patch(ctx, expectedCopy, gomock.AssignableToTypeOf(client.MergeFrom(expected)))
+
+			defaultDepWaiter = backupentry.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
+			Expect(defaultDepWaiter.Migrate(ctx)).To(Succeed())
+		})
+
+		It("should not return error if resource does not exist", func() {
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Get(ctx, kutil.Key(name), gomock.AssignableToTypeOf(&extensionsv1alpha1.BackupEntry{})).Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("BackupEntry"), expected.Name))
+
+			defaultDepWaiter = backupentry.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
+			Expect(defaultDepWaiter.Migrate(ctx)).To(Succeed())
+		})
+	})
+
+	Describe("#WaitMigrate", func() {
+		It("should not return error when resource is missing", func() {
+			Expect(defaultDepWaiter.WaitMigrate(ctx)).To(Succeed())
+		})
+
+		It("should return error if resource is not yet migrated successfully", func() {
+			expected.Status.LastError = &gardencorev1beta1.LastError{
+				Description: "Some error",
+			}
+
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateError,
+				Type:  gardencorev1beta1.LastOperationTypeMigrate,
+			}
+
+			Expect(c.Create(ctx, expected)).To(Succeed(), "creating BackupEntry succeeds")
+			Expect(defaultDepWaiter.WaitMigrate(ctx)).To(MatchError(ContainSubstring("is not Migrate=Succeeded")))
+		})
+
+		It("should not return error if resource gets migrated successfully", func() {
+			expected.Status.LastError = nil
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+				Type:  gardencorev1beta1.LastOperationTypeMigrate,
+			}
+
+			Expect(c.Create(ctx, expected)).To(Succeed(), "creating BackupEntry succeeds")
+			Expect(defaultDepWaiter.WaitMigrate(ctx)).To(Succeed(), "BackupEntry is ready, should not return an error")
+		})
+	})
+})

--- a/pkg/operation/botanist/extensions/network/network_test.go
+++ b/pkg/operation/botanist/extensions/network/network_test.go
@@ -95,7 +95,7 @@ var _ = Describe("#Network", func() {
 		}
 
 		values = &network.Values{
-			Name:           "test-deploy",
+			Name:           networkName,
 			Namespace:      networkNs,
 			Type:           networkType,
 			ProviderConfig: nil,

--- a/pkg/operation/botanist/migration.go
+++ b/pkg/operation/botanist/migration.go
@@ -38,6 +38,7 @@ func (b *Botanist) AnnotateExtensionCRsForMigration(ctx context.Context) (err er
 	}
 
 	fns = append(fns,
+		b.Shoot.Components.Extensions.BackupEntry.Migrate,
 		b.Shoot.Components.Extensions.ContainerRuntime.Migrate,
 		b.Shoot.Components.Extensions.ControlPlane.Migrate,
 		b.Shoot.Components.Extensions.ControlPlaneExposure.Migrate,
@@ -79,6 +80,7 @@ func (b *Botanist) WaitForExtensionsOperationMigrateToSucceed(ctx context.Contex
 	}
 
 	fns = append(fns,
+		b.Shoot.Components.Extensions.BackupEntry.WaitMigrate,
 		b.Shoot.Components.Extensions.ContainerRuntime.WaitMigrate,
 		b.Shoot.Components.Extensions.ControlPlane.WaitMigrate,
 		b.Shoot.Components.Extensions.ControlPlaneExposure.WaitMigrate,
@@ -105,6 +107,7 @@ func (b *Botanist) DeleteAllExtensionCRs(ctx context.Context) error {
 	}
 
 	fns = append(fns,
+		b.Shoot.Components.Extensions.BackupEntry.Destroy,
 		b.Shoot.Components.Extensions.ContainerRuntime.Destroy,
 		b.Shoot.Components.Extensions.ControlPlane.Destroy,
 		b.Shoot.Components.Extensions.ControlPlaneExposure.Destroy,
@@ -142,44 +145,6 @@ func (b *Botanist) restoreExtensionObject(ctx context.Context, extensionObj exte
 	}
 
 	return common.AnnotateExtensionObjectWithOperation(ctx, b.K8sSeedClient.Client(), extensionObj, v1beta1constants.GardenerOperationRestore)
-}
-
-// AnnotateBackupEntryInSeedForMigration annotates the BackupEntry with gardener.cloud/operation=migrate
-func (b *Botanist) AnnotateBackupEntryInSeedForMigration(ctx context.Context) error {
-	name := common.GenerateBackupEntryName(b.Shoot.Info.Status.TechnicalID, b.Shoot.Info.Status.UID)
-	return common.MigrateExtensionCR(
-		ctx,
-		b.K8sSeedClient.Client(),
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.BackupEntry{} },
-		"",
-		name,
-	)
-}
-
-// WaitForBackupEntryOperationMigrateToSucceed waits until BackupEntry has lastOperation equal to Migrate=Succeeded
-func (b *Botanist) WaitForBackupEntryOperationMigrateToSucceed(ctx context.Context) error {
-	name := common.GenerateBackupEntryName(b.Shoot.Info.Status.TechnicalID, b.Shoot.Info.Status.UID)
-	return common.WaitUntilExtensionCRMigrated(
-		ctx,
-		b.K8sSeedClient.DirectClient(),
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.BackupEntry{} },
-		"",
-		name,
-		5*time.Second,
-		600*time.Second,
-	)
-}
-
-// DeleteBackupEntryFromSeed deletes the migrated BackupEntry from the Seed
-func (b *Botanist) DeleteBackupEntryFromSeed(ctx context.Context) error {
-	name := common.GenerateBackupEntryName(b.Shoot.Info.Status.TechnicalID, b.Shoot.Info.Status.UID)
-	return common.DeleteExtensionCR(
-		ctx,
-		b.K8sSeedClient.Client(),
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.BackupEntry{} },
-		"",
-		name,
-	)
 }
 
 func (b *Botanist) isRestorePhase() bool {

--- a/pkg/operation/botanist/migration_test.go
+++ b/pkg/operation/botanist/migration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/botanist"
+	extensionsbackupentry "github.com/gardener/gardener/pkg/operation/botanist/extensions/backupentry"
 	"github.com/gardener/gardener/pkg/operation/botanist/extensions/containerruntime"
 	"github.com/gardener/gardener/pkg/operation/botanist/extensions/controlplane"
 	"github.com/gardener/gardener/pkg/operation/botanist/extensions/extension"
@@ -54,6 +55,7 @@ var _ = Describe("control plane migration", func() {
 		networkName          = "test-network"
 		containerRuntimeName = "testContainerRuntime"
 		extensionName        = "testExtension"
+		backupEntryName      = "test-backupEntry"
 	)
 
 	var (
@@ -109,6 +111,9 @@ var _ = Describe("control plane migration", func() {
 					SeedNamespace: testSeedNamespace,
 					Components: &shoot.Components{
 						Extensions: &shoot.Extensions{
+							BackupEntry: extensionsbackupentry.New(log, fakeClient, &extensionsbackupentry.Values{
+								Name: backupEntryName,
+							}, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond),
 							ContainerRuntime: containerruntime.New(log, fakeClient, &containerruntime.Values{
 								Namespace: testSeedNamespace,
 								Workers:   []gardencorev1beta1.Worker{},

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -16,12 +16,10 @@ package botanist
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"time"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/operation/common"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -236,29 +234,6 @@ func (b *Botanist) WaitUntilEndpointsDoNotContainPodIPs(ctx context.Context) err
 		}
 
 		return retry.Ok()
-	})
-}
-
-// WaitUntilBackupEntryInGardenReconciled waits until the backup entry within the garden cluster has
-// been reconciled.
-func (b *Botanist) WaitUntilBackupEntryInGardenReconciled(ctx context.Context) error {
-	return retry.UntilTimeout(ctx, 5*time.Second, 600*time.Second, func(ctx context.Context) (done bool, err error) {
-		be := &gardencorev1beta1.BackupEntry{}
-		if err := b.K8sGardenClient.DirectClient().Get(ctx, kutil.Key(b.Shoot.Info.Namespace, common.GenerateBackupEntryName(b.Shoot.SeedNamespace, b.Shoot.Info.Status.UID)), be); err != nil {
-			return retry.SevereError(err)
-		}
-		if be.Status.LastOperation != nil {
-			if be.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
-				b.Logger.Info("Backup entry has been successfully reconciled.")
-				return retry.Ok()
-			}
-			if be.Status.LastOperation.State == gardencorev1beta1.LastOperationStateError {
-				b.Logger.Info("Backup entry has been reconciled with error.")
-				return retry.SevereError(errors.New(be.Status.LastError.Description))
-			}
-		}
-		b.Logger.Info("Waiting until the backup entry has been reconciled in the Garden cluster...")
-		return retry.MinorError(fmt.Errorf("backup entry %q has not yet been reconciled", be.Name))
 	})
 }
 

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/controlplane/etcd"
 	"github.com/gardener/gardener/pkg/operation/botanist/controlplane/kubecontrollermanager"
 	"github.com/gardener/gardener/pkg/operation/botanist/controlplane/kubescheduler"
+	extensionsbackupentry "github.com/gardener/gardener/pkg/operation/botanist/extensions/backupentry"
 	"github.com/gardener/gardener/pkg/operation/botanist/extensions/extension"
 	"github.com/gardener/gardener/pkg/operation/botanist/systemcomponents/metricsserver"
 	"github.com/gardener/gardener/pkg/operation/etcdencryption"
@@ -87,6 +88,7 @@ type Shoot struct {
 
 // Components contains different components deployed in the Shoot cluster.
 type Components struct {
+	BackupEntry      component.DeployWaiter
 	ClusterIdentity  component.Deployer
 	Extensions       *Extensions
 	ControlPlane     *ControlPlane
@@ -107,6 +109,7 @@ type ControlPlane struct {
 
 // Extensions contains references to extension resources.
 type Extensions struct {
+	BackupEntry          extensionsbackupentry.BackupEntry
 	ContainerRuntime     ExtensionContainerRuntime
 	ControlPlane         ExtensionControlPlane
 	ControlPlaneExposure ExtensionControlPlane


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity quality robustness
/kind technical-debt test
/priority normal
/topology seed
/platform all
/exp intermediate

**What this PR does / why we need it**:
This PR refactors the deployment for the `BackupEntry` extension resource as well as the `BackupEntry` core resource and adopts the component concept, similar to #3222. This improves several aspects and the overall code quality.

Please note that there are two `BackupEntry` resources (one in `core.gardener.cloud` and one in `extensions.gardener.cloud` API groups). This PR introduces the component concept for both.

/invite @plkokanov @swilen-iwanow @kris94 

**Which issue(s) this PR fixes**:
Part of #2754

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
