### PR TITLE
Update cloud-config-downloader files via Original OSC

### DIFF
--- a/charts/seed-operatingsystemconfig/downloader/templates/cloud-config-downloader/_download-cloud-config-service.content
+++ b/charts/seed-operatingsystemconfig/downloader/templates/cloud-config-downloader/_download-cloud-config-service.content
@@ -1,0 +1,14 @@
+{{- define "cloud-config-downloader-service-content" -}}
+[Unit]
+Description=Downloads the actual cloud config from the Shoot API server and executes it
+After=docker.service docker.socket
+Wants=docker.socket
+[Service]
+Restart=always
+RestartSec=30
+RuntimeMaxSec=1200
+EnvironmentFile=/etc/environment
+ExecStart=/var/lib/cloud-config-downloader/download-cloud-config.sh
+[Install]
+WantedBy=multi-user.target
+{{- end }}

--- a/charts/seed-operatingsystemconfig/downloader/templates/cloud-config-downloader/_download-cloud-config-service.file
+++ b/charts/seed-operatingsystemconfig/downloader/templates/cloud-config-downloader/_download-cloud-config-service.file
@@ -1,0 +1,8 @@
+{{- define "cloud-config-downloader-service-file" -}}
+- path: /etc/systemd/system/cloud-config-downloader.service
+  permissions: 0644
+  content:
+    inline:
+      encoding: b64
+      data: {{ include "cloud-config-downloader-service-content" . | b64enc }}
+{{- end -}}

--- a/charts/seed-operatingsystemconfig/downloader/templates/cloud-config-downloader/_download-cloud-config.files
+++ b/charts/seed-operatingsystemconfig/downloader/templates/cloud-config-downloader/_download-cloud-config.files
@@ -1,0 +1,32 @@
+{{- define "cloud-config-downloader-files" -}}
+- path: /var/lib/cloud-config-downloader/credentials/server
+  permissions: 0644
+  content:
+    inline:
+      encoding: b64
+      data: {{ .Values.osc.server | b64enc }}
+- path: /var/lib/cloud-config-downloader/credentials/ca.crt
+  permissions: 0644
+  content:
+    secretRef:
+      name: cloud-config-downloader
+      dataKey: ca.crt
+- path: /var/lib/cloud-config-downloader/credentials/client.crt
+  permissions: 0644
+  content:
+    secretRef:
+      name: cloud-config-downloader
+      dataKey: cloud-config-downloader.crt
+- path: /var/lib/cloud-config-downloader/credentials/client.key
+  permissions: 0644
+  content:
+    secretRef:
+      name: cloud-config-downloader
+      dataKey: cloud-config-downloader.key
+- path: /var/lib/cloud-config-downloader/download-cloud-config.sh
+  permissions: 0744
+  content:
+    inline:
+      encoding: b64
+      data: {{ include "seed-operatingsystemconfig.downloader.download-script" . | b64enc }}
+{{- end -}}

--- a/charts/seed-operatingsystemconfig/downloader/templates/cloud-config-downloader/_download-cloud-config.service
+++ b/charts/seed-operatingsystemconfig/downloader/templates/cloud-config-downloader/_download-cloud-config.service
@@ -1,0 +1,7 @@
+{{- define "cloud-config-downloader-service" -}}
+- name: cloud-config-downloader.service
+  command: start
+  enable: true
+  content: |
+{{ include "cloud-config-downloader-service-content" . | indent 4 }}
+{{- end }}

--- a/charts/seed-operatingsystemconfig/downloader/templates/cloud-config-downloader/_download-cloud-config.sh
+++ b/charts/seed-operatingsystemconfig/downloader/templates/cloud-config-downloader/_download-cloud-config.sh
@@ -1,7 +1,7 @@
 {{- define "seed-operatingsystemconfig.downloader.download-script" -}}
 #!/bin/bash -eu
 
-SECRET_NAME="{{ required "secretName is required" .Values.secretName }}"
+SECRET_NAME="{{ required "osc.secretName is required" .Values.osc.secretName }}"
 
 DIR_CLOUDCONFIG_DOWNLOADER="/var/lib/cloud-config-downloader"
 DIR_CLOUDCONFIG_DOWNLOADER_CREDENTIALS="$DIR_CLOUDCONFIG_DOWNLOADER/credentials"

--- a/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
+++ b/charts/seed-operatingsystemconfig/downloader/templates/osc.yaml
@@ -7,67 +7,23 @@
 apiVersion: extensions.gardener.cloud/v1alpha1
 kind: OperatingSystemConfig
 metadata:
-  name: {{ required "secretName is required" .Values.secretName }}-downloader
+  name: {{ required "osc.name is required" .Values.osc.name }}
   namespace: {{ .Release.Namespace }}
   annotations:
     gardener.cloud/operation: reconcile
