### PR TITLE
Fix IndexerFuncs signatures

### DIFF
--- a/extensions/pkg/util/index/index.go
+++ b/extensions/pkg/util/index/index.go
@@ -17,14 +17,14 @@ package index
 import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 
-	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // SecretRefNamespaceField is the field name for the index function that extracts the corresponding field from SecretBinding.
 const SecretRefNamespaceField string = "secretRef.namespace"
 
 // SecretRefNamespaceIndexerFunc extracts the secretRef.namespace field of a SecretBinding.
-func SecretRefNamespaceIndexerFunc(rawObj runtime.Object) []string {
+func SecretRefNamespaceIndexerFunc(rawObj client.Object) []string {
 	secretBinding, ok := rawObj.(*gardencorev1beta1.SecretBinding)
 	if !ok {
 		return []string{}
@@ -36,7 +36,7 @@ func SecretRefNamespaceIndexerFunc(rawObj runtime.Object) []string {
 const SecretBindingNameField string = "spec.secretBindingName"
 
 // SecretBindingNameIndexerFunc extracts the spec.secretBindingName field of a Shoot.
-func SecretBindingNameIndexerFunc(rawObj runtime.Object) []string {
+func SecretBindingNameIndexerFunc(rawObj client.Object) []string {
 	shoot, ok := rawObj.(*gardencorev1beta1.Shoot)
 	if !ok {
 		return []string{}


### PR DESCRIPTION
/kind bug

provider-gcp is currently using `SecretRefNamespaceIndexerFunc` and `SecretBindingNameIndexerFunc` - ref https://github.com/gardener/gardener-extension-provider-gcp/blob/v1.14.0/cmd/gardener-extension-admission-gcp/app/app.go#L81-L86.
With `controller-runtime@v0.7.x`, the IndexerFunc is changed as follows:

```diff
- type IndexerFunc func(runtime.Object) []string
+ type IndexerFunc func(Object) []string
```

This PR is required to vendor g/g@master into g/gardener-extension-provider-gcp.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
