### PR TITLE
Add side-car container to kube-proxy to remove incorrect conntrack table entries

### DIFF
--- a/charts/shoot-core/components/charts/kube-proxy/templates/conntrack-fix-script.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/conntrack-fix-script.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: conntrack-fix-script
+  namespace: kube-system
+  labels:
+    app: kubernetes
+    gardener.cloud/role: system-component
+    origin: gardener
+    role: proxy
+data:
+  conntrack_fix.sh: |
+    #!/bin/sh -e
+    trap "kill -s INT 1" TERM
+    apk add conntrack-tools
+    sleep 120 & wait
+    date
+    # conntrack example:
+    # tcp      6 113 SYN_SENT src=21.73.193.93 dst=21.71.0.65 sport=1413 dport=443 \
+    #   [UNREPLIED] src=21.71.0.65 dst=21.73.193.93 sport=443 dport=1413 mark=0 use=1
+    eval "$(
+      conntrack -L -p tcp --state SYN_SENT \
+      | sed 's/=/ /g'                      \
+      | awk '$6 !~ /^10\./ &&
+             $8 !~ /^10\./ &&
+             $6  == $17    &&
+             $8  == $15    &&
+             $10 == $21    &&
+             $12 == $19 {
+               printf "conntrack -D -p tcp -s %s --sport %s -d %s --dport %s;\n",
+                                              $6,        $10,  $8,        $12}'
+    )"
+    while true; do
+      date
+      sleep 3600 & wait
+    done
+

--- a/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -21,6 +21,7 @@ spec:
         checksum/secret-kube-proxy: {{ include (print $.Template.BasePath "/kube-proxy-secret.yaml") . | sha256sum }}
         checksum/configmap-componentconfig: {{ include (print $.Template.BasePath "/componentconfig.yaml") . | sha256sum }}
         checksum/configmap-kube-proxy-cleanup-script: {{ include (print $.Template.BasePath "/kube-proxy-cleanup-script.yaml") . | sha256sum }}
+        checksum/configmap-conntrack-fix-script: {{ include (print $.Template.BasePath "/conntrack-fix-script.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
@@ -132,6 +133,21 @@ spec:
           mountPath: /var/run/dbus/system_bus_socket
         - name: kernel-modules
           mountPath: /lib/modules
+      # sidecar container with fix for conntrack
+      - name: conntrack-fix
+        image: {{ index .Values.images "alpine" }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - /script/conntrack_fix.sh
+        hostNetwork: true
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+        volumeMounts:
+        - name: conntrack-fix-script
+          mountPath: /script
       volumes:
       - name: kubeconfig
         secret:
@@ -160,3 +176,7 @@ spec:
         hostPath:
           path: /var/lib/kube-proxy/mode
           type: FileOrCreate
+      - name: conntrack-fix-script
+        configMap:
+          name: conntrack-fix-script
+


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/priority normal

**What this PR does / why we need it**:
We observed that from the shoot cluster the kubernetes `api-server` was sometimes unavailable.

This PR mitigates the issue by deleting the incorrect conntrack table entries, that might appear after restarting the `kube-proxy`. These incorrect conntrack table entries prevented the establishment of a tcp connection to the `api-server`.

After deploying this PR the `ApiServerUnreachableViaKubernetesService` alerts are expected to disappear.
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A side-car container is added to `kube-proxy` that deletes the incorrect conntrack table entries which sometime occur after restart of `kube-proxy` and prevent the establishment of a tcp connection to the `api-server`.
```
