### PR TITLE
Cleanup a couple of `context.TODO()`s

### DIFF
--- a/extensions/pkg/util/shoot.go
+++ b/extensions/pkg/util/shoot.go
@@ -39,7 +39,7 @@ const CAChecksumAnnotation = "checksum/ca"
 // If the CA of an existing Kubeconfig has changed, it creates a new Kubeconfig.
 // Newly generated Kubeconfigs are applied with the given `client` to the given `namespace`.
 func GetOrCreateShootKubeconfig(ctx context.Context, c client.Client, certificateConfig secrets.CertificateSecretConfig, namespace string) (*corev1.Secret, error) {
-	caSecret, ca, err := secrets.LoadCAFromSecret(c, namespace, v1beta1constants.SecretNameCACluster)
+	caSecret, ca, err := secrets.LoadCAFromSecret(ctx, c, namespace, v1beta1constants.SecretNameCACluster)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching CA secret %s/%s: %v", namespace, v1beta1constants.SecretNameCACluster, err)
 	}

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -112,7 +112,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 	secrets, err := garden.ReadGardenSecrets(f.k8sInformers, f.k8sGardenCoreInformers)
 	runtime.Must(err)
 
-	runtime.Must(garden.BootstrapCluster(k8sGardenClient, v1beta1constants.GardenNamespace, secrets))
+	runtime.Must(garden.BootstrapCluster(ctx, k8sGardenClient, v1beta1constants.GardenNamespace, secrets))
 	logger.Logger.Info("Successfully bootstrapped the Garden cluster.")
 
 	// Initialize the workqueue metrics collection.

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -133,7 +133,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	if secret, ok := secrets[common.GardenRoleInternalDomain]; ok {
 		shootList, err := f.k8sGardenCoreInformers.Core().V1beta1().Shoots().Lister().List(labels.Everything())
 		runtime.Must(err)
-		runtime.Must(garden.VerifyInternalDomainSecret(k8sGardenClient, len(shootList), secret))
+		runtime.Must(garden.VerifyInternalDomainSecret(ctx, k8sGardenClient, len(shootList), secret))
 	}
 
 	imageVector, err := imagevector.ReadGlobalImageVectorWithEnvOverride(filepath.Join(common.ChartPath, DefaultImageVector))

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -272,7 +272,7 @@ func (c *defaultCareControl) Care(shootObj *gardencorev1beta1.Shoot, key string)
 		return nil // We do not want to run in the exponential backoff for the condition checks.
 	}
 