-    gardener.cloud/timestamp: {{ required "annotationCurrentTimestamp is required" .Values.annotationCurrentTimestamp }}
+    gardener.cloud/timestamp: {{ required "osc.annotationCurrentTimestamp is required" .Values.osc.annotationCurrentTimestamp }}
 spec:
-  type: {{ required "type is required" .Values.type }}
-  purpose: {{ required "purpose is required" .Values.purpose }}
-  {{- if .Values.providerConfig }}
+  type: {{ required "osc.type is required" .Values.osc.type }}
+  purpose: {{ required "osc.purpose is required" .Values.osc.purpose }}
+  {{- if .Values.osc.providerConfig }}
   providerConfig:
-{{ .Values.providerConfig | indent 4 }}
+{{ .Values.osc.providerConfig | indent 4 }}
   {{- end }}
-  {{- if .Values.cri }}
+  {{- if .Values.osc.cri }}
   criConfig:
-    name: {{ .Values.cri.name }}
+    name: {{ .Values.osc.cri.name }}
   {{- end }}
   units:
-  - name: cloud-config-downloader.service
-    command: start
-    enable: true
-    content: |
-      [Unit]
-      Description=Downloads the actual cloud config from the Shoot API server and executes it
-      After=docker.service docker.socket
-      Wants=docker.socket
-      [Service]
-      Restart=always
-      RestartSec=30
-      RuntimeMaxSec=1200
-      EnvironmentFile=/etc/environment
-      ExecStart=/var/lib/cloud-config-downloader/download-cloud-config.sh
-      [Install]
-      WantedBy=multi-user.target
+{{ include "cloud-config-downloader-service" . | indent 2 }}
   files:
-  - path: /var/lib/cloud-config-downloader/credentials/server
-    permissions: 0644
-    content:
-      inline:
-        encoding: b64
-        data: {{ .Values.server | b64enc }}
-  - path: /var/lib/cloud-config-downloader/credentials/ca.crt
-    permissions: 0644
-    content:
-      secretRef:
-        name: cloud-config-downloader
-        dataKey: ca.crt
-  - path: /var/lib/cloud-config-downloader/credentials/client.crt
-    permissions: 0644
-    content:
-      secretRef:
-        name: cloud-config-downloader
-        dataKey: cloud-config-downloader.crt
-  - path: /var/lib/cloud-config-downloader/credentials/client.key
-    permissions: 0644
-    content:
-      secretRef:
-        name: cloud-config-downloader
-        dataKey: cloud-config-downloader.key
-  - path: /var/lib/cloud-config-downloader/download-cloud-config.sh
-    permissions: 0744
-    content:
-      inline:
-        encoding: b64
-        data: {{ include "seed-operatingsystemconfig.downloader.download-script" . | b64enc }}
+{{ include "cloud-config-downloader-files" . | indent 2 }}

--- a/charts/seed-operatingsystemconfig/downloader/values.yaml
+++ b/charts/seed-operatingsystemconfig/downloader/values.yaml
@@ -1,10 +1,12 @@
-type: coreos
-purpose: bootstrap
-secretName: cpu-worker-0
-server: api.shoot-cluster.example.com
-annotationCurrentTimestamp: 2020-05-06T10:18:01Z
-#providerConfig:
-#  some-provider-specific-config
+osc:
+  name: cpu-worker-0-downloader
+  type: coreos
+  purpose: bootstrap
+  secretName: cpu-worker-0
+  server: api.shoot-cluster.example.com
+  annotationCurrentTimestamp: 2020-05-06T10:18:01Z
+  #providerConfig:
+  #  some-provider-specific-config
 
-# cri:
-#   name: containerd
+  #cri:
+  # name: containerd

--- a/charts/seed-operatingsystemconfig/original/templates/cloud-config-downloader
+++ b/charts/seed-operatingsystemconfig/original/templates/cloud-config-downloader
@@ -1,0 +1,1 @@
+../../downloader/templates/cloud-config-downloader/

--- a/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet-binary
+++ b/charts/seed-operatingsystemconfig/original/templates/kubelet/_kubelet-binary
@@ -4,7 +4,7 @@
   content:
     inline:
       encoding: b64
-      data: {{ ( required "kubernetes.worker.caCert is required" .Values.worker.kubelet.caCert ) | b64enc }}
+      data: {{ ( required "worker.kubelet.caCert is required" .Values.worker.kubelet.caCert ) | b64enc }}
 - path: /var/lib/kubelet/config/kubelet
   permissions: 0644
   content:

--- a/charts/seed-operatingsystemconfig/original/templates/osc.yaml
+++ b/charts/seed-operatingsystemconfig/original/templates/osc.yaml
@@ -2,14 +2,14 @@
 apiVersion: extensions.gardener.cloud/v1alpha1
 kind: OperatingSystemConfig
 metadata:
