### PR TITLE
[GEP-13] Add ManagedSeed apiserver storage

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/apiservice-v1alpha1-seedmanagement-gardener-cloud.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/apiservice-v1alpha1-seedmanagement-gardener-cloud.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.global.apiserver.enabled }}
+apiVersion: {{ include "apiserviceversion" . }}
+kind: APIService
+metadata:
+  name: v1alpha1.seedmanagement.gardener.cloud
+  labels:
+    app: gardener
+    role: apiserver
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  insecureSkipTLSVerify: {{ .Values.global.apiserver.insecureSkipTLSVerify }}
+  {{- if not .Values.global.apiserver.insecureSkipTLSVerify }}
+  caBundle: {{ required ".Values.global.apiserver.caBundle is required" (b64enc .Values.global.apiserver.caBundle) }}
+  {{- end }}
+  group: seedmanagement.gardener.cloud
+  version: v1alpha1
+  groupPriorityMinimum: {{ required ".Values.global.apiserver.groupPriorityMinimum is required" .Values.global.apiserver.groupPriorityMinimum }}
+  versionPriority: {{ required ".Values.global.apiserver.versionPriority is required" .Values.global.apiserver.versionPriority }}
+  service:
+    name: gardener-apiserver
+    namespace: garden
+{{- end }}

