### PR TITLE
[GEP-13] Add ManagedSeed admission plugins

### DIFF
--- a/pkg/apiserver/plugins.go
+++ b/pkg/apiserver/plugins.go
@@ -49,6 +49,7 @@ var (
 		extensionvalidation.PluginName,             // ExtensionValidator
 		shoottolerationrestriction.PluginName,      // ShootTolerationRestriction
 		shootdns.PluginName,                        // ShootDNS
+		shootmanagedseed.PluginName,                // ShootManagedSeed
 		shootquotavalidator.PluginName,             // ShootQuotaValidator
 		shootvalidator.PluginName,                  // ShootValidator
 		seedvalidator.PluginName,                   // SeedValidator
@@ -80,6 +81,7 @@ var (
 		extensionvalidation.PluginName,             // ExtensionValidator
 		shoottolerationrestriction.PluginName,      // ShootTolerationRestriction
 		shootdns.PluginName,                        // ShootDNS
+		shootmanagedseed.PluginName,                // ShootManagedSeed
 		shootquotavalidator.PluginName,             // ShootQuotaValidator
 		shootvalidator.PluginName,                  // ShootValidator
 		seedvalidator.PluginName,                   // SeedValidator
@@ -90,6 +92,7 @@ var (
 		clusteropenidconnectpreset.PluginName,      // ClusterOpenIDConnectPreset
 		shootstatedeletionvalidator.PluginName,     // ShootStateDeletionValidator
 		customverbauthorizer.PluginName,            // CustomVerbAuthorizer
+		managedseedvalidator.PluginName,            // ManagedSeed
 		mutatingwebhook.PluginName,                 // MutatingAdmissionWebhook
 		validatingwebhook.PluginName,               // ValidatingAdmissionWebhook
 		resourcequota.PluginName,                   // ResourceQuota

--- a/pkg/apiserver/plugins.go
+++ b/pkg/apiserver/plugins.go
@@ -26,9 +26,11 @@ import (
 	"github.com/gardener/gardener/plugin/pkg/global/deletionconfirmation"
 	"github.com/gardener/gardener/plugin/pkg/global/extensionvalidation"
 	"github.com/gardener/gardener/plugin/pkg/global/resourcereferencemanager"
+	managedseedvalidator "github.com/gardener/gardener/plugin/pkg/managedseed/validator"
 	plantvalidator "github.com/gardener/gardener/plugin/pkg/plant"
 	seedvalidator "github.com/gardener/gardener/plugin/pkg/seed/validator"
 	shootdns "github.com/gardener/gardener/plugin/pkg/shoot/dns"
+	shootmanagedseed "github.com/gardener/gardener/plugin/pkg/shoot/managedseed"
 	"github.com/gardener/gardener/plugin/pkg/shoot/oidc/clusteropenidconnectpreset"
 	"github.com/gardener/gardener/plugin/pkg/shoot/oidc/openidconnectpreset"
 	shootquotavalidator "github.com/gardener/gardener/plugin/pkg/shoot/quotavalidator"
@@ -58,6 +60,7 @@ var (
 		shootstatedeletionvalidator.PluginName,     // ShootStateDeletionValidator
 		customverbauthorizer.PluginName,            // CustomVerbAuthorizer
 		shootvpa.PluginName,                        // ShootVPAEnabledByDefault
+		managedseedvalidator.PluginName,            // ManagedSeed
 
 		// new admission plugins should generally be inserted above here
 		// webhook, and resourcequota plugins must go at the end
@@ -104,6 +107,7 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	shoottolerationrestriction.Register(plugins)
 	shootquotavalidator.Register(plugins)
 	shootdns.Register(plugins)
+	shootmanagedseed.Register(plugins)
 	shootvalidator.Register(plugins)
 	seedvalidator.Register(plugins)
 	controllerregistrationresources.Register(plugins)
@@ -112,6 +116,7 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	clusteropenidconnectpreset.Register(plugins)
 	shootstatedeletionvalidator.Register(plugins)
 	customverbauthorizer.Register(plugins)
+	managedseedvalidator.Register(plugins)
 	resourcequota.Register(plugins)
 	shootvpa.Register(plugins)
 }

--- a/pkg/utils/kubernetes/managedseed.go
+++ b/pkg/utils/kubernetes/managedseed.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	gardenseedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+)
+
+// GetManagedSeed gets the ManagedSeed resource for the given shoot namespace and name,
+// by searching for all ManagedSeeds in the shoot namespace that have spec.shoot.name set to the shoot name.
+// If no such ManagedSeeds are found, nil is returned.
+func GetManagedSeed(ctx context.Context, seedManagementClient gardenseedmanagementclientset.Interface, shootNamespace, shootName string) (*seedmanagementv1alpha1.ManagedSeed, error) {
+	managedSeedList, err := seedManagementClient.SeedmanagementV1alpha1().ManagedSeeds(shootNamespace).List(ctx, metav1.ListOptions{
+		FieldSelector: fields.SelectorFromSet(fields.Set{seedmanagement.ManagedSeedShootName: shootName}).String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(managedSeedList.Items) == 0 {
+		return nil, nil
+	}
+	if len(managedSeedList.Items) > 1 {
+		return nil, fmt.Errorf("found more than one ManagedSeed objects for shoot %s/%s", shootNamespace, shootName)
+	}
+	return &managedSeedList.Items[0], nil
+}

--- a/pkg/utils/kubernetes/managedseed_test.go
+++ b/pkg/utils/kubernetes/managedseed_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes_test
+
+import (
+	"context"
+	"errors"
+
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	seedmanagementfake "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned/fake"
+	. "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/testing"
+)
+
+const (
+	name      = "foo"
+	namespace = "garden"
+)
+
+var _ = Describe("managedseed", func() {
+	Describe("#GetManagedSeed", func() {
+		var (
+			seedManagementClient *seedmanagementfake.Clientset
+			managedSeed          *seedmanagementv1alpha1.ManagedSeed
+		)
+
+		BeforeEach(func() {
+			seedManagementClient = &seedmanagementfake.Clientset{}
+
+			managedSeed = &seedmanagementv1alpha1.ManagedSeed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+					Shoot: seedmanagementv1alpha1.Shoot{
+						Name: name,
+					},
+				},
+			}
+		})
+
+		It("should return the ManagedSeed for the given shoot namespace and name, if it exists", func() {
+			seedManagementClient.AddReactor("list", "managedseeds", func(action testing.Action) (bool, runtime.Object, error) {
+				return true, &seedmanagementv1alpha1.ManagedSeedList{Items: []seedmanagementv1alpha1.ManagedSeed{*managedSeed}}, nil
+			})
+
+			result, err := GetManagedSeed(context.TODO(), seedManagementClient, namespace, name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(managedSeed))
+		})
+
+		It("should return nil if a ManagedSeed does not exist", func() {
+			seedManagementClient.AddReactor("list", "managedseeds", func(action testing.Action) (bool, runtime.Object, error) {
+				return true, &seedmanagementv1alpha1.ManagedSeedList{Items: []seedmanagementv1alpha1.ManagedSeed{}}, nil
+			})
+
+			result, err := GetManagedSeed(context.TODO(), seedManagementClient, namespace, name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+
+		It("should fail if more than one ManagedSeeds exist", func() {
+			seedManagementClient.AddReactor("list", "managedseeds", func(action testing.Action) (bool, runtime.Object, error) {
+				return true, &seedmanagementv1alpha1.ManagedSeedList{Items: []seedmanagementv1alpha1.ManagedSeed{*managedSeed, *managedSeed}}, nil
+			})
+
+			_, err := GetManagedSeed(context.TODO(), seedManagementClient, namespace, name)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail if listing the ManagedSeeds fails", func() {
+			seedManagementClient.AddReactor("list", "managedseeds", func(action testing.Action) (bool, runtime.Object, error) {
+				return true, nil, errors.New("error")
+			})
+
+			_, err := GetManagedSeed(context.TODO(), seedManagementClient, namespace, name)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/pkg/utils/test/matchers/matchers.go
+++ b/pkg/utils/test/matchers/matchers.go
@@ -102,3 +102,11 @@ func BeInternalServerError() types.GomegaMatcher {
 		message:   "",
 	}
 }
+
+// BeInvalidError checks if error is an InvalidError.
+func BeInvalidError() types.GomegaMatcher {
+	return &kubernetesErrors{
+		checkFunc: apierrors.IsInvalid,
+		message:   "Invalid",
+	}
+}

--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -1,0 +1,463 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement/helper"
+	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
+	coreclientset "github.com/gardener/gardener/pkg/client/core/clientset/internalversion"
+	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
+	corelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
+	clientkubernetes "github.com/gardener/gardener/pkg/client/kubernetes"
+	seedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
+	"github.com/gardener/gardener/pkg/operation/common"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+	kubeinformers "k8s.io/client-go/informers"
+	kubecorev1listers "k8s.io/client-go/listers/core/v1"
+)
+
+const (
+	// PluginName is the name of this admission plugin.
+	PluginName = "ManagedSeedValidator"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return New()
+	})
+}
+
+// ValidateManagedSeed contains listers and and admission handler.
+type ValidateManagedSeed struct {
+	*admission.Handler
+	shootLister          corelisters.ShootLister
+	secretBindingLister  corelisters.SecretBindingLister
+	secretLister         kubecorev1listers.SecretLister
+	coreClient           coreclientset.Interface
+	seedManagementClient seedmanagementclientset.Interface
+	readyFunc            admission.ReadyFunc
+}
+
+var (
+	_ = admissioninitializer.WantsInternalCoreInformerFactory(&ValidateManagedSeed{})
+	_ = admissioninitializer.WantsInternalCoreClientset(&ValidateManagedSeed{})
+	_ = admissioninitializer.WantsSeedManagementClientset(&ValidateManagedSeed{})
+	_ = admissioninitializer.WantsKubeInformerFactory(&ValidateManagedSeed{})
+
+	readyFuncs = []admission.ReadyFunc{}
+)
+
+// New creates a new ValidateManagedSeed admission plugin.
+func New() (*ValidateManagedSeed, error) {
+	return &ValidateManagedSeed{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+	}, nil
+}
+
+// AssignReadyFunc assigns the ready function to the admission handler.
+func (v *ValidateManagedSeed) AssignReadyFunc(f admission.ReadyFunc) {
+	v.readyFunc = f
+	v.SetReadyFunc(f)
+}
+
+// SetInternalCoreInformerFactory gets Lister from SharedInformerFactory.
+func (v *ValidateManagedSeed) SetInternalCoreInformerFactory(f coreinformers.SharedInformerFactory) {
+	shootInformer := f.Core().InternalVersion().Shoots()
+	v.shootLister = shootInformer.Lister()
+
+	secretBindingInformer := f.Core().InternalVersion().SecretBindings()
+	v.secretBindingLister = secretBindingInformer.Lister()
+
+	readyFuncs = append(readyFuncs, shootInformer.Informer().HasSynced, secretBindingInformer.Informer().HasSynced)
+}
+
+// SetKubeInformerFactory gets Lister from SharedInformerFactory.
+func (v *ValidateManagedSeed) SetKubeInformerFactory(f kubeinformers.SharedInformerFactory) {
+	secretInformer := f.Core().V1().Secrets()
+	v.secretLister = secretInformer.Lister()
+
+	readyFuncs = append(readyFuncs, secretInformer.Informer().HasSynced)
+}
+
+// SetInternalCoreClientset sets the garden core clientset.
+func (v *ValidateManagedSeed) SetInternalCoreClientset(c coreclientset.Interface) {
+	v.coreClient = c
+}
+
+// SetSeedManagementClientset sets the garden seedmanagement clientset.
+func (v *ValidateManagedSeed) SetSeedManagementClientset(c seedmanagementclientset.Interface) {
+	v.seedManagementClient = c
+}
+
+// ValidateInitialization checks whether the plugin was correctly initialized.
+func (v *ValidateManagedSeed) ValidateInitialization() error {
+	if v.shootLister == nil {
+		return errors.New("missing shoot lister")
+	}
+	if v.secretBindingLister == nil {
+		return errors.New("missing secret binding lister")
+	}
+	if v.secretLister == nil {
+		return errors.New("missing secret lister")
+	}
+	if v.coreClient == nil {
+		return errors.New("missing garden core client")
+	}
+	if v.seedManagementClient == nil {
+		return errors.New("missing garden seedmanagement client")
+	}
+	return nil
+}
+
+var _ admission.MutationInterface = &ValidateManagedSeed{}
+
+// Admit validates and if appropriate mutates the given managed seed against the shoot that it references.
+func (v *ValidateManagedSeed) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	// Wait until the caches have been synced
+	if v.readyFunc == nil {
+		v.AssignReadyFunc(func() bool {
+			for _, readyFunc := range readyFuncs {
+				if !readyFunc() {
+					return false
+				}
+			}
+			return true
+		})
+	}
+	if !v.WaitForReady() {
+		return admission.NewForbidden(a, errors.New("not yet ready to handle request"))
+	}
+
+	// Ignore all kinds other than ManagedSeed
+	if a.GetKind().GroupKind() != seedmanagement.Kind("ManagedSeed") {
+		return nil
+	}
+
+	// Ignore updates to status or other subresources
+	if a.GetSubresource() != "" {
+		return nil
+	}
+
+	// Convert object to ManagedSeed
+	managedSeed, ok := a.GetObject().(*seedmanagement.ManagedSeed)
+	if !ok {
+		return apierrors.NewBadRequest("could not convert object to ManagedSeed")
+	}
+
+	var allErrs field.ErrorList
+	gk := schema.GroupKind{Group: seedmanagement.GroupName, Kind: "ManagedSeed"}
+
+	// Ensure shoot name is specified
+	shootNamePath := field.NewPath("spec", "shoot", "name")
+	if managedSeed.Spec.Shoot.Name == "" {
+		return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Required(shootNamePath, "shoot name is required")))
+	}
+
+	// Get shoot
+	shoot, err := v.getShoot(ctx, managedSeed.Namespace, managedSeed.Spec.Shoot.Name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Invalid(shootNamePath, managedSeed.Spec.Shoot.Name, fmt.Sprintf("shoot %s/%s not found", managedSeed.Namespace, managedSeed.Spec.Shoot.Name))))
+		}
+		return apierrors.NewInternalError(fmt.Errorf("could not get shoot %s/%s: %v", managedSeed.Namespace, managedSeed.Spec.Shoot.Name, err))
+	}
+
+	// Ensure shoot can be registered as seed (specifies a domain)
+	if shoot.Spec.DNS == nil || shoot.Spec.DNS.Domain == nil || *shoot.Spec.DNS.Domain == "" {
+		return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Invalid(shootNamePath, managedSeed.Spec.Shoot.Name, fmt.Sprintf("shoot %s does not specify a domain", kutil.ObjectName(shoot)))))
+	}
+
+	// Ensure shoot is not already registered as seed
+	ms, err := kutil.GetManagedSeed(ctx, v.seedManagementClient, managedSeed.Namespace, managedSeed.Spec.Shoot.Name)
+	if err != nil {
+		return apierrors.NewInternalError(fmt.Errorf("could not get managed seed for shoot %s/%s: %v", managedSeed.Namespace, managedSeed.Spec.Shoot.Name, err))
+	}
+	if ms != nil && ms.Name != managedSeed.Name {
+		return apierrors.NewInvalid(gk, managedSeed.Name, append(allErrs, field.Invalid(shootNamePath, managedSeed.Spec.Shoot.Name, fmt.Sprintf("shoot %s already registered as seed", kutil.ObjectName(shoot)))))
+	}
+
+	switch {
+	case managedSeed.Spec.SeedTemplate != nil:
+		// Admit seed spec against shoot
+		errs, err := v.admitSeedSpec(ctx, &managedSeed.Spec.SeedTemplate.Spec, shoot, field.NewPath("spec", "seedTemplate", "spec"))
+		if err != nil {
+			return err
+		}
+		allErrs = append(allErrs, errs...)
+
+	case managedSeed.Spec.Gardenlet != nil:
+		// Admit gardelnet against shoot
+		errs, err := v.admitGardenlet(ctx, managedSeed.Spec.Gardenlet, shoot, field.NewPath("spec", "gardenlet"))
+		if err != nil {
+			return err
+		}
+		allErrs = append(allErrs, errs...)
+	}
+
+	if len(allErrs) > 0 {
+		return apierrors.NewInvalid(gk, managedSeed.Name, allErrs)
+	}
+
+	return nil
+}
+
+func (v *ValidateManagedSeed) admitGardenlet(ctx context.Context, gardenlet *seedmanagement.Gardenlet, shoot *gardencore.Shoot, fldPath *field.Path) (field.ErrorList, error) {
+	var allErrs field.ErrorList
+
+	if gardenlet.Config != nil {
+		configPath := fldPath.Child("config")
+
+		// Decode gardenlet config to an internal version
+		// Without defaults, since we don't want to set gardenlet config defaults in the resource at this point
+		gardenletConfig, err := helper.ConvertGardenletConfigExternal(gardenlet.Config)
+		if err != nil {
+			return append(allErrs, field.Invalid(configPath, gardenlet.Config, fmt.Sprintf("could not decode config: %v", err))), nil
+		}
+
+		if gardenletConfig.SeedConfig != nil {
+			seedConfigPath := fldPath.Child("seedConfig")
+
+			// Convert seed config to internal version
+			seed, err := helper.ConvertSeed(&gardenletConfig.SeedConfig.Seed)
+			if err != nil {
+				return allErrs, apierrors.NewInternalError(fmt.Errorf("could not convert seed config: %v", err))
+			}
+
+			// Admit seed spec against shoot
+			errs, err := v.admitSeedSpec(ctx, &seed.Spec, shoot, seedConfigPath.Child("spec"))
+			if err != nil {
+				return allErrs, err
+			}
+			allErrs = append(allErrs, errs...)
+
+			// Set seed config back to gardenletConfig.SeedConfig.Seed
+			seedx, err := helper.ConvertSeedExternal(seed)
+			if err != nil {
+				return allErrs, apierrors.NewInternalError(fmt.Errorf("could not convert seed config: %v", err))
+			}
+			gardenletConfig.SeedConfig.Seed = *seedx
+		}
+
+		// Set gardenlet config back to gardenlet.Config
+		gardenlet.Config = gardenletConfig
+	}
+
+	return allErrs, nil
+}
+
+func (v *ValidateManagedSeed) admitSeedSpec(ctx context.Context, spec *gardencore.SeedSpec, shoot *gardencore.Shoot, fldPath *field.Path) (field.ErrorList, error) {
+	var allErrs field.ErrorList
+
+	// Initialize backup provider
+	if spec.Backup != nil && spec.Backup.Provider == "" {
+		spec.Backup.Provider = shoot.Spec.Provider.Type
+	}
+
+	// Initialize and validate DNS and ingress
+	ingressDomain := fmt.Sprintf("%s.%s", common.IngressPrefix, *(shoot.Spec.DNS.Domain))
+	if spec.Ingress != nil {
+		if gardencorehelper.NginxIngressEnabled(shoot.Spec.Addons) {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("ingress"), fmt.Sprintf("seed ingress controller cannot be enabled on shoot %s", kutil.ObjectName(shoot))))
+		}
+
+		if spec.DNS.Provider == nil {
+			dnsProvider, err := v.getSeedDNSProvider(ctx, shoot)
+			if err != nil {
+				if apierrors.IsInternalError(err) {
+					return allErrs, err
+				}
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("ingress"), spec.Ingress, err.Error()))
+			}
+			spec.DNS.Provider = dnsProvider
+		}
+		// TODO If spec.DNS.Provider is not nil should we check if the user specified exactly the DNS provider we found above?
+		// I assume not, since the shoot may have multiple DNS providers
+
+		if spec.Ingress.Domain == "" {
+			spec.Ingress.Domain = ingressDomain
+		} else if spec.Ingress.Domain != ingressDomain {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("ingress", "domain"), spec.Ingress.Domain, fmt.Sprintf("seed ingress domain must be equal to shoot DNS domain %s", ingressDomain)))
+		}
+	} else {
+		if spec.DNS.IngressDomain == nil || *spec.DNS.IngressDomain == "" {
+			spec.DNS.IngressDomain = &ingressDomain
+		} else if *spec.DNS.IngressDomain != ingressDomain {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("dns", "ingressDomain"), spec.DNS.IngressDomain, fmt.Sprintf("seed ingress domain must be equal to shoot DNS domain %s", ingressDomain)))
+		}
+	}
+
+	// Initialize and validate networks
+	if spec.Networks.Nodes == nil {
+		spec.Networks.Nodes = shoot.Spec.Networking.Nodes
+	} else if shoot.Spec.Networking.Nodes != nil && *spec.Networks.Nodes != *shoot.Spec.Networking.Nodes {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("networks", "nodes"), spec.Networks.Nodes, fmt.Sprintf("seed nodes CIDR must be equal to shoot nodes CIDR %s", *shoot.Spec.Networking.Nodes)))
+	}
+	if spec.Networks.Pods == "" && shoot.Spec.Networking.Pods != nil {
+		spec.Networks.Pods = *shoot.Spec.Networking.Pods
+	} else if shoot.Spec.Networking.Pods != nil && spec.Networks.Pods != *shoot.Spec.Networking.Pods {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("networks", "pods"), spec.Networks.Pods, fmt.Sprintf("seed pods CIDR must be equal to shoot pods CIDR %s", *shoot.Spec.Networking.Pods)))
+	}
+	if spec.Networks.Services == "" && shoot.Spec.Networking.Services != nil {
+		spec.Networks.Services = *shoot.Spec.Networking.Services
+	} else if shoot.Spec.Networking.Services != nil && spec.Networks.Services != *shoot.Spec.Networking.Services {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("networks", "services"), spec.Networks.Pods, fmt.Sprintf("seed services CIDR must be equal to shoot services CIDR %s", *shoot.Spec.Networking.Services)))
+	}
+
+	// Initialize and validate provider
+	if spec.Provider.Type == "" {
+		spec.Provider.Type = shoot.Spec.Provider.Type
+	} else if spec.Provider.Type != shoot.Spec.Provider.Type {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("provider", "type"), spec.Provider.Type, fmt.Sprintf("seed provider type must be equal to shoot provider type %s", shoot.Spec.Provider.Type)))
+	}
+	if spec.Provider.Region == "" {
+		spec.Provider.Region = shoot.Spec.Region
+	} else if spec.Provider.Region != shoot.Spec.Region {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("provider", "region"), spec.Provider.Region, fmt.Sprintf("seed provider region must be equal to shoot region %s", shoot.Spec.Region)))
+	}
+
+	return allErrs, nil
+}
+
+func (v *ValidateManagedSeed) getSeedDNSProvider(ctx context.Context, shoot *gardencore.Shoot) (*gardencore.SeedDNSProvider, error) {
+	dnsProvider, err := v.getSeedDNSProviderForCustomDomain(ctx, shoot)
+	if err != nil {
+		return nil, err
+	}
+	if dnsProvider == nil {
+		dnsProvider, err = v.getSeedDNSProviderForDefaultDomain(ctx, shoot)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if dnsProvider == nil {
+		return nil, fmt.Errorf("domain of shoot %s is neither a custom domain nor a default domain", kutil.ObjectName(shoot))
+	}
+	return dnsProvider, nil
+}
+
+func (v *ValidateManagedSeed) getSeedDNSProviderForCustomDomain(ctx context.Context, shoot *gardencore.Shoot) (*gardencore.SeedDNSProvider, error) {
+	// Find a primary DNS provider in the list of shoot DNS providers
+	primaryProvider := gardencorehelper.FindPrimaryDNSProvider(shoot.Spec.DNS.Providers)
+	if primaryProvider == nil {
+		return nil, nil
+	}
+	if primaryProvider.Type == nil {
+		return nil, fmt.Errorf("primary DNS provider of shoot %s does not have a type", kutil.ObjectName(shoot))
+	}
+	if *primaryProvider.Type == gardencore.DNSUnmanaged {
+		return nil, nil
+	}
+
+	// Initialize a reference to the primary DNS provider secret
+	var secretRef corev1.SecretReference
+	if primaryProvider.SecretName != nil {
+		secretRef.Name = *primaryProvider.SecretName
+		secretRef.Namespace = shoot.Namespace
+	} else {
+		secretBinding, err := v.getSecretBinding(shoot.Namespace, shoot.Spec.SecretBindingName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, fmt.Errorf("secret binding %s/%s not found", shoot.Namespace, shoot.Spec.SecretBindingName)
+			}
+			return nil, apierrors.NewInternalError(fmt.Errorf("could not get secret binding %s/%s: %v", shoot.Namespace, shoot.Spec.SecretBindingName, err))
+		}
+		secretRef = secretBinding.SecretRef
+	}
+
+	return &gardencore.SeedDNSProvider{
+		Type:      *primaryProvider.Type,
+		SecretRef: secretRef,
+		Domains:   primaryProvider.Domains,
+		Zones:     primaryProvider.Zones,
+	}, nil
+}
+
+func (v *ValidateManagedSeed) getSeedDNSProviderForDefaultDomain(ctx context.Context, shoot *gardencore.Shoot) (*gardencore.SeedDNSProvider, error) {
+	// Get all default domain secrets in the garden namespace
+	defaultDomainSecrets, err := v.getSecrets(v1beta1constants.GardenNamespace, labels.SelectorFromValidatedSet(map[string]string{
+		v1beta1constants.GardenRole: common.GardenRoleDefaultDomain,
+	}))
+	if err != nil {
+		return nil, apierrors.NewInternalError(fmt.Errorf("could not list default domain secrets in namespace %s: %v", v1beta1constants.GardenNamespace, err))
+	}
+
+	// Search for a default domain secret that matches the shoot domain
+	for _, secret := range defaultDomainSecrets {
+		provider, domain, includeZones, excludeZones, err := common.GetDomainInfoFromAnnotations(secret.Annotations)
+		if err != nil {
+			return nil, apierrors.NewInternalError(fmt.Errorf("could not get domain info from domain secret annotations: %v", err))
+		}
+
+		if strings.HasSuffix(*shoot.Spec.DNS.Domain, domain) {
+			var zones *gardencore.DNSIncludeExclude
+			if includeZones != nil || excludeZones != nil {
+				zones = &gardencore.DNSIncludeExclude{
+					Include: includeZones,
+					Exclude: excludeZones,
+				}
+			}
+
+			return &gardencore.SeedDNSProvider{
+				Type: provider,
+				SecretRef: corev1.SecretReference{
+					Name:      secret.Name,
+					Namespace: secret.Namespace,
+				},
+				Domains: &gardencore.DNSIncludeExclude{
+					Include: []string{domain},
+				},
+				Zones: zones,
+			}, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (v *ValidateManagedSeed) getShoot(ctx context.Context, namespace, name string) (*gardencore.Shoot, error) {
+	shoot, err := v.shootLister.Shoots(namespace).Get(name)
+	if err != nil && apierrors.IsNotFound(err) {
+		// Read from the client to ensure that if the managed seed has been created shortly after the shoot
+		// and the shoot is not yet present in the lister cache, it could still be found
+		return v.coreClient.Core().Shoots(namespace).Get(ctx, name, clientkubernetes.DefaultGetOptions())
+	}
+	return shoot, err
+}
+
+func (v *ValidateManagedSeed) getSecretBinding(namespace, name string) (*gardencore.SecretBinding, error) {
+	return v.secretBindingLister.SecretBindings(namespace).Get(name)
+}
+
+func (v *ValidateManagedSeed) getSecrets(namespace string, selector labels.Selector) ([]*corev1.Secret, error) {
+	return v.secretLister.Secrets(namespace).List(selector)
+}

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -1,0 +1,508 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator_test
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	seedmanagement "github.com/gardener/gardener/pkg/apis/seedmanagement"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement/helper"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	corefake "github.com/gardener/gardener/pkg/client/core/clientset/internalversion/fake"
+	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
+	seedmanagementfake "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned/fake"
+	configv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	"github.com/gardener/gardener/pkg/operation/common"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/gardener/gardener/plugin/pkg/managedseed/validator"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/admission"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/testing"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	name        = "foo"
+	namespace   = "garden"
+	domain      = "foo.example.com"
+	provider    = "foo-provider"
+	region      = "foo-region"
+	dnsProvider = "dns-provider"
+)
+
+var _ = Describe("ValidateManagedSeed", func() {
+	Describe("#Admit", func() {
+		var (
+			managedSeed          *seedmanagement.ManagedSeed
+			shoot                *core.Shoot
+			secret               *corev1.Secret
+			seed                 func(withIngress bool) *core.Seed
+			coreInformerFactory  coreinformers.SharedInformerFactory
+			coreClient           *corefake.Clientset
+			seedManagementClient *seedmanagementfake.Clientset
+			kubeInformerFactory  kubeinformers.SharedInformerFactory
+			admissionHandler     *ValidateManagedSeed
+		)
+
+		BeforeEach(func() {
+			managedSeed = &seedmanagement.ManagedSeed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: seedmanagement.ManagedSeedSpec{
+					Shoot: seedmanagement.Shoot{
+						Name: name,
+					},
+				},
+			}
+
+			shoot = &core.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: core.ShootSpec{
+					DNS: &core.DNS{
+						Domain: pointer.StringPtr(domain),
+					},
+					Networking: core.Networking{
+						Pods:     pointer.StringPtr("100.96.0.0/11"),
+						Nodes:    pointer.StringPtr("10.250.0.0/16"),
+						Services: pointer.StringPtr("100.64.0.0/13"),
+					},
+					Provider: core.Provider{
+						Type: provider,
+					},
+					Region: region,
+				},
+			}
+
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Labels: map[string]string{
+						v1beta1constants.GardenRole: common.GardenRoleDefaultDomain,
+					},
+					Annotations: map[string]string{
+						common.DNSProvider: dnsProvider,
+						common.DNSDomain:   domain,
+					},
+				},
+			}
+
+			seed = func(withIngress bool) *core.Seed {
+				var (
+					dns     core.SeedDNS
+					ingress *core.Ingress
+				)
+
+				if withIngress {
+					dns = core.SeedDNS{
+						Provider: &core.SeedDNSProvider{
+							Type: dnsProvider,
+							SecretRef: corev1.SecretReference{
+								Name:      name,
+								Namespace: namespace,
+							},
+							Domains: &core.DNSIncludeExclude{
+								Include: []string{domain},
+							},
+						},
+					}
+					ingress = &core.Ingress{
+						Domain: "ingress." + domain,
+						Controller: core.IngressController{
+							Kind: "nginx",
+						},
+					}
+				} else {
+					dns = core.SeedDNS{
+						IngressDomain: pointer.StringPtr("ingress." + domain),
+					}
+				}
+
+				return &core.Seed{
+					Spec: core.SeedSpec{
+						Backup: &core.SeedBackup{
+							Provider: provider,
+						},
+						DNS: dns,
+						Networks: core.SeedNetworks{
+							Nodes:    pointer.StringPtr("10.250.0.0/16"),
+							Pods:     "100.96.0.0/11",
+							Services: "100.64.0.0/13",
+						},
+						Provider: core.SeedProvider{
+							Type:   provider,
+							Region: region,
+						},
+						Ingress: ingress,
+					},
+				}
+			}
+
+			admissionHandler, _ = New()
+			admissionHandler.AssignReadyFunc(func() bool { return true })
+
+			coreInformerFactory = coreinformers.NewSharedInformerFactory(nil, 0)
+			admissionHandler.SetInternalCoreInformerFactory(coreInformerFactory)
+
+			coreClient = &corefake.Clientset{}
+			admissionHandler.SetInternalCoreClientset(coreClient)
+
+			seedManagementClient = &seedmanagementfake.Clientset{}
+			admissionHandler.SetSeedManagementClientset(seedManagementClient)
+
+			kubeInformerFactory = kubeinformers.NewSharedInformerFactory(nil, 0)
+			admissionHandler.SetKubeInformerFactory(kubeInformerFactory)
+		})
+
+		It("should do nothing if the resource is not a ManagedSeed", func() {
+			attrs := admission.NewAttributesRecord(nil, nil, core.Kind(name).WithVersion("version"), managedSeed.Namespace, managedSeed.Name, core.Resource("foos").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+			err := admissionHandler.Admit(context.TODO(), attrs, nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should forbid the ManagedSeed creation if a Shoot name is not specified", func() {
+			managedSeed.Spec.Shoot.Name = ""
+
+			err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
+			Expect(err).To(BeInvalidError())
+			Expect(getErrorList(err)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.shoot.name"),
+				})),
+			))
+		})
+
+		It("should forbid the ManagedSeed creation if the Shoot does not exist", func() {
+			coreClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+				return true, nil, apierrors.NewNotFound(core.Resource("shoot"), "")
+			})
+
+			err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
+			Expect(err).To(BeInvalidError())
+			Expect(getErrorList(err)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.shoot.name"),
+				})),
+			))
+		})
+
+		It("should forbid the ManagedSeed creation if the Shoot does not specify a domain", func() {
+			shoot.Spec.DNS = nil
+
+			coreClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+				return true, shoot, nil
+			})
+
+			err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
+			Expect(err).To(BeInvalidError())
+			Expect(getErrorList(err)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.shoot.name"),
+				})),
+			))
+		})
+
+		It("should forbid the ManagedSeed creation if the Shoot is already registered as Seed", func() {
+			anotherManagedSeed := &seedmanagementv1alpha1.ManagedSeed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar",
+					Namespace: namespace,
+				},
+				Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+					Shoot: seedmanagementv1alpha1.Shoot{
+						Name: name,
+					},
+				},
+			}
+
+			coreClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+				return true, shoot, nil
+			})
+			seedManagementClient.AddReactor("list", "managedseeds", func(action testing.Action) (bool, runtime.Object, error) {
+				return true, &seedmanagementv1alpha1.ManagedSeedList{Items: []seedmanagementv1alpha1.ManagedSeed{*anotherManagedSeed}}, nil
+			})
+
+			err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
+			Expect(err).To(BeInvalidError())
+			Expect(getErrorList(err)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.shoot.name"),
+				})),
+			))
+		})
+
+		Context("seed template", func() {
+			BeforeEach(func() {
+				managedSeed.Spec.SeedTemplate = &seedmanagement.SeedTemplate{
+					Spec: core.SeedSpec{
+						Backup: &core.SeedBackup{},
+					},
+				}
+			})
+
+			It("should allow the ManagedSeed creation if the Shoot exists and can be registered as Seed (w/o ingress)", func() {
+				coreClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, shoot, nil
+				})
+
+				err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(managedSeed.Spec.SeedTemplate).To(Equal(&seedmanagement.SeedTemplate{
+					Spec: seed(false).Spec,
+				}))
+			})
+
+			It("should allow the ManagedSeed creation if the Shoot exists and can be registered as Seed (w/ ingress)", func() {
+				managedSeed.Spec.SeedTemplate.Spec = core.SeedSpec{
+					Backup: &core.SeedBackup{},
+					Ingress: &core.Ingress{
+						Controller: core.IngressController{
+							Kind: "nginx",
+						},
+					},
+				}
+
+				coreClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, shoot, nil
+				})
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(secret)).NotTo(HaveOccurred())
+
+				err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(managedSeed.Spec.SeedTemplate).To(Equal(&seedmanagement.SeedTemplate{
+					Spec: seed(true).Spec,
+				}))
+			})
+
+			It("should forbid the ManagedSeed creation if the seed spec contains invalid values (w/o ingress)", func() {
+				managedSeed.Spec.SeedTemplate.Spec = core.SeedSpec{
+					DNS: core.SeedDNS{
+						IngressDomain: pointer.StringPtr("bar.example.com"),
+					},
+					Networks: core.SeedNetworks{
+						Nodes:    pointer.StringPtr("10.251.0.0/16"),
+						Pods:     "100.97.0.0/11",
+						Services: "100.65.0.0/13",
+					},
+					Provider: core.SeedProvider{
+						Type:   "bar-provider",
+						Region: "bar-region",
+					},
+				}
+
+				coreClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, shoot, nil
+				})
+
+				err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
+				Expect(err).To(BeInvalidError())
+				Expect(getErrorList(err)).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.seedTemplate.spec.dns.ingressDomain"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.seedTemplate.spec.networks.nodes"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.seedTemplate.spec.networks.pods"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.seedTemplate.spec.networks.services"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.seedTemplate.spec.provider.type"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.seedTemplate.spec.provider.region"),
+					})),
+				))
+			})
+
+			It("should forbid the ManagedSeed creation if the seed spec contains invalid values (w/ ingress)", func() {
+				shoot.Spec.Addons = &core.Addons{
+					NginxIngress: &core.NginxIngress{
+						Addon: core.Addon{
+							Enabled: true,
+						},
+					},
+				}
+				managedSeed.Spec.SeedTemplate.Spec = core.SeedSpec{
+					Ingress: &core.Ingress{
+						Domain: "bar.example.com",
+						Controller: core.IngressController{
+							Kind: "nginx",
+						},
+					},
+				}
+
+				coreClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, shoot, nil
+				})
+				Expect(kubeInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(secret)).NotTo(HaveOccurred())
+
+				err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
+				Expect(err).To(BeInvalidError())
+				Expect(getErrorList(err)).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeForbidden),
+						"Field": Equal("spec.seedTemplate.spec.ingress"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.seedTemplate.spec.ingress.domain"),
+					})),
+				))
+			})
+		})
+
+		Context("gardenlet", func() {
+			var (
+				seedx *gardencorev1beta1.Seed
+				err   error
+			)
+
+			BeforeEach(func() {
+				managedSeed.Spec.Gardenlet = &seedmanagement.Gardenlet{
+					Config: &configv1alpha1.GardenletConfiguration{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: configv1alpha1.SchemeGroupVersion.String(),
+							Kind:       "GardenletConfiguration",
+						},
+						SeedConfig: &configv1alpha1.SeedConfig{
+							Seed: gardencorev1beta1.Seed{
+								Spec: gardencorev1beta1.SeedSpec{
+									Backup: &gardencorev1beta1.SeedBackup{},
+								},
+							},
+						},
+					},
+				}
+
+				seedx, err = helper.ConvertSeedExternal(seed(false))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should allow the ManagedSeed creation if the Shoot exists and can be registered as Seed", func() {
+				coreClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, shoot, nil
+				})
+
+				err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(managedSeed.Spec.Gardenlet).To(Equal(&seedmanagement.Gardenlet{
+					Config: &configv1alpha1.GardenletConfiguration{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: configv1alpha1.SchemeGroupVersion.String(),
+							Kind:       "GardenletConfiguration",
+						},
+						SeedConfig: &configv1alpha1.SeedConfig{
+							Seed: *seedx,
+						},
+					},
+				}))
+			})
+		})
+	})
+
+	Describe("#Register", func() {
+		It("should register the plugin", func() {
+			plugins := admission.NewPlugins()
+			Register(plugins)
+
+			registered := plugins.Registered()
+			Expect(registered).To(HaveLen(1))
+			Expect(registered).To(ContainElement(PluginName))
+		})
+	})
+
+	Describe("#New", func() {
+		It("should only handle CREATE and UPDATE operations", func() {
+			admissionHandler, err := New()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(admissionHandler.Handles(admission.Create)).To(BeTrue())
+			Expect(admissionHandler.Handles(admission.Update)).To(BeTrue())
+			Expect(admissionHandler.Handles(admission.Connect)).NotTo(BeTrue())
+			Expect(admissionHandler.Handles(admission.Delete)).NotTo(BeTrue())
+		})
+	})
+
+	Describe("#ValidateInitialization", func() {
+		It("should fail if the required clients are not set", func() {
+			admissionHandler, _ := New()
+
+			err := admissionHandler.ValidateInitialization()
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should not fail if the required clients are set", func() {
+			admissionHandler, _ := New()
+			admissionHandler.SetInternalCoreInformerFactory(coreinformers.NewSharedInformerFactory(nil, 0))
+			admissionHandler.SetInternalCoreClientset(&corefake.Clientset{})
+			admissionHandler.SetSeedManagementClientset(&seedmanagementfake.Clientset{})
+			admissionHandler.SetKubeInformerFactory(kubeinformers.NewSharedInformerFactory(nil, 0))
+
+			err := admissionHandler.ValidateInitialization()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})
+
+func getManagedSeedAttributes(managedSeed *seedmanagement.ManagedSeed) admission.Attributes {
+	return admission.NewAttributesRecord(managedSeed, nil, seedmanagementv1alpha1.Kind("ManagedSeed").WithVersion("v1alpha1"), managedSeed.Namespace, managedSeed.Name, seedmanagementv1alpha1.Resource("managedseeds").WithVersion("v1alpha1"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+}
+
+func getErrorList(err error) field.ErrorList {
+	statusError, ok := err.(*apierrors.StatusError)
+	if !ok {
+		return field.ErrorList{}
+	}
+	var errs field.ErrorList
+	for _, cause := range statusError.ErrStatus.Details.Causes {
+		errs = append(errs, &field.Error{
+			Type:   field.ErrorType(cause.Type),
+			Field:  cause.Field,
+			Detail: cause.Message,
+		})
+	}
+	return errs
+}

--- a/plugin/pkg/managedseed/validator/validator_suite_test.go
+++ b/plugin/pkg/managedseed/validator/validator_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Admission ManagedSeedValidator Suite")
+}

--- a/plugin/pkg/shoot/managedseed/admission.go
+++ b/plugin/pkg/shoot/managedseed/admission.go
@@ -136,7 +136,7 @@ func (v *ManagedSeed) validateDeleteCollection(ctx context.Context, a admission.
 		return err
 	}
 	for _, shoot := range shoots {
-		if err := v.validateDelete(ctx, v.newAttributesWithName(a, shoot.Name)); err != nil {
+		if err := v.validateDelete(ctx, newAttributesWithName(a, shoot.Name)); err != nil {
 			return err
 		}
 	}
@@ -156,7 +156,7 @@ func (v *ManagedSeed) validateDelete(ctx context.Context, a admission.Attributes
 	return admission.NewForbidden(a, fmt.Errorf("cannot delete shoot %s/%s since it is still referenced by a managed seed", a.GetNamespace(), a.GetName()))
 }
 
-func (d *ManagedSeed) newAttributesWithName(a admission.Attributes, name string) admission.Attributes {
+func newAttributesWithName(a admission.Attributes, name string) admission.Attributes {
 	return admission.NewAttributesRecord(a.GetObject(),
 		a.GetOldObject(),
 		a.GetKind(),

--- a/plugin/pkg/shoot/managedseed/admission.go
+++ b/plugin/pkg/shoot/managedseed/admission.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedseed
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
+	coreclientset "github.com/gardener/gardener/pkg/client/core/clientset/internalversion"
+	seedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const (
+	// PluginName is the name of this admission plugin.
+	PluginName = "ShootManagedSeed"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return New()
+	})
+}
+
+// ManagedSeed contains listers and and admission handler.
+type ManagedSeed struct {
+	*admission.Handler
+	coreClient           coreclientset.Interface
+	seedManagementClient seedmanagementclientset.Interface
+	readyFunc            admission.ReadyFunc
+}
+
+var (
+	_ = admissioninitializer.WantsInternalCoreClientset(&ManagedSeed{})
+	_ = admissioninitializer.WantsSeedManagementClientset(&ManagedSeed{})
+
+	readyFuncs = []admission.ReadyFunc{}
+)
+
+// New creates a new ManagedSeed admission plugin.
+func New() (*ManagedSeed, error) {
+	return &ManagedSeed{
+		Handler: admission.NewHandler(admission.Delete),
+	}, nil
+}
+
+// AssignReadyFunc assigns the ready function to the admission handler.
+func (v *ManagedSeed) AssignReadyFunc(f admission.ReadyFunc) {
+	v.readyFunc = f
+	v.SetReadyFunc(f)
+}
+
+// SetInternalCoreClientset sets the garden core clientset.
+func (v *ManagedSeed) SetInternalCoreClientset(c coreclientset.Interface) {
+	v.coreClient = c
+}
+
+// SetSeedManagementClientset sets the garden seedmanagement clientset.
+func (v *ManagedSeed) SetSeedManagementClientset(c seedmanagementclientset.Interface) {
+	v.seedManagementClient = c
+}
+
+// ValidateInitialization checks whether the plugin was correctly initialized.
+func (v *ManagedSeed) ValidateInitialization() error {
+	if v.coreClient == nil {
+		return errors.New("missing garden core client")
+	}
+	if v.seedManagementClient == nil {
+		return errors.New("missing garden seedmanagement client")
+	}
+	return nil
+}
+
+var _ admission.ValidationInterface = &ManagedSeed{}
+
+// Validate validates if the Shoot can be deleted. If the
+func (v *ManagedSeed) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+	// Wait until the caches have been synced
+	if v.readyFunc == nil {
+		v.AssignReadyFunc(func() bool {
+			for _, readyFunc := range readyFuncs {
+				if !readyFunc() {
+					return false
+				}
+			}
+			return true
+		})
+	}
+	if !v.WaitForReady() {
+		return admission.NewForbidden(a, errors.New("not yet ready to handle request"))
+	}
+
+	// Ignore all kinds other than Shoot
+	if a.GetKind().GroupKind() != core.Kind("Shoot") {
+		return nil
+	}
+
+	// Ignore updates to status or other subresources
+	if a.GetSubresource() != "" {
+		return nil
+	}
+
+	switch {
+	case a.GetName() == "":
+		return v.validateDeleteCollection(ctx, a)
+	default:
+		return v.validateDelete(ctx, a)
+	}
+}
+
+func (v *ManagedSeed) validateDeleteCollection(ctx context.Context, a admission.Attributes) error {
+	shoots, err := v.getShoots(ctx, labels.Everything())
+	if err != nil {
+		return err
+	}
+	for _, shoot := range shoots {
+		if err := v.validateDelete(ctx, v.newAttributesWithName(a, shoot.Name)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (v *ManagedSeed) validateDelete(ctx context.Context, a admission.Attributes) error {
+	managedSeed, err := kutil.GetManagedSeed(ctx, v.seedManagementClient, a.GetNamespace(), a.GetName())
+	if err != nil {
+		return apierrors.NewInternalError(fmt.Errorf("could not get ManagedSeed for shoot '%s/%s': %v", a.GetNamespace(), a.GetName(), err))
+	}
+	if managedSeed == nil {
+		return nil
+	}
+
+	return admission.NewForbidden(a, fmt.Errorf("cannot delete shoot %s/%s since it is still referenced by a managed seed", a.GetNamespace(), a.GetName()))
+}
+
+func (d *ManagedSeed) newAttributesWithName(a admission.Attributes, name string) admission.Attributes {
+	return admission.NewAttributesRecord(a.GetObject(),
+		a.GetOldObject(),
+		a.GetKind(),
+		a.GetNamespace(),
+		name,
+		a.GetResource(),
+		a.GetSubresource(),
+		a.GetOperation(),
+		a.GetOperationOptions(),
+		a.IsDryRun(),
+		a.GetUserInfo())
+}
+
+func (v *ManagedSeed) getShoots(ctx context.Context, selector labels.Selector) ([]core.Shoot, error) {
+	shootList, err := v.coreClient.Core().Shoots("").List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, err
+	}
+	return shootList.Items, nil
+}

--- a/plugin/pkg/shoot/managedseed/admission_test.go
+++ b/plugin/pkg/shoot/managedseed/admission_test.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedseed_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	corefake "github.com/gardener/gardener/pkg/client/core/clientset/internalversion/fake"
+	seedmanagementfake "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned/fake"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/gardener/gardener/plugin/pkg/shoot/managedseed"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/client-go/testing"
+)
+
+const (
+	name      = "foo"
+	namespace = "garden"
+)
+
+var _ = Describe("ManagedSeed", func() {
+	Describe("#Validate", func() {
+		var (
+			shoot                *core.Shoot
+			managedSeed          *seedmanagementv1alpha1.ManagedSeed
+			coreClient           *corefake.Clientset
+			seedManagementClient *seedmanagementfake.Clientset
+			admissionHandler     *ManagedSeed
+		)
+
+		BeforeEach(func() {
+			shoot = &core.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+			}
+
+			managedSeed = &seedmanagementv1alpha1.ManagedSeed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+					Shoot: seedmanagementv1alpha1.Shoot{
+						Name: name,
+					},
+				},
+			}
+
+			admissionHandler, _ = New()
+			admissionHandler.AssignReadyFunc(func() bool { return true })
+
+			coreClient = &corefake.Clientset{}
+			admissionHandler.SetInternalCoreClientset(coreClient)
+
+			seedManagementClient = &seedmanagementfake.Clientset{}
+			admissionHandler.SetSeedManagementClientset(seedManagementClient)
+		})
+
+		Context("delete", func() {
+			It("should do nothing if the resource is not a Shoot", func() {
+				attrs := admission.NewAttributesRecord(nil, nil, core.Kind("Foo").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("foos").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should forbid the Shoot deletion if a ManagedSeed referencing the Shoot exists", func() {
+				seedManagementClient.AddReactor("list", "managedseeds", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, &seedmanagementv1alpha1.ManagedSeedList{Items: []seedmanagementv1alpha1.ManagedSeed{*managedSeed}}, nil
+				})
+
+				err := admissionHandler.Validate(context.TODO(), getShootAttributes(shoot), nil)
+				Expect(err).To(BeForbiddenError())
+			})
+
+			It("should allow the Shoot deletion if a ManagedSeed referencing the Shoot does not exist", func() {
+				seedManagementClient.AddReactor("list", "managedseeds", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, &seedmanagementv1alpha1.ManagedSeedList{Items: []seedmanagementv1alpha1.ManagedSeed{}}, nil
+				})
+
+				err := admissionHandler.Validate(context.TODO(), getShootAttributes(shoot), nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should fail with an error different from Forbidden if retrieving the ManagedSeed fails with an error different from NotFound", func() {
+				seedManagementClient.AddReactor("list", "managedseeds", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrors.NewInternalError(errors.New("Internal Server Error"))
+				})
+
+				err := admissionHandler.Validate(context.TODO(), getShootAttributes(shoot), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err).ToNot(BeForbiddenError())
+			})
+		})
+
+		Context("delete collection", func() {
+			var (
+				anotherShoot *core.Shoot
+			)
+
+			BeforeEach(func() {
+				anotherShoot = &core.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bar",
+						Namespace: "garden",
+					},
+				}
+			})
+
+			It("should forbid multiple Shoots deletion if a ManagedSeed referencing any of the Shoots exists", func() {
+				coreClient.AddReactor("list", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, &core.ShootList{Items: []core.Shoot{*shoot, *anotherShoot}}, nil
+				})
+				seedManagementClient.AddReactor("list", "managedseeds", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, &seedmanagementv1alpha1.ManagedSeedList{Items: []seedmanagementv1alpha1.ManagedSeed{*managedSeed}}, nil
+				})
+
+				err := admissionHandler.Validate(context.TODO(), getAllShootsAttributes(shoot.Namespace), nil)
+				Expect(err).To(BeForbiddenError())
+			})
+
+			It("should allow multiple Shoots deletion if no ManagedSeeds referencing the Shoots exist", func() {
+				coreClient.AddReactor("list", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, &core.ShootList{Items: []core.Shoot{*shoot, *anotherShoot}}, nil
+				})
+				seedManagementClient.AddReactor("list", "managedseeds", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, &seedmanagementv1alpha1.ManagedSeedList{Items: []seedmanagementv1alpha1.ManagedSeed{}}, nil
+				})
+
+				err := admissionHandler.Validate(context.TODO(), getAllShootsAttributes(shoot.Namespace), nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("#Register", func() {
+		It("should register the plugin", func() {
+			plugins := admission.NewPlugins()
+			Register(plugins)
+
+			registered := plugins.Registered()
+			Expect(registered).To(HaveLen(1))
+			Expect(registered).To(ContainElement(PluginName))
+		})
+	})
+
+	Describe("#New", func() {
+		It("should only handle DELETE operations", func() {
+			admissionHandler, err := New()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(admissionHandler.Handles(admission.Create)).NotTo(BeTrue())
+			Expect(admissionHandler.Handles(admission.Update)).NotTo(BeTrue())
+			Expect(admissionHandler.Handles(admission.Connect)).NotTo(BeTrue())
+			Expect(admissionHandler.Handles(admission.Delete)).To(BeTrue())
+		})
+	})
+
+	Describe("#ValidateInitialization", func() {
+		It("should fail if the required clients are not set", func() {
+			admissionHandler, _ := New()
+
+			err := admissionHandler.ValidateInitialization()
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should not fail if the required clients are set", func() {
+			admissionHandler, _ := New()
+			admissionHandler.SetInternalCoreClientset(&corefake.Clientset{})
+			admissionHandler.SetSeedManagementClientset(&seedmanagementfake.Clientset{})
+
+			err := admissionHandler.ValidateInitialization()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})
+
+func getShootAttributes(shoot *core.Shoot) admission.Attributes {
+	return admission.NewAttributesRecord(shoot, nil, corev1beta1.Kind("Shoot").WithVersion("v1beta1"), shoot.Namespace, shoot.Name, corev1beta1.Resource("shoots").WithVersion("v1beta1"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+}
+
+func getAllShootsAttributes(namespace string) admission.Attributes {
+	return admission.NewAttributesRecord(nil, nil, corev1beta1.Kind("Shoot").WithVersion("v1beta1"), namespace, "", corev1beta1.Resource("shoots").WithVersion("v1beta1"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+}

--- a/plugin/pkg/shoot/managedseed/managedseed_suite_test.go
+++ b/plugin/pkg/shoot/managedseed/managedseed_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedseed_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestManagedSeed(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Admission ShootManagedSeed Suite")
+}


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Adds `gardener-apiserver` admission plugins for `ManagedSeed` resources.

* Admission plugin for `ManagedSeed` resources that validates / mutates a managed seed against the shoot it references.
* Admission plugin for `Shoot` resources that prevents deleting a shoot if it's being referenced by a managed seed.

Creating, updating, and deleting `ManagedSeed` resources can now be tested with full admission, which means that the user has to supply fewer values. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Based on #3415. This is the fourth of several PRs that are split from #3177 since it became too big and hard to review. Before commenting, please check if the topic has been already discussed in the previous PR.

**Release note**:

```improvement operator
NONE
```