### PR TITLE
Do not ignore the updated shoot to prevent empty .status.uid

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -468,14 +468,16 @@ func (c *Controller) reconcileShoot(logger *logrus.Entry, shoot *gardencorev1bet
 
 	// write UID to status when operation was created successfully once
 	if len(o.Shoot.Info.Status.UID) == 0 {
-		if _, err := kutil.TryUpdateShootStatus(ctx, gardenClient.GardenCore(), retry.DefaultRetry, o.Shoot.Info.ObjectMeta,
+		newShoot, err := kutil.TryUpdateShootStatus(ctx, gardenClient.GardenCore(), retry.DefaultRetry, o.Shoot.Info.ObjectMeta,
 			func(shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
 				shoot.Status.UID = shoot.UID
 				return shoot, nil
 			},
-		); err != nil {
+		)
+		if err != nil {
 			return reconcile.Result{}, err
 		}
+		o.Shoot.Info = newShoot
 	}
 
 	// At this point the reconciliation is allowed, hence, check if the seed is up-to-date, then sync the Cluster resource


### PR DESCRIPTION
/kind bug
/kind regression

In https://github.com/gardener/gardener/pull/3106 we remove the early exit on Shoot .status.uid as we no longer need it (the `updateShootStatusOperationStart` is moved as first step and it sets the status.observedGeneration and no further unwanted reconciles will happen - as metadata.generation will be equal to status.observedGeneration).

Currently as described in https://github.com/gardener/gardener/pull/3318#issuecomment-756648854, the Shoot status.uid is set, but `o.Shoot.Info` is not updated and `o.Shoot.Info.Status.UID` is evaluated to `""`.

Steps to reproduce:

1. Craete a new Shoot
2. Ensure that the `.status.clusterIdentity` is not computed properly. For example it has the value `shoot--foo--bar--gardener-local-baz` when the expected clusterIdentity should be `shoot--foo--bar-109d62f5-6860-42b5-b6b5-c8274c70a7d7-gardener-local-baz`


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing gardenlet to do not properly compute the `.status.clusterIdentity` field is now fixed.
```
