### PR TITLE
Add ShootVPAEnabledByDefault admission plugin

### DIFF
--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -134,6 +134,7 @@ func NewOptions(out, errOut io.Writer) *Options {
 		schema.GroupKind{Group: gardencorev1beta1.GroupName},
 	)
 	apiserver.RegisterAllAdmissionPlugins(o.Recommended.Admission.Plugins)
+	o.Recommended.Admission.DefaultOffPlugins = apiserver.DefaultOffPlugins
 	o.Recommended.Admission.RecommendedPluginOrder = apiserver.AllOrderedPlugins
 
 	return o

--- a/docs/concepts/apiserver_admission_plugins.md
+++ b/docs/concepts/apiserver_admission_plugins.md
@@ -105,7 +105,7 @@ _(disabled by default)_
 
 This admission controller reacts on `CREATE` operations for `Shoot`s.
 If enabled, it will enable the managed `VerticalPodAutoscaler` components (see [this doc](../usage/shoot_autoscaling.md#vertical-pod-auto-scaling))
-per default by setting `spec.kubernetes.verticalPodAutoscaler.enabled=true` for newly created Shoots.
+by setting `spec.kubernetes.verticalPodAutoscaler.enabled=true` for newly created Shoots.
 Already existing Shoots and new Shoots that explicitly disable VPA (`spec.kubernetes.verticalPodAutoscaler.enabled=false`)
 will not be affected by this admission plugin.
 

--- a/docs/concepts/apiserver_admission_plugins.md
+++ b/docs/concepts/apiserver_admission_plugins.md
@@ -99,6 +99,16 @@ It validates the resource consumption declared in the specification against appl
 Only if the applicable `Quota` resources admit the configured resources in the `Shoot` then it allows the request.
 Applicable `Quota`s are referred in the `SecretBinding` that is used by the `Shoot`.
 
+## `ShootVPAEnabledByDefault`
+
+_(disabled by default)_
+
+This admission controller reacts on `CREATE` operations for `Shoot`s.
+If enabled, it will enable the managed `VerticalPodAutoscaler` components (see [this doc](../usage/shoot_autoscaling.md#vertical-pod-auto-scaling))
+per default by setting `spec.kubernetes.verticalPodAutoscaler.enabled=true` for newly created Shoots.
+Already existing Shoots and new Shoots that explicitly disable VPA (`spec.kubernetes.verticalPodAutoscaler.enabled=false`)
+will not be affected by this admission plugin.
+
 ## `ShootStateDeletionValidator`
 
 _(enabled by default)_

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -45,6 +45,7 @@ apiserver_flags="
   --tls-cert-file $TLS_CERT_FILE \
   --tls-private-key-file $TLS_KEY_FILE \
   --feature-gates SeedChange=true \
+  --enable-admission-plugins=ShootVPAEnabledByDefault \
   --v 2"
 
 if [[ "$(uname -s)" == "Linux" && "$(uname -r)" =~ "microsoft-standard" ]]; then

--- a/pkg/apiserver/plugins.go
+++ b/pkg/apiserver/plugins.go
@@ -86,7 +86,7 @@ var (
 		openidconnectpreset.PluginName,             // OpenIDConnectPreset
 		clusteropenidconnectpreset.PluginName,      // ClusterOpenIDConnectPreset
 		shootstatedeletionvalidator.PluginName,     // ShootStateDeletionValidator
-		customverbauthorizer.PluginName,            // ShootVPA
+		customverbauthorizer.PluginName,            // CustomVerbAuthorizer
 		mutatingwebhook.PluginName,                 // MutatingAdmissionWebhook
 		validatingwebhook.PluginName,               // ValidatingAdmissionWebhook
 		resourcequota.PluginName,                   // ResourceQuota

--- a/pkg/apiserver/plugins.go
+++ b/pkg/apiserver/plugins.go
@@ -15,6 +15,7 @@
 package apiserver
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle"
 	mutatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/mutating"
@@ -33,38 +34,67 @@ import (
 	shootquotavalidator "github.com/gardener/gardener/plugin/pkg/shoot/quotavalidator"
 	shoottolerationrestriction "github.com/gardener/gardener/plugin/pkg/shoot/tolerationrestriction"
 	shootvalidator "github.com/gardener/gardener/plugin/pkg/shoot/validator"
+	shootvpa "github.com/gardener/gardener/plugin/pkg/shoot/vpa"
 	shootstatedeletionvalidator "github.com/gardener/gardener/plugin/pkg/shootstate/validator"
 	"github.com/gardener/gardener/third_party/forked/kubernetes/plugin/pkg/admission/resourcequota"
 )
 
-// AllOrderedPlugins is the list of all the plugins in order.
-var AllOrderedPlugins = []string{
-	lifecycle.PluginName, // NamespaceLifecycle
-	resourcereferencemanager.PluginName,
-	extensionvalidation.PluginName,
-	shoottolerationrestriction.PluginName,
-	shootdns.PluginName,
-	shootquotavalidator.PluginName,
-	shootvalidator.PluginName,
-	seedvalidator.PluginName,
-	controllerregistrationresources.PluginName,
-	plantvalidator.PluginName,
-	deletionconfirmation.PluginName,
-	openidconnectpreset.PluginName,
-	clusteropenidconnectpreset.PluginName,
-	shootstatedeletionvalidator.PluginName,
-	customverbauthorizer.PluginName,
+var (
+	// AllOrderedPlugins is the list of all the plugins in order.
+	AllOrderedPlugins = []string{
+		lifecycle.PluginName,                       // NamespaceLifecycle
+		resourcereferencemanager.PluginName,        // ResourceReferenceManager
+		extensionvalidation.PluginName,             // ExtensionValidator
+		shoottolerationrestriction.PluginName,      // ShootTolerationRestriction
+		shootdns.PluginName,                        // ShootDNS
+		shootquotavalidator.PluginName,             // ShootQuotaValidator
+		shootvalidator.PluginName,                  // ShootValidator
+		seedvalidator.PluginName,                   // SeedValidator
+		controllerregistrationresources.PluginName, // ControllerRegistrationResources
+		plantvalidator.PluginName,                  // PlantValidator
+		deletionconfirmation.PluginName,            // DeletionConfirmation
+		openidconnectpreset.PluginName,             // OpenIDConnectPreset
+		clusteropenidconnectpreset.PluginName,      // ClusterOpenIDConnectPreset
+		shootstatedeletionvalidator.PluginName,     // ShootStateDeletionValidator
+		customverbauthorizer.PluginName,            // CustomVerbAuthorizer
+		shootvpa.PluginName,                        // ShootVPAEnabledByDefault
 
-	// new admission plugins should generally be inserted above here
-	// webhook, and resourcequota plugins must go at the end
+		// new admission plugins should generally be inserted above here
+		// webhook, and resourcequota plugins must go at the end
 
-	mutatingwebhook.PluginName,   // MutatingAdmissionWebhook
-	validatingwebhook.PluginName, // ValidatingAdmissionWebhook
+		mutatingwebhook.PluginName,   // MutatingAdmissionWebhook
+		validatingwebhook.PluginName, // ValidatingAdmissionWebhook
 
-	// This plugin must remain the last one in the list since it updates the quota usage
-	// which can only happen reliably if previous plugins permitted the request.
-	resourcequota.PluginName, // ResourceQuota
-}
+		// This plugin must remain the last one in the list since it updates the quota usage
+		// which can only happen reliably if previous plugins permitted the request.
+		resourcequota.PluginName, // ResourceQuota
+	}
+
+	// DefaultOnPlugins is the set of admission plugins that are enabled by default.
+	DefaultOnPlugins = sets.NewString(
+		lifecycle.PluginName,                       // NamespaceLifecycle
+		resourcereferencemanager.PluginName,        // ResourceReferenceManager
+		extensionvalidation.PluginName,             // ExtensionValidator
+		shoottolerationrestriction.PluginName,      // ShootTolerationRestriction
+		shootdns.PluginName,                        // ShootDNS
+		shootquotavalidator.PluginName,             // ShootQuotaValidator
+		shootvalidator.PluginName,                  // ShootValidator
+		seedvalidator.PluginName,                   // SeedValidator
+		controllerregistrationresources.PluginName, // ControllerRegistrationResources
+		plantvalidator.PluginName,                  // PlantValidator
+		deletionconfirmation.PluginName,            // DeletionConfirmation
+		openidconnectpreset.PluginName,             // OpenIDConnectPreset
+		clusteropenidconnectpreset.PluginName,      // ClusterOpenIDConnectPreset
+		shootstatedeletionvalidator.PluginName,     // ShootStateDeletionValidator
+		customverbauthorizer.PluginName,            // ShootVPA
+		mutatingwebhook.PluginName,                 // MutatingAdmissionWebhook
+		validatingwebhook.PluginName,               // ValidatingAdmissionWebhook
+		resourcequota.PluginName,                   // ResourceQuota
+	)
+
+	// DefaultOffPlugins is the set of admission plugins that are disabled by default.
+	DefaultOffPlugins = sets.NewString(AllOrderedPlugins...).Difference(DefaultOnPlugins)
+)
 
 // RegisterAllAdmissionPlugins registers all admission plugins.
 func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
@@ -83,4 +113,5 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	shootstatedeletionvalidator.Register(plugins)
 	customverbauthorizer.Register(plugins)
 	resourcequota.Register(plugins)
+	shootvpa.Register(plugins)
 }

--- a/pkg/utils/test/matchers/matchers.go
+++ b/pkg/utils/test/matchers/matchers.go
@@ -94,3 +94,11 @@ func BeMissingKindError() types.GomegaMatcher {
 		message:   "Object 'Kind' is missing",
 	}
 }
+
+// BeInternalServerError checks if error is a InternalServerError.
+func BeInternalServerError() types.GomegaMatcher {
+	return &kubernetesErrors{
+		checkFunc: apierrors.IsInternalError,
+		message:   "",
+	}
+}

--- a/plugin/pkg/shoot/vpa/admission.go
+++ b/plugin/pkg/shoot/vpa/admission.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vpa
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const (
+	// PluginName is the name of this admission plugin.
+	PluginName = "ShootVPAEnabledByDefault"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return New(), nil
+	})
+}
+
+// ShootVPA contains required information to process admission requests.
+type ShootVPA struct {
+	*admission.Handler
+}
+
+// New creates a new ShootVPA admission plugin.
+func New() admission.MutationInterface {
+	return &ShootVPA{
+		Handler: admission.NewHandler(admission.Create),
+	}
+}
+
+// Admit defaults spec.kubernetes.verticalPodAutoscaler.enabled=true for new shoot clusters.
+func (c *ShootVPA) Admit(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+	switch {
+	case a.GetKind().GroupKind() != core.Kind("Shoot"),
+		a.GetOperation() != admission.Create,
+		a.GetSubresource() != "":
+		return nil
+	}
+
+	shoot, ok := a.GetObject().(*core.Shoot)
+	if !ok {
+		return apierrors.NewInternalError(errors.New("could not convert resource into Shoot object"))
+	}
+
+	if shoot.Spec.Kubernetes.VerticalPodAutoscaler == nil {
+		shoot.Spec.Kubernetes.VerticalPodAutoscaler = &core.VerticalPodAutoscaler{Enabled: true}
+	}
+
+	return nil
+}

--- a/plugin/pkg/shoot/vpa/admission_test.go
+++ b/plugin/pkg/shoot/vpa/admission_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vpa_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"github.com/gardener/gardener/plugin/pkg/shoot/vpa"
+)
+
+var _ = Describe("ShootVPAEnabledByDefault", func() {
+	var (
+		ctx      context.Context
+		plugin   admission.MutationInterface
+		attrs    admission.Attributes
+		userInfo *user.DefaultInfo
+
+		shoot, expectedShoot *core.Shoot
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		plugin = vpa.New()
+
+		userInfo = &user.DefaultInfo{Name: "foo"}
+
+		shoot = &core.Shoot{}
+		expectedShoot = shoot.DeepCopy()
+	})
+
+	Describe("#Register", func() {
+		It("should register the plugin", func() {
+			plugins := admission.NewPlugins()
+			vpa.Register(plugins)
+
+			registered := plugins.Registered()
+			Expect(registered).To(HaveLen(1))
+			Expect(registered).To(ContainElement("ShootVPAEnabledByDefault"))
+		})
+	})
+
+	Describe("#Handles", func() {
+		It("should only handle CREATE operation", func() {
+			Expect(plugin.Handles(admission.Create)).To(BeTrue())
+			Expect(plugin.Handles(admission.Update)).NotTo(BeTrue())
+			Expect(plugin.Handles(admission.Connect)).NotTo(BeTrue())
+			Expect(plugin.Handles(admission.Delete)).NotTo(BeTrue())
+		})
+	})
+
+	Describe("#Admit", func() {
+		Context("ignored requests", func() {
+			It("should ignore resources other than Shoot", func() {
+				project := &core.Project{}
+				attrs = admission.NewAttributesRecord(project, nil, core.Kind("Project").WithVersion("version"), project.Namespace, project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+				Expect(plugin.Admit(ctx, attrs, nil)).To(Succeed())
+			})
+			It("should ignore operations other than Create", func() {
+				attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+				Expect(plugin.Admit(ctx, attrs, nil)).To(Succeed())
+				Expect(shoot).To(Equal(expectedShoot))
+			})
+			It("should ignore subresources", func() {
+				attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "status", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+				Expect(plugin.Admit(ctx, attrs, nil)).To(Succeed())
+				Expect(shoot).To(Equal(expectedShoot))
+			})
+		})
+
+		It("should fail, if object is not a shoot", func() {
+			attrs = admission.NewAttributesRecord(&core.Project{}, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+			err := plugin.Admit(ctx, attrs, nil)
+			Expect(err).To(BeInternalServerError())
+			Expect(err).To(MatchError(ContainSubstring("could not convert")))
+		})
+
+		It("should not enable VPA if explicitly disabled", func() {
+			shoot.Spec.Kubernetes.VerticalPodAutoscaler = &core.VerticalPodAutoscaler{Enabled: false}
+			expectedShoot = shoot.DeepCopy()
+
+			attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+			Expect(plugin.Admit(ctx, attrs, nil)).To(Succeed())
+			Expect(shoot).To(Equal(expectedShoot))
+		})
+
+		It("should enable VPA if not explicitly disabled", func() {
+			expectedShoot.Spec.Kubernetes.VerticalPodAutoscaler = &core.VerticalPodAutoscaler{Enabled: true}
+
+			attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+			Expect(plugin.Admit(ctx, attrs, nil)).To(Succeed())
+			Expect(shoot).To(Equal(expectedShoot))
+		})
+	})
+})

--- a/plugin/pkg/shoot/vpa/vpa_suite_test.go
+++ b/plugin/pkg/shoot/vpa/vpa_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vpa_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCustomVerbAuthorizer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Admission ShootVPAEnabledByDefault Suite")
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/priority normal

**What this PR does / why we need it**:

This PR adds a new `ShootVPAEnabledByDefault` admission plugin (disabled by default) to the gardener-apiserver.
If enabled, the `.spec.kubernetes.verticalPodAutoscaler.enabled` field for newly created Shoot resources is defaulted to `true`. Existing Shoots and shoot explicitly disabling VPA are not modified.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/3304

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The new `ShootVPAEnabledByDefault` admission plugin of the `gardener-apiserver` (disabled by default) controls whether the `.spec.kubernetes.verticalPodAutoscaler.enabled` field for newly created `Shoot` resources is defaulted to `true`. Existing `Shoot`s are not modified, i.e., if VPA shall be enabled then it needs to be explicitly set. Also Shoot's can still explicitly disable the VPA by setting `.spec.kubernetes.verticalPodAutoscaler.enabled=false`. See [this document](https://github.com/gardener/gardener/blob/master/docs/concepts/apiserver_admission_plugins.md#shootvpaenabledbydefault).
```
