### PR TITLE
Clean up unused variable roots in graph flow

### DIFF
--- a/pkg/utils/flow/graph.go
+++ b/pkg/utils/flow/graph.go
@@ -81,19 +81,12 @@ func (g *Graph) Add(task Task) TaskID {
 
 // Compile compiles the graph into an executable Flow.
 func (g *Graph) Compile() *Flow {
-	var (
-		nodes = make(nodes, len(g.tasks))
-		roots = NewTaskIDs()
-	)
+	nodes := make(nodes, len(g.tasks))
 
 	for taskName, taskSpec := range g.tasks {
 		for dependencyID := range taskSpec.Dependencies {
 			dependency := nodes.getOrCreate(dependencyID)
 			dependency.addTargets(taskName)
-		}
-
-		if taskSpec.Dependencies.Len() == 0 {
-			roots.Insert(taskName)
 		}
 
 		node := nodes.getOrCreate(taskName)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Reduce the doubts of other readers when they read codes in pkg/utils/flow/graph.go
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
