### PR TITLE
Remove deprecated monitoring hosts

### DIFF
--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -121,11 +121,6 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 	}
 
 	hosts := []map[string]interface{}{
-		// TODO: timuthy - remove in the future. Old Prometheus host is retained for migration reasons.
-		{
-			"hostName":   b.ComputePrometheusHostDeprecated(),
-			"secretName": common.PrometheusTLS,
-		},
 		{
 			"hostName":   b.ComputePrometheusHost(),
 			"secretName": prometheusTLSOverride,
@@ -273,11 +268,6 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		}
 
 		hosts := []map[string]interface{}{
-			// TODO: timuthy - remove in the future. Old Prometheus host is retained for migration reasons.
-			{
-				"hostName":   b.ComputeAlertManagerHostDeprecated(),
-				"secretName": common.AlertManagerTLS,
-			},
 			{
 				"hostName":   b.ComputeAlertManagerHost(),
 				"secretName": alertManagerTLSOverride,
@@ -400,10 +390,6 @@ func (b *Botanist) deployGrafanaCharts(ctx context.Context, role, dashboards, ba
 	}
 
 	hosts := []map[string]interface{}{
-		{
-			"hostName":   b.ComputeIngressHostDeprecated(subDomain),
-			"secretName": common.GrafanaTLS,
-		},
 		{
 			"hostName":   b.ComputeIngressHost(subDomain),
 			"secretName": grafanaTLSOverride,

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -510,8 +510,6 @@ func (o *Operation) SwitchBackupEntryToTargetSeed(ctx context.Context) error {
 // ComputeGrafanaHosts computes the host for both grafanas.
 func (o *Operation) ComputeGrafanaHosts() []string {
 	return []string{
-		o.ComputeGrafanaOperatorsHostDeprecated(),
-		o.ComputeGrafanaUsersHostDeprecated(),
 		o.ComputeGrafanaOperatorsHost(),
 		o.ComputeGrafanaUsersHost(),
 	}
@@ -520,7 +518,6 @@ func (o *Operation) ComputeGrafanaHosts() []string {
 // ComputePrometheusHosts computes the hosts for prometheus.
 func (o *Operation) ComputePrometheusHosts() []string {
 	return []string{
-		o.ComputePrometheusHostDeprecated(),
 		o.ComputePrometheusHost(),
 	}
 }
@@ -528,21 +525,8 @@ func (o *Operation) ComputePrometheusHosts() []string {
 // ComputeAlertManagerHosts computes the host for alert manager.
 func (o *Operation) ComputeAlertManagerHosts() []string {
 	return []string{
-		o.ComputeAlertManagerHostDeprecated(),
 		o.ComputeAlertManagerHost(),
 	}
-}
-
-// ComputeGrafanaOperatorsHostDeprecated computes the host for users Grafana.
-// TODO: timuthy - remove in the future. Old Grafana host is retained for migration reasons.
-func (o *Operation) ComputeGrafanaOperatorsHostDeprecated() string {
-	return o.ComputeIngressHostDeprecated(common.GrafanaOperatorsPrefix)
-}
-
-// ComputeGrafanaUsersHostDeprecated computes the host for operators Grafana.
-// TODO: timuthy - remove in the future. Old Grafana host is retained for migration reasons.
-func (o *Operation) ComputeGrafanaUsersHostDeprecated() string {
-	return o.ComputeIngressHostDeprecated(common.GrafanaUsersPrefix)
 }
 
 // ComputeGrafanaOperatorsHost computes the host for users Grafana.
@@ -555,32 +539,14 @@ func (o *Operation) ComputeGrafanaUsersHost() string {
 	return o.ComputeIngressHost(common.GrafanaUsersPrefix)
 }
 
-// ComputeAlertManagerHostDeprecated computes the host for alert manager.
-// TODO: timuthy - remove in the future. Old AlertManager host is retained for migration reasons.
-func (o *Operation) ComputeAlertManagerHostDeprecated() string {
-	return o.ComputeIngressHostDeprecated(common.AlertManagerPrefix)
-}
-
 // ComputeAlertManagerHost computes the host for alert manager.
 func (o *Operation) ComputeAlertManagerHost() string {
 	return o.ComputeIngressHost(common.AlertManagerPrefix)
 }
 
-// ComputePrometheusHostDeprecated computes the host for prometheus.
-// TODO: timuthy - remove in the future. Old Prometheus host is retained for migration reasons.
-func (o *Operation) ComputePrometheusHostDeprecated() string {
-	return o.ComputeIngressHostDeprecated(common.PrometheusPrefix)
-}
-
 // ComputePrometheusHost computes the host for prometheus.
 func (o *Operation) ComputePrometheusHost() string {
 	return o.ComputeIngressHost(common.PrometheusPrefix)
-}
-
-// ComputeIngressHostDeprecated computes the host for a given prefix.
-// TODO: timuthy - remove in the future. Only retained for migration reasons.
-func (o *Operation) ComputeIngressHostDeprecated(prefix string) string {
-	return o.Seed.GetIngressFQDNDeprecated(prefix, o.Shoot.Info.Name, o.Garden.Project.Name)
 }
 
 // ComputeIngressHost computes the host for a given prefix.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind cleanup
/priority normal

**What this PR does / why we need it**:
This PR removes monitoring hosts which were deprecated over a year ago (https://github.com/gardener/gardener/pull/1769).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Deprecated ingress hostnames i.e., AlertManager - `au.<shoot-name>.<project-name>.<seed-ingress-domain>`, Grafana - `gu.<shoot-name>.<project-name>.<seed-ingress-domain>`, `go.<shoot-name>.<project-name>.<seed-ingress-domain>`, Prometheus - `p.<shoot-name>.<project-name>.<seed-ingress-domain>` were removed and will not be reachable anymore. Please use the hostnames introduced with Gardener [v0.34.0](https://github.com/gardener/gardener/releases/tag/v0.34.0) instead.
```
