### PR TITLE
Add `ShootVPAEnabledByDefault` API server feature gate

### DIFF
--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -44,7 +44,7 @@ apiserver_flags="
   --secure-port=8443 \
   --tls-cert-file $TLS_CERT_FILE \
   --tls-private-key-file $TLS_KEY_FILE \
-  --feature-gates SeedChange=true \
+  --feature-gates SeedChange=true,ShootVPAEnabledByDefault=true \
   --v 2"
 
 if [[ "$(uname -s)" == "Linux" && "$(uname -r)" =~ "microsoft-standard" ]]; then

--- a/pkg/apis/core/v1alpha1/defaults.go
+++ b/pkg/apis/core/v1alpha1/defaults.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
@@ -28,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/pointer"
 )
 
@@ -167,6 +169,13 @@ func SetDefaults_Shoot(obj *Shoot) {
 	if obj.Spec.Kubernetes.KubeProxy.Mode == nil {
 		defaultProxyMode := ProxyModeIPTables
 		obj.Spec.Kubernetes.KubeProxy.Mode = &defaultProxyMode
+	}
+
+	if obj.Spec.Kubernetes.VerticalPodAutoscaler == nil &&
+		len(obj.Status.TechnicalID) == 0 &&
+		features.IsFeatureGateKnown(utilfeature.DefaultFeatureGate, features.ShootVPAEnabledByDefault) &&
+		utilfeature.DefaultFeatureGate.Enabled(features.ShootVPAEnabledByDefault) {
+		obj.Spec.Kubernetes.VerticalPodAutoscaler = &VerticalPodAutoscaler{Enabled: true}
 	}
 
 	if obj.Spec.Addons == nil {

--- a/pkg/apis/core/v1alpha1/defaults_test.go
+++ b/pkg/apis/core/v1alpha1/defaults_test.go
@@ -19,6 +19,8 @@ import (
 
 	. "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/features"
+	"github.com/gardener/gardener/pkg/utils/test"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -27,6 +29,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/pointer"
 )
 
@@ -427,6 +430,48 @@ var _ = Describe("Defaults", func() {
 			SetDefaults_Shoot(obj)
 			Expect(obj.Spec.Kubernetes.KubeAPIServer.Requests.MaxNonMutatingInflight).To(Equal(&maxNonMutatingRequestsInflight))
 			Expect(obj.Spec.Kubernetes.KubeAPIServer.Requests.MaxMutatingInflight).To(Equal(&maxMutatingRequestsInflight))
+		})
+
+		It("should not change the VPA field for new shoots if the feature gate is enabled and VPA is already configured", func() {
+			defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootVPAEnabledByDefault, true)()
+			obj.Spec.Kubernetes.VerticalPodAutoscaler = &VerticalPodAutoscaler{Enabled: false}
+
+			SetDefaults_Shoot(obj)
+
+			Expect(obj.Spec.Kubernetes.VerticalPodAutoscaler).NotTo(BeNil())
+			Expect(obj.Spec.Kubernetes.VerticalPodAutoscaler.Enabled).To(BeFalse())
+		})
+
+		It("should default the VPA field for new shoots if the feature gate is enabled", func() {
+			defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootVPAEnabledByDefault, true)()
+
+			SetDefaults_Shoot(obj)
+
+			Expect(obj.Spec.Kubernetes.VerticalPodAutoscaler).NotTo(BeNil())
+			Expect(obj.Spec.Kubernetes.VerticalPodAutoscaler.Enabled).To(BeTrue())
+		})
+
+		It("should not default the VPA field for existing shoots if the feature gate is enabled", func() {
+			defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootVPAEnabledByDefault, true)()
+			obj.Status.TechnicalID = "foo"
+
+			SetDefaults_Shoot(obj)
+
+			Expect(obj.Spec.Kubernetes.VerticalPodAutoscaler).To(BeNil())
+		})
+
+		It("should not default the VPA field for new shoots if the feature gate is disabled", func() {
+			SetDefaults_Shoot(obj)
+
+			Expect(obj.Spec.Kubernetes.VerticalPodAutoscaler).To(BeNil())
+		})
+
+		It("should not default the VPA field for existing shoots if the feature gate is disabled", func() {
+			obj.Status.TechnicalID = "foo"
+
+			SetDefaults_Shoot(obj)
+
+			Expect(obj.Spec.Kubernetes.VerticalPodAutoscaler).To(BeNil())
 		})
 	})
 

--- a/pkg/apis/core/v1beta1/defaults.go
+++ b/pkg/apis/core/v1beta1/defaults.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
@@ -28,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/pointer"
 )
 