-  name: {{ required ".osc.secretName is required" .Values.osc.secretName }}-original
+  name: {{ required "osc.name is required" .Values.osc.name }}
   namespace: {{ .Release.Namespace }}
   annotations:
     gardener.cloud/operation: reconcile
-    gardener.cloud/timestamp: {{ required ".osc.annotationCurrentTimestamp is required" .Values.osc.annotationCurrentTimestamp }}
+    gardener.cloud/timestamp: {{ required "osc.annotationCurrentTimestamp is required" .Values.osc.annotationCurrentTimestamp }}
 spec:
-  type: {{ required ".osc.type is required" .Values.osc.type }}
-  purpose: {{ required ".osc.purpose is required" .Values.osc.purpose }}
+  type: {{ required "osc.type is required" .Values.osc.type }}
+  purpose: {{ required "osc.purpose is required" .Values.osc.purpose }}
   {{- if .Values.worker.cri }}
   criConfig:
     name: {{ .Values.worker.cri.name }}
@@ -18,7 +18,7 @@ spec:
   providerConfig:
 {{ .Values.osc.providerConfig | indent 4 }}
   {{- end }}
-  reloadConfigFilePath: {{ required ".osc.reloadConfigFilePath is required" .Values.osc.reloadConfigFilePath }}
+  reloadConfigFilePath: {{ required "osc.reloadConfigFilePath is required" .Values.osc.reloadConfigFilePath }}
   units:
 {{ include "var-lib-mount" . | indent 2 }}
 {{ include "update-ca-certs" . | indent 2 }}
@@ -58,3 +58,5 @@ spec:
 {{ include "kernel-config" . | indent 2 }}
 {{ include "health-monitor" . | indent 2 }}
 {{ include "gardener-user-script" . | indent 2 }}
+{{ include "cloud-config-downloader-files" . | indent 2 }}
+{{ include "cloud-config-downloader-service-file" . | indent 2 }}

--- a/charts/seed-operatingsystemconfig/original/values.yaml
+++ b/charts/seed-operatingsystemconfig/original/values.yaml
@@ -1,9 +1,11 @@
 osc:
+  name: cpu-worker-0-original
   type: coreos
   purpose: bootstrap
   annotationCurrentTimestamp: 2020-05-06T10:18:01Z
   reloadConfigFilePath: /var/lib/...
   secretName: cpu-worker-0
+  server: api.shoot-cluster.example.com
   sshKey: "ssh-rsa"
   cri:
     containerRuntimesBinaryPath: /var/bin/containerruntimes

--- a/charts/shoot-cloud-config/templates/scripts/_cloud-config-script.sh
+++ b/charts/shoot-cloud-config/templates/scripts/_cloud-config-script.sh
@@ -95,7 +95,7 @@ if ! diff "$PATH_CLOUDCONFIG" "$PATH_CLOUDCONFIG_OLD" >/dev/null; then
     echo "Successfully applied new cloud config version"
     systemctl daemon-reload
 {{- range $name := (required ".worker.units is required" .worker.units) }}
-{{- if and (ne $name "docker.service") (ne $name "var-lib.mount") }}
+{{- if and (ne $name "docker.service") (ne $name "var-lib.mount") (ne $name "cloud-config-downloader.service") }}
     systemctl enable {{ $name }} && systemctl restart --no-block {{ $name }}
 {{- end }}
 {{- end }}

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -373,7 +373,7 @@ func (b *Botanist) DeployControlPlane(ctx context.Context) error {
 	return b.deployOrRestoreControlPlane(ctx, b.Shoot.Components.Extensions.ControlPlane)
 }
 
-// DeployControlPlane deploys or restores the ControlPlane custom resource (purpose exposure).
+// DeployControlPlaneExposure deploys or restores the ControlPlane custom resource (purpose exposure).
 func (b *Botanist) DeployControlPlaneExposure(ctx context.Context) error {
 	return b.deployOrRestoreControlPlane(ctx, b.Shoot.Components.Extensions.ControlPlaneExposure)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity os
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this change, cloud-config-downloader service is updated also via the original OperatingSystemConfig which is applied regularly. 

**Which issue(s) this PR fixes**:
More improvements for #2981 

**Special notes for your reviewer**:
~~The OS extensions must ensure that they restart the `cloud-config-downloader.service` only for the bootstrap OSC.~~
~~/hold~~ 
~~till all extensions support it.~~

~~- [ ] gardenlinux https://github.com/gardener/gardener-extension-os-gardenlinux/pull/24~~
~~- [ ] suse-chost https://github.com/gardener/gardener-extension-os-suse-chost/pull/32~~
~~- [ ] ubuntu https://github.com/gardener/gardener-extension-os-ubuntu/pull/32~~
~~- [ ] coreos :heavy_check_mark:  no changes required in the controller~~



**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The specification and the configuration files of the `cloud-config-downloader.service` systemd service are now updated regularly with the original `OperatingSystemConfig`. 
```
