### PR TITLE
Separate the Seeds and the Shoots loggins stack deleteion

### DIFF
--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -25,22 +25,12 @@ import (
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/common"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DeploySeedLogging will install the Helm release "seed-bootstrap/charts/loki" in the Seed clusters.
 func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
-	// TODO: remove in a future release
-	// Clean up the stale loki-vpa.
-	lokiVpa := &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "loki-vpa", Namespace: b.Shoot.SeedNamespace}}
-	if err := b.K8sSeedClient.Client().Delete(ctx, lokiVpa); client.IgnoreNotFound(err) != nil {
-		return err
-	}
-
 	if b.Shoot.Purpose == gardencorev1beta1.ShootPurposeTesting || !gardenletfeatures.FeatureGate.Enabled(features.Logging) {
-		return common.DeleteLoggingStack(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace)
+		return common.DeleteShootLoggingStack(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace)
 	}
 
 	images, err := b.InjectSeedSeedImages(map[string]interface{}{},

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -33,21 +33,20 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/version"
+	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/util/retry"
@@ -318,56 +317,52 @@ func DeleteVpa(ctx context.Context, c client.Client, namespace string, isShoot b
 	return nil
 }
 
-// DeleteLoggingStack deletes all resource of the EFK logging stack in the given namespace.
-func DeleteLoggingStack(ctx context.Context, k8sClient client.Client, namespace string) error {
-	if k8sClient == nil {
-		return errors.New("must provide non-nil kubernetes client to common.DeleteLoggingStack")
+// DeleteShootLoggingStack deletes all shoot resource of the logging stack in the given namespace.
+func DeleteShootLoggingStack(ctx context.Context, k8sClient client.Client, namespace string) error {
+	return DeleteLoki(ctx, k8sClient, namespace)
+}
+
+// DeleteLoki  deletes all resources of the Loki in a given namespace.
+func DeleteLoki(ctx context.Context, k8sClient client.Client, namespace string) error {
+	resources := []client.Object{
+		&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-loki", Namespace: namespace}},
+		&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-to-loki", Namespace: namespace}},
+		&hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: namespace}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "loki-config", Namespace: namespace}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: namespace}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: namespace}},
+		&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: namespace}},
+		&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "loki-loki-0", Namespace: namespace}},
 	}
 
-	// Delete the resources below that match "gardener.cloud/role=logging"
-	lists := []client.ObjectList{
-		&corev1.ConfigMapList{},
-		&batchv1beta1.CronJobList{},
-		&rbacv1.ClusterRoleList{},
-		&rbacv1.ClusterRoleBindingList{},
-		&rbacv1.RoleList{},
-		&rbacv1.RoleBindingList{},
-		&appsv1.DaemonSetList{},
-		&appsv1.DeploymentList{},
-		// TODO: Use autoscaling/v2beta2 for Kubernetes 1.19+ shoots once kubernetes-v1.19 golang dependencies were vendored.
-		&autoscalingv2beta1.HorizontalPodAutoscalerList{},
-		&extensionsv1beta1.IngressList{},
-		&corev1.SecretList{},
-		&corev1.ServiceAccountList{},
-		&corev1.ServiceList{},
-		&appsv1.StatefulSetList{},
-	}
-
-	for _, list := range lists {
-		if err := k8sClient.List(ctx, list,
-			client.InNamespace(namespace),
-			client.MatchingLabels{v1beta1constants.GardenRole: v1beta1constants.GardenRoleLogging}); err != nil {
-			return err
-		}
-
-		if err := meta.EachListItem(list, func(obj runtime.Object) error {
-			return client.IgnoreNotFound(k8sClient.Delete(ctx, obj.(client.Object), kubernetes.DefaultDeleteOptions...))
-		}); err != nil {
+	for _, resource := range resources {
+		if err := k8sClient.Delete(ctx, resource); client.IgnoreNotFound(err) != nil && !meta.IsNoMatchError(err) {
 			return err
 		}
 	}
-
-	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "loki-loki-0",
-			Namespace: namespace,
-		},
-	}
-	if err := k8sClient.Delete(ctx, pvc); client.IgnoreNotFound(err) != nil && !meta.IsNoMatchError(err) {
-		return err
-	}
-
 	return nil
+}
+
+// DeleteSeedLoggingStack deletes all seed resource of the logging stack in the garden namespace.
+func DeleteSeedLoggingStack(ctx context.Context, k8sClient client.Client) error {
+	resources := []client.Object{
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "fluent-bit-config", Namespace: v1beta1constants.GardenNamespace}},
+		&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "fluent-bit", Namespace: v1beta1constants.GardenNamespace}},
+		&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-fluentbit", Namespace: v1beta1constants.GardenNamespace}},
+		&schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "fluent-bit"}},
+		&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "fluent-bit-read"}},
+		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "fluent-bit-read"}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "fluent-bit", Namespace: v1beta1constants.GardenNamespace}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "fluent-bit", Namespace: v1beta1constants.GardenNamespace}},
+	}
+
+	for _, resource := range resources {
+		if err := k8sClient.Delete(ctx, resource); client.IgnoreNotFound(err) != nil && !meta.IsNoMatchError(err) {
+			return err
+		}
+	}
+
+	return DeleteLoki(ctx, k8sClient, v1beta1constants.GardenNamespace)
 }
 
 // GetContainerResourcesInStatefulSet  returns the containers resources in StatefulSet

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -469,7 +469,7 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 			}
 		}
 	} else {
-		if err := common.DeleteLoggingStack(ctx, k8sSeedClient.Client(), v1beta1constants.GardenNamespace); client.IgnoreNotFound(err) != nil {
+		if err := common.DeleteSeedLoggingStack(ctx, k8sSeedClient.Client()); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR we separate the seed and shoot logging stack deletion in two different functions.
This is needed because when we delete the logging stack of a shoot we delete a cluster scoped resources like [Clusterolebindings](https://github.com/gardener/gardener/blob/master/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-role-binding.yaml) and [Clusterroles](https://github.com/gardener/gardener/blob/master/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-role.yaml) which are needed for the Seed logging stack.
   
**Which issue(s) this PR fixes**:
Fixes [#3433](https://github.com/gardener/gardener/issues/3433#)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
The Seed and Shoot logging stack deletion is separated in two functions to avoid accidental deletion of cluster scoped resources.  
```
