### PR TITLE
Fix 'make install'

### DIFF
--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -16,6 +16,7 @@ package botanist
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"


### PR DESCRIPTION
```
$ make install
> Install
# github.com/gardener/gardener/pkg/operation/botanist
pkg/operation/botanist/waiter.go:108:7: undefined: errors
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
