### PR TITLE
Make fluent-bit always privileged for the integration tests

### DIFF
--- a/test/framework/resources/templates/fluent-bit-psp-clusterrolebinding.yaml
+++ b/test/framework/resources/templates/fluent-bit-psp-clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: fluent-bit
+    gardener.cloud/role: logging
+    role: logging
+  name: fluent-bit-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gardener.cloud:psp:privileged
+subjects:
+- kind: ServiceAccount
+  name: fluent-bit
+  namespace: garden

--- a/test/framework/resources/templates/logger-app.yaml.tpl
+++ b/test/framework/resources/templates/logger-app.yaml.tpl
@@ -51,3 +51,7 @@ spec:
 {{ else }}
           value: 0s
 {{- end }}
+      securityContext:
+        fsGroup: 65532
+        runAsUser: 65532
+        runAsNonRoot: true

--- a/test/integration/shoots/logging/seed_logging_stack.go
+++ b/test/integration/shoots/logging/seed_logging_stack.go
@@ -164,6 +164,7 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), fluentBitPriorityClass))
 		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), fluentBitClusterRole))
 		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), fluentBitClusterRoleBinding))
+		framework.ExpectNoError(f.RenderAndDeployTemplate(ctx, f.ShootClient, "fluent-bit-psp-clusterrolebinding.yaml", nil))
 
 		ginkgo.By("Deploy the fluent-bit DaemonSet")
 		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), fluentBitConfMap))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind test
/priority normal

**What this PR does / why we need it**:
With this PR fluent-bit is always privileged when integration tests are run.
When test is run on a shoot with `allowPrivilegedContainers` set to false, the fluent-bit does not start up due to lack of root privileges. For the purpose a new ClusterroleBinding is created to grant the fluent-bit privileged escalation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Enable fluent-bit privileged escalation for the integration test via "gardener.privileged" PodSecurityPolicy
```
