### PR TITLE
Revert "Increase the Loki chunk idle period from 3m to 1h"

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/loki-configmap.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/loki-configmap.yaml
@@ -10,7 +10,7 @@ data:
     auth_enabled: {{ .Values.authEnabled }}
     ingester:
       chunk_target_size: 1536000
-      chunk_idle_period: 1h
+      chunk_idle_period: 3m
       chunk_block_size: 262144
       chunk_retain_period: 3m
       max_transfer_retries: 3


### PR DESCRIPTION
Reverts gardener/gardener#3369

/assign @vlvasilev @Kristian-ZH 
/invite  @vlvasilev @Kristian-ZH 

#3369 has the disadvantage of potential increased memory usage. Till a more prominent solution is found, let's revert it.
/area logging