### PR TITLE
Set revisionHistoryLimit to 1 for deployments

### DIFF
--- a/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/charts/istio/istio-ingress/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
 {{ .Values.labels | toYaml | indent 6 }}

--- a/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/charts/istio/istio-istiod/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   strategy:
     rollingUpdate:
       maxSurge: 100%

--- a/charts/seed-bootstrap/charts/dependency-watchdog/templates/endpoint-deployment.yaml
+++ b/charts/seed-bootstrap/charts/dependency-watchdog/templates/endpoint-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     role: dependency-watchdog-endpoint
 spec:
   replicas: {{ .Values.replicas }}
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       role: dependency-watchdog-endpoint

--- a/charts/seed-bootstrap/charts/dependency-watchdog/templates/probe-deployment.yaml
+++ b/charts/seed-bootstrap/charts/dependency-watchdog/templates/probe-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     role: dependency-watchdog-probe
 spec:
   replicas: {{ .Values.replicas }}
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       role: dependency-watchdog-probe

--- a/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
@@ -16,7 +16,7 @@ metadata:
 {{ toYaml .Values.labels | indent 4 }}
 spec:
   replicas: 1
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       app: hvpa-controller

--- a/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     component: kube-state-metrics
     type: seed
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:

--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: garden
 spec:
   replicas: 3
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       app: nginx-ingress

--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/default-backend-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: nginx-ingress-k8s-backend
   namespace: garden
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   replicas: 1
   selector:
     matchLabels:

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
@@ -14,7 +14,7 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.admissionController.replicas }}
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       app: vpa-admission-controller

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
@@ -14,7 +14,7 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.recommender.replicas }}
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       app: vpa-recommender

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.updater.replicas }}
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       app: vpa-updater

--- a/charts/seed-bootstrap/templates/gardener-resource-manager/deployment.yaml
+++ b/charts/seed-bootstrap/templates/gardener-resource-manager/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: gardener-resource-manager
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   replicas: {{ .Values.gardenerResourceManager.replicas }}
   selector:
     matchLabels:

--- a/charts/seed-bootstrap/templates/grafana/grafana-deployment.yaml
+++ b/charts/seed-bootstrap/templates/grafana/grafana-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     role: monitoring
     component: grafana
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   replicas: 1
   selector:
     matchLabels:

--- a/charts/seed-bootstrap/templates/reserve-excess-capacity/deployment.yaml
+++ b/charts/seed-bootstrap/templates/reserve-excess-capacity/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app: kubernetes
     role: reserve-excess-capacity
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   replicas: {{ index .Values.replicas "reserve-excess-capacity" }}
   selector:
     matchLabels:

--- a/charts/seed-bootstrap/templates/vpa-exporter/deployment-exporter.yaml
+++ b/charts/seed-bootstrap/templates/vpa-exporter/deployment-exporter.yaml
@@ -9,7 +9,7 @@ metadata:
 {{ toYaml .Values.vpa.exporter.labels | indent 4 }}
 spec:
   replicas: {{ .Values.vpa.exporter.replicas }}
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       app: vpa-exporter

--- a/charts/seed-controlplane/charts/gardener-resource-manager/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/gardener-resource-manager/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     gardener.cloud/role: controlplane
     app: gardener-resource-manager
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   minReadySeconds: 30
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/deployment.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     component: kube-state-metrics
     type: shoot
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     component: grafana
     role: {{ .Values.role }}
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:

--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-dashboard.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-dashboard.yaml
@@ -8,7 +8,7 @@ metadata:
     origin: gardener
     k8s-app: kubernetes-dashboard
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   replicas: 1
   selector:
     matchLabels:

--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-metrics-scraper.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-metrics-scraper.yaml
@@ -10,7 +10,7 @@ metadata:
     origin: gardener
     k8s-app: dashboard-metrics-scraper
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   replicas: 1
   selector:
     matchLabels:

--- a/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -13,7 +13,7 @@ metadata:
   name: {{ template "nginx-ingress.controller.fullname" . }}
   namespace: kube-system
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   replicas: {{ .Values.controller.replicaCount }}
   selector:
     matchLabels:

