### PR TITLE
Increase CPU resources for seed nginx default backend

### DIFF
--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/default-backend-deployment.yaml
@@ -42,9 +42,9 @@ spec:
               protocol: TCP
           resources:
             limits:
-              cpu: 20m
+              cpu: 100m
               memory: 100Mi
             requests:
-              cpu: 10m
+              cpu: 20m
               memory: 20Mi
       terminationGracePeriodSeconds: 60


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR increases the CPU resource requests and limits for the nginx-ingress default backend according to the recent observations.

/cc @BeckerMax @istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
