### PR TITLE
Add disruptive testsdefinition and flag rotate test as disruptive

### DIFF
--- a/.test-defs/TestSuiteShootBetaDisruptive.yaml
+++ b/.test-defs/TestSuiteShootBetaDisruptive.yaml
@@ -1,14 +1,14 @@
 kind: TestDefinition
 metadata:
-  name: shoot-release-serial-test-suite
+  name: shoot-beta-disruptive-test-suite
 spec:
   owner: gardener-oq@listserv.sap.com
-  description: shoot test suites that includes all serial release tests
+  description: shoot test suites that includes all disruptive beta tests
 
   activeDeadlineSeconds: 7200
-  labels: ["shoot", "release"]
+  labels: ["shoot", "beta"]
   behavior:
-  - serial
+  - disruptive
 
   command: [bash, -c]
   args:
@@ -20,7 +20,7 @@ spec:
       -shoot-name=$SHOOT_NAME
       -project-namespace=$PROJECT_NAMESPACE
       -fenced=$FENCED
-      -ginkgo.focus="\[RELEASE\].*\[SERIAL\]"
-      -ginkgo.skip="\[DISRUPTIVE\]"
+      -ginkgo.focus="\[BETA\].*\[DISRUPTIVE\]"
+      -ginkgo.skip="\[SERIAL\]"
 
   image: golang:1.15.3

--- a/.test-defs/TestSuiteShootDefaultDisruptive.yaml
+++ b/.test-defs/TestSuiteShootDefaultDisruptive.yaml
@@ -1,14 +1,14 @@
 kind: TestDefinition
 metadata:
-  name: shoot-release-serial-test-suite
+  name: shoot-default-disruptive-test-suite
 spec:
   owner: gardener-oq@listserv.sap.com
-  description: shoot test suites that includes all serial release tests
+  description: shoot test suites that includes all disruptive default tests
 
   activeDeadlineSeconds: 7200
-  labels: ["shoot", "release"]
+  labels: ["shoot", "default"]
   behavior:
-  - serial
+  - disruptive
 
   command: [bash, -c]
   args:
@@ -20,7 +20,7 @@ spec:
       -shoot-name=$SHOOT_NAME
       -project-namespace=$PROJECT_NAMESPACE
       -fenced=$FENCED
-      -ginkgo.focus="\[RELEASE\].*\[SERIAL\]"
-      -ginkgo.skip="\[DISRUPTIVE\]"
+      -ginkgo.focus="\[DEFAULT\].*\[DISRUPTIVE\]"
+      -ginkgo.skip="\[SERIAL\]"
 
   image: golang:1.15.3

--- a/.test-defs/TestSuiteShootReleaseDisruptive.yaml
+++ b/.test-defs/TestSuiteShootReleaseDisruptive.yaml
@@ -1,14 +1,14 @@
 kind: TestDefinition
 metadata:
-  name: shoot-release-serial-test-suite
+  name: shoot-release-disruptive-test-suite
 spec:
   owner: gardener-oq@listserv.sap.com
-  description: shoot test suites that includes all serial release tests
+  description: shoot test suites that includes all disruptive release tests
 
   activeDeadlineSeconds: 7200
   labels: ["shoot", "release"]
   behavior:
-  - serial
+  - disruptive
 
   command: [bash, -c]
   args:
@@ -20,7 +20,7 @@ spec:
       -shoot-name=$SHOOT_NAME
       -project-namespace=$PROJECT_NAMESPACE
       -fenced=$FENCED
-      -ginkgo.focus="\[RELEASE\].*\[SERIAL\]"
-      -ginkgo.skip="\[DISRUPTIVE\]"
+      -ginkgo.focus="\[RELEASE\].*\[DISRUPTIVE\]"
+      -ginkgo.skip="\[SERIAL\]"
 
   image: golang:1.15.3

--- a/test/framework/test_description.go
+++ b/test/framework/test_description.go
@@ -56,7 +56,7 @@ func (t TestDescription) Serial() TestDescription {
 }
 
 // Disruptive labels a test as disruptive.
-// Tis kind of test should not run on a productive landscape.
+// This kind of test should run with care.
 func (t TestDescription) Disruptive() TestDescription {
 	return t.newLabel("DISRUPTIVE")
 }

--- a/test/integration/shoots/operations/operations.go
+++ b/test/integration/shoots/operations/operations.go
@@ -108,7 +108,7 @@ var _ = ginkgo.Describe("Shoot operation testing", func() {
 		framework.ExpectNoError(err)
 	}, reconcileTimeout)
 
-	f.Beta().Serial().CIt("should rotate the kubeconfig for a shoot cluster", func(ctx context.Context) {
+	f.Beta().Disruptive().CIt("should rotate the kubeconfig for a shoot cluster", func(ctx context.Context) {
 		ginkgo.By("rotate kubeconfig")
 		var (
 			secretName = f.Shoot.Name + ".kubeconfig"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test
/priority normal

**What this PR does / why we need it**:

A new testsuite is introduced that contains disruptive tests.
Disruptive tests are special kind of test that may break something if the test is not successfully finished.
The TestDefinitions are labeled `disruptive` so that the testmachinery can act accordingly.

With that change, also the kubeconfig rotate test is updated to be of kind disruptive.
With that the previous issues with the test to update the kubeconfig in the testmachinery is fixed.

When the test works as expected we can also promote it again to the `default` test group.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
TestDefinitions have been added that contains disruptive tests
```
