### PR TITLE
replace image vector component descriptor creation with component-cli

### DIFF
--- a/hack/.ci/component_descriptor
+++ b/hack/.ci/component_descriptor
@@ -8,20 +8,12 @@ descriptor_out_file="${COMPONENT_DESCRIPTOR_PATH}"
 
 echo "enriching creating component descriptor from ${BASE_DEFINITION_PATH}"
 
-if [[ -f "$repo_root_dir/charts/images.yaml" ]]; then
-  images="$(yaml2json < "$repo_root_dir/charts/images.yaml")"
-  eval "$(jq -r ".images |
-    map(select(.sourceRepository != \"$repo_name\") |
-    if (.name == \"hyperkube\" or .name == \"kube-apiserver\" or .name == \"kube-controller-manager\" or .name == \"kube-scheduler\" or .name == \"kube-proxy\" or .repository == \"k8s.gcr.io/hyperkube\") then
-      \"--generic-dependencies '{\\\"name\\\": \\\"\" + .name + \"\\\", \\\"version\\\": \\\"\" + .tag + \"\\\"}'\"
-    elif (.repository | startswith(\"eu.gcr.io/gardener-project/gardener\")) then
-      \"--component-dependencies '{\\\"name\\\": \\\"\" + .sourceRepository + \"\\\", \\\"version\\\": \\\"\" + .tag + \"\\\"}'\"
-    else
-      \"--container-image-dependencies '{\\\"name\\\": \\\"\" + .name + \"\\\", \\\"image_reference\\\": \\\"\" + .repository + \":\" + .tag + \"\\\", \\\"version\\\": \\\"\" + .tag + \"\\\"}'\"
-    end) |
-    \"${ADD_DEPENDENCIES_CMD} \\\\\n\" +
-    join(\" \\\\\n\")" <<< "$images")"
-fi
+# translates all images defined the images.yaml into component descriptor resources.
+# For detailed documentation see https://github.com/gardener/component-cli/blob/main/docs/reference/components-cli_image-vector_add.md
+component-cli image-vector add --comp-desc ${BASE_DEFINITION_PATH} \
+  --image-vector "$repo_root_dir/charts/images.yaml" \
+  --component-prefixes eu.gcr.io/gardener-project/gardener \
+  --generic-dependencies hyperkube,kube-apiserver,kube-controller-manager,kube-scheduler,kube-proxy
 
 if [[ -d "$repo_root_dir/charts/" ]]; then
   for image_tpl_path in "$repo_root_dir/charts/"*"/templates/_images.tpl"; do


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind task
/priority normal

**What this PR does / why we need it**:

The images defines in the `images.yaml` are now added to the component descriptor using the component-cli.
The new cli command understands the semantics of the images.yaml and adds the needed information to the componentdescriptor v2.

The new script basically does the same thing as the old bash script so all current automation will stay in place.
In addition, it adds new labels that are later used generate the image overwrites without the need of the gardener images.yaml during deployment.

For detailed information how the resources are translated see https://github.com/gardener/component-cli/blob/main/docs/reference/components-cli_image-vector_add.md .<br>
For the detailed implementation see https://github.com/gardener/component-cli/blob/main/pkg/imagevector/imagevector.go#L29

This is the first step towards testing release candidates.

**Special notes for your reviewer**:

cc @AndreasBurger @ccwienk 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
