### PR TITLE
Fix nil pointer dereference while hibernating Shoot

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -367,7 +367,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until all shoot worker nodes have updated the cloud config user data",
-			Fn:           botanist.WaitUntilCloudConfigUpdatedForAllWorkerPools,
+			Fn:           flow.TaskFn(botanist.WaitUntilCloudConfigUpdatedForAllWorkerPools).SkipIf(o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(waitUntilWorkerReady, waitUntilTunnelConnectionExists),
 		})
 		_ = g.Add(flow.Task{


### PR DESCRIPTION
/kind bug

`WaitUntilCloudConfigUpdatedForAllWorkerPools` func is trying to use `b.K8sShootClient` but the shootClient is nil for a hibernating cluster when the apiserver is not running - ref https://github.com/gardener/gardener/blob/v1.15.3/pkg/operation/operation.go#L296-L319

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x1b4305d]

goroutine 32700 [running]:
github.com/gardener/gardener/pkg/operation/botanist.(*Botanist).WaitUntilCloudConfigUpdatedForAllWorkerPools.func1(0x22ce660, 0xc00e251620, 0xc0034511c0, 0xc001334bd8, 0x1771307)
	/go/src/github.com/gardener/gardener/pkg/operation/botanist/worker.go:158 +0x3d
github.com/gardener/gardener/pkg/utils/retry.UntilFor(0x22ce660, 0xc00e251620, 0xc026f88020, 0x22b79a0, 0xc0034511c0, 0xc0034511b0, 0xc00aafc400, 0x0)
	/go/src/github.com/gardener/gardener/pkg/utils/retry/retry.go:147 +0x3e
github.com/gardener/gardener/pkg/utils/retry.(*ops).Until(0xc00063c990, 0x22ce660, 0xc00e251620, 0x12a05f200, 0xc0034511b0, 0xc00e251601, 0xc0034511b0)
	/go/src/github.com/gardener/gardener/pkg/utils/retry/retry.go:191 +0xa5
github.com/gardener/gardener/pkg/operation/botanist.(*Botanist).WaitUntilCloudConfigUpdatedForAllWorkerPools(0xc00a741ad0, 0x22ce620, 0xc000136000, 0x0, 0x0)
	/go/src/github.com/gardener/gardener/pkg/operation/botanist/worker.go:157 +0x1e6
github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode.func1(0xc00ec278f0, 0x2088572, 0x4c, 0x22ce620, 0xc000136000)
	/go/src/github.com/gardener/gardener/pkg/utils/flow/flow.go:219 +0x1d5
created by github.com/gardener/gardener/pkg/utils/flow.(*execution).runNode
	/go/src/github.com/gardener/gardener/pkg/utils/flow/flow.go:214 +0x14f
```


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
