### PR TITLE
Apply ingress controller limits to the right file

### DIFF
--- a/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/charts/istio/istio-ingress/templates/deployment.yaml
@@ -75,10 +75,10 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 512Mi
+            memory: 128Mi
           limits:
-            cpu: 400m
-            memory: 2048Mi
+            cpu: 2000m
+            memory: 1024Mi
         env:
         - name: NODE_NAME
           valueFrom:

--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -104,10 +104,10 @@ spec:
           resources:
             limits:
               cpu: 400m
-              memory: 400Mi
+              memory: 2048Mi
             requests:
               cpu: 100m
-              memory: 100Mi
+              memory: 512Mi
       hostNetwork: false
       serviceAccountName: nginx-ingress
       terminationGracePeriodSeconds: 60


### PR DESCRIPTION
Apply ingress controller limits to the right file

Correction for https://github.com/gardener/gardener/pull/3342.

  /area control-plane
  /area auto-scaling

/priority normal

```other operator
NONE
```
