### PR TITLE
Add MaintenanceWindow to the Loki hvpa

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/hvpa.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/hvpa.yaml
@@ -10,6 +10,10 @@ metadata:
 {{ toYaml .Values.labels | indent 4 }}
 spec:
   replicas: 1
+{{- if .Values.hvpa.maintenanceTimeWindow }}
+  maintenanceTimeWindow:
+{{ toYaml .Values.hvpa.maintenanceTimeWindow | indent 4 }}
+{{- end }}
   hpa:
     selector:
       matchLabels:
@@ -44,7 +48,11 @@ spec:
 {{- end }}
     scaleDown:
       updatePolicy:
+{{- if .Values.hvpa.maintenanceTimeWindow }}
+        updateMode: "MaintenanceWindow"
+{{- else }}
         updateMode: "Auto"
+{{- end }}
 {{- if .Values.hvpa.scaleDownStabilization }}
 {{ toYaml .Values.hvpa.scaleDownStabilization | indent 6 }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/loki/values.yaml
+++ b/charts/seed-bootstrap/charts/loki/values.yaml
@@ -50,7 +50,7 @@ resources:
     memory: 512Mi
   requests:
     cpu: 200m
-    memory: 64Mi
+    memory: 300Mi
 
 securityContext:
   fsGroup: 10001
@@ -70,7 +70,7 @@ hvpa:
     memory: 2G
   minAllowed:
     cpu: 200m
-    memory: 64M
+    memory: 300M
   targetAverageUtilizationCpu: 80
   targetAverageUtilizationMemory: 80
   scaleUpStabilization:
@@ -80,21 +80,21 @@ hvpa:
         value: "100m"
         percentage: 80
       memory:
-        value: 200M
+        value: 300M
         percentage: 80
   scaleDownStabilization:
-    stabilizationDuration: "15m"
+    stabilizationDuration: "2h"
     minChange:
       cpu:
-        value: "100m"
+        value: "200m"
         percentage: 80
       memory:
-        value: 200M
+        value: 500M
         percentage: 80
   limitsRequestsGapScaleParams:
     cpu:
       value: "300m"
       percentage: 40
     memory:
-      value: "400M"
+      value: "1000M"
       percentage: 40

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -383,9 +383,6 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 
 	if loggingEnabled {
 		lokiValues["authEnabled"] = false
-		lokiValues["hvpa"] = map[string]interface{}{
-			"enabled": hvpaEnabled,
-		}
 
 		lokiVpa := &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "loki-vpa", Namespace: v1beta1constants.GardenNamespace}}
 		if err := k8sSeedClient.Client().Delete(ctx, lokiVpa); client.IgnoreNotFound(err) != nil && !meta.IsNoMatchError(err) {
@@ -393,6 +390,26 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 		}
 
 		if hvpaEnabled {
+			shootInfo := &corev1.ConfigMap{}
+			maintenanceBegin := "220000-0000"
+			maintenanceEnd := "230000-0000"
+			if err := k8sSeedClient.Client().Get(ctx, kutil.Key(metav1.NamespaceSystem, "shoot-info"), shootInfo); err != nil {
+				if !apierrors.IsNotFound(err) {
+					return err
+				}
+			} else {
+				maintenanceBegin = shootInfo.Data["maintenanceBegin"]
+				maintenanceEnd = shootInfo.Data["maintenanceEnd"]
+			}
+
+			lokiValues["hvpa"] = map[string]interface{}{
+				"enabled": true,
+				"maintenanceTimeWindow": map[string]interface{}{
+					"begin": maintenanceBegin,
+					"end":   maintenanceEnd,
+				},
+			}
+
 			currentResources, err := common.GetContainerResourcesInStatefulSet(ctx, k8sSeedClient.Client(), kutil.Key(v1beta1constants.GardenNamespace, "loki"))
 			if err != nil {
 				return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Add MaintenanceTimeWindow for scale down to Loki's hvpa in `garden` namespace.
This will prevent Loki from frequently scale downs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@amshuman-kr @vlvasilev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
MaintenanceTimeWindow for scale-down is added to Loki's hvpa in garden namespace
```
