### PR TITLE
Switch the HealthChecker to use the 'gardener.cloud/role' label key

### DIFF
--- a/charts/seed-bootstrap/charts/loki/values.yaml
+++ b/charts/seed-bootstrap/charts/loki/values.yaml
@@ -12,7 +12,7 @@ authEnabled: true
 annotations: {}
 
 labels:
-  # deprecated label only for the health check
+  # deprecated label
   garden.sapcloud.io/role: logging
   gardener.cloud/role: logging
   app: loki

--- a/charts/seed-controlplane/charts/gardener-resource-manager/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/templates/deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     gardener.cloud/role: controlplane
-    garden.sapcloud.io/role: controlplane
     app: gardener-resource-manager
 spec:
   revisionHistoryLimit: 0

--- a/charts/seed-controlplane/charts/gardener-resource-manager/templates/rbac.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/templates/rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gardener-resource-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: controlplane
+    gardener.cloud/role: controlplane
     app: gardener-resource-manager
 rules:
 - apiGroups:
@@ -54,7 +54,7 @@ metadata:
   name: gardener-resource-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: controlplane
+    gardener.cloud/role: controlplane
     app: gardener-resource-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/seed-controlplane/charts/gardener-resource-manager/templates/service.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gardener-resource-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: controlplane
+    gardener.cloud/role: controlplane
     app: gardener-resource-manager
 spec:
   type: ClusterIP

--- a/charts/seed-controlplane/charts/gardener-resource-manager/templates/serviceaccount.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/templates/serviceaccount.yaml
@@ -4,5 +4,5 @@ metadata:
   name: gardener-resource-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: controlplane
+    gardener.cloud/role: controlplane
     app: gardener-resource-manager

--- a/charts/seed-controlplane/charts/gardener-resource-manager/templates/vpa.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/templates/vpa.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gardener-resource-manager-vpa
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: controlplane
+    gardener.cloud/role: controlplane
     app: gardener-resource-manager
 spec:
   targetRef:

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     gardener.cloud/role: controlplane
-    garden.sapcloud.io/role: controlplane
     app: kubernetes
     role: apiserver
 {{- if .Values.sni.enabled }}

--- a/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
@@ -41,7 +41,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     gardener.cloud/role: monitoring
-    garden.sapcloud.io/role: monitoring
     component: alertmanager
     role: monitoring
 spec:

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/deployment.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     gardener.cloud/role: monitoring
-    garden.sapcloud.io/role: monitoring
     component: kube-state-metrics
     type: shoot
 spec:

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -34,7 +34,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     gardener.cloud/role: monitoring
-    garden.sapcloud.io/role: monitoring
     app: prometheus
     role: monitoring
 spec:

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     gardener.cloud/role: monitoring
-    garden.sapcloud.io/role: monitoring
     component: grafana
     role: {{ .Values.role }}
 spec:

--- a/charts/shoot-core/components/charts/vpn-shoot/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/vpn-shoot/templates/deployment.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: kube-system
   labels:
     gardener.cloud/role: system-component
-    # TODO (ialidzhikov): remove in a future version
-    garden.sapcloud.io/role: system-component
     app: vpn-shoot
     origin: gardener
 spec:
@@ -33,8 +31,6 @@ spec:
       labels:
         origin: gardener
         gardener.cloud/role: system-component
-        # TODO (ialidzhikov): remove in a future version
-        garden.sapcloud.io/role: system-component
         app: vpn-shoot
         type: tunnel
     spec:

