### PR TITLE
Ensure stable order of extension webhooks when registering

### DIFF
--- a/extensions/pkg/webhook/cmd/cmd_suite_test.go
+++ b/extensions/pkg/webhook/cmd/cmd_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Webhook Cmd Suite")
+}

--- a/extensions/pkg/webhook/cmd/factory.go
+++ b/extensions/pkg/webhook/cmd/factory.go
@@ -15,6 +15,8 @@
 package cmd
 
 import (
+	"sort"
+
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -52,6 +54,12 @@ func (a *FactoryAggregator) Webhooks(mgr manager.Manager) ([]*extensionswebhook.
 
 		webhooks = append(webhooks, wh)
 	}
+
+	// ensure stable order of webhooks, otherwise the WebhookConfig might be reordered on every restart
+	// leading to a different invocation order which can lead to unnecessary rollouts of components
+	sort.Slice(webhooks, func(i, j int) bool {
+		return webhooks[i].Name < webhooks[j].Name
+	})
 
 	return webhooks, nil
 }

--- a/extensions/pkg/webhook/cmd/factory_test.go
+++ b/extensions/pkg/webhook/cmd/factory_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("FactoryAggregator", func() {
+	var (
+		wh1, wh2               *extensionswebhook.Webhook
+		whFactory1, whFactory2 func(manager.Manager) (*extensionswebhook.Webhook, error)
+	)
+
+	BeforeEach(func() {
+		wh1 = &extensionswebhook.Webhook{
+			Name: "webhook-1",
+		}
+		whFactory1 = func(manager.Manager) (*extensionswebhook.Webhook, error) {
+			return wh1, nil
+		}
+		wh2 = &extensionswebhook.Webhook{
+			Name: "webhook-2",
+		}
+		whFactory2 = func(manager.Manager) (*extensionswebhook.Webhook, error) {
+			return wh2, nil
+		}
+	})
+
+	Describe("#Webhooks", func() {
+		It("should return webhooks sorted by name", func() {
+			agg := NewFactoryAggregator(FactoryAggregator{whFactory1, whFactory2})
+			hooks, err := agg.Webhooks(nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hooks).To(Equal([]*extensionswebhook.Webhook{wh1, wh2}))
+
+			agg = NewFactoryAggregator(FactoryAggregator{whFactory2, whFactory1})
+			hooks, err = agg.Webhooks(nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hooks).To(Equal([]*extensionswebhook.Webhook{wh1, wh2}))
+		})
+	})
+})

--- a/extensions/pkg/webhook/cmd/options_test.go
+++ b/extensions/pkg/webhook/cmd/options_test.go
@@ -15,8 +15,6 @@
 package cmd
 
 import (
-	"testing"
-
 	"github.com/gardener/gardener/extensions/pkg/util/test"
 
 	"github.com/golang/mock/gomock"
@@ -24,11 +22,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/pflag"
 )
-
-func TestCmd(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Webhook Cmd Suite")
-}
 
 var _ = Describe("Options", func() {
 	var (


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/priority normal

**What this PR does / why we need it**:

Before this PR, the extension webhook self-registration was indeterministic wrt the order of webhooks in a single `MutatingWebhookConfig`. Thus, it could happen that the webhooks were registered again with a different order, when an extension controller restarts (wich happens quite frequently with rollouts, VPA, etc.).
With this, mutations of extension webhooks (e.g. controlplane and controlplaneexposures) were sometimes applied in different order, resulting for example in changed order of command line flags in the kube-apiserver deployment, although there was no semantical change.
This behaviour often led to unnecessary rollouts of control plane components, which we generally want to avoid.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rfranzke 

This bug can be reproduced by starting e.g. provider-azure multiple times in a row and observing the order of the mutating webhook config.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
Ensure a stable order of self-registered webhooks in extensions to avoid unnecessary rollouts of control plane components.
```
