### PR TITLE
Fix seed ingressdomain validation

### DIFF
--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -199,16 +199,16 @@ func ValidateSeedSpecUpdate(newSeedSpec, oldSeedSpec *core.SeedSpec, fldPath *fi
 	}
 
 	if oldSeedSpec.DNS.IngressDomain != nil && newSeedSpec.DNS.IngressDomain != nil {
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.DNS.IngressDomain, oldSeedSpec.DNS.IngressDomain, fldPath.Child("dns", "ingressDomain"))...)
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(*newSeedSpec.DNS.IngressDomain, *oldSeedSpec.DNS.IngressDomain, fldPath.Child("dns", "ingressDomain"))...)
 	}
 	if oldSeedSpec.Ingress != nil && newSeedSpec.Ingress != nil {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Ingress.Domain, oldSeedSpec.Ingress.Domain, fldPath.Child("ingress", "domain"))...)
 	}
 	if oldSeedSpec.Ingress != nil && newSeedSpec.DNS.IngressDomain != nil {
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.DNS.IngressDomain, oldSeedSpec.Ingress.Domain, fldPath.Child("dns", "ingressDomain"))...)
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(*newSeedSpec.DNS.IngressDomain, oldSeedSpec.Ingress.Domain, fldPath.Child("dns", "ingressDomain"))...)
 	}
 	if oldSeedSpec.DNS.IngressDomain != nil && newSeedSpec.Ingress != nil {
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Ingress.Domain, oldSeedSpec.DNS.IngressDomain, fldPath.Child("ingress", "domain"))...)
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Ingress.Domain, *oldSeedSpec.DNS.IngressDomain, fldPath.Child("ingress", "domain"))...)
 	}
 
 	if oldSeedSpec.Backup != nil {

--- a/pkg/apis/core/validation/seed_test.go
+++ b/pkg/apis/core/validation/seed_test.go
@@ -488,6 +488,14 @@ var _ = Describe("Seed Validation Tests", func() {
 				}))
 			})
 
+			It("should succeed if ingress domain stays the same when migrating from dns.ingressDomain to ingress.domain", func() {
+				newSeed := prepareSeedForUpdate(seed)
+				seed.Spec.DNS.IngressDomain = pointer.StringPtr(seed.Spec.Ingress.Domain)
+				seed.Spec.Ingress = nil
+
+				Expect(ValidateSeedUpdate(newSeed, seed)).To(BeEmpty())
+			})
+
 			It("should fail if ingress domain changed when migrating from dns.ingressDomain to ingress.domain", func() {
 				newSeed := prepareSeedForUpdate(seed)
 				otherDomain := "other-domain"
@@ -501,6 +509,15 @@ var _ = Describe("Seed Validation Tests", func() {
 					"Field":  Equal("spec.ingress.domain"),
 					"Detail": Equal(`field is immutable`),
 				}))
+			})
+
+			It("should succeed if ingress domain stays the same when migrating from ingress.domain to dns.ingressDomain", func() {
+				newSeed := prepareSeedForUpdate(seed)
+				currentDomain := seed.Spec.Ingress.Domain
+				newSeed.Spec.Ingress = nil
+				newSeed.Spec.DNS.IngressDomain = &currentDomain
+
+				Expect(ValidateSeedUpdate(newSeed, seed)).To(BeEmpty())
 			})
 
 			It("should fail if ingress domain changed when migrating from ingress.domain to dns.ingressDomain", func() {


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane seed
/kind bug
/priority critical

**What this PR does / why we need it**:

Fixes a bug that prevents the Seed ingressDomain from being migrated
between dns.IngressDomain and ingress.Domain. This is a necessary 
step when activating the Seed Ingress Controller.
Currently, the validation will always throw an error. With this fix
the validation only throws an error if the value of the ingressDomain
actually changes.

Introduced with https://github.com/gardener/gardener/pull/3394

**Release note**:
```bugfix operator
An issue in the API validation has been fixed which prevented the managed ingress feature for seeds being enabled.
```
