### PR TITLE
Prefix global nginx-ingress resources to prevent naming conflicts

### DIFF
--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/clusterrole.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/clusterrole.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: nginx-ingress
-  name: nginx-ingress
+  name: gardener.cloud:seed:nginx-ingress
 rules:
   - apiGroups:
       - ""

--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/clusterrolebinding.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/clusterrolebinding.yaml
@@ -3,11 +3,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: nginx-ingress
-  name: nginx-ingress
+  name: gardener.cloud:seed:nginx-ingress
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: nginx-ingress
+  name: gardener.cloud:seed:nginx-ingress
 subjects:
   - kind: ServiceAccount
     name: nginx-ingress


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/priority normal

**What this PR does / why we need it**:
In order to prevent conflicts with potentially existing global resources with the same name we are now prefixing our global nginx-ingress resources with `gardener.cloud:seed:`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
