### PR TITLE
Enable autoscaler during rolling-update

### DIFF
--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -277,6 +277,8 @@ func computeRequiredControlPlaneDeployments(
 			return nil, err
 		}
 
+		// TODO: This check can be removed after few releases, as the cluster-autoscaler is now enabled even
+		// during the rolling-update. Related change: https://github.com/gardener/gardener/pull/3332
 		// if worker resource is processing (during maintenance), there might be a rolling update in progress
 		// during rolling updates, the autoscaler deployment is scaled down & therefore not required
 		rollingUpdateMightBeOngoing := false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**: This PR enables the autoscaler during rolling-updates of the shoot. 
I couldn't find a place to add a test for this case, would be great to have quick guidance.

**Which issue(s) this PR fixes**:
Fixes #3193 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `cluster-autoscaler` is now activated even during rolling-update of the shoot clusters. The change in `machine-controller-manager` of adding the `cluster-autoscaler.kubernetes.io/scale-down-disabled` annotation during rolling-update is required, in order for autoscaler to not scale-down worker-pools (coming with machine-controller-manager `0.34.0`). 
```
```action operator
With the activated `cluster-autoscaler` during roll-outs, following are the minimum versions required for different provider-extensions: gardener-extension-provider-aws `v1.16.0`, gardener-extension-provider-openstack `v1.12.0`,  gardener-extension-provider-azure `v1.14.0`, gardener-extension-provider-gcp `v1.12.0`, gardener-extension-provider-alicloud `v1.18.0`, gardener-extension-provider-vsphere `v0.1.0`.
```