### PR TITLE
Re-use utility function when updating the `.spec.keepObjects` for `ManagedResource`s

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -230,7 +230,7 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 		})
 		keepManagedResourcesObjectsInShoot = g.Add(flow.Task{
 			Name:         "Configuring Managed Resources objects to be kept in the Shoot",
-			Fn:           flow.TaskFn(botanist.KeepManagedResourcesObjects).DoIf(cleanupShootResources),
+			Fn:           flow.TaskFn(botanist.KeepObjectsForAllManagedResources).DoIf(cleanupShootResources),
 			Dependencies: flow.NewTaskIDs(deleteAllExtensionCRs),
 		})
 		deleteAllManagedResourcesFromShootNamespace = g.Add(flow.Task{

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -137,6 +137,7 @@ func KeepManagedResourceObjects(ctx context.Context, c client.Client, namespace,
 			Namespace: namespace,
 		},
 	}
+
 	if err := kutil.TryUpdate(ctx, k8sretry.DefaultBackoff, c, resource, func() error {
 		resource.Spec.KeepObjects = &keepObjects
 		return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup technical-debt
/priority normal

**What this PR does / why we need it**:
Re-use utility function when updating the `.spec.keepObjects` for `ManagedResource`s.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