--- a/charts/shoot-addons/charts/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/default-backend-deployment.yaml
@@ -13,7 +13,7 @@ metadata:
   name: {{ template "nginx-ingress.defaultBackend.fullname" . }}
   namespace: kube-system
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   replicas: {{ .Values.defaultBackend.replicaCount }}
   selector:
     matchLabels:

--- a/charts/shoot-core/components/charts/coredns/templates/coredns-deployment.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     gardener.cloud/role: system-component
     k8s-app: kube-dns
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     component: blackbox-exporter
     origin: gardener
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   replicas: 1
   selector:
     matchLabels:

--- a/charts/shoot-core/components/charts/vpn-shoot/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/vpn-shoot/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app: vpn-shoot
     origin: gardener
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   replicas: 1
   strategy:
     rollingUpdate:

--- a/pkg/gardenlet/controller/shoot/seed_registration_control.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control.go
@@ -736,7 +736,7 @@ func deployGardenlet(ctx context.Context, gardenClient, seedClient, shootedSeedC
 					"tag":        tag,
 				},
 				"podAnnotations":                 gardenletAnnotations(shoot),
-				"revisionHistoryLimit":           0,
+				"revisionHistoryLimit":           1,
 				"vpa":                            true,
 				"imageVectorOverwrite":           imageVectorOverwrite,
 				"componentImageVectorOverwrites": componentImageVectorOverwrites,

--- a/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler.go
@@ -169,7 +169,7 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
 		})
 		deployment.Spec.Replicas = &c.replicas
-		deployment.Spec.RevisionHistoryLimit = pointer.Int32Ptr(0)
+		deployment.Spec.RevisionHistoryLimit = pointer.Int32Ptr(1)
 		deployment.Spec.Selector = &metav1.LabelSelector{MatchLabels: getLabels()}
 		deployment.Spec.Template = corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler_test.go
@@ -222,7 +222,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 				},
 				Spec: appsv1.DeploymentSpec{
 					Replicas:             &replicas,
-					RevisionHistoryLimit: pointer.Int32Ptr(0),
+					RevisionHistoryLimit: pointer.Int32Ptr(1),
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
 							"app":  "kubernetes",

--- a/pkg/operation/botanist/controlplane/etcd/bootstrap.go
+++ b/pkg/operation/botanist/controlplane/etcd/bootstrap.go
@@ -209,7 +209,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas:             pointer.Int32Ptr(1),
-				RevisionHistoryLimit: pointer.Int32Ptr(0),
+				RevisionHistoryLimit: pointer.Int32Ptr(1),
 				Selector: &metav1.LabelSelector{
 					MatchLabels: labels(),
 				},

--- a/pkg/operation/botanist/controlplane/etcd/bootstrap_test.go
+++ b/pkg/operation/botanist/controlplane/etcd/bootstrap_test.go
@@ -216,7 +216,7 @@ metadata:
   namespace: ` + namespace + `
 spec:
   replicas: 1
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       gardener.cloud/role: etcd-druid
@@ -258,7 +258,7 @@ metadata:
   namespace: ` + namespace + `
 spec:
   replicas: 1
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       gardener.cloud/role: etcd-druid

--- a/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager.go
@@ -172,7 +172,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
 		})
 		deployment.Spec.Replicas = &k.replicas
-		deployment.Spec.RevisionHistoryLimit = pointer.Int32Ptr(0)
+		deployment.Spec.RevisionHistoryLimit = pointer.Int32Ptr(1)
 		deployment.Spec.Selector = &metav1.LabelSelector{MatchLabels: getLabels()}
 		deployment.Spec.Template = corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager_test.go
@@ -361,7 +361,7 @@ var _ = Describe("KubeControllerManager", func() {
 							},
 						},
 						Spec: appsv1.DeploymentSpec{
-							RevisionHistoryLimit: pointer.Int32Ptr(0),
+							RevisionHistoryLimit: pointer.Int32Ptr(1),
 							Replicas:             &replicas,
 							Selector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{

--- a/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler.go
+++ b/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler.go
@@ -168,7 +168,7 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
 		})
 		deployment.Spec.Replicas = &k.replicas
