### PR TITLE
Make ingress domain for Seeds immutable

### DIFF
--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -3082,7 +3082,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>Domain is the external available domain of the Shoot cluster. This domain will be written into the
-kubeconfig that is handed out to end-users.</p>
+kubeconfig that is handed out to end-users. Once set it is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -3771,7 +3771,7 @@ string
 </td>
 <td>
 <p>Domain specifies the IngressDomain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-to construct ingress URLs for system applications running in Shoot clusters.</p>
+to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -6955,7 +6955,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-to construct ingress URLs for system applications running in Shoot clusters.
+to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
 This will be removed in the next API version and replaced by spec.ingress.domain.</p>
 </td>
 </tr>

--- a/pkg/apis/core/types_seed.go
+++ b/pkg/apis/core/types_seed.go
@@ -114,7 +114,7 @@ type SeedBackup struct {
 // SeedDNS contains the external domain and configuration for the DNS provider
 type SeedDNS struct {
 	// IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-	// to construct ingress URLs for system applications running in Shoot clusters.
+	// to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
 	// This will be removed in the next API version and replaced by spec.ingress.domain.
 	IngressDomain *string
 	// Provider configures a DNSProvider
@@ -136,7 +136,7 @@ type SeedDNSProvider struct {
 // Ingress configures the Ingress specific settings of the Seed cluster
 type Ingress struct {
 	// Domain specifies the ingress domain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-	// to construct ingress URLs for system applications running in Shoot clusters.
+	// to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
 	Domain string
 	// Controller configures a Gardener managed Ingress Controller listening on the ingressDomain
 	Controller IngressController

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -179,7 +179,7 @@ type NginxIngress struct {
 // DNS holds information about the provider, the hosted zone id and the domain.
 type DNS struct {
 	// Domain is the external available domain of the Shoot cluster. This domain will be written into the
-	// kubeconfig that is handed out to end-users.
+	// kubeconfig that is handed out to end-users. Once set it is immutable.
 	Domain *string
 	// Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
 	// not a default domain is used.

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -499,7 +499,7 @@ message ControllerResource {
 // DNS holds information about the provider, the hosted zone id and the domain.
 message DNS {
   // Domain is the external available domain of the Shoot cluster. This domain will be written into the
-  // kubeconfig that is handed out to end-users.
+  // kubeconfig that is handed out to end-users. Once set it is immutable.
   // +optional
   optional string domain = 1;
 
@@ -715,7 +715,7 @@ message HorizontalPodAutoscalerConfig {
 // Ingress configures the Ingress specific settings of the Seed cluster.
 message Ingress {
   // Domain specifies the IngressDomain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-  // to construct ingress URLs for system applications running in Shoot clusters.
+  // to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
   optional string domain = 1;
 
   // Controller configures a Gardener managed Ingress Controller listening on the ingressDomain
@@ -1681,7 +1681,7 @@ message SeedBackup {
 // SeedDNS contains DNS-relevant information about this seed cluster.
 message SeedDNS {
   // IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-  // to construct ingress URLs for system applications running in Shoot clusters.
+  // to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
   // This will be removed in the next API version and replaced by spec.ingress.domain.
   // +optional
   optional string ingressDomain = 1;

--- a/pkg/apis/core/v1alpha1/types_seed.go
+++ b/pkg/apis/core/v1alpha1/types_seed.go
@@ -125,7 +125,7 @@ type SeedBackup struct {
 // SeedDNS contains DNS-relevant information about this seed cluster.
 type SeedDNS struct {
 	// IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-	// to construct ingress URLs for system applications running in Shoot clusters.
+	// to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
 	// This will be removed in the next API version and replaced by spec.ingress.domain.
 	// +optional
 	IngressDomain *string `json:"ingressDomain,omitempty" protobuf:"bytes,1,opt,name=ingressDomain"`
@@ -151,7 +151,7 @@ type SeedDNSProvider struct {
 // Ingress configures the Ingress specific settings of the Seed cluster.
 type Ingress struct {
 	// Domain specifies the IngressDomain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-	// to construct ingress URLs for system applications running in Shoot clusters.
+	// to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
 	Domain string `json:"domain" protobuf:"bytes,1,opt,name=domain"`
 	// Controller configures a Gardener managed Ingress Controller listening on the ingressDomain
 	Controller IngressController `json:"controller" protobuf:"bytes,2,opt,name=controller"`

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -213,7 +213,7 @@ type NginxIngress struct {
 // DNS holds information about the provider, the hosted zone id and the domain.
 type DNS struct {
 	// Domain is the external available domain of the Shoot cluster. This domain will be written into the
-	// kubeconfig that is handed out to end-users.
+	// kubeconfig that is handed out to end-users. Once set it is immutable.
 	// +optional
 	Domain *string `json:"domain,omitempty" protobuf:"bytes,1,opt,name=domain"`
 	// Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -498,7 +498,7 @@ message ControllerResource {
 // DNS holds information about the provider, the hosted zone id and the domain.
 message DNS {
   // Domain is the external available domain of the Shoot cluster. This domain will be written into the
-  // kubeconfig that is handed out to end-users.
+  // kubeconfig that is handed out to end-users. Once set it is immutable.
   // +optional
   optional string domain = 1;
 
@@ -679,7 +679,7 @@ message HorizontalPodAutoscalerConfig {
 // Ingress configures the Ingress specific settings of the Seed cluster
 message Ingress {
   // Domain specifies the IngressDomain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-  // to construct ingress URLs for system applications running in Shoot clusters.
+  // to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
   optional string domain = 1;
 
   // Controller configures a Gardener managed Ingress Controller listening on the ingressDomain
@@ -1637,7 +1637,7 @@ message SeedBackup {
 // SeedDNS contains DNS-relevant information about this seed cluster.
 message SeedDNS {
   // IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-  // to construct ingress URLs for system applications running in Shoot clusters.
+  // to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
   // This will be removed in the next API version and replaced by spec.ingress.domain.
   // +optional
   optional string ingressDomain = 1;

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -128,7 +128,7 @@ type SeedBackup struct {
 // SeedDNS contains DNS-relevant information about this seed cluster.
 type SeedDNS struct {
 	// IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-	// to construct ingress URLs for system applications running in Shoot clusters.
+	// to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
 	// This will be removed in the next API version and replaced by spec.ingress.domain.
 	// +optional
 	IngressDomain *string `json:"ingressDomain,omitempty" protobuf:"bytes,1,opt,name=ingressDomain"`
@@ -154,7 +154,7 @@ type SeedDNSProvider struct {
 // Ingress configures the Ingress specific settings of the Seed cluster
 type Ingress struct {
 	// Domain specifies the IngressDomain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-	// to construct ingress URLs for system applications running in Shoot clusters.
+	// to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
 	Domain string `json:"domain" protobuf:"bytes,1,opt,name=domain"`
 	// Controller configures a Gardener managed Ingress Controller listening on the ingressDomain
 	Controller IngressController `json:"controller" protobuf:"bytes,2,opt,name=controller"`

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -210,7 +210,7 @@ type NginxIngress struct {
 // DNS holds information about the provider, the hosted zone id and the domain.
 type DNS struct {
 	// Domain is the external available domain of the Shoot cluster. This domain will be written into the
-	// kubeconfig that is handed out to end-users.
+	// kubeconfig that is handed out to end-users. Once set it is immutable.
 	// +optional
 	Domain *string `json:"domain,omitempty" protobuf:"bytes,1,opt,name=domain"`
 	// Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if

--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -198,6 +198,19 @@ func ValidateSeedSpecUpdate(newSeedSpec, oldSeedSpec *core.SeedSpec, fldPath *fi
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Networks.Nodes, oldSeedSpec.Networks.Nodes, fldPath.Child("networks", "nodes"))...)
 	}
 
+	if oldSeedSpec.DNS.IngressDomain != nil && newSeedSpec.DNS.IngressDomain != nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.DNS.IngressDomain, oldSeedSpec.DNS.IngressDomain, fldPath.Child("dns", "ingressDomain"))...)
+	}
+	if oldSeedSpec.Ingress != nil && newSeedSpec.Ingress != nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Ingress.Domain, oldSeedSpec.Ingress.Domain, fldPath.Child("ingress", "domain"))...)
+	}
+	if oldSeedSpec.Ingress != nil && newSeedSpec.DNS.IngressDomain != nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.DNS.IngressDomain, oldSeedSpec.Ingress.Domain, fldPath.Child("dns", "ingressDomain"))...)
+	}
+	if oldSeedSpec.DNS.IngressDomain != nil && newSeedSpec.Ingress != nil {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Ingress.Domain, oldSeedSpec.DNS.IngressDomain, fldPath.Child("ingress", "domain"))...)
+	}
+
 	if oldSeedSpec.Backup != nil {
 		if newSeedSpec.Backup != nil {
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Backup.Provider, oldSeedSpec.Backup.Provider, fldPath.Child("backup", "provider"))...)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2011,7 +2011,7 @@ func schema_pkg_apis_core_v1alpha1_DNS(ref common.ReferenceCallback) common.Open
 				Properties: map[string]spec.Schema{
 					"domain": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Domain is the external available domain of the Shoot cluster. This domain will be written into the kubeconfig that is handed out to end-users.",
+							Description: "Domain is the external available domain of the Shoot cluster. This domain will be written into the kubeconfig that is handed out to end-users. Once set it is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2543,7 +2543,7 @@ func schema_pkg_apis_core_v1alpha1_Ingress(ref common.ReferenceCallback) common.
 				Properties: map[string]spec.Schema{
 					"domain": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Domain specifies the IngressDomain of the Seed cluster pointing to the ingress controller endpoint. It will be used to construct ingress URLs for system applications running in Shoot clusters.",
+							Description: "Domain specifies the IngressDomain of the Seed cluster pointing to the ingress controller endpoint. It will be used to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5103,7 +5103,7 @@ func schema_pkg_apis_core_v1alpha1_SeedDNS(ref common.ReferenceCallback) common.
 				Properties: map[string]spec.Schema{
 					"ingressDomain": {
 						SchemaProps: spec.SchemaProps{
-							Description: "IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used to construct ingress URLs for system applications running in Shoot clusters. This will be removed in the next API version and replaced by spec.ingress.domain.",
+							Description: "IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable. This will be removed in the next API version and replaced by spec.ingress.domain.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8210,7 +8210,7 @@ func schema_pkg_apis_core_v1beta1_DNS(ref common.ReferenceCallback) common.OpenA
 				Properties: map[string]spec.Schema{
 					"domain": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Domain is the external available domain of the Shoot cluster. This domain will be written into the kubeconfig that is handed out to end-users.",
+							Description: "Domain is the external available domain of the Shoot cluster. This domain will be written into the kubeconfig that is handed out to end-users. Once set it is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8650,7 +8650,7 @@ func schema_pkg_apis_core_v1beta1_Ingress(ref common.ReferenceCallback) common.O
 				Properties: map[string]spec.Schema{
 					"domain": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Domain specifies the IngressDomain of the Seed cluster pointing to the ingress controller endpoint. It will be used to construct ingress URLs for system applications running in Shoot clusters.",
+							Description: "Domain specifies the IngressDomain of the Seed cluster pointing to the ingress controller endpoint. It will be used to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -11167,7 +11167,7 @@ func schema_pkg_apis_core_v1beta1_SeedDNS(ref common.ReferenceCallback) common.O
 				Properties: map[string]spec.Schema{
 					"ingressDomain": {
 						SchemaProps: spec.SchemaProps{
-							Description: "IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used to construct ingress URLs for system applications running in Shoot clusters. This will be removed in the next API version and replaced by spec.ingress.domain.",
+							Description: "IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable. This will be removed in the next API version and replaced by spec.ingress.domain.",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
**How to categorize this PR?**

  /area control-plane
  /area robustness
/kind bug
/priority normal


**What this PR does / why we need it**:
Make ingress domain for Seeds immutable

Changing the ingress domain on running Seed clusters can cause
a temporary unavailability of the Shoots monitoring.

We decided to not support the use case of changing the
ingress Domain for Seeds. This is in line with the
Shoot resource where the ingress domain is also immutable.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/3281

**Release note**:
```noteworthy operator
The ingress domain configuration for Seeds is now immutable.
```
