### PR TITLE
Use protobuf in gardener components

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/configmap-componentconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/configmap-componentconfig.yaml
@@ -16,8 +16,12 @@ data:
     apiVersion: admissioncontroller.config.gardener.cloud/v1alpha1
     kind: AdmissionControllerConfiguration
     gardenClientConnection:
-      acceptContentTypes: {{ required ".Values.global.admission.config.gardenClientConnection.acceptContentTypes is required" .Values.global.admission.config.gardenClientConnection.acceptContentTypes }}
-      contentType: {{ required ".Values.global.admission.config.gardenClientConnection.contentType is required" .Values.global.admission.config.gardenClientConnection.contentType }}
+      {{- with .Values.global.admission.config.gardenClientConnection.acceptContentTypes }}
+      acceptContentTypes: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.global.admission.config.gardenClientConnection.contentType }}
+      contentType: {{ . | quote }}
+      {{- end }}
       qps: {{ required ".Values.global.admission.config.gardenClientConnection.qps is required" .Values.global.admission.config.gardenClientConnection.qps }}
       burst: {{ required ".Values.global.admission.config.gardenClientConnection.burst is required" .Values.global.admission.config.gardenClientConnection.burst }}
       {{- if .Values.global.admission.config.gardenClientConnection.kubeconfig }}

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/configmap-componentconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/configmap-componentconfig.yaml
@@ -16,8 +16,12 @@ data:
     apiVersion: controllermanager.config.gardener.cloud/v1alpha1
     kind: ControllerManagerConfiguration
     gardenClientConnection:
-      acceptContentTypes: {{ required ".Values.global.controller.config.gardenClientConnection.acceptContentTypes is required" .Values.global.controller.config.gardenClientConnection.acceptContentTypes }}
-      contentType: {{ required ".Values.global.controller.config.gardenClientConnection.contentType is required" .Values.global.controller.config.gardenClientConnection.contentType }}
+      {{- with .Values.global.controller.config.gardenClientConnection.acceptContentTypes }}
+      acceptContentTypes: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.global.controller.config.gardenClientConnection.contentType }}
+      contentType: {{ . | quote }}
+      {{- end }}
       qps: {{ required ".Values.global.controller.config.gardenClientConnection.qps is required" .Values.global.controller.config.gardenClientConnection.qps }}
       burst: {{ required ".Values.global.controller.config.gardenClientConnection.burst is required" .Values.global.controller.config.gardenClientConnection.burst }}
       {{- if .Values.global.controller.config.gardenClientConnection.kubeconfig }}

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/configmap-componentconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/configmap-componentconfig.yaml
@@ -16,8 +16,12 @@ data:
     apiVersion: scheduler.config.gardener.cloud/v1alpha1
     kind: SchedulerConfiguration
     clientConnection:
