### PR TITLE
Allow setting Seed spec.settings.loadBalancerServices.annotations via "shoot.gardener.cloud/use-as-seed"

### DIFF
--- a/docs/usage/shooted_seed.md
+++ b/docs/usage/shooted_seed.md
@@ -59,6 +59,7 @@ Option | Description
 `disable-dns` | Set `spec.settings.shootDNS.enabled` in the seed cluster to false  (see [/example/50-seed.yaml](../../example/50-seed.yaml)).
 `protected` | Only shoot clusters in the `garden` namespace can use this seed cluster.
 `unprotected` | Shoot clusters from all namespaces can use this seed cluster (**default**).
+`loadBalancerServices.annotations.*` | Set `spec.settings.loadBalancerServices.annotations` in the seed cluster (see [/example/50-seed.yaml](../../example/50-seed.yaml)), e.g `loadBalancerServices.annotations.service.beta.kubernetes.io/aws-load-balancer-type=nlb`.
 `with-secret-ref` | Creates a secret with the `kubeconfig` of the cluster in the `garden` namespace in the garden cluster and specifies the `.spec.secretRef` in the `Seed` object accordingly.
 `shootDefaults.pods` | Default pod network CIDR for shoot clusters created on this seed cluster.
 `shootDefaults.services` | Default service network CIDR for shoot clusters created on this seed cluster.

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -645,6 +645,25 @@ var _ = Describe("helper", func() {
 				}))
 			})
 
+			It("should return a filled load balancer services annotations map", func() {
+				shoot.Annotations = map[string]string{
+					v1beta1constants.AnnotationShootUseAsSeed: "true,loadBalancerServices.annotations.role=apiserver,loadBalancerServices.annotations.service.beta.kubernetes.io/aws-load-balancer-type=nlb",
+				}
+
+				shootedSeed, err := ReadShootedSeed(shoot)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shootedSeed).To(Equal(&ShootedSeed{
+					APIServer: &defaultAPIServer,
+					LoadBalancerServicesAnnotations: map[string]string{
+						"role": "apiserver",
+						"service.beta.kubernetes.io/aws-load-balancer-type": "nlb",
+					},
+					Backup:    &gardencorev1beta1.SeedBackup{},
+					Resources: &defaultResources,
+				}))
+			})
+
 			It("should return a filled feature gates map", func() {
 				shoot.Annotations = map[string]string{
 					v1beta1constants.AnnotationShootUseAsSeed: "true,featureGates.Foo=bar,featureGates.Bar=true,featureGates.Baz=false",

--- a/pkg/gardenlet/controller/shoot/seed_registration_control.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control.go
@@ -385,6 +385,13 @@ func prepareSeedConfig(ctx context.Context, gardenClient client.Client, seedClie
 		dns.IngressDomain = &ingressDomain
 	}
 
+	var loadBalancerServices *gardencorev1beta1.SeedSettingLoadBalancerServices
+	if shootedSeedConfig.LoadBalancerServicesAnnotations != nil {
+		loadBalancerServices = &gardencorev1beta1.SeedSettingLoadBalancerServices{
+			Annotations: shootedSeedConfig.LoadBalancerServicesAnnotations,
+		}
+	}
+
 	return &gardencorev1beta1.SeedSpec{
 		Provider: gardencorev1beta1.SeedProvider{
 			Type:           shoot.Spec.Provider.Type,
@@ -411,6 +418,7 @@ func prepareSeedConfig(ctx context.Context, gardenClient client.Client, seedClie
 			ShootDNS: &gardencorev1beta1.SeedSettingShootDNS{
 				Enabled: shootedSeedConfig.DisableDNS == nil || !*shootedSeedConfig.DisableDNS,
 			},
+			LoadBalancerServices: loadBalancerServices,
 			VerticalPodAutoscaler: &gardencorev1beta1.SeedSettingVerticalPodAutoscaler{
 				Enabled: vpaEnabled,
 			},


### PR DESCRIPTION
/area usability
/kind enhancement
/priority normal

Fixes #3186 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
It is now possible to specify the `spec.settings.loadBalancerServices.annotations` field for shooted seeds via the "shoot.gardener.cloud/use-as-seed" annotation. You can do this by specifying the `loadBalancerServices.annotations.*` option - for example `loadBalancerServices.annotations.service.beta.kubernetes.io/aws-load-balancer-type=nlb`.
```
