### PR TITLE
Fix allow-prometheus NetworkPolicy

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-prometheus-network-policy.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-prometheus-network-policy.yaml
@@ -39,14 +39,13 @@ spec:
         matchLabels:
           component: alertmanager
           role: monitoring
-          garden.sapcloud.io/role: monitoring
       namespaceSelector:
         matchLabels:
           role: garden
     - podSelector:
         matchLabels:
           app: vpa-exporter
-          garden.sapcloud.io/role: vpa
+          gardener.cloud/role: vpa
       namespaceSelector:
         matchLabels:
           role: garden


### PR DESCRIPTION
/kind bug
/kind regression

https://github.com/gardener/gardener/pull/3264 adapts/unifies the labels of multiple components but `charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-prometheus-network-policy.yaml` needs also to be adapted and this is missed in #3264.
After #3264 alertmanager no longer contains `garden.sapcloud.io/role=monitoring` and vpa-exporter's ` garden.sapcloud.io/role=vpa` is replaced with `gardener.cloud/role: vpa`
The issue is causing prometheus to fail reaching alertmanager/vpa-exporter:

```
level=error ts=2021-01-08T07:14:53.149Z caller=notifier.go:527 component=notifier alertmanager=http://10.40.1.195:9093/api/v1/alerts count=1 msg="Error sending alert" err="Post \"http://10.40.1.195:9093/api/v1/alerts\": context deadline exceeded"
level=error ts=2021-01-08T07:16:53.081Z caller=notifier.go:527 component=notifier alertmanager=http://10.40.1.195:9093/api/v1/alerts count=1 msg="Error sending alert" err="Post \"http://10.40.1.195:9093/api/v1/alerts\": context deadline exceeded"
level=error ts=2021-01-08T07:18:53.194Z caller=notifier.go:527 component=notifier alertmanager=http://10.40.1.195:9093/api/v1/alerts count=1 msg="Error sending alert" err="Post \"http://10.40.1.195:9093/api/v1/alerts\": context deadline exceeded"
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing a NetworkPolicy to do not allow egress from prometheus Pod to alertmanager and vpa-exporter Pods is now fixed.
```