-      acceptContentTypes: {{ required ".Values.global.scheduler.config.clientConnection.acceptContentTypes is required" .Values.global.scheduler.config.clientConnection.acceptContentTypes }}
-      contentType: {{ required ".Values.global.scheduler.config.clientConnection.contentType is required" .Values.global.scheduler.config.clientConnection.contentType }}
+      {{- with .Values.global.scheduler.config.clientConnection.acceptContentTypes }}
+      acceptContentTypes: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.global.scheduler.config.clientConnection.contentType }}
+      contentType: {{ . | quote }}
+      {{- end }}
       qps: {{ required ".Values.global.scheduler.config.clientConnection.qps is required" .Values.global.scheduler.config.clientConnection.qps }}
       burst: {{ required ".Values.global.scheduler.config.clientConnection.burst is required" .Values.global.scheduler.config.clientConnection.burst }}
       {{- if .Values.global.scheduler.config.clientConnection.kubeconfig }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -272,8 +272,8 @@ global:
     vpa: false
     config:
       gardenClientConnection:
-        acceptContentTypes: application/json
-        contentType: application/json
+       # acceptContentTypes: application/json
+       # contentType: application/json
         qps: 100
         burst: 130
       server:
@@ -328,8 +328,8 @@ global:
     vpa: false
     config:
       gardenClientConnection:
-        acceptContentTypes: application/json
-        contentType: application/json
+      # acceptContentTypes: application/json
+      # contentType: application/json
         qps: 100
         burst: 130
       controllers:
@@ -421,8 +421,8 @@ global:
     vpa: false
     config:
       clientConnection:
-        acceptContentTypes: application/json
-        contentType: application/json
+      # acceptContentTypes: application/json
+      # contentType: application/json
         qps: 100
         burst: 130
       leaderElection:

--- a/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
@@ -16,8 +16,12 @@ data:
     apiVersion: gardenlet.config.gardener.cloud/v1alpha1
     kind: GardenletConfiguration
     gardenClientConnection:
-      acceptContentTypes: {{ required ".Values.global.gardenlet.config.gardenClientConnection.acceptContentTypes is required" .Values.global.gardenlet.config.gardenClientConnection.acceptContentTypes }}
-      contentType: {{ required ".Values.global.gardenlet.config.gardenClientConnection.contentType is required" .Values.global.gardenlet.config.gardenClientConnection.contentType }}
+      {{- with .Values.global.gardenlet.config.gardenClientConnection.acceptContentTypes }}
+      acceptContentTypes: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.global.gardenlet.config.gardenClientConnection.contentType }}
+      contentType: {{ . | quote }}
+      {{- end }}
       qps: {{ required ".Values.global.gardenlet.config.gardenClientConnection.qps is required" .Values.global.gardenlet.config.gardenClientConnection.qps }}
       burst: {{ required ".Values.global.gardenlet.config.gardenClientConnection.burst is required" .Values.global.gardenlet.config.gardenClientConnection.burst }}
       {{- if .Values.global.gardenlet.config.gardenClientConnection.gardenClusterAddress }}
@@ -40,16 +44,24 @@ data:
       kubeconfig: /etc/gardenlet/kubeconfig-garden/kubeconfig
       {{- end }}
     seedClientConnection:
-      acceptContentTypes: {{ required ".Values.global.gardenlet.config.seedClientConnection.acceptContentTypes is required" .Values.global.gardenlet.config.seedClientConnection.acceptContentTypes }}
-      contentType: {{ required ".Values.global.gardenlet.config.seedClientConnection.contentType is required" .Values.global.gardenlet.config.seedClientConnection.contentType }}
+      {{- with .Values.global.gardenlet.config.seedClientConnection.acceptContentTypes }}
+      acceptContentTypes: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.global.gardenlet.config.seedClientConnection.contentType }}
+      contentType: {{ . | quote }}
+      {{- end }}
       qps: {{ required ".Values.global.gardenlet.config.seedClientConnection.qps is required" .Values.global.gardenlet.config.seedClientConnection.qps }}
       burst: {{ required ".Values.global.gardenlet.config.seedClientConnection.burst is required" .Values.global.gardenlet.config.seedClientConnection.burst }}
       {{- if .Values.global.gardenlet.config.seedClientConnection.kubeconfig }}
       kubeconfig: /etc/gardenlet/kubeconfig-seed/kubeconfig
       {{- end }}
     shootClientConnection:
-      acceptContentTypes: {{ required ".Values.global.gardenlet.config.shootClientConnection.acceptContentTypes is required" .Values.global.gardenlet.config.shootClientConnection.acceptContentTypes }}
-      contentType: {{ required ".Values.global.gardenlet.config.shootClientConnection.contentType is required" .Values.global.gardenlet.config.shootClientConnection.contentType }}
+      {{- with .Values.global.gardenlet.config.shootClientConnection.acceptContentTypes }}
+      acceptContentTypes: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.global.gardenlet.config.shootClientConnection.contentType }}
+      contentType: {{ . | quote }}
+      {{- end }}
       qps: {{ required ".Values.global.gardenlet.config.shootClientConnection.qps is required" .Values.global.gardenlet.config.shootClientConnection.qps }}
       burst: {{ required ".Values.global.gardenlet.config.shootClientConnection.burst is required" .Values.global.gardenlet.config.shootClientConnection.burst }}
     controllers:

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -28,8 +28,8 @@ global:
   #  Please find documentation in docs/deployment/image_vector.md
     config:
       gardenClientConnection:
