### PR TITLE
Promote the hibernation test to default

### DIFF
--- a/test/integration/shoots/operations/operations.go
+++ b/test/integration/shoots/operations/operations.go
@@ -67,7 +67,7 @@ var _ = ginkgo.Describe("Shoot operation testing", func() {
 
 	f := framework.NewShootFramework(nil)
 
-	f.Beta().Serial().CIt("Testing if Shoot can be hibernated successfully", func(ctx context.Context) {
+	f.Default().Serial().CIt("Testing if Shoot can be hibernated successfully", func(ctx context.Context) {
 		guestBookTest, err := applications.NewGuestBookTest(f)
 		framework.ExpectNoError(err)
 


### PR DESCRIPTION
/area testing

In https://github.com/gardener/gardener/pull/3300 we didn't promote the hibernation test  as we wanted to recheck the test success rate after applying a recent fix in the g/g@v1.14.1 patch release.
Now the success rate looks better:
- ✅  `Shoot operation testing [BETA] [SERIAL] [SHOOT] Testing if Shoot can be hibernated successfully` - 25 failures in the last 607 runs

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
