### PR TITLE
Demote rotate-kubeconfig test to beta again (breaks other tests)

### DIFF
--- a/test/integration/shoots/operations/operations.go
+++ b/test/integration/shoots/operations/operations.go
@@ -108,7 +108,7 @@ var _ = ginkgo.Describe("Shoot operation testing", func() {
 		framework.ExpectNoError(err)
 	}, reconcileTimeout)
 
-	f.Default().Serial().CIt("should rotate the kubeconfig for a shoot cluster", func(ctx context.Context) {
+	f.Beta().Serial().CIt("should rotate the kubeconfig for a shoot cluster", func(ctx context.Context) {
 		ginkgo.By("rotate kubeconfig")
 		var (
 			secretName = f.Shoot.Name + ".kubeconfig"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug
/priority normal

**What this PR does / why we need it**:
Reverts the promotion of test `should rotate kubeconfig for a shoot cluster` from #3300 as it unfortunately still breaks tests that are executed later on.
See https://github.com/gardener/test-infra/issues/322 for details.

**Which issue(s) this PR fixes**:
Partially fixes https://github.com/gardener/test-infra/issues/322


cc @schrodit @ialidzhikov 