### PR TITLE
Increase the Loki chunk idle period from 3m to 1h

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/loki-configmap.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/loki-configmap.yaml
@@ -10,7 +10,7 @@ data:
     auth_enabled: {{ .Values.authEnabled }}
     ingester:
       chunk_target_size: 1536000
-      chunk_idle_period: 3m
+      chunk_idle_period: 1h
       chunk_block_size: 262144
       chunk_retain_period: 3m
       max_transfer_retries: 3


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug
/priority critical

**What this PR does / why we need it**:
This PR increase the Loki chunk idle period from 3m to 1h.
This is required because when a chunk size is greatly lower than the default inode size we hit the maximum available files on the volume and Loki stops to work until old chunks are deleted. This issue was hit on Azure mainly.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