--- a/pkg/controllermanager/controller/project/project_control_delete.go
+++ b/pkg/controllermanager/controller/project/project_control_delete.go
@@ -84,12 +84,9 @@ func (c *defaultControl) releaseNamespace(ctx context.Context, gardenClient kube
 
 	if keepNamespace {
 		delete(namespace.Annotations, common.NamespaceProject)
-		delete(namespace.Annotations, common.NamespaceProjectDeprecated)
 		delete(namespace.Annotations, common.NamespaceKeepAfterProjectDeletion)
 		delete(namespace.Labels, common.ProjectName)
 		delete(namespace.Labels, v1beta1constants.GardenRole)
-		delete(namespace.Labels, common.ProjectNameDeprecated)
-		delete(namespace.Labels, v1beta1constants.DeprecatedGardenRole)
 		for i := len(namespace.OwnerReferences) - 1; i >= 0; i-- {
 			if ownerRef := namespace.OwnerReferences[i]; ownerRef.APIVersion == gardencorev1beta1.SchemeGroupVersion.String() &&
 				ownerRef.Kind == "Project" &&

--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -248,15 +248,6 @@ func (c *defaultControl) reconcileNamespaceForProject(ctx context.Context, garde
 		ns.Labels = utils.MergeStringMaps(ns.Labels, projectLabels)
 		ns.Annotations = utils.MergeStringMaps(ns.Annotations, projectAnnotations)
 
-		// TODO (ialidzhikov): remove the cleanup of deprecated annotation and labels in a future version
-		if metav1.HasAnnotation(ns.ObjectMeta, common.NamespaceProjectDeprecated) {
-			delete(ns.Annotations, common.NamespaceProjectDeprecated)
-		}
-		deprecatedLabels := []string{v1beta1constants.DeprecatedGardenRole, common.ProjectNameDeprecated}
-		for _, deprecatedLabel := range deprecatedLabels {
-			delete(ns.Labels, deprecatedLabel)
-		}
-
 		// If the project is reconciled for the first time then its observed generation is 0. Only in this case we want
 		// to add the "keep-after-project-deletion" annotation to the namespace when we adopt it.
 		if project.Status.ObservedGeneration == 0 {

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -166,8 +166,7 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 			"recommender":         recommender,
 			"updater":             updater,
 			"deploymentLabels": map[string]interface{}{
-				v1beta1constants.GardenRole:           v1beta1constants.GardenRoleControlPlane,
-				v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
+				v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
 			},
 			"clusterType": "shoot",
 		}

--- a/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler.go
@@ -166,8 +166,7 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, c.client, deployment, func() error {
 		deployment.Labels = utils.MergeStringMaps(getLabels(), map[string]string{
-			v1beta1constants.GardenRole:           v1beta1constants.GardenRoleControlPlane,
-			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
+			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
 		})
 		deployment.Spec.Replicas = &c.replicas
 		deployment.Spec.RevisionHistoryLimit = pointer.Int32Ptr(0)

--- a/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler_test.go
@@ -215,10 +215,9 @@ var _ = Describe("ClusterAutoscaler", func() {
 					Name:      deploymentName,
 					Namespace: namespace,
 					Labels: map[string]string{
-						"app":                     "kubernetes",
-						"role":                    "cluster-autoscaler",
-						"gardener.cloud/role":     "controlplane",
-						"garden.sapcloud.io/role": "controlplane",
+						"app":                 "kubernetes",
+						"role":                "cluster-autoscaler",
+						"gardener.cloud/role": "controlplane",
 					},
 				},
 				Spec: appsv1.DeploymentSpec{

--- a/pkg/operation/botanist/controlplane/etcd/etcd.go
+++ b/pkg/operation/botanist/controlplane/etcd/etcd.go
@@ -280,9 +280,8 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			v1beta1constants.GardenerTimestamp: TimeNow().UTC().String(),
 		}
 		etcd.Labels = map[string]string{
-			v1beta1constants.LabelRole:            e.role,
-			v1beta1constants.GardenRole:           v1beta1constants.GardenRoleControlPlane,
-			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
+			v1beta1constants.LabelRole:  e.role,
+			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
 		}
 		etcd.Spec.Replicas = replicas
 		etcd.Spec.PriorityClassName = pointer.StringPtr(v1beta1constants.PriorityClassNameShootControlPlane)

--- a/pkg/operation/botanist/controlplane/etcd/etcd_test.go
+++ b/pkg/operation/botanist/controlplane/etcd/etcd_test.go
@@ -215,9 +215,8 @@ var _ = Describe("Etcd", func() {
 						"gardener.cloud/timestamp": now.String(),
 					},
 					Labels: map[string]string{
-						"gardener.cloud/role":     "controlplane",
-						"garden.sapcloud.io/role": "controlplane",
-						"role":                    testRole,
+						"gardener.cloud/role": "controlplane",
+						"role":                testRole,
 					},
 				},
 				Spec: druidv1alpha1.EtcdSpec{

--- a/pkg/operation/botanist/controlplane/etcd/waiter.go
+++ b/pkg/operation/botanist/controlplane/etcd/waiter.go
@@ -54,7 +54,7 @@ func WaitUntilEtcdsReady(
 			ctx,
 			etcdList,
 			client.InNamespace(namespace),
-			client.MatchingLabels{v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane},
+			client.MatchingLabels{v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane},
 		); err != nil {
 			return retry.SevereError(err)
 		}

--- a/pkg/operation/botanist/controlplane/etcd/waiter_test.go
+++ b/pkg/operation/botanist/controlplane/etcd/waiter_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Waiter", func() {
 
 	Describe("#WaitUntilEtcdsReady", func() {
 		It("should return an error when the listing fail", func() {
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"garden.sapcloud.io/role": "controlplane"}).Return(fakeErr)
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).Return(fakeErr)
 
 			Expect(WaitUntilEtcdsReady(ctx, c, logger.NewFieldLogger(logger.NewNopLogger(), "", ""), namespace, 0, interval, severeThreshold, timeout)).To(MatchError(fakeErr))
 		})
@@ -66,7 +66,7 @@ var _ = Describe("Waiter", func() {
 		It("should return an error when not all required etcds are created", func() {
 			etcdList := &druidv1alpha1.EtcdList{}
 
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"garden.sapcloud.io/role": "controlplane"}).DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
 				etcdList.DeepCopyInto(obj.(*druidv1alpha1.EtcdList))
 				return nil
 			}).AnyTimes()
@@ -92,7 +92,7 @@ var _ = Describe("Waiter", func() {
 				},
 			}
 
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"garden.sapcloud.io/role": "controlplane"}).DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
 				etcdList.DeepCopyInto(obj.(*druidv1alpha1.EtcdList))
 				return nil
 			}).AnyTimes()
@@ -114,7 +114,7 @@ var _ = Describe("Waiter", func() {
 				}
 			)
 
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"garden.sapcloud.io/role": "controlplane"}).DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
 				etcdList.DeepCopyInto(obj.(*druidv1alpha1.EtcdList))
 				return nil
 			}).AnyTimes()
