### PR TITLE
[release-v1.15] change the fluent bit to loki plugin to.0.33 and set new configuration

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -214,7 +214,7 @@ images:
 - name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.32.0"
+  tag: "v0.33.0"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
@@ -97,7 +97,7 @@
         BatchSize 30720
         Labels {test="fluent-bit-go"}
         LineFormat json
-        ReplaceOutOfOrderTS true
+        SortByTimestamp true
         DropSingleKey false
         AutoKubernetesLabels false
         LabelSelector gardener.cloud/role:shoot
@@ -119,6 +119,8 @@
         FallbackToTagWhenMetadataIsMissing true
         TagKey tag
         DropLogEntryWithoutK8sMetadata true
+        ControllerSyncTimeout 120
+        NumberOfBatchIDs 5
         TenantID operator
     
     [Output]
@@ -130,7 +132,7 @@
         BatchSize 30720
         Labels {test="fluent-bit-go", lang="Golang"}
         LineFormat json
-        ReplaceOutOfOrderTS true
+        SortByTimestamp true
         DropSingleKey false
         AutoKubernetesLabels true
         LabelSelector gardener.cloud/role:shoot
@@ -152,6 +154,8 @@
         FallbackToTagWhenMetadataIsMissing true
         TagKey tag
         DropLogEntryWithoutK8sMetadata true
+        ControllerSyncTimeout 120
+        NumberOfBatchIDs 5
         TenantID user
 
     [Output]
@@ -163,7 +167,7 @@
         BatchSize 30720
         Labels {test="fluent-bit-go"}
         LineFormat json
-        ReplaceOutOfOrderTS true
+        SortByTimestamp true
         DropSingleKey false
         RemoveKeys kubernetes,stream,hostname,unit
         LabelMapPath /fluent-bit/etc/systemd_label_map.json
@@ -176,5 +180,6 @@
         QueueSegmentSize 300
         QueueSync normal
         QueueName gardener-journald
+        NumberOfBatchIDs 5
 {{ end }}
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR we make the number of maximum Batch IDs for the fluent-bit-to-loki plugin configurable.
Initially  It was hardcoded to 10 IDs but now is it set to 5 in order to decrease the number of chunks created by Loki.
This is needed because when chunks are too small they consume all of the available inodes on the filesystem without consuming all of the free disk space.

**Which issue(s) this PR fixes**:
cherry-pick of #3402 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
``` improvement operator github.com/gardener/logging #83 @vlvasilev
Batch IDs are configurable via `NumberOfBatchIDs`.
```

``` improvement operator github.com/gardener/logging #83 @vlvasilev
Add `ControllerSyncTimeout` to control the informer sync period. Prior it was infinity time.
```

``` improvement operator github.com/gardener/logging #83 @vlvasilev
`ReplaceOutOfOrderTS` is replaces by `SortByTimestamp`. The timestamp is no longer replaced. Instead the logs are sorted by their timestamp.
```

``` improvement operator
`NumberOfBatchIDs` for the fluent-bit-to-loki plugin is set to 5 numbers.
```
