### PR TITLE
Move some waiter code into dedicated files

### DIFF
--- a/pkg/operation/botanist/kubecontrollermanager.go
+++ b/pkg/operation/botanist/kubecontrollermanager.go
@@ -64,6 +64,13 @@ func (b *Botanist) DeployKubeControllerManager(ctx context.Context) error {
 	return b.Shoot.Components.ControlPlane.KubeControllerManager.Deploy(ctx)
 }
 
+// WaitForKubeControllerManagerToBeActive waits for the kube controller manager of a Shoot cluster has acquired leader election, thus is active.
+func (b *Botanist) WaitForKubeControllerManagerToBeActive(ctx context.Context) error {
+	b.Shoot.Components.ControlPlane.KubeControllerManager.SetShootClient(b.K8sShootClient.Client())
+
+	return b.Shoot.Components.ControlPlane.KubeControllerManager.WaitForControllerToBeActive(ctx)
+}
+
 // ScaleKubeControllerManagerToOne scales kube-controller-manager replicas to one.
 func (b *Botanist) ScaleKubeControllerManagerToOne(ctx context.Context) error {
 	return kubernetes.ScaleDeployment(ctx, b.K8sSeedClient.DirectClient(), kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeControllerManager), 1)

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -131,13 +131,6 @@ func (b *Botanist) WaitUntilKubeAPIServerReady(ctx context.Context) error {
 	return nil
 }
 
-// WaitForKubeControllerManagerToBeActive waits for the kube controller manager of a Shoot cluster has acquired leader election, thus is active.
-func (b *Botanist) WaitForKubeControllerManagerToBeActive(ctx context.Context) error {
-	b.Shoot.Components.ControlPlane.KubeControllerManager.SetShootClient(b.K8sShootClient.Client())
-
-	return b.Shoot.Components.ControlPlane.KubeControllerManager.WaitForControllerToBeActive(ctx)
-}
-
 // WaitUntilTunnelConnectionExists waits until a port forward connection to the tunnel pod (vpn-shoot or konnectivity-agent) in the kube-system
 // namespace of the Shoot cluster can be established.
 func (b *Botanist) WaitUntilTunnelConnectionExists(ctx context.Context) error {
@@ -148,25 +141,6 @@ func (b *Botanist) WaitUntilTunnelConnectionExists(ctx context.Context) error {
 		}
 
 		return b.CheckTunnelConnection(ctx, b.Logger, tunnelName)
-	})
-}
-
-// WaitUntilSeedNamespaceDeleted waits until the namespace of the Shoot cluster within the Seed cluster is deleted.
-func (b *Botanist) WaitUntilSeedNamespaceDeleted(ctx context.Context) error {
-	return b.waitUntilNamespaceDeleted(ctx, b.Shoot.SeedNamespace)
-}
-
-// WaitUntilNamespaceDeleted waits until the <namespace> within the Seed cluster is deleted.
-func (b *Botanist) waitUntilNamespaceDeleted(ctx context.Context, namespace string) error {
-	return retry.UntilTimeout(ctx, 5*time.Second, 900*time.Second, func(ctx context.Context) (done bool, err error) {
-		if err := b.K8sSeedClient.Client().Get(ctx, client.ObjectKey{Name: namespace}, &corev1.Namespace{}); err != nil {
-			if apierrors.IsNotFound(err) {
-				return retry.Ok()
-			}
-			return retry.SevereError(err)
-		}
-		b.Logger.Infof("Waiting until the namespace '%s' has been cleaned up and deleted in the Seed cluster...", namespace)
-		return retry.MinorError(fmt.Errorf("namespace %q is not yet cleaned up", namespace))
 	})
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Some waiter code was forgotten to be moved to the dedicated files after the component refactorings #2881 and #3257.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
