### PR TITLE
Expose FetchEvents function

### DIFF
--- a/pkg/operation/botanist/controlplane/kube_apiserver_service.go
+++ b/pkg/operation/botanist/controlplane/kube_apiserver_service.go
@@ -153,8 +153,11 @@ func (d *kubeAPIService) Wait(ctx context.Context) error {
 		loadBalancerIngress, err := kutil.GetLoadBalancerIngress(
 			ctx,
 			d.client,
-			d.loadBalancerServicekey.Namespace,
-			d.loadBalancerServicekey.Name,
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: d.loadBalancerServicekey.Name, Namespace: d.loadBalancerServicekey.Namespace,
+				},
+			},
 		)
 		if err != nil {
 			d.logger.Info("Waiting until the KubeAPI Server ingress LoadBalancer deployed in the Seed cluster is ready...")

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -213,9 +213,10 @@ func WaitUntilLoadBalancerIsReady(ctx context.Context, kubeClient kubernetes.Int
 	return loadBalancerIngress, nil
 }
 
-// GetLoadBalancerIngress takes a context, a client, a service object. It queries for a load balancer's technical name
-// (ip address or hostname). It returns the value of the technical name whereby it always prefers the hostname (if given)
-// over the IP address. It also returns the list of all load balancer ingresses.
+// GetLoadBalancerIngress takes a context, a client, a service object. It gets the `service` and
+// queries for a load balancer's technical name (ip address or hostname). It returns the value of the technical name
+// whereby it always prefers the hostname (if given) over the IP address.
+// The passed `service` instance is updated with the information received from the API server.
 func GetLoadBalancerIngress(ctx context.Context, c client.Client, service *corev1.Service) (string, error) {
 	if err := c.Get(ctx, client.ObjectKeyFromObject(service), service); err != nil {
 		return "", err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR exposes an already implemented functionality to fetch event messages for involved objects. The motivation for this change is to allow extensions / Gardener Resource Manager calling the functionality as well.

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
