### PR TITLE
Make HVPA CRD deployment work for special semver versions

### DIFF
--- a/charts/seed-bootstrap/charts/hvpa/templates/hvpa-crd.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/templates/hvpa-crd.yaml
@@ -1193,7 +1193,7 @@ spec:
               format: int32
               type: integer
           type: object
-      {{- if semverCompare ">= 1.12" .Capabilities.KubeVersion.GitVersion }}
+      {{- if semverCompare ">= 1.12-0" .Capabilities.KubeVersion.GitVersion }}
       type: object
       {{- end }}
   versions:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/priority normal

**What this PR does / why we need it**:
With #3296 we set `preserveUnknownFields=true` which reveals an issue with GKE seed clusters when trying to bootstrap and install the HVPA CRD:

```
Shoot cannot be synced with Seed: seed is not yet ready: condition "Bootstrapped" has invalid status False (expected True) due to BootstrappingFailed: failed to apply manifests: 1 error occurred: could not apply object of kind "CustomResourceDefinition" "/hvpas.autoscaling.k8s.io": CustomResourceDefinition.apiextensions.k8s.io "hvpas.autoscaling.k8s.io" is invalid: spec.validation.openAPIV3Schema.type: Required value: must not be empty at the root
```

**Special notes for your reviewer**:
Some Kubernetes clusters (that might be used as seeds in a Gardener
landscape) might contain a suffix, e.g., `v1.16.15-gke.4300`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
