### PR TITLE
Wait until the finalizer of the credentials secret is removed

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -253,7 +253,7 @@ func (a *genericActuator) shallowDeleteMachineClassSecrets(ctx context.Context, 
 	return nil
 }
 
-// cleanupMachineClassSecrets deletes MachineSets having number of desired and actual replicas equaling 0
+// cleanupMachineSets deletes MachineSets having number of desired and actual replicas equaling 0
 func (a *genericActuator) cleanupMachineSets(ctx context.Context, logger logr.Logger, namespace string) error {
 	logger.Info("Cleaning up machine sets")
 	machineSetList := &machinev1alpha1.MachineSetList{}

--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -164,6 +164,8 @@ func (a *genericActuator) waitUntilMachineResourcesDeleted(ctx context.Context, 
 		countMachineDeployments  = -1
 		countMachineClasses      = -1
 		countMachineClassSecrets = -1
+
+		releasedMachineClassCredentialsSecret = false
 	)
 	logger.Info("Waiting until all machine resources have been deleted")
 
@@ -237,8 +239,34 @@ func (a *genericActuator) waitUntilMachineResourcesDeleted(ctx context.Context, 
 			msg += fmt.Sprintf("%d machine class secrets, ", countMachineClassSecrets)
 		}
 
-		if countMachines != 0 || countMachineSets != 0 || countMachineDeployments != 0 || countMachineClasses != 0 || countMachineClassSecrets != 0 {
-			msg := fmt.Sprintf("Waiting until the following machine resources have been deleted: %s", strings.TrimSuffix(msg, ", "))
+		// Check whether the finalizer of the machine class credentials secret is removed.
+		// This check is only applicable when the given workerDelegate does not implement the
+		// deprecated WorkerCredentialsDelegate interface, i.e. machine classes reference a separate
+		// Secret for cloud provider credentials.
+		if !releasedMachineClassCredentialsSecret {
+			_, ok := workerDelegate.(WorkerCredentialsDelegate)
+			if ok {
+				releasedMachineClassCredentialsSecret = true
+			} else {
+				secret, err := controller.GetSecretByReference(ctx, a.client, &worker.Spec.SecretRef)
+				if err != nil {
+					return retryutils.SevereError(fmt.Errorf("could not get the secret referenced by worker: %+v", err))
+				}
+
+				hasFinalizer, err := controller.HasFinalizer(secret, mcmFinalizer)
+				if err != nil {
+					return retryutils.SevereError(fmt.Errorf("could not check whether machine class credentials secret has finalizer: %+v", err))
+				}
+				if hasFinalizer {
+					msg += "1 machine class credentials secret, "
+				} else {
+					releasedMachineClassCredentialsSecret = true
+				}
+			}
+		}
+
+		if countMachines != 0 || countMachineSets != 0 || countMachineDeployments != 0 || countMachineClasses != 0 || countMachineClassSecrets != 0 || !releasedMachineClassCredentialsSecret {
+			msg := fmt.Sprintf("Waiting until the following machine resources have been deleted or released: %s", strings.TrimSuffix(msg, ", "))
 			logger.Info(msg)
 			return retryutils.MinorError(errors.New(msg))
 		}


### PR DESCRIPTION
/kind bug

Ref https://github.com/gardener/gardener-extension-provider-aws/pull/238#issuecomment-761986865

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The generic Worker actuator does now wait until the machine-controller-manager finalizer is removed from the credentials secret that is referenced from the machine classes.
```
