### PR TITLE
Fix ./hack/generate-controller-registration.sh

### DIFF
--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -22,7 +22,7 @@ GO111MODULE=off go get golang.org/x/tools/cmd/goimports
 
 export GO111MODULE=on
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
-curl -s "https://raw.githubusercontent.com/helm/helm/v2.16.9/scripts/get" | bash -s -- --version 'v2.13.1'
+curl -s "https://raw.githubusercontent.com/helm/helm/v2.17.0/scripts/get" | bash -s -- --version 'v2.17.0'
 
 if [[ "$(uname -s)" == *"Darwin"* ]]; then
   cat <<EOM


### PR DESCRIPTION
/kind bug

We missed https://helm.sh/blog/new-location-stable-incubator-charts/. `https://kubernetes-charts.storage.googleapis.com` is replaced by `https://charts.helm.sh/stable`. helm < v2.17.0 still use the old location and `helm init` with such versions fail.


`helm init` fails with:

```
Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com 
Error: error initializing: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden
```

Our `hack/generate-controller-registration.sh` is using `helm init` and this is causing `make generate` and builds for the extensions to fail.

Ref https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-extension-provider-azure-master/jobs/master-head-update-job/builds/30

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
