### PR TITLE
Keep VPA namespace env variable in sync

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
@@ -56,6 +56,14 @@ spec:
           value: kube-apiserver
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
+{{- else }}
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+{{- end }}
+{{- if not .Values.updater.enableServiceAccount }}
         volumeMounts:
         - name: vpa-updater
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug
/priority critical

**What this PR does / why we need it**:
Keep VPA namespace env variable in sync in all cases. If they are out of sync between the admission controller and the updater, the updater might become inactive and stop actively scaling targets that have update mode `Auto` or `Recreate`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Keep VPA namespace env variable in sync in all cases. If they are out of sync between the admission controller and the updater, the updater might become inactive and stop actively scaling targets that have update mode `Auto` or `Recreate`.
```
