### PR TITLE
Prevent "lastTransitionTime" and "lastUpdateTime" of constraints to be updated continuously

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -246,7 +246,7 @@ func (c *defaultCareControl) Care(shootObj *gardencorev1beta1.Shoot, key string)
 		gardencorev1beta1.ShootHibernationPossible,
 		gardencorev1beta1.ShootMaintenancePreconditionsSatisfied,
 	} {
-		constraints = append(constraints, gardencorev1beta1helper.GetOrInitCondition(shoot.Status.Conditions, cond))
+		constraints = append(constraints, gardencorev1beta1helper.GetOrInitCondition(shoot.Status.Constraints, cond))
 	}
 
 	seedClient, err := c.clientMap.GetClient(ctx, keys.ForSeedWithName(*shoot.Spec.SeedName))


### PR DESCRIPTION
/kind bug

After #3377 the Shoot constraints  "lastTransitionTime" and "lastUpdateTime" are updated continuously no matter whether there is a change in the constraint or not. This is something we want to avoid.

The root cause for this regression seems to be that we try to lookup for the existing constraint not in `.status.constraints` but in `.status.conditions` which always returns a newly initialized constraint with updated  "lastTransitionTime" and "lastUpdateTime".

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
