### PR TITLE
Fix bug when debootstrapping Seed cluster

### DIFF
--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -858,9 +858,13 @@ func bootstrapComponents(c kubernetes.Interface, namespace string, imageVector i
 	}
 
 	// gardener-resource-manager
-	image, err := imageVector.FindImage(common.GardenerResourceManagerImageName, imagevector.RuntimeVersion(c.Version()), imagevector.TargetVersion(c.Version()))
-	if err != nil {
-		return nil, err
+	var grmImage string
+	if imageVector != nil {
+		image, err := imageVector.FindImage(common.GardenerResourceManagerImageName, imagevector.RuntimeVersion(c.Version()), imagevector.TargetVersion(c.Version()))
+		if err != nil {
+			return nil, err
+		}
+		grmImage = image.String()
 	}
 	cfg := resourcemanager.Values{
 		ConcurrentSyncs:  pointer.Int32Ptr(20),
@@ -869,7 +873,7 @@ func bootstrapComponents(c kubernetes.Interface, namespace string, imageVector i
 
 		SyncPeriod: utils.DurationPtr(time.Hour),
 	}
-	rm := resourcemanager.New(c.Client(), namespace, image.String(), 1, cfg)
+	rm := resourcemanager.New(c.Client(), namespace, grmImage, 1, cfg)
 	components = append(components, rm)
 
 	// cluster-autoscaler


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/priority critical

**What this PR does / why we need it**:

Without this change debootstraping a Seed cluster will fail. Introduced with https://github.com/gardener/gardener/pull/3445

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/3513

```other operator
NONE
```