@@ -167,6 +169,13 @@ func SetDefaults_Shoot(obj *Shoot) {
 	if obj.Spec.Kubernetes.KubeProxy.Mode == nil {
 		defaultProxyMode := ProxyModeIPTables
 		obj.Spec.Kubernetes.KubeProxy.Mode = &defaultProxyMode
+	}
+
+	if obj.Spec.Kubernetes.VerticalPodAutoscaler == nil &&
+		len(obj.Status.TechnicalID) == 0 &&
+		features.IsFeatureGateKnown(utilfeature.DefaultFeatureGate, features.ShootVPAEnabledByDefault) &&
+		utilfeature.DefaultFeatureGate.Enabled(features.ShootVPAEnabledByDefault) {
+		obj.Spec.Kubernetes.VerticalPodAutoscaler = &VerticalPodAutoscaler{Enabled: true}
 	}
 
 	if obj.Spec.Addons == nil {

--- a/pkg/apis/core/v1beta1/v1beta1_suite_test.go
+++ b/pkg/apis/core/v1beta1/v1beta1_suite_test.go
@@ -17,11 +17,14 @@ package v1beta1_test
 import (
 	"testing"
 
+	"github.com/gardener/gardener/pkg/apiserver/features"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 func TestV1alpha1(t *testing.T) {
+	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "API Core V1beta1 Suite")
 }

--- a/pkg/apiserver/features/features.go
+++ b/pkg/apiserver/features/features.go
@@ -24,7 +24,8 @@ import (
 
 var (
 	featureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		features.SeedChange: {Default: false, PreRelease: featuregate.Alpha},
+		features.SeedChange:               {Default: false, PreRelease: featuregate.Alpha},
+		features.ShootVPAEnabledByDefault: {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -15,6 +15,8 @@
 package features
 
 import (
+	"strings"
+
 	"k8s.io/component-base/featuregate"
 )
 
@@ -88,4 +90,21 @@ const (
 	// owner: @mvladev
 	// alpha: v1.15.0
 	SeedKubeScheduler featuregate.Feature = "SeedKubeScheduler"
+
+	// ShootVPAEnabledByDefault defines whether the `.spec.kubernetes.verticalPodAutoscaler.enabled` field for newly
+	// created Shoots shall be set to `true` by default. Existing Shoots will remain untouched and must explicitly
+	// enable the VPA if desired.
+	// owner: @rfranzke
+	// alpha: v1.16.0
+	ShootVPAEnabledByDefault featuregate.Feature = "ShootVPAEnabledByDefault"
 )
+
+// IsFeatureGateKnown returns true if the provided <feature> is known in the provided list of <featureGates>.
+func IsFeatureGateKnown(featureGates featuregate.FeatureGate, feature featuregate.Feature) bool {
+	for _, fg := range featureGates.KnownFeatures() {
+		if strings.HasPrefix(fg, string(feature)) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/features/features_suite_test.go
+++ b/pkg/features/features_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,19 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1alpha1_test
+package features_test
 
 import (
 	"testing"
-
-	"github.com/gardener/gardener/pkg/apiserver/features"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-func TestV1alpha1(t *testing.T) {
-	features.RegisterFeatureGates()
+func TestFeatures(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "API Core V1Alpha1 Suite")
+	RunSpecs(t, "Features Suite")
 }

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package features_test
+
+import (
+	. "github.com/gardener/gardener/pkg/features"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
+	"k8s.io/component-base/featuregate"
+)
+
+var _ = Describe("Features", func() {
+	var (
+		fooGate = featuregate.Feature("Foo")
+
+		emptyFeatureGates    = featuregate.NewFeatureGate()
+		nonEmptyFeatureGates = featuregate.NewFeatureGate()
+	)
+
+	BeforeEach(func() {
+		Expect(nonEmptyFeatureGates.Add(map[featuregate.Feature]featuregate.FeatureSpec{
+			fooGate: {Default: false, PreRelease: featuregate.Alpha},
+		})).To(Succeed())
+	})
+
+	DescribeTable("IsFeatureGateKnown",
+		func(featureGates featuregate.FeatureGate, feature featuregate.Feature, matcher gomegatypes.GomegaMatcher) {
+			Expect(IsFeatureGateKnown(featureGates, feature)).To(matcher)
+		},
+
+		Entry("known", nonEmptyFeatureGates, fooGate, BeTrue()),
+		Entry("unknown", emptyFeatureGates, fooGate, BeFalse()),
+	)
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR adds a new `ShootVPAEnabledByDefault` feature gate (alpha, disabled by default) to the gardener-apiserver. If enabled, the `.spec.kubernetes.verticalPodAutoscaler.enabled` field for newly created `Shoot` resources is defaulted to `true`. Existing `Shoot`s are not modified, i.e., if VPA shall be enabled then it needs to be explicitly set.

**Which issue(s) this PR fixes**:
Fixes #3304

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The new `ShootVPAEnabledByDefault` feature gate for the `gardener-apiserver` (alpha, disabled by default) controls whether the `.spec.kubernetes.verticalPodAutoscaler.enabled` field for newly created `Shoot` resources is defaulted to `true`. Existing `Shoot`s are not modified, i.e., if VPA shall be enabled then it needs to be explicitly set. In the future, the feature gate will be removed again and the API defaulting will be changed in general.
```
