### PR TITLE
Introduce per test suite timeout

### DIFF
--- a/hack/test-cover.sh
+++ b/hack/test-cover.sh
@@ -19,7 +19,7 @@ source "$(dirname $0)/setup-envtest.sh"
 
 echo "> Test Cover"
 
-GO111MODULE=on ginkgo -cover -race -mod=vendor $@
+GO111MODULE=on ginkgo -cover -timeout=2m -race -mod=vendor $@
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 COVERPROFILE="$REPO_ROOT/test.coverprofile"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing dev-productivity
/kind bug
/priority normal

**What this PR does / why we need it**:

This PR introduces a general per test suite timeout for unit tests, when running via `make test-cover`, e.g. in the CI verify step.

Unit tests should be quick / fail early. Long running unit tests indicate either some issues in the tests or some performance problem in the underlying production code itself.

**Which issue(s) this PR fixes**:
I had some tests, that took very long to fail, which was annoying to notice/debug.

**Special notes for your reviewer**:

I didn't add a timeout to `make test`, i.e. for manually/locally executing unit tests.
The reason for that is, that the go test `-timeout` flag is not "cacheable" and therefore will cause all test suites to be executed everytime, although the results may be cached ([ref](https://golang.org/cmd/go/#hdr-Testing_flags)).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Unit tests are now limited to a timeout of 2 minutes per test suite.
```
