### PR TITLE
Replace `TryUpdateShoot{Labels,Annotations}` functions with `Patch` requests

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -385,7 +385,7 @@ func (c *defaultCareControl) Care(shootObj *gardencorev1beta1.Shoot, key string)
 		conditionEveryNodeReady,
 		conditionSystemComponentsHealthy,
 	)))
-	if err := gardenClient.DirectClient().Patch(ctx, shoot, client.MergeFrom(oldObj)); err != nil {
+	if err := gardenClient.Client().Patch(ctx, shoot, client.MergeFrom(oldObj)); err != nil {
 		botanist.Logger.Errorf("Could not update Shoot health label: %+v", err)
 		return nil // We do not want to run in the exponential backoff for the condition checks.
 	}

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -696,7 +696,7 @@ func (c *Controller) updateShootStatusOperationError(ctx context.Context, garden
 
 	oldObj := newShoot.DeepCopy()
 	kutil.SetMetaDataLabel(&newShoot.ObjectMeta, common.ShootStatus, string(shootpkg.StatusUnhealthy))
-	if err := gardenClient.DirectClient().Patch(ctx, newShoot, client.MergeFrom(oldObj)); err != nil {
+	if err := gardenClient.Client().Patch(ctx, newShoot, client.MergeFrom(oldObj)); err != nil {
 		return nil, err
 	}
 

--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -332,7 +332,7 @@ func (c *Controller) finalizeShootPrepareForMigration(ctx context.Context, garde
 
 	oldObj := o.Shoot.Info.DeepCopy()
 	controllerutils.RemoveAllTasks(o.Shoot.Info.Annotations)
-	if err := gardenClient.DirectClient().Patch(ctx, o.Shoot.Info, client.MergeFrom(oldObj)); err != nil {
+	if err := gardenClient.Client().Patch(ctx, o.Shoot.Info, client.MergeFrom(oldObj)); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -511,5 +511,5 @@ func removeTaskAnnotation(ctx context.Context, o *operation.Operation, generatio
 
 	oldObj := o.Shoot.Info.DeepCopy()
 	controllerutils.RemoveTasks(o.Shoot.Info.Annotations, tasksToRemove...)
-	return o.K8sGardenClient.DirectClient().Patch(ctx, o.Shoot.Info, client.MergeFrom(oldObj))
+	return o.K8sGardenClient.Client().Patch(ctx, o.Shoot.Info, client.MergeFrom(oldObj))
 }

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -499,7 +499,8 @@ func (c *Controller) runReconcileShootFlow(o *operation.Operation) *gardencorev1
 }
 
 func removeTaskAnnotation(ctx context.Context, o *operation.Operation, generation int64, tasksToRemove ...string) error {
-	// Check if shoot generation was changed mid-air
+	// Check if shoot generation was changed mid-air, i.e., whether we need to wait for the next reconciliation until we
+	// can safely remove the task annotations to ensure all required tasks are executed.
 	shoot := &gardencorev1beta1.Shoot{}
 	if err := o.K8sGardenClient.DirectClient().Get(ctx, kutil.Key(o.Shoot.Info.Namespace, o.Shoot.Info.Name), shoot); err != nil {
 		return err

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -220,7 +220,7 @@ func (b *Botanist) rotateKubeconfigSecrets(ctx context.Context, gardenerResource
 
 	oldObj := b.Shoot.Info.DeepCopy()
 	delete(b.Shoot.Info.Annotations, v1beta1constants.GardenerOperation)
-	return b.K8sGardenClient.DirectClient().Patch(ctx, b.Shoot.Info, client.MergeFrom(oldObj))
+	return b.K8sGardenClient.Client().Patch(ctx, b.Shoot.Info, client.MergeFrom(oldObj))
 }
 
 func (b *Botanist) deleteBasicAuthDependantSecrets(ctx context.Context, gardenerResourceDataList *gardencorev1alpha1helper.GardenerResourceDataList) error {

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -28,12 +28,10 @@ import (
 	"github.com/gardener/gardener/pkg/operation/shootsecrets"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -219,11 +217,10 @@ func (b *Botanist) rotateKubeconfigSecrets(ctx context.Context, gardenerResource
 		}
 		gardenerResourceDataList.Delete(secretName)
 	}
-	_, err := kutil.TryUpdateShootAnnotations(ctx, b.K8sGardenClient.GardenCore(), retry.DefaultRetry, b.Shoot.Info.ObjectMeta, func(shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
-		delete(shoot.Annotations, v1beta1constants.GardenerOperation)
-		return shoot, nil
-	})
-	return err
+
+	oldObj := b.Shoot.Info.DeepCopy()
+	delete(b.Shoot.Info.Annotations, v1beta1constants.GardenerOperation)
+	return b.K8sGardenClient.DirectClient().Patch(ctx, b.Shoot.Info, client.MergeFrom(oldObj))
 }
 
 func (b *Botanist) deleteBasicAuthDependantSecrets(ctx context.Context, gardenerResourceDataList *gardencorev1alpha1helper.GardenerResourceDataList) error {

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -410,7 +410,7 @@ func (o *Operation) CleanShootTaskErrorAndUpdateStatusLabel(ctx context.Context,
 			o.Shoot.Info.Status.LastErrors,
 			o.Shoot.Info.Status.Conditions...,
 		)))
-		if err := o.K8sGardenClient.DirectClient().Patch(ctx, o.Shoot.Info, client.MergeFrom(oldObj)); err != nil {
+		if err := o.K8sGardenClient.Client().Patch(ctx, o.Shoot.Info, client.MergeFrom(oldObj)); err != nil {
 			o.Logger.Errorf("Could not update shoot's %s/%s status label after removing an erroneous task: %v", o.Shoot.Info.Namespace, o.Shoot.Info.Name, err)
 			return
 		}

--- a/pkg/operation/shoot/status.go
+++ b/pkg/operation/shoot/status.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/operation/common"
-	"github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // Status is the status of a shoot used in the common.ShootStatus label.
@@ -58,14 +56,6 @@ func (s Status) OrWorse(other Status) Status {
 		return other
 	}
 	return s
-}
-
-// StatusLabelTransform transforms the shoot labels depending on the given Status.
-func StatusLabelTransform(status Status) func(*gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
-	return func(shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
-		kubernetes.SetMetaDataLabel(&shoot.ObjectMeta, common.ShootStatus, string(status))
-		return shoot, nil
-	}
 }
 
 // ConditionStatusToStatus converts the given ConditionStatus to a shoot label Status.

--- a/pkg/operation/shoot/status_test.go
+++ b/pkg/operation/shoot/status_test.go
@@ -15,7 +15,6 @@ package shoot_test
 
 import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/operation/common"
 	. "github.com/gardener/gardener/pkg/operation/shoot"
 
 	. "github.com/onsi/ginkgo"
@@ -109,28 +108,6 @@ var _ = Describe("Shoot Utils", func() {
 				&gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateSucceeded}, nil, []gardencorev1beta1.Condition{{Status: gardencorev1beta1.ConditionFalse}}, StatusUnhealthy),
 			Entry("lastOperation.Type is LastOperationTypeCreate and lastOperation.State is LastOperationStateSucceeded with unhealthy conditions",
 				&gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeCreate, State: gardencorev1beta1.LastOperationStateSucceeded}, nil, []gardencorev1beta1.Condition{{Status: gardencorev1beta1.ConditionFalse}}, StatusUnhealthy),
-		)
-
-		DescribeTable("#StatusLabelTransform",
-			func(status Status, expectedLabels map[string]string) {
-				original := &gardencorev1beta1.Shoot{}
-
-				modified, err := StatusLabelTransform(status)(original.DeepCopy())
-				Expect(err).NotTo(HaveOccurred())
-				modifiedWithoutLabels := modified.DeepCopy()
-				modifiedWithoutLabels.Labels = nil
-				Expect(modifiedWithoutLabels).To(Equal(original), "not only labels were modified")
-				Expect(modified.Labels).To(Equal(expectedLabels))
-			},
-			Entry("StatusHealthy", StatusHealthy, map[string]string{
-				common.ShootStatus: string(StatusHealthy),
-			}),
-			Entry("StatusProgressing", StatusProgressing, map[string]string{
-				common.ShootStatus: string(StatusProgressing),
-			}),
-			Entry("StatusUnhealthy", StatusUnhealthy, map[string]string{
-				common.ShootStatus: string(StatusUnhealthy),
-			}),
 		)
 	})
 })