-        acceptContentTypes: application/json
-        contentType: application/json
+      # acceptContentTypes: application/json
+      # contentType: application/json
         qps: 100
         burst: 130
       # gardenClusterAddress: https://some-external-ip-address-to-garden-cluster
@@ -52,15 +52,15 @@ global:
       #   `bootstrapKubeconfig` and `kubeconfigSecret` then it will try to create a CertificateSigningRequest
       #   and to procure a client certificate.
       seedClientConnection:
-        acceptContentTypes: application/json
-        contentType: application/json
+      # acceptContentTypes: application/json
+      # contentType: application/json
         qps: 100
         burst: 130
       # kubeconfig: |
       #   Specify a kubeconfig for the seed cluster here if you don't want to use the Gardenlet's service account.
       shootClientConnection:
-        acceptContentTypes: application/json
-        contentType: application/json
+      # acceptContentTypes: application/json
+      # contentType: application/json
         qps: 25
         burst: 50
       controllers:

--- a/example/20-componentconfig-gardener-admission-controller.yaml
+++ b/example/20-componentconfig-gardener-admission-controller.yaml
@@ -2,8 +2,6 @@
 apiVersion: admissioncontroller.config.gardener.cloud/v1alpha1
 kind: AdmissionControllerConfiguration
 gardenClientConnection:
-  acceptContentTypes: application/json
-  contentType: application/json
   qps: 100
   burst: 130
 server:

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -2,8 +2,6 @@
 apiVersion: controllermanager.config.gardener.cloud/v1alpha1
 kind: ControllerManagerConfiguration
 gardenClientConnection:
-  acceptContentTypes: application/json
-  contentType: application/json
   qps: 100
   burst: 130
 controllers:

--- a/example/20-componentconfig-gardener-scheduler.yaml
+++ b/example/20-componentconfig-gardener-scheduler.yaml
@@ -2,8 +2,6 @@
 apiVersion: scheduler.config.gardener.cloud/v1alpha1
 kind: SchedulerConfiguration
 clientConnection:
-  acceptContentTypes: application/json
-  contentType: application/json
   qps: 100
   burst: 130
 leaderElection:

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -2,18 +2,12 @@
 apiVersion: gardenlet.config.gardener.cloud/v1alpha1
 kind: GardenletConfiguration
 gardenClientConnection:
-  acceptContentTypes: application/json
-  contentType: application/json
   qps: 100
   burst: 130
 seedClientConnection:
-  acceptContentTypes: application/json
-  contentType: application/json
   qps: 100
   burst: 130
 shootClientConnection:
-  acceptContentTypes: application/json
-  contentType: application/json
   qps: 25
   burst: 50
 controllers:

--- a/pkg/admissioncontroller/apis/config/v1alpha1/defaults.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/defaults.go
@@ -17,6 +17,7 @@ package v1alpha1
 import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -44,5 +45,15 @@ func SetDefaults_AdmissionControllerConfiguration(obj *AdmissionControllerConfig
 		if (subject.Kind == rbacv1.UserKind || subject.Kind == rbacv1.GroupKind) && subject.APIGroup == "" {
 			resourceAdmission.UnrestrictedSubjects[i].APIGroup = rbacv1.GroupName
 		}
+	}
+}
+
+// SetDefaults_ClientConnectionConfiguration sets defaults for the garden client connection.
+func SetDefaults_ClientConnectionConfiguration(obj *componentbaseconfigv1alpha1.ClientConnectionConfiguration) {
+	if obj.QPS == 0.0 {
+		obj.QPS = 50.0
+	}
+	if obj.Burst == 0 {
+		obj.Burst = 100
 	}
 }

