### PR TITLE
Add BackupBucketReady seed condition

### DIFF
--- a/docs/concepts/scheduler.md
+++ b/docs/concepts/scheduler.md
@@ -27,7 +27,7 @@ The following **sequence** describes the steps involved to determine a seed cand
 1. Determine usable seeds with "usable" defined as follows:
    * no `.metadata.deletionTimestamp`
    * `.spec.settings.scheduling.visible` is `true`
-   * conditions `Bootstrapped`, `GardenletReady` are `true`
+   * conditions `Bootstrapped`, `GardenletReady`, `BackupBucketReady` (if available) are `true`
 1. Filter seeds:
    * matching `.spec.seedSelector` in `CloudProfile` used by the `Shoot`
    * matching `.spec.seedSelector` in `Shoot`

--- a/docs/deployment/deploy_gardenlet_manually.md
+++ b/docs/deployment/deploy_gardenlet_manually.md
@@ -477,6 +477,14 @@ This helm chart creates:
         "reason": "BootstrappingSucceeded",
         "status": "True",
         "type": "Bootstrapped"
+      },
+      {
+        "lastTransitionTime": "2020-07-17T09:17:49Z",
+        "lastUpdateTime": "2020-07-17T09:53:17Z",
+        "message": "Backup Bucket has been reconciled successfully.",
+        "reason": "BackupBucketAvailable",
+        "status": "True",
+        "type": "BackupBucketReady"
       }
     ]
     ```

--- a/pkg/apis/core/types_seed.go
+++ b/pkg/apis/core/types_seed.go
@@ -275,6 +275,8 @@ const (
 	SeedExtensionsReady ConditionType = "ExtensionsReady"
 	// SeedGardenletReady is a constant for a condition type indicating that the Gardenlet is ready.
 	SeedGardenletReady ConditionType = "GardenletReady"
+	// SeedBackupBucketReady is a constant for a condition type indicating that the associated BackupBucket is ready.
+	SeedBackupBucketReady ConditionType = "BackupBucketReady"
 )
 
 // Resource constants for Gardener object types

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 )
 
@@ -1763,4 +1764,20 @@ var _ = Describe("helper", func() {
 		Entry("nginxIngress disabled", &gardencorev1beta1.Addons{NginxIngress: &gardencorev1beta1.NginxIngress{Addon: gardencorev1beta1.Addon{Enabled: false}}}, BeFalse()),
 		Entry("nginxIngress enabled", &gardencorev1beta1.Addons{NginxIngress: &gardencorev1beta1.NginxIngress{Addon: gardencorev1beta1.Addon{Enabled: true}}}, BeTrue()),
 	)
+
+	Describe("#ConstantConditionPatch", func() {
+		It("should calculate the correct patch", func() {
+			condition := gardencorev1beta1.Condition{
+				Type:   gardencorev1beta1.SeedGardenletReady,
+				Status: gardencorev1beta1.ConditionFalse,
+			}
+
+			expectedPatchData := []byte(`{"status":{"conditions":[{"type":"GardenletReady","status":"False","lastTransitionTime":null,"lastUpdateTime":null,"reason":"","message":""}]}}`)
+
+			patch, err := ConstantConditionPatch(condition)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(patch.Type()).To(Equal(apitypes.StrategicMergePatchType))
+			Expect(patch.Data(nil)).To(Equal(expectedPatchData))
+		})
+	})
 })

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -311,6 +311,8 @@ const (
 	SeedExtensionsReady ConditionType = "ExtensionsReady"
 	// SeedGardenletReady is a constant for a condition type indicating that the Gardenlet is ready.
 	SeedGardenletReady ConditionType = "GardenletReady"
+	// SeedBackupBucketReady is a constant for a condition type indicating that the associated BackupBucket is ready.
+	SeedBackupBucketReady ConditionType = "BackupBucketReady"
 )
 
 // Resource constants for Gardener object types

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -425,7 +425,7 @@ func deployBackupBucketInGarden(ctx context.Context, k8sGardenClient client.Clie
 		backupBucket.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 		backupBucket.Spec = gardencorev1beta1.BackupBucketSpec{
 			Provider: gardencorev1beta1.BackupBucketProvider{
-				Type:   string(seed.Spec.Backup.Provider),
+				Type:   seed.Spec.Backup.Provider,
 				Region: region,
 			},
 			ProviderConfig: seed.Spec.Backup.ProviderConfig,

--- a/pkg/registry/core/seed/storage/tableconvertor.go
+++ b/pkg/registry/core/seed/storage/tableconvertor.go
@@ -76,12 +76,14 @@ func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tabl
 
 		gardenletReadyCondition := helper.GetCondition(seed.Status.Conditions, core.SeedGardenletReady)
 		seedBootstrappedCondition := helper.GetCondition(seed.Status.Conditions, core.SeedBootstrapped)
+		backupbucketCondition := helper.GetCondition(seed.Status.Conditions, core.SeedBackupBucketReady)
 
 		cells = append(cells, seed.Name)
 		if gardenletReadyCondition != nil && gardenletReadyCondition.Status == core.ConditionUnknown {
 			cells = append(cells, "Unknown")
 		} else if (gardenletReadyCondition == nil || gardenletReadyCondition.Status != core.ConditionTrue) ||
-			(seedBootstrappedCondition == nil || seedBootstrappedCondition.Status != core.ConditionTrue) {
+			(seedBootstrappedCondition == nil || seedBootstrappedCondition.Status != core.ConditionTrue) ||
+			(backupbucketCondition != nil && backupbucketCondition.Status != core.ConditionTrue) {
 			cells = append(cells, "NotReady")
 		} else {
 			cells = append(cells, "Ready")

--- a/pkg/scheduler/controller/common/common_suite_test.go
+++ b/pkg/scheduler/controller/common/common_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommon(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Common Suite")
+}

--- a/pkg/scheduler/controller/common/seed.go
+++ b/pkg/scheduler/controller/common/seed.go
@@ -27,5 +27,14 @@ func VerifySeedReadiness(seed *gardencorev1beta1.Seed) bool {
 	if cond := gardencorev1beta1helper.GetCondition(seed.Status.Conditions, gardencorev1beta1.SeedGardenletReady); cond == nil || cond.Status != gardencorev1beta1.ConditionTrue {
 		return false
 	}
+
+	if seed.Spec.Backup != nil {
+		// Only consider condition if it's found because we haven't maintained it in previous releases.
+		// TODO: Handle this condition more conservatively in the future
+		if cond := gardencorev1beta1helper.GetCondition(seed.Status.Conditions, gardencorev1beta1.SeedBackupBucketReady); cond != nil && cond.Status != gardencorev1beta1.ConditionTrue {
+			return false
+		}
+	}
+
 	return true
 }

--- a/pkg/scheduler/controller/common/seed_test.go
+++ b/pkg/scheduler/controller/common/seed_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_test
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	. "github.com/gardener/gardener/pkg/scheduler/controller/common"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
+)
+
+var _ = Describe("#VerifySeedReadiness", func() {
+	var seed *gardencorev1beta1.Seed
+
+	DescribeTable("condition is false",
+		func(conditionType gardencorev1beta1.ConditionType, backup bool, expected gomegatypes.GomegaMatcher) {
+			var seedBackup *gardencorev1beta1.SeedBackup
+			if backup {
+				seedBackup = &gardencorev1beta1.SeedBackup{}
+			}
+			seed = &gardencorev1beta1.Seed{
+				Spec: gardencorev1beta1.SeedSpec{
+					Backup: seedBackup,
+				},
+				Status: gardencorev1beta1.SeedStatus{
+					Conditions: []gardencorev1beta1.Condition{
+						{Type: gardencorev1beta1.SeedBootstrapped, Status: gardencorev1beta1.ConditionTrue},
+						{Type: gardencorev1beta1.SeedGardenletReady, Status: gardencorev1beta1.ConditionTrue},
+						{Type: gardencorev1beta1.SeedBackupBucketReady, Status: gardencorev1beta1.ConditionTrue},
+						{Type: gardencorev1beta1.SeedExtensionsReady, Status: gardencorev1beta1.ConditionTrue},
+					},
+				},
+			}
+
+			for i, cond := range seed.Status.Conditions {
+				if cond.Type == conditionType {
+					seed.Status.Conditions[i].Status = gardencorev1beta1.ConditionFalse
+					break
+				}
+			}
+			Expect(VerifySeedReadiness(seed)).To(expected)
+		},
+		Entry("SeedBootstrapped is false", gardencorev1beta1.SeedBootstrapped, true, BeFalse()),
+		Entry("SeedGardenletReady is false", gardencorev1beta1.SeedGardenletReady, true, BeFalse()),
+		Entry("SeedBackupBucketReady is false", gardencorev1beta1.SeedBackupBucketReady, true, BeFalse()),
+		Entry("SeedBackupBucketReady is false but no backup specified", gardencorev1beta1.SeedBackupBucketReady, false, BeTrue()),
+		Entry("SeedExtensionsReady is false", gardencorev1beta1.SeedExtensionsReady, true, BeTrue()),
+	)
+
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR adds a new condition type `BackupBucketReady` to `seed.status.conditions` in case the seed specifies a backup configuration. Please refer to the linked issue for more details.

**Which issue(s) this PR fixes**:
Fixes #3428

/cc @amshuman-kr 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`Seed` resources now have a new condition type `BackupBucketReady` that is added when the corresponding seed has a backup configuration. `Seeds` whose `BackupBucketReady` condition is `status: "False"` are considered `NotReady` and thus are excluded from scheduling during that time.
```
