### PR TITLE
Fixing minor issue with UnmarshalRawState logic and adding unit tests.

### DIFF
--- a/extensions/pkg/terraformer/raw_state.go
+++ b/extensions/pkg/terraformer/raw_state.go
@@ -30,7 +30,7 @@ func (trs *RawState) Marshal() ([]byte, error) {
 	return json.Marshal(trs.encodeBase64())
 }
 
-// GetRawState returns the conten of terraform state config map
+// GetRawState returns the content of terraform state config map
 func (t *terraformer) GetRawState(ctx context.Context) (*RawState, error) {
 	configMap := &corev1.ConfigMap{}
 	if err := t.client.Get(ctx, kutil.Key(t.namespace, t.stateName), configMap); err != nil {
@@ -72,13 +72,13 @@ func UnmarshalRawState(rawState interface{}) (*RawState, error) {
 
 // buildRawState returns RawState from byte slice
 func buildRawState(terraformRawState []byte) (*RawState, error) {
-	trs := &RawState{}
+	trs := &RawState{
+		Data:     "",
+		Encoding: NoneEncoding,
+	}
 
 	if terraformRawState == nil {
-		return &RawState{
-			Data:     "",
-			Encoding: NoneEncoding,
-		}, nil
+		return trs, nil
 	}
 
 	if err := json.Unmarshal(terraformRawState, trs); err != nil {

--- a/extensions/pkg/terraformer/raw_state_test.go
+++ b/extensions/pkg/terraformer/raw_state_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terraformer_test
+
+import (
+	"github.com/gardener/gardener/extensions/pkg/terraformer"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	testJsonArray = `{"test": 1}`
+)
+
+var _ = Describe("raw_state", func() {
+
+	Describe("#UnmarshalRawState", func() {
+		It("shoud unmarshal successfully json string and have NoneEncoding", func() {
+			rs, err := terraformer.UnmarshalRawState(testJsonArray)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rs.Encoding).To(Equal(terraformer.NoneEncoding))
+		})
+
+		It("shoud unmarshal successfully nill and have NoneEncoding", func() {
+			rs, err := terraformer.UnmarshalRawState(nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rs.Encoding).To(Equal(terraformer.NoneEncoding))
+		})
+		It("shoud unmarshal successfully []byte and have NoneEncoding", func() {
+			rs, err := terraformer.UnmarshalRawState([]byte(testJsonArray))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rs.Encoding).To(Equal(terraformer.NoneEncoding))
+		})
+		It("shoud unmarshal successfully RawExtension and have NoneEncoding", func() {
+			re := &runtime.RawExtension{
+				Raw: []byte(testJsonArray),
+			}
+			rs, err := terraformer.UnmarshalRawState(re)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rs.Encoding).To(Equal(terraformer.NoneEncoding))
+		})
+		It("shoud not unmarshal successfully RawExtension because of invalid data type", func() {
+			_, err := terraformer.UnmarshalRawState(1)
+			Expect(err).To(HaveOccurred())
+		})
+		It("shoud not unmarshal successfully RawExtension because of invalid data", func() {
+			_, err := terraformer.UnmarshalRawState("NOT JSON")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("#MarshalRawState", func() {
+		It("shoud marshal and then unmarshall successfully RawExtension", func() {
+			re := &terraformer.RawState{
+				Data: testJsonArray,
+			}
+			data, err := re.Marshal()
+			Expect(err).ToNot(HaveOccurred())
+
+			rs, err := terraformer.UnmarshalRawState(data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rs.Encoding).To(Equal(terraformer.NoneEncoding))
+			Expect(rs.Data).To(Equal(testJsonArray))
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/area robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
If JSON byte array or string is passed as a value to ```func UnmarshalRawState(rawState interface{}) (*RawState, error)``` encoding value is not set to the ```RawState``` object. This leads to error : ```unrecognised encoding "" for RawState.Data``` later in the ```func (trs *RawState) decode() (*RawState, error) ```. This can be observed during the restore of an infrastructure object, where the state is set to `{}`. There the error in that case is ```Error restoring infrastructure: unrecognised encoding "" for RawState.Data```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I have thought that it would be a good idea to add some tests for the Marshal/Unmarshal functions, even though they are a bit basic.
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
