### PR TITLE
[GEP-13] Add ManagedSeed validation

### DIFF
--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -143,7 +143,7 @@ func run(ctx context.Context, o *Options) error {
 			return fmt.Errorf("unable to read the configuration file: %v", err)
 		}
 
-		if errs := configvalidation.ValidateGardenletConfiguration(c); len(errs) > 0 {
+		if errs := configvalidation.ValidateGardenletConfiguration(c, nil); len(errs) > 0 {
 			return fmt.Errorf("errors validating the configuration: %+v", errs)
 		}
 

--- a/pkg/apis/seedmanagement/validation/managedseed.go
+++ b/pkg/apis/seedmanagement/validation/managedseed.go
@@ -1,0 +1,327 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"fmt"
+
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	corevalidation "github.com/gardener/gardener/pkg/apis/core/validation"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement/helper"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	configvalidation "github.com/gardener/gardener/pkg/gardenlet/apis/config/validation"
+	"github.com/gardener/gardener/pkg/utils"
+
+	corev1 "k8s.io/api/core/v1"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateManagedSeed validates a ManagedSeed object.
+func ValidateManagedSeed(managedSeed *seedmanagement.ManagedSeed) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Ensure namespace is garden
+	if managedSeed.Namespace != v1beta1constants.GardenNamespace {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "namespace"), managedSeed.Namespace, "namespace must be garden"))
+	}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&managedSeed.ObjectMeta, true, corevalidation.ValidateName, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateManagedSeedSpec(&managedSeed.Spec, field.NewPath("spec"))...)
+
+	return allErrs
+}
+
+// ValidateManagedSeedUpdate validates a ManagedSeed object before an update.
+func ValidateManagedSeedUpdate(newManagedSeed, oldManagedSeed *seedmanagement.ManagedSeed) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newManagedSeed.ObjectMeta, &oldManagedSeed.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateManagedSeedSpecUpdate(&newManagedSeed.Spec, &oldManagedSeed.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateManagedSeed(newManagedSeed)...)
+
+	return allErrs
+}
+
+// ValidateManagedSeedSpec validates the specification of a ManagedSeed object.
+func ValidateManagedSeedSpec(spec *seedmanagement.ManagedSeedSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Ensure shoot name is specified
+	if spec.Shoot.Name == "" {
+		allErrs = append(allErrs, field.Required(fldPath.Child("shoot", "name"), "shoot name is required"))
+	}
+
+	// Ensure either seed template or gardenlet is specified
+	if (spec.SeedTemplate == nil && spec.Gardenlet == nil) || (spec.SeedTemplate != nil && spec.Gardenlet != nil) {
+		allErrs = append(allErrs, field.Invalid(fldPath, spec, "either seed template or gardenlet is required"))
+	}
+
+	switch {
+	case spec.SeedTemplate != nil:
+		allErrs = append(allErrs, validateSeedTemplate(spec.SeedTemplate, fldPath.Child("seedTemplate"))...)
+	case spec.Gardenlet != nil:
+		allErrs = append(allErrs, validateGardenlet(spec.Gardenlet, fldPath.Child("gardenlet"))...)
+	}
+
+	return allErrs
+}
+
+// ValidateManagedSeedSpecUpdate validates the specification updates of a ManagedSeed object.
+func ValidateManagedSeedSpecUpdate(newSpec, oldSpec *seedmanagement.ManagedSeedSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Ensure shoot name is not changed
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Shoot.Name, oldSpec.Shoot.Name, fldPath.Child("shoot", "name"))...)
+
+	// Ensure no changing from seed template to gardenlet or vice versa takes place
+	if (newSpec.SeedTemplate != nil) != (oldSpec.SeedTemplate != nil) || (newSpec.Gardenlet != nil) != (oldSpec.Gardenlet != nil) {
+		allErrs = append(allErrs, field.Invalid(fldPath, newSpec, "changing from seed template to gardenlet and vice versa is not allowed"))
+	}
+
+	switch {
+	case newSpec.SeedTemplate != nil && oldSpec.SeedTemplate != nil:
+		allErrs = append(allErrs, validateSeedTemplateUpdate(newSpec.SeedTemplate, oldSpec.SeedTemplate, fldPath.Child("seedTemplate"))...)
+	case newSpec.Gardenlet != nil && oldSpec.Gardenlet != nil:
+		allErrs = append(allErrs, validateGardenletUpdate(newSpec.Gardenlet, oldSpec.Gardenlet, fldPath.Child("gardenlet"))...)
+	}
+
+	return allErrs
+}
+
+func validateSeedTemplate(seedTemplate *seedmanagement.SeedTemplate, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Validate labels, annotations, and spec
+	allErrs = append(allErrs, metav1validation.ValidateLabels(seedTemplate.Labels, fldPath.Child("metadata", "labels"))...)
+	allErrs = append(allErrs, apivalidation.ValidateAnnotations(seedTemplate.Annotations, fldPath.Child("metadata", "annotations"))...)
+	allErrs = append(allErrs, corevalidation.ValidateSeedSpec(&seedTemplate.Spec, fldPath.Child("spec"))...)
+
+	return allErrs
+}
+
+func validateSeedTemplateUpdate(newSeedTemplate, oldSeedTemplate *seedmanagement.SeedTemplate, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, corevalidation.ValidateSeedSpecUpdate(&newSeedTemplate.Spec, &oldSeedTemplate.Spec, fldPath.Child("spec"))...)
+
+	return allErrs
+}
+
+func validateGardenlet(gardenlet *seedmanagement.Gardenlet, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if gardenlet.Deployment != nil {
+		allErrs = append(allErrs, validateGardenletDeployment(gardenlet.Deployment, fldPath.Child("deployment"))...)
+	}
+
+	if gardenlet.Config != nil {
+		configPath := fldPath.Child("config")
+
+		// Convert gardenlet config to an internal version
+		gardenletConfig, err := helper.ConvertGardenletConfig(gardenlet.Config)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(configPath, gardenlet.Config, fmt.Sprintf("could not convert gardenlet config: %v", err)))
+			return allErrs
+		}
+
+		// Validate gardenlet config
+		allErrs = append(allErrs, validateGardenletConfiguration(gardenletConfig, helper.GetBootstrap(gardenlet.Bootstrap), utils.IsTrue(gardenlet.MergeWithParent), configPath)...)
+	}
+
+	if gardenlet.Bootstrap != nil {
+		validValues := []string{string(seedmanagement.BootstrapServiceAccount), string(seedmanagement.BootstrapToken), string(seedmanagement.BootstrapNone)}
+		if !utils.ValueExists(string(*gardenlet.Bootstrap), validValues) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("bootstrap"), *gardenlet.Bootstrap, validValues))
+		}
+	}
+
+	return allErrs
+}
+
+func validateGardenletUpdate(newGardenlet, oldGardenlet *seedmanagement.Gardenlet, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if newGardenlet.Config != nil && oldGardenlet.Config != nil {
+		configPath := fldPath.Child("config")
+
+		// Convert new gardenlet config to an internal version
+		newGardenletConfig, err := helper.ConvertGardenletConfig(newGardenlet.Config)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(configPath, newGardenlet.Config, fmt.Sprintf("could not convert gardenlet config: %v", err)))
+			return allErrs
+		}
+
+		// Convert old gardenlet config to an internal version
+		oldGardenletConfig, err := helper.ConvertGardenletConfig(oldGardenlet.Config)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(configPath, oldGardenlet.Config, fmt.Sprintf("could not convert gardenlet config: %v", err)))
+			return allErrs
+		}
+
+		// Validate gardenlet config update
+		allErrs = append(allErrs, validateGardenletConfigurationUpdate(newGardenletConfig, oldGardenletConfig, configPath)...)
+	}
+
+	// Ensure bootstrap is not changed
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newGardenlet.Bootstrap, oldGardenlet.Bootstrap, fldPath.Child("bootstrap"))...)
+
+	// Ensure merge with parent is not changed
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newGardenlet.MergeWithParent, oldGardenlet.MergeWithParent, fldPath.Child("mergeWithParent"))...)
+
+	return allErrs
+}
+
+func validateGardenletDeployment(deployment *seedmanagement.GardenletDeployment, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if deployment.ReplicaCount != nil {
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*deployment.ReplicaCount), fldPath.Child("replicaCount"))...)
+	}
+	if deployment.RevisionHistoryLimit != nil {
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*deployment.RevisionHistoryLimit), fldPath.Child("revisionHistoryLimit"))...)
+	}
+
+	if deployment.Image != nil {
+		allErrs = append(allErrs, validateImage(deployment.Image, fldPath.Child("image"))...)
+	}
+
+	allErrs = append(allErrs, metav1validation.ValidateLabels(deployment.PodLabels, fldPath.Child("podLabels"))...)
+	allErrs = append(allErrs, apivalidation.ValidateAnnotations(deployment.PodAnnotations, fldPath.Child("podAnnotations"))...)
+
+	return allErrs
+}
+
+func validateImage(image *seedmanagement.Image, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if image.PullPolicy != nil {
+		validValues := []string{string(corev1.PullAlways), string(corev1.PullIfNotPresent), string(corev1.PullNever)}
+		if !utils.ValueExists(string(*image.PullPolicy), validValues) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("pullPolicy"), *image.PullPolicy, validValues))
+		}
+	}
+
+	return allErrs
+}
+
+func validateGardenletConfiguration(gardenletConfig *config.GardenletConfiguration, bootstrap seedmanagement.Bootstrap, mergeWithParent bool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Ensure seed selector is not specified
+	if gardenletConfig.SeedSelector != nil {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("seedSelector"), "seed selector is forbidden"))
+	}
+
+	// Validate gardenlet config
+	allErrs = append(allErrs, configvalidation.ValidateGardenletConfiguration(gardenletConfig, fldPath)...)
+
+	if gardenletConfig.SeedConfig != nil {
+		seedConfigPath := fldPath.Child("seedConfig")
+
+		// Convert seed to internal version
+		seed, err := helper.ConvertSeed(&gardenletConfig.SeedConfig.Seed)
+		if err != nil {
+			allErrs = append(allErrs, field.InternalError(seedConfigPath, fmt.Errorf("could not convert seed config: %v", err)))
+			return allErrs
+		}
+
+		// Validate seed
+		allErrs = append(allErrs, validateSeed(seed, seedConfigPath)...)
+	}
+
+	if gardenletConfig.GardenClientConnection != nil {
+		allErrs = append(allErrs, validateGardenClientConnection(gardenletConfig.GardenClientConnection, bootstrap, mergeWithParent, fldPath.Child("gardenClientConnection"))...)
+	}
+
+	return allErrs
+}
+
+func validateGardenletConfigurationUpdate(newGardenletConfig, oldGardenletConfig *config.GardenletConfiguration, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if newGardenletConfig.SeedConfig != nil && oldGardenletConfig != nil {
+		seedConfigPath := fldPath.Child("seedConfig")
+
+		// Convert new seed to internal version
+		newSeed, err := helper.ConvertSeed(&newGardenletConfig.SeedConfig.Seed)
+		if err != nil {
+			allErrs = append(allErrs, field.InternalError(seedConfigPath, fmt.Errorf("could not convert seed config: %v", err)))
+			return allErrs
+		}
+
+		// Convert old seed to internal version
+		oldSeed, err := helper.ConvertSeed(&oldGardenletConfig.SeedConfig.Seed)
+		if err != nil {
+			allErrs = append(allErrs, field.InternalError(seedConfigPath, fmt.Errorf("could not convert seed config: %v", err)))
+			return allErrs
+		}
+
+		// Validate seed
+		allErrs = append(allErrs, validateSeedUpdate(newSeed, oldSeed, seedConfigPath)...)
+	}
+
+	return allErrs
+}
+
+func validateSeed(seed *gardencore.Seed, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Ensure name is not specified since it will be set by the controller
+	if seed.Name != "" {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("metadata", "name"), "seed name is forbidden"))
+	}
+
+	// Validate labels, annotations, and spec
+	allErrs = append(allErrs, metav1validation.ValidateLabels(seed.Labels, fldPath.Child("metadata", "labels"))...)
+	allErrs = append(allErrs, apivalidation.ValidateAnnotations(seed.Annotations, fldPath.Child("metadata", "annotations"))...)
+	allErrs = append(allErrs, corevalidation.ValidateSeedSpec(&seed.Spec, fldPath.Child("spec"))...)
+
+	return allErrs
+}
+
+func validateSeedUpdate(newSeed, oldSeed *gardencore.Seed, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, corevalidation.ValidateSeedSpecUpdate(&newSeed.Spec, &oldSeed.Spec, fldPath.Child("spec"))...)
+
+	return allErrs
+}
+
+func validateGardenClientConnection(gcc *config.GardenClientConnection, bootstrap seedmanagement.Bootstrap, mergeWithParent bool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	switch bootstrap {
+	case seedmanagement.BootstrapServiceAccount, seedmanagement.BootstrapToken:
+		if gcc.Kubeconfig != "" {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("kubeconfig"), "kubeconfig is forbidden if bootstrap is specified"))
+		}
+	case seedmanagement.BootstrapNone:
+		if gcc.Kubeconfig == "" && !mergeWithParent {
+			allErrs = append(allErrs, field.Required(fldPath.Child("kubeconfig"), "kubeconfig is required if bootstrap is not specified and merging with parent is disabled"))
+		}
+		if gcc.BootstrapKubeconfig != nil {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("bootstrapKubeconfig"), "bootstrap kubeconfig is forbidden if bootstrap is not specified"))
+		}
+		if gcc.KubeconfigSecret != nil {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("kubeconfigSecret"), "kubeconfig secret is forbidden if bootstrap is not specified"))
+		}
+	}
+
+	return allErrs
+}

