### PR TITLE
Normalize versions when comparing against constraints

### DIFF
--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -883,21 +883,18 @@ func bootstrapComponents(c kubernetes.Interface, namespace string, imageVector i
 	}
 	components = append(components, seedadmission.New(c.Client(), namespace, gsacImage.String(), kubernetesVersion))
 
-	// gardener-seed-scheduler.
+	// kube-scheduler for shoot control plane pods
 	var schedulerImage *imagevector.Image
-
 	if imageVector != nil {
 		schedulerImage, err = imageVector.FindImage(common.KubeSchedulerImageName, imagevector.TargetVersion(kubernetesVersion.String()))
 		if err != nil {
 			return nil, err
 		}
 	}
-
 	sched, err := scheduler.Bootstrap(c.DirectClient(), namespace, schedulerImage, kubernetesVersion)
 	if err != nil {
 		return nil, err
 	}
-
 	components = append(components, sched)
 
 	return components, nil

--- a/pkg/utils/imagevector/imagevector_test.go
+++ b/pkg/utils/imagevector/imagevector_test.go
@@ -37,18 +37,20 @@ var _ = Describe("imagevector", func() {
 			image1Src1VectorJSON string
 			image1Src1VectorYAML string
 
-			k8s164               = "1.6.4"
-			k8s180               = "1.8.0"
-			k8s113               = "1.13"
-			k8s1142              = "1.14.2"
-			k8s1170              = "1.17.0"
-			k8s164RuntimeVersion = RuntimeVersion(k8s164)
-			k8s164TargetVersion  = TargetVersion(k8s164)
-			k8s1170TargetVersion = TargetVersion(k8s1170)
-			k8s180RuntimeVersion = RuntimeVersion(k8s180)
-			k8s180TargetVersion  = TargetVersion(k8s180)
-			k8s113TargetVersion  = TargetVersion(k8s113)
-			k8s1142TargetVersion = TargetVersion(k8s1142)
+			k8s164                         = "1.6.4"
+			k8s164WithSuffix               = "1.6.4-foo.5"
+			k8s180                         = "1.8.0"
+			k8s113                         = "1.13"
+			k8s1142                        = "1.14.2"
+			k8s1170                        = "1.17.0"
+			k8s164RuntimeVersion           = RuntimeVersion(k8s164)
+			k8s164WithSuffixRuntimeVersion = RuntimeVersion(k8s164WithSuffix)
+			k8s164TargetVersion            = TargetVersion(k8s164)
+			k8s1170TargetVersion           = TargetVersion(k8s1170)
+			k8s180RuntimeVersion           = RuntimeVersion(k8s180)
+			k8s180TargetVersion            = TargetVersion(k8s180)
+			k8s113TargetVersion            = TargetVersion(k8s113)
+			k8s1142TargetVersion           = TargetVersion(k8s1142)
 
 			tag1, tag2, tag3, tag4, tag5 string
 			repo1, repo2, repo3, repo4   string
@@ -263,6 +265,7 @@ images:
 			Entry("no entries, no match", ImageVector{}, image1Name, nil, BeNil(), HaveOccurred()),
 			Entry("single entry, match with runtime wildcard", ImageVector{image1Src1}, image1Name, nil, Equal(image1Src1.ToImage(nil)), Not(HaveOccurred())),
 			Entry("single entry, match with runtime version", ImageVector{image1Src1}, image1Name, []FindOptionFunc{k8s164RuntimeVersion}, Equal(image1Src1.ToImage(nil)), Not(HaveOccurred())),
+			Entry("single entry w/ suffix, match with runtime version", ImageVector{image1Src1}, image1Name, []FindOptionFunc{k8s164WithSuffixRuntimeVersion}, Equal(image1Src1.ToImage(nil)), Not(HaveOccurred())),
 			Entry("single entry, match with runtime and target version", ImageVector{image1Src1}, image1Name, []FindOptionFunc{k8s164RuntimeVersion, k8s164TargetVersion}, Equal(image1Src1.ToImage(&k8s164)), Not(HaveOccurred())),
 			Entry("single entry, match with runtime and non-runtime target version", ImageVector{image1Src1}, image1Name, []FindOptionFunc{k8s164RuntimeVersion, k8s180TargetVersion}, Equal(image1Src1.ToImage(&k8s180)), Not(HaveOccurred())),
 			Entry("single entry, name mismatch", ImageVector{image1Src1}, image2Name, nil, BeNil(), HaveOccurred()),

--- a/pkg/utils/version/version.go
+++ b/pkg/utils/version/version.go
@@ -50,7 +50,7 @@ func CheckVersionMeetsConstraint(version, constraint string) (bool, error) {
 		return false, err
 	}
 
-	v, err := semver.NewVersion(version)
+	v, err := semver.NewVersion(normalizeVersion(version))
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/priority normal

**What this PR does / why we need it**:
Currently, when run for example in a `GKE` cluster, the gardenlet fails bootstrapping the seed with the following error message:

```
time="2021-01-21T08:24:12Z" level=error msg="seed is not yet ready: condition \"Bootstrapped\" has invalid status False (expected True) due to BootstrappingFailed: could not find image \"kube-scheduler\" opts target version 1.16.15-gke.6000" operation=reconcile shoot=garden-foo/bar
```

As we are not interested in evaluating pre-release suffixes when we compare versions, we now normalize it (which removes the pre-release suffix) before comparing it against a constraint.

**Special notes for your reviewer**:
/cc @ialidzhikov @mvladev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
