### PR TITLE
[release-v1.15] Allow kube-proxy PSP to use NET_ADMIN

### DIFF
--- a/charts/shoot-core/components/charts/kube-proxy/templates/psp/kube-proxy-psp.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/psp/kube-proxy-psp.yaml
@@ -17,6 +17,8 @@ spec:
   - pathPrefix: /var/run/dbus/system_bus_socket
   - pathPrefix: /lib/modules
   - pathPrefix: /var/lib/kube-proxy
+  allowedCapabilities:
+  - NET_ADMIN
   runAsUser:
     rule: 'RunAsAny'
   seLinux:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind regression
/priority critical

**What this PR does / why we need it**:
#3395 introduced a regression that prevents `kube-proxy` pods from being created in case `spec.kubernetes.allowPrivilegedContainers=false`:

```
 Warning  FailedCreate  18s (x6 over 59s)  daemonset-controller  Error creating: pods "kube-proxy-" is forbidden: PodSecurityPolicy: unable to admit pod: [spec.securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used spec.volumes[2]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[3]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[4]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[6]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[7]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.initContainers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed spec.containers[0].hostPort: Invalid value: 10249: Host port 10249 is not allowed to be used. Allowed ports: [] spec.containers[1].securityContext.capabilities.add: Invalid value: "NET_ADMIN": capability may not be added spec.containers[1].securityContext.capabilities.add: Invalid value: "NET_ADMIN": capability may not be added]
```

This PR adds `NET_ADMIN` to the allowed capabilities in kube-proxy's `PodSecurityPolicy`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed that prevented shoot clusters from coming up in case `.spec.kubernetes.allowPrivilegedContainers=false`.
```