--- a/pkg/apis/seedmanagement/validation/managedseed_test.go
+++ b/pkg/apis/seedmanagement/validation/managedseed_test.go
@@ -1,0 +1,477 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation_test
+
+import (
+	"k8s.io/component-base/config/v1alpha1"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement/helper"
+	. "github.com/gardener/gardener/pkg/apis/seedmanagement/validation"
+	configv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	name      = "test"
+	namespace = "garden"
+)
+
+var _ = Describe("ManagedSeed Validation Tests", func() {
+	var (
+		seed = &core.Seed{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+			},
+			Spec: core.SeedSpec{
+				Backup: &core.SeedBackup{
+					Provider: "foo",
+					Region:   pointer.StringPtr("some-region"),
+					SecretRef: corev1.SecretReference{
+						Name:      "backup-test",
+						Namespace: "garden",
+					},
+				},
+				DNS: core.SeedDNS{
+					IngressDomain: pointer.StringPtr("ingress.test.example.com"),
+				},
+				Networks: core.SeedNetworks{
+					Nodes:    pointer.StringPtr("10.250.0.0/16"),
+					Pods:     "100.96.0.0/11",
+					Services: "100.64.0.0/13",
+					ShootDefaults: &core.ShootNetworks{
+						Pods:     pointer.StringPtr("10.240.0.0/16"),
+						Services: pointer.StringPtr("10.241.0.0/16"),
+					},
+				},
+				Provider: core.SeedProvider{
+					Type:   "foo",
+					Region: "some-region",
+				},
+				SecretRef: &corev1.SecretReference{
+					Name:      "seed-test",
+					Namespace: "garden",
+				},
+				Taints: []core.SeedTaint{
+					{Key: "foo"},
+				},
+			},
+		}
+
+		managedSeed *seedmanagement.ManagedSeed
+	)
+
+	BeforeEach(func() {
+		managedSeed = &seedmanagement.ManagedSeed{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: seedmanagement.ManagedSeedSpec{
+				Shoot: seedmanagement.Shoot{
+					Name: name,
+				},
+				SeedTemplate: &seedmanagement.SeedTemplate{
+					ObjectMeta: seed.ObjectMeta,
+					Spec:       seed.Spec,
+				},
+			},
+		}
+	})
+
+	Describe("#ValidateManagedSeed", func() {
+		It("should forbid empty metadata", func() {
+			managedSeed.ObjectMeta = metav1.ObjectMeta{}
+
+			errorList := ValidateManagedSeed(managedSeed)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("metadata.name"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("metadata.namespace"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("metadata.namespace"),
+				})),
+			))
+		})
+
+		It("should forbid namespace different from garden", func() {
+			managedSeed.Namespace = "foo"
+
+			errorList := ValidateManagedSeed(managedSeed)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("metadata.namespace"),
+				})),
+			))
+		})
+
+		It("should forbid empty shoot name", func() {
+			managedSeed.Spec.Shoot.Name = ""
+
+			errorList := ValidateManagedSeed(managedSeed)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.shoot.name"),
+				})),
+			))
+		})
+
+		It("should forbid both seed template and gardenlet", func() {
+			managedSeed.Spec.Gardenlet = &seedmanagement.Gardenlet{}
+
+			errorList := ValidateManagedSeed(managedSeed)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec"),
+				})),
+			))
+		})
+
+		Context("seed template", func() {
+			It("should allow valid resources", func() {
+				errorList := ValidateManagedSeed(managedSeed)
+
+				Expect(errorList).To(HaveLen(0))
+			})
+
+			It("should forbid empty or invalid fields in seed template", func() {
+				seedCopy := seed.DeepCopy()
+				seedCopy.Spec.Provider.Type = ""
+				managedSeed.Spec.SeedTemplate.Spec = seedCopy.Spec
+
+				errorList := ValidateManagedSeed(managedSeed)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.seedTemplate.spec.provider.type"),
+					})),
+				))
+			})
+		})
+
+		Context("gardenlet", func() {
+			var (
+				seedx *gardencorev1beta1.Seed
+				err   error
+			)
+
+			BeforeEach(func() {
+				seedx, err = helper.ConvertSeedExternal(seed)
+				Expect(err).NotTo(HaveOccurred())
+
+				managedSeed.Spec.SeedTemplate = nil
+				managedSeed.Spec.Gardenlet = &seedmanagement.Gardenlet{
+					Deployment: &seedmanagement.GardenletDeployment{
+						Image: &seedmanagement.Image{
+							PullPolicy: pullPolicyPtr(corev1.PullIfNotPresent),
+						},
+					},
+					Config:          gardenletConfiguration(seedx, nil),
+					Bootstrap:       bootstrapPtr(seedmanagement.BootstrapToken),
+					MergeWithParent: pointer.BoolPtr(true),
+				}
+			})
+
+			It("should allow valid resources", func() {
+				errorList := ValidateManagedSeed(managedSeed)
+
+				Expect(errorList).To(HaveLen(0))
+			})
+
+			It("should forbid empty or invalid fields in gardenlet", func() {
+				seedxCopy := seedx.DeepCopy()
+				seedxCopy.Name = "foo"
+				seedxCopy.Spec.Provider.Type = ""
+
+				managedSeed.Spec.Gardenlet.Deployment = &seedmanagement.GardenletDeployment{
+					ReplicaCount:         pointer.Int32Ptr(-1),
+					RevisionHistoryLimit: pointer.Int32Ptr(-1),
+					Image: &seedmanagement.Image{
+						PullPolicy: pullPolicyPtr("foo"),
+					},
+					PodLabels:      map[string]string{"foo!": "bar"},
+					PodAnnotations: map[string]string{"bar@": "baz"},
+				}
+				managedSeed.Spec.Gardenlet.Config = gardenletConfiguration(seedxCopy, nil)
+				managedSeed.Spec.Gardenlet.Bootstrap = bootstrapPtr("foo")
+
+				errorList := ValidateManagedSeed(managedSeed)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.gardenlet.deployment.replicaCount"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.gardenlet.deployment.revisionHistoryLimit"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeNotSupported),
+						"Field": Equal("spec.gardenlet.deployment.image.pullPolicy"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.gardenlet.deployment.podLabels"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.gardenlet.deployment.podAnnotations"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeForbidden),
+						"Field": Equal("spec.gardenlet.config.seedConfig.metadata.name"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.gardenlet.config.seedConfig.spec.provider.type"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeNotSupported),
+						"Field": Equal("spec.gardenlet.bootstrap"),
+					})),
+				))
+			})
+
+			It("should forbid garden client connection kubeconfig if bootstrap is specified", func() {
+				managedSeed.Spec.Gardenlet.Config = gardenletConfiguration(seedx,
+					&configv1alpha1.GardenClientConnection{
+						ClientConnectionConfiguration: v1alpha1.ClientConnectionConfiguration{
+							Kubeconfig: "foo",
+						},
+					})
+
+				errorList := ValidateManagedSeed(managedSeed)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeForbidden),
+						"Field": Equal("spec.gardenlet.config.gardenClientConnection.kubeconfig"),
+					})),
+				))
+			})
+
+			It("should forbid garden client connection bootstrap kubeconfig and kubeconfig secret if bootstrap is not specified", func() {
+				managedSeed.Spec.Gardenlet.Config = gardenletConfiguration(seedx,
+					&configv1alpha1.GardenClientConnection{
+						BootstrapKubeconfig: &corev1.SecretReference{
+							Name:      name,
+							Namespace: namespace,
+						},
+						KubeconfigSecret: &corev1.SecretReference{
+							Name:      name,
+							Namespace: namespace,
+						},
+					})
+				managedSeed.Spec.Gardenlet.Bootstrap = bootstrapPtr(seedmanagement.BootstrapNone)
+				managedSeed.Spec.Gardenlet.MergeWithParent = pointer.BoolPtr(false)
+
+				errorList := ValidateManagedSeed(managedSeed)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.gardenlet.config.gardenClientConnection.kubeconfig"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeForbidden),
+						"Field": Equal("spec.gardenlet.config.gardenClientConnection.bootstrapKubeconfig"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeForbidden),
+						"Field": Equal("spec.gardenlet.config.gardenClientConnection.kubeconfigSecret"),
+					})),
+				))
+			})
+		})
+	})
+
+	Describe("#ValidateManagedSeedUpdate", func() {
+		var (
+			newManagedSeed *seedmanagement.ManagedSeed
+		)
+
+		BeforeEach(func() {
+			newManagedSeed = managedSeed.DeepCopy()
+			newManagedSeed.ResourceVersion = "1"
+		})
+
+		It("should forbid changes to immutable metadata fields", func() {
+			newManagedSeed.Name = name + "x"
+
+			errorList := ValidateManagedSeedUpdate(newManagedSeed, managedSeed)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("metadata.name"),
+					"Detail": Equal("field is immutable"),
+				})),
+			))
+		})
+
+		It("should forbid changing the shoot name", func() {
+			newManagedSeed.Spec.Shoot.Name = name + "x"
+
+			errorList := ValidateManagedSeedUpdate(newManagedSeed, managedSeed)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.shoot.name"),
+					"Detail": Equal("field is immutable"),
+				})),
+			))
+		})
+
+		It("should forbid changing from seed template to gardenlet", func() {
+			newManagedSeed.Spec.SeedTemplate = nil
+			newManagedSeed.Spec.Gardenlet = &seedmanagement.Gardenlet{}
+
+			errorList := ValidateManagedSeedUpdate(newManagedSeed, managedSeed)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec"),
+					"Detail": Equal("changing from seed template to gardenlet and vice versa is not allowed"),
+				})),
+			))
+		})
+
+		Context("seed template", func() {
+			It("should allow valid updates", func() {
+				errorList := ValidateManagedSeedUpdate(newManagedSeed, managedSeed)
+
+				Expect(errorList).To(HaveLen(0))
+			})
+
+			It("should forbid changes to immutable fields in seed template", func() {
+				seedCopy := seed.DeepCopy()
+				seedCopy.Spec.Backup.Provider = "bar"
+				newManagedSeed.Spec.SeedTemplate.Spec = seedCopy.Spec
+
+				errorList := ValidateManagedSeedUpdate(newManagedSeed, managedSeed)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.seedTemplate.spec.backup.provider"),
+						"Detail": Equal("field is immutable"),
+					})),
+				))
+			})
+		})
+
+		Context("gardenlet", func() {
+			var (
+				seedx *gardencorev1beta1.Seed
+				err   error
+			)
+
+			BeforeEach(func() {
+				seedx, err = helper.ConvertSeedExternal(seed)
+				Expect(err).NotTo(HaveOccurred())
+
+				managedSeed.Spec.SeedTemplate = nil
+				managedSeed.Spec.Gardenlet = &seedmanagement.Gardenlet{
+					Config:          gardenletConfiguration(seedx, nil),
+					Bootstrap:       bootstrapPtr(seedmanagement.BootstrapToken),
+					MergeWithParent: pointer.BoolPtr(true),
+				}
+
+				newManagedSeed = managedSeed.DeepCopy()
+				newManagedSeed.ResourceVersion = "1"
+			})
+
+			It("should allow valid updates", func() {
+				errorList := ValidateManagedSeedUpdate(newManagedSeed, managedSeed)
+
+				Expect(errorList).To(HaveLen(0))
+			})
+
+			It("should forbid changes to immutable fields in gardenlet", func() {
+				seedxCopy := seedx.DeepCopy()
+				seedxCopy.Spec.Backup.Provider = "bar"
+
+				newManagedSeed.Spec.Gardenlet.Config = gardenletConfiguration(seedxCopy, nil)
+				newManagedSeed.Spec.Gardenlet.Bootstrap = bootstrapPtr(seedmanagement.BootstrapServiceAccount)
+				newManagedSeed.Spec.Gardenlet.MergeWithParent = pointer.BoolPtr(false)
+
+				errorList := ValidateManagedSeedUpdate(newManagedSeed, managedSeed)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.gardenlet.config.seedConfig.spec.backup.provider"),
+						"Detail": Equal("field is immutable"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.gardenlet.bootstrap"),
+						"Detail": Equal("field is immutable"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.gardenlet.mergeWithParent"),
+						"Detail": Equal("field is immutable"),
+					})),
+				))
+			})
+		})
+	})
+})
+
+func gardenletConfiguration(seed *gardencorev1beta1.Seed, gcc *configv1alpha1.GardenClientConnection) *configv1alpha1.GardenletConfiguration {
+	return &configv1alpha1.GardenletConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: configv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "GardenletConfiguration",
+		},
+		SeedConfig: &configv1alpha1.SeedConfig{
+			Seed: *seed,
+		},
+		GardenClientConnection: gcc,
+	}
+}
+
+func pullPolicyPtr(v corev1.PullPolicy) *corev1.PullPolicy { return &v }
+
+func bootstrapPtr(v seedmanagement.Bootstrap) *seedmanagement.Bootstrap { return &v }

