### PR TITLE
Fix deletion of clusterrole for seed nginx ingress

### DIFF
--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1216,8 +1216,8 @@ func deleteIngressController(ctx context.Context, c client.Client) error {
 	return kutil.DeleteObjects(
 		ctx,
 		c,
-		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "nginx-ingress"}},
-		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "nginx-ingress"}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:seed:nginx-ingress"}},
+		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "gardener.cloud:seed:nginx-ingress"}},
 		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "nginx-ingress", Namespace: v1beta1constants.GardenNamespace}},
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "nginx-ingress-controller", Namespace: v1beta1constants.GardenNamespace}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "nginx-ingress-controller", Namespace: v1beta1constants.GardenNamespace}},


### PR DESCRIPTION
/area control-plane
/kind bug
/priority critical

**What this PR does / why we need it**:
We previously renamed the clusterrolebinding and clusterrole
from `nginx-ingress` to `gardener.cloud:seed:nginx-ingress` in
order to avoid a name clash with existing clusterroles.
Done with https://github.com/gardener/gardener/pull/3337

Before this commit the deletion flow still used the old name.
With this commit the correct clusterrole gets deleted.

**Release note**:
```other operator
NONE
```
