### PR TITLE
Remove kubernetes.Interface.RESTMapper in favor of client.RESTMapper

### DIFF
--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -292,7 +292,6 @@ func newClientSet(conf *Config) (Interface, error) {
 
 	cs := &clientSet{
 		config:     conf.restConfig,
-		restMapper: conf.clientOptions.Mapper,
 		restClient: kubernetes.Discovery().RESTClient(),
 
 		applier: NewApplier(runtimeClient, conf.clientOptions.Mapper),

--- a/pkg/client/kubernetes/clientset.go
+++ b/pkg/client/kubernetes/clientset.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gardener/gardener/pkg/logger"
 
 	apiextensionclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -41,7 +40,6 @@ import (
 // The version string contains only the major/minor part in the form <major>.<minor>.
 type clientSet struct {
 	config     *rest.Config
-	restMapper meta.RESTMapper
 	restClient rest.Interface
 
 	applier       Applier
@@ -101,11 +99,6 @@ func (c *clientSet) DirectClient() client.Client {
 // Cache returns the ClientSet's controller-runtime cache. It can be used to get Informers for arbitrary objects.
 func (c *clientSet) Cache() cache.Cache {
 	return c.cache
-}
-
-// RESTMapper returns the restMapper of this ClientSet.
-func (c *clientSet) RESTMapper() meta.RESTMapper {
-	return c.restMapper
 }
 
 // Kubernetes will return the kubernetes attribute of the Client object.

--- a/pkg/client/kubernetes/fake/builder.go
+++ b/pkg/client/kubernetes/fake/builder.go
@@ -159,7 +159,6 @@ func (b *ClientSetBuilder) Build() *ClientSet {
 		client:                b.client,
 		directClient:          b.directClient,
 		cache:                 b.cache,
-		restMapper:            b.restMapper,
 		kubernetes:            b.kubernetes,
 		gardenCore:            b.gardenCore,
 		apiextension:          b.apiextension,

--- a/pkg/client/kubernetes/fake/clientset.go
+++ b/pkg/client/kubernetes/fake/clientset.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/version"
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -44,7 +43,6 @@ type ClientSet struct {
 	client          client.Client
 	directClient    client.Client
 	cache           cache.Cache
-	restMapper      meta.RESTMapper
 	kubernetes      kubernetesclientset.Interface
 	gardenCore      gardencoreclientset.Interface
 	apiextension    apiextensionsclientset.Interface
@@ -92,11 +90,6 @@ func (c *ClientSet) DirectClient() client.Client {
 // Cache returns the clientset's controller-runtime cache. It can be used to get Informers for arbitrary objects.
 func (c *ClientSet) Cache() cache.Cache {
 	return c.cache
-}
-
-// RESTMapper returns the restMapper of this ClientSet.
-func (c *ClientSet) RESTMapper() meta.RESTMapper {
-	return c.restMapper
 }
 
 // Kubernetes will return the kubernetes attribute of the Client object.

--- a/pkg/client/kubernetes/fake/fake_test.go
+++ b/pkg/client/kubernetes/fake/fake_test.go
@@ -22,7 +22,6 @@ import (
 	gardencorefake "github.com/gardener/gardener/pkg/client/core/clientset/versioned/fake"
 	"github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	"github.com/gardener/gardener/pkg/client/kubernetes/test"
-	"github.com/gardener/gardener/pkg/mock/apimachinery/api/meta"
 	mockdiscovery "github.com/gardener/gardener/pkg/mock/client-go/discovery"
 	mockcache "github.com/gardener/gardener/pkg/mock/controller-runtime/cache"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
@@ -101,13 +100,6 @@ var _ = Describe("Fake ClientSet", func() {
 		cs := builder.WithCache(cache).Build()
 
 		Expect(cs.Cache()).To(BeIdenticalTo(cache))
-	})
-
-	It("should correctly set restMapper attribute", func() {
-		restMapper := meta.NewMockRESTMapper(ctrl)
-		cs := builder.WithRESTMapper(restMapper).Build()
-
-		Expect(cs.RESTMapper()).To(BeIdenticalTo(restMapper))
 	})
 
 	It("should correctly set kubernetes attribute", func() {

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -28,7 +28,6 @@ import (
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -136,7 +135,6 @@ type Applier interface {
 // of several Kubernetes versions.
 type Interface interface {
 	RESTConfig() *rest.Config
-	RESTMapper() meta.RESTMapper
 	RESTClient() rest.Interface
 
 	// Client returns the ClientSet's controller-runtime client. This client should be used by default, as it carries

--- a/pkg/mock/gardener/client/kubernetes/mocks.go
+++ b/pkg/mock/gardener/client/kubernetes/mocks.go
@@ -13,7 +13,6 @@ import (
 	kubernetes "github.com/gardener/gardener/pkg/client/kubernetes"
 	gomock "github.com/golang/mock/gomock"
 	clientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	meta "k8s.io/apimachinery/pkg/api/meta"
 	version "k8s.io/apimachinery/pkg/version"
 	kubernetes0 "k8s.io/client-go/kubernetes"
 	rest "k8s.io/client-go/rest"
@@ -255,20 +254,6 @@ func (m *MockInterface) RESTConfig() *rest.Config {
 func (mr *MockInterfaceMockRecorder) RESTConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RESTConfig", reflect.TypeOf((*MockInterface)(nil).RESTConfig))
-}
-
-// RESTMapper mocks base method.
-func (m *MockInterface) RESTMapper() meta.RESTMapper {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RESTMapper")
-	ret0, _ := ret[0].(meta.RESTMapper)
-	return ret0
-}
-
-// RESTMapper indicates an expected call of RESTMapper.
-func (mr *MockInterfaceMockRecorder) RESTMapper() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RESTMapper", reflect.TypeOf((*MockInterface)(nil).RESTMapper))
 }
 
 // Start mocks base method.

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -243,7 +243,7 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 	vpaEnabled := seed.Info.Spec.Settings == nil || seed.Info.Spec.Settings.VerticalPodAutoscaler == nil || seed.Info.Spec.Settings.VerticalPodAutoscaler.Enabled
 	if !vpaEnabled {
 		// VPA is a prerequisite. If it's not enabled via the seed spec it must be provided through some other mechanism.
-		if _, err := k8sSeedClient.RESTMapper().RESTMapping(vpaGK); err != nil {
+		if _, err := k8sSeedClient.Client().RESTMapper().RESTMapping(vpaGK); err != nil {
 			return fmt.Errorf("VPA is required for seed cluster: %s", err)
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority normal

**What this PR does / why we need it**:

This PR cleans up the duplicated `kubernetes.Interface.RESTMapper` func in favor of `client.RESTMapper`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3109

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
The `kubernetes.Interface.RESTMapper` func has been removed in favor of the `client.RESTMapper` func. Please adapt your usage accordingly.
```
