### PR TITLE
Enhance create Shoot test with Shoot status expectations

### DIFF
--- a/test/system/shoot_creation/create_test.go
+++ b/test/system/shoot_creation/create_test.go
@@ -28,11 +28,13 @@ package shoot_creation
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/gardener/gardener/test/framework"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 const (
@@ -54,7 +56,24 @@ var _ = Describe("Shoot Creation testing", func() {
 	})
 
 	f.CIt("Create and Reconcile Shoot", func(ctx context.Context) {
-		_, err := f.CreateShoot(ctx, true, true)
+		actual, err := f.CreateShoot(ctx, true, true)
 		framework.ExpectNoError(err)
+
+		// Verify Shoot status
+		var (
+			expectedTechnicalID           = fmt.Sprintf("shoot--%s--%s", f.GetShootFramework().Project.Name, actual.Name)
+			expectedClusterIdentityPrefix = fmt.Sprintf("%s-%s", actual.Status.TechnicalID, actual.Status.UID)
+		)
+
+		Expect(actual.Status.Gardener.ID).NotTo(BeEmpty())
+		Expect(actual.Status.Gardener.Name).NotTo(BeEmpty())
+		Expect(actual.Status.Gardener.Version).NotTo(BeEmpty())
+		Expect(actual.Status.LastErrors).To(BeEmpty())
+		Expect(actual.Status.SeedName).NotTo(BeNil())
+		Expect(*actual.Status.SeedName).NotTo(BeEmpty())
+		Expect(actual.Status.TechnicalID).To(Equal(expectedTechnicalID))
+		Expect(actual.Status.UID).NotTo(BeEmpty())
+		Expect(actual.Status.ClusterIdentity).NotTo(BeNil())
+		Expect(*actual.Status.ClusterIdentity).To(HavePrefix(expectedClusterIdentityPrefix))
 	}, CreateAndReconcileTimeout)
 })


### PR DESCRIPTION
/area testing
/kind enhancement

This PR adds expectations to the Shoot status in the create Shoot integration test to make sure that the fix for wrong `.status.clusterIdentity` in https://github.com/gardener/gardener/pull/3366 won't regress.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
