### PR TITLE
Add options for configuring leader election resource lock

### DIFF
--- a/extensions/pkg/controller/cmd/options_test.go
+++ b/extensions/pkg/controller/cmd/options_test.go
@@ -199,15 +199,17 @@ var _ = Describe("Options", func() {
 
 	Context("ManagerOptions", func() {
 		const (
-			name                    = "foo"
-			leaderElectionID        = "id"
-			leaderElectionNamespace = "namespace"
+			name                       = "foo"
+			leaderElectionResourceLock = "leases"
+			leaderElectionID           = "id"
+			leaderElectionNamespace    = "namespace"
 		)
 		command := test.NewCommandBuilder(name).
 			Flags(
-				test.BoolFlag(LeaderElectionFlag, true),
-				test.StringFlag(LeaderElectionIDFlag, leaderElectionID),
-				test.StringFlag(LeaderElectionNamespaceFlag, leaderElectionNamespace),
+				test.BoolFlag("leader-election", true),
+				test.StringFlag("leader-election-resource-lock", leaderElectionResourceLock),
+				test.StringFlag("leader-election-id", leaderElectionID),
+				test.StringFlag("leader-election-namespace", leaderElectionNamespace),
 			).
 			Command().
 			Slice()
@@ -221,9 +223,34 @@ var _ = Describe("Options", func() {
 
 				Expect(fs.Parse(command)).NotTo(HaveOccurred())
 				Expect(opts).To(Equal(ManagerOptions{
-					LeaderElection:          true,
-					LeaderElectionID:        leaderElectionID,
-					LeaderElectionNamespace: leaderElectionNamespace,
+					LeaderElection:             true,
+					LeaderElectionResourceLock: leaderElectionResourceLock,
+					LeaderElectionID:           leaderElectionID,
+					LeaderElectionNamespace:    leaderElectionNamespace,
+				}))
+			})
+
+			It("should default resource lock to configmapsleases", func() {
+				fs := pflag.NewFlagSet(name, pflag.ExitOnError)
+				opts := ManagerOptions{}
+
+				opts.AddFlags(fs)
+
+				Expect(fs.Parse(
+					test.NewCommandBuilder(name).
+						Flags(
+							test.BoolFlag("leader-election", true),
+							test.StringFlag("leader-election-id", leaderElectionID),
+							test.StringFlag("leader-election-namespace", leaderElectionNamespace),
+						).
+						Command().
+						Slice(),
+				)).NotTo(HaveOccurred())
+				Expect(opts).To(Equal(ManagerOptions{
+					LeaderElection:             true,
+					LeaderElectionResourceLock: "configmapsleases",
+					LeaderElectionID:           leaderElectionID,
+					LeaderElectionNamespace:    leaderElectionNamespace,
 				}))
 			})
 		})
@@ -250,9 +277,10 @@ var _ = Describe("Options", func() {
 				Expect(fs.Parse(command)).NotTo(HaveOccurred())
 				Expect(opts.Complete()).NotTo(HaveOccurred())
 				Expect(opts.Completed()).To(Equal(&ManagerConfig{
-					LeaderElection:          true,
-					LeaderElectionID:        leaderElectionID,
-					LeaderElectionNamespace: leaderElectionNamespace,
+					LeaderElection:             true,
+					LeaderElectionResourceLock: leaderElectionResourceLock,
+					LeaderElectionID:           leaderElectionID,
+					LeaderElectionNamespace:    leaderElectionNamespace,
 				}))
 			})
 		})
@@ -498,25 +526,28 @@ var _ = Describe("Options", func() {
 
 	Context("ManagerConfig", func() {
 		const (
-			leaderElectionID        = "id"
-			leaderElectionNamespace = "namespace"
+			leaderElectionResourceLock = "leases"
+			leaderElectionID           = "id"
+			leaderElectionNamespace    = "namespace"
 		)
 
 		Describe("#Apply", func() {
 			It("should apply the values to the given manager.Options", func() {
 				cfg := &ManagerConfig{
-					LeaderElection:          true,
-					LeaderElectionID:        leaderElectionID,
-					LeaderElectionNamespace: leaderElectionNamespace,
+					LeaderElection:             true,
+					LeaderElectionResourceLock: leaderElectionResourceLock,
+					LeaderElectionID:           leaderElectionID,
+					LeaderElectionNamespace:    leaderElectionNamespace,
 				}
 
 				opts := manager.Options{}
 				cfg.Apply(&opts)
 
 				Expect(opts).To(Equal(manager.Options{
-					LeaderElection:          true,
-					LeaderElectionID:        leaderElectionID,
-					LeaderElectionNamespace: leaderElectionNamespace,
+					LeaderElection:             true,
+					LeaderElectionResourceLock: leaderElectionResourceLock,
+					LeaderElectionID:           leaderElectionID,
+					LeaderElectionNamespace:    leaderElectionNamespace,
 				}))
 			})
 		})
@@ -524,14 +555,16 @@ var _ = Describe("Options", func() {
 		Describe("#Options", func() {
 			It("should return manager.Options with the given values set", func() {
 				cfg := &ManagerConfig{
-					LeaderElection:          true,
-					LeaderElectionID:        leaderElectionID,
-					LeaderElectionNamespace: leaderElectionNamespace,
+					LeaderElection:             true,
+					LeaderElectionResourceLock: leaderElectionResourceLock,
+					LeaderElectionID:           leaderElectionID,
+					LeaderElectionNamespace:    leaderElectionNamespace,
 				}
 
 				opts := cfg.Options()
 
 				Expect(opts.LeaderElection).To(BeTrue())
+				Expect(opts.LeaderElectionResourceLock).To(Equal(leaderElectionResourceLock))
 				Expect(opts.LeaderElectionID).To(Equal(leaderElectionID))
 				Expect(opts.LeaderElectionNamespace).To(Equal(leaderElectionNamespace))
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:

This PR adds a flag / option to the extensions lib to specify the leader election resource lock (currently defaulted to `configmapsleases` just like in `c-r@v0.7.0`).

From the doc string:

> When changing the default resource lock, please make sure to migrate via multilocks to
avoid situations where multiple running instances of your controller have each acquired leadership
through different resource locks (e.g. during upgrades) and thus act on the same resources concurrently.
For example, if you want to migrate to the "leases" resource lock, you might do so by migrating
to the respective multilock first ("configmapsleases" or "endpointsleases"), which will acquire
a leader lock on both resources. After one release with the multilock as a default, you can
go ahead and migrate to "leases". Please also keep in mind, that users might skip versions
of your controller, so at least add a flashy release note when changing the default lock.
>
> Note: before controller-runtime version v0.7, the resource lock was set to "configmaps".
Please keep this in mind, when planning a proper migration path for your controller.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

As you can see in https://github.com/gardener/gardener-extension-provider-aws/pull/263, there isn't really anything to do for extensions to leverage the new option (at least for now). Extensions might decide to change the default resource lock later on after a couple of releases.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature dependency
The extensions library now allows to specify the leader election resource lock (currently defaulted to `configmapsleases`). Please read through the doc string of the respective field (`ManagerOptions.LeaderElectionResourceLock`) carefully before changing the default resource lock.
```
