### PR TITLE
Add CPU throttling to the "Kubernetes Pods" Grafana dashboard

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
@@ -135,6 +135,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "description": "The experimental \"Throttle factor\" metric tries to estimate how much more time the execution of the pod takes due to CPU throttling. A factor of 1 means no throttling, a factor of 2 could be OK, a factor of 10 could indicate underprovisioned requests/limits or contention for the burstable CPU shares",
       "editable": true,
       "error": false,
       "fill": 0,
@@ -172,6 +173,12 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
+          "alias": "Throttle factor",
+          "dashLength": 5,
+          "dashes": true,
+          "yaxis": 2
+        },
+        {
           "alias": "/Requests|Limits/",
           "dashes": true
         }
@@ -205,6 +212,14 @@
           "intervalFactor": 2,
           "legendFormat": "Limits",
           "refId": "C"
+        },
+        {
+          "expr": "1 / (1 -\nmax(\nrate(container_cpu_cfs_throttled_periods_total{container=~\"$container\",pod=~\"$pod\"}[$__rate_interval])\n/\nrate(container_cpu_cfs_periods_total{container=~\"$container\",pod=~\"$pod\"}[$__rate_interval])\n))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Throttle factor",
+          "refId": "D"
         }
       ],
       "thresholds": [],
@@ -240,7 +255,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "1",
           "show": true
         }
       ],

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
@@ -62,7 +62,7 @@
         {
           "expr": "sum (container_memory_working_set_bytes{pod=~\"$pod\", container=~\"$container\"})",
           "format": "time_series",
-          "interval": "10s",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Current",
           "metric": "container_memory_working_set_bytes",
@@ -73,16 +73,16 @@
           "expr": "sum(kube_pod_container_resource_requests_memory_bytes{pod=~\"$pod\", container=~\"$container\"})",
           "format": "time_series",
           "hide": false,
-          "interval": "10s",
-          "intervalFactor": 2,
+          "interval": "",
+          "intervalFactor": 1,
           "legendFormat": "Requests",
           "refId": "C"
         },
         {
           "expr": "sum(kube_pod_container_resource_limits_memory_bytes{pod=~\"$pod\", container=~\"$container\"})",
           "format": "time_series",
-          "interval": "10s",
-          "intervalFactor": 2,
+          "interval": "",
+          "intervalFactor": 1,
           "legendFormat": "Limits",
           "refId": "B"
         }
@@ -190,7 +190,7 @@
         {
           "expr": "sum(rate(container_cpu_usage_seconds_total{container=~\"$container\",pod=~\"$pod\"}[$__rate_interval]))",
           "format": "time_series",
-          "interval": "10s",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Current",
           "refId": "A",
@@ -200,16 +200,16 @@
           "expr": "sum(kube_pod_container_resource_requests_cpu_cores{container=~\"$container\",pod=~\"$pod\"})",
           "format": "time_series",
           "hide": false,
-          "interval": "10s",
-          "intervalFactor": 2,
+          "interval": "",
+          "intervalFactor": 1,
           "legendFormat": "Requests",
           "refId": "B"
         },
         {
           "expr": "sum(kube_pod_container_resource_limits_cpu_cores{container=~\"$container\",pod=~\"$pod\"})",
           "format": "time_series",
-          "interval": "10s",
-          "intervalFactor": 2,
+          "interval": "",
+          "intervalFactor": 1,
           "legendFormat": "Limits",
           "refId": "C"
         },
@@ -313,7 +313,8 @@
         {
           "expr": "sum(rate(container_network_receive_bytes_total{pod=~\"$pod\"}[$__rate_interval])) by (pod)",
           "format": "time_series",
-          "intervalFactor": 2,
+          "interval": "",
+          "intervalFactor": 1,
           "legendFormat": "Received",
           "refId": "A",
           "step": 20
@@ -418,7 +419,7 @@
           "expr": "sum(container_fs_usage_bytes{pod=~\"$pod\", container=~\"$container\",})",
           "format": "time_series",
           "hide": false,
-          "interval": "10s",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Current",
           "metric": "container_fs_usage_bytes",
@@ -429,7 +430,7 @@
           "expr": "sum(container_fs_usage_bytes{pod=~\"$pod\", image!=\"\"})",
           "format": "time_series",
           "hide": false,
-          "interval": "10s",
+          "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Total",
           "metric": "container_fs_usage_bytes",

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
@@ -49,7 +49,12 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "/Requests|Limits/",
+          "dashes": true
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
@@ -165,7 +170,12 @@
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "/Requests|Limits/",
+          "dashes": true
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
@@ -5,6 +5,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
+  "id": 24,
   "iteration": 1591170710914,
   "links": [],
   "panels": [
@@ -16,6 +17,13 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "grid": {},
@@ -43,9 +51,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.2.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -138,6 +147,13 @@
       "description": "The experimental \"Throttle factor\" metric tries to estimate how much more time the execution of the pod takes due to CPU throttling. A factor of 1 means no throttling, a factor of 2 could be OK, a factor of 10 could indicate underprovisioned requests/limits or contention for the burstable CPU shares",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "grid": {},
@@ -165,9 +181,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.2.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -272,6 +289,13 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "grid": {},
@@ -299,9 +323,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.2.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -377,6 +402,13 @@
       "datasource": "prometheus",
       "editable": true,
       "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
       "fill": 0,
       "fillGradient": 0,
       "grid": {},
@@ -404,9 +436,10 @@
       "links": [],
       "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "alertThreshold": true
       },
       "percentage": false,
+      "pluginVersion": "7.2.1",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -482,6 +515,12 @@
     },
     {
       "datasource": "loki",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 21,
         "w": 24,
@@ -510,7 +549,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 25,
+  "schemaVersion": 26,
   "style": "dark",
   "tags": [
     "kubernetes",
@@ -549,6 +588,7 @@
           }
         ],
         "query": "seed,shoot",
+        "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
       },

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
@@ -78,7 +78,7 @@
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 2,
-          "legendFormat": "Limits:",
+          "legendFormat": "Limits",
           "refId": "B"
         }
       ],


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement
/priority normal

**What this PR does / why we need it**:

This PR adds a "throttle factor" metric to the CPU Usage panel of the Kubernetes Pods Grafana dashboard. This estimates how much more time the pod needs to execute due to CPU throttling.
A factor of 1 means no throttling, a factor of 2 could be OK, a factor of 10 could indicate underprovisioned requests/limits or contention for the burstable CPU shares.

The PR also includes minor improvements (e.g. use dashes for the requests and limits).

cc @wyb1 

<img width="1468" alt="image" src="https://user-images.githubusercontent.com/23032437/105156658-6b211f00-5b0c-11eb-878b-b0474384fb4f.png">

**Release note**:

```other operator
Add CPU throttling to the "Kubernetes Pods" Grafana dashboard
```
