### PR TITLE
Vendor controller-runtime@v0.7.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	k8s.io/kubelet v0.19.6
 	k8s.io/metrics v0.19.6
 	k8s.io/utils v0.0.0-20200912215256-4140de9c8800
-	sigs.k8s.io/controller-runtime v0.7.0
+	sigs.k8s.io/controller-runtime v0.7.1
 	sigs.k8s.io/controller-tools v0.4.1
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	k8s.io/helm v2.16.1+incompatible
 	k8s.io/klog v1.0.0
 	k8s.io/kube-aggregator v0.19.6
-	k8s.io/kube-openapi v0.0.0-20201221124747-75e88872edcf // keep this value in sync with k8s.io/apiserver
+	k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6 // keep this value in sync with k8s.io/apiserver
 	k8s.io/kube-scheduler v0.19.6
 	k8s.io/kubelet v0.19.6
 	k8s.io/metrics v0.19.6

--- a/go.sum
+++ b/go.sum
@@ -1013,8 +1013,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9/go.mod h1:dzAXnQb
 sigs.k8s.io/controller-runtime v0.2.0-beta.5/go.mod h1:HweyYKQ8fBuzdu2bdaeBJvsFgAi/OqBBnrVGXcqKhME=
 sigs.k8s.io/controller-runtime v0.4.0/go.mod h1:ApC79lpY3PHW9xj/w9pj+lYkLgwAAUZwfXkME1Lajns=
 sigs.k8s.io/controller-runtime v0.6.3/go.mod h1:WlZNXcM0++oyaQt4B7C2lEE5JYRs8vJUzRP4N4JpdAY=
-sigs.k8s.io/controller-runtime v0.7.0 h1:bU20IBBEPccWz5+zXpLnpVsgBYxqclaHu1pVDl/gEt8=
-sigs.k8s.io/controller-runtime v0.7.0/go.mod h1:pJ3YBrJiAqMAZKi6UVGuE98ZrroV1p+pIhoHsMm9wdU=
+sigs.k8s.io/controller-runtime v0.7.1 h1:nqVwzVzdenfd9xIbB35pC7JJH2IXVL4hDo3MNzkyCh4=
+sigs.k8s.io/controller-runtime v0.7.1/go.mod h1:pJ3YBrJiAqMAZKi6UVGuE98ZrroV1p+pIhoHsMm9wdU=
 sigs.k8s.io/controller-tools v0.2.0-beta.4/go.mod h1:8t/X+FVWvk6TaBcsa+UKUBbn7GMtvyBKX30SGl4em6Y=
 sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
 sigs.k8s.io/controller-tools v0.2.9/go.mod h1:ArP7w60JQKkZf7UU2oWTVnEhoNGA+sOMyuSuS+JFNDQ=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1227,7 +1227,7 @@ k8s.io/kube-aggregator/pkg/client/informers/externalversions/internalinterfaces
 k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1
 k8s.io/kube-aggregator/pkg/controllers
 k8s.io/kube-aggregator/pkg/controllers/autoregister
-# k8s.io/kube-openapi v0.0.0-20201221124747-75e88872edcf => github.com/gardener/kube-openapi v0.0.0-20201221124747-75e88872edcf
+# k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6 => github.com/gardener/kube-openapi v0.0.0-20201221124747-75e88872edcf
 ## explicit
 k8s.io/kube-openapi/cmd/openapi-gen
 k8s.io/kube-openapi/cmd/openapi-gen/args

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1263,7 +1263,7 @@ k8s.io/utils/trace
 # sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
-# sigs.k8s.io/controller-runtime v0.7.0
+# sigs.k8s.io/controller-runtime v0.7.1
 ## explicit
 sigs.k8s.io/controller-runtime
 sigs.k8s.io/controller-runtime/pkg/builder

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/split.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/split.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -98,6 +99,11 @@ func (d *delegatingReader) shouldBypassCache(obj runtime.Object) (bool, error) {
 	gvk, err := apiutil.GVKForObject(obj, d.scheme)
 	if err != nil {
 		return false, err
+	}
+	// TODO: this is producing unsafe guesses that don't actually work,
+	// but it matches ~99% of the cases out there.
+	if meta.IsListType(obj) {
+		gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
 	}
 	_, isUncached := d.uncachedGVKs[gvk]
 	_, isUnstructured := obj.(*unstructured.Unstructured)

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go
@@ -35,18 +35,50 @@ package log
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 )
 
 // SetLogger sets a concrete logging implementation for all deferred Loggers.
 func SetLogger(l logr.Logger) {
+	loggerWasSetLock.Lock()
+	defer loggerWasSetLock.Unlock()
+
+	loggerWasSet = true
 	Log.Fulfill(l)
 }
 
+// It is safe to assume that if this wasn't set within the first 30 seconds of a binaries
+// lifetime, it will never get set. The DelegatingLogger causes a high number of memory
+// allocations when not given an actual Logger, so we set a NullLogger to avoid that.
+//
+// We need to keep the DelegatingLogger because we have various inits() that get a logger from
+// here. They will always get executed before any code that imports controller-runtime
+// has a chance to run and hence to set an actual logger.
+func init() {
+	// Init is blocking, so start a new goroutine
+	go func() {
+		time.Sleep(30 * time.Second)
+		loggerWasSetLock.Lock()
+		defer loggerWasSetLock.Unlock()
+		if !loggerWasSet {
+			Log.Fulfill(NullLogger{})
+		}
+	}()
+}
+
+var (
+	loggerWasSetLock sync.Mutex
+	loggerWasSet     bool
+)
+
 // Log is the base logger used by kubebuilder.  It delegates
-// to another logr.Logger.  You *must* call SetLogger to
-// get any actual logging.
+// to another logr.Logger. You *must* call SetLogger to
+// get any actual logging. If SetLogger is not called within
+// the first 30 seconds of a binaries lifetime, it will get
+// set to a NullLogger.
 var Log = NewDelegatingLogger(NullLogger{})
 
 // FromContext returns a logger with predefined values from a context.Context.

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/response.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/response.go
@@ -90,8 +90,14 @@ func PatchResponseFromRaw(original, current []byte) Response {
 	return Response{
 		Patches: patches,
 		AdmissionResponse: admissionv1.AdmissionResponse{
-			Allowed:   true,
-			PatchType: func() *admissionv1.PatchType { pt := admissionv1.PatchTypeJSONPatch; return &pt }(),
+			Allowed: true,
+			PatchType: func() *admissionv1.PatchType {
+				if len(patches) == 0 {
+					return nil
+				}
+				pt := admissionv1.PatchTypeJSONPatch
+				return &pt
+			}(),
 		},
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR updates Controller-Runtime dependencies to [v0.7.1](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.7.1) which contains an important fix for uncached objects.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
Go dependency `kubernetes-sigs/controller-runtime` was updated to `v0.7.1`.
```
