### PR TITLE
Adapt "problematic webhook timeout" check 

### DIFF
--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -17,11 +17,11 @@ package genericactuator
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"time"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/controlplane"
+	"github.com/gardener/gardener/extensions/pkg/webhook"
 	extensionswebhookshoot "github.com/gardener/gardener/extensions/pkg/webhook/shoot"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -474,7 +474,7 @@ func marshalWebhooks(webhooks []admissionregistrationv1beta1.MutatingWebhook, na
 				Kind:       kind,
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("gardener-extension-%s-shoot", name),
+				Name: webhook.NamePrefix + name + webhook.NameSuffixShoot,
 			},
 			Webhooks: webhooks,
 		}

--- a/extensions/pkg/webhook/registration.go
+++ b/extensions/pkg/webhook/registration.go
@@ -33,12 +33,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
+const (
+	// NamePrefix is the prefix used for {Valida,Muta}tingWebhookConfigurations of extensions.
+	NamePrefix = "gardener-extension-"
+	// NameSuffixShoots is the suffix used for {Valida,Muta}tingWebhookConfigurations of extensions targeting a shoot.
+	NameSuffixShoot = "-shoot"
+)
+
 // RegisterWebhooks registers the given webhooks in the Kubernetes cluster targeted by the provided manager.
 func RegisterWebhooks(ctx context.Context, mgr manager.Manager, namespace, providerName string, servicePort int, mode, url string, caBundle []byte, webhooks []*Webhook) (webhooksToRegisterSeed []admissionregistrationv1beta1.MutatingWebhook, webhooksToRegisterShoot []admissionregistrationv1beta1.MutatingWebhook, err error) {
 	var (
 		fail                             = admissionregistrationv1beta1.Fail
 		ignore                           = admissionregistrationv1beta1.Ignore
-		mutatingWebhookConfigurationSeed = &admissionregistrationv1beta1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "gardener-extension-" + providerName}}
+		mutatingWebhookConfigurationSeed = &admissionregistrationv1beta1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: NamePrefix + providerName}}
 	)
 
 	for _, webhook := range webhooks {

--- a/extensions/pkg/webhook/registration.go
+++ b/extensions/pkg/webhook/registration.go
@@ -55,6 +55,7 @@ func RegisterWebhooks(ctx context.Context, mgr manager.Manager, namespace, provi
 			Name:              fmt.Sprintf("%s.%s.extensions.gardener.cloud", webhook.Name, strings.TrimPrefix(providerName, "provider-")),
 			NamespaceSelector: webhook.Selector,
 			Rules:             rules,
+			TimeoutSeconds:    pointer.Int32Ptr(10),
 		}
 
 		switch webhook.Target {

--- a/pkg/operation/care/constraints.go
+++ b/pkg/operation/care/constraints.go
@@ -17,7 +17,9 @@ package care
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/operation"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -139,12 +141,33 @@ func (c *Constraint) constraintsChecks(
 // CheckForProblematicWebhooks checks the Shoot for problematic webhooks which could prevent shoot worker nodes from
 // joining the cluster.
 func (c *Constraint) CheckForProblematicWebhooks(ctx context.Context) (gardencorev1beta1.ConditionStatus, string, string, error) {
+	// Earlier, the Gardener extensions library was not setting the timeout for auto-registered webhooks, hence, they
+	// ended up with the default (30s) which we consider problematic in shoots. For backwards-compatibility, we skip the
+	// check for shooted seeds to prevent it from failures caused by extension webhooks having a too high timeout value.
+	// See for more details: https://github.com/gardener/gardener/pull/3413#issuecomment-763974466
+	// TODO: Remove this in a future version.
+	if shootedSeed, err := gardencorev1beta1helper.ReadShootedSeed(c.shoot.Info); err == nil && shootedSeed != nil {
+		return gardencorev1beta1.ConditionTrue,
+			"NoProblematicWebhooks",
+			"Check is not executed for shooted seeds.",
+			nil
+	}
+
 	validatingWebhookConfigs := &admissionregistrationv1beta1.ValidatingWebhookConfigurationList{}
 	if err := c.shootClient.List(ctx, validatingWebhookConfigs); err != nil {
 		return "", "", "", fmt.Errorf("could not get ValidatingWebhookConfigurations of Shoot cluster to check for problematic webhooks")
 	}
 
 	for _, webhookConfig := range validatingWebhookConfigs.Items {
+		// Earlier, the Gardener extensions library was not setting the timeout for auto-registered webhooks, hence, they
+		// ended up with the default (30s) which we consider problematic in shoots. For backwards-compatibility, we skip the
+		// check for shooted seeds to prevent it from failures caused by extension webhooks having a too high timeout value.
+		// See for more details: https://github.com/gardener/gardener/pull/3413#issuecomment-763974466
+		// TODO: Remove this in a future version.
+		if strings.HasPrefix(webhookConfig.Name, webhook.NamePrefix) && strings.HasSuffix(webhookConfig.Name, webhook.NameSuffixShoot) {
+			continue
+		}
+
 		for _, w := range webhookConfig.Webhooks {
 			if IsProblematicWebhook(w.FailurePolicy, w.ObjectSelector, w.NamespaceSelector, w.Rules, w.TimeoutSeconds) {
 				return gardencorev1beta1.ConditionFalse,
@@ -161,6 +184,15 @@ func (c *Constraint) CheckForProblematicWebhooks(ctx context.Context) (gardencor
 	}
 
 	for _, webhookConfig := range mutatingWebhookConfigs.Items {
+		// Earlier, the Gardener extensions library was not setting the timeout for auto-registered webhooks, hence, they
+		// ended up with the default (30s) which we consider problematic in shoots. For backwards-compatibility, we skip the
+		// check for shooted seeds to prevent it from failures caused by extension webhooks having a too high timeout value.
+		// See for more details: https://github.com/gardener/gardener/pull/3413#issuecomment-763974466
+		// TODO: Remove this in a future version.
+		if strings.HasPrefix(webhookConfig.Name, webhook.NamePrefix) && strings.HasSuffix(webhookConfig.Name, webhook.NameSuffixShoot) {
+			continue
+		}
+
 		for _, w := range webhookConfig.Webhooks {
 			if IsProblematicWebhook(w.FailurePolicy, w.ObjectSelector, w.NamespaceSelector, w.Rules, w.TimeoutSeconds) {
 				return gardencorev1beta1.ConditionFalse,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR is a builds on top of #3413 and adapts the behaviour as follows:

~1. "Problematic timeout check" is also performed for `Fail` failure policy (earlier, it was only done for `Ignore`)~
2. Extensions library registers webhooks (both seed and shoot) with a timeout of `10s`
3. For backwards-compatibility, we skip the entire "problematic webhook" check for shooted seeds to have enough time for extensions to revendor this change (and get 2.)

/assign @ialidzhikov @timebertt @timuthy 
/squash

**Special notes for your reviewer**:
See https://github.com/gardener/gardener/pull/3413#issuecomment-763974466 for more details - thanks @ialidzhikov for bringing this to attention.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
The extensions library is now registering webhooks for both seeds and shoots with a `10s` timeout.
```