-	botanist, err := botanistpkg.New(operation)
+	botanist, err := botanistpkg.New(ctx, operation)
 	if err != nil {
 		shootLogger.Errorf("Failed to create a botanist object to perform the care operations: %s", err.Error())
 

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -74,7 +74,7 @@ func (c *Controller) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		nil,
 		errors.ToExecute("Create botanist", func() error {
 			return retryutils.UntilTimeout(ctx, 10*time.Second, 10*time.Minute, func(context.Context) (done bool, err error) {
-				botanist, err = botanistpkg.New(o)
+				botanist, err = botanistpkg.New(ctx, o)
 				if err != nil {
 					return retryutils.MinorError(err)
 				}

--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -112,7 +112,7 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 		nil,
 		utilerrors.ToExecute("Create botanist", func() error {
 			return retryutils.UntilTimeout(ctx, 10*time.Second, 10*time.Minute, func(context.Context) (done bool, err error) {
-				botanist, err = botanistpkg.New(o)
+				botanist, err = botanistpkg.New(ctx, o)
 				if err != nil {
 					return retryutils.MinorError(err)
 				}

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -64,7 +64,7 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 		nil,
 		errors.ToExecute("Create botanist", func() error {
 			return retryutils.UntilTimeout(ctx, 10*time.Second, 10*time.Minute, func(context.Context) (done bool, err error) {
-				botanist, err = botanistpkg.New(o)
+				botanist, err = botanistpkg.New(ctx, o)
 				if err != nil {
 					return retryutils.MinorError(err)
 				}

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -46,11 +46,10 @@ const (
 // New takes an operation object <o> and creates a new Botanist object. It checks whether the given Shoot DNS
 // domain is covered by a default domain, and if so, it sets the <DefaultDomainSecret> attribute on the Botanist
 // object.
-func New(o *operation.Operation) (*Botanist, error) {
+func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	var (
 		b   = &Botanist{Operation: o}
 		err error
-		ctx = context.TODO()
 	)
 
 	// Determine all default domain secrets and check whether the used Shoot domain matches a default domain.
@@ -69,7 +68,7 @@ func New(o *operation.Operation) (*Botanist, error) {
 		}
 	}
 
-	if err = b.InitializeSeedClients(); err != nil {
+	if err = b.InitializeSeedClients(ctx); err != nil {
 		return nil, err
 	}
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -699,7 +699,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 
 	foundDeployment := true
 	deployment := &appsv1.Deployment{}
-	if err := b.K8sSeedClient.Client().Get(context.TODO(), kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), deployment); err != nil && !apierrors.IsNotFound(err) {
+	if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), deployment); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	} else if apierrors.IsNotFound(err) {
 		foundDeployment = false
@@ -795,7 +795,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 			}
 
 			if signingKeySecret := serviceAccountConfig.SigningKeySecret; signingKeySecret != nil {
-				signingKey, err := common.GetServiceAccountSigningKeySecret(context.TODO(), b.K8sGardenClient.Client(), b.Shoot.Info.Namespace, signingKeySecret.Name)
+				signingKey, err := common.GetServiceAccountSigningKeySecret(ctx, b.K8sGardenClient.Client(), b.Shoot.Info.Namespace, signingKeySecret.Name)
 				if err != nil {
 					return err
 				}
@@ -828,7 +828,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 			apiServerConfig.AuditConfig.AuditPolicy != nil &&
 			apiServerConfig.AuditConfig.AuditPolicy.ConfigMapRef != nil {
 
-			auditPolicy, err := b.getAuditPolicy(apiServerConfig.AuditConfig.AuditPolicy.ConfigMapRef.Name, b.Shoot.Info.Namespace)
+			auditPolicy, err := b.getAuditPolicy(ctx, apiServerConfig.AuditConfig.AuditPolicy.ConfigMapRef.Name, b.Shoot.Info.Namespace)
 			if err != nil {
 				// Ignore missing audit configuration on shoot deletion to prevent failing redeployments of the
 				// kube-apiserver in case the end-user deleted the configmap before/simultaneously to the shoot
@@ -920,9 +920,9 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 	return b.K8sSeedClient.ChartApplier().Apply(ctx, filepath.Join(chartPathControlPlane, v1beta1constants.DeploymentNameKubeAPIServer), b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer, kubernetes.Values(values))
 }
 
-func (b *Botanist) getAuditPolicy(name, namespace string) (string, error) {
+func (b *Botanist) getAuditPolicy(ctx context.Context, name, namespace string) (string, error) {
 	auditPolicyCm := &corev1.ConfigMap{}
-	if err := b.K8sGardenClient.Client().Get(context.TODO(), kutil.Key(namespace, name), auditPolicyCm); err != nil {
+	if err := b.K8sGardenClient.Client().Get(ctx, kutil.Key(namespace, name), auditPolicyCm); err != nil {
 		return "", err
 	}
 	auditPolicy, ok := auditPolicyCm.Data[auditPolicyConfigMapDataKey]

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -276,12 +276,12 @@ func (b *Builder) Build(ctx context.Context, clientMap clientmap.ClientMap) (*Op
 // cluster which contains a Kubeconfig that can be used to authenticate against the Seed cluster. With it,
 // a Kubernetes client as well as a Chart renderer for the Seed cluster will be initialized and attached to
 // the already existing Operation object.
-func (o *Operation) InitializeSeedClients() error {
+func (o *Operation) InitializeSeedClients(ctx context.Context) error {
 	if o.K8sSeedClient != nil {
 		return nil
 	}
 
-	seedClient, err := o.ClientMap.GetClient(context.TODO(), keys.ForSeed(o.Seed.Info))
+	seedClient, err := o.ClientMap.GetClient(ctx, keys.ForSeed(o.Seed.Info))
 	if err != nil {
 		return fmt.Errorf("failed to get seed client: %w", err)
 	}
@@ -489,7 +489,7 @@ func (o *Operation) SaveGardenerResourcesInShootState(ctx context.Context, resou
 
 // DeleteClusterResourceFromSeed deletes the `Cluster` extension resource for the shoot in the seed cluster.
 func (o *Operation) DeleteClusterResourceFromSeed(ctx context.Context) error {
-	if err := o.InitializeSeedClients(); err != nil {
+	if err := o.InitializeSeedClients(ctx); err != nil {
 		o.Logger.Errorf("Could not initialize a new Kubernetes client for the seed cluster: %s", err.Error())
 		return err
 	}

--- a/pkg/utils/secrets/certificates.go
+++ b/pkg/utils/secrets/certificates.go
@@ -265,9 +265,9 @@ func LoadCertificate(name string, privateKeyPEM, certificatePEM []byte) (*Certif
 }
 
 // LoadCAFromSecret loads a CA certificate from an existing Kubernetes secret object. It returns the secret, the Certificate and an error.
-func LoadCAFromSecret(k8sClient client.Client, namespace, name string) (*corev1.Secret, *Certificate, error) {
+func LoadCAFromSecret(ctx context.Context, k8sClient client.Client, namespace, name string) (*corev1.Secret, *Certificate, error) {
 	secret := &corev1.Secret{}
-	if err := k8sClient.Get(context.TODO(), kutil.Key(namespace, name), secret); err != nil {
+	if err := k8sClient.Get(ctx, kutil.Key(namespace, name), secret); err != nil {
 		return nil, nil, err
 	}
 
@@ -335,7 +335,7 @@ func signCertificate(certificateTemplate *x509.Certificate, privateKey *rsa.Priv
 	return utils.EncodeCertificate(certificate), nil
 }
 
-func generateCA(k8sClusterClient kubernetes.Interface, config *CertificateSecretConfig, namespace string) (*corev1.Secret, *Certificate, error) {
+func generateCA(ctx context.Context, k8sClusterClient kubernetes.Interface, config *CertificateSecretConfig, namespace string) (*corev1.Secret, *Certificate, error) {
 	certificate, err := config.GenerateCertificate()
 	if err != nil {
 		return nil, nil, err
@@ -350,7 +350,7 @@ func generateCA(k8sClusterClient kubernetes.Interface, config *CertificateSecret
 		Data: certificate.SecretData(),
 	}
 
-	if err := k8sClusterClient.Client().Create(context.TODO(), secret); err != nil {
+	if err := k8sClusterClient.Client().Create(ctx, secret); err != nil {
 		return nil, nil, err
 	}
 	return secret, certificate, nil
@@ -367,7 +367,7 @@ func loadCA(name string, existingSecret *corev1.Secret) (*corev1.Secret, *Certif
 // GenerateCertificateAuthorities get a map of wanted certificates and check If they exist in the existingSecretsMap based on the keys in the map. If they exist it get only the certificate from the corresponding
 // existing secret and makes a certificate DataInterface from the existing secret. If there is no existing secret contaning the wanted certificate, we make one certificate and with it we deploy in K8s cluster
 // a secret with that  certificate and then return the newly existing secret. The function returns a map of secrets contaning the wanted CA, a map with the wanted CA certificate and an error.
-func GenerateCertificateAuthorities(k8sClusterClient kubernetes.Interface, existingSecretsMap map[string]*corev1.Secret, wantedCertificateAuthorities map[string]*CertificateSecretConfig, namespace string) (map[string]*corev1.Secret, map[string]*Certificate, error) {
+func GenerateCertificateAuthorities(ctx context.Context, k8sClusterClient kubernetes.Interface, existingSecretsMap map[string]*corev1.Secret, wantedCertificateAuthorities map[string]*CertificateSecretConfig, namespace string) (map[string]*corev1.Secret, map[string]*Certificate, error) {
 	type caOutput struct {
 		secret      *corev1.Secret
 		certificate *Certificate
@@ -388,7 +388,7 @@ func GenerateCertificateAuthorities(k8sClusterClient kubernetes.Interface, exist
 		if existingSecret, ok := existingSecretsMap[name]; !ok {
 			go func(config *CertificateSecretConfig) {
 				defer wg.Done()
-				secret, certificate, err := generateCA(k8sClusterClient, config, namespace)
+				secret, certificate, err := generateCA(ctx, k8sClusterClient, config, namespace)
 				results <- &caOutput{secret, certificate, err}
 			}(config)
 		} else {

--- a/pkg/utils/secrets/secrets.go
+++ b/pkg/utils/secrets/secrets.go
@@ -45,7 +45,10 @@ func (s *Secrets) Deploy(
 	cs kubernetes.Interface,
 	gcs gardenerkubernetes.Interface,
 	namespace string,
-) (map[string]*corev1.Secret, error) {
+) (
+	map[string]*corev1.Secret,
+	error,
+) {
 	// Get existing secrets in the namespace
 	existingSecrets, err := getSecrets(ctx, cs, namespace)
 	if err != nil {
@@ -53,7 +56,7 @@ func (s *Secrets) Deploy(
 	}
 
 	// Generate CAs
-	_, cas, err := GenerateCertificateAuthorities(gcs, existingSecrets, s.CertificateSecretConfigs, namespace)
+	_, cas, err := GenerateCertificateAuthorities(ctx, gcs, existingSecrets, s.CertificateSecretConfigs, namespace)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not generate CA secrets in namespace '%s'", namespace)
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind technical-debt cleanup
/priority normal

**What this PR does / why we need it**:
This PR cleans up a couple of `context.TODO()` calls in our code.

**Which issue(s) this PR fixes**:
Part of #1648 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
