### PR TITLE
Enhance remote garden setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ remote-garden-up:
 	@./hack/local-development/remote-garden/run-gardener-etcd $(REMOTE_GARDEN_LABEL)
 
 	# Open tunnels for accessing local gardener components from the remote cluster
-	@./hack/local-development/remote-garden/open-gardener-tunnels ip $(REMOTE_GARDEN_LABEL)
+	@./hack/local-development/remote-garden/open-gardener-tunnels $(REMOTE_GARDEN_LABEL)
 
 	# Now, run `make dev-setup` to setup config and certificates files for gardener's components and to register the gardener-apiserver.
 	# Finally, run `make start-apiserver,start-controller-manager,start-scheduler,start-gardenlet` to start the gardener components as usual.

--- a/hack/local-development/remote-garden/generate-certs
+++ b/hack/local-development/remote-garden/generate-certs
@@ -64,5 +64,8 @@ openssl x509 -req -in "$CERTS_DIR/$CLIENT_NAME.csr" -CA "$CERTS_DIR/$CA_NAME.crt
 
 # Clean up after we're done.
 rm "$CERTS_DIR/$SERVER_NAME.csr" "$CERTS_DIR/$CLIENT_NAME.csr"
-rm "$CERTS_DIR/$CA_NAME.srl"
 rm "$CERTS_DIR/$SERVER_NAME.conf" "$CERTS_DIR/$CLIENT_NAME.conf"
+
+if [ -f "$CERTS_DIR/$CA_NAME.srl" ]; then
+    rm "$CERTS_DIR/$CA_NAME.srl"
+fi

--- a/hack/local-development/remote-garden/open-gardener-tunnels
+++ b/hack/local-development/remote-garden/open-gardener-tunnels
@@ -53,6 +53,8 @@ kind: Service
 metadata:
   name: quic-lb
   namespace: garden
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 spec:
   type: LoadBalancer
   selector:
@@ -71,12 +73,25 @@ EOF
 }
 
 waitForQuicLBServiceToBeReady() {
-  local hostnameOrIP=${1:-ip}
+  while svcIngress=''; do
+    ingress=$(kubectl -n garden get svc quic-lb -o go-template="{{ index .status.loadBalancer.ingress 0 }}" 2> /dev/null)
+    if [[ $ingress == *"hostname"* ]]; then
+      svcIngress="hostname"
+      break
+    fi
 
-  until host "$(kubectl -n garden get svc quic-lb -o go-template="{{ index (index .status.loadBalancer.ingress 0).$hostnameOrIP }}" 2> /dev/null)" 2>&1 > /dev/null; do
+    if [[ $ingress == *"ip"* ]]; then
+      svcIngress="ip"
+      break
+    fi
+
     sleep 2s
   done
-  kubectl -n garden get svc quic-lb -o go-template="{{ index (index .status.loadBalancer.ingress 0).$hostnameOrIP }}"
+
+  until host "$(kubectl -n garden get svc quic-lb -o go-template="{{ index (index .status.loadBalancer.ingress 0).$svcIngress }}")"; do
+    sleep 2s
+  done
+  kubectl -n garden get svc quic-lb -o go-template="{{ index (index .status.loadBalancer.ingress 0).$svcIngress }}"
 }
 
 deleteQuicLBService() {
@@ -231,12 +246,11 @@ if [ "$1" == "-c" ]; then
   deleteQuicLBService
   
   exit 0
-elif [ "$1" == "-h" ] || [ "$1" != "ip" ] && [ "$1" != "hostname" ] && [ "$1" != "" ]; then
+elif [ "$1" == "-h" ]; then
   usage
 fi
 
-HOSTNAME_OR_IP=${1:-ip}
-LABEL="${2:-remote-garden}"
+LABEL="${1:-remote-garden}"
 
 echo "Checking prerequisites..."
 checkPrereqs
@@ -248,7 +262,7 @@ echo "Applying quic LB service..."
 applyQuicLBService && sleep 2s
 
 echo "Waiting for quic LB service to be ready..."
-output=$(waitForQuicLBServiceToBeReady "$HOSTNAME_OR_IP")
+output=$(waitForQuicLBServiceToBeReady)
 loadbalancerHostname=$(echo "$output" | tail -n1)
 echo "LoadBalancer hostname or IP is $loadbalancerHostname"
 
@@ -263,11 +277,40 @@ echo "Applying gardener services..."
 applyGardenerServices
 
 echo "Starting quic clients..."
-docker run -d --name $APISERVER_SERVICE_NAME-quic-client -l "$LABEL" --network host --rm -v "$CERTS_DIR":/certs $QUIC_CLIENT_IMAGE \
+
+# the DNS name 'host.docker.internal' is only available for containers run by docker
+# for desktop on Mac / Windows - otherwise use localhost.
+# Check: desktop on Mac / Windows has not docker0 interface on the host
+# should be run on the actual host (important when running docker over ssh)
+hostname="host.docker.internal"
+if ip addr show docker0 > /dev/null 2>&1; then
+    hostname="localhost"
+fi
+
+docker run \
+  -d \
+  --name $APISERVER_SERVICE_NAME-quic-client \
+  -l "$LABEL" \
+  --network host  \
+  --rm \
+  -v "$CERTS_DIR":/certs \
+  $QUIC_CLIENT_IMAGE \
   --server="$loadbalancerHostname:$APISERVER_LB_PORT" \
-  --upstream="host.docker.internal:$API_SERVER_SECURE_PORT" \
-  --ca-file=/certs/$CA_NAME.crt --cert-file=/certs/$CLIENT_NAME.crt --cert-key=/certs/$CLIENT_NAME.key
-docker run -d --name $ADMISSION_CONTROLLER_SERVICE_NAME-quic-client -l "$LABEL" --network host --rm -v "$CERTS_DIR":/certs $QUIC_CLIENT_IMAGE \
+  --upstream="$hostname:$API_SERVER_SECURE_PORT" \
+  --ca-file=/certs/$CA_NAME.crt \
+  --cert-file=/certs/$CLIENT_NAME.crt  \
+  --cert-key=/certs/$CLIENT_NAME.key
+
+docker run \
+  -d \
+  --name $ADMISSION_CONTROLLER_SERVICE_NAME-quic-client \
+  -l "$LABEL" \
+  --network host  \
+  --rm \
+  -v "$CERTS_DIR":/certs \
+  $QUIC_CLIENT_IMAGE \
   --server="$loadbalancerHostname:$ADMISSION_CONTROLLER_LB_PORT" \
-  --upstream="host.docker.internal:$ADMISSION_CONTROLLER_SECURE_PORT" \
-  --ca-file=/certs/$CA_NAME.crt --cert-file=/certs/$CLIENT_NAME.crt --cert-key=/certs/$CLIENT_NAME.key
+  --upstream="$hostname:$ADMISSION_CONTROLLER_SECURE_PORT" \
+  --ca-file=/certs/$CA_NAME.crt \
+  --cert-file=/certs/$CLIENT_NAME.crt \
+  --cert-key=/certs/$CLIENT_NAME.key


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Enables the remote garden setup to work
 - outside of Docker for Desktop (e.g Linux)
 - on Garden K8s clusters with DNS hostname for the LB (e.g on AWS)
 - adding annotation for NLB on  AWS (required because ELB classic cannot have UDP ports)
   - annotation is always added (should not make a problem on other clusters - will simply be ignored)

Also fixes a bug trying to remove a non-existing certificate file.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Using this for testing [managed seed PR](https://github.com/gardener/gardener/pull/3177)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
