### PR TITLE
Skip stale project reconciliation when deletionTimestamp is already set

### DIFF
--- a/pkg/controllermanager/controller/project/project_stale_control.go
+++ b/pkg/controllermanager/controller/project/project_stale_control.go
@@ -121,7 +121,7 @@ type projectInUseChecker struct {
 }
 
 func (c *defaultStaleControl) ReconcileStaleProject(obj *gardencorev1beta1.Project, nowFunc func() metav1.Time) error {
-	if obj.Spec.Namespace == nil {
+	if obj.DeletionTimestamp != nil || obj.Spec.Namespace == nil {
 		return nil
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/priority normal

**What this PR does / why we need it**:
When a `Project` was updated right before deletion (`.metadata.generation != .status.observedGeneration`) and the corresponding `Namespace` for the `Project` is stuck in deletion (because it contains non-finalized resources) then this may lead to a continuous reconciliation of the "stale project controller". The flow is as follows:
1. Stale project controller tries to delete `Project` (updating the `gardener.cloud/timestamp` annotation)
2. This triggers an `UPDATE` event on the `Project which makes
  1. Project controller to delete the `Namespace`
  2. Stale project controller to trigger again because `.metadata.generation != .status.observedGeneration`
3. Go to step 1

```
Status:
  Observed Generation:          4
  Phase:                        Terminating
  Stale Auto Delete Timestamp:  2020-11-25T10:57:23Z
  Stale Since Timestamp:        2020-08-27T10:57:23Z
Events:
  Type    Reason                      Age                          From                         Message
  ----    ------                      ----                         ----                         -------
  Normal  NamespaceMarkedForDeletion  2m13s (x2816551 over 6d19h)  gardener-controller-manager  Successfully marked namespace "garden-foobar" for deletion.
```

The stale project controller can just ignore `Project`s that already have a deletion timestamp, preventing this "endless" loop from occurring.

**Special notes for your reviewer**:
Thanks @holgerkoser for finding this!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed in `gardener-controller-manager`'s `Project` controller that can lead to a continuous reconciliation of `Project` resources if they are stuck in `Terminating` state.
```
