### PR TITLE
Pin sigs.k8s.io/structured-merge-diff/v4 back to upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,5 +83,5 @@ replace (
 	k8s.io/helm => k8s.io/helm v2.13.1+incompatible
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.19.6
 	k8s.io/kube-openapi => github.com/gardener/kube-openapi v0.0.0-20201221124747-75e88872edcf // k8s-1.19
-	sigs.k8s.io/structured-merge-diff/v4 => github.com/gardener/structured-merge-diff/v4 v4.0.2-0.20210114123732-dc8c8e7e22b6
+	sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.0.2-0.20210114175505-c02124475cb0
 )

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,6 @@ github.com/gardener/kube-openapi v0.0.0-20201221124747-75e88872edcf/go.mod h1:Uu
 github.com/gardener/machine-controller-manager v0.27.0/go.mod h1:zlIxuLQMtRO+aXOFsG6qtYkBmggbWY82K7MSO051ARU=
 github.com/gardener/machine-controller-manager v0.33.0 h1:58Gh4MW7Yv9XoARKhP4wORDcn2Hofbuv/1OlMe9y1eY=
 github.com/gardener/machine-controller-manager v0.33.0/go.mod h1:jxxE+mGgXwg4iPlCHTG4GtUfK2CcHA6yYoIIowoxOZU=
-github.com/gardener/structured-merge-diff/v4 v4.0.2-0.20210114123732-dc8c8e7e22b6 h1:IrHdgivXoWVvjsbzVvDCtOmbbp+AXiCikISP2IlkDis=
-github.com/gardener/structured-merge-diff/v4 v4.0.2-0.20210114123732-dc8c8e7e22b6/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -1021,6 +1019,8 @@ sigs.k8s.io/controller-tools v0.2.9/go.mod h1:ArP7w60JQKkZf7UU2oWTVnEhoNGA+sOMyu
 sigs.k8s.io/controller-tools v0.4.1 h1:VkuV0MxlRPmRu5iTgBZU4UxUX2LiR99n3sdQGRxZF4w=
 sigs.k8s.io/controller-tools v0.4.1/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
 sigs.k8s.io/kind v0.7.0/go.mod h1:An/AbWHT6pA/Lm0Og8j3ukGhfJP3RiVN/IBU6Lo3zl8=
+sigs.k8s.io/structured-merge-diff/v4 v4.0.2-0.20210114175505-c02124475cb0 h1:xDZ/PNrvwsTGvehqFNUEKpYHl+qJTwPeynpme0dQk44=
+sigs.k8s.io/structured-merge-diff/v4 v4.0.2-0.20210114175505-c02124475cb0/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=
 sigs.k8s.io/testing_frameworks v0.1.2/go.mod h1:ToQrwSC3s8Xf/lADdZp3Mktcql9CG0UAmdJG9th5i0w=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1325,7 +1325,7 @@ sigs.k8s.io/controller-tools/pkg/schemapatcher
 sigs.k8s.io/controller-tools/pkg/schemapatcher/internal/yaml
 sigs.k8s.io/controller-tools/pkg/version
 sigs.k8s.io/controller-tools/pkg/webhook
-# sigs.k8s.io/structured-merge-diff/v4 v4.0.1 => github.com/gardener/structured-merge-diff/v4 v4.0.2-0.20210114123732-dc8c8e7e22b6
+# sigs.k8s.io/structured-merge-diff/v4 v4.0.1 => sigs.k8s.io/structured-merge-diff/v4 v4.0.2-0.20210114175505-c02124475cb0
 sigs.k8s.io/structured-merge-diff/v4/fieldpath
 sigs.k8s.io/structured-merge-diff/v4/merge
 sigs.k8s.io/structured-merge-diff/v4/schema
@@ -1350,4 +1350,4 @@ sigs.k8s.io/yaml
 # k8s.io/helm => k8s.io/helm v2.13.1+incompatible
 # k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.19.6
 # k8s.io/kube-openapi => github.com/gardener/kube-openapi v0.0.0-20201221124747-75e88872edcf
-# sigs.k8s.io/structured-merge-diff/v4 => github.com/gardener/structured-merge-diff/v4 v4.0.2-0.20210114123732-dc8c8e7e22b6
+# sigs.k8s.io/structured-merge-diff/v4 => sigs.k8s.io/structured-merge-diff/v4 v4.0.2-0.20210114175505-c02124475cb0


### PR DESCRIPTION
/area dev-productivity
/kind cleanup
/priority normal

Pin sigs.k8s.io/structured-merge-diff/v4 back to upstream as https://github.com/kubernetes-sigs/structured-merge-diff/pull/182 is now merged.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