--- a/pkg/utils/kubernetes/shoot.go
+++ b/pkg/utils/kubernetes/shoot.go
@@ -106,27 +106,3 @@ func TryUpdateShootStatus(ctx context.Context, g gardencore.Interface, backoff w
 		return equality.Semantic.DeepEqual(cur.Status, updated.Status)
 	})
 }
-
-// TryUpdateShootLabels tries to update the status of the shoot matching the given <meta>.
-// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
-// The transformation function is applied to the current state of the Shoot object. If the transformation
-// yields a semantically equal Shoot (regarding labels), no update is done and the operation returns normally.
-func TryUpdateShootLabels(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error)) (*gardencorev1beta1.Shoot, error) {
-	return tryUpdateShoot(ctx, g, backoff, meta, transform, func(g gardencore.Interface, shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
-		return g.CoreV1beta1().Shoots(shoot.Namespace).Update(ctx, shoot, kubernetes.DefaultUpdateOptions())
-	}, func(cur, updated *gardencorev1beta1.Shoot) bool {
-		return equality.Semantic.DeepEqual(cur.Labels, updated.Labels)
-	})
-}
-
-// TryUpdateShootAnnotations tries to update the annotations of the shoot matching the given <meta>.
-// It retries with the given <backoff> characteristics as long as it gets Conflict errors.
-// The transformation function is applied to the current state of the Shoot object. If the transformation
-// yields a semantically equal Shoot (regarding conditions), no update is done and the operation returns normally.
-func TryUpdateShootAnnotations(ctx context.Context, g gardencore.Interface, backoff wait.Backoff, meta metav1.ObjectMeta, transform func(*gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error)) (*gardencorev1beta1.Shoot, error) {
-	return tryUpdateShoot(ctx, g, backoff, meta, transform, func(g gardencore.Interface, shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
-		return g.CoreV1beta1().Shoots(shoot.Namespace).Update(ctx, shoot, kubernetes.DefaultUpdateOptions())
-	}, func(cur, updated *gardencorev1beta1.Shoot) bool {
-		return equality.Semantic.DeepEqual(cur.Annotations, updated.Annotations)
-	})
-}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind cleanup technical-debt
/priority normal

**What this PR does / why we need it**:
This PR replaces the `TryUpdateShoot{Labels,Annotations}` functions with `Patch` requests to prevent undesired conflict updates that we anyways don't care about.

**Which issue(s) this PR fixes**:
Fixes #3351

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
