### PR TITLE
Wait for the out-of-tree mcm provider finalizer as well

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -317,6 +317,9 @@ const (
 	// mcmFinalizer is the finalizer used by the machine controller manager
 	// not imported from the MCM to reduce dependencies
 	mcmFinalizer = "machine.sapcloud.io/machine-controller-manager"
+	// mcmProviderFinalizer is the finalizer used by the out-of-tree machine controller provider
+	// not imported from the out-of-tree MCM provider to reduce dependencies
+	mcmProviderFinalizer = "machine.sapcloud.io/machine-controller"
 )
 
 // isMachineControllerStuck determines if the machine controller pod is stuck.

--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -255,7 +255,10 @@ func (a *genericActuator) waitUntilMachineResourcesDeleted(ctx context.Context, 
 					return retryutils.SevereError(fmt.Errorf("could not get the secret referenced by worker: %+v", err))
 				}
 
-				if controllerutil.ContainsFinalizer(secret, mcmFinalizer) {
+				// We need to check for both mcmFinalizer and mcmProviderFinalizer:
+				// - mcmFinalizer is the finalizer used by machine controller manager and its in-tree providers
+				// - mcmProviderFinalizer is the finalizer used by out-of-tree machine controller providers
+				if controllerutil.ContainsFinalizer(secret, mcmFinalizer) || controllerutil.ContainsFinalizer(secret, mcmProviderFinalizer) {
 					msg += "1 machine class credentials secret, "
 				} else {
 					releasedMachineClassCredentialsSecret = true


### PR DESCRIPTION
/kind bug

In https://github.com/gardener/gardener/pull/3425 we introduced a check that wait until the mcm finalizer is released from the cloudprovider Secret.
It seems that the finalizers used by in-tree MCM and out-of-tree MCM providers are different and we have to respect both of them.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing the generic Worker actuator to not wait until the finalizer of the out-of-tree machine controller provider is removed from the credentials secret is now fixed.
```
