### PR TITLE
Owner reference for extension webhooks

### DIFF
--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -244,7 +244,7 @@ func (c *defaultControl) reconcileNamespaceForProject(ctx context.Context, garde
 			return nil, fmt.Errorf("namespace is already in-use by another project")
 		}
 
-		ns.OwnerReferences = common.MergeOwnerReferences(ns.OwnerReferences, *ownerReference)
+		ns.OwnerReferences = kutils.MergeOwnerReferences(ns.OwnerReferences, *ownerReference)
 		ns.Labels = utils.MergeStringMaps(ns.Labels, projectLabels)
 		ns.Annotations = utils.MergeStringMaps(ns.Annotations, projectAnnotations)
 
@@ -323,7 +323,7 @@ func createOrUpdateResourceQuota(ctx context.Context, c client.Client, projectNa
 	}
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, c, projectResourceQuota, func() error {
-		projectResourceQuota.SetOwnerReferences(common.MergeOwnerReferences(projectResourceQuota.GetOwnerReferences(), *ownerReference))
+		projectResourceQuota.SetOwnerReferences(kutils.MergeOwnerReferences(projectResourceQuota.GetOwnerReferences(), *ownerReference))
 		quotas := make(map[corev1.ResourceName]resource.Quantity)
 		for resourceName, quantity := range resourceQuota.Spec.Hard {
 			if val, ok := projectResourceQuota.Spec.Hard[resourceName]; ok {

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -205,22 +205,6 @@ func ProjectNameForNamespace(namespace *corev1.Namespace) string {
 	return namespace.Name
 }
 
-// MergeOwnerReferences merges the newReferences with the list of existing references.
-func MergeOwnerReferences(references []metav1.OwnerReference, newReferences ...metav1.OwnerReference) []metav1.OwnerReference {
-	uids := make(map[types.UID]struct{})
-	for _, reference := range references {
-		uids[reference.UID] = struct{}{}
-	}
-
-	for _, newReference := range newReferences {
-		if _, ok := uids[newReference.UID]; !ok {
-			references = append(references, newReference)
-		}
-	}
-
-	return references
-}
-
 // GardenerDeletionGracePeriod is the default grace period for Gardener's force deletion methods.
 var GardenerDeletionGracePeriod = 5 * time.Minute
 

--- a/pkg/operation/common/utils_test.go
+++ b/pkg/operation/common/utils_test.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -200,30 +199,6 @@ var _ = Describe("common", func() {
 					))
 				})
 			})
-		})
-	})
-
-	Describe("#MergeOwnerReferences", func() {
-		It("should merge the new references into the list of existing references", func() {
-			var (
-				references = []metav1.OwnerReference{
-					{
-						UID: types.UID("1234"),
-					},
-				}
-				newReferences = []metav1.OwnerReference{
-					{
-						UID: types.UID("1234"),
-					},
-					{
-						UID: types.UID("1235"),
-					},
-				}
-			)
-
-			result := MergeOwnerReferences(references, newReferences...)
-
-			Expect(result).To(ConsistOf(newReferences))
 		})
 	})
 

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -365,4 +366,20 @@ func translateMicroTimestampSince(timestamp metav1.MicroTime) string {
 	}
 
 	return duration.HumanDuration(time.Since(timestamp.Time))
