### PR TITLE
Clean-up ingress DNS Resources on Seed deletion

### DIFF
--- a/pkg/operation/seed/seed_test.go
+++ b/pkg/operation/seed/seed_test.go
@@ -16,30 +16,43 @@ package seed_test
 
 import (
 	"context"
+	"errors"
 
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	mockkubernetes "github.com/gardener/gardener/pkg/mock/gardener/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/common"
 	. "github.com/gardener/gardener/pkg/operation/seed"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("seed", func() {
 	var (
-		ctrl          *gomock.Controller
-		runtimeClient *mockclient.MockClient
+		ctx              context.Context
+		ctrl             *gomock.Controller
+		runtimeClient    *mockclient.MockClient
+		kubernetesClient *mockkubernetes.MockInterface
 	)
 
 	BeforeEach(func() {
+		ctx = context.TODO()
 		ctrl = gomock.NewController(GinkgoT())
 		runtimeClient = mockclient.NewMockClient(ctrl)
+		kubernetesClient = mockkubernetes.NewMockInterface(ctrl)
 	})
 
 	AfterEach(func() {
@@ -48,9 +61,9 @@ var _ = Describe("seed", func() {
 
 	Describe("#GetWildcardCertificate", func() {
 		It("should return no wildcard certificate secret", func() {
-			runtimeClient.EXPECT().List(context.TODO(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels{v1beta1constants.GardenRole: common.ControlPlaneWildcardCert})
+			runtimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels{v1beta1constants.GardenRole: common.ControlPlaneWildcardCert})
 
-			secret, err := GetWildcardCertificate(context.TODO(), runtimeClient)
+			secret, err := GetWildcardCertificate(ctx, runtimeClient)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(secret).To(BeNil())
@@ -62,13 +75,13 @@ var _ = Describe("seed", func() {
 					{},
 				},
 			}
-			runtimeClient.EXPECT().List(context.TODO(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels{v1beta1constants.GardenRole: common.ControlPlaneWildcardCert}).DoAndReturn(
+			runtimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels{v1beta1constants.GardenRole: common.ControlPlaneWildcardCert}).DoAndReturn(
 				func(_ context.Context, secrets *corev1.SecretList, _ client.ListOption, _ client.ListOption) error {
 					*secrets = *secretList
 					return nil
 				})
 
-			secret, err := GetWildcardCertificate(context.TODO(), runtimeClient)
+			secret, err := GetWildcardCertificate(ctx, runtimeClient)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*secret).To(Equal(secretList.Items[0]))
@@ -81,16 +94,126 @@ var _ = Describe("seed", func() {
 					{},
 				},
 			}
-			runtimeClient.EXPECT().List(context.TODO(), gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels{v1beta1constants.GardenRole: common.ControlPlaneWildcardCert}).DoAndReturn(
+			runtimeClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), client.InNamespace(v1beta1constants.GardenNamespace), client.MatchingLabels{v1beta1constants.GardenRole: common.ControlPlaneWildcardCert}).DoAndReturn(
 				func(_ context.Context, secrets *corev1.SecretList, _ client.ListOption, _ client.ListOption) error {
 					*secrets = *secretList
 					return nil
 				})
 
-			secret, err := GetWildcardCertificate(context.TODO(), runtimeClient)
+			secret, err := GetWildcardCertificate(ctx, runtimeClient)
 
 			Expect(err).To(HaveOccurred())
 			Expect(secret).To(BeNil())
+		})
+	})
+
+	Describe("#DeleteDNSProvider", func() {
+		var (
+			dnsProvider    *dnsv1alpha1.DNSProvider
+			providerSecret *corev1.Secret
+			fakeErr        error
+		)
+		BeforeEach(func() {
+			dnsProvider = &dnsv1alpha1.DNSProvider{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: v1beta1constants.GardenNamespace,
+					Name:      "seed",
+				},
+			}
+			providerSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: v1beta1constants.GardenNamespace,
+					Name:      "dnsprovider-seed",
+				},
+			}
+			kubernetesClient.EXPECT().Client().Return(runtimeClient)
+			fakeErr = errors.New("fake")
+		})
+
+		It("should delete DSNProvider and Secret", func() {
+			runtimeClient.EXPECT().Delete(ctx, dnsProvider).Return(nil)
+			runtimeClient.EXPECT().Delete(ctx, providerSecret).Return(nil)
+			err := DeleteDNSProvider(ctx, kubernetesClient.Client())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should propagate the error if deletion fails on dnsProvider", func() {
+			runtimeClient.EXPECT().Delete(ctx, dnsProvider).Return(fakeErr)
+			err := DeleteDNSProvider(ctx, kubernetesClient.Client())
+			Expect(err).To(Equal(fakeErr))
+		})
+		It("should propagate the error if deletion fails on providerSecret", func() {
+			runtimeClient.EXPECT().Delete(ctx, dnsProvider).Return(nil)
+			runtimeClient.EXPECT().Delete(ctx, providerSecret).Return(fakeErr)
+			err := DeleteDNSProvider(ctx, kubernetesClient.Client())
+			Expect(err).To(Equal(fakeErr))
+		})
+	})
+
+	Describe("#DeleteIngressDNSEntry", func() {
+		var (
+			chartApplier *mockkubernetes.MockChartApplier
+			seed         *Seed
+			entry        *dnsv1alpha1.DNSEntry
+		)
+		BeforeEach(func() {
+			seed = &Seed{Info: &gardencorev1beta1.Seed{ObjectMeta: metav1.ObjectMeta{Name: "fakeSeed"}}}
+			entry = &dnsv1alpha1.DNSEntry{ObjectMeta: metav1.ObjectMeta{Name: "ingress", Namespace: v1beta1constants.GardenNamespace}}
+			chartApplier = mockkubernetes.NewMockChartApplier(ctrl)
+			kubernetesClient.EXPECT().ChartApplier().Return(chartApplier)
+			kubernetesClient.EXPECT().Client().Return(runtimeClient)
+			logger.Logger = logger.NewNopLogger()
+		})
+
+		It("should delete the DNS Entry", func() {
+			runtimeClient.EXPECT().Delete(ctx, entry).Return(nil)
+			err := DeleteIngressDNSEntry(ctx, kubernetesClient, seed)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should propagate the error if deletion fails", func() {
+			fakeErr := errors.New("fake")
+			runtimeClient.EXPECT().Delete(ctx, entry).Return(fakeErr)
+			err := DeleteIngressDNSEntry(ctx, kubernetesClient, seed)
+			Expect(err).To(Equal(fakeErr))
+		})
+	})
+
+	Describe("#CopyDNSProviderSecretToSeed", func() {
+		var (
+			gardenRuntimeClient    *mockclient.MockClient
+			cloudProviderSecretKey = kutil.Key("cloudprovider-secret-ns", "cloudprovider-secret-name")
+			dnsProviderSecretKey   = kutil.Key(v1beta1constants.GardenNamespace, "dnsprovider-seed")
+		)
+		BeforeEach(func() {
+			gardenRuntimeClient = mockclient.NewMockClient(ctrl)
+		})
+
+		It("should copy the provided secret", func() {
+			gardenRuntimeClient.EXPECT().Get(ctx, cloudProviderSecretKey, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+				obj.Type = "someType"
+				obj.Data = map[string][]byte{"somedata": []byte{}}
+				return nil
+			})
+			runtimeClient.EXPECT().Get(ctx, dnsProviderSecretKey, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(nil)
+			runtimeClient.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+				secret, ok := obj.(*corev1.Secret)
+				Expect(ok).To(BeTrue())
+				Expect(secret.Name).To(Equal(dnsProviderSecretKey.Name))
+				Expect(secret.Namespace).To(Equal(dnsProviderSecretKey.Namespace))
+				Expect(secret.Data).To(Equal(map[string][]byte{"somedata": []byte{}}))
+				Expect(secret.Type).To(Equal(corev1.SecretType("someType")))
+				return nil
+			})
+
+			err := CopyDNSProviderSecretToSeed(ctx, gardenRuntimeClient, runtimeClient, cloudProviderSecretKey)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should fail if the provider secret is not found", func() {
+			gardenRuntimeClient.EXPECT().Get(ctx, cloudProviderSecretKey, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(apierrors.NewNotFound(schema.GroupResource{Group: "baz", Resource: "bar"}, "foo"))
+			err := CopyDNSProviderSecretToSeed(ctx, gardenRuntimeClient, runtimeClient, cloudProviderSecretKey)
+			Expect(err).To(BeNotFoundError())
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
  /area control-plane
  /kind bug
/priority normal

**What this PR does / why we need it**:
Without this change Seeds which have turned on the managed Ingress controller feature will not properly be cleaned up on deletion.
With this change all created DNS ingress resources will be deleted on Seed deletion. This includes:
* DNSProvider
* ProviderSecret
* DNSEntry
* DNS ControllerInstallation

The Controllerinstallation might still not be cleaned up until https://github.com/gardener/gardener/issues/3495 is resolved.

**Release note**:

```bugfix operator
Fixes a bug on seed deletion which caused dns related resources not being cleaned-up if `seed.spec.ingress.kind` was set.
```
