### PR TITLE
Clean up the deprecated confirmation and operation annotations

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -301,7 +301,7 @@ func mustMaintainNow(shoot *gardencorev1beta1.Shoot) bool {
 }
 
 func hasMaintainNowAnnotation(shoot *gardencorev1beta1.Shoot) bool {
-	operation, ok := common.GetShootOperationAnnotation(shoot.Annotations)
+	operation, ok := shoot.Annotations[v1beta1constants.GardenerOperation]
 	return ok && operation == common.ShootOperationMaintain
 }
 

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -46,7 +46,7 @@ import (
 func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 	gardenerResourceDataList := gardencorev1alpha1helper.GardenerResourceDataList(b.ShootState.Spec.Gardener).DeepCopy()
 
-	if val, ok := common.GetShootOperationAnnotation(b.Shoot.Info.Annotations); ok && val == common.ShootOperationRotateKubeconfigCredentials {
+	if val, ok := b.Shoot.Info.Annotations[v1beta1constants.GardenerOperation]; ok && val == common.ShootOperationRotateKubeconfigCredentials {
 		if err := b.rotateKubeconfigSecrets(ctx, &gardenerResourceDataList); err != nil {
 			return err
 		}
@@ -221,7 +221,6 @@ func (b *Botanist) rotateKubeconfigSecrets(ctx context.Context, gardenerResource
 	}
 	_, err := kutil.TryUpdateShootAnnotations(ctx, b.K8sGardenClient.GardenCore(), retry.DefaultRetry, b.Shoot.Info.ObjectMeta, func(shoot *gardencorev1beta1.Shoot) (*gardencorev1beta1.Shoot, error) {
 		delete(shoot.Annotations, v1beta1constants.GardenerOperation)
-		delete(shoot.Annotations, common.ShootOperationDeprecated)
 		return shoot, nil
 	})
 	return err

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -47,12 +47,6 @@ const (
 	// allow deleting the resource (if the annotation is not set any DELETE request will be denied).
 	ConfirmationDeletion = "confirmation.gardener.cloud/deletion"
 
-	// ConfirmationDeletionDeprecated is an annotation on a Shoot resource whose value must be set to "true" in order to
-	// allow deleting the Shoot (if the annotation is not set any DELETE request will be denied).
-	//
-	// Deprecated: Use `ConfirmationDeletion` instead.
-	ConfirmationDeletionDeprecated = "confirmation.garden.sapcloud.io/deletion"
-
 	// ControllerManagerInternalConfigMapName is the name of the internal config map in which the Gardener controller
 	// manager stores its configuration.
 	ControllerManagerInternalConfigMapName = "gardener-controller-manager-internal-config"
@@ -255,11 +249,6 @@ const (
 
 	// ShootStatus is a constant for a label on a Shoot resource indicating that the Shoot's health.
 	ShootStatus = "shoot.gardener.cloud/status"
-
-	// ShootOperationDeprecated is a constant for an annotation on a Shoot in a failed state indicating that an operation shall be performed.
-	//
-	// Deprecated: Use `v1beta1constants.GardenerOperation` instead.
-	ShootOperationDeprecated = "shoot.garden.sapcloud.io/operation"
 
 	// ShootOperationMaintain is a constant for an annotation on a Shoot indicating that the Shoot maintenance shall be executed as soon as
 	// possible.

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -701,27 +701,6 @@ func GetSecretFromSecretRef(ctx context.Context, c client.Client, secretRef *cor
 	return secret, nil
 }
 
-// GetConfirmationDeletionAnnotation fetches the value for ConfirmationDeletion annotation.
-// If not present, it fallbacks to ConfirmationDeletionDeprecated.
-func GetConfirmationDeletionAnnotation(annotations map[string]string) (string, bool) {
-	return getDeprecatedAnnotation(annotations, ConfirmationDeletion, ConfirmationDeletionDeprecated)
-}
-
-// GetShootOperationAnnotation fetches the value for v1beta1constants.GardenerOperation annotation.
-// If not present, it fallbacks to ShootOperationDeprecated.
-func GetShootOperationAnnotation(annotations map[string]string) (string, bool) {
-	return getDeprecatedAnnotation(annotations, v1beta1constants.GardenerOperation, ShootOperationDeprecated)
-}
-
-func getDeprecatedAnnotation(annotations map[string]string, annotationKey, deprecatedAnnotationKey string) (string, bool) {
-	val, ok := annotations[annotationKey]
-	if !ok {
-		val, ok = annotations[deprecatedAnnotationKey]
-	}
-
-	return val, ok
-}
-
 // CheckIfDeletionIsConfirmed returns whether the deletion of an object is confirmed or not.
 func CheckIfDeletionIsConfirmed(obj metav1.Object) error {
 	annotations := obj.GetAnnotations()
@@ -729,8 +708,8 @@ func CheckIfDeletionIsConfirmed(obj metav1.Object) error {
 		return annotationRequiredError()
 	}
 
-	value, _ := GetConfirmationDeletionAnnotation(annotations)
-	if true, err := strconv.ParseBool(value); err != nil || !true {
+	value := annotations[ConfirmationDeletion]
+	if confirmed, err := strconv.ParseBool(value); err != nil || !confirmed {
 		return annotationRequiredError()
 	}
 	return nil

--- a/pkg/operation/common/utils_test.go
+++ b/pkg/operation/common/utils_test.go
@@ -474,56 +474,28 @@ var _ = Describe("common", func() {
 			Expect(CheckIfDeletionIsConfirmed(obj)).To(HaveOccurred())
 		})
 
-		Context("deprecated annotation", func() {
-			It("should prevent the deletion due annotation value != true", func() {
-				obj := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							ConfirmationDeletionDeprecated: "false",
-						},
+		It("should prevent the deletion due annotation value != true", func() {
+			obj := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ConfirmationDeletion: "false",
 					},
-				}
+				},
+			}
 
-				Expect(CheckIfDeletionIsConfirmed(obj)).To(HaveOccurred())
-			})
-
-			It("should allow the deletion due annotation value == true", func() {
-				obj := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							ConfirmationDeletionDeprecated: "true",
-						},
-					},
-				}
-
-				Expect(CheckIfDeletionIsConfirmed(obj)).To(Succeed())
-			})
+			Expect(CheckIfDeletionIsConfirmed(obj)).To(HaveOccurred())
 		})
 
-		Context("non-deprecated annotation", func() {
-			It("should prevent the deletion due annotation value != true", func() {
-				obj := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							ConfirmationDeletion: "false",
-						},
+		It("should allow the deletion due annotation value == true", func() {
+			obj := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ConfirmationDeletion: "true",
 					},
-				}
+				},
+			}
 
-				Expect(CheckIfDeletionIsConfirmed(obj)).To(HaveOccurred())
-			})
-
-			It("should allow the deletion due annotation value == true", func() {
-				obj := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: map[string]string{
-							ConfirmationDeletion: "true",
-						},
-					},
-				}
-
-				Expect(CheckIfDeletionIsConfirmed(obj)).To(Succeed())
-			})
+			Expect(CheckIfDeletionIsConfirmed(obj)).To(Succeed())
 		})
 	})
 

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -85,12 +85,12 @@ func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
 		switch lastOperation.State {
 		case core.LastOperationStateFailed:
 			// The shoot state is failed and the retry annotation is set.
-			if val, ok := common.GetShootOperationAnnotation(newShoot.Annotations); ok && val == common.ShootOperationRetry {
+			if val, ok := newShoot.Annotations[v1beta1constants.GardenerOperation]; ok && val == common.ShootOperationRetry {
 				mustIncrease = true
 			}
 		default:
 			// The shoot state is not failed and the reconcile or rotate-credentials annotation is set.
-			if val, ok := common.GetShootOperationAnnotation(newShoot.Annotations); ok {
+			if val, ok := newShoot.Annotations[v1beta1constants.GardenerOperation]; ok {
 				if val == common.ShootOperationReconcile {
 					mustIncrease = true
 				}
@@ -104,7 +104,6 @@ func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
 
 		if mustIncrease {
 			delete(newShoot.Annotations, v1beta1constants.GardenerOperation)
-			delete(newShoot.Annotations, common.ShootOperationDeprecated)
 			return true
 		}
 	}

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -277,18 +277,15 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 		// disallow any changes to the annotations of a shoot that references a seed which is already marked for deletion
 		// except changes to the deletion confirmation annotation
 		if !reflect.DeepEqual(newMeta.Annotations, oldMeta.Annotations) {
-			confimationAnnotations := []string{common.ConfirmationDeletion, common.ConfirmationDeletionDeprecated}
-			for _, annotation := range confimationAnnotations {
-				newConfirmation, newHasConfirmation := newMeta.Annotations[annotation]
+			newConfirmation, newHasConfirmation := newMeta.Annotations[common.ConfirmationDeletion]
 
-				// copy the new confirmation value to the old annotations to see if
-				// anything else was changed other than the confirmation annotation
-				if newHasConfirmation {
-					if oldMeta.Annotations == nil {
-						oldMeta.Annotations = make(map[string]string)
-					}
-					oldMeta.Annotations[annotation] = newConfirmation
+			// copy the new confirmation value to the old annotations to see if
+			// anything else was changed other than the confirmation annotation
+			if newHasConfirmation {
+				if oldMeta.Annotations == nil {
+					oldMeta.Annotations = make(map[string]string)
 				}
+				oldMeta.Annotations[common.ConfirmationDeletion] = newConfirmation
 			}
 
 			if !reflect.DeepEqual(newMeta.Annotations, oldMeta.Annotations) {

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -812,19 +812,15 @@ var _ = Describe("validator", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			DescribeTable("should allow adding the deletion confirmation",
-				func(annotation string) {
-					shoot.Annotations = make(map[string]string)
-					shoot.Annotations[annotation] = "true"
+			It("should allow adding the deletion confirmation", func() {
+				shoot.Annotations = make(map[string]string)
+				shoot.Annotations[common.ConfirmationDeletion] = "true"
 
-					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
-					Expect(err).ToNot(HaveOccurred())
-				},
-				Entry("deletion confirmation annotation", common.ConfirmationDeletion),
-				Entry("deprecated deletion confirmation annotation", common.ConfirmationDeletionDeprecated),
-			)
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				Expect(err).ToNot(HaveOccurred())
+			})
 
 			It("should reject modifying the shoot spec when seed is marked for deletion", func() {
 				shoot.Spec.Region = "other-region"


### PR DESCRIPTION
/kind cleanup
/kind api-change

Part of #1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The already deprecated annotation keys `confirmation.garden.sapcloud.io/deletion` and `shoot.garden.sapcloud.io/operation` are no longer respected by Gardener components. If you are still using the deprecated annotation keys, please switch the the equivalents from the new API group - respectively `confirmation.gardener.cloud/deletion` and `gardener.cloud/operation`.
```
