### PR TITLE
Write updated kubeconfig to testmachinery output

### DIFF
--- a/test/framework/common.go
+++ b/test/framework/common.go
@@ -33,6 +33,10 @@ const (
 
 	// WorkerNamePrefix is the default prefix that will be used for Shoot workers
 	WorkerNamePrefix = "worker-"
+
+	// TestMachineryKubeconfigsPathEnvVarName is the name of the environment variable that holds the path to the
+	// testmachinery provided kubeconfigs.
+	TestMachineryKubeconfigsPathEnvVarName = "TM_KUBECONFIG_PATH"
 )
 
 // SearchResponse represents the response from a search query to loki


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug
/priority normal

**What this PR does / why we need it**:

When the "kubeconfig rotate" tesst is executed, the kubeconfig that was downloaded during its creation is invalidated.
So subsequent steps that use that config are unable to connect to the shoot.
This PR updates the kubeconfig if it was rotated by the test.

**Special notes for your reviewer**:

The kubeconfig is only updated (written to the filesystem) if the testmachinery environment variable is set.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
