### PR TITLE
Use version and verflag pkgs from k8s.io/component-base

### DIFF
--- a/cmd/gardener-admission-controller/app/gardener_admission_controller.go
+++ b/cmd/gardener-admission-controller/app/gardener_admission_controller.go
@@ -32,13 +32,13 @@ import (
 	"github.com/gardener/gardener/pkg/healthz"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/server"
-	"github.com/gardener/gardener/pkg/version/verflag"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/component-base/version/verflag"
 )
 
 // options has all the context and parameters needed to run a Gardener admission controller.

--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -39,8 +39,6 @@ import (
 	settingsclientset "github.com/gardener/gardener/pkg/client/settings/clientset/versioned"
 	settingsinformer "github.com/gardener/gardener/pkg/client/settings/informers/externalversions"
 	"github.com/gardener/gardener/pkg/openapi"
-	"github.com/gardener/gardener/pkg/version"
-	"github.com/gardener/gardener/pkg/version/verflag"
 	"github.com/gardener/gardener/third_party/forked/kubernetes/pkg/quota/v1/generic"
 
 	"github.com/spf13/cobra"
@@ -62,6 +60,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/component-base/version"
+	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/cmd/gardener-controller-manager/app/gardener_controller_manager.go
+++ b/cmd/gardener-controller-manager/app/gardener_controller_manager.go
@@ -37,7 +37,6 @@ import (
 	"github.com/gardener/gardener/pkg/healthz"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/server"
-	"github.com/gardener/gardener/pkg/version/verflag"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -50,6 +49,7 @@ import (
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/version/verflag"
 )
 
 // Options has all the context and parameters needed to run a Gardener controller manager.

--- a/cmd/gardener-scheduler/app/gardener_scheduler.go
+++ b/cmd/gardener-scheduler/app/gardener_scheduler.go
@@ -35,7 +35,6 @@ import (
 	shootcontroller "github.com/gardener/gardener/pkg/scheduler/controller/shoot"
 	schedulerfeatures "github.com/gardener/gardener/pkg/scheduler/features"
 	"github.com/gardener/gardener/pkg/server"
-	"github.com/gardener/gardener/pkg/version/verflag"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -44,6 +43,7 @@ import (
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/cmd/gardener-seed-admission-controller/app/gardener_seed_admission_controller.go
+++ b/cmd/gardener-seed-admission-controller/app/gardener_seed_admission_controller.go
@@ -24,11 +24,11 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerlogger "github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/seedadmission"
-	"github.com/gardener/gardener/pkg/version/verflag"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -50,8 +50,6 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
-	"github.com/gardener/gardener/pkg/version"
-	"github.com/gardener/gardener/pkg/version/verflag"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
@@ -66,6 +64,8 @@ import (
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/version"
+	"k8s.io/component-base/version/verflag"
 )
 
 // Options has all the context and parameters needed to run a Gardenlet.

--- a/hack/get-build-ld-flags.sh
+++ b/hack/get-build-ld-flags.sh
@@ -14,10 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SOURCE_REPOSITORY="${1:-github.com/gardener/gardener}"
+PACKAGE_PATH="${1:-k8s.io/component-base}"
 VERSION_PATH="${2:-$(dirname $0)/../VERSION}"
+PROGRAM_NAME="${3:-Gardener}"
 VERSION_VERSIONFILE="$(cat "$VERSION_PATH")"
 VERSION="${EFFECTIVE_VERSION:-$VERSION_VERSIONFILE}"
+
+MAJOR_VERSION=""
+MINOR_VERSION=""
+
+if [[ "${VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?([+].*)?$ ]]; then
+  MAJOR_VERSION=${BASH_REMATCH[1]}
+  MINOR_VERSION=${BASH_REMATCH[2]}
+  if [[ -n "${BASH_REMATCH[4]}" ]]; then
+    MINOR_VERSION+="+"
+  fi
+fi
 
 # .dockerignore ignores all files unrelevant for build (e.g. docs) to only copy relevant source files to the build
 # container. Hence, git will always detect a dirty work tree when building in a container (many deleted files).
@@ -27,7 +39,10 @@ VERSION="${EFFECTIVE_VERSION:-$VERSION_VERSIONFILE}"
 # version-to-build in our pipelines (see https://github.com/gardener/cc-utils/issues/431).
 TREE_STATE="$([ -z "$(git status --porcelain 2>/dev/null | grep -vf <(git ls-files --deleted --ignored --exclude-from=.dockerignore) -e 'VERSION')" ] && echo clean || echo dirty)"
 
-echo "-X $SOURCE_REPOSITORY/pkg/version.gitVersion=$VERSION
-      -X $SOURCE_REPOSITORY/pkg/version.gitTreeState=$TREE_STATE
-      -X $SOURCE_REPOSITORY/pkg/version.gitCommit=$(git rev-parse --verify HEAD)
-      -X $SOURCE_REPOSITORY/pkg/version.buildDate=$(date '+%Y-%m-%dT%H:%M:%S%z' | sed 's/\([0-9][0-9]\)$/:\1/g')"
+echo "-X $PACKAGE_PATH/version.gitMajor=$MAJOR_VERSION
+      -X $PACKAGE_PATH/version.gitMinor=$MINOR_VERSION
+      -X $PACKAGE_PATH/version.gitVersion=$VERSION
+      -X $PACKAGE_PATH/version.gitTreeState=$TREE_STATE
+      -X $PACKAGE_PATH/version.gitCommit=$(git rev-parse --verify HEAD)
+      -X $PACKAGE_PATH/version.buildDate=$(date '+%Y-%m-%dT%H:%M:%S%z' | sed 's/\([0-9][0-9]\)$/:\1/g')
+      -X $PACKAGE_PATH/version/verflag.programName=$PROGRAM_NAME"

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -38,12 +38,12 @@ import (
 	gardenmetrics "github.com/gardener/gardener/pkg/controllerutils/metrics"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation/garden"
-	"github.com/gardener/gardener/pkg/version"
 
 	"k8s.io/apimachinery/pkg/util/runtime"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/version"
 )
 
 // GardenControllerFactory contains information relevant to controllers for the Garden API group.

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -40,7 +40,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/garden"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/version"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -48,6 +47,7 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/version"
 )
 
 // DefaultImageVector is a constant for the path to the default image vector file.

--- a/pkg/gardenlet/controller/shoot/seed_registration_control.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control.go
@@ -44,7 +44,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
-	"github.com/gardener/gardener/pkg/version"
 
 	"github.com/Masterminds/semver"
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
@@ -63,6 +62,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
 	bootstraptokenutil "k8s.io/cluster-bootstrap/token/util"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -40,7 +40,6 @@ import (
 	utilerrors "github.com/gardener/gardener/pkg/utils/errors"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
-	"github.com/gardener/gardener/pkg/version"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -48,6 +47,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/component-base/version"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/version"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -50,6 +49,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/operation/common/utils_test.go
+++ b/pkg/operation/common/utils_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
-	"github.com/gardener/gardener/pkg/version"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 
 	"github.com/golang/mock/gomock"
@@ -47,6 +46,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -50,7 +50,6 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
-	"github.com/gardener/gardener/pkg/version"
 
 	"github.com/Masterminds/semver"
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
@@ -70,6 +69,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Deprecated: use k8s.io/component-base/version instead.
 package version
 
 import (

--- a/vendor/k8s.io/component-base/version/verflag/verflag.go
+++ b/vendor/k8s.io/component-base/version/verflag/verflag.go
@@ -1,18 +1,21 @@
-// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2014 The Kubernetes Authors.
 
-// Deprecated: use k8s.io/component-base/version/verflag instead.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package verflag defines utility functions to handle command line flags
+// related to version of Kubernetes.
 package verflag
 
 import (
@@ -20,35 +23,29 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/gardener/gardener/pkg/version"
-
 	flag "github.com/spf13/pflag"
+
+	"k8s.io/component-base/version"
 )
 
 type versionValue int
 
 const (
-	// VersionFalse represents 'false' value for the version flag
 	VersionFalse versionValue = 0
-	// VersionTrue represents 'true' value for the version flag
-	VersionTrue versionValue = 1
-	// VersionRaw represents 'raw' value for the version flag
-	VersionRaw versionValue = 2
+	VersionTrue  versionValue = 1
+	VersionRaw   versionValue = 2
 )
 
 const strRawVersion string = "raw"
 
-// IsBoolFlag is defined to allow the flag to be defined without an argument
 func (v *versionValue) IsBoolFlag() bool {
 	return true
 }
 
-// Get gets the version value for the flag.Getter interface.
 func (v *versionValue) Get() interface{} {
 	return versionValue(*v)
 }
 
-// Set sets the version value for the flag.Value interface.
 func (v *versionValue) Set(s string) error {
 	if s == strRawVersion {
 		*v = VersionRaw
@@ -63,7 +60,6 @@ func (v *versionValue) Set(s string) error {
 	return err
 }
 
-// String returns a string representation of the version value.
 func (v *versionValue) String() string {
 	if *v == VersionRaw {
 		return strRawVersion
@@ -71,12 +67,11 @@ func (v *versionValue) String() string {
 	return fmt.Sprintf("%v", bool(*v == VersionTrue))
 }
 
-// Type returns the type of the flag as required by the pflag.Value interface
+// The type of the flag as required by the pflag.Value interface
 func (v *versionValue) Type() string {
 	return "version"
 }
 
-// VersionVar defines the given version flag
 func VersionVar(p *versionValue, name string, value versionValue, usage string) {
 	*p = value
 	flag.Var(p, name, usage)
@@ -84,7 +79,6 @@ func VersionVar(p *versionValue, name string, value versionValue, usage string) 
 	flag.Lookup(name).NoOptDefVal = "true"
 }
 
-// Version returns a new version flag
 func Version(name string, value versionValue, usage string) *versionValue {
 	p := new(versionValue)
 	VersionVar(p, name, value, usage)
@@ -95,7 +89,7 @@ const versionFlagName = "version"
 
 var (
 	versionFlag = Version(versionFlagName, VersionFalse, "Print version information and quit")
-	programName = "Gardener"
+	programName = "Kubernetes"
 )
 
 // AddFlags registers this package's flags on arbitrary FlagSets, such that they point to the
@@ -104,7 +98,7 @@ func AddFlags(fs *flag.FlagSet) {
 	fs.AddFlag(flag.Lookup(versionFlagName))
 }
 
-// PrintAndExitIfRequested will check if the --version flag was passed
+// PrintAndExitIfRequested will check if the -version flag was passed
 // and, if so, print the version and exit.
 func PrintAndExitIfRequested() {
 	if *versionFlag == VersionRaw {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1170,6 +1170,7 @@ k8s.io/component-base/metrics
 k8s.io/component-base/metrics/legacyregistry
 k8s.io/component-base/metrics/testutil
 k8s.io/component-base/version
+k8s.io/component-base/version/verflag
 # k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14
 ## explicit
 k8s.io/gengo/args


### PR DESCRIPTION
/kind cleanup

Currently `github.com/gardener/gardener/pkg/version` and `github.com/gardener/gardener/pkg/version/verflag` are 90% similar to `k8s.io/component-base/version` and `k8s.io/component-base/version/verflag`. Until now we were not able to use the k8s.io/component-base packages as the programName was not configurable (hard-coded to `Kubernetes`). This limitation is fixed with https://github.com/kubernetes/kubernetes/pull/90139 and we can now reuse the pkgs from `k8s.io/component-base`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
The packages `github.com/gardener/gardener/pkg/version` and `github.com/gardener/gardener/pkg/version/verflag` are now deprecated in favour of `k8s.io/component-base/version` and `k8s.io/component-base/version/verflag`.
```