--- a/pkg/apis/seedmanagement/validation/validation_suite_test.go
+++ b/pkg/apis/seedmanagement/validation/validation_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SeedManagement API Validation Suite")
+}

--- a/pkg/gardenlet/apis/config/validation/validation.go
+++ b/pkg/gardenlet/apis/config/validation/validation.go
@@ -29,15 +29,15 @@ func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath 
 
 	if cfg.Controllers != nil {
 		if cfg.Controllers.Shoot != nil {
-			allErrs = append(allErrs, ValidateShootControllerConfiguration(cfg.Controllers.Shoot, fieldPath(fldPath, "controllers", "shoot"))...)
+			allErrs = append(allErrs, ValidateShootControllerConfiguration(cfg.Controllers.Shoot, fldPath.Child("controllers", "shoot"))...)
 		}
 	}
 
 	if (cfg.SeedConfig == nil && cfg.SeedSelector == nil) || (cfg.SeedConfig != nil && cfg.SeedSelector != nil) {
-		allErrs = append(allErrs, field.Invalid(fieldPath(fldPath, "seedConfig"), cfg, "either seed config or seed selector is required"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("seedConfig"), cfg, "either seed config or seed selector is required"))
 	}
 
-	serverPath := fieldPath(fldPath, "server")
+	serverPath := fldPath.Child("server")
 	if cfg.Server != nil {
 		if len(cfg.Server.HTTPS.BindAddress) == 0 {
 			allErrs = append(allErrs, field.Required(serverPath.Child("https", "bindAddress"), "bind address is required"))
@@ -47,7 +47,7 @@ func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath 
 		}
 	}
 