+}
+
+// MergeOwnerReferences merges the newReferences with the list of existing references.
+func MergeOwnerReferences(references []metav1.OwnerReference, newReferences ...metav1.OwnerReference) []metav1.OwnerReference {
+	uids := make(map[types.UID]struct{})
+	for _, reference := range references {
+		uids[reference.UID] = struct{}{}
+	}
+
+	for _, newReference := range newReferences {
+		if _, ok := uids[newReference.UID]; !ok {
+			references = append(references, newReference)
+		}
+	}
+
+	return references
 }

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/types"
+	gomegatypes "github.com/onsi/gomega/types"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -287,7 +288,7 @@ var _ = Describe("kubernetes", func() {
 				Entry("b labels in n2", deployments, "n2", labels.SelectorFromSet(labels.Set(bLabels)), []*appsv1.Deployment{n2BDeployment}))
 
 			DescribeTable("#Get",
-				func(source []*appsv1.Deployment, namespace, name string, deploymentMatcher, errMatcher types.GomegaMatcher) {
+				func(source []*appsv1.Deployment, namespace, name string, deploymentMatcher, errMatcher gomegatypes.GomegaMatcher) {
 					lister := NewDeploymentLister(func() ([]*appsv1.Deployment, error) {
 						return source, nil
 					})
@@ -378,7 +379,7 @@ var _ = Describe("kubernetes", func() {
 				Entry("b labels in n2", statefulSets, "n2", labels.SelectorFromSet(labels.Set(bLabels)), []*appsv1.StatefulSet{n2BStatefulSet}))
 
 			DescribeTable("#Get",
-				func(source []*appsv1.StatefulSet, namespace, name string, statefulSetMatcher, errMatcher types.GomegaMatcher) {
+				func(source []*appsv1.StatefulSet, namespace, name string, statefulSetMatcher, errMatcher gomegatypes.GomegaMatcher) {
 					lister := NewStatefulSetLister(func() ([]*appsv1.StatefulSet, error) {
 						return source, nil
 					})
@@ -469,7 +470,7 @@ var _ = Describe("kubernetes", func() {
 				Entry("b labels in n2", daemonSets, "n2", labels.SelectorFromSet(labels.Set(bLabels)), []*appsv1.DaemonSet{n2BDaemonSet}))
 
 			DescribeTable("#Get",
-				func(source []*appsv1.DaemonSet, namespace, name string, daemonSetMatcher, errMatcher types.GomegaMatcher) {
+				func(source []*appsv1.DaemonSet, namespace, name string, daemonSetMatcher, errMatcher gomegatypes.GomegaMatcher) {
 					lister := NewDaemonSetLister(func() ([]*appsv1.DaemonSet, error) {
 						return source, nil
 					})
@@ -560,7 +561,7 @@ var _ = Describe("kubernetes", func() {
 				Entry("b labels in n2", machineDeployments, "n2", labels.SelectorFromSet(labels.Set(bLabels)), []*extensionsv1alpha1.Worker{n2BWorker}))
 
 			DescribeTable("#Get",
-				func(source []*extensionsv1alpha1.Worker, namespace, name string, machineDeploymentMatcher, errMatcher types.GomegaMatcher) {
+				func(source []*extensionsv1alpha1.Worker, namespace, name string, machineDeploymentMatcher, errMatcher gomegatypes.GomegaMatcher) {
 					lister := NewWorkerLister(func() ([]*extensionsv1alpha1.Worker, error) {
 						return source, nil
 					})
@@ -856,7 +857,7 @@ var _ = Describe("kubernetes", func() {
 	})
 
 	DescribeTable("#FeatureGatesToCommandLineParameter",
-		func(fg map[string]bool, matcher types.GomegaMatcher) {
+		func(fg map[string]bool, matcher gomegatypes.GomegaMatcher) {
 			Expect(FeatureGatesToCommandLineParameter(fg)).To(matcher)
 		},
 		Entry("nil map", nil, BeEmpty()),
@@ -887,7 +888,7 @@ var _ = Describe("kubernetes", func() {
 	)
 
 	DescribeTable("#ReconcileServicePorts",
-		func(existingPorts []corev1.ServicePort, matcher types.GomegaMatcher) {
+		func(existingPorts []corev1.ServicePort, matcher gomegatypes.GomegaMatcher) {
 			Expect(ReconcileServicePorts(existingPorts, desiredPorts)).To(matcher)
 		},
 		Entry("existing ports is nil", nil, ConsistOf(port1, port2, port3)),
@@ -994,4 +995,25 @@ var _ = Describe("kubernetes", func() {
 		})
 	})
 
+	Describe("#MergeOwnerReferences", func() {
+		It("should merge the new references into the list of existing references", func() {
+			var (
+				references = []metav1.OwnerReference{
+					{
+						UID: types.UID("1234"),
+					},
+				}
+				newReferences = []metav1.OwnerReference{
+					{
+						UID: types.UID("1234"),
+					},
+					{
+						UID: types.UID("1235"),
+					},
+				}
+			)
+
+			Expect(MergeOwnerReferences(references, newReferences...)).To(ConsistOf(newReferences))
+		})
+	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind technical-debt
/priority normal

**What this PR does / why we need it**:
Earlier, there were no means for auto-cleanup of extension webhooks. With this PR, when a namespace was provided via the `--webhook-config-namespace` flag, we add an owner reference for the webhook configuration (owner=namespace).
This will make the garbage collector to auto-delete the webhook config after the namespace is deleted, i.e., after the extension has been removed from a (seed) cluster.

Please note that this does usually not work for local development cases because here the "url" mode is used and no namespace is provided.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy dependency
During the extension webhook registration, when a namespace is provided via the `--webhook-config-namespace` flag, the webhook config is enhanced with an owner reference pointing to the provided namespace. This will lead to auto-cleanup of the webhook config when the extension is uninstalled from a seed (earlier, the webhook config was orphaned even after uninstallation from a seed).
```