-		deployment.Spec.RevisionHistoryLimit = pointer.Int32Ptr(0)
+		deployment.Spec.RevisionHistoryLimit = pointer.Int32Ptr(1)
 		deployment.Spec.Selector = &metav1.LabelSelector{MatchLabels: getLabels()}
 		deployment.Spec.Template = corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler_test.go
+++ b/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler_test.go
@@ -147,7 +147,7 @@ var _ = Describe("KubeScheduler", func() {
 					},
 				},
 				Spec: appsv1.DeploymentSpec{
-					RevisionHistoryLimit: pointer.Int32Ptr(0),
+					RevisionHistoryLimit: pointer.Int32Ptr(1),
 					Replicas:             &replicas,
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{

--- a/pkg/operation/botanist/seedsystemcomponents/seedadmission/seedadmission.go
+++ b/pkg/operation/botanist/seedsystemcomponents/seedadmission/seedadmission.go
@@ -177,7 +177,7 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 				Labels:    getLabels(),
 			},
 			Spec: appsv1.DeploymentSpec{
-				RevisionHistoryLimit: pointer.Int32Ptr(0),
+				RevisionHistoryLimit: pointer.Int32Ptr(1),
 				Replicas:             pointer.Int32Ptr(3),
 				Selector:             &metav1.LabelSelector{MatchLabels: getLabels()},
 				Template: corev1.PodTemplateSpec{

--- a/pkg/operation/botanist/seedsystemcomponents/seedadmission/seedadmission_test.go
+++ b/pkg/operation/botanist/seedsystemcomponents/seedadmission/seedadmission_test.go
@@ -112,7 +112,7 @@ metadata:
   namespace: shoot--foo--bar
 spec:
   replicas: 3
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       app: gardener

--- a/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server.go
@@ -265,7 +265,7 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 				}),
 			},
 			Spec: appsv1.DeploymentSpec{
-				RevisionHistoryLimit: pointer.Int32Ptr(0),
+				RevisionHistoryLimit: pointer.Int32Ptr(1),
 				Selector:             &metav1.LabelSelector{MatchLabels: getLabels()},
 				Strategy: appsv1.DeploymentStrategy{
 					RollingUpdate: &appsv1.RollingUpdateDeployment{

--- a/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server_test.go
@@ -204,7 +204,7 @@ metadata:
   name: metrics-server
   namespace: kube-system
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       k8s-app: metrics-server
@@ -294,7 +294,7 @@ metadata:
   name: metrics-server
   namespace: kube-system
 spec:
-  revisionHistoryLimit: 0
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       k8s-app: metrics-server

--- a/pkg/operation/seed/scheduler/gardener_kube_scheduler.go
+++ b/pkg/operation/seed/scheduler/gardener_kube_scheduler.go
@@ -188,7 +188,7 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas:             pointer.Int32Ptr(2),
-				RevisionHistoryLimit: pointer.Int32Ptr(0),
+				RevisionHistoryLimit: pointer.Int32Ptr(1),
 				Selector:             &metav1.LabelSelector{MatchLabels: getLabels()},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operation/seed/scheduler/gardener_kube_scheduler_test.go
+++ b/pkg/operation/seed/scheduler/gardener_kube_scheduler_test.go
@@ -330,7 +330,7 @@ var _ = Describe("New", func() {
 					},
 					Spec: appsv1.DeploymentSpec{
 						Replicas:             pointer.Int32Ptr(2),
-						RevisionHistoryLimit: pointer.Int32Ptr(0),
+						RevisionHistoryLimit: pointer.Int32Ptr(1),
 						Selector:             &metav1.LabelSelector{MatchLabels: expectedLabels},
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR increases the `.spec.revisionHistoryLimit` for `Deployment`s to `1`.

**Which issue(s) this PR fixes**:
Fixes #3325

**Special notes for your reviewer**:
This will lead to some DB size increase in etcd, though, probably not too much.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `.spec.revisionHistoryLimit` is now set to `1` for `Deployment`s.
```
