### PR TITLE
Enhance webhook constraints checks

### DIFF
--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -49,16 +49,45 @@ Let's check the following example to get better understanding. Let's say that th
 ### Constraints
 
 Constraints represent conditions of a Shoot’s current state that constraint some operations on it.
-
 Currently there are two constraints:
 
-- `HibernationPossible`
+**`HibernationPossible`**:
 
-  This constraint indicates whether a Shoot is allowed to be hibernated. The rationale behind this constraint is that a Shoot can have `ValidatingWebhookConfiguration`s or `MutatingWebhookConfiguration`s with rules for CREATE Pods or Nodes and `failurePolicy=Fail`. Such webhooks are preventing wake up for a Shoot cluster as new Nodes cannot be created or new system component Pods cannot be created because the webhook is not running. To prevent such deadlock situation, the gardener-apiserver does not allow Shoot to be hibernated when the `HibernationPossible` has status `False`.
+This constraint indicates whether a Shoot is allowed to be hibernated.
+The rationale behind this constraint is that a Shoot can have `ValidatingWebhookConfiguration`s or `MutatingWebhookConfiguration`s acting on resources that are critical for waking up a cluster.
+For example, if a webhook has rules for `CREATE/UPDATE` Pods or Nodes and `failurePolicy=Fail`, the webhook will block joining `Nodes` and creating critical system component Pods and thus block the entire wakeup
+operation, because the server backing the webhook is not running.
 
-- `MaintenancePreconditionsSatisfied`
+Even if the `failurePolicy` is set to `Ignore`, high timeouts (`>15s`) can lead to blocking requests of control plane components.
+That's because most control-plane API calls are made with a client-side timeout of `30s`, so if a webhook has `timeoutSeconds=30`
+the overall request might still fail as there is overhead in communication with the API server and potential other webhooks.
+Generally, it's [best pratice](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts)
+to specify low timeouts in WebhookConfigs.
+Also, it's [best practice](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#avoiding-operating-on-the-kube-system-namespace)
+to exclude the `kube-system` namespace from webhooks to avoid blocking critical operations on system components of the cluster.
+Shoot owners can do so by adding a `namespaceSelector` similar to this one to their webhook configurations:
+```yaml
+namespaceSelector:
+  matchExpressions:
+  - key: gardener.cloud/purpose
+    operator: NotIn
+    values:
+    - kube-system
+```
 
-  This constraint indicates whether all preconditions for a safe maintenance operation are satisfied (see also [this document](shoot_maintenance.md) for more information about what happens during a shoot maintenance). As of today, the same checks as in the `HibernationPossible` constraint are being performed (user-deployed webhooks that might interfere with potential rolling updates of shoot worker nodes). There is no further action being performed on this constraint's status (maintenance is still being performed). It is meant to make the user aware of potential problems that might occur due to his configurations. 
+If the Shoot still has webhooks with either `failurePolicy={Fail,nil}` or `failurePolicy=Ignore && timeoutSeconds>15` that
+act on [critical resources](https://github.com/gardener/gardener/blob/master/pkg/operation/botanist/matchers/matcher.go#L60)
+in the `kube-system` namespace, Gardener will set the `HibernationPossible` to `False` indicating, that the Shoot can
+probably not be woken up again after hibernation without manual intervention of the Gardener Operator.
+`gardener-apiserver` will prevent any Shoot with the `HibernationPossible` constraint set to `False` from being hibernated,
+that is via manual hibernation as well as scheduled hibernation.
+
+**`MaintenancePreconditionsSatisfied`**:
+  
+This constraint indicates whether all preconditions for a safe maintenance operation are satisfied (see also [this document](shoot_maintenance.md) for more information about what happens during a shoot maintenance).
+As of today, the same checks as in the `HibernationPossible` constraint are being performed (user-deployed webhooks that might interfere with potential rolling updates of shoot worker nodes).
+There is no further action being performed on this constraint's status (maintenance is still being performed).
+It is meant to make the user aware of potential problems that might occur due to his configurations. 
 
 ### Last Operation
 

--- a/pkg/operation/botanist/matchers/matcher.go
+++ b/pkg/operation/botanist/matchers/matcher.go
@@ -48,7 +48,6 @@ import (
 var (
 	kubeSystemLabels = labels.Set{
 		common.ShootNoCleanup:            "true",
-		v1beta1constants.LabelRole:       metav1.NamespaceSystem,
 		v1beta1constants.GardenerPurpose: metav1.NamespaceSystem,
 	}
 	podsLabels = labels.Set{
@@ -60,9 +59,10 @@ var (
 	WebhookConstraintMatchers = []WebhookConstraintMatcher{
 		{GVR: corev1.SchemeGroupVersion.WithResource("pods"), NamespaceLabels: kubeSystemLabels, ObjectLabels: podsLabels},
 		{GVR: corev1.SchemeGroupVersion.WithResource("pods"), NamespaceLabels: kubeSystemLabels, ObjectLabels: podsLabels, Subresource: "status"},
-		{GVR: corev1.SchemeGroupVersion.WithResource("configmaps"), NamespaceLabels: kubeSystemLabels},
 
-		// kube-system and default namespaces for apiserver in-cluster discovery.
+		// leader election of kube-controller-manager, kube-scheduler, cloud-controller-manager, cluster-autoscaler, ...
+		{GVR: corev1.SchemeGroupVersion.WithResource("configmaps"), NamespaceLabels: kubeSystemLabels},
+		// kube-system and default namespaces for leader election and apiserver in-cluster discovery.
 		{GVR: corev1.SchemeGroupVersion.WithResource("endpoints")},
 
 		{GVR: corev1.SchemeGroupVersion.WithResource("secrets"), NamespaceLabels: kubeSystemLabels},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality ops-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:

This PR enhances the webhook constraints checks in the following ways:
- webhooks with `FailurePolicy=Ignore` but `TimeoutSeconds>15` are now also marked as problematic (long timeouts are discouraged by the [k8s documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts) and can cause problems on wakeup as well
- webhooks that act on `configmaps` in the `kube-system` namespace are now also marked as problematic (older versions of k8s control plane components used leader election via `configmaps`)
- the webhook matchers assumed a label `role=kube-system` on the `kube-system` namespace for shoots, although there is no such label, [ref](https://github.com/gardener/gardener/blob/3a403423130b8a52028b94ef756d97afa4963089/pkg/operation/botanist/systemcomponents/namespaces/namespaces.go#L82), that assumption is corrected

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Webhooks acting on `configmaps` in the `kube-system` namespace and webhooks with a `TimeoutSeconds>15` for problematic resources are now also blocking `Maintenance` and `Hibernation` operations. Please consult [this doc](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_status.md#constraints) for more details.
```
