### PR TITLE
Add networkpolicy labels to node-problem-detector

### DIFF
--- a/charts/shoot-core/components/charts/node-problem-detector/templates/daemonset.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/templates/daemonset.yaml
@@ -23,6 +23,8 @@ spec:
         app: {{ include "node-problem-detector.name" . }}
         gardener.cloud/role: system-component
         origin: gardener
+        networking.gardener.cloud/to-apiserver: allowed
+        networking.gardener.cloud/to-dns: allowed
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/custom-config-configmap.yaml") . | sha256sum }}
         scheduler.alpha.kubernetes.io/critical-pod: ''


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/priority normal

**What this PR does / why we need it**:

NPD is not matched by any `NetworkPolicies` and if deny-all policy is applied to `kube-system`, it breaks it.

**Which issue(s) this PR fixes**:

Fixes #565

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Node Problem Detector is now matched by `gardener.cloud--allow-to-dns` and `gardener.cloud--allow-to-apiserver` networkpolicies can run with deny-all networkpolicy in `kube-system` namespace.
```
