### PR TITLE
Remove redundant apierrors.IsNotFound check

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -24,7 +24,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -258,9 +257,6 @@ func (a *genericActuator) cleanupMachineSets(ctx context.Context, logger logr.Lo
 	logger.Info("Cleaning up machine sets")
 	machineSetList := &machinev1alpha1.MachineSetList{}
 	if err := a.client.List(ctx, machineSetList, client.InNamespace(namespace)); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
 		return err
 	}
 

--- a/pkg/operation/care/constraints.go
+++ b/pkg/operation/care/constraints.go
@@ -20,19 +20,16 @@ import (
 	"strings"
 
 	"github.com/gardener/gardener/extensions/pkg/webhook"
-	"github.com/gardener/gardener/pkg/operation"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/gardener/gardener/pkg/operation/shoot"
-	"github.com/sirupsen/logrus"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/botanist/matchers"
+	"github.com/gardener/gardener/pkg/operation/shoot"
 
+	"github.com/sirupsen/logrus"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // WebhookMaximumTimeoutSecondsNotProblematic is the maximum timeout in seconds a webhooks on critical resources can
@@ -80,10 +77,10 @@ func (c *Constraint) ConstraintsChecks(
 	ctx context.Context,
 	constraints []gardencorev1beta1.Condition,
 ) []gardencorev1beta1.Condition {
-	updatedConstrataints := c.constraintsChecks(ctx, constraints)
+	updatedConstraints := c.constraintsChecks(ctx, constraints)
 	lastOp := c.shoot.Info.Status.LastOperation
 	lastErrors := c.shoot.Info.Status.LastErrors
-	return PardonConditions(updatedConstrataints, lastOp, lastErrors)
+	return PardonConditions(updatedConstraints, lastOp, lastErrors)
 }
 
 func (c *Constraint) constraintsChecks(


### PR DESCRIPTION
/kind cleanup

`client.List` will return an empty list, not a not found error

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
