### PR TITLE
Update metrics-server to v0.4.2

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -123,7 +123,7 @@ images:
 - name: metrics-server
   sourceRepository: github.com/kubernetes-incubator/metrics-server
   repository: k8s.gcr.io/metrics-server/metrics-server
-  tag: v0.4.1
+  tag: v0.4.2
   targetVersion: ">= 1.11"
 - name: metrics-server
   sourceRepository: github.com/kubernetes-incubator/metrics-server


### PR DESCRIPTION

/area monitoring
/kind bug
/priority normal

Ref https://github.com/kubernetes-sigs/metrics-server/issues/671

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
metrics-server's version is updated from v0.4.1 to v0.4.2 to adopt upstream fix that was causing metrics-server to be unavailable for a while after rolling update of Nodes.
```
