### PR TITLE
Update the organization of the grafana and prometheus certificates

### DIFF
--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -158,7 +158,7 @@ func generateWantedSecrets(seed *Seed, certificateAuthorities map[string]*secret
 			Name: common.GrafanaTLS,
 
 			CommonName:   "grafana",
-			Organization: []string{"garden.sapcloud.io:monitoring:ingress"},
+			Organization: []string{"gardener.cloud:monitoring:ingress"},
 			DNSNames:     []string{seed.GetIngressFQDN(grafanaPrefix)},
 			IPAddresses:  nil,
 
@@ -170,7 +170,7 @@ func generateWantedSecrets(seed *Seed, certificateAuthorities map[string]*secret
 			Name: prometheusTLS,
 
 			CommonName:   "prometheus",
-			Organization: []string{"garden.sapcloud.io:monitoring:ingress"},
+			Organization: []string{"gardener.cloud:monitoring:ingress"},
 			DNSNames:     []string{seed.GetIngressFQDN(prometheusPrefix)},
 			IPAddresses:  nil,
 


### PR DESCRIPTION
/kind cleanup

Checking back in https://github.com/gardener/gardener/pull/1832 on how we adapted the Organization of the controlplane certificates, I guess we can adapt in the same way the Organization of the seed grafana and prometheus certificates.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
