### PR TITLE
Adjust minimum resource limits for ingress Controller

### DIFF
--- a/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/charts/istio/istio-ingress/templates/deployment.yaml
@@ -75,10 +75,10 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 128Mi
+            memory: 512Mi
           limits:
-            cpu: 2000m
-            memory: 1024Mi
+            cpu: 400m
+            memory: 2048Mi
         env:
         - name: NODE_NAME
           valueFrom:

--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/vpa.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/vpa.yaml
@@ -8,7 +8,7 @@ spec:
     containerPolicies:
       - containerName: '*'
         minAllowed:
-          cpu: 100m
+          cpu: 25m
           memory: 100Mi
   targetRef:
     apiVersion: "apps/v1"


### PR DESCRIPTION
Problems on startup of the nginx ingress controller were observed when introducing #3131 to larger Seeds.

We have observed on large landscapes (approx. 200 shoots). That the nginx
requires 2 GB memory. Therefore, the current limits led to OOMKills of the
Ingress Controller on startup. With all pods being unavailable and a
poddisruptionbudget of 1 the vpa was not able to delete a pod and
apply his higher recommendations.

With this commit we increased the initial requests and limits so that even
on large landscapes the ingress Controller can start. We also decreased the
minAllowed values so that on smaller landscapes the vpa is able to downscale
according to load.

Co-authored-by: Rafael Franzke <rafael.franzke@sap.com>

/area control-plane
/area auto-scaling
/priority normal

```other operator
NONE
```