@@ -150,7 +150,7 @@ var _ = Describe("Waiter", func() {
 				},
 			}
 
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"garden.sapcloud.io/role": "controlplane"}).DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
 				etcdList.DeepCopyInto(obj.(*druidv1alpha1.EtcdList))
 				return nil
 			}).AnyTimes()

--- a/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager.go
@@ -169,8 +169,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, k.seedClient, deployment, func() error {
 		deployment.Labels = utils.MergeStringMaps(getLabels(), map[string]string{
-			v1beta1constants.GardenRole:           v1beta1constants.GardenRoleControlPlane,
-			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
+			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
 		})
 		deployment.Spec.Replicas = &k.replicas
 		deployment.Spec.RevisionHistoryLimit = pointer.Int32Ptr(0)

--- a/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager_test.go
@@ -355,10 +355,9 @@ var _ = Describe("KubeControllerManager", func() {
 							Name:      v1beta1constants.DeploymentNameKubeControllerManager,
 							Namespace: namespace,
 							Labels: map[string]string{
-								"app":                     "kubernetes",
-								"role":                    "controller-manager",
-								"gardener.cloud/role":     "controlplane",
-								"garden.sapcloud.io/role": "controlplane",
+								"app":                 "kubernetes",
+								"role":                "controller-manager",
+								"gardener.cloud/role": "controlplane",
 							},
 						},
 						Spec: appsv1.DeploymentSpec{

--- a/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler.go
+++ b/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler.go
@@ -165,8 +165,7 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, k.client, deployment, func() error {
 		deployment.Labels = utils.MergeStringMaps(getLabels(), map[string]string{
-			v1beta1constants.GardenRole:           v1beta1constants.GardenRoleControlPlane,
-			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
+			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
 		})
 		deployment.Spec.Replicas = &k.replicas
 		deployment.Spec.RevisionHistoryLimit = pointer.Int32Ptr(0)

--- a/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler_test.go
+++ b/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler_test.go
@@ -141,10 +141,9 @@ var _ = Describe("KubeScheduler", func() {
 					Name:      deploymentName,
 					Namespace: namespace,
 					Labels: map[string]string{
-						"app":                     "kubernetes",
-						"role":                    "scheduler",
-						"gardener.cloud/role":     "controlplane",
-						"garden.sapcloud.io/role": "controlplane",
+						"app":                 "kubernetes",
+						"role":                "scheduler",
+						"gardener.cloud/role": "controlplane",
 					},
 				},
 				Spec: appsv1.DeploymentSpec{

--- a/pkg/operation/botanist/health_check.go
+++ b/pkg/operation/botanist/health_check.go
@@ -53,13 +53,12 @@ import (
 )
 
 func mustGardenRoleLabelSelector(gardenRoles ...string) labels.Selector {
-	// TODO (ialidzhikov): switch to v1beta1constants.GardenRole in a future version.
 	if len(gardenRoles) == 1 {
-		return labels.SelectorFromSet(map[string]string{v1beta1constants.DeprecatedGardenRole: gardenRoles[0]})
+		return labels.SelectorFromSet(map[string]string{v1beta1constants.GardenRole: gardenRoles[0]})
 	}
 
 	selector := labels.NewSelector()
-	requirement, err := labels.NewRequirement(v1beta1constants.DeprecatedGardenRole, selection.In, gardenRoles)
+	requirement, err := labels.NewRequirement(v1beta1constants.GardenRole, selection.In, gardenRoles)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -282,7 +282,6 @@ const (
 	secretSuffixKubeConfig = "kubeconfig"
 	secretSuffixSSHKeyPair = v1beta1constants.SecretNameSSHKeyPair
 	secretSuffixMonitoring = "monitoring"
-	secretSuffixLogging    = "logging" // deprecated, used only to delete unused secrets
 )
 
 func computeProjectSecretName(shootName, suffix string) string {
@@ -349,19 +348,6 @@ func (b *Botanist) SyncShootCredentialsToGarden(ctx context.Context) error {
 			return err
 		})
 	}
-
-	// Clean Kibana credentials that are not used since https://github.com/gardener/gardener/pull/2515
-	// TOOD, remove in future version.
-	fns = append(fns, func(ctx context.Context) error {
-		secretObj := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      computeProjectSecretName(b.Shoot.Info.Name, secretSuffixLogging),
-				Namespace: b.Shoot.Info.Namespace,
-			},
-		}
-
-		return client.IgnoreNotFound(b.K8sGardenClient.Client().Delete(ctx, secretObj, &client.DeleteOptions{}))
-	})
 
 	return flow.Parallel(fns...)(ctx)
 }

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -224,11 +224,6 @@ const (
 	// ProjectName is they key of a label on namespaces whose value holds the project name.
 	ProjectName = "project.gardener.cloud/name"
 
-	// ProjectNameDeprecated is they key of a label on namespaces whose value holds the project name.
-	//
-	// Deprecated: Use `ProjectName` instead.
-	ProjectNameDeprecated = "project.garden.sapcloud.io/name"
-
 	// ProjectSkipStaleCheck is the key of an annotation on a project namespace that marks the associated Project to be
 	// skipped by the stale project controller. If the project has already configured stale timestamps in its status
 	// then they will be reset.
@@ -236,11 +231,6 @@ const (
 
 	// NamespaceProject is they key of an annotation on namespace whose value holds the project uid.
 	NamespaceProject = "namespace.gardener.cloud/project"
-
-	// NamespaceProjectDeprecated is they key of an annotation on namespace whose value holds the project uid.
-	//
-	// Deprecated: Use `NamespaceProject` instead.
-	NamespaceProjectDeprecated = "namespace.garden.sapcloud.io/project"
 
 	// NamespaceKeepAfterProjectDeletion is a constant for an annotation on a `Namespace` resource that states that it
 	// should not be deleted if the corresponding `Project` gets deleted. Please note that all project related labels

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -221,7 +221,7 @@ const (
 	// ProjectPrefix is the prefix of namespaces representing projects.
 	ProjectPrefix = "garden-"
 
-	// ProjectName is they key of a label on namespaces whose value holds the project name.
+	// ProjectName is the key of a label on namespaces whose value holds the project name.
 	ProjectName = "project.gardener.cloud/name"
 
 	// ProjectSkipStaleCheck is the key of an annotation on a project namespace that marks the associated Project to be
@@ -229,7 +229,7 @@ const (
 	// then they will be reset.
 	ProjectSkipStaleCheck = "project.gardener.cloud/skip-stale-check"
 
-	// NamespaceProject is they key of an annotation on namespace whose value holds the project uid.
+	// NamespaceProject is the key of an annotation on namespace whose value holds the project uid.
 	NamespaceProject = "namespace.gardener.cloud/project"
 
 	// NamespaceKeepAfterProjectDeletion is a constant for an annotation on a `Namespace` resource that states that it
@@ -249,7 +249,7 @@ const (
 	// of referenced quotas.
 	ShootExpirationTimestamp = "shoot.gardener.cloud/expiration-timestamp"
 
-	// ShootNoCleanup is a constant for a label on a resource indicating the the Gardener cleaner should not delete this
+	// ShootNoCleanup is a constant for a label on a resource indicating that the Gardener cleaner should not delete this
 	// resource when cleaning a shoot during the deletion flow.
 	ShootNoCleanup = "shoot.gardener.cloud/no-cleanup"
 


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
This PR:
- adapts the HealthChecker to use the `gardener.cloud/role` label key to select controlplane components (Deployments, StatefulSets, Etcds) for health check. This is follow-up on https://github.com/gardener/gardener/pull/3231.
- removes the `garden.sapcloud.io/role` label key from most of the controlplane components as it is no longer used for health checks.
- contains also some minor cleanups

**Which issue(s) this PR fixes**:
Part of #1649 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
gardenlet's shoot-care-control is now using the `gardener.cloud/role` label key (until now it was `garden.sapcloud.io/role`) to perform health checks on controlplane components. Make sure you have first upgraded to at least Gardener v1.14 before you upgrade to this version of Gardener.
```
