### PR TITLE
Use `patch` to update Seed.Status

### DIFF
--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -382,14 +382,6 @@ func (c *defaultControl) updateSeedStatus(
 ) error {
 	seedCopy := seed.DeepCopy()
 
-	// remove "available condition"
-	for i, c := range seed.Status.Conditions {
-		if c.Type == "Available" {
-			seed.Status.Conditions = append(seed.Status.Conditions[:i], seed.Status.Conditions[i+1:]...)
-			break
-		}
-	}
-
 	seed.Status.Conditions = gardencorev1beta1helper.MergeConditions(seed.Status.Conditions, updateConditions...)
 	seed.Status.ObservedGeneration = seed.Generation
 	seed.Status.Gardener = c.identity


### PR DESCRIPTION
**How to categorize this PR?**
  /area quality
/kind enhancement
/priority normal

**What this PR does / why we need it**:

We were seeing log output when updating seed conditions like 
```
Operation cannot be fulfilled on seeds.<..> : the object has been modified; please apply your changes to the latest version and try again
```
which sometimes delayed the update or even needed a gardenlet restart to recover in some cases.

Before this change the seed status was updated using optimistic locking which could result in ongoing retries if different clients were updating the Seed object.

As an optimization we are now switching to a `patch` call which will send only the diff to the apiserver. We ensure that other conditions are not changed by:
a. only sending the actual diff (for example only the specific condition type that changed)
b. Requesting the strategy `StrategicMergePatchType` from the server.

The downside of this change is that if two clients try to update the same Condition type (or any other field in the status) it could happen due to no guaranteed ordering that the outdated update wins (as it arrives at server at a later point in time). We currently do not see this as an issue as one condition type is only updated by one controller and not multiple ones in parallel.

**Release note**:
```other operator
NONE
```