### PR TITLE
Fix ToExceptNetworks to handle overlapping except nets

### DIFF
--- a/pkg/operation/common/network_policies.go
+++ b/pkg/operation/common/network_policies.go
@@ -106,11 +106,11 @@ func excludeBlock(parentBlock *net.IPNet, cidrs ...string) ([]string, error) {
 	matchedCIDRs := []string{}
 
 	for _, cidr := range cidrs {
-		ip, _, err := net.ParseCIDR(string(cidr))
+		ip, ipNet, err := net.ParseCIDR(string(cidr))
 		if err != nil {
 			return matchedCIDRs, err
 		}
-		if parentBlock.Contains(ip) {
+		if parentBlock.Contains(ip) && !ipNet.Contains(parentBlock.IP) {
 			matchedCIDRs = append(matchedCIDRs, cidr)
 		}
 	}

--- a/pkg/operation/common/network_policies_test.go
+++ b/pkg/operation/common/network_policies_test.go
@@ -60,5 +60,39 @@ var _ = Describe("networkpolicies", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(ConsistOf(expectedResult))
 		})
+
+		It("should not have overlapping excepts", func() {
+			result, err := ToExceptNetworks(
+				AllPrivateNetworkBlocks(),
+				"192.167.0.0/16",
+				"192.168.0.0/16",
+				"10.10.0.0/24",
+				"10.0.0.0/8",
+				"100.64.0.0/10",
+				"172.16.0.0/12",
+			)
+
+			expectedResult := []interface{}{
+				map[string]interface{}{
+					"network": "10.0.0.0/8",
+					"except":  []string{"10.10.0.0/24"},
+				},
+				map[string]interface{}{
+					"network": "172.16.0.0/12",
+					"except":  []string{},
+				},
+				map[string]interface{}{
+					"network": "192.168.0.0/16",
+					"except":  []string{},
+				},
+				map[string]interface{}{
+					"network": "100.64.0.0/10",
+					"except":  []string{},
+				},
+			}
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(ConsistOf(expectedResult))
+		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/priority normal

**What this PR does / why we need it**:

`ToExceptNetworks` doesn't handle when provided except nets are part of the private and carrier grade NAT:

```yaml
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  annotations:
    gardener.cloud/description: |
      Allows Egress from pods labeled with 'networking.gardener.cloud/to-private-networks=allowed'
      to the Private networks (RFC1918), Carrier-grade NAT (RFC6598) except for
      - CloudProvider's specific metadata service IP
      - Seed networks
      - Shoot networks
  name: allow-to-private-networks
spec:
  podSelector:
    matchLabels:
      networking.gardener.cloud/to-private-networks: allowed
  egress:
  - to:
    - ipBlock:
        cidr: 192.168.0.0/16
        except:
        - 192.168.0.0/16 # <-- this should not be here
  policyTypes:
  - Egress
  ingress: []
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a bug where service, pod or node CIDRs that are private network (RFC1918) or carrier-grade NAT (RFC6598) IPv4 blocks would produce an invalid `allow-to-private-networks` networkpolicy.
```
