### PR TITLE
Changed schedule of community meeting from weekly to bi-weekly and fixed link to target correct anchor in the target README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ We also have a [Gardener Helm Chart](https://github.com/gardener/gardener/tree/m
 
 Feedback and contributions are always welcome!
 
-All channels for getting in touch or learning about our project are listed under the [community](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md#community) section. We are cordially inviting interested parties to join our [weekly meetings](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md#weekly-meeting).
+All channels for getting in touch or learning about our project are listed under the [community](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md#community) section. We are cordially inviting interested parties to join our [bi-weekly meetings](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md#bi-weekly-meetings).
 
 Please report bugs or suggestions about our Kubernetes clusters as such or the Gardener itself as [GitHub issues](https://github.com/gardener/gardener/issues) or join our [Slack channel #gardener](https://kubernetes.slack.com/messages/gardener) (please invite yourself to the Kubernetes workspace [here](http://slack.k8s.io)).
 


### PR DESCRIPTION
**How to categorize this PR?**

/area documentation
/kind cleanup
/priority normal

**What this PR does / why we need it**:

- This PR updates the description of the community meeting from weekly to bi-weekly and fixes the anchor in the target document that is linked to.

**Which issue(s) this PR fixes**:
Minor doc change, I have not created an issue for it.

**Special notes for your reviewer**:
Community call was recently changed from weekly to bi-weekly, which was reflected in the documentation repo but not the main readme.

**Release note**:
NONE
