### PR TITLE
[GEP-13] Add ManagedSeed controller prerequisites

### DIFF
--- a/extensions/pkg/controller/backupbucket/reconciler.go
+++ b/extensions/pkg/controller/backupbucket/reconciler.go
@@ -34,6 +34,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 const (
@@ -98,7 +99,7 @@ func (r *reconciler) reconcile(ctx context.Context, bb *extensionsv1alpha1.Backu
 		return reconcile.Result{}, err
 	}
 
-	secret, err := extensionscontroller.GetSecretByReference(ctx, r.client, &bb.Spec.SecretRef)
+	secret, err := kutil.GetSecretByReference(ctx, r.client, &bb.Spec.SecretRef)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get backup bucket secret: %+v", err)
 	}
@@ -151,7 +152,7 @@ func (r *reconciler) delete(ctx context.Context, bb *extensionsv1alpha1.BackupBu
 		return reconcile.Result{}, err
 	}
 
-	secret, err := extensionscontroller.GetSecretByReference(ctx, r.client, &bb.Spec.SecretRef)
+	secret, err := kutil.GetSecretByReference(ctx, r.client, &bb.Spec.SecretRef)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get backup bucket secret: %+v", err)
 	}

--- a/extensions/pkg/controller/backupentry/genericactuator/actuator.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/actuator.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 
-	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/backupentry"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -77,7 +76,7 @@ func (a *actuator) deployEtcdBackupSecret(ctx context.Context, be *extensionsv1a
 		return nil
 	}
 
-	backupSecret, err := extensionscontroller.GetSecretByReference(ctx, a.client, &be.Spec.SecretRef)
+	backupSecret, err := kutil.GetSecretByReference(ctx, a.client, &be.Spec.SecretRef)
 	if err != nil {
 		a.logger.Error(err, "failed to read backup extension secret")
 		return err

--- a/extensions/pkg/controller/backupentry/reconciler.go
+++ b/extensions/pkg/controller/backupentry/reconciler.go
@@ -35,6 +35,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 const (
@@ -124,7 +125,7 @@ func (r *reconciler) reconcile(ctx context.Context, be *extensionsv1alpha1.Backu
 		return reconcile.Result{}, err
 	}
 
-	secret, err := extensionscontroller.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
+	secret, err := kutil.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get backup entry secret: %+v", err)
 	}
@@ -159,7 +160,7 @@ func (r *reconciler) restore(ctx context.Context, be *extensionsv1alpha1.BackupE
 		return reconcile.Result{}, err
 	}
 
-	secret, err := extensionscontroller.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
+	secret, err := kutil.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get backup entry secret: %+v", err)
 	}
@@ -204,7 +205,7 @@ func (r *reconciler) delete(ctx context.Context, be *extensionsv1alpha1.BackupEn
 	r.logger.Info("Starting the deletion of backupentry", "backupentry", be.Name)
 	r.recorder.Event(be, corev1.EventTypeNormal, EventBackupEntryDeletion, "Deleting the backupentry")
 
-	secret, err := extensionscontroller.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
+	secret, err := kutil.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return reconcile.Result{}, fmt.Errorf("failed to get backup entry secret: %+v", err)
@@ -265,7 +266,7 @@ func (r *reconciler) migrate(ctx context.Context, be *extensionsv1alpha1.BackupE
 		return reconcile.Result{}, err
 	}
 
-	secret, err := extensionscontroller.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
+	secret, err := kutil.GetSecretByReference(ctx, r.client, &be.Spec.SecretRef)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get backup entry secret: %+v", err)
 	}

--- a/extensions/pkg/controller/utils.go
+++ b/extensions/pkg/controller/utils.go
@@ -28,7 +28,6 @@ import (
 
 	resourcemanagerv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -126,20 +125,6 @@ func DeleteAllFinalizers(ctx context.Context, client client.Client, obj client.O
 		obj.SetFinalizers(nil)
 		return nil
 	})