-	resourcesPath := field.NewPath("resources")
+	resourcesPath := fldPath.Child("resources")
 	if cfg.Resources != nil {
 		for resourceName, quantity := range cfg.Resources.Capacity {
 			if reservedQuantity, ok := cfg.Resources.Reserved[resourceName]; ok && reservedQuantity.Value() > quantity.Value() {
@@ -96,11 +96,4 @@ func ValidateShootControllerConfiguration(cfg *config.ShootControllerConfigurati
 	}
 
 	return allErrs
-}
-
-func fieldPath(fldPath *field.Path, name string, moreNames ...string) *field.Path {
-	if fldPath != nil {
-		return fldPath.Child(name, moreNames...)
-	}
-	return field.NewPath(name, moreNames...)
 }

--- a/pkg/gardenlet/apis/config/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/validation/validation_test.go
@@ -49,21 +49,6 @@ var _ = Describe("GardenletConfiguration", func() {
 				},
 			},
 			SeedConfig: &config.SeedConfig{},
-			Server: &config.ServerConfiguration{
-				HTTPS: config.HTTPSServer{
-					Server: config.Server{
-						BindAddress: "0.0.0.0",
-						Port:        2720,
-					},
-				},
-			},
-			SNI: &config.SNI{
-				Ingress: &config.SNIIngress{
-					Namespace:   pointer.StringPtr("foo"),
-					Labels:      map[string]string{"baz": "bar"},
-					ServiceName: pointer.StringPtr("waldo"),
-				},
-			},
 			Resources: &config.ResourcesConfiguration{
 				Capacity: corev1.ResourceList{
 					"foo": resource.MustParse("42"),

--- a/pkg/gardenlet/apis/config/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/validation/validation_test.go
@@ -76,9 +76,9 @@ var _ = Describe("GardenletConfiguration", func() {
 		}
 	})
 
-	Describe("#ValidGardenletConfiguration", func() {
+	Describe("#ValidateGardenletConfiguration", func() {
 		It("should allow valid configurations", func() {
-			errorList := ValidateGardenletConfiguration(cfg)
+			errorList := ValidateGardenletConfiguration(cfg, nil)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -92,7 +92,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				cfg.Controllers.Shoot.SyncPeriod = &metav1.Duration{Duration: -1}
 				cfg.Controllers.Shoot.RetryDuration = &metav1.Duration{Duration: -1}
 
-				errorList := ValidateGardenletConfiguration(cfg)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
@@ -117,7 +117,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			It("should forbid too low values for the DNS TTL", func() {
 				cfg.Controllers.Shoot.DNSEntryTTLSeconds = pointer.Int64Ptr(-1)
 
-				errorList := ValidateGardenletConfiguration(cfg)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
@@ -128,7 +128,7 @@ var _ = Describe("GardenletConfiguration", func() {
 			It("should forbid too high values for the DNS TTL", func() {
 				cfg.Controllers.Shoot.DNSEntryTTLSeconds = pointer.Int64Ptr(601)
 
-				errorList := ValidateGardenletConfiguration(cfg)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
@@ -142,11 +142,11 @@ var _ = Describe("GardenletConfiguration", func() {
 				cfg.SeedSelector = nil
 				cfg.SeedConfig = nil
 
-				errorList := ValidateGardenletConfiguration(cfg)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("seedSelector/seedConfig"),
+					"Field": Equal("seedConfig"),
 				}))))
 			})
 
@@ -154,31 +154,20 @@ var _ = Describe("GardenletConfiguration", func() {
 				cfg.SeedSelector = &metav1.LabelSelector{}
 				cfg.SeedConfig = &config.SeedConfig{}
 
-				errorList := ValidateGardenletConfiguration(cfg)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("seedSelector/seedConfig"),
+					"Field": Equal("seedConfig"),
 				}))))
 			})
 		})
 
 		Context("server", func() {
-			It("should forbid not specifying a server configuration", func() {
-				cfg.Server = nil
-
-				errorList := ValidateGardenletConfiguration(cfg)
-
-				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("server"),
-				}))))
-			})
-
 			It("should forbid invalid server configuration", func() {
 				cfg.Server = &config.ServerConfiguration{}
 
-				errorList := ValidateGardenletConfiguration(cfg)
+				errorList := ValidateGardenletConfiguration(cfg, nil)
 
 				Expect(errorList).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
@@ -193,61 +182,6 @@ var _ = Describe("GardenletConfiguration", func() {
 			})
 		})
 
