### PR TITLE
Node exporter changes

### DIFF
--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -97,16 +97,11 @@ spec:
           timeoutSeconds: 5
         resources:
           requests:
-            cpu: 5m
-            memory: 10Mi
+            cpu: 50m
+            memory: 50Mi
           limits:
-          {{- if .Values.global.vpaEnabled }}
-            cpu: 20m
-            memory: 40Mi
-          {{- else }}
-            cpu: 25m
-            memory: 100Mi
-          {{- end }}
+            cpu: 50m
+            memory: 50Mi
         volumeMounts:
         - name: host
           readOnly: true

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -71,13 +71,19 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - /bin/node_exporter
+        - --web.listen-address=:{{ .Values.ports.metrics }}
         - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
-        - --collector.filesystem.ignored-mount-points=^/.+$
-        - --web.listen-address=:{{ .Values.ports.metrics }}
         - --path.rootfs=/host
         - --log.level=error
-        - --no-collector.netclass
+        - --collector.disable-defaults
+        - --collector.conntrack
+        - --collector.cpu
+        - --collector.filefd
+        - --collector.filesystem
+        - --collector.filesystem.ignored-mount-points=^/.+$
+        - --collector.loadavg
+        - --collector.meminfo
         ports:
         - containerPort: {{ .Values.ports.metrics }}
           protocol: TCP


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Node exporter collectors are now all disabled by default unless explicitly needed.

This PR changes the default requests and limits of the node-exporter and makes the node exporter of class `Guaranteed`. This should reduce problems with CPU throttling of the node-exporter. If there is an active VPA the node-exporter will no longer have very high limits, especially for memory. This is helpful because the node-exporter does not need so much memory (it needs more CPU) and will allow for better scheduling.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