--- a/pkg/admissioncontroller/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/defaults_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Defaults", func() {
 			It("should not default ContentType and AcceptContentTypes", func() {
 				SetObjectDefaults_AdmissionControllerConfiguration(obj)
 
-				// ContentType fields will be defaulted by client constructors / controller-runtime based on wether a
+				// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
 				// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
 				// logic will be overwritten
 				Expect(obj.GardenClientConnection.ContentType).To(BeEmpty())

--- a/pkg/admissioncontroller/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/zz_generated.defaults.go
@@ -36,4 +36,5 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 
 func SetObjectDefaults_AdmissionControllerConfiguration(in *AdmissionControllerConfiguration) {
 	SetDefaults_AdmissionControllerConfiguration(in)
+	SetDefaults_ClientConnectionConfiguration(&in.GardenClientConnection)
 }

--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -35,6 +35,7 @@ import (
 
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	gardenercorescheme "github.com/gardener/gardener/pkg/client/core/clientset/versioned/scheme"
+	seedmanagementscheme "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned/scheme"
 	settingsscheme "github.com/gardener/gardener/pkg/client/settings/clientset/versioned/scheme"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
@@ -53,6 +54,7 @@ func init() {
 	// enable protobuf for Gardener API for controller-runtime clients
 	protobufSchemeBuilder := runtime.NewSchemeBuilder(
 		gardenercorescheme.AddToScheme,
+		seedmanagementscheme.AddToScheme,
 		settingsscheme.AddToScheme,
 	)
 

--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -19,11 +19,10 @@ import (
 	"errors"
 	"fmt"
 
-	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
-	versionutils "github.com/gardener/gardener/pkg/utils/version"
-
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -32,6 +31,12 @@ import (
 	apiserviceclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
+	gardenercorescheme "github.com/gardener/gardener/pkg/client/core/clientset/versioned/scheme"
+	settingsscheme "github.com/gardener/gardener/pkg/client/settings/clientset/versioned/scheme"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 )
 
 var (
@@ -43,6 +48,16 @@ var (
 
 // KubeConfig is the key to the kubeconfig
 const KubeConfig = "kubeconfig"
+
+func init() {
+	// enable protobuf for Gardener API for controller-runtime clients
+	protobufSchemeBuilder := runtime.NewSchemeBuilder(
+		gardenercorescheme.AddToScheme,
+		settingsscheme.AddToScheme,
+	)
+
+	utilruntime.Must(apiutil.AddToProtobufScheme(protobufSchemeBuilder.AddToScheme))
+}
 
 // NewClientFromFile creates a new Client struct for a given kubeconfig. The kubeconfig will be
 // read from the filesystem at location <kubeconfigPath>. If given, <masterURL> overrides the
@@ -270,22 +285,26 @@ func newClientSet(conf *Config) (Interface, error) {
 		runtimeClient = directClient
 	}
 
-	kubernetes, err := kubernetesclientset.NewForConfig(conf.restConfig)
+	// prepare rest config with contentType defaulted to protobuf for client-go style clients that either talk to
+	// kubernetes or aggregated APIs that support protobuf.
+	cfg := defaultContentTypeProtobuf(conf.restConfig)
+
+	kubernetes, err := kubernetesclientset.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	gardenCore, err := gardencoreclientset.NewForConfig(conf.restConfig)
+	gardenCore, err := gardencoreclientset.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	apiRegistration, err := apiserviceclientset.NewForConfig(conf.restConfig)
+	apiRegistration, err := apiserviceclientset.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	apiExtension, err := apiextensionsclientset.NewForConfig(conf.restConfig)
+	apiExtension, err := apiextensionsclientset.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -315,5 +334,16 @@ func newClientSet(conf *Config) (Interface, error) {
 }
 
 func setConfigDefaults(conf *Config) error {
+	// we can't default to protobuf ContentType here, otherwise controller-runtime clients will also try to talk to
+	// CRD resources (e.g. extension CRs in the Seed) using protobuf, but CRDs don't support protobuf
+	// see https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#advanced-features-and-flexibility
 	return setClientOptionsDefaults(conf.restConfig, &conf.clientOptions)
+}
+
+func defaultContentTypeProtobuf(c *rest.Config) *rest.Config {
+	config := *c
+	if config.ContentType == "" {
+		config.ContentType = runtime.ContentTypeProtobuf
+	}
+	return &config
 }

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -127,16 +127,8 @@ func SetDefaults_ControllerManagerConfiguration(obj *ControllerManagerConfigurat
 	}
 }
 
-// SetDefaults_GardenClientConnection sets defaults for the client connection.
-func SetDefaults_GardenClientConnection(obj *componentbaseconfigv1alpha1.ClientConnectionConfiguration) {
-	//componentbaseconfigv1alpha1.RecommendedDefaultClientConnectionConfiguration(obj)
-	// https://github.com/kubernetes/client-go/issues/76#issuecomment-396170694
-	if len(obj.AcceptContentTypes) == 0 {
-		obj.AcceptContentTypes = "application/json"
-	}
-	if len(obj.ContentType) == 0 {
-		obj.ContentType = "application/json"
-	}
+// SetDefaults_ClientConnectionConfiguration sets defaults for the garden client connection.
+func SetDefaults_ClientConnectionConfiguration(obj *componentbaseconfigv1alpha1.ClientConnectionConfiguration) {
 	if obj.QPS == 0.0 {
 		obj.QPS = 50.0
 	}

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -17,16 +17,17 @@ package v1alpha1_test
 import (
 	"time"
 
-	. "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
+
+	. "github.com/gardener/gardener/pkg/controllermanager/apis/config/v1alpha1"
 )
 
 var _ = Describe("Defaults", func() {
-	Describe("#SetDefaults_ControllerManagerConfiguration", func() {
+	Describe("ControllerManagerConfiguration", func() {
 		var obj *ControllerManagerConfiguration
 
 		BeforeEach(func() {
@@ -34,7 +35,7 @@ var _ = Describe("Defaults", func() {
 		})
 
 		It("should correctly default the controller manager configuration", func() {
-			SetDefaults_ControllerManagerConfiguration(obj)
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
 
 			Expect(obj.Server.HTTP.BindAddress).To(Equal("0.0.0.0"))
 			Expect(obj.Server.HTTP.Port).To(Equal(2718))
@@ -88,10 +89,29 @@ var _ = Describe("Defaults", func() {
 					},
 				},
 			}
-			SetDefaults_ControllerManagerConfiguration(obj)
+			SetObjectDefaults_ControllerManagerConfiguration(obj)
 
 			Expect(obj.Controllers.Project.Quotas[0].ProjectSelector).To(Equal(fooSelector))
 			Expect(obj.Controllers.Project.Quotas[1].ProjectSelector).To(Equal(&metav1.LabelSelector{}))
+		})
+
+		Describe("GardenClientConnection", func() {
+			It("should not default ContentType and AcceptContentTypes", func() {
+				SetObjectDefaults_ControllerManagerConfiguration(obj)
+
+				// ContentType fields will be defaulted by client constructors / controller-runtime based on wether a
+				// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+				// logic will be overwritten
+				Expect(obj.GardenClientConnection.ContentType).To(BeEmpty())
+				Expect(obj.GardenClientConnection.AcceptContentTypes).To(BeEmpty())
+			})
+			It("should correctly default GardenClientConnection", func() {
+				SetObjectDefaults_ControllerManagerConfiguration(obj)
+				Expect(obj.GardenClientConnection).To(Equal(componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+					QPS:   50.0,
+					Burst: 100,
+				}))
+			})
 		})
 	})
 	Describe("#SetDefaults_EventControllerConfiguration", func() {

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Defaults", func() {
 			It("should not default ContentType and AcceptContentTypes", func() {
 				SetObjectDefaults_ControllerManagerConfiguration(obj)
 
-				// ContentType fields will be defaulted by client constructors / controller-runtime based on wether a
+				// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
 				// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
 				// logic will be overwritten
 				Expect(obj.GardenClientConnection.ContentType).To(BeEmpty())

--- a/pkg/controllermanager/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/zz_generated.defaults.go
@@ -36,6 +36,7 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 
 func SetObjectDefaults_ControllerManagerConfiguration(in *ControllerManagerConfiguration) {
 	SetDefaults_ControllerManagerConfiguration(in)
+	SetDefaults_ClientConnectionConfiguration(&in.GardenClientConnection)
 	if in.Controllers.Event != nil {
 		SetDefaults_EventControllerConfiguration(in.Controllers.Event)
 	}

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -109,31 +109,8 @@ func SetDefaults_GardenletConfiguration(obj *GardenletConfiguration) {
 	}
 }
 
-// SetDefaults_GardenClientConnection sets defaults for the client connection objects.
-func SetDefaults_GardenClientConnection(obj *GardenClientConnection) {
-	SetDefaults_ClientConnectionConfiguration(&obj.ClientConnectionConfiguration)
-}
-
-// SetDefaults_SeedClientConnection sets defaults for the client connection objects.
-func SetDefaults_SeedClientConnection(obj *SeedClientConnection) {
-	SetDefaults_ClientConnectionConfiguration(&obj.ClientConnectionConfiguration)
-}
-
-// SetDefaults_ShootClientConnection sets defaults for the client connection objects.
-func SetDefaults_ShootClientConnection(obj *ShootClientConnection) {
-	SetDefaults_ClientConnectionConfiguration(&obj.ClientConnectionConfiguration)
-}
-
 // SetDefaults_ClientConnectionConfiguration sets defaults for the client connection objects.
 func SetDefaults_ClientConnectionConfiguration(obj *componentbaseconfigv1alpha1.ClientConnectionConfiguration) {
-	// componentbaseconfigv1alpha1.RecommendedDefaultClientConnectionConfiguration(obj)
-	// https://github.com/kubernetes/client-go/issues/76#issuecomment-396170694
-	if len(obj.AcceptContentTypes) == 0 {
-		obj.AcceptContentTypes = "application/json"
-	}
-	if len(obj.ContentType) == 0 {
-		obj.ContentType = "application/json"
-	}
 	if obj.QPS == 0.0 {
 		obj.QPS = 50.0
 	}

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.SNI.Ingress.ServiceName).To(PointTo(Equal("istio-ingressgateway")))
 		})
 
-		Describe("GardenClientConnection", func() {
+		Describe("ClientConnection settings", func() {
 			It("should not default ContentType and AcceptContentTypes", func() {
 				SetObjectDefaults_GardenletConfiguration(obj)
 
@@ -72,10 +72,26 @@ var _ = Describe("Defaults", func() {
 				// logic will be overwritten
 				Expect(obj.GardenClientConnection.ContentType).To(BeEmpty())
 				Expect(obj.GardenClientConnection.AcceptContentTypes).To(BeEmpty())
+				Expect(obj.SeedClientConnection.ContentType).To(BeEmpty())
+				Expect(obj.SeedClientConnection.AcceptContentTypes).To(BeEmpty())
+				Expect(obj.ShootClientConnection.ContentType).To(BeEmpty())
+				Expect(obj.ShootClientConnection.AcceptContentTypes).To(BeEmpty())
 			})
 			It("should correctly default GardenClientConnection", func() {
 				SetObjectDefaults_GardenletConfiguration(obj)
 				Expect(obj.GardenClientConnection).To(Equal(&GardenClientConnection{
+					ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+						QPS:   50.0,
+						Burst: 100,
+					},
+				}))
+				Expect(obj.SeedClientConnection).To(Equal(&SeedClientConnection{
+					ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+						QPS:   50.0,
+						Burst: 100,
+					},
+				}))
+				Expect(obj.ShootClientConnection).To(Equal(&ShootClientConnection{
 					ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 						QPS:   50.0,
 						Burst: 100,

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Defaults", func() {
 			It("should not default ContentType and AcceptContentTypes", func() {
 				SetObjectDefaults_GardenletConfiguration(obj)
 
-				// ContentType fields will be defaulted by client constructors / controller-runtime based on wether a
+				// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
 				// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
 				// logic will be overwritten
 				Expect(obj.GardenClientConnection.ContentType).To(BeEmpty())

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -17,18 +17,18 @@ package v1alpha1_test
 import (
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
-
-	. "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
+	"k8s.io/klog"
+
+	. "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 )
 
 var _ = Describe("Defaults", func() {
-	Describe("#SetDefaults_GardenletConfiguration", func() {
+	Describe("GardenletConfiguration", func() {
 		var obj *GardenletConfiguration
 
 		BeforeEach(func() {
@@ -61,6 +61,27 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.SNI.Ingress.Labels).To(Equal(map[string]string{"istio": "ingressgateway"}))
 			Expect(obj.SNI.Ingress.Namespace).To(PointTo(Equal("istio-ingress")))
 			Expect(obj.SNI.Ingress.ServiceName).To(PointTo(Equal("istio-ingressgateway")))
+		})
+
+		Describe("GardenClientConnection", func() {
+			It("should not default ContentType and AcceptContentTypes", func() {
+				SetObjectDefaults_GardenletConfiguration(obj)
+
+				// ContentType fields will be defaulted by client constructors / controller-runtime based on wether a
+				// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+				// logic will be overwritten
+				Expect(obj.GardenClientConnection.ContentType).To(BeEmpty())
+				Expect(obj.GardenClientConnection.AcceptContentTypes).To(BeEmpty())
+			})
+			It("should correctly default GardenClientConnection", func() {
+				SetObjectDefaults_GardenletConfiguration(obj)
+				Expect(obj.GardenClientConnection).To(Equal(&GardenClientConnection{
+					ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+						QPS:   50.0,
+						Burst: 100,
+					},
+				}))
+			})
 		})
 	})
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.defaults.go
@@ -35,15 +35,12 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 func SetObjectDefaults_GardenletConfiguration(in *GardenletConfiguration) {
 	SetDefaults_GardenletConfiguration(in)
 	if in.GardenClientConnection != nil {
-		SetDefaults_GardenClientConnection(in.GardenClientConnection)
 		SetDefaults_ClientConnectionConfiguration(&in.GardenClientConnection.ClientConnectionConfiguration)
 	}
 	if in.SeedClientConnection != nil {
-		SetDefaults_SeedClientConnection(in.SeedClientConnection)
 		SetDefaults_ClientConnectionConfiguration(&in.SeedClientConnection.ClientConnectionConfiguration)
 	}
 	if in.ShootClientConnection != nil {
-		SetDefaults_ShootClientConnection(in.ShootClientConnection)
 		SetDefaults_ClientConnectionConfiguration(&in.ShootClientConnection.ClientConnectionConfiguration)
 	}
 	if in.Controllers != nil {

--- a/pkg/scheduler/apis/config/v1alpha1/defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults.go
@@ -30,6 +30,10 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 
 // SetDefaults_SchedulerConfiguration sets defaults for the configuration of the Gardener scheduler.
 func SetDefaults_SchedulerConfiguration(obj *SchedulerConfiguration) {
+	if obj.LogLevel == "" {
+		obj.LogLevel = "info"
+	}
+
 	if len(obj.Server.HTTP.BindAddress) == 0 {
 		obj.Server.HTTP.BindAddress = "0.0.0.0"
 	}
@@ -62,19 +66,10 @@ func SetDefaults_SchedulerConfiguration(obj *SchedulerConfiguration) {
 	if obj.Schedulers.Shoot.ConcurrentSyncs == 0 {
 		obj.Schedulers.Shoot.ConcurrentSyncs = 5
 	}
-
 }
 
-// SetDefaults_ClientConnection sets defaults for the client connection.
-func SetDefaults_ClientConnection(obj *componentbaseconfigv1alpha1.ClientConnectionConfiguration) {
-	//componentbaseconfigv1alpha1.RecommendedDefaultClientConnectionConfiguration(obj)
-	// https://github.com/kubernetes/client-go/issues/76#issuecomment-396170694
-	if len(obj.AcceptContentTypes) == 0 {
-		obj.AcceptContentTypes = "application/json"
-	}
-	if len(obj.ContentType) == 0 {
-		obj.ContentType = "application/json"
-	}
+// SetDefaults_ClientConnectionConfiguration sets defaults for the garden client connection.
+func SetDefaults_ClientConnectionConfiguration(obj *componentbaseconfigv1alpha1.ClientConnectionConfiguration) {
 	if obj.QPS == 0.0 {
 		obj.QPS = 50.0
 	}

--- a/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
+
+	configv1alpha1 "github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
+)
+
+var _ = Describe("Defaults", func() {
+	Describe("SchedulerConfiguration", func() {
+		var obj *configv1alpha1.SchedulerConfiguration
+
+		Context("Empty configuration", func() {
+			BeforeEach(func() {
+				obj = &configv1alpha1.SchedulerConfiguration{}
+			})
+
+			It("should correctly default the admission controller configuration", func() {
+				configv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+
+				Expect(obj.LogLevel).To(Equal("info"))
+				Expect(obj.Server.HTTP.BindAddress).To(Equal("0.0.0.0"))
+				Expect(obj.Server.HTTP.Port).To(Equal(10251))
+				Expect(obj.Schedulers).To(Equal(configv1alpha1.SchedulerControllerConfiguration{
+					BackupBucket: &configv1alpha1.BackupBucketSchedulerConfiguration{
+						ConcurrentSyncs: 2,
+						RetrySyncPeriod: metav1.Duration{
+							Duration: 15 * time.Second,
+						},
+					},
+					Shoot: &configv1alpha1.ShootSchedulerConfiguration{
+						ConcurrentSyncs: 5,
+						RetrySyncPeriod: metav1.Duration{
+							Duration: 15 * time.Second,
+						},
+						Strategy: configv1alpha1.Default,
+					},
+				}))
+			})
+		})
+
+		Describe("ClientConnection", func() {
+			It("should not default ContentType and AcceptContentTypes", func() {
+				configv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+
+				// ContentType fields will be defaulted by client constructors / controller-runtime based on wether a
+				// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
+				// logic will be overwritten
+				Expect(obj.ClientConnection.ContentType).To(BeEmpty())
+				Expect(obj.ClientConnection.AcceptContentTypes).To(BeEmpty())
+			})
+			It("should correctly default ClientConnection", func() {
+				configv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
+				Expect(obj.ClientConnection).To(Equal(componentbaseconfigv1alpha1.ClientConnectionConfiguration{
+					QPS:   50.0,
+					Burst: 100,
+				}))
+			})
+		})
+	})
+})

--- a/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Defaults", func() {
 			It("should not default ContentType and AcceptContentTypes", func() {
 				configv1alpha1.SetObjectDefaults_SchedulerConfiguration(obj)
 
-				// ContentType fields will be defaulted by client constructors / controller-runtime based on wether a
+				// ContentType fields will be defaulted by client constructors / controller-runtime based on whether a
 				// given APIGroup supports protobuf or not. defaults must not touch these, otherwise the integelligent
 				// logic will be overwritten
 				Expect(obj.ClientConnection.ContentType).To(BeEmpty())

--- a/pkg/scheduler/apis/config/v1alpha1/v1alpha1_suite_test.go
+++ b/pkg/scheduler/apis/config/v1alpha1/v1alpha1_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestV1alpha1(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Scheduler API Config V1alpha1 Suite")
+}

--- a/pkg/scheduler/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/zz_generated.defaults.go
@@ -34,5 +34,6 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 
 func SetObjectDefaults_SchedulerConfiguration(in *SchedulerConfiguration) {
 	SetDefaults_SchedulerConfiguration(in)
+	SetDefaults_ClientConnectionConfiguration(&in.ClientConnection)
 	SetDefaults_LeaderElectionConfiguration(&in.LeaderElection)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area performance cost networking
/kind enhancement
/priority normal

**What this PR does / why we need it**:

This PR configures clients in all gardener components to use the protobuf content type wherever possible.
Earlier we used `application/json` everywhere (set in gardener helm charts, defaulted in component configs).

Now, the content type fields are optional in the charts as well as the component configs and are not defaulted anymore.
If left empty, gardener will configure all clients that talk to k8s / gardener APIs using protobuf, for CRDs we still use `application/json` as they don't support protobuf.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/2836
Part of https://github.com/gardener/gardener/issues/3109

**Special notes for your reviewer**:
I think, I cut down json requests to the minimum amount that is possible ATM. There are still json requests in the following cases:
- g-API posts `tokenreviews/subjectaccessreviews` to k-api via json as part of the delegating authn/authz mechanisms (not configurable in the API server library, IISIC)
- some kcm controllers (maybe gc controller?) seem to talk to g-api via json sometimes, also not configurable but not to frequent
- g-api and kcm watch the `kube-system/extension-apiserver-authentication` cm using json, also not configurable
- unstructured requests to c-r clients still use json (-> therefore also the chart applier) -> usage of these requests will decrease significantly with the ongoing refactorings

/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Gardener components now use the protobuf content type wherever possible when talking to the Gardener or Kubernetes APIs, if the content type fields are left empty in the respective component configs.
Operators can override this behavior by explicitly specifying `application/json` as the content type in the respective component configs.
```