-		It("should forbid not specifying a sni configuration", func() {
-			cfg.SNI = nil
-
-			errorList := ValidateGardenletConfiguration(cfg)
-
-			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("sni"),
-			}))))
-		})
-
-		It("should forbid not specifying a sni ingress configuration", func() {
-			cfg.SNI.Ingress = nil
-
-			errorList := ValidateGardenletConfiguration(cfg)
-
-			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("sni.ingress"),
-			}))))
-		})
-
-		It("should forbid not specifying a sni ingress namespace configuration", func() {
-			cfg.SNI.Ingress.Namespace = pointer.StringPtr("")
-
-			errorList := ValidateGardenletConfiguration(cfg)
-
-			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("sni.ingress.namespace"),
-			}))))
-		})
-
-		It("should forbid not specifying a sni ingress service name configuration", func() {
-			cfg.SNI.Ingress.ServiceName = pointer.StringPtr("")
-
-			errorList := ValidateGardenletConfiguration(cfg)
-
-			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("sni.ingress.serviceName"),
-			}))))
-		})
-
-		It("should forbid not specifying a sni ingress labels configuration", func() {
-			cfg.SNI.Ingress.Labels = nil
-
-			errorList := ValidateGardenletConfiguration(cfg)
-
-			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("sni.ingress.labels"),
-			}))))
-		})
-
 		It("should forbid reserved greater than capacity", func() {
 			cfg.Resources = &config.ResourcesConfiguration{
 				Capacity: corev1.ResourceList{
@@ -258,7 +192,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				},
 			}
 
-			errorList := ValidateGardenletConfiguration(cfg)
+			errorList := ValidateGardenletConfiguration(cfg, nil)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
@@ -273,7 +207,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				},
 			}
 
-			errorList := ValidateGardenletConfiguration(cfg)
+			errorList := ValidateGardenletConfiguration(cfg, nil)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Adds validation for `ManagedSeed` resources.

* `ManagedSeed` validation code
* Changes to the `GardenletConfiguration` validation to ensure that a correct field path is used if it's invoked as part of `ManagedSeed` validation.
* Removed the check that `server` and `sni` (and their optional fields) are specified in `GardenletConfiguration` validation, as this is inconsistent (these fields are optional in the API) and would break the `ManagedSeed` validation unless the user specifies values for all these fields. This was already discussed and agreed upon during the review of #3177.

The new validation code is not testable (except by unit tests), since the `ManagedSeed` resource is not yet registered in the API server. This is on purpose, to make this PR easier to review.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Based on #3412. This is the second of several PRs that are split from #3177 since it became too big and hard to review. Before commenting, please check if the topic has been already discussed in the previous PR.

**Release note**:

```improvement operator
NONE
```