### PR TITLE
Docforge manifest

### DIFF
--- a/.docforge/manifest.yaml
+++ b/.docforge/manifest.yaml
@@ -1,0 +1,6 @@
+nodesSelector:
+  path: https://github.com/gardener/gardener/tree/master/docs    
+links:
+  downloads:
+    scope:
+      gardener/gardener/(blob|raw)/(.*)/docs: ~


### PR DESCRIPTION
**How to categorize this PR?**
/area documentation
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Declares gardener as documentation component and makes it discoverable for the tools building documentation e.g. for gardener.cloud

**Which issue(s) this PR fixes**:
Fixes #3430 

**Release note**:
```
NONE
```
