### PR TITLE
Expose VerticalPodAutoscaler logs

### DIFF
--- a/charts/seed-monitoring/charts/grafana/templates/grafana-dashboards-configmap.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-dashboards-configmap.yaml
@@ -37,6 +37,8 @@ data:
 {{- toString .Values.extensions.dashboards | indent 2 }}
 {{ end }}
 {{ range $component := .Values.exposedComponents }}
+  {{ if or (ne $component.fileName "vpa-logging.json") ($.Values.vpaEnabled)}}
   {{ $component.fileName }}: |-
 {{ include "logging-dashboard" $component | indent 4 }}
+  {{ end }}
 {{- end }}

--- a/charts/seed-monitoring/charts/grafana/values.yaml
+++ b/charts/seed-monitoring/charts/grafana/values.yaml
@@ -27,18 +27,24 @@ sni:
 
 exposedComponents:
 - dashboardName: "Kube Apiserver"
-  jobName: "kube-apiserver"
-  podPrefix: "kube-apiserver"
-  fileName: "kube-apiserver.json"
+  fileName: "kube-apiserver-logging.json"
+  pods:
+  - podPrefix: "kube-apiserver"
 - dashboardName: "Kube Controller Manager"
-  jobName: "kube-controller-manager"
-  podPrefix: "kube-controller-manager"
-  fileName: "kube-controller-manager.json"
+  fileName: "kube-controller-manager-logging.json"
+  pods:
+  - podPrefix: "kube-controller-manager"
 - dashboardName: "Kube Scheduler"
-  jobName: "kube-scheduler"
-  podPrefix: "kube-scheduler"
-  fileName: "kube-scheduler.json"
+  fileName: "kube-scheduler-logging.json"
+  pods:
+  - podPrefix: "kube-scheduler"
 - dashboardName: "Cluster Autoscaler"
-  jobName: "cluster-autoscaler"
-  podPrefix: "cluster-autoscaler"
-  fileName: "cluster-autoscaler.json"
+  fileName: "cluster-autoscaler-logging.json"
+  pods:
+  - podPrefix: "cluster-autoscaler"
+- dashboardName: "Vertical Pod Autoscaler"
+  fileName: "vpa-logging.json"
+  pods:
+  - podPrefix: "vpa-admission-controller"
+  - podPrefix: "vpa-recommender"
+  - podPrefix: "vpa-updater"

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -413,7 +413,9 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 			// shoot system components
 			metricsserver.CentralLoggingConfiguration,
 		}
-		userAllowedComponents := []string{v1beta1constants.DeploymentNameKubeAPIServer}
+		userAllowedComponents := []string{v1beta1constants.DeploymentNameKubeAPIServer,
+			v1beta1constants.DeploymentNameVPAExporter, v1beta1constants.DeploymentNameVPARecommender,
+			v1beta1constants.DeploymentNameVPAAdmissionController}
 
 		// Fetch component specific logging configurations
 		for _, componentFn := range componentsFunctions {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
1. Expose VPA logs to the end-user
2. Add `Component` field in the dashboards. This is needed to merge the `vpa-admission-controller`, `vpa-exporter` and `vpa-recommender` logs into one dashboard. Also with this feature we can consider in the future to merge all logging dashboards into one.
3. Add `Container` filed which lists all existing containers of the selected `Component` from `2.` for more flexible log queries.  

**Which issue(s) this PR fixes**:
Closes #3451

**Special notes for your reviewer**:
@vlvasilev @timuthy @wyb1 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Logs from `VerticalPodAutoscaler` are accessible via the `Vertical Pod Autoscaler` dashboard in Grafana.
```
```other user
`Component` and `Container` fields are added in the logging dashboards for more flexible log queries.
```
