### PR TITLE
Reduce the initialDelaySeconds to 80 seconds for the Loki readinessProbe

### DIFF
--- a/charts/seed-bootstrap/charts/loki/values.yaml
+++ b/charts/seed-bootstrap/charts/loki/values.yaml
@@ -33,12 +33,14 @@ livenessProbe:
     path: /ready
     port: metrics
   initialDelaySeconds: 120
+  failureThreshold: 5
 
 readinessProbe:
   httpGet:
     path: /ready
     port: metrics
-  initialDelaySeconds: 120
+  initialDelaySeconds: 80
+  failureThreshold: 7
 
 replicas: 1
 


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Whit this PR we reduce the Loki readinessProbe `initialDelaySeconds` from 120 to 80 seconds.
This is because the current control plane health controller check the pods every two minutes which is the initial delay of the Loki readiness probe. With the initial delay of 80 seconds the readiness probe is started before the health controller.
The `failureThreshold` is increased with 4 times to preserve the 2 minutes delay plus 30 second of retries.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The Loki `initialDelaySeconds` for the `readinessProbe` is reduces to 80 seconds.
```