-}
-
-// SecretReferenceToKey returns the key of the given SecretReference.
-func SecretReferenceToKey(ref *corev1.SecretReference) client.ObjectKey {
-	return kutil.Key(ref.Namespace, ref.Name)
-}
-
-// GetSecretByReference returns the Secret object matching the given SecretReference.
-func GetSecretByReference(ctx context.Context, c client.Client, ref *corev1.SecretReference) (*corev1.Secret, error) {
-	secret := &corev1.Secret{}
-	if err := c.Get(ctx, SecretReferenceToKey(ref), secret); err != nil {
-		return nil, err
-	}
-	return secret, nil
 }
 
 // TryPatch tries to apply the given transformation function onto the given object, and to patch it afterwards with optimistic locking.

--- a/extensions/pkg/controller/utils.go
+++ b/extensions/pkg/controller/utils.go
@@ -127,6 +127,9 @@ func DeleteAllFinalizers(ctx context.Context, client client.Client, obj client.O
 	})
 }
 
+// GetSecretByReference returns the Secret object matching the given SecretReference.
+var GetSecretByReference = kutil.GetSecretByReference
+
 // TryPatch tries to apply the given transformation function onto the given object, and to patch it afterwards with optimistic locking.
 // It retries the patch with an exponential backoff.
 var TryPatch = kutil.TryPatch

--- a/extensions/pkg/controller/utils_test.go
+++ b/extensions/pkg/controller/utils_test.go
@@ -23,7 +23,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -54,58 +53,6 @@ var _ = Describe("Utils", func() {
 	Describe("UnsafeGuessKind", func() {
 		It("should guess the kind correctly", func() {
 			Expect(controller.UnsafeGuessKind(&extensionsv1alpha1.Infrastructure{})).To(Equal("Infrastructure"))
-		})
-	})
-
-	Describe("#GetSecretByRef", func() {
-		var (
-			ctx = context.TODO()
-
-			name      = "foo"
-			namespace = "bar"
-		)
-
-		It("should get the secret", func() {
-			var (
-				objectMeta = metav1.ObjectMeta{
-					Name:      name,
-					Namespace: namespace,
-				}
-				data = map[string][]byte{
-					"foo": []byte("bar"),
-				}
-			)
-
-			c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret) error {
-				secret.ObjectMeta = objectMeta
-				secret.Data = data
-				return nil
-			})
-
-			secret, err := controller.GetSecretByReference(ctx, c, &corev1.SecretReference{
-				Name:      name,
-				Namespace: namespace,
-			})
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(secret).To(Equal(&corev1.Secret{
-				ObjectMeta: objectMeta,
-				Data:       data,
-			}))
-		})
-
-		It("should return the error", func() {
-			ctx := context.TODO()
-
-			c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fmt.Errorf("error"))
-
-			secret, err := controller.GetSecretByReference(ctx, c, &corev1.SecretReference{
-				Name:      name,
-				Namespace: namespace,
-			})
-
-			Expect(err).To(HaveOccurred())
-			Expect(secret).To(BeNil())
 		})
 	})
 

--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -32,6 +32,7 @@ import (
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/flow"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
 )
 
