### PR TITLE
Add minAllowed to VPA recommender and admission controller

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/vpa-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/vpa-admission-controller.yaml
@@ -5,6 +5,12 @@ metadata:
   name: vpa-admission-controller
   namespace: {{ .Release.Namespace }}
 spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        cpu: 50m
+        memory: 100Mi
   targetRef:
     apiVersion: {{ include "deploymentversion" . }}
     kind: Deployment

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/vpa-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/vpa-updater.yaml
@@ -5,6 +5,12 @@ metadata:
   name: vpa-updater
   namespace: {{ .Release.Namespace }}
 spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        cpu: 10m
+        memory: 50Mi
   targetRef:
     apiVersion: {{ include "deploymentversion" . }}
     kind: Deployment


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Ensures some minimal CPU and memory to the VPA updater and admission controller pods.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `vpa-admission-controller` and `vpa-updater` pods are now ensured with some minimal CPU and memory resources.
```
