### PR TITLE
Scale down MCM deployment instead of deleting it during restore

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -29,6 +29,8 @@ import (
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	workercontroller "github.com/gardener/gardener/extensions/pkg/controller/worker"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	gardeneretry "github.com/gardener/gardener/pkg/utils/retry"
 )
 
@@ -65,13 +67,13 @@ func (a *genericActuator) Restore(ctx context.Context, worker *extensionsv1alpha
 
 	wantedMachineDeployments = removeWantedDeploymentWithoutState(wantedMachineDeployments)
 
-	// Delete the machine-controller-manager. During restoration MCM must not exist
-	if err := a.deleteMachineControllerManager(ctx, logger, worker); err != nil {
-		return errors.Wrap(err, "failed deleting machine-controller-manager")
+	// Scale the machine-controller-manager to 0. During restoration MCM must not be working
+	if err := a.scaleMachineControllerManager(ctx, logger, worker, 0); err != nil {
+		return errors.Wrap(err, "failed scale down machine-controller-manager")
 	}
 
-	if err := a.waitUntilMachineControllerManagerIsDeleted(ctx, logger, worker.Namespace); err != nil {
-		return errors.Wrap(err, "failed deleting machine-controller-manager")
+	if err := kubernetes.WaitUntilDeploymentScaledToDesiredReplicas(ctx, a.client, kutil.Key(worker.Namespace, McmDeploymentName), 0); err != nil && !apierrors.IsNotFound(err) {
+		return errors.Wrap(err, "deadline exceeded while scaling down machine-controller-manager")
 	}
 
 	// Do the actual restoration

--- a/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -125,7 +125,7 @@ func (a *genericActuator) waitUntilMachineControllerManagerIsDeleted(ctx context
 
 func (a *genericActuator) scaleMachineControllerManager(ctx context.Context, logger logr.Logger, worker *extensionsv1alpha1.Worker, replicas int32) error {
 	logger.Info("Scaling machine-controller-manager", "replicas", replicas)
-	return kubernetes.ScaleDeployment(ctx, a.client, kutil.Key(worker.Namespace, McmDeploymentName), replicas)
+	return client.IgnoreNotFound(kubernetes.ScaleDeployment(ctx, a.client, kutil.Key(worker.Namespace, McmDeploymentName), replicas))
 }
 
 func (a *genericActuator) applyMachineControllerManagerShootChart(ctx context.Context, workerDelegate WorkerDelegate, workerObj *extensionsv1alpha1.Worker, cluster *controller.Cluster) error {

--- a/pkg/client/kubernetes/scaling.go
+++ b/pkg/client/kubernetes/scaling.go
@@ -17,8 +17,10 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"time"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils/retry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -69,4 +71,29 @@ func scaleResource(ctx context.Context, c client.Client, obj client.Object, repl
 	// TODO: replace this with call to scale subresource once controller-runtime supports it
 	// see: https://github.com/kubernetes-sigs/controller-runtime/issues/172
 	return c.Patch(ctx, obj, client.RawPatch(types.MergePatchType, patch))
+}
+
+// WaitUntilDeploymentScaledToDesiredReplicas waits for the number of available replicas to be equal to the deployment's desired replicas count.
+func WaitUntilDeploymentScaledToDesiredReplicas(ctx context.Context, client client.Client, key types.NamespacedName, desiredReplicas int32) error {
+	return retry.UntilTimeout(ctx, 5*time.Second, 300*time.Second, func(ctx context.Context) (done bool, err error) {
+		deployment := &appsv1.Deployment{}
+		if err := client.Get(ctx, key, deployment); err != nil {
+			return retry.SevereError(err)
+		}
+
+		if deployment.Generation != deployment.Status.ObservedGeneration {
+			return retry.MinorError(fmt.Errorf("%q not observed at latest generation (%d/%d)", key.Name,
+				deployment.Status.ObservedGeneration, deployment.Generation))
+		}
+
+		if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != desiredReplicas {
+			return retry.SevereError(fmt.Errorf("waiting for deployment %q to scale failed. spec.replicas does not match the desired replicas", key.Name))
+		}
+
+		if deployment.Status.Replicas == desiredReplicas && deployment.Status.AvailableReplicas == desiredReplicas {
+			return retry.Ok()
+		}
+
+		return retry.MinorError(fmt.Errorf("deployment %q currently has '%d' replicas. Desired: %d", key.Name, deployment.Status.AvailableReplicas, desiredReplicas))
+	})
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
After the worker restore operation if the reconcile fails for some reason the restore will start again. The MCM then will exists and all resources will be deleted and recreated. This behaviour is not expected during migration as the machines should be preserved.  
Scaling down the MCM to '0' instead of deleting all resources should be sufficient enough to ensure that the restore is successful.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
