### PR TITLE
Increase the LokiDown alert trigger period

### DIFF
--- a/charts/seed-bootstrap/aggregate-prometheus-rules-tests/loki.rules.test.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules-tests/loki.rules.test.yaml
@@ -12,7 +12,7 @@ tests:
   - series: 'up{app="loki"}'
     values: '0+0x30'
   alert_rule_test:
-  - eval_time: 15m
+  - eval_time: 30m
     alertname: LokiDown
     exp_alerts:
     - exp_labels:

--- a/charts/seed-bootstrap/aggregate-prometheus-rules/loki.rules.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules/loki.rules.yaml
@@ -3,7 +3,7 @@ groups:
   rules:
   - alert: LokiDown
     expr: absent(up{app="loki"} == 1)
-    for: 15m
+    for: 30m
     labels:
       service: logging
       severity: warning


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR increase the time after the LokiDown alert will be triggered.
Because of the slow detach/attach process some Loki instances are unable to get in running state for more than 15 minutes.
This triggers LokiDown alerts.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
LokiDown alert is triggered after Loki is not in running state for 30 minutes
```
