### PR TITLE
Add PiorityClass for Loki

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/priorityclass.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/priorityclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: {{ include "priorityclassversion" . }}
+kind: PriorityClass
+metadata:
+  name: loki
+value: 40
+globalDefault: false
+description: "This class is used to ensure that the Loki has a higher priority than pods without PriorityClass set."

--- a/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
@@ -23,6 +23,7 @@ spec:
       serviceAccountName: loki
       securityContext:
         {{- toYaml .Values.securityContext | nindent 8 }}
+      priorityClassName: loki
       containers:
         - name: loki
           image: {{ index .Values.global.images "loki" }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Add PriorityClass for Loki.
The weight is enough small to not affect more critical components

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@vpnachev @vlvasilev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
