### PR TITLE
[release-v1.15] Calculate ingressDomain for ControllerInstallation deployment

### DIFF
--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_control.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_control.go
@@ -222,6 +222,11 @@ func (c *defaultControllerInstallationControl) reconcile(controllerInstallation 
 	}
 	seedClusterIdentity := *seed.Status.ClusterIdentity
 
+	ingressDomain := seed.Spec.DNS.IngressDomain
+	if ingressDomain == nil {
+		ingressDomain = &seed.Spec.Ingress.Domain
+	}
+
 	// Mix-in some standard values for garden and seed.
 	gardenerValues := map[string]interface{}{
 		"gardener": map[string]interface{}{
@@ -238,7 +243,7 @@ func (c *defaultControllerInstallationControl) reconcile(controllerInstallation 
 				"region":          seed.Spec.Provider.Region,
 				"volumeProvider":  volumeProvider,
 				"volumeProviders": volumeProviders,
-				"ingressDomain":   seed.Spec.DNS.IngressDomain,
+				"ingressDomain":   ingressDomain,
 				"protected":       gardencorev1beta1helper.TaintsHave(seed.Spec.Taints, gardencorev1beta1.SeedTaintProtected),
 				"visible":         seed.Spec.Settings.Scheduling.Visible,
 				"taints":          seed.Spec.Taints,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
#3131 implies an API change of a seed's ingress domain from `.spec.dns.ingressDomain` -> `.spec.ingress.domain`. For compatibility reasons we should consider this change when passing the ingress domain as a value to the chart of a `ControllerRegistration`.

**Special notes for your reviewer**:
/cc @rfranzke @BeckerMax

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardener now considers the `seed.spec.ingress.domain` field when passing the value via `gradener.seed.ingressDomain` to `ControllerRegistration` charts.
```
