### PR TITLE
Terraformer execution adopts still running pods

### DIFF
--- a/extensions/pkg/controller/infrastructure/controller.go
+++ b/extensions/pkg/controller/infrastructure/controller.go
@@ -105,10 +105,5 @@ func add(mgr manager.Manager, args AddArgs) error {
 	}
 
 	// Add additional watches to the controller besides the standard one.
-	err = args.WatchBuilder.AddToController(ctrl)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return args.WatchBuilder.AddToController(ctrl)
 }

--- a/extensions/pkg/terraformer/config.go
+++ b/extensions/pkg/terraformer/config.go
@@ -208,22 +208,6 @@ func DefaultInitializer(c client.Client, main, variables string, tfvars []byte, 
 	})
 }
 
-// prepare checks whether all required ConfigMaps and Secrets exist. It returns the number of
-// existing ConfigMaps/Secrets, or the error in case something unexpected happens.
-func (t *terraformer) prepare(ctx context.Context) (int, error) {
-	numberOfExistingResources, err := t.NumberOfResources(ctx)
-	if err != nil {
-		return -1, err
-	}
-
-	// Clean up possible existing pod artifacts from previous runs
-	if err := t.EnsureCleanedUp(ctx); err != nil {
-		return -1, err
-	}
-
-	return numberOfExistingResources, nil
-}
-
 // NumberOfResources returns the number of existing Terraform resources or an error in case something went wrong.
 func (t *terraformer) NumberOfResources(ctx context.Context) (int, error) {
 	numberOfExistingResources := 0
@@ -280,12 +264,13 @@ func (t *terraformer) CleanupConfiguration(ctx context.Context) error {
 
 // EnsureCleanedUp deletes the Terraformer pods, and waits until everything has been cleaned up.
 func (t *terraformer) EnsureCleanedUp(ctx context.Context) error {
-	t.logger.Info("Ensuring all terraformer Pods have been deleted")
+	t.logger.Info("Ensuring all Terraformer pods have been deleted")
 
-	podList, err := t.listTerraformerPods(ctx)
+	podList, err := t.listPods(ctx)
 	if err != nil {
 		return err
 	}
+
 	if err := t.deleteTerraformerPods(ctx, podList); err != nil {
 		return err
 	}

--- a/extensions/pkg/terraformer/errors.go
+++ b/extensions/pkg/terraformer/errors.go
@@ -24,23 +24,21 @@ import (
 // retrieveTerraformErrors gets a map <logList> whose keys are pod names and whose values are the corresponding logs,
 // and it parses the logs for Terraform errors. If none are found, it will return nil, and otherwise the list of
 // found errors as string slice.
-func retrieveTerraformErrors(logList map[string]string) []string {
+func retrieveTerraformErrors(podName, logs string) []string {
 	var (
-		foundErrors = map[string]string{}
+		foundErrors = map[string]struct{}{}
 		errorList   []string
 	)
 
-	for podName, output := range logList {
-		errorMessage := findTerraformErrors(output)
+	errorMessage := findTerraformErrors(logs)
 
-		// Add the errorMessage to the list of found errors (only if it does not already exist).
-		if _, ok := foundErrors[errorMessage]; !ok && errorMessage != "" {
-			foundErrors[errorMessage] = podName
-		}
+	// Add the errorMessage to the list of found errors (only if it does not already exist).
+	if _, ok := foundErrors[errorMessage]; !ok && errorMessage != "" {
+		foundErrors[errorMessage] = struct{}{}
 	}
 
-	for errorMessage, podName := range foundErrors {
-		errorList = append(errorList, fmt.Sprintf("-> Pod '%s' reported:\n%s", podName, errorMessage))
+	for message := range foundErrors {
+		errorList = append(errorList, fmt.Sprintf("-> Pod '%s' reported:\n%s", podName, message))
 	}
 
 	if len(errorList) == 0 {

--- a/extensions/pkg/terraformer/errors_test.go
+++ b/extensions/pkg/terraformer/errors_test.go
@@ -18,6 +18,7 @@ import (
 	"regexp"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -139,20 +140,16 @@ Error: ` + errorLog5error2
 			regexMultiNewline = regexp.MustCompile(`\n{2,}`)
 		)
 
-		It("should parse and format the errors correctly", func() {
-			Expect(retrieveTerraformErrors(map[string]string{
-				"pod1": errorLog1,
-				"pod2": errorLog2,
-				"pod3": errorLog3,
-				"pod4": errorLog4,
-				"pod5": errorLog5,
-			})).To(ConsistOf(
-				"-> Pod 'pod1' reported:\n* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog1error1, "\n"), "<omitted>"),
-				"-> Pod 'pod2' reported:\n* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog2error2, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog2error1, "\n"), "<omitted>"),
-				"-> Pod 'pod3' reported:\n* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog3error1, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog3error2, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog3error3, "\n"), "<omitted>"),
-				"-> Pod 'pod4' reported:\n* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog4error1, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog4error1, "\n"), "<omitted>"),
-				"-> Pod 'pod5' reported:\n* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog5error2, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog5error1, "\n"), "<omitted>"),
-			))
-		})
+		DescribeTable("detects correct errors",
+			func(podName, logs, expectedMessage string) {
+				Expect(retrieveTerraformErrors(podName, logs)).To(ConsistOf(expectedMessage))
+			},
+
+			Entry("pod1", "pod1", errorLog1, "-> Pod 'pod1' reported:\n* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog1error1, "\n"), "<omitted>")),
+			Entry("pod2", "pod2", errorLog2, "-> Pod 'pod2' reported:\n* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog2error2, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog2error1, "\n"), "<omitted>")),
+			Entry("pod3", "pod3", errorLog3, "-> Pod 'pod3' reported:\n* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog3error1, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog3error2, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog3error3, "\n"), "<omitted>")),
+			Entry("pod4", "pod4", errorLog4, "-> Pod 'pod4' reported:\n* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog4error1, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog4error1, "\n"), "<omitted>")),
+			Entry("pod5", "pod5", errorLog5, "-> Pod 'pod5' reported:\n* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog5error2, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog5error1, "\n"), "<omitted>")),
+		)
 	})
 })

--- a/extensions/pkg/terraformer/terraform_test.go
+++ b/extensions/pkg/terraformer/terraform_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package terraformer
+package terraformer_test
 
 import (
 	"context"
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	. "github.com/gardener/gardener/extensions/pkg/terraformer"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"

--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -80,14 +80,14 @@ type RawState struct {
 const (
 	numberOfConfigResources = 3
 
-	// TerraformerConfigSuffix is the suffix used for the ConfigMap which stores the Terraform configuration and variables declaration.
-	TerraformerConfigSuffix = ".tf-config"
+	// ConfigSuffix is the suffix used for the ConfigMap which stores the Terraform configuration and variables declaration.
+	ConfigSuffix = ".tf-config"
 
-	// TerraformerVariablesSuffix is the suffix used for the Secret which stores the Terraform variables definition.
-	TerraformerVariablesSuffix = ".tf-vars"
+	// VariablesSuffix is the suffix used for the Secret which stores the Terraform variables definition.
+	VariablesSuffix = ".tf-vars"
 
-	// TerraformerStateSuffix is the suffix used for the ConfigMap which stores the Terraform state.
-	TerraformerStateSuffix = ".tf-state"
+	// StateSuffix is the suffix used for the ConfigMap which stores the Terraform state.
+	StateSuffix = ".tf-state"
 
 	// Base64Encoding denotes base64 encoding for the RawState.Data
 	Base64Encoding = "base64"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement technical-debt
/priority normal

**What this PR does / why we need it**:
This PR adapts the Terraformer library in a way that it does no longer delete still running Terraform pods from previous runs but it adopts them instead. This makes status/result propagation a lot faster and prevents unhelpful error message like "Terraform pod is still running".

Along the way, I cleaned up some technical debt that was left from the switch from a Terraform `Job` to a `Pod` some months back. Concretely, a few function signatures are adapted. Also, a few constants and function names were adapted to prevent stuttering according to the Golang conventions.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy dependency
The `terraformer` library in `extensions/pkg/terraformer` does now adopt still running pods instead of deleting them and waiting for their deletion. This enables a faster and more reliable status/result propagation and prevents unhelpful error messages. `Infrastructure` extension developers do not need to wait for a clean Terraform environment in their `Delete()` function anymore as the library is now handling this case out-of-the-box.
```
