### PR TITLE
[minor] fix typo

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -193,7 +193,7 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 			Name: "Deploying backup entry",
 			Fn:   flow.TaskFn(botanist.DeployBackupEntryInGarden).DoIf(allowBackup),
 		})
-		wailtUntilBackupEntryInGardenReconciled = g.Add(flow.Task{
+		waitUntilBackupEntryInGardenReconciled = g.Add(flow.Task{
 			Name:         "Waiting until the backup entry has been reconciled",
 			Fn:           flow.TaskFn(botanist.WaitUntilBackupEntryInGardenReconciled).DoIf(allowBackup),
 			Dependencies: flow.NewTaskIDs(deployBackupEntryInGarden),
@@ -201,7 +201,7 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 		deployETCD = g.Add(flow.Task{
 			Name:         "Deploying main and events etcd",
 			Fn:           flow.TaskFn(botanist.DeployEtcd).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(deploySecrets, deployCloudProviderSecret, wailtUntilBackupEntryInGardenReconciled),
+			Dependencies: flow.NewTaskIDs(deploySecrets, deployCloudProviderSecret, waitUntilBackupEntryInGardenReconciled),
 		})
 		waitUntilEtcdReady = g.Add(flow.Task{
 			Name:         "Waiting until main and event etcd report readiness",

--- a/pkg/operation/botanist/extensions/infrastructure/infrastructure_test.go
+++ b/pkg/operation/botanist/extensions/infrastructure/infrastructure_test.go
@@ -184,8 +184,6 @@ var _ = Describe("#ExtensionInfrastructure", func() {
 		})
 
 		It("should return unexpected errors", func() {
-			waiter.MaxAttempts = 2
-
 			fakeErr := errors.New("fake")
 
 			c.


### PR DESCRIPTION
/area control-plane
/priority normal

**What this PR does / why we need it**:
Fix typo and delete unneeded setup line in infrastructure test

```other other
NONE
```
