### PR TITLE
Remove insensitive terms

### DIFF
--- a/docs/concepts/network_policies.md
+++ b/docs/concepts/network_policies.md
@@ -11,7 +11,7 @@ Gardener deploys network policies into
  - the `kube-system` namespace in the Shoot.
  
 The aforementioned namespaces in the Seed contain a `deny-all` network policy that [denies all ingress and egress traffic](https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-and-all-egress-traffic).
-This [secure by default](https://en.wikipedia.org/wiki/Secure_by_default) setting requires pods to whitelist network traffic.
+This [secure by default](https://en.wikipedia.org/wiki/Secure_by_default) setting requires pods to allow network traffic.
 This is done by pods having [labels matching to the selectors of the network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/#networkpolicy-resource) deployed by Gardener.
 
 More details on the deployed network policies can be found in the [development](https://github.com/gardener/gardener/tree/master/docs/development/seed_network_policies.md) and [usage](https://github.com/gardener/gardener/tree/master/docs/usage/shoot_network_policies.md) sections.

--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -5962,7 +5962,7 @@ Addon
 </td>
 <td>
 <em>(Optional)</em>
-<p>LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress</p>
+<p>LoadBalancerSourceRanges is list of allowed IP sources for NginxIngress</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/core/types_project.go
+++ b/pkg/apis/core/types_project.go
@@ -63,7 +63,7 @@ type ProjectSpec struct {
 	// Namespace is the name of the namespace that has been created for the Project object.
 	// A nil value means that Gardener will determine the name of the namespace.
 	Namespace *string
-	// Tolerations contains the default tolerations and a whitelist for taints on seed clusters.
+	// Tolerations contains the default tolerations and a list for allowed taints on seed clusters.
 	Tolerations *ProjectTolerations
 }
 

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -162,7 +162,7 @@ const (
 // NginxIngress describes configuration values for the nginx-ingress addon.
 type NginxIngress struct {
 	Addon
-	// LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress
+	// LoadBalancerSourceRanges is list of allowed IP sources for NginxIngress
 	LoadBalancerSourceRanges []string
 	// Config contains custom configuration for the nginx-ingress-controller configuration.
 	// See https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#configuration-options

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -1288,7 +1288,7 @@ message Networking {
 message NginxIngress {
   optional Addon addon = 4;
 
-  // LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress
+  // LoadBalancerSourceRanges is list of allowed IP sources for NginxIngress
   // +optional
   repeated string loadBalancerSourceRanges = 1;
 

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -193,7 +193,7 @@ const (
 // NginxIngress describes configuration values for the nginx-ingress addon.
 type NginxIngress struct {
 	Addon `json:",inline" protobuf:"bytes,4,opt,name=addon"`
-	// LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress
+	// LoadBalancerSourceRanges is list of allowed IP sources for NginxIngress
 	// +optional
 	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty" protobuf:"bytes,1,rep,name=loadBalancerSourceRanges"`
 	// Config contains custom configuration for the nginx-ingress-controller configuration.

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1252,7 +1252,7 @@ message Networking {
 message NginxIngress {
   optional Addon addon = 1;
 
-  // LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress
+  // LoadBalancerSourceRanges is list of allowed IP sources for NginxIngress
   // +optional
   repeated string loadBalancerSourceRanges = 2;
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -190,7 +190,7 @@ const (
 // NginxIngress describes configuration values for the nginx-ingress addon.
 type NginxIngress struct {
 	Addon `json:",inline" protobuf:"bytes,1,opt,name=addon"`
-	// LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress
+	// LoadBalancerSourceRanges is list of allowed IP sources for NginxIngress
 	// +optional
 	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty" protobuf:"bytes,2,rep,name=loadBalancerSourceRanges"`
 	// Config contains custom configuration for the nginx-ingress-controller configuration.

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3903,7 +3903,7 @@ func schema_pkg_apis_core_v1alpha1_NginxIngress(ref common.ReferenceCallback) co
 					},
 					"loadBalancerSourceRanges": {
 						SchemaProps: spec.SchemaProps{
-							Description: "LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress",
+							Description: "LoadBalancerSourceRanges is list of allowed IP sources for NginxIngress",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -10010,7 +10010,7 @@ func schema_pkg_apis_core_v1beta1_NginxIngress(ref common.ReferenceCallback) com
 					},
 					"loadBalancerSourceRanges": {
 						SchemaProps: spec.SchemaProps{
-							Description: "LoadBalancerSourceRanges is list of whitelist IP sources for NginxIngress",
+							Description: "LoadBalancerSourceRanges is list of allowed IP sources for NginxIngress",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/test/framework/utils.go
+++ b/test/framework/utils.go
@@ -158,26 +158,26 @@ func ParseFileAsWorkers(filepath string) ([]gardencorev1beta1.Worker, error) {
 }
 
 // TextValidation is a map of regular expression to description
-// that is used to validate texts based on white- or blacklisted regexps.
+// that is used to validate texts based on allowed or denied regexps.
 type TextValidation map[string]string
 
-// ValidateAsWhitelist validates that all whitelisted regular expressions
+// ValidateAsAllowlist validates that all allowed regular expressions
 // are in the given text.
-func (v *TextValidation) ValidateAsWhitelist(text []byte) error {
+func (v *TextValidation) ValidateAsAllowlist(text []byte) error {
 	return v.validate(text, func(matches [][]byte) error {
 		if len(matches) == 0 {
-			return errors.New("whitelisted RegExp not found")
+			return errors.New("allowed RegExp not found")
 		}
 		return nil
 	})
 }
 
-// ValidateAsBlacklist validates that no blacklisted regular expressions
+// ValidateAsDenylist validates that no denied regular expressions
 // are in the given text.
-func (v *TextValidation) ValidateAsBlacklist(text []byte) error {
+func (v *TextValidation) ValidateAsDenylist(text []byte) error {
 	return v.validate(text, func(matches [][]byte) error {
 		if len(matches) != 0 {
-			return errors.New("blacklisted RegExp found")
+			return errors.New("denied RegExp found")
 		}
 		return nil
 	})

--- a/test/integration/shoots/operatingsystem/os.go
+++ b/test/integration/shoots/operatingsystem/os.go
@@ -82,7 +82,7 @@ var _ = ginkgo.Describe("Operating system testing", func() {
 			ginkgo.By("Expect no segfault")
 
 			journalctlValidation := framework.TextValidation{"segfault": "expect no systemctl segfault"}
-			err = journalctlValidation.ValidateAsBlacklist(response)
+			err = journalctlValidation.ValidateAsDenylist(response)
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Expect systemctl to respond")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup
/priority normal

**What this PR does / why we need it**:
This PR follows inclusive language best practices ([ref](https://github.com/kubernetes/kubernetes/pull/91927)). API changes (`projects.core.gardener.cloud`, `shoottolerationrestriction.admission.gardener.cloud` ) are not covered by this PR for stability reasons.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Certain insensitive terms were removed from the source code and inline documentation to follow inclusive language best practices.
```
