### PR TITLE
[release-v1.15] Avoid Grafana restarts

### DIFF
--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -99,6 +99,9 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		return err
 	}
 
+	// Need stable order before passing the dashboards to Grafana config to avoid unnecessary changes
+	kutil.ByName().Sort(existingConfigMaps)
+
 	// Read extension monitoring configurations
 	for _, cm := range existingConfigMaps.Items {
 		alertingRules.WriteString(fmt.Sprintln(cm.Data[v1beta1constants.PrometheusConfigMapAlertingRules]))

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -73,12 +72,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
-
-type byName []corev1.ConfigMap
-
-func (a byName) Len() int           { return len(a) }
-func (a byName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a byName) Less(i, j int) bool { return a[i].ObjectMeta.Name < a[j].ObjectMeta.Name }
 
 // NewBuilder returns a new Builder.
 func NewBuilder() *Builder {
@@ -451,7 +444,9 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 			client.MatchingLabels{v1beta1constants.LabelExtensionConfiguration: v1beta1constants.LabelLogging}); err != nil {
 			return err
 		}
-		sort.Sort(byName(existingConfigMaps.Items))
+
+		// Need stable order before passing the dashboards to Grafana config to avoid unnecessary changes
+		kutil.ByName().Sort(existingConfigMaps)
 
 		// Read all filters and parsers coming from the extension provider configurations
 		for _, cm := range existingConfigMaps.Items {

--- a/pkg/utils/kubernetes/sorter.go
+++ b/pkg/utils/kubernetes/sorter.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"sort"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// ByName returns a comparison function for sorting by name.
+func ByName() SortBy {
+	return func(o1, o2 controllerutil.Object) bool {
+		return o1.GetName() < o2.GetName()
+	}
+}
+
+// ByCreationTimestamp returns a comparison function for sorting by creation timestamp.
+func ByCreationTimestamp() SortBy {
+	return func(o1, o2 controllerutil.Object) bool {
+		return o1.GetCreationTimestamp().Time.Before(o2.GetCreationTimestamp().Time)
+	}
+}
+
+// SortBy the type of a "less" function that defines the ordering of its object arguments.
+type SortBy func(o1, o2 controllerutil.Object) bool
+
+// Sort sorts the items in the provided list objects according to the sort-by function.
+func (sortBy SortBy) Sort(objList runtime.Object) {
+	if !meta.IsListType(objList) {
+		panic("provided <objList> is not a list type")
+	}
+
+	items, err := meta.ExtractList(objList)
+	if err != nil {
+		panic(err)
+	}
+
+	ps := &objectSorter{objects: items, compareFn: sortBy}
+	sort.Sort(ps)
+
+	if err := meta.SetList(objList, ps.objects); err != nil {
+		panic(err)
+	}
+}
+
+type objectSorter struct {
+	objects   []runtime.Object
+	compareFn SortBy
+}
+
+func (s *objectSorter) Len() int {
+	return len(s.objects)
+}
+
+func (s *objectSorter) Swap(i, j int) {
+	s.objects[i], s.objects[j] = s.objects[j], s.objects[i]
+}
+
+func (s *objectSorter) Less(i, j int) bool {
+	return s.compareFn(
+		s.objects[i].(controllerutil.Object),
+		s.objects[j].(controllerutil.Object),
+	)
+}

--- a/pkg/utils/kubernetes/sorter_test.go
+++ b/pkg/utils/kubernetes/sorter_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes_test
+
+import (
+	"time"
+
+	. "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+var _ = Describe("Sort", func() {
+	var (
+		listObj = &corev1.PodList{}
+
+		pod1 = corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pod1",
+				CreationTimestamp: metav1.Now(),
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{}, {}},
+			},
+		}
+		pod2 = corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pod2",
+				CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Hour)},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{}},
+			},
+		}
+		pod3 = corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "pod3",
+				CreationTimestamp: metav1.Time{Time: time.Now().Add(time.Hour)},
+			},
+		}
+	)
+
+	Describe("ByName", func() {
+		It("should sort correctly", func() {
+			listObj.Items = []corev1.Pod{pod2, pod3, pod1}
+			ByName().Sort(listObj)
+			Expect(listObj.Items).To(Equal([]corev1.Pod{pod1, pod2, pod3}))
+		})
+	})
+
+	Describe("ByCreationTimestamp", func() {
+		It("should sort correctly", func() {
+			listObj.Items = []corev1.Pod{pod1, pod2, pod3}
+			ByCreationTimestamp().Sort(listObj)
+			Expect(listObj.Items).To(Equal([]corev1.Pod{pod2, pod1, pod3}))
+		})
+	})
+
+	Describe("SortBy", func() {
+		It("should sort correctly", func() {
+			sortByContainers := func(o1, o2 controllerutil.Object) bool {
+				obj1, ok1 := o1.(*corev1.Pod)
+				obj2, ok2 := o2.(*corev1.Pod)
+
+				if !ok1 || !ok2 {
+					return false
+				}
+
+				return len(obj1.Spec.Containers) < len(obj2.Spec.Containers)
+			}
+
+			listObj.Items = []corev1.Pod{pod1, pod2, pod3}
+			SortBy(sortByContainers).Sort(listObj)
+			Expect(listObj.Items).To(Equal([]corev1.Pod{pod3, pod2, pod1}))
+		})
+	})
+})


### PR DESCRIPTION
/kind bug

Cherry pick of #3379 on release-v1.15.

#3379: Avoid Grafana restarts

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
An issue has been fixed which caused unwanted restarts for Grafana instances.
```
