### PR TITLE
Adapt the ShootUID annotation to the new API group

### DIFF
--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -130,8 +130,12 @@ const (
 
 	// DeprecatedShootUID is an annotation key for the shoot namespace in the seed cluster,
 	// which value will be the value of `shoot.status.uid`
-	// +deprecated: Use `Cluster` resource instead.
+	//
+	// Deprecated: Use the `Cluster` resource or the annotation key from the new API group `ShootUID`.
 	DeprecatedShootUID = "shoot.garden.sapcloud.io/uid"
+	// ShootUID is an annotation key for the shoot namespace in the seed cluster,
+	// which value will be the value of `shoot.status.uid`
+	ShootUID = "shoot.gardener.cloud/uid"
 
 	// SeedResourceManagerClass is the resource-class managed by the Gardener-Resource-Manager
 	// instance in the garden namespace on the seeds.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -159,8 +159,12 @@ const (
 
 	// DeprecatedShootUID is an annotation key for the shoot namespace in the seed cluster,
 	// which value will be the value of `shoot.status.uid`
-	// +deprecated: Use `Cluster` resource instead.
+	//
+	// Deprecated: Use the `Cluster` resource or the annotation key from the new API group `ShootUID`.
 	DeprecatedShootUID = "shoot.garden.sapcloud.io/uid"
+	// ShootUID is an annotation key for the shoot namespace in the seed cluster,
+	// which value will be the value of `shoot.status.uid`
+	ShootUID = "shoot.gardener.cloud/uid"
 
 	// SeedResourceManagerClass is the resource-class managed by the Gardener-Resource-Manager
 	// instance in the garden namespace on the seeds.

--- a/pkg/operation/botanist/namespaces.go
+++ b/pkg/operation/botanist/namespaces.go
@@ -40,6 +40,7 @@ func (b *Botanist) DeploySeedNamespace(ctx context.Context) error {
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), namespace, func() error {
 		namespace.Annotations = map[string]string{
+			v1beta1constants.ShootUID:           string(b.Shoot.Info.Status.UID),
 			v1beta1constants.DeprecatedShootUID: string(b.Shoot.Info.Status.UID),
 		}
 		namespace.Labels = map[string]string{

--- a/pkg/operation/botanist/namespaces_test.go
+++ b/pkg/operation/botanist/namespaces_test.go
@@ -108,6 +108,7 @@ var _ = Describe("Namespaces", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namespace,
 					Annotations: map[string]string{
+						"shoot.gardener.cloud/uid":     string(uid),
 						"shoot.garden.sapcloud.io/uid": string(uid),
 					},
 					Labels: map[string]string{


### PR DESCRIPTION
/kind cleanup

In the NamespaceToBackupEntryMapper case the ShootUID annotation usage cannot be replace with Cluster resource watch. Hence this PR adds a ShootUID annotation to the Shoot namespace in the Seed.

Ref https://github.com/gardener/gardener/issues/1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
