### PR TITLE
adding the to-private-networks networkpolicy to the dependency watchdog prober

### DIFF
--- a/charts/seed-bootstrap/charts/dependency-watchdog/templates/probe-deployment.yaml
+++ b/charts/seed-bootstrap/charts/dependency-watchdog/templates/probe-deployment.yaml
@@ -26,6 +26,7 @@ spec:
         networking.gardener.cloud/to-seed-apiserver: allowed
         networking.gardener.cloud/to-all-shoot-apiservers: allowed
         networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-private-networks: allowed
     spec:
       serviceAccountName: dependency-watchdog-probe
       terminationGracePeriodSeconds: 5


### PR DESCRIPTION
**How to categorize this PR?**
/area networking
/area security
/kind enhancement
/kind discussion
/priority normal

**What this PR does / why we need it**:
This enables the dependency watchdog prober to also check the internal load balancer CIDRs. This makes it possible to use internal loadbalancer for the kube-api servers of the shoot clusters.

**Which issue(s) this PR fixes**:
Fixes #3478 

**Special notes for your reviewer**:

**Release note**:
```feature operator
Enabling the usage of internal load balancers for the kube-api servers of the shoots.
```
