### PR TITLE
Cleanup of runtime.Object and meta.Accessor

### DIFF
--- a/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -44,7 +44,6 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -496,8 +495,8 @@ var _ = Describe("Actuator", func() {
 	})
 })
 
-func clientGet(result runtime.Object) interface{} {
-	return func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+func clientGet(result client.Object) interface{} {
+	return func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 		switch obj.(type) {
 		case *corev1.Secret:
 			*obj.(*corev1.Secret) = *result.(*corev1.Secret)

--- a/extensions/pkg/controller/csimigration/predicate.go
+++ b/extensions/pkg/controller/csimigration/predicate.go
@@ -15,16 +15,17 @@
 package csimigration
 
 import (
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
 // ClusterCSIMigrationControllerNotFinished is a predicate for an annotation on the cluster.
 func ClusterCSIMigrationControllerNotFinished() predicate.Predicate {
-	f := func(obj runtime.Object) bool {
+	f := func(obj client.Object) bool {
 		if obj == nil {
 			return false
 		}

--- a/extensions/pkg/controller/healthcheck/actuator.go
+++ b/extensions/pkg/controller/healthcheck/actuator.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -53,7 +52,7 @@ type GetExtensionObjectFunc = func() extensionsv1alpha1.Object
 type GetExtensionObjectListFunc = func() client.ObjectList
 
 // PreCheckFunc checks whether the health check shall be performed based on the given object and cluster.
-type PreCheckFunc = func(runtime.Object, *extensionscontroller.Cluster) bool
+type PreCheckFunc = func(client.Object, *extensionscontroller.Cluster) bool
 
 // ConditionTypeToHealthCheck registers a HealthCheck for the given ConditionType. If the PreCheckFunc is not nil it will
 // be executed with the given object before the health check if performed. Otherwise, the health check will always be

--- a/extensions/pkg/controller/healthcheck/controller.go
+++ b/extensions/pkg/controller/healthcheck/controller.go
@@ -57,7 +57,7 @@ type AddArgs struct {
 	// The Gardenlet reads the conditions on the extension Resource.
 	// Through this mechanism, the extension can contribute to the Shoot's HealthStatus.
 	registeredExtension *RegisteredExtension
-	// GetExtensionObjListFunc returns a list of the runtime.Object representation of the extension to register
+	// GetExtensionObjListFunc returns a client.ObjectList representation of the extension to register
 	GetExtensionObjListFunc GetExtensionObjectListFunc
 }
 
@@ -85,8 +85,8 @@ type RegisteredExtension struct {
 // the NewActuator reconciles a single extension with a specific type and writes conditions for each distinct healthConditionTypes.
 // extensionType (e.g aws) defines the spec.type of the extension to watch
 // kind defines the GroupVersionKind of the extension
-// GetExtensionObjListFunc returns a list of the runtime.Object representation of the extension to register
-// getExtensionObjFunc returns a runtime.Object representation of the extension to register
+// GetExtensionObjListFunc returns a client.ObjectList representation of the extension to register
+// getExtensionObjFunc returns a extensionsv1alpha1.Object representation of the extension to register
 // mgr is the controller runtime manager
 // opts contain config for the healthcheck controller
 // custom predicates allow for fine-grained control which resources to watch

--- a/extensions/pkg/controller/utils.go
+++ b/extensions/pkg/controller/utils.go
@@ -20,7 +20,6 @@ import (
 	"reflect"
 
 	controllererror "github.com/gardener/gardener/extensions/pkg/controller/error"
-	"github.com/gardener/gardener/pkg/api/extensions"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -216,13 +215,8 @@ func RemoveAnnotation(ctx context.Context, c client.Client, obj client.Object, a
 }
 
 // IsMigrated checks if an extension object has been migrated
-func IsMigrated(obj runtime.Object) bool {
-	acc, err := extensions.Accessor(obj)
-	if err != nil {
-		return false
-	}
-
-	lastOp := acc.GetExtensionStatus().GetLastOperation()
+func IsMigrated(obj extensionsv1alpha1.Object) bool {
+	lastOp := obj.GetExtensionStatus().GetLastOperation()
 	return lastOp != nil &&
 		lastOp.Type == gardencorev1beta1.LastOperationTypeMigrate &&
 		lastOp.State == gardencorev1beta1.LastOperationStateSucceeded

--- a/extensions/pkg/controller/worker/mapper.go
+++ b/extensions/pkg/controller/worker/mapper.go
@@ -143,7 +143,7 @@ func newMachineToObjectMapper(newObjListFunc func() client.ObjectList, predicate
 	return &machineToObjectMapper{newObjListFunc: newObjListFunc, predicates: predicates}
 }
 
-func getReconcileRequestsFromObjectList(objList runtime.Object, predicates []predicate.Predicate) []reconcile.Request {
+func getReconcileRequestsFromObjectList(objList client.ObjectList, predicates []predicate.Predicate) []reconcile.Request {
 	var requests []reconcile.Request
 
 	utilruntime.HandleError(meta.EachListItem(objList, func(obj runtime.Object) error {

--- a/extensions/pkg/controller/worker/predicate.go
+++ b/extensions/pkg/controller/worker/predicate.go
@@ -16,14 +16,14 @@ package worker
 
 import (
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 // MachineStatusHasChanged is a predicate deciding whether the status of a Machine has been changed.
 func MachineStatusHasChanged() predicate.Predicate {
-	statusHasChanged := func(oldObj runtime.Object, newObj runtime.Object) bool {
+	statusHasChanged := func(oldObj client.Object, newObj client.Object) bool {
 		oldMachine, ok := oldObj.(*machinev1alpha1.Machine)
 		if !ok {
 			return false

--- a/extensions/pkg/predicate/predicate.go
+++ b/extensions/pkg/predicate/predicate.go
@@ -115,7 +115,7 @@ func HasOperationAnnotation() predicate.Predicate {
 
 // LastOperationNotSuccessful is a predicate for unsuccessful last operations **only** for creation events.
 func LastOperationNotSuccessful() predicate.Predicate {
-	operationNotSucceeded := func(obj runtime.Object) bool {
+	operationNotSucceeded := func(obj client.Object) bool {
 		acc, err := extensions.Accessor(obj)
 		if err != nil {
 			return false
@@ -191,7 +191,7 @@ func HasPurpose(purpose extensionsv1alpha1.Purpose) predicate.Predicate {
 
 // ClusterShootProviderType is a predicate for the provider type of the shoot in the cluster resource.
 func ClusterShootProviderType(decoder runtime.Decoder, providerType string) predicate.Predicate {
-	f := func(obj runtime.Object) bool {
+	f := func(obj client.Object) bool {
 		if obj == nil {
 			return false
 		}
@@ -227,7 +227,7 @@ func ClusterShootProviderType(decoder runtime.Decoder, providerType string) pred
 
 // GardenCoreProviderType is a predicate for the provider type of a `gardencore.Object` implementation.
 func GardenCoreProviderType(providerType string) predicate.Predicate {
-	f := func(obj runtime.Object) bool {
+	f := func(obj client.Object) bool {
 		if obj == nil {
 			return false
 		}
@@ -258,7 +258,7 @@ func GardenCoreProviderType(providerType string) predicate.Predicate {
 
 // ClusterShootKubernetesVersionAtLeast is a predicate for the kubernetes version of the shoot in the cluster resource.
 func ClusterShootKubernetesVersionAtLeast(decoder runtime.Decoder, kubernetesVersion string) predicate.Predicate {
-	f := func(obj runtime.Object) bool {
+	f := func(obj client.Object) bool {
 		if obj == nil {
 			return false
 		}

--- a/extensions/pkg/webhook/cloudprovider/mutator.go
+++ b/extensions/pkg/webhook/cloudprovider/mutator.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
@@ -68,12 +67,7 @@ func (m *mutator) InjectScheme(scheme *runtime.Scheme) error {
 
 // Mutate validates and if needed mutates the given object.
 func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
-	acc, err := meta.Accessor(new)
-	if err != nil {
-		return fmt.Errorf("could not create accessor during webhook: %v", err)
-	}
-
-	if acc.GetDeletionTimestamp() != nil {
+	if new.GetDeletionTimestamp() != nil {
 		return nil
 	}
 

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -425,8 +425,8 @@ func checkOperatingSystemConfig(osc *extensionsv1alpha1.OperatingSystemConfig) {
 	Expect(cloudProvider.Content.Inline).To(Equal(&extensionsv1alpha1.FileContentInline{Data: cloudproviderconfEncoded, Encoding: encoding}))
 }
 
-func clientGet(result runtime.Object) interface{} {
-	return func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+func clientGet(result client.Object) interface{} {
+	return func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 		switch obj.(type) {
 		case *extensionsv1alpha1.Cluster:
 			*obj.(*extensionsv1alpha1.Cluster) = *result.(*extensionsv1alpha1.Cluster)

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -15,12 +15,12 @@
 package v1alpha1
 
 import (
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
 
 // Status is the status of an Object.
@@ -63,8 +63,7 @@ type Spec interface {
 
 // Object is an extension object resource.
 type Object interface {
-	metav1.Object
-	runtime.Object
+	client.Object
 
 	// GetExtensionSpec retrieves the object's spec.
 	GetExtensionSpec() Spec

--- a/pkg/client/kubernetes/applier_test.go
+++ b/pkg/client/kubernetes/applier_test.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -42,7 +41,7 @@ var (
 	configMapTypeMeta = metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"}
 )
 
-func mkManifest(objs ...runtime.Object) []byte {
+func mkManifest(objs ...client.Object) []byte {
 	var out bytes.Buffer
 	for _, obj := range objs {
 		data, err := yaml.Marshal(obj)

--- a/pkg/client/kubernetes/clientmap/internal/plant_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/internal/plant_clientmap_test.go
@@ -34,7 +34,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -115,7 +114,7 @@ var _ = Describe("PlantClientMap", func() {
 		It("should fail if Plant object does not have a secretRef", func() {
 			plant.Spec.SecretRef = corev1.LocalObjectReference{}
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: plant.Namespace, Name: plant.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Plant{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					plant.DeepCopyInto(obj.(*gardencorev1beta1.Plant))
 					return nil
 				})
@@ -128,7 +127,7 @@ var _ = Describe("PlantClientMap", func() {
 		It("should fail if NewClientFromSecret fails", func() {
 			fakeErr := fmt.Errorf("fake")
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: plant.Namespace, Name: plant.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Plant{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					plant.DeepCopyInto(obj.(*gardencorev1beta1.Plant))
 					return nil
 				})
@@ -144,12 +143,12 @@ var _ = Describe("PlantClientMap", func() {
 		It("should correctly construct a new ClientSet", func() {
 			fakeCS := fakeclientset.NewClientSet()
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: plant.Namespace, Name: plant.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Plant{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					plant.DeepCopyInto(obj.(*gardencorev1beta1.Plant))
 					return nil
 				}).Times(2)
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: plant.Namespace, Name: plant.Spec.SecretRef.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					return nil
 				})
 			internal.NewClientFromSecret = func(ctx context.Context, c client.Client, namespace, secretName string, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
@@ -192,12 +191,12 @@ var _ = Describe("PlantClientMap", func() {
 		It("should fail if Get Plant Secret fails", func() {
 			fakeErr := fmt.Errorf("fake")
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: plant.Namespace, Name: plant.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Plant{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					plant.DeepCopyInto(obj.(*gardencorev1beta1.Plant))
 					return nil
 				})
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: plant.Namespace, Name: plant.Spec.SecretRef.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					return fakeErr
 				})
 
@@ -208,12 +207,12 @@ var _ = Describe("PlantClientMap", func() {
 
 		It("should correctly calculate hash", func() {
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: plant.Namespace, Name: plant.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Plant{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					plant.DeepCopyInto(obj.(*gardencorev1beta1.Plant))
 					return nil
 				})
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: plant.Namespace, Name: plant.Spec.SecretRef.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					(&corev1.Secret{}).DeepCopyInto(obj.(*corev1.Secret))
 					return nil
 				})

--- a/pkg/client/kubernetes/clientmap/internal/seed_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/internal/seed_clientmap_test.go
@@ -34,7 +34,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	baseconfig "k8s.io/component-base/config"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -155,7 +154,7 @@ var _ = Describe("SeedClientMap", func() {
 		It("should fail if Seed object does not have a secretRef", func() {
 			seed.Spec.SecretRef = nil
 			c.EXPECT().Get(ctx, client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					seed.DeepCopyInto(obj.(*gardencorev1beta1.Seed))
 					return nil
 				})
@@ -168,7 +167,7 @@ var _ = Describe("SeedClientMap", func() {
 		It("should fail if NewClientFromSecret fails", func() {
 			fakeErr := fmt.Errorf("fake")
 			c.EXPECT().Get(ctx, client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					seed.DeepCopyInto(obj.(*gardencorev1beta1.Seed))
 					return nil
 				})
@@ -184,12 +183,12 @@ var _ = Describe("SeedClientMap", func() {
 		It("should correctly construct a new ClientSet", func() {
 			fakeCS := fakeclientset.NewClientSet()
 			c.EXPECT().Get(ctx, client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					seed.DeepCopyInto(obj.(*gardencorev1beta1.Seed))
 					return nil
 				}).Times(2)
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: seed.Spec.SecretRef.Namespace, Name: seed.Spec.SecretRef.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					return nil
 				})
 			internal.NewClientFromSecret = func(ctx context.Context, c client.Client, namespace, secretName string, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
@@ -231,12 +230,12 @@ var _ = Describe("SeedClientMap", func() {
 		It("should fail if Get Seed Secret fails", func() {
 			fakeErr := fmt.Errorf("fake")
 			c.EXPECT().Get(ctx, client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					seed.DeepCopyInto(obj.(*gardencorev1beta1.Seed))
 					return nil
 				})
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: seed.Spec.SecretRef.Namespace, Name: seed.Spec.SecretRef.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					return fakeErr
 				})
 
@@ -247,12 +246,12 @@ var _ = Describe("SeedClientMap", func() {
 
 		It("should correctly calculate hash", func() {
 			c.EXPECT().Get(ctx, client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					seed.DeepCopyInto(obj.(*gardencorev1beta1.Seed))
 					return nil
 				})
 			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: seed.Spec.SecretRef.Namespace, Name: seed.Spec.SecretRef.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					(&corev1.Secret{}).DeepCopyInto(obj.(*corev1.Secret))
 					return nil
 				})

--- a/pkg/client/kubernetes/clientmap/internal/shoot_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/internal/shoot_clientmap_test.go
@@ -34,7 +34,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	baseconfig "k8s.io/component-base/config"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -152,7 +151,7 @@ var _ = Describe("ShootClientMap", func() {
 		It("should fail if Shoot is not scheduled yet", func() {
 			shoot.Spec.SeedName = nil
 			mockGardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					shoot.DeepCopyInto(obj.(*gardencorev1beta1.Shoot))
 					return nil
 				})
@@ -165,7 +164,7 @@ var _ = Describe("ShootClientMap", func() {
 		It("should fail if GetSeedClient fails", func() {
 			fakeErr := fmt.Errorf("fake")
 			mockGardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					shoot.DeepCopyInto(obj.(*gardencorev1beta1.Shoot))
 					return nil
 				})
@@ -183,7 +182,7 @@ var _ = Describe("ShootClientMap", func() {
 
 			fakeErr := fmt.Errorf("fake")
 			mockGardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					shoot.DeepCopyInto(obj.(*gardencorev1beta1.Shoot))
 					return nil
 				})
@@ -202,7 +201,7 @@ var _ = Describe("ShootClientMap", func() {
 
 			fakeErr := fmt.Errorf("fake")
 			mockGardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					shoot.DeepCopyInto(obj.(*gardencorev1beta1.Shoot))
 					return nil
 				})
@@ -225,7 +224,7 @@ var _ = Describe("ShootClientMap", func() {
 		It("should fall-back to external kubeconfig if internal kubeconfig is not found", func() {
 			fakeErr := fmt.Errorf("fake")
 			mockGardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					shoot.DeepCopyInto(obj.(*gardencorev1beta1.Shoot))
 					return nil
 				})
@@ -263,22 +262,22 @@ var _ = Describe("ShootClientMap", func() {
 			changedTechnicalID := "foo"
 			gomock.InOrder(
 				mockGardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).
-					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 						shoot.DeepCopyInto(obj.(*gardencorev1beta1.Shoot))
 						return nil
 					}),
 				mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Status.TechnicalID, Name: "gardener"}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 						return nil
 					}),
 				mockGardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).
-					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 						shoot.Status.TechnicalID = changedTechnicalID
 						shoot.DeepCopyInto(obj.(*gardencorev1beta1.Shoot))
 						return nil
 					}),
 				mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: changedTechnicalID, Name: "gardener"}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 						return nil
 					}),
 			)
@@ -329,12 +328,12 @@ var _ = Describe("ShootClientMap", func() {
 		It("should fail if Get gardener Secret fails", func() {
 			fakeErr := fmt.Errorf("fake")
 			mockGardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					shoot.DeepCopyInto(obj.(*gardencorev1beta1.Shoot))
 					return nil
 				})
 			mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Status.TechnicalID, Name: "gardener"}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					return fakeErr
 				})
 
@@ -347,23 +346,23 @@ var _ = Describe("ShootClientMap", func() {
 			changedTechnicalID := "foo"
 			gomock.InOrder(
 				mockGardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).
-					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 						shoot.DeepCopyInto(obj.(*gardencorev1beta1.Shoot))
 						return nil
 					}),
 				mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Status.TechnicalID, Name: "gardener"}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 						(&corev1.Secret{}).DeepCopyInto(obj.(*corev1.Secret))
 						return nil
 					}),
 				mockGardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).
-					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 						shoot.Status.TechnicalID = changedTechnicalID
 						shoot.DeepCopyInto(obj.(*gardencorev1beta1.Shoot))
 						return nil
 					}),
 				mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: changedTechnicalID, Name: "gardener"}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 						(&corev1.Secret{}).DeepCopyInto(obj.(*corev1.Secret))
 						return nil
 					}),

--- a/pkg/controllermanager/controller/event/event_control_test.go
+++ b/pkg/controllermanager/controller/event/event_control_test.go
@@ -29,7 +29,6 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -199,7 +198,7 @@ func mockClientGet(k8sGardenRuntimeClient *mockclient.MockClient, key client.Obj
 	k8sGardenRuntimeClient.
 		EXPECT().
 		Get(context.TODO(), key, &corev1.Event{}).
-		DoAndReturn(func(_ context.Context, _ client.ObjectKey, o runtime.Object) error {
+		DoAndReturn(func(_ context.Context, _ client.ObjectKey, o client.Object) error {
 			event, ok := o.(*corev1.Event)
 			Expect(ok).To(BeTrue())
 			result.DeepCopyInto(event)

--- a/pkg/controllermanager/controller/plant/plant_test.go
+++ b/pkg/controllermanager/controller/plant/plant_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/rest"
 	fakerestclient "k8s.io/client-go/rest/fake"
@@ -94,7 +93,7 @@ var _ = Describe("Plant", func() {
 				testLogger          = logger.NewFieldLogger(logger.NewLogger("info"), "test", "test-plant")
 			)
 
-			runtimeClient.EXPECT().List(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+			runtimeClient.EXPECT().List(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 				Expect(list).To(BeAssignableToTypeOf(&corev1.NodeList{}))
 				list.(*corev1.NodeList).Items = []corev1.Node{mockNode}
 				return nil
@@ -161,7 +160,7 @@ var _ = Describe("Plant", func() {
 				)
 
 				healthChecker = plant.NewHealthChecker(runtimeClient, discoveryMockclient)
-				runtimeClient.EXPECT().List(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+				runtimeClient.EXPECT().List(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 					Expect(list).To(BeAssignableToTypeOf(&corev1.NodeList{}))
 					list.(*corev1.NodeList).Items = []corev1.Node{*node}
 					return nil
@@ -186,7 +185,7 @@ var _ = Describe("Plant", func() {
 				)
 
 				healthChecker = plant.NewHealthChecker(runtimeClient, discoveryMockclient)
-				runtimeClient.EXPECT().List(context.TODO(), gomock.Any()).DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+				runtimeClient.EXPECT().List(context.TODO(), gomock.Any()).DoAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 					return fmt.Errorf("Some Error")
 				})
 

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
@@ -29,7 +29,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
@@ -141,7 +140,7 @@ var _ = Describe("Certificates", func() {
 
 			// mock update of secret in seed with the rotated kubeconfig
 			mockSeedClient.EXPECT().Get(ctx, kutil.Key(gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name), gomock.AssignableToTypeOf(&corev1.Secret{}))
-			mockSeedClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
+			mockSeedClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 				secret, ok := obj.(*corev1.Secret)
 				Expect(ok).To(BeTrue())
 				Expect(secret.Name).To(Equal(gardenClientConnection.KubeconfigSecret.Name))

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
@@ -32,7 +32,6 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	kretry "k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -228,7 +227,7 @@ func (a *actuator) waitUntilBackupBucketExtensionReconciled(ctx context.Context)
 		defaultInterval,
 		defaultSevereThreshold,
 		defaultTimeout,
-		func(obj runtime.Object) error {
+		func(obj client.Object) error {
 			backupBucket, ok := obj.(*extensionsv1alpha1.BackupBucket)
 			if !ok {
 				return fmt.Errorf("expected extensionsv1alpha1.BackupBucket but got %T", backupBucket)

--- a/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
@@ -34,7 +34,6 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	kretry "k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -199,7 +198,7 @@ func (a *actuator) waitUntilBackupBucketReconciled(ctx context.Context) error {
 		defaultInterval,
 		defaultSevereThreshold,
 		defaultTimeout,
-		func(obj runtime.Object) error {
+		func(obj client.Object) error {
 			bb, ok := obj.(*gardencorev1beta1.BackupBucket)
 			if !ok {
 				return fmt.Errorf("expected gardencorev1beta1.BackupBucket but got %T", obj)

--- a/pkg/gardenlet/controller/federatedseed/networkpolicy/helper/helper_test.go
+++ b/pkg/gardenlet/controller/federatedseed/networkpolicy/helper/helper_test.go
@@ -31,7 +31,6 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -210,7 +209,7 @@ var _ = Describe("helper", func() {
 
 		It("should create the allow-to-seed-apiserver Network Policy", func() {
 			mockRuntimeClient.EXPECT().Get(ctx, kutil.Key(namespace, AllowToSeedAPIServer), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Return(errors.NewNotFound(core.Resource("networkpolicy"), ""))
-			mockRuntimeClient.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).DoAndReturn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
+			mockRuntimeClient.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).DoAndReturn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 				policy, ok := obj.(*networkingv1.NetworkPolicy)
 				Expect(ok).To(BeTrue())
 				Expect(policy.Annotations).To(HaveKeyWithValue("gardener.cloud/description", "Allows Egress from pods labeled with 'networking.gardener.cloud/to-seed-apiserver=allowed' to Seed's Kubernetes API Server endpoints in the default namespace."))
@@ -231,7 +230,7 @@ var _ = Describe("helper", func() {
 
 		It("should update the allow-to-seed-apiserver Network Policy", func() {
 			mockRuntimeClient.EXPECT().Get(ctx, kutil.Key(namespace, AllowToSeedAPIServer), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Return(nil)
-			mockRuntimeClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).DoAndReturn(func(_ context.Context, obj runtime.Object, _ ...client.UpdateOption) error {
+			mockRuntimeClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).DoAndReturn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 				policy, ok := obj.(*networkingv1.NetworkPolicy)
 				Expect(ok).To(BeTrue())
 				Expect(policy.Annotations).To(HaveKeyWithValue("gardener.cloud/description", "Allows Egress from pods labeled with 'networking.gardener.cloud/to-seed-apiserver=allowed' to Seed's Kubernetes API Server endpoints in the default namespace."))

--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -37,7 +37,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/kube-aggregator/pkg/controllers/autoregister"
@@ -156,7 +155,7 @@ var (
 	NamespaceErrorToleration = utilclient.TolerateErrors{apierrors.IsConflict}
 )
 
-func cleanResourceFn(cleanOps utilclient.CleanOps, c client.Client, list runtime.Object, opts ...utilclient.CleanOption) flow.TaskFn {
+func cleanResourceFn(cleanOps utilclient.CleanOps, c client.Client, list client.ObjectList, opts ...utilclient.CleanOption) flow.TaskFn {
 	return func(ctx context.Context) error {
 		return retry.Until(ctx, DefaultInterval, func(ctx context.Context) (done bool, err error) {
 			if err := cleanOps.CleanAndEnsureGone(ctx, c, list, opts...); err != nil {

--- a/pkg/operation/botanist/controlplane/clusterautoscaler/bootstrap_test.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/bootstrap_test.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -133,11 +132,11 @@ rules:
 		It("should successfully deploy all the resources", func() {
 			gomock.InOrder(
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
-				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 					Expect(obj).To(DeepEqual(managedResourceSecret))
 				}),
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 					Expect(obj).To(DeepEqual(managedResource))
 				}),
 			)
@@ -163,7 +162,7 @@ rules:
 			TimeoutWaitForManagedResource = time.Millisecond
 
 			c.EXPECT().Get(gomock.Any(), kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(
-				func(ctx context.Context, _ client.ObjectKey, obj runtime.Object) error {
+				func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
 					(&resourcesv1alpha1.ManagedResource{
 						ObjectMeta: metav1.ObjectMeta{
 							Generation: 1,
@@ -191,7 +190,7 @@ rules:
 
 		It("should successfully wait for all resources to be ready", func() {
 			c.EXPECT().Get(gomock.Any(), kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(
-				func(ctx context.Context, _ client.ObjectKey, obj runtime.Object) error {
+				func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
 					(&resourcesv1alpha1.ManagedResource{
 						ObjectMeta: metav1.ObjectMeta{
 							Generation: 1,

--- a/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/operation/botanist/controlplane/clusterautoscaler/cluster_autoscaler_test.go
@@ -29,7 +29,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/utils/pointer"
@@ -613,27 +612,27 @@ subjects:
 					gomock.InOrder(
 						c.EXPECT().Create(ctx, serviceAccount),
 						c.EXPECT().Get(ctx, kutil.Key(clusterRoleBindingName), gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&rbacv1.ClusterRoleBinding{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(clusterRoleBinding))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, serviceName), gomock.AssignableToTypeOf(&corev1.Service{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Service{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Service{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(service))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, deploymentName), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(deploymentFor(withConfig)))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, vpaName), gomock.AssignableToTypeOf(&autoscalingv1beta2.VerticalPodAutoscaler{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&autoscalingv1beta2.VerticalPodAutoscaler{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&autoscalingv1beta2.VerticalPodAutoscaler{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(vpa))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(managedResourceSecret))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(managedResource))
 						}),
 					)

--- a/pkg/operation/botanist/controlplane/etcd/bootstrap.go
+++ b/pkg/operation/botanist/controlplane/etcd/bootstrap.go
@@ -38,7 +38,6 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/utils/pointer"
@@ -250,7 +249,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 			},
 		}
 
-		resourcesToAdd = []runtime.Object{
+		resourcesToAdd = []client.Object{
 			serviceAccount,
 			clusterRole,
 			clusterRoleBinding,

--- a/pkg/operation/botanist/controlplane/etcd/bootstrap_test.go
+++ b/pkg/operation/botanist/controlplane/etcd/bootstrap_test.go
@@ -36,7 +36,6 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -376,11 +375,11 @@ status: {}
 			It("should successfully deploy all the resources (w/o image vector overwrite)", func() {
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResourceSecret))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
 				)
@@ -396,11 +395,11 @@ status: {}
 
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResourceSecret))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
 				)
@@ -420,11 +419,11 @@ status: {}
 
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResourceSecret))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
 				)
@@ -440,11 +439,11 @@ status: {}
 
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResourceSecret))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
 				)
@@ -464,11 +463,11 @@ status: {}
 
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResourceSecret))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
 				)
@@ -484,11 +483,11 @@ status: {}
 
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResourceSecret))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
 				)
@@ -515,7 +514,7 @@ status: {}
 			TimeoutWaitForManagedResource = time.Millisecond
 
 			c.EXPECT().Get(gomock.Any(), kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(
-				func(ctx context.Context, _ client.ObjectKey, obj runtime.Object) error {
+				func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
 					(&resourcesv1alpha1.ManagedResource{
 						ObjectMeta: metav1.ObjectMeta{
 							Generation: 1,
@@ -547,7 +546,7 @@ status: {}
 			TimeoutWaitForManagedResource = time.Millisecond
 
 			c.EXPECT().Get(gomock.Any(), kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(
-				func(ctx context.Context, _ client.ObjectKey, obj runtime.Object) error {
+				func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
 					(&resourcesv1alpha1.ManagedResource{
 						ObjectMeta: metav1.ObjectMeta{
 							Generation: 1,
@@ -606,10 +605,10 @@ status: {}
 
 			It("should fail when there are etcd resources left", func() {
 				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{})).DoAndReturn(
-					func(ctx context.Context, obj runtime.Object, _ ...client.ListOptions) error {
+					func(ctx context.Context, list client.ObjectList, _ ...client.ListOptions) error {
 						(&druidv1alpha1.EtcdList{
 							Items: []druidv1alpha1.Etcd{{}},
-						}).DeepCopyInto(obj.(*druidv1alpha1.EtcdList))
+						}).DeepCopyInto(list.(*druidv1alpha1.EtcdList))
 						return nil
 					},
 				)

--- a/pkg/operation/botanist/controlplane/etcd/etcd.go
+++ b/pkg/operation/botanist/controlplane/etcd/etcd.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
@@ -525,7 +524,7 @@ func (e *etcd) getExistingStatefulSet(ctx context.Context, name string) (*appsv1
 	return nil, found, err
 }
 
-func (e *etcd) getExistingResource(ctx context.Context, name string, obj client.Object) (runtime.Object, bool, error) {
+func (e *etcd) getExistingResource(ctx context.Context, name string, obj client.Object) (client.Object, bool, error) {
 	if err := e.client.Get(ctx, kutil.Key(e.namespace, name), obj); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return nil, false, err

--- a/pkg/operation/botanist/controlplane/etcd/etcd_test.go
+++ b/pkg/operation/botanist/controlplane/etcd/etcd_test.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
@@ -515,7 +514,7 @@ var _ = Describe("Etcd", func() {
 				statefulSetName := "sts-name"
 
 				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
-					func(ctx context.Context, _ client.ObjectKey, obj runtime.Object) error {
+					func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
 						(&druidv1alpha1.Etcd{
 							Status: druidv1alpha1.EtcdStatus{
 								Etcd: druidv1alpha1.CrossVersionObjectReference{
@@ -600,11 +599,11 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(networkPolicy))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
 							1,
@@ -616,7 +615,7 @@ var _ = Describe("Etcd", func() {
 						)))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(hvpaFor(class, 1)))
 					}),
 				)
@@ -638,7 +637,7 @@ var _ = Describe("Etcd", func() {
 				setSecretsAndHVPAConfig()
 
 				gomock.InOrder(
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj runtime.Object) error {
+					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
 						(&druidv1alpha1.Etcd{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      etcdName,
@@ -658,11 +657,11 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(networkPolicy))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
 							int(existingReplicas),
@@ -674,7 +673,7 @@ var _ = Describe("Etcd", func() {
 						)))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(hvpaFor(class, existingReplicas)))
 					}),
 				)
@@ -690,7 +689,7 @@ var _ = Describe("Etcd", func() {
 				existingDefragmentationSchedule := "foobardefragexisting"
 
 				gomock.InOrder(
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj runtime.Object) error {
+					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
 						(&druidv1alpha1.Etcd{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      etcdName,
@@ -712,11 +711,11 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(networkPolicy))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
 							1,
@@ -728,7 +727,7 @@ var _ = Describe("Etcd", func() {
 						)))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(hvpaFor(class, 1)))
 					}),
 				)
@@ -766,7 +765,7 @@ var _ = Describe("Etcd", func() {
 
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj runtime.Object) error {
+					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
 						(&appsv1.StatefulSet{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      etcdName,
@@ -793,11 +792,11 @@ var _ = Describe("Etcd", func() {
 					}),
 
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(networkPolicy))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
 							1,
@@ -809,7 +808,7 @@ var _ = Describe("Etcd", func() {
 						)))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(hvpaFor(class, 1)))
 					}),
 				)
@@ -831,11 +830,11 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(networkPolicy))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
 							1,
@@ -847,7 +846,7 @@ var _ = Describe("Etcd", func() {
 						)))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(hvpaFor(class, 1)))
 					}),
 				)
@@ -878,11 +877,11 @@ var _ = Describe("Etcd", func() {
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(networkPolicy))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(etcdObjFor(
 								class,
 								1,
@@ -894,7 +893,7 @@ var _ = Describe("Etcd", func() {
 							)))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(hvpaFor(class, 1)))
 						}),
 					)
@@ -910,7 +909,7 @@ var _ = Describe("Etcd", func() {
 					existingBackupSchedule := "foobarbackupexisting"
 
 					gomock.InOrder(
-						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj runtime.Object) error {
+						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
 							(&druidv1alpha1.Etcd{
 								ObjectMeta: metav1.ObjectMeta{
 									Name:      etcdName,
@@ -932,11 +931,11 @@ var _ = Describe("Etcd", func() {
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(networkPolicy))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(etcdObjFor(
 								class,
 								1,
@@ -948,7 +947,7 @@ var _ = Describe("Etcd", func() {
 							)))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(hvpaFor(class, 1)))
 						}),
 					)
@@ -1047,8 +1046,8 @@ var _ = Describe("Etcd", func() {
 					client.InNamespace(testNamespace),
 					client.MatchingLabelsSelector{Selector: selector},
 				).DoAndReturn(
-					func(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
-						podList.DeepCopyInto(obj.(*corev1.PodList))
+					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+						podList.DeepCopyInto(list.(*corev1.PodList))
 						return nil
 					},
 				)
@@ -1084,8 +1083,8 @@ var _ = Describe("Etcd", func() {
 					client.InNamespace(testNamespace),
 					client.MatchingLabelsSelector{Selector: selector},
 				).DoAndReturn(
-					func(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
-						podList.DeepCopyInto(obj.(*corev1.PodList))
+					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+						podList.DeepCopyInto(list.(*corev1.PodList))
 						return nil
 					},
 				)
@@ -1107,8 +1106,8 @@ var _ = Describe("Etcd", func() {
 					client.InNamespace(testNamespace),
 					client.MatchingLabelsSelector{Selector: selector},
 				).DoAndReturn(
-					func(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
-						podList.DeepCopyInto(obj.(*corev1.PodList))
+					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+						podList.DeepCopyInto(list.(*corev1.PodList))
 						return nil
 					},
 				)
@@ -1133,7 +1132,7 @@ var _ = Describe("Etcd", func() {
 					client.InNamespace(testNamespace),
 					client.MatchingLabelsSelector{Selector: selector},
 				).DoAndReturn(
-					func(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
+					func(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
 						podList.DeepCopyInto(obj.(*corev1.PodList))
 						return nil
 					},

--- a/pkg/operation/botanist/controlplane/etcd/waiter_test.go
+++ b/pkg/operation/botanist/controlplane/etcd/waiter_test.go
@@ -28,7 +28,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -66,8 +65,8 @@ var _ = Describe("Waiter", func() {
 		It("should return an error when not all required etcds are created", func() {
 			etcdList := &druidv1alpha1.EtcdList{}
 
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
-				etcdList.DeepCopyInto(obj.(*druidv1alpha1.EtcdList))
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).DoAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				etcdList.DeepCopyInto(list.(*druidv1alpha1.EtcdList))
 				return nil
 			}).AnyTimes()
 
@@ -92,8 +91,8 @@ var _ = Describe("Waiter", func() {
 				},
 			}
 
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
-				etcdList.DeepCopyInto(obj.(*druidv1alpha1.EtcdList))
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).DoAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				etcdList.DeepCopyInto(list.(*druidv1alpha1.EtcdList))
 				return nil
 			}).AnyTimes()
 
@@ -114,8 +113,8 @@ var _ = Describe("Waiter", func() {
 				}
 			)
 
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
-				etcdList.DeepCopyInto(obj.(*druidv1alpha1.EtcdList))
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).DoAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				etcdList.DeepCopyInto(list.(*druidv1alpha1.EtcdList))
 				return nil
 			}).AnyTimes()
 
@@ -150,8 +149,8 @@ var _ = Describe("Waiter", func() {
 				},
 			}
 
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.ListOption) error {
-				etcdList.DeepCopyInto(obj.(*druidv1alpha1.EtcdList))
+			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).DoAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+				etcdList.DeepCopyInto(list.(*druidv1alpha1.EtcdList))
 				return nil
 			}).AnyTimes()
 

--- a/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/controlplane/kubecontrollermanager/kube_controller_manager_test.go
@@ -43,7 +43,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/utils/pointer"
@@ -586,15 +585,15 @@ subjects:
 
 					gomock.InOrder(
 						c.EXPECT().Get(ctx, kutil.Key(namespace, ServiceName), gomock.AssignableToTypeOf(&corev1.Service{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Service{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Service{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(serviceFor(version)))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, v1beta1constants.DeploymentNameKubeControllerManager), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(deploymentFor(version, config)))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, vpaName), gomock.AssignableToTypeOf(&autoscalingv1beta2.VerticalPodAutoscaler{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&autoscalingv1beta2.VerticalPodAutoscaler{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&autoscalingv1beta2.VerticalPodAutoscaler{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(vpa))
 						}),
 					)
@@ -605,11 +604,11 @@ subjects:
 					if is112Version || is113Version {
 						gomock.InOrder(
 							c.EXPECT().Get(ctx, kutil.Key(namespace, common.ManagedResourceSecretName(managedResourceName)), gomock.AssignableToTypeOf(&corev1.Secret{})),
-							c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+							c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 								Expect(obj).To(DeepEqual(managedResourceSecret))
 							}),
 							c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-							c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+							c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 								Expect(obj).To(DeepEqual(managedResource))
 							}),
 						)

--- a/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler_test.go
+++ b/pkg/operation/botanist/controlplane/kubescheduler/kube_scheduler_test.go
@@ -30,7 +30,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/utils/pointer"
@@ -479,19 +478,19 @@ subjects:
 
 					gomock.InOrder(
 						c.EXPECT().Get(ctx, kutil.Key(namespace, configMapName), gomock.AssignableToTypeOf(&corev1.ConfigMap{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.ConfigMap{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(configMapFor(version)))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, serviceName), gomock.AssignableToTypeOf(&corev1.Service{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Service{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Service{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(serviceFor(version)))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, deploymentName), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(deploymentFor(version, config)))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, vpaName), gomock.AssignableToTypeOf(&autoscalingv1beta2.VerticalPodAutoscaler{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&autoscalingv1beta2.VerticalPodAutoscaler{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&autoscalingv1beta2.VerticalPodAutoscaler{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 							Expect(obj).To(DeepEqual(vpa))
 						}),
 					)
@@ -499,11 +498,11 @@ subjects:
 					if k8sVersionEqual113, _ := versionutils.CompareVersions(version, "~", "1.13"); k8sVersionEqual113 {
 						gomock.InOrder(
 							c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
-							c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+							c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 								Expect(obj).To(DeepEqual(managedResourceSecret))
 							}),
 							c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-							c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+							c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 								Expect(obj).To(DeepEqual(managedResource))
 							}),
 						)

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -42,7 +42,6 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -345,7 +344,7 @@ var _ = Describe("Etcd", func() {
 
 			It("should set the secrets and deploy", func() {
 				kubernetesClient.EXPECT().Client().Return(c)
-				c.EXPECT().Get(ctx, kutil.Key(namespace, "etcd-backup"), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				c.EXPECT().Get(ctx, kutil.Key(namespace, "etcd-backup"), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					backupSecret.DeepCopyInto(obj.(*corev1.Secret))
 					return nil
 				})
@@ -371,7 +370,7 @@ var _ = Describe("Etcd", func() {
 
 			It("should fail when the backup schedule cannot be determined", func() {
 				kubernetesClient.EXPECT().Client().Return(c)
-				c.EXPECT().Get(ctx, kutil.Key(namespace, "etcd-backup"), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				c.EXPECT().Get(ctx, kutil.Key(namespace, "etcd-backup"), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					backupSecret.DeepCopyInto(obj.(*corev1.Secret))
 					return nil
 				})

--- a/pkg/operation/botanist/extensions/controlplane/controlplane.go
+++ b/pkg/operation/botanist/extensions/controlplane/controlplane.go
@@ -195,7 +195,7 @@ func (c *controlPlane) Wait(ctx context.Context) error {
 		c.waitInterval,
 		c.waitSevereThreshold,
 		c.waitTimeout,
-		func(obj runtime.Object) error {
+		func(obj client.Object) error {
 			controlPlane, ok := obj.(*extensionsv1alpha1.ControlPlane)
 			if !ok {
 				return fmt.Errorf("expected extensionsv1alpha1.ControlPlane but got %T", controlPlane)

--- a/pkg/operation/botanist/extensions/infrastructure/infrastructure.go
+++ b/pkg/operation/botanist/extensions/infrastructure/infrastructure.go
@@ -193,7 +193,7 @@ func (i *infrastructure) Wait(ctx context.Context) error {
 		i.waitInterval,
 		i.waitSevereThreshold,
 		i.waitTimeout,
-		func(obj runtime.Object) error {
+		func(obj client.Object) error {
 			infrastructure, ok := obj.(*extensionsv1alpha1.Infrastructure)
 			if !ok {
 				return fmt.Errorf("expected extensionsv1alpha1.Infrastructure but got %T", infrastructure)

--- a/pkg/operation/botanist/extensions/worker/worker.go
+++ b/pkg/operation/botanist/extensions/worker/worker.go
@@ -285,7 +285,7 @@ func (w *worker) Wait(ctx context.Context) error {
 		w.waitInterval,
 		w.waitSevereThreshold,
 		w.waitTimeout,
-		func(obj runtime.Object) error {
+		func(obj client.Object) error {
 			worker, ok := obj.(*extensionsv1alpha1.Worker)
 			if !ok {
 				return fmt.Errorf("expected extensionsv1alpha1.Worker but got %T", worker)

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -446,7 +445,7 @@ func (b *Botanist) applyAndWaitForShootOperatingSystemConfig(ctx context.Context
 		DefaultInterval,
 		15*time.Second,
 		30*time.Second,
-		func(obj runtime.Object) error {
+		func(obj client.Object) error {
 			o, ok := obj.(*extensionsv1alpha1.OperatingSystemConfig)
 			if !ok {
 				return fmt.Errorf("expected extensionsv1alpha1.OperatingSystemConfig but got %T", obj)

--- a/pkg/operation/botanist/seedsystemcomponents/seedadmission/seedadmission_test.go
+++ b/pkg/operation/botanist/seedsystemcomponents/seedadmission/seedadmission_test.go
@@ -33,7 +33,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -386,11 +385,11 @@ status: {}
 		It("should successfully deploy all resources (k8s < 1.15)", func() {
 			gomock.InOrder(
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
-				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 					Expect(obj).To(DeepEqual(managedResourceSecret))
 				}),
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 					Expect(obj).To(DeepEqual(managedResource))
 				}),
 			)
@@ -404,11 +403,11 @@ status: {}
 
 			gomock.InOrder(
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
-				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 					Expect(obj).To(DeepEqual(managedResourceSecret))
 				}),
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 					Expect(obj).To(DeepEqual(managedResource))
 				}),
 			)
@@ -434,7 +433,7 @@ status: {}
 			TimeoutWaitForManagedResource = time.Millisecond
 
 			c.EXPECT().Get(gomock.Any(), kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(
-				func(ctx context.Context, _ client.ObjectKey, obj runtime.Object) error {
+				func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
 					(&resourcesv1alpha1.ManagedResource{
 						ObjectMeta: metav1.ObjectMeta{
 							Generation: 1,
@@ -462,7 +461,7 @@ status: {}
 
 		It("should successfully wait for all resources to be ready", func() {
 			c.EXPECT().Get(gomock.Any(), kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(
-				func(ctx context.Context, _ client.ObjectKey, obj runtime.Object) error {
+				func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
 					(&resourcesv1alpha1.ManagedResource{
 						ObjectMeta: metav1.ObjectMeta{
 							Generation: 1,

--- a/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server_test.go
@@ -30,7 +30,6 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -468,11 +467,11 @@ status: {}
 			It("should successfully deploy all resources (w/o VPA, w/o host env)", func() {
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResourceSecret))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
 				)
@@ -489,11 +488,11 @@ status: {}
 
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResourceSecret))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
 				)

--- a/pkg/operation/botanist/systemcomponents/namespaces/namespaces_test.go
+++ b/pkg/operation/botanist/systemcomponents/namespaces/namespaces_test.go
@@ -30,7 +30,6 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -123,11 +122,11 @@ status: {}
 		It("should successfully deploy all resources", func() {
 			gomock.InOrder(
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
-				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 					Expect(obj).To(DeepEqual(managedResourceSecret))
 				}),
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
-				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) {
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 					Expect(obj).To(DeepEqual(managedResource))
 				}),
 			)

--- a/pkg/operation/common/extensions.go
+++ b/pkg/operation/common/extensions.go
@@ -113,7 +113,7 @@ func WaitUntilExtensionCRReady(
 	interval time.Duration,
 	severeThreshold time.Duration,
 	timeout time.Duration,
-	postReadyFunc func(runtime.Object) error,
+	postReadyFunc func(client.Object) error,
 ) error {
 	return WaitUntilObjectReadyWithHealthFunction(
 		ctx,
@@ -145,7 +145,7 @@ func WaitUntilObjectReadyWithHealthFunction(
 	interval time.Duration,
 	severeThreshold time.Duration,
 	timeout time.Duration,
-	postReadyFunc func(runtime.Object) error,
+	postReadyFunc func(client.Object) error,
 ) error {
 	var (
 		errorWithCode         *gardencorev1beta1helper.ErrorWithCodes

--- a/pkg/operation/common/extensions_test.go
+++ b/pkg/operation/common/extensions_test.go
@@ -150,7 +150,7 @@ var _ = Describe("extensions", func() {
 				ctx, c, log,
 				func() client.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
 				namespace, name,
-				defaultInterval, defaultThreshold, defaultTimeout, func(runtime.Object) error {
+				defaultInterval, defaultThreshold, defaultTimeout, func(client.Object) error {
 					val++
 					return nil
 				},
@@ -164,7 +164,7 @@ var _ = Describe("extensions", func() {
 		It("should return error if object does not exist error", func() {
 			err := WaitUntilObjectReadyWithHealthFunction(
 				ctx, c, log,
-				func(obj runtime.Object) error {
+				func(obj client.Object) error {
 					return nil
 				},
 				func() client.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
@@ -179,7 +179,7 @@ var _ = Describe("extensions", func() {
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
 			err := WaitUntilObjectReadyWithHealthFunction(
 				ctx, c, log,
-				func(obj runtime.Object) error {
+				func(obj client.Object) error {
 					return errors.New("error")
 				},
 				func() client.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
@@ -194,7 +194,7 @@ var _ = Describe("extensions", func() {
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
 			err := WaitUntilObjectReadyWithHealthFunction(
 				ctx, c, log,
-				func(obj runtime.Object) error {
+				func(obj client.Object) error {
 					return nil
 				},
 				func() client.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
@@ -209,7 +209,7 @@ var _ = Describe("extensions", func() {
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
 			err := WaitUntilObjectReadyWithHealthFunction(
 				ctx, c, log,
-				func(obj runtime.Object) error {
+				func(obj client.Object) error {
 					Expect(obj).To(Equal(expected))
 					return nil
 				},
@@ -231,12 +231,12 @@ var _ = Describe("extensions", func() {
 			val := 0
 			err := WaitUntilObjectReadyWithHealthFunction(
 				ctx, c, log,
-				func(obj runtime.Object) error {
+				func(obj client.Object) error {
 					return nil
 				},
 				func() client.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
 				namespace, name,
-				defaultInterval, defaultThreshold, defaultTimeout, func(runtime.Object) error {
+				defaultInterval, defaultThreshold, defaultTimeout, func(client.Object) error {
 					val++
 					return nil
 				},

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -697,7 +697,7 @@ func GetSecretFromSecretRef(ctx context.Context, c client.Client, secretRef *cor
 }
 
 // CheckIfDeletionIsConfirmed returns whether the deletion of an object is confirmed or not.
-func CheckIfDeletionIsConfirmed(obj metav1.Object) error {
+func CheckIfDeletionIsConfirmed(obj client.Object) error {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		return annotationRequiredError()
@@ -725,13 +725,8 @@ func ConfirmDeletion(ctx context.Context, c client.Client, obj client.Object) er
 		}
 
 		existing := obj.DeepCopyObject()
-
-		acc, err := meta.Accessor(obj)
-		if err != nil {
-			return err
-		}
-		kutil.SetMetaDataAnnotation(acc, ConfirmationDeletion, "true")
-		kutil.SetMetaDataAnnotation(acc, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		kutil.SetMetaDataAnnotation(obj, ConfirmationDeletion, "true")
+		kutil.SetMetaDataAnnotation(obj, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 
 		if reflect.DeepEqual(existing, obj) {
 			return nil

--- a/pkg/operation/common/utils_test.go
+++ b/pkg/operation/common/utils_test.go
@@ -45,7 +45,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -700,8 +699,8 @@ var _ = Describe("common", func() {
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 			c.EXPECT().Get(ctx, gomock.AssignableToTypeOf(client.ObjectKey{}), obj)
 			c.EXPECT().Update(ctx, expectedObj).Return(apierrors.NewConflict(corev1.Resource("namespaces"), "", errors.New("conflict")))
-			c.EXPECT().Get(ctx, gomock.AssignableToTypeOf(client.ObjectKey{}), expectedObj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, o runtime.Object) error {
-				baseObj.DeepCopyInto(o.(*corev1.Namespace))
+			c.EXPECT().Get(ctx, gomock.AssignableToTypeOf(client.ObjectKey{}), expectedObj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+				baseObj.DeepCopyInto(obj.(*corev1.Namespace))
 				return nil
 			})
 			c.EXPECT().Update(ctx, expectedObj)

--- a/pkg/scheduler/controller/shoot/scheduler_control_test.go
+++ b/pkg/scheduler/controller/shoot/scheduler_control_test.go
@@ -19,6 +19,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
@@ -29,7 +30,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 )
 
@@ -897,7 +897,7 @@ var _ = Describe("Scheduler_Control", func() {
 			var runtimeClient = mockclient.NewMockClient(ctrl)
 
 			shoot.Spec.SeedName = &seed.Name
-			runtimeClient.EXPECT().Update(context.TODO(), shoot).DoAndReturn(func(ctx context.Context, list runtime.Object) error {
+			runtimeClient.EXPECT().Update(context.TODO(), shoot).DoAndReturn(func(_ context.Context, _ client.Object) error {
 				return nil
 			})
 

--- a/pkg/seedadmission/extension_crds.go
+++ b/pkg/seedadmission/extension_crds.go
@@ -134,19 +134,19 @@ func admitObjectDeletion(logger logrus.FieldLogger, obj runtime.Object, kind str
 
 // checkIfObjectDeletionIsConfirmed checks if the object was annotated with the deletion confirmation. If it is a custom
 // resource definition then it is only considered if the CRD has the deletion protection label.
-func checkIfObjectDeletionIsConfirmed(logger logrus.FieldLogger, obj runtime.Object, kind string) error {
-	acc, err := meta.Accessor(obj)
-	if err != nil {
-		return err
+func checkIfObjectDeletionIsConfirmed(logger logrus.FieldLogger, object runtime.Object, kind string) error {
+	obj, ok := object.(client.Object)
+	if !ok {
+		return fmt.Errorf("%T does not implement client.Object", object)
 	}
 
-	logger = logger.WithField("name", acc.GetName())
+	logger = logger.WithField("name", obj.GetName())
 
-	if kind == "CustomResourceDefinition" && !crdMustBeConsidered(logger, acc.GetLabels()) {
+	if kind == "CustomResourceDefinition" && !crdMustBeConsidered(logger, obj.GetLabels()) {
 		return nil
 	}
 
-	if err := common.CheckIfDeletionIsConfirmed(acc); err != nil {
+	if err := common.CheckIfDeletionIsConfirmed(obj); err != nil {
 		logger.Info("Deletion is not confirmed - preventing deletion")
 		return err
 	}

--- a/pkg/seedadmission/extension_crds_test.go
+++ b/pkg/seedadmission/extension_crds_test.go
@@ -316,8 +316,8 @@ var _ = Describe("Extension CRDs", func() {
 					for _, resource := range crdResources {
 						prepareRequestAndObjectWithResource(&request, obj, resource)
 
-						c.EXPECT().Get(gomock.Any(), kutil.Key(request.Name), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, o runtime.Object) error {
-							prepareObjectWithLabelsAnnotations(o, resource, nil, nil)
+						c.EXPECT().Get(gomock.Any(), kutil.Key(request.Name), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+							prepareObjectWithLabelsAnnotations(obj, resource, nil, nil)
 							return nil
 						})
 
@@ -329,8 +329,8 @@ var _ = Describe("Extension CRDs", func() {
 					for _, resource := range crdResources {
 						prepareRequestAndObjectWithResource(&request, obj, resource)
 
-						c.EXPECT().Get(gomock.Any(), kutil.Key(request.Name), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, o runtime.Object) error {
-							prepareObjectWithLabelsAnnotations(o, resource, deletionUnprotectedLabels, nil)
+						c.EXPECT().Get(gomock.Any(), kutil.Key(request.Name), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+							prepareObjectWithLabelsAnnotations(obj, resource, deletionUnprotectedLabels, nil)
 							return nil
 						})
 
@@ -342,8 +342,8 @@ var _ = Describe("Extension CRDs", func() {
 					for _, resource := range crdResources {
 						prepareRequestAndObjectWithResource(&request, obj, resource)
 
-						c.EXPECT().Get(gomock.Any(), kutil.Key(request.Name), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, o runtime.Object) error {
-							prepareObjectWithLabelsAnnotations(o, resource, deletionProtectedLabels, nil)
+						c.EXPECT().Get(gomock.Any(), kutil.Key(request.Name), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+							prepareObjectWithLabelsAnnotations(obj, resource, deletionProtectedLabels, nil)
 							return nil
 						})
 
@@ -355,8 +355,8 @@ var _ = Describe("Extension CRDs", func() {
 					for _, resource := range crdResources {
 						prepareRequestAndObjectWithResource(&request, obj, resource)
 
-						c.EXPECT().Get(gomock.Any(), kutil.Key(request.Name), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, o runtime.Object) error {
-							prepareObjectWithLabelsAnnotations(o, resource, deletionProtectedLabels, deletionConfirmedAnnotations)
+						c.EXPECT().Get(gomock.Any(), kutil.Key(request.Name), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+							prepareObjectWithLabelsAnnotations(obj, resource, deletionProtectedLabels, deletionConfirmedAnnotations)
 							return nil
 						})
 
@@ -375,8 +375,8 @@ var _ = Describe("Extension CRDs", func() {
 					for _, resource := range otherResources {
 						prepareRequestAndObjectWithResource(&request, obj, resource)
 
-						c.EXPECT().Get(gomock.Any(), kutil.Key(request.Namespace, request.Name), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, o runtime.Object) error {
-							prepareObjectWithLabelsAnnotations(o, resource, nil, nil)
+						c.EXPECT().Get(gomock.Any(), kutil.Key(request.Namespace, request.Name), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+							prepareObjectWithLabelsAnnotations(obj, resource, nil, nil)
 							return nil
 						})
 
@@ -388,8 +388,8 @@ var _ = Describe("Extension CRDs", func() {
 					for _, resource := range otherResources {
 						prepareRequestAndObjectWithResource(&request, obj, resource)
 
-						c.EXPECT().Get(gomock.Any(), kutil.Key(request.Namespace, request.Name), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, o runtime.Object) error {
-							prepareObjectWithLabelsAnnotations(o, resource, nil, deletionConfirmedAnnotations)
+						c.EXPECT().Get(gomock.Any(), kutil.Key(request.Namespace, request.Name), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+							prepareObjectWithLabelsAnnotations(obj, resource, nil, deletionConfirmedAnnotations)
 							return nil
 						})
 
@@ -442,8 +442,8 @@ var _ = Describe("Extension CRDs", func() {
 						prepareRequestAndObjectWithResource(&request, obj, resource)
 						obj.SetKind(obj.GetKind() + "List")
 
-						c.EXPECT().List(gomock.Any(), obj, client.InNamespace(request.Namespace)).DoAndReturn(func(_ context.Context, o runtime.Object, _ ...client.ListOption) error {
-							prepareObjectWithLabelsAnnotations(o, resource, nil, nil)
+						c.EXPECT().List(gomock.Any(), obj, client.InNamespace(request.Namespace)).DoAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+							prepareObjectWithLabelsAnnotations(list, resource, nil, nil)
 							return nil
 						})
 
@@ -456,8 +456,8 @@ var _ = Describe("Extension CRDs", func() {
 						prepareRequestAndObjectWithResource(&request, obj, resource)
 						obj.SetKind(obj.GetKind() + "List")
 
-						c.EXPECT().List(gomock.Any(), obj, client.InNamespace(request.Namespace)).DoAndReturn(func(_ context.Context, o runtime.Object, _ ...client.ListOption) error {
-							prepareObjectWithLabelsAnnotations(o, resource, deletionUnprotectedLabels, nil)
+						c.EXPECT().List(gomock.Any(), obj, client.InNamespace(request.Namespace)).DoAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+							prepareObjectWithLabelsAnnotations(list, resource, deletionUnprotectedLabels, nil)
 							return nil
 						})
 
@@ -470,8 +470,8 @@ var _ = Describe("Extension CRDs", func() {
 						prepareRequestAndObjectWithResource(&request, obj, resource)
 						obj.SetKind(obj.GetKind() + "List")
 
-						c.EXPECT().List(gomock.Any(), obj, client.InNamespace(request.Namespace)).DoAndReturn(func(_ context.Context, o runtime.Object, _ ...client.ListOption) error {
-							prepareObjectWithLabelsAnnotations(o, resource, deletionProtectedLabels, nil)
+						c.EXPECT().List(gomock.Any(), obj, client.InNamespace(request.Namespace)).DoAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+							prepareObjectWithLabelsAnnotations(list, resource, deletionProtectedLabels, nil)
 							return nil
 						})
 
@@ -484,8 +484,8 @@ var _ = Describe("Extension CRDs", func() {
 						prepareRequestAndObjectWithResource(&request, obj, resource)
 						obj.SetKind(obj.GetKind() + "List")
 
-						c.EXPECT().List(gomock.Any(), obj, client.InNamespace(request.Namespace)).DoAndReturn(func(_ context.Context, o runtime.Object, _ ...client.ListOption) error {
-							prepareObjectWithLabelsAnnotations(o, resource, deletionProtectedLabels, deletionConfirmedAnnotations)
+						c.EXPECT().List(gomock.Any(), obj, client.InNamespace(request.Namespace)).DoAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+							prepareObjectWithLabelsAnnotations(list, resource, deletionProtectedLabels, deletionConfirmedAnnotations)
 							return nil
 						})
 
@@ -504,8 +504,8 @@ var _ = Describe("Extension CRDs", func() {
 						prepareRequestAndObjectWithResource(&request, obj, resource)
 						obj.SetKind(obj.GetKind() + "List")
 
-						c.EXPECT().List(gomock.Any(), obj, client.InNamespace(request.Namespace)).DoAndReturn(func(_ context.Context, o runtime.Object, _ ...client.ListOption) error {
-							prepareObjectWithLabelsAnnotations(o, resource, nil, nil)
+						c.EXPECT().List(gomock.Any(), obj, client.InNamespace(request.Namespace)).DoAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+							prepareObjectWithLabelsAnnotations(list, resource, nil, nil)
 							return nil
 						})
 
@@ -518,8 +518,8 @@ var _ = Describe("Extension CRDs", func() {
 						prepareRequestAndObjectWithResource(&request, obj, resource)
 						obj.SetKind(obj.GetKind() + "List")
 
-						c.EXPECT().List(gomock.Any(), obj, client.InNamespace(request.Namespace)).DoAndReturn(func(_ context.Context, o runtime.Object, _ ...client.ListOption) error {
-							prepareObjectWithLabelsAnnotations(o, resource, nil, deletionConfirmedAnnotations)
+						c.EXPECT().List(gomock.Any(), obj, client.InNamespace(request.Namespace)).DoAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+							prepareObjectWithLabelsAnnotations(list, resource, nil, deletionConfirmedAnnotations)
 							return nil
 						})
 

--- a/pkg/seedadmission/utils_test.go
+++ b/pkg/seedadmission/utils_test.go
@@ -148,10 +148,10 @@ var _ = Describe("Utils", func() {
 			})
 
 			It("Shoul return the looked up resource", func() {
-				c.EXPECT().Get(ctx, kutil.Key(request.Namespace, request.Name), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, o runtime.Object) error {
-					ob, ok := o.(*unstructured.Unstructured)
+				c.EXPECT().Get(ctx, kutil.Key(request.Namespace, request.Name), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj client.Object) error {
+					ob, ok := obj.(*unstructured.Unstructured)
 					if !ok {
-						return fmt.Errorf("Error casting %v to Unstructured object", o)
+						return fmt.Errorf("Error casting %v to Unstructured object", obj)
 					}
 					ob.SetAPIVersion(fmt.Sprintf("%s/%s", resource.Group, resource.Version))
 					ob.SetKind(resource.Resource)
@@ -187,10 +187,10 @@ var _ = Describe("Utils", func() {
 			})
 
 			It("Shoul return the looked up resource", func() {
-				c.EXPECT().List(ctx, obj, client.InNamespace(request.Namespace)).DoAndReturn(func(_ context.Context, o runtime.Object, _ ...client.ListOption) error {
-					ob, ok := o.(*unstructured.UnstructuredList)
+				c.EXPECT().List(ctx, obj, client.InNamespace(request.Namespace)).DoAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					ob, ok := list.(*unstructured.UnstructuredList)
 					if !ok {
-						return fmt.Errorf("Error casting %v to UnstructuredList object", o)
+						return fmt.Errorf("Error casting %v to UnstructuredList object", list)
 					}
 					ob.SetAPIVersion(request.Kind.Group + "/" + request.Kind.Version)
 					ob.SetKind(request.Kind.Kind + "List")

--- a/pkg/utils/kubernetes/client/client_test.go
+++ b/pkg/utils/kubernetes/client/client_test.go
@@ -54,12 +54,11 @@ var _ = Describe("Cleaner", func() {
 		cm2    corev1.ConfigMap
 		cmList corev1.ConfigMapList
 		ns     corev1.Namespace
-		//cmObjects []runtime.Object
 
 		cm2WithFinalizer corev1.ConfigMap
 		nsWithFinalizer  corev1.Namespace
-		//cmListWithFinalizer corev1.ConfigMapList
 	)
+
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		c = mockclient.NewMockClient(ctrl)

--- a/pkg/utils/kubernetes/health/and.go
+++ b/pkg/utils/kubernetes/health/and.go
@@ -15,16 +15,16 @@
 package health
 
 import (
-	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Func is a type for a function that checks the health of a runtime.Object.
-type Func func(runtime.Object) error
+type Func func(client.Object) error
 
 // And combines multiple health check funcs to a single func, checking all funcs sequentially and return the first
 // error that occurs or nil if no error occurs.¬
 func And(fns ...Func) Func {
-	return func(o runtime.Object) error {
+	return func(o client.Object) error {
 		for _, fn := range fns {
 			if err := fn(o); err != nil {
 				return err

--- a/pkg/utils/kubernetes/health/and_test.go
+++ b/pkg/utils/kubernetes/health/and_test.go
@@ -20,23 +20,23 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 )
 
 var _ = Describe("And", func() {
 	var (
-		obj                runtime.Object
+		obj                client.Object
 		healthy, unhealthy health.Func
 	)
 
 	BeforeEach(func() {
 		obj = &corev1.Pod{}
-		healthy = func(o runtime.Object) error {
+		healthy = func(o client.Object) error {
 			return nil
 		}
-		unhealthy = func(o runtime.Object) error {
+		unhealthy = func(o client.Object) error {
 			return fmt.Errorf("unhealthy")
 		}
 	})

--- a/pkg/utils/kubernetes/health/health.go
+++ b/pkg/utils/kubernetes/health/health.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -291,7 +290,7 @@ func checkSeed(seed *gardencorev1beta1.Seed, identity *gardencorev1beta1.Gardene
 // * No gardener.cloud/operation is set
 // * No lastError is in the status
 // * A last operation is state succeeded is present
-func CheckExtensionObject(o runtime.Object) error {
+func CheckExtensionObject(o client.Object) error {
 	obj, ok := o.(extensionsv1alpha1.Object)
 	if !ok {
 		return fmt.Errorf("expected extensionsv1alpha1.Object but got %T", o)
@@ -304,7 +303,7 @@ func CheckExtensionObject(o runtime.Object) error {
 // ExtensionOperationHasBeenUpdatedSince returns a health check function that checks if an extension Object's last
 // operation has been updated since `lastUpdateTime`.
 func ExtensionOperationHasBeenUpdatedSince(lastUpdateTime metav1.Time) Func {
-	return func(o runtime.Object) error {
+	return func(o client.Object) error {
 		obj, ok := o.(extensionsv1alpha1.Object)
 		if !ok {
 			return fmt.Errorf("expected extensionsv1alpha1.Object but got %T", o)
@@ -319,7 +318,7 @@ func ExtensionOperationHasBeenUpdatedSince(lastUpdateTime metav1.Time) Func {
 }
 
 // CheckBackupBucket checks if an backup bucket Object is healthy or not.
-func CheckBackupBucket(bb runtime.Object) error {
+func CheckBackupBucket(bb client.Object) error {
 	obj, ok := bb.(*gardencorev1beta1.BackupBucket)
 	if !ok {
 		return fmt.Errorf("expected gardencorev1beta1.BackupBucket but got %T", bb)

--- a/pkg/utils/kubernetes/health/health_test.go
+++ b/pkg/utils/kubernetes/health/health_test.go
@@ -38,7 +38,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -291,7 +290,7 @@ var _ = Describe("health", func() {
 
 	Describe("CheckExtensionObject", func() {
 		DescribeTable("extension objects",
-			func(obj runtime.Object, match types.GomegaMatcher) {
+			func(obj client.Object, match types.GomegaMatcher) {
 				Expect(health.CheckExtensionObject(obj)).To(match)
 			},
 			Entry("not an extensionsv1alpha1.Object",

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -77,12 +77,8 @@ func HasMetaDataAnnotation(meta metav1.Object, key, value string) bool {
 }
 
 // HasDeletionTimestamp checks if an object has a deletion timestamp
-func HasDeletionTimestamp(obj runtime.Object) (bool, error) {
-	metadata, err := meta.Accessor(obj)
-	if err != nil {
-		return false, err
-	}
-	return metadata.GetDeletionTimestamp() != nil, nil
+func HasDeletionTimestamp(obj client.Object) bool {
+	return obj.GetDeletionTimestamp() != nil
 }
 
 func nameAndNamespace(namespaceOrName string, nameOpt ...string) (namespace, name string) {
@@ -414,13 +410,8 @@ func MergeOwnerReferences(references []metav1.OwnerReference, newReferences ...m
 }
 
 // OwnedBy checks if the given object's owner reference contains an entry with the provided attributes.
-func OwnedBy(obj runtime.Object, apiVersion, kind, name string, uid types.UID) bool {
-	acc, err := meta.Accessor(obj)
-	if err != nil {
-		return false
-	}
-
-	for _, ownerReference := range acc.GetOwnerReferences() {
+func OwnedBy(obj client.Object, apiVersion, kind, name string, uid types.UID) bool {
+	for _, ownerReference := range obj.GetOwnerReferences() {
 		return ownerReference.APIVersion == apiVersion &&
 			ownerReference.Kind == kind &&
 			ownerReference.Name == name &&
@@ -434,7 +425,7 @@ func OwnedBy(obj runtime.Object, apiVersion, kind, name string, uid types.UID) b
 // is provided then it will be applied for each object right after listing all objects. If no object remains then nil
 // is returned. The Items field in the list object will be populated with the result returned from the server after
 // applying the filter function (if provided).
-func NewestObject(ctx context.Context, c client.Client, listObj client.ObjectList, filterFn func(runtime.Object) bool, listOpts ...client.ListOption) (runtime.Object, error) {
+func NewestObject(ctx context.Context, c client.Client, listObj client.ObjectList, filterFn func(client.Object) bool, listOpts ...client.ListOption) (client.Object, error) {
 	if err := c.List(ctx, listObj, listOpts...); err != nil {
 		return nil, err
 	}
@@ -442,7 +433,12 @@ func NewestObject(ctx context.Context, c client.Client, listObj client.ObjectLis
 	if filterFn != nil {
 		var items []runtime.Object
 
-		if err := meta.EachListItem(listObj, func(obj runtime.Object) error {
+		if err := meta.EachListItem(listObj, func(object runtime.Object) error {
+			obj, ok := object.(client.Object)
+			if !ok {
+				return fmt.Errorf("%T does not implement client.Object", object)
+			}
+
 			if filterFn(obj) {
 				items = append(items, obj)
 			}
@@ -467,7 +463,13 @@ func NewestObject(ctx context.Context, c client.Client, listObj client.ObjectLis
 		return nil, err
 	}
 
-	return items[meta.LenList(listObj)-1], nil
+	newestObject := items[meta.LenList(listObj)-1]
+	obj, ok := newestObject.(client.Object)
+	if !ok {
+		return nil, fmt.Errorf("%T does not implement client.Object", newestObject)
+	}
+
+	return obj, nil
 }
 
 // NewestPodForDeployment returns the most recently created Pod object for the given deployment.
@@ -481,7 +483,7 @@ func NewestPodForDeployment(ctx context.Context, c client.Client, deployment *ap
 		ctx,
 		c,
 		&appsv1.ReplicaSetList{},
-		func(obj runtime.Object) bool {
+		func(obj client.Object) bool {
 			return OwnedBy(obj, appsv1.SchemeGroupVersion.String(), "Deployment", deployment.Name, deployment.UID)
 		},
 		listOpts...,
@@ -502,7 +504,7 @@ func NewestPodForDeployment(ctx context.Context, c client.Client, deployment *ap
 		ctx,
 		c,
 		&corev1.PodList{},
-		func(obj runtime.Object) bool {
+		func(obj client.Object) bool {
 			return OwnedBy(obj, appsv1.SchemeGroupVersion.String(), "ReplicaSet", newestReplicaSet.Name, newestReplicaSet.UID)
 		},
 		listOpts...,

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -76,11 +76,6 @@ func HasMetaDataAnnotation(meta metav1.Object, key, value string) bool {
 	return ok && val == value
 }
 
-// HasDeletionTimestamp checks if an object has a deletion timestamp
-func HasDeletionTimestamp(obj client.Object) bool {
-	return obj.GetDeletionTimestamp() != nil
-}
-
 func nameAndNamespace(namespaceOrName string, nameOpt ...string) (namespace, name string) {
 	if len(nameOpt) > 1 {
 		panic(fmt.Sprintf("more than name/namespace for key specified: %s/%v", namespaceOrName, nameOpt))

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -42,7 +42,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -609,7 +608,7 @@ var _ = Describe("kubernetes", func() {
 
 			gomock.InOrder(
 				c.EXPECT().Get(ctx, key, configMap),
-				c.EXPECT().Get(ctx, key, configMap).DoAndReturn(func(_ context.Context, _ client.ObjectKey, _ runtime.Object) error {
+				c.EXPECT().Get(ctx, key, configMap).DoAndReturn(func(_ context.Context, _ client.ObjectKey, _ client.Object) error {
 					cancel()
 					return nil
 				}),
@@ -653,7 +652,7 @@ var _ = Describe("kubernetes", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			c.EXPECT().List(ctx, configMapList).DoAndReturn(func(_ context.Context, _ runtime.Object, _ ...client.ListOption) error {
+			c.EXPECT().List(ctx, configMapList).DoAndReturn(func(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
 				cancel()
 				configMapList.Items = append(configMapList.Items, configMap)
 				return nil

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -109,17 +109,13 @@ var _ = Describe("kubernetes", func() {
 			},
 		}
 		It("should return false if no deletion timestamp is set", func() {
-			result, err := HasDeletionTimestamp(namespace)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeFalse())
+			Expect(HasDeletionTimestamp(namespace)).To(BeFalse())
 		})
 
 		It("should return true if timestamp is set", func() {
 			now := metav1.Now()
 			namespace.ObjectMeta.DeletionTimestamp = &now
-			result, err := HasDeletionTimestamp(namespace)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeTrue())
+			Expect(HasDeletionTimestamp(namespace)).To(BeTrue())
 		})
 	})
 
@@ -1120,7 +1116,7 @@ var _ = Describe("kubernetes", func() {
 	})
 
 	DescribeTable("#OwnedBy",
-		func(obj runtime.Object, apiVersion, kind, name string, uid types.UID, matcher gomegatypes.GomegaMatcher) {
+		func(obj client.Object, apiVersion, kind, name string, uid types.UID, matcher gomegatypes.GomegaMatcher) {
 			Expect(OwnedBy(obj, apiVersion, kind, name, uid)).To(matcher)
 		},
 		Entry("no owner references", &corev1.Pod{}, "apiVersion", "kind", "name", types.UID("uid"), BeFalse()),
@@ -1170,7 +1166,7 @@ var _ = Describe("kubernetes", func() {
 		})
 
 		It("should return the newest object w/ filter func", func() {
-			filterFn := func(o runtime.Object) bool {
+			filterFn := func(o client.Object) bool {
 				obj := o.(*corev1.Pod)
 				return obj.Name != "obj2"
 			}

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -101,23 +101,6 @@ var _ = Describe("kubernetes", func() {
 		})
 	})
 
-	Describe("#HasDeletionTimestamp", func() {
-		var namespace = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "foo",
-			},
-		}
-		It("should return false if no deletion timestamp is set", func() {
-			Expect(HasDeletionTimestamp(namespace)).To(BeFalse())
-		})
-
-		It("should return true if timestamp is set", func() {
-			now := metav1.Now()
-			namespace.ObjectMeta.DeletionTimestamp = &now
-			Expect(HasDeletionTimestamp(namespace)).To(BeTrue())
-		})
-	})
-
 	Describe("#CreateTwoWayMergePatch", func() {
 		It("should fail for two different object types", func() {
 			_, err := CreateTwoWayMergePatch(&corev1.ConfigMap{}, &corev1.Secret{})

--- a/pkg/utils/kubernetes/sorter.go
+++ b/pkg/utils/kubernetes/sorter.go
@@ -19,25 +19,25 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ByName returns a comparison function for sorting by name.
 func ByName() SortBy {
-	return func(o1, o2 controllerutil.Object) bool {
+	return func(o1, o2 client.Object) bool {
 		return o1.GetName() < o2.GetName()
 	}
 }
 
 // ByCreationTimestamp returns a comparison function for sorting by creation timestamp.
 func ByCreationTimestamp() SortBy {
-	return func(o1, o2 controllerutil.Object) bool {
+	return func(o1, o2 client.Object) bool {
 		return o1.GetCreationTimestamp().Time.Before(o2.GetCreationTimestamp().Time)
 	}
 }
 
 // SortBy the type of a "less" function that defines the ordering of its object arguments.
-type SortBy func(o1, o2 controllerutil.Object) bool
+type SortBy func(o1, o2 client.Object) bool
 
 // Sort sorts the items in the provided list objects according to the sort-by function.
 func (sortBy SortBy) Sort(objList runtime.Object) {
@@ -73,7 +73,7 @@ func (s *objectSorter) Swap(i, j int) {
 
 func (s *objectSorter) Less(i, j int) bool {
 	return s.compareFn(
-		s.objects[i].(controllerutil.Object),
-		s.objects[j].(controllerutil.Object),
+		s.objects[i].(client.Object),
+		s.objects[j].(client.Object),
 	)
 }

--- a/pkg/utils/kubernetes/sorter_test.go
+++ b/pkg/utils/kubernetes/sorter_test.go
@@ -17,13 +17,13 @@ package kubernetes_test
 import (
 	"time"
 
-	. "github.com/gardener/gardener/pkg/utils/kubernetes"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 var _ = Describe("Sort", func() {
@@ -74,7 +74,7 @@ var _ = Describe("Sort", func() {
 
 	Describe("SortBy", func() {
 		It("should sort correctly", func() {
-			sortByContainers := func(o1, o2 controllerutil.Object) bool {
+			sortByContainers := func(o1, o2 client.Object) bool {
 				obj1, ok1 := o1.(*corev1.Pod)
 				obj2, ok2 := o2.(*corev1.Pod)
 

--- a/pkg/utils/managedresources/registry.go
+++ b/pkg/utils/managedresources/registry.go
@@ -19,11 +19,11 @@ import (
 	"reflect"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
@@ -36,7 +36,7 @@ type Registry struct {
 }
 
 type object struct {
-	obj           runtime.Object
+	obj           client.Object
 	serialization []byte
 }
 
@@ -57,7 +57,7 @@ func NewRegistry(scheme *runtime.Scheme, codec serializer.CodecFactory, serializ
 
 // Add adds the given object the registry. It computes a filename based on its type, namespace, and name. It serializes
 // the object to YAML and stores both representations (object and serialization) in the registry.
-func (r *Registry) Add(obj runtime.Object) error {
+func (r *Registry) Add(obj client.Object) error {
 	if obj == nil || reflect.ValueOf(obj) == reflect.Zero(reflect.TypeOf(obj)) {
 		return nil
 	}
@@ -95,7 +95,7 @@ func (r *Registry) SerializedObjects() map[string][]byte {
 }
 
 // AddAllAndSerialize calls Add() for all the given objects before calling SerializedObjects().
-func (r *Registry) AddAllAndSerialize(objects ...runtime.Object) (map[string][]byte, error) {
+func (r *Registry) AddAllAndSerialize(objects ...client.Object) (map[string][]byte, error) {
 	for _, resource := range objects {
 		if err := r.Add(resource); err != nil {
 			return nil, err
@@ -122,13 +122,8 @@ func (r *Registry) String() string {
 	return strings.Join(out, "\n\n")
 }
 
-func (r *Registry) objectName(obj runtime.Object) (string, error) {
+func (r *Registry) objectName(obj client.Object) (string, error) {
 	gvk, err := apiutil.GVKForObject(obj, r.scheme)
-	if err != nil {
-		return "", err
-	}
-
-	acc, err := meta.Accessor(obj)
 	if err != nil {
 		return "", err
 	}
@@ -136,7 +131,7 @@ func (r *Registry) objectName(obj runtime.Object) (string, error) {
 	return fmt.Sprintf(
 		"%s__%s__%s",
 		strings.ToLower(gvk.Kind),
-		acc.GetNamespace(),
-		strings.Replace(acc.GetName(), ":", "_", -1),
+		obj.GetNamespace(),
+		strings.Replace(obj.GetName(), ":", "_", -1),
 	), nil
 }

--- a/pkg/utils/managedresources/registry.go
+++ b/pkg/utils/managedresources/registry.go
@@ -105,8 +105,8 @@ func (r *Registry) AddAllAndSerialize(objects ...client.Object) (map[string][]by
 }
 
 // RegisteredObjects returns a map whose keys are filenames and whose values are objects.
-func (r *Registry) RegisteredObjects() map[string]runtime.Object {
-	out := make(map[string]runtime.Object, len(r.nameToObject))
+func (r *Registry) RegisteredObjects() map[string]client.Object {
+	out := make(map[string]client.Object, len(r.nameToObject))
 	for name, object := range r.nameToObject {
 		out[name] = object.obj
 	}

--- a/pkg/utils/managedresources/registry_test.go
+++ b/pkg/utils/managedresources/registry_test.go
@@ -86,14 +86,6 @@ roleRef:
 			Expect(registry.Add(nil)).To(Succeed())
 		})
 
-		It("should return an error when the object name cannot be computed", func() {
-			Expect(registry.Add(&metav1.APIGroup{})).To(MatchError(ContainSubstring("cannot create group-version-kind for unversioned type")))
-		})
-
-		It("should return an error when the object name cannot be computed", func() {
-			Expect(registry.Add(&corev1.SecretList{})).To(MatchError(ContainSubstring("does not implement the Object interfaces")))
-		})
-
 		It("should return an error due to duplicates in registry", func() {
 			Expect(registry.Add(&corev1.Secret{})).To(Succeed())
 			Expect(registry.Add(&corev1.Secret{})).To(MatchError(ContainSubstring("duplicate filename in registry")))

--- a/pkg/utils/managedresources/registry_test.go
+++ b/pkg/utils/managedresources/registry_test.go
@@ -16,6 +16,7 @@ package managedresources_test
 
 import (
 	. "github.com/gardener/gardener/pkg/utils/managedresources"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -128,7 +129,7 @@ roleRef:
 			Expect(registry.Add(secret)).To(Succeed())
 			Expect(registry.Add(roleBinding)).To(Succeed())
 
-			Expect(registry.RegisteredObjects()).To(Equal(map[string]runtime.Object{
+			Expect(registry.RegisteredObjects()).To(Equal(map[string]client.Object{
 				secretFilename:      secret,
 				roleBindingFilename: roleBinding,
 			}))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority normal

**What this PR does / why we need it**:

With `controller-runtime@v0.7` there are `client.Object` and `client.ObjectList` to distinguish between single API objects and object lists.
c-r has replaced their usage of `runtime.Object` (which is more generic) by those two interfaces to have a clearer func/interface contract of what implementations expect from passed objects.

I followed up on this and cleaned up our usage of `runtime.Object` as well and replaced it with `client.{Object,ObjectList}` wherever applicable.
Though, there are still a lot of `runtime.Object` usages left, e.g. in API and registry packages, which have to comply with other interfaces expecting `runtime.Object`. 
Also some of our helper funcs are generic and accept a single object as well as an object list, so for those cases `runtime.Object` is also still needed.
I think I cut it down to the bare minimum now.

I also cleaned up some unnecessary usages of `meta.Accessor` in favor of `client.Object` where it is helpful and makes code a bit slimmer.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3109

**Special notes for your reviewer**:
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
Some helper functions and interface types have been changed to accept `client.{Object,ObjectList}` instead of `runtime.Object` where applicable to have a clearer contract of what is expected from passed parameters.
```
