### PR TITLE
Preserve unknown metadata fields in HVPA CRD

### DIFF
--- a/charts/seed-bootstrap/charts/hvpa/templates/hvpa-crd.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/templates/hvpa-crd.yaml
@@ -219,6 +219,9 @@ spec:
                     metadata:
                       description: Metadata of the pods created from this template.
                       type: object
+                      {{- if semverCompare ">= 1.15-0" .Capabilities.KubeVersion.GitVersion }}
+                      x-kubernetes-preserve-unknown-fields: true # To be replaced by proper OpenAPI spec
+                      {{- end }}
                     spec:
                       description: Spec defines the behavior of a HPA.
                       properties:
@@ -801,6 +804,9 @@ spec:
                     metadata:
                       description: Metadata of the pods created from this template.
                       type: object
+                      {{- if semverCompare ">= 1.15-0" .Capabilities.KubeVersion.GitVersion }}
+                      x-kubernetes-preserve-unknown-fields: true # To be replaced by proper OpenAPI spec
+                      {{- end }}
                     spec:
                       description: Spec defines the behavior of a VPA.
                       properties:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind regression
/priority normal

**What this PR does / why we need it**:
Preserve unknown metadata fields in HVPA CRD for now until the OpenAPI spec can be fixed.

**Special notes for your reviewer**:
/invite @vpnachev @amshuman-kr @kallurbsk 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which prevented proper auto-scaling of components under control of HVPA.
```
