### PR TITLE
[release-v1.15] Fix error during creation of fresh seed clusters

### DIFF
--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -699,10 +699,6 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 		return err
 	}
 
-	if err := handleDNSProvider(ctx, k8sGardenClient.Client(), k8sSeedClient.Client(), seed.Info.Spec.DNS); err != nil {
-		return err
-	}
-
 	values := kubernetes.Values(map[string]interface{}{
 		"priorityClassName": v1beta1constants.PriorityClassNameShootControlPlane,
 		"global": map[string]interface{}{
@@ -778,6 +774,10 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 	})
 
 	if err := chartApplier.Apply(ctx, filepath.Join(common.ChartPath, chartName), v1beta1constants.GardenNamespace, chartName, values, applierOptions); err != nil {
+		return err
+	}
+
+	if err := handleDNSProvider(ctx, k8sGardenClient.Client(), k8sSeedClient.Client(), seed.Info.Spec.DNS); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
/area control-plane
/kind bug
/priority normal

**What this PR does / why we need it**:
With the introduction of the Seed nginx ingress controller an instance
of the the dnsProvider crd is attempted to be created (or deleted) during
Seed bootstrap.
This commit fixes a bug where the instance of the crd is created
before the actual crd was registered. This leads to an error during
the Seed bootstrap.

**Release note**:

```bugfix operator
Fixes a bug causing newly created Seeds to fail during bootstrap
```