--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -24,6 +24,7 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	settingsv1alpha1 "github.com/gardener/gardener/pkg/apis/settings/v1alpha1"
 	"github.com/gardener/gardener/pkg/apiserver"
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
@@ -33,6 +34,8 @@ import (
 	gardenexternalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	clientkubernetes "github.com/gardener/gardener/pkg/client/kubernetes"
+	seedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
+	seedmanagementinformer "github.com/gardener/gardener/pkg/client/seedmanagement/informers/externalversions"
 	settingsclientset "github.com/gardener/gardener/pkg/client/settings/clientset/versioned"
 	settingsinformer "github.com/gardener/gardener/pkg/client/settings/informers/externalversions"
 	"github.com/gardener/gardener/pkg/openapi"
@@ -97,15 +100,16 @@ These so-called control plane components are hosted in Kubernetes clusters thems
 
 // Options has all the context and parameters needed to run a Gardener API server.
 type Options struct {
-	Recommended                 *genericoptions.RecommendedOptions
-	ServerRunOptions            *genericoptions.ServerRunOptions
-	ExtraOptions                *apiserver.ExtraOptions
-	CoreInformerFactory         gardencoreinformers.SharedInformerFactory
-	ExternalCoreInformerFactory gardenexternalcoreinformers.SharedInformerFactory
-	KubeInformerFactory         kubeinformers.SharedInformerFactory
-	SettingsInformerFactory     settingsinformer.SharedInformerFactory
-	StdOut                      io.Writer
-	StdErr                      io.Writer
+	Recommended                   *genericoptions.RecommendedOptions
+	ServerRunOptions              *genericoptions.ServerRunOptions
+	ExtraOptions                  *apiserver.ExtraOptions
+	CoreInformerFactory           gardencoreinformers.SharedInformerFactory
+	ExternalCoreInformerFactory   gardenexternalcoreinformers.SharedInformerFactory
+	KubeInformerFactory           kubeinformers.SharedInformerFactory
+	SeedManagementInformerFactory seedmanagementinformer.SharedInformerFactory
+	SettingsInformerFactory       settingsinformer.SharedInformerFactory
+	StdOut                        io.Writer
+	StdErr                        io.Writer
 }
 
 // NewOptions returns a new Options object.
@@ -115,6 +119,7 @@ func NewOptions(out, errOut io.Writer) *Options {
 			"/registry-gardener",
 			api.Codecs.LegacyCodec(
 				gardencorev1alpha1.SchemeGroupVersion,
+				seedmanagementv1alpha1.SchemeGroupVersion,
 				settingsv1alpha1.SchemeGroupVersion,
 			),
 		),
@@ -172,6 +177,13 @@ func (o *Options) config(kubeAPIServerConfig *rest.Config, kubeClient *kubernete
 		}
 		o.ExternalCoreInformerFactory = gardenexternalcoreinformers.NewSharedInformerFactory(versionedCoreClient, gardenerAPIServerConfig.LoopbackClientConfig.Timeout)
 
+		// seedmanagement client
+		seedManagementClient, err := seedmanagementclientset.NewForConfig(gardenerAPIServerConfig.LoopbackClientConfig)
+		if err != nil {
+			return nil, err
+		}
+		o.SeedManagementInformerFactory = seedmanagementinformer.NewSharedInformerFactory(seedManagementClient, gardenerAPIServerConfig.LoopbackClientConfig.Timeout)
+
 		// settings client
 		settingsClient, err := settingsclientset.NewForConfig(gardenerAPIServerConfig.LoopbackClientConfig)
 		if err != nil {
@@ -190,6 +202,8 @@ func (o *Options) config(kubeAPIServerConfig *rest.Config, kubeClient *kubernete
 				o.CoreInformerFactory,
 				coreClient,
 				o.ExternalCoreInformerFactory,
+				o.SeedManagementInformerFactory,
+				seedManagementClient,
 				o.SettingsInformerFactory,
 				o.KubeInformerFactory,
 				kubeClient,
@@ -242,6 +256,7 @@ func (o Options) run(stopCh <-chan struct{}) error {
 		o.CoreInformerFactory.Start(context.StopCh)
 		o.ExternalCoreInformerFactory.Start(context.StopCh)
 		o.KubeInformerFactory.Start(context.StopCh)
+		o.SeedManagementInformerFactory.Start(context.StopCh)
 		o.SettingsInformerFactory.Start(context.StopCh)
 		return nil
 	}); err != nil {
@@ -333,6 +348,7 @@ func (o *Options) ApplyTo(config *apiserver.Config) error {
 	resourceConfig := serverstorage.NewResourceConfig()
 	resourceConfig.EnableVersions(
 		gardencorev1alpha1.SchemeGroupVersion,
+		seedmanagementv1alpha1.SchemeGroupVersion,
 		settingsv1alpha1.SchemeGroupVersion,
 	)
 

--- a/example/55-managedseed-gardenlet.yaml
+++ b/example/55-managedseed-gardenlet.yaml
@@ -1,0 +1,40 @@
+apiVersion: seedmanagement.gardener.cloud/v1alpha1
+kind: ManagedSeed
+metadata:
+  name: my-managed-seed
+  namespace: garden # Must be garden
+spec:
+  shoot:
+    name: crazy-botany
+  # gardenlet specifies that the ManagedSeed controller should deploy a gardenlet into the cluster
+  # with the given deployment parameters and GardenletConfiguration.
+  gardenlet:
+    bootstrap: ServiceAccount # Mechanism that should be used for bootstrapping gardenlet connection to the Garden cluster, one of ServiceAccount, BootstrapToken, None
+    mergeWithParent: true # If true, the deployment parameters and GardenletConfiguration of the parent gardenlet will be merged with the specified deployment parameters and GardenletConfiguration
+#   deployment: # gardenlet deployment parameters
+#     replicaCount: 1      
+#     revisionHistoryLimit: 1
+#     serviceAccountName: gardenlet
+#     image:
+#       repository: eu.gcr.io/gardener-project/gardener/gardenlet
+#       tag: latest
+#       pullPolicy: IfNotPresent
+#     resources:
+#       requests:
+#         cpu: 100m
+#         memory: 100Mi
+#       limits:
+#         cpu: 2000m
+#         memory: 512Mi
+#     podAnnotations:
+#       foo: bar
+#     podLabels:
+#       foo: bar
+#     additionalVolumes: []
+#     additionalVolumeMounts: []
+#     env: []
+#     vpa: true
+    config: # GardenletConfiguration resource
+      apiVersion: gardenlet.config.gardener.cloud/v1alpha1
+      kind: GardenletConfiguration
+#     <See `20-componentconfig-gardenlet.yaml` for more details>

--- a/example/55-managedseed-seedtemplate.yaml
+++ b/example/55-managedseed-seedtemplate.yaml
@@ -1,0 +1,17 @@
+apiVersion: seedmanagement.gardener.cloud/v1alpha1
+kind: ManagedSeed
+metadata:
+  name: my-managed-seed
+  namespace: garden # Must be garden
+spec:
+  shoot:
+    name: crazy-botany
+  # seedTemplate is a template for a Seed object, that should be used to register a given cluster as a Seed.
+  # When seedTemplate is specified, the ManagedSeed controller will not deploy a gardenlet into the cluster
+  # and an existing gardenlet reconciling the new Seed is required.    
+  seedTemplate:
+#   metadata:
+#     labels:
+#       seed.gardener.cloud/gardenlet: local # Label to use in seedSelector of the existing gardenlet 
+    spec: # Seed spec
+#     <See `spec` in `50-seed.yaml` for more details>

--- a/hack/local-development/dev-setup-register-gardener
+++ b/hack/local-development/dev-setup-register-gardener
@@ -31,6 +31,7 @@ fi
 
 CORE_V1ALPHA1_APISERVICE_NAME="v1alpha1.core.gardener.cloud"
 CORE_V1BETA1_APISERVICE_NAME="v1beta1.core.gardener.cloud"
+SEEDMANAGEMENT_APISERVICE_NAME="v1alpha1.seedmanagement.gardener.cloud"
 SETTINGS_APISERVICE_NAME="v1alpha1.settings.gardener.cloud"
 
 ADMISSION_CONTROLLER_SERVICE_NAME="gardener-admission-controller"
@@ -60,6 +61,10 @@ fi
 if kubectl get apiservice "$CORE_V1BETA1_APISERVICE_NAME" &> /dev/null; then
   kubectl delete apiservice $CORE_V1BETA1_APISERVICE_NAME --wait=false
   kubectl patch  apiservice $CORE_V1BETA1_APISERVICE_NAME -p '{"metadata":{"finalizers":null}}' 2> /dev/null || true
+fi
+if kubectl get apiservice "$SEEDMANAGEMENT_APISERVICE_NAME" &> /dev/null; then
+  kubectl delete apiservice $SEEDMANAGEMENT_APISERVICE_NAME --wait=false
+  kubectl patch  apiservice $SEEDMANAGEMENT_APISERVICE_NAME -p '{"metadata":{"finalizers":null}}' 2> /dev/null || true
 fi
 if kubectl get apiservice "$SETTINGS_APISERVICE_NAME" &> /dev/null; then
   kubectl delete apiservice $SETTINGS_APISERVICE_NAME --wait=false
@@ -177,6 +182,21 @@ spec:
   insecureSkipTLSVerify: true
   group: core.gardener.cloud
   version: v1beta1
+  groupPriorityMinimum: 10000
+  versionPriority: 20
+  service:
+    name: gardener-apiserver
+    namespace: garden
+$APISERVICE_PORT_STRING
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: $SEEDMANAGEMENT_APISERVICE_NAME
+spec:
+  insecureSkipTLSVerify: true
+  group: seedmanagement.gardener.cloud
+  version: v1alpha1
   groupPriorityMinimum: 10000
   versionPriority: 20
   service:
@@ -305,6 +325,15 @@ $ADMISSION_CONTROLLER_PORT_STRING
     - secretbindings
     - quotas
     - plants
+  - apiGroups:
+    - seedmanagement.gardener.cloud
+    apiVersions:
+    - "*"
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - managedseeds
   - apiGroups:
     - settings.gardener.cloud
     apiVersions:

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	coreinstall "github.com/gardener/gardener/pkg/apis/core/install"
+	seedmanagementinstall "github.com/gardener/gardener/pkg/apis/seedmanagement/install"
 	settingsinstall "github.com/gardener/gardener/pkg/apis/settings/install"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +34,7 @@ var (
 
 func init() {
 	coreinstall.Install(Scheme)
+	seedmanagementinstall.Install(Scheme)
 	settingsinstall.Install(Scheme)
 
 	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})

--- a/pkg/apis/seedmanagement/validation/managedseed.go
+++ b/pkg/apis/seedmanagement/validation/managedseed.go
@@ -105,6 +105,12 @@ func ValidateManagedSeedSpecUpdate(newSpec, oldSpec *seedmanagement.ManagedSeedS
 	return allErrs
 }
 
+// ValidateManagedSeedStatusUpdate validates a ManagedSeed object before a status update.
+func ValidateManagedSeedStatusUpdate(newManagedSeed, oldManagedSeed *seedmanagement.ManagedSeed) field.ErrorList {
+	allErrs := field.ErrorList{}
+	return allErrs
+}
+
 func validateSeedTemplate(metadata *metav1.ObjectMeta, seedSpec *gardencore.SeedSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 

--- a/pkg/apiserver/admission/initializer/initializer.go
+++ b/pkg/apiserver/admission/initializer/initializer.go
@@ -18,6 +18,8 @@ import (
 	coreclientset "github.com/gardener/gardener/pkg/client/core/clientset/internalversion"
 	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
+	seedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
+	seedmanagementinformers "github.com/gardener/gardener/pkg/client/seedmanagement/informers/externalversions"
 	settingsinformer "github.com/gardener/gardener/pkg/client/settings/informers/externalversions"
 	"github.com/gardener/gardener/third_party/forked/kubernetes/pkg/quota/v1"
 
@@ -33,6 +35,8 @@ func New(
 	coreInformers coreinformers.SharedInformerFactory,
 	coreClient coreclientset.Interface,
 	externalCoreInformers externalcoreinformers.SharedInformerFactory,
+	seedManagementInformers seedmanagementinformers.SharedInformerFactory,
+	seedManagementClient seedmanagementclientset.Interface,
 	settingsInformers settingsinformer.SharedInformerFactory,
 	kubeInformers kubeinformers.SharedInformerFactory,
 	kubeClient kubernetes.Interface,
@@ -45,6 +49,9 @@ func New(
 		coreClient:    coreClient,
 
 		externalCoreInformers: externalCoreInformers,
+
+		seedManagementInformers: seedManagementInformers,
+		seedManagementClient:    seedManagementClient,
 
 		settingsInformers: settingsInformers,
 
@@ -71,6 +78,13 @@ func (i pluginInitializer) Initialize(plugin admission.Interface) {
 
 	if wants, ok := plugin.(WantsExternalCoreInformerFactory); ok {
 		wants.SetExternalCoreInformerFactory(i.externalCoreInformers)
+	}
+
+	if wants, ok := plugin.(WantsSeedManagementInformerFactory); ok {
+		wants.SetSeedManagementInformerFactory(i.seedManagementInformers)
+	}
+	if wants, ok := plugin.(WantsSeedManagementClientset); ok {
+		wants.SetSeedManagementClientset(i.seedManagementClient)
 	}
 
 	if wants, ok := plugin.(WantsSettingsInformerFactory); ok {

--- a/pkg/apiserver/admission/initializer/types.go
+++ b/pkg/apiserver/admission/initializer/types.go
@@ -18,6 +18,8 @@ import (
 	coreclientset "github.com/gardener/gardener/pkg/client/core/clientset/internalversion"
 	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
+	seedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
+	seedmanagementinformers "github.com/gardener/gardener/pkg/client/seedmanagement/informers/externalversions"
 	settingsinformer "github.com/gardener/gardener/pkg/client/settings/informers/externalversions"
 	"github.com/gardener/gardener/third_party/forked/kubernetes/pkg/quota/v1"
 
@@ -49,6 +51,18 @@ type WantsExternalCoreInformerFactory interface {
 // WantsKubeInformerFactory defines a function which sets InformerFactory for admission plugins that need it.
 type WantsKubeInformerFactory interface {
 	SetKubeInformerFactory(kubeinformers.SharedInformerFactory)
+	admission.InitializationValidator
+}
+
+// WantsSeedManagementInformerFactory defines a function which sets InformerFactory for admission plugins that need it.
+type WantsSeedManagementInformerFactory interface {
+	SetSeedManagementInformerFactory(seedmanagementinformers.SharedInformerFactory)
+	admission.InitializationValidator
+}
+
+// WantsSeedManagementClientset defines a function which sets SeedManagement Clientset for admission plugins that need it.
+type WantsSeedManagementClientset interface {
+	SetSeedManagementClientset(seedmanagementclientset.Interface)
 	admission.InitializationValidator
 }
 
@@ -87,6 +101,9 @@ type pluginInitializer struct {
 	coreClient    coreclientset.Interface
 
 	externalCoreInformers externalcoreinformers.SharedInformerFactory
+
+	seedManagementInformers seedmanagementinformers.SharedInformerFactory
+	seedManagementClient    seedmanagementclientset.Interface
 
 	settingsInformers settingsinformer.SharedInformerFactory
 

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -18,9 +18,10 @@ import (
 	"fmt"
 
 	corerest "github.com/gardener/gardener/pkg/registry/core/rest"
+	seedmanagementrest "github.com/gardener/gardener/pkg/registry/seedmanagement/rest"
 	settingsrest "github.com/gardener/gardener/pkg/registry/settings/rest"
-	"github.com/spf13/pflag"
 
+	"github.com/spf13/pflag"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 )
 
@@ -67,11 +68,12 @@ func (c completedConfig) New() (*GardenerServer, error) {
 	var (
 		s = &GardenerServer{GenericAPIServer: genericServer}
 
-		coreAPIGroupInfo     = (corerest.StorageProvider{}).NewRESTStorage(c.GenericConfig.RESTOptionsGetter)
-		settingsAPIGroupInfo = (settingsrest.StorageProvider{}).NewRESTStorage(c.GenericConfig.RESTOptionsGetter)
+		coreAPIGroupInfo           = (corerest.StorageProvider{}).NewRESTStorage(c.GenericConfig.RESTOptionsGetter)
+		seedManagementAPIGroupInfo = (seedmanagementrest.StorageProvider{}).NewRESTStorage(c.GenericConfig.RESTOptionsGetter)
+		settingsAPIGroupInfo       = (settingsrest.StorageProvider{}).NewRESTStorage(c.GenericConfig.RESTOptionsGetter)
 	)
 
-	if err := s.GenericAPIServer.InstallAPIGroups(&coreAPIGroupInfo, &settingsAPIGroupInfo); err != nil {
+	if err := s.GenericAPIServer.InstallAPIGroups(&coreAPIGroupInfo, &settingsAPIGroupInfo, &seedManagementAPIGroupInfo); err != nil {
 		return nil, err
 	}
 

--- a/pkg/registry/seedmanagement/managedseed/managedseed_suite_test.go
+++ b/pkg/registry/seedmanagement/managedseed/managedseed_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedseed_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestShoot(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Registry ManagedSeed Suite")
+}

--- a/pkg/registry/seedmanagement/managedseed/storage/storage.go
+++ b/pkg/registry/seedmanagement/managedseed/storage/storage.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+	"github.com/gardener/gardener/pkg/registry/seedmanagement/managedseed"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/generic"
+	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/storage"
+)
+
+// REST implements a RESTStorage for ManagedSeed.
+type REST struct {
+	*genericregistry.Store
+}
+
+// ManagedSeedStorage implements the storage for ManagedSeeds and their status subresource.
+type ManagedSeedStorage struct {
+	ManagedSeed *REST
+	Status      *StatusREST
+}
+
+// NewStorage creates a new ManagedSeedStorage object.
+func NewStorage(optsGetter generic.RESTOptionsGetter) ManagedSeedStorage {
+	managedSeedRest, managedSeedStatusRest := NewREST(optsGetter)
+
+	return ManagedSeedStorage{
+		ManagedSeed: managedSeedRest,
+		Status:      managedSeedStatusRest,
+	}
+}
+
+// NewREST returns a RESTStorage object that will work with ManagedSeed objects.
+func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
+	strategy := managedseed.NewStrategy()
+	statusStrategy := managedseed.NewStatusStrategy()
+
+	store := &genericregistry.Store{
+		NewFunc:                  func() runtime.Object { return &seedmanagement.ManagedSeed{} },
+		NewListFunc:              func() runtime.Object { return &seedmanagement.ManagedSeedList{} },
+		PredicateFunc:            managedseed.MatchManagedSeed,
+		DefaultQualifiedResource: seedmanagement.Resource("managedseeds"),
+		EnableGarbageCollection:  true,
+
+		CreateStrategy: strategy,
+		UpdateStrategy: strategy,
+		DeleteStrategy: strategy,
+
+		TableConvertor: newTableConvertor(),
+	}
+	options := &generic.StoreOptions{
+		RESTOptions: optsGetter,
+		AttrFunc:    managedseed.GetAttrs,
+		TriggerFunc: map[string]storage.IndexerFunc{seedmanagement.ManagedSeedShootName: managedseed.ShootNameTriggerFunc},
+	}
+	if err := store.CompleteWithOptions(options); err != nil {
+		panic(err)
+	}
+
+	statusStore := *store
+	statusStore.UpdateStrategy = statusStrategy
+
+	return &REST{store}, &StatusREST{store: &statusStore}
+}
+
+// StatusREST implements the REST endpoint for changing the status of a ManagedSeed.
+type StatusREST struct {
+	store *genericregistry.Store
+}
+
+var (
+	_ rest.Storage = &StatusREST{}
+	_ rest.Getter  = &StatusREST{}
+	_ rest.Updater = &StatusREST{}
+)
+
+// New creates a new (empty) internal ManagedSeed object.
+func (r *StatusREST) New() runtime.Object {
+	return &seedmanagement.ManagedSeed{}
+}
+
+// Get retrieves the object from the storage. It is required to support Patch.
+func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	return r.store.Get(ctx, name, options)
+}
+
+// Update alters the status subset of an object.
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+}
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{}
+}

--- a/pkg/registry/seedmanagement/managedseed/storage/tableconvertor.go
+++ b/pkg/registry/seedmanagement/managedseed/storage/tableconvertor.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metatable "k8s.io/apimachinery/pkg/api/meta/table"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/helper"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+)
+
+var swaggerMetadataDescriptions = metav1.ObjectMeta{}.SwaggerDoc()
+
+type convertor struct {
+	headers []metav1beta1.TableColumnDefinition
+}
+
+func newTableConvertor() rest.TableConvertor {
+	return &convertor{
+		headers: []metav1beta1.TableColumnDefinition{
+			{Name: "Name", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["name"]},
+			{Name: "Status", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["status"]},
+			{Name: "Shoot", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["shootName"]},
+			{Name: "Gardenlet", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["gardenlet"]},
+			{Name: "Age", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"]},
+		},
+	}
+}
+
+// ConvertToTable converts the output to a table.
+func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+	var (
+		err   error
+		table = &metav1beta1.Table{
+			ColumnDefinitions: c.headers,
+		}
+	)
+
+	if m, err := meta.ListAccessor(obj); err == nil {
+		table.ResourceVersion = m.GetResourceVersion()
+		table.SelfLink = m.GetSelfLink()
+		table.Continue = m.GetContinue()
+	} else {
+		if m, err := meta.CommonAccessor(obj); err == nil {
+			table.ResourceVersion = m.GetResourceVersion()
+			table.SelfLink = m.GetSelfLink()
+		}
+	}
+
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {
+		var (
+			managedSeed = obj.(*seedmanagement.ManagedSeed)
+			cells       = []interface{}{}
+		)
+
+		seedRegisteredCondition := helper.GetCondition(managedSeed.Status.Conditions, seedmanagement.ManagedSeedSeedRegistered)
+
+		cells = append(cells, managedSeed.Name)
+		if seedRegisteredCondition == nil || seedRegisteredCondition.Status == core.ConditionUnknown {
+			cells = append(cells, "Unknown")
+		} else if seedRegisteredCondition.Status != core.ConditionTrue {
+			cells = append(cells, "NotReady")
+		} else {
+			cells = append(cells, "Ready")
+		}
+		cells = append(cells, managedSeed.Spec.Shoot.Name)
+		if managedSeed.Spec.Gardenlet != nil {
+			cells = append(cells, "True")
+		} else {
+			cells = append(cells, "False")
+		}
+		cells = append(cells, metatable.ConvertToHumanReadableDateType(managedSeed.CreationTimestamp))
+
+		return cells, nil
+	})
+
+	return table, err
+}

--- a/pkg/registry/seedmanagement/managedseed/strategy.go
+++ b/pkg/registry/seedmanagement/managedseed/strategy.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedseed
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/api"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement/validation"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/apiserver/pkg/storage/names"
+)
+
+// Strategy defines the strategy for storing managedseeds.
+type Strategy struct {
+	runtime.ObjectTyper
+	names.NameGenerator
+}
+
+// NewStrategy defines the storage strategy for ManagedSeeds.
+func NewStrategy() Strategy {
+	return Strategy{api.Scheme, names.SimpleNameGenerator}
+}
+
+// NamespaceScoped returns true if the object must be within a namespace.
+func (Strategy) NamespaceScoped() bool {
+	return true
+}
+
+// PrepareForCreate mutates some fields in the object before it's created.
+func (s Strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+	managedSeed := obj.(*seedmanagement.ManagedSeed)
+
+	managedSeed.Generation = 1
+	managedSeed.Status = seedmanagement.ManagedSeedStatus{}
+}
+
+// PrepareForUpdate is invoked on update before validation to normalize
+// the object.  For example: remove fields that are not to be persisted,
+// sort order-insensitive list fields, etc.  This should not remove fields
+// whose presence would be considered a validation error.
+func (s Strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	newManagedSeed := obj.(*seedmanagement.ManagedSeed)
+	oldManagedSeed := old.(*seedmanagement.ManagedSeed)
+	newManagedSeed.Status = oldManagedSeed.Status
+
+	if !apiequality.Semantic.DeepEqual(oldManagedSeed.Spec, newManagedSeed.Spec) ||
+		oldManagedSeed.DeletionTimestamp == nil && newManagedSeed.DeletionTimestamp != nil {
+		newManagedSeed.Generation = oldManagedSeed.Generation + 1
+	}
+}
+
+// Validate validates the given object.
+func (Strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	managedSeed := obj.(*seedmanagement.ManagedSeed)
+	return validation.ValidateManagedSeed(managedSeed)
+}
+
+// Canonicalize allows an object to be mutated into a canonical form. This
+// ensures that code that operates on these objects can rely on the common
+// form for things like comparison.  Canonicalize is invoked after
+// validation has succeeded but before the object has been persisted.
+// This method may mutate the object.
+func (Strategy) Canonicalize(obj runtime.Object) {
+}
+
+// AllowCreateOnUpdate returns true if the object can be created by a PUT.
+func (Strategy) AllowCreateOnUpdate() bool {
+	return false
+}
+
+// AllowUnconditionalUpdate returns true if the object can be updated
+// unconditionally (irrespective of the latest resource version), when
+// there is no resource version specified in the object.
+func (Strategy) AllowUnconditionalUpdate() bool {
+	return false
+}
+
+// ValidateUpdate validates the update on the given old and new object.
+func (Strategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+	oldManagedSeed, newManagedSeed := oldObj.(*seedmanagement.ManagedSeed), newObj.(*seedmanagement.ManagedSeed)
+	return validation.ValidateManagedSeedUpdate(newManagedSeed, oldManagedSeed)
+}
+
+// StatusStrategy defines the strategy for storing seeds statuses.
+type StatusStrategy struct {
+	Strategy
+}
+
+// NewStatusStrategy defines the storage strategy for the status subresource of ManagedSeeds.
+func NewStatusStrategy() StatusStrategy {
+	return StatusStrategy{NewStrategy()}
+}
+
+// PrepareForUpdate is invoked on update before validation to normalize
+// the object.  For example: remove fields that are not to be persisted,
+// sort order-insensitive list fields, etc.  This should not remove fields
+// whose presence would be considered a validation error.
+func (s StatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	newManagedSeed := obj.(*seedmanagement.ManagedSeed)
+	oldManagedSeed := old.(*seedmanagement.ManagedSeed)
+	newManagedSeed.Spec = oldManagedSeed.Spec
+}
+
+// ValidateUpdate validates the update on the given old and new object.
+func (StatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+	return validation.ValidateManagedSeedStatusUpdate(obj.(*seedmanagement.ManagedSeed), old.(*seedmanagement.ManagedSeed))
+}
+
+// MatchManagedSeed returns a generic matcher for a given label and field selector.
+func MatchManagedSeed(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+	return storage.SelectionPredicate{
+		Label:       label,
+		Field:       field,
+		GetAttrs:    GetAttrs,
+		IndexFields: []string{seedmanagement.ManagedSeedShootName},
+	}
+}
+
+// GetAttrs returns labels and fields of a given object for filtering purposes.
+func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
+	managedSeed, ok := obj.(*seedmanagement.ManagedSeed)
+	if !ok {
+		return nil, nil, fmt.Errorf("not a ManagedSeed")
+	}
+	return labels.Set(managedSeed.ObjectMeta.Labels), ToSelectableFields(managedSeed), nil
+}
+
+// ToSelectableFields returns a field set that represents the object.
+func ToSelectableFields(managedSeed *seedmanagement.ManagedSeed) fields.Set {
+	// The purpose of allocation with a given number of elements is to reduce
+	// amount of allocations needed to create the fields.Set. If you add any
+	// field here or the number of object-meta related fields changes, this should
+	// be adjusted.
+	shootSpecificFieldsSet := make(fields.Set, 3)
+	shootSpecificFieldsSet[seedmanagement.ManagedSeedShootName] = managedSeed.Spec.Shoot.Name
+	return generic.AddObjectMetaFieldsSet(shootSpecificFieldsSet, &managedSeed.ObjectMeta, true)
+}
+
+// ShootNameTriggerFunc returns spec.shoot.name of the given ManagedSeed.
+func ShootNameTriggerFunc(obj runtime.Object) string {
+	managedSeed, ok := obj.(*seedmanagement.ManagedSeed)
+	if !ok {
+		return ""
+	}
+
+	return managedSeed.Spec.Shoot.Name
+}

--- a/pkg/registry/seedmanagement/managedseed/strategy_test.go
+++ b/pkg/registry/seedmanagement/managedseed/strategy_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedseed_test
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+	. "github.com/gardener/gardener/pkg/registry/seedmanagement/managedseed"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var _ = Describe("Strategy", func() {
+	var (
+		ctx      = context.TODO()
+		strategy = Strategy{}
+	)
+
+	Describe("#PrepareForUpdate", func() {
+		var oldManagedSeed, newManagedSeed *seedmanagement.ManagedSeed
+
+		BeforeEach(func() {
+			oldManagedSeed = &seedmanagement.ManagedSeed{}
+			newManagedSeed = &seedmanagement.ManagedSeed{}
+		})
+
+		It("should increase the generation if the spec has changed", func() {
+			newManagedSeed.Spec.Shoot = seedmanagement.Shoot{Name: "foo"}
+
+			strategy.PrepareForUpdate(ctx, newManagedSeed, oldManagedSeed)
+			Expect(newManagedSeed.Generation).To(Equal(oldManagedSeed.Generation + 1))
+		})
+
+		It("should increase the generation if the deletion timestamp is set", func() {
+			deletionTimestamp := metav1.Now()
+			newManagedSeed.DeletionTimestamp = &deletionTimestamp
+
+			strategy.PrepareForUpdate(ctx, newManagedSeed, oldManagedSeed)
+			Expect(newManagedSeed.Generation).To(Equal(oldManagedSeed.Generation + 1))
+		})
+
+		It("should not increase the generation if neither the spec has changed nor the deletion timestamp is set", func() {
+			strategy.PrepareForUpdate(ctx, newManagedSeed, oldManagedSeed)
+			Expect(newManagedSeed.Generation).To(Equal(oldManagedSeed.Generation))
+		})
+	})
+})
+
+var _ = Describe("ToSelectableFields", func() {
+	It("should return correct fields", func() {
+		result := ToSelectableFields(newManagedSeed("foo"))
+
+		Expect(result).To(HaveLen(3))
+		Expect(result.Has(seedmanagement.ManagedSeedShootName)).To(BeTrue())
+		Expect(result.Get(seedmanagement.ManagedSeedShootName)).To(Equal("foo"))
+	})
+})
+
+var _ = Describe("GetAttrs", func() {
+	It("should return error when object is not ManagedSeed", func() {
+		_, _, err := GetAttrs(&core.Seed{})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return correct result", func() {
+		ls, fs, err := GetAttrs(newManagedSeed("foo"))
+
+		Expect(ls).To(HaveLen(1))
+		Expect(ls.Get("foo")).To(Equal("bar"))
+		Expect(fs.Get(seedmanagement.ManagedSeedShootName)).To(Equal("foo"))
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("ShootNameTriggerFunc", func() {
+	It("should return spec.shoot.name", func() {
+		actual := ShootNameTriggerFunc(newManagedSeed("foo"))
+		Expect(actual).To(Equal("foo"))
+	})
+})
+
+var _ = Describe("MatchManagedSeed", func() {
+	It("should return correct predicate", func() {
+		ls, _ := labels.Parse("app=test")
+		fs := fields.OneTermEqualSelector(seedmanagement.ManagedSeedShootName, "foo")
+
+		result := MatchManagedSeed(ls, fs)
+
+		Expect(result.Label).To(Equal(ls))
+		Expect(result.Field).To(Equal(fs))
+		Expect(result.IndexFields).To(ConsistOf(seedmanagement.ManagedSeedShootName))
+	})
+})
+
+func newManagedSeed(shootName string) *seedmanagement.ManagedSeed {
+	return &seedmanagement.ManagedSeed{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-namespace",
+			Labels:    map[string]string{"foo": "bar"},
+		},
+		Spec: seedmanagement.ManagedSeedSpec{
+			Shoot: seedmanagement.Shoot{
+				Name: shootName,
+			},
+		},
+	}
+}

--- a/pkg/registry/seedmanagement/rest/storage_seedmanagement.go
+++ b/pkg/registry/seedmanagement/rest/storage_seedmanagement.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+import (
+	"github.com/gardener/gardener/pkg/api"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	managedseedstore "github.com/gardener/gardener/pkg/registry/seedmanagement/managedseed/storage"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/rest"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+)
+
+// StorageProvider is an empty struct.
+type StorageProvider struct{}
+
+// NewRESTStorage creates a new API group info object and registers the v1alpha1 Garden storage.
+func (p StorageProvider) NewRESTStorage(restOptionsGetter generic.RESTOptionsGetter) genericapiserver.APIGroupInfo {
+	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(seedmanagement.GroupName, api.Scheme, metav1.ParameterCodec, api.Codecs)
+	apiGroupInfo.VersionedResourcesStorageMap[seedmanagementv1alpha1.SchemeGroupVersion.Version] = p.v1alpha1Storage(restOptionsGetter)
+	return apiGroupInfo
+}
+
+// GroupName returns the garden group name.
+func (p StorageProvider) GroupName() string {
+	return seedmanagement.GroupName
+}
+
+func (p StorageProvider) v1alpha1Storage(restOptionsGetter generic.RESTOptionsGetter) map[string]rest.Storage {
+	storage := map[string]rest.Storage{}
+
+	managedSeedStorage := managedseedstore.NewStorage(restOptionsGetter)
+
+	storage["managedseeds"] = managedSeedStorage.ManagedSeed
+	storage["managedseeds/status"] = managedSeedStorage.Status
+
+	return storage
+}


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Adds `gardener-apiserver` registration and storage for `ManagedSeed` resources.

Creating, updating, and deleting `ManagedSeed` resources can now be tested, but admission plugins are still missing. This is on purpose, to make this PR easier to review. Without admission plugins, the user has to specify a few mandatory values that would otherwise be filled by the plugins based on the shoot.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Based on #3414. This is the third of several PRs that are split from #3177 since it became too big and hard to review. Before commenting, please check if the topic has been already discussed in the previous PR.

**Release note**:

```improvement operator
NONE
```