@@ -249,7 +250,7 @@ func (a *genericActuator) waitUntilMachineResourcesDeleted(ctx context.Context, 
 			if ok {
 				releasedMachineClassCredentialsSecret = true
 			} else {
-				secret, err := extensionscontroller.GetSecretByReference(ctx, a.client, &worker.Spec.SecretRef)
+				secret, err := kutil.GetSecretByReference(ctx, a.client, &worker.Spec.SecretRef)
 				if err != nil {
 					return retryutils.SevereError(fmt.Errorf("could not get the secret referenced by worker: %+v", err))
 				}

--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -35,6 +35,7 @@ import (
 
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	gardenercorescheme "github.com/gardener/gardener/pkg/client/core/clientset/versioned/scheme"
+	gardenseedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
 	seedmanagementscheme "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned/scheme"
 	settingsscheme "github.com/gardener/gardener/pkg/client/settings/clientset/versioned/scheme"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
@@ -301,6 +302,11 @@ func newClientSet(conf *Config) (Interface, error) {
 		return nil, err
 	}
 
+	gardenSeedManagement, err := gardenseedmanagementclientset.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	apiRegistration, err := apiserviceclientset.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
@@ -321,10 +327,11 @@ func newClientSet(conf *Config) (Interface, error) {
 		directClient: directClient,
 		cache:        runtimeCache,
 
-		kubernetes:      kubernetes,
-		gardenCore:      gardenCore,
-		apiregistration: apiRegistration,
-		apiextension:    apiExtension,
+		kubernetes:           kubernetes,
+		gardenCore:           gardenCore,
+		gardenSeedManagement: gardenSeedManagement,
+		apiregistration:      apiRegistration,
+		apiextension:         apiExtension,
 	}
 
 	if _, err := cs.DiscoverVersion(); err != nil {

--- a/pkg/client/kubernetes/clientset.go
+++ b/pkg/client/kubernetes/clientset.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
+	gardenseedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
 	"github.com/gardener/gardener/pkg/logger"
 
 	apiextensionclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -57,10 +58,11 @@ type clientSet struct {
 	// startOnce guards starting the cache only once
 	startOnce sync.Once
 
-	kubernetes      kubernetes.Interface
-	gardenCore      gardencoreclientset.Interface
-	apiextension    apiextensionclientset.Interface
-	apiregistration apiregistrationclientset.Interface
+	kubernetes           kubernetes.Interface
+	gardenCore           gardencoreclientset.Interface
+	gardenSeedManagement gardenseedmanagementclientset.Interface
+	apiextension         apiextensionclientset.Interface
+	apiregistration      apiregistrationclientset.Interface
 
 	version string
 }
@@ -109,6 +111,11 @@ func (c *clientSet) Kubernetes() kubernetes.Interface {
 // GardenCore will return the gardenCore attribute of the Client object.
 func (c *clientSet) GardenCore() gardencoreclientset.Interface {
 	return c.gardenCore
+}
+
+// GardenSeedManagement will return the gardenSeedManagement attribute of the Client object.
+func (c *clientSet) GardenSeedManagement() gardenseedmanagementclientset.Interface {
+	return c.gardenSeedManagement
 }
 
 // APIExtension will return the apiextensions attribute of the Client object.

--- a/pkg/client/kubernetes/fake/clientset.go
+++ b/pkg/client/kubernetes/fake/clientset.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	gardenseedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
 
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/version"
@@ -36,19 +37,20 @@ var _ kubernetes.Interface = &ClientSet{}
 type ClientSet struct {
 	CheckForwardPodPortFn
 
-	applier         kubernetes.Applier
-	chartRenderer   chartrenderer.Interface
-	chartApplier    kubernetes.ChartApplier
-	restConfig      *rest.Config
-	client          client.Client
-	directClient    client.Client
-	cache           cache.Cache
-	kubernetes      kubernetesclientset.Interface
-	gardenCore      gardencoreclientset.Interface
-	apiextension    apiextensionsclientset.Interface
-	apiregistration apiregistrationclientset.Interface
-	restClient      rest.Interface
-	version         string
+	applier              kubernetes.Applier
+	chartRenderer        chartrenderer.Interface
+	chartApplier         kubernetes.ChartApplier
+	restConfig           *rest.Config
+	client               client.Client
+	directClient         client.Client
+	cache                cache.Cache
+	kubernetes           kubernetesclientset.Interface
+	gardenCore           gardencoreclientset.Interface
+	gardenSeedManagement gardenseedmanagementclientset.Interface
+	apiextension         apiextensionsclientset.Interface
+	apiregistration      apiregistrationclientset.Interface
+	restClient           rest.Interface
+	version              string
 }
 
 // NewClientSet returns a new empty fake ClientSet.
@@ -100,6 +102,11 @@ func (c *ClientSet) Kubernetes() kubernetesclientset.Interface {
 // GardenCore will return the gardenCore attribute of the Client object.
 func (c *ClientSet) GardenCore() gardencoreclientset.Interface {
 	return c.gardenCore
+}
+
+// GardenSeedManagement will return the gardenSeedManagement attribute of the Client object.
+func (c *ClientSet) GardenSeedManagement() gardenseedmanagementclientset.Interface {
+	return c.gardenSeedManagement
 }
 
 // APIExtension will return the apiextension ClientSet attribute of the Client object.

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -21,6 +21,8 @@ import (
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	gardencorescheme "github.com/gardener/gardener/pkg/client/core/clientset/versioned/scheme"
 	gardenextensionsscheme "github.com/gardener/gardener/pkg/client/extensions/clientset/versioned/scheme"
+	gardenseedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
+	gardenseedmanagementscheme "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned/scheme"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
@@ -90,6 +92,7 @@ func init() {
 	gardenSchemeBuilder := runtime.NewSchemeBuilder(
 		corescheme.AddToScheme,
 		gardencorescheme.AddToScheme,
+		gardenseedmanagementscheme.AddToScheme,
 	)
 	utilruntime.Must(gardenSchemeBuilder.AddToScheme(GardenScheme))
 
@@ -155,6 +158,7 @@ type Interface interface {
 
 	Kubernetes() kubernetesclientset.Interface
 	GardenCore() gardencoreclientset.Interface
+	GardenSeedManagement() gardenseedmanagementclientset.Interface
 	APIExtension() apiextensionsclientset.Interface
 	APIRegistration() apiregistrationclientset.Interface
 

--- a/pkg/mock/gardener/client/kubernetes/mocks.go
+++ b/pkg/mock/gardener/client/kubernetes/mocks.go
@@ -11,6 +11,7 @@ import (
 	chartrenderer "github.com/gardener/gardener/pkg/chartrenderer"
 	versioned "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	kubernetes "github.com/gardener/gardener/pkg/client/kubernetes"
+	versioned0 "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
 	gomock "github.com/golang/mock/gomock"
 	clientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	version "k8s.io/apimachinery/pkg/version"
@@ -212,6 +213,20 @@ func (m *MockInterface) GardenCore() versioned.Interface {
 func (mr *MockInterfaceMockRecorder) GardenCore() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GardenCore", reflect.TypeOf((*MockInterface)(nil).GardenCore))
+}
+
+// GardenSeedManagement mocks base method.
+func (m *MockInterface) GardenSeedManagement() versioned0.Interface {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GardenSeedManagement")
+	ret0, _ := ret[0].(versioned0.Interface)
+	return ret0
+}
+
+// GardenSeedManagement indicates an expected call of GardenSeedManagement.
+func (mr *MockInterfaceMockRecorder) GardenSeedManagement() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GardenSeedManagement", reflect.TypeOf((*MockInterface)(nil).GardenSeedManagement))
 }
 
 // Kubernetes mocks base method.

--- a/pkg/utils/kubernetes/secretref.go
+++ b/pkg/utils/kubernetes/secretref.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// GetSecretByReference returns the secret referenced by the given secret reference.
+func GetSecretByReference(ctx context.Context, c client.Client, ref *corev1.SecretReference) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, Key(ref.Namespace, ref.Name), secret); err != nil {
+		return nil, err
+	}
+	return secret, nil
+}
+
+// CreateOrUpdateSecretByReference creates or updates the secret referenced by the given secret reference
+// with the given type, data, and owner references.
+func CreateOrUpdateSecretByReference(ctx context.Context, c client.Client, ref *corev1.SecretReference, secretType corev1.SecretType, data map[string][]byte, ownerRefs []metav1.OwnerReference) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ref.Name,
+			Namespace: ref.Namespace,
+		},
+	}
+	if _, err := controllerutil.CreateOrUpdate(ctx, c, secret, func() error {
+		secret.ObjectMeta.OwnerReferences = ownerRefs
+		secret.Type = secretType
+		secret.Data = data
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteSecretByReference deletes the secret referenced by the given secret reference.
+func DeleteSecretByReference(ctx context.Context, c client.Client, ref *corev1.SecretReference) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ref.Name,
+			Namespace: ref.Namespace,
+		},
+	}
+	return client.IgnoreNotFound(c.Delete(ctx, secret))
+}

--- a/pkg/utils/kubernetes/secretref_test.go
+++ b/pkg/utils/kubernetes/secretref_test.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes_test
+
+import (
+	"context"
+	"fmt"
+
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("secretref", func() {
+	var (
+		ctrl *gomock.Controller
+		c    *mockclient.MockClient
+
+		ctx context.Context
+
+		secretRef *corev1.SecretReference
+		secret    *corev1.Secret
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		c = mockclient.NewMockClient(ctrl)
+
+		ctx = context.TODO()
+
+		secretRef = &corev1.SecretReference{
+			Name:      name,
+			Namespace: namespace,
+		}
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "core.gardener.cloud/v1beta1",
+						Kind:               "Shoot",
+						Name:               name,
+						UID:                "uid",
+						Controller:         pointer.BoolPtr(true),
+						BlockOwnerDeletion: pointer.BoolPtr(true),
+					},
+				},
+			},
+			Data: map[string][]byte{
+				"foo": []byte("bar"),
+			},
+			Type: corev1.SecretTypeOpaque,
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#GetSecretByReference", func() {
+		It("should get the secret", func() {
+			c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, s *corev1.Secret) error {
+				*s = *secret
+				return nil
+			})
+
+			result, err := kutil.GetSecretByReference(ctx, c, secretRef)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(secret))
+		})
+
+		It("should fail if getting the secret failed", func() {
+			c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fmt.Errorf("error"))
+
+			result, err := kutil.GetSecretByReference(ctx, c, secretRef)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Describe("#CreateOrUpdateSecretByReference", func() {
+		It("should create the secret if it doesn't exist", func() {
+			c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(apierrors.NewNotFound(corev1.Resource("secret"), name))
+			c.EXPECT().Create(ctx, secret).Return(nil)
+
+			err := kutil.CreateOrUpdateSecretByReference(ctx, c, secretRef, secret.Type, secret.Data, secret.OwnerReferences)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should update the secret if it exists", func() {
+			newSecret := secret.DeepCopy()
+			newSecret.Data = map[string][]byte{
+				"bar": []byte("baz"),
+			}
+
+			c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, s *corev1.Secret) error {
+				*s = *secret
+				return nil
+			})
+			c.EXPECT().Update(ctx, newSecret).Return(nil)
+
+			err := kutil.CreateOrUpdateSecretByReference(ctx, c, secretRef, newSecret.Type, newSecret.Data, newSecret.OwnerReferences)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should fail if getting the secret failed", func() {
+			c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fmt.Errorf("error"))
+
+			err := kutil.CreateOrUpdateSecretByReference(ctx, c, secretRef, secret.Type, secret.Data, secret.OwnerReferences)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("#DeleteSecretByReference", func() {
+		BeforeEach(func() {
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+			}
+		})
+
+		It("should delete the secret if it exists", func() {
+			c.EXPECT().Delete(ctx, secret).Return(nil)
+
+			err := kutil.DeleteSecretByReference(ctx, c, secretRef)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should succeed if the secret doesn't exist", func() {
+			c.EXPECT().Delete(ctx, secret).Return(apierrors.NewNotFound(corev1.Resource("secret"), name))
+
+			err := kutil.DeleteSecretByReference(ctx, c, secretRef)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should fail if deleting the secret failed", func() {
+			c.EXPECT().Delete(ctx, secret).Return(fmt.Errorf("error"))
+
+			err := kutil.DeleteSecretByReference(ctx, c, secretRef)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Adds prerequisites for introducing the `ManagedSeed` controller.

* Utility functions for working with `SecretRefs`.
* Changes to the client `Interface` and related functions for the new `seedmanagement` group.

This PR contains mostly trivial changes / refactorings. They are introduced in a separate PR in order to make the subsequent PR that will introduce the `ManagedSeed` controller itself easier to review.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Based on #3416. This is the fifth of several PRs that are split from #3177 since it became too big and hard to review. Before commenting, please check if the topic has been already discussed in the previous PR.

**Release note**:

```improvement operator
NONE
```