### PR TITLE
Fix conversion of SeedConfig in seed registration

### DIFF
--- a/pkg/gardenlet/controller/shoot/seed_registration_control.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	confighelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	configv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	bootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
@@ -55,7 +56,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -636,20 +636,9 @@ func deployGardenlet(ctx context.Context, gardenClient, seedClient, shootedSeedC
 	}
 
 	// convert config from internal version to v1alpha1 as Helm chart is based on v1alpha1
-	scheme := runtime.NewScheme()
-	if err := config.AddToScheme(scheme); err != nil {
-		return err
-	}
-	if err := configv1alpha1.AddToScheme(scheme); err != nil {
-		return err
-	}
-	external, err := scheme.ConvertToVersion(cfg, configv1alpha1.SchemeGroupVersion)
+	externalConfig, err := confighelper.ConvertGardenletConfigurationExternal(cfg)
 	if err != nil {
 		return err
-	}
-	externalConfig, ok := external.(*configv1alpha1.GardenletConfiguration)
-	if !ok {
-		return fmt.Errorf("error converting config to external version")
 	}
 
 	var secretRef *corev1.SecretReference

--- a/pkg/gardenlet/controller/shoot/seed_registration_control_test.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control_test.go
@@ -15,55 +15,129 @@
 package shoot
 
 import (
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
+	"context"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
-var _ = Describe("gardenletAnnotations", func() {
-	BeforeEach(func() {
-		gardenletfeatures.RegisterFeatureGates()
+var _ = Describe("Seed registration control", func() {
+	Describe("gardenletAnnotations", func() {
+		BeforeEach(func() {
+			gardenletfeatures.RegisterFeatureGates()
+		})
+
+		DescribeTable("with different values annotation", func(added bool, version string, SNIEnabled bool) {
+			Expect(gardenletfeatures.FeatureGate.SetFromMap(map[string]bool{"APIServerSNI": SNIEnabled})).NotTo(HaveOccurred())
+
+			s := &gardencorev1beta1.Shoot{
+				Status: gardencorev1beta1.ShootStatus{
+					Gardener: gardencorev1beta1.Gardener{
+						Version: version,
+					},
+				},
+			}
+
+			actualAnnotations := gardenletAnnotations(s)
+
+			if added {
+				Expect(actualAnnotations).To(HaveKeyWithValue("networking.gardener.cloud/seed-sni-enabled", "true"))
+				Expect(actualAnnotations).To(HaveLen(1))
+			} else {
+				Expect(actualAnnotations).To(BeEmpty())
+			}
+		},
+			Entry("should be added for SNIEnabled release 1.14.1", true, "1.14.1", true),
+			Entry("should be added for SNIEnabled pre-release 1.14", true, "1.14-dev", true),
+			Entry("should be added for SNIEnabled pre-release 1.14.0", true, "1.14.0-dev", true),
+			Entry("should be added for SNIEnabled release 1.13.3", true, "1.13.3", true),
+			Entry("should be added for SNIEnabled pre-release 1.13", true, "1.13-dev", true),
+			Entry("should be added for SNIEnabled pre-release 1.13.0", true, "1.13.0-dev", true),
+			Entry("should not be added for SNIEnabled release 1.12.8", false, "1.12.8", true),
+			Entry("should not be added for SNIEnabled unparsable version", false, "not a semver", true),
+
+			Entry("should not be added for SNIDisabled release 1.14.1", false, "1.14.1", false),
+			Entry("should not be added for SNIDisabled pre-release 1.14", false, "1.14-dev", false),
+			Entry("should not be added for SNIDisabled pre-release 1.14.0", false, "1.14.0-dev", false),
+			Entry("should not be added for SNIDisabled release 1.13.3", false, "1.13.3", false),
+			Entry("should not be added for SNIDisabled pre-release 1.13", false, "1.13-dev", false),
+			Entry("should not be added for SNIDisabled pre-release 1.13.0", false, "1.13.0-dev", false),
+			Entry("should not be added for SNIDisabled release 1.12.8", false, "1.12.8", false),
+			Entry("should not be added for SNIDisabled unparsable version", false, "not a semver", false),
+		)
 	})
 
-	DescribeTable("with different values annotation", func(added bool, version string, SNIEnabled bool) {
-		Expect(gardenletfeatures.FeatureGate.SetFromMap(map[string]bool{"APIServerSNI": SNIEnabled})).NotTo(HaveOccurred())
+	Describe("deployGardenlet", func() {
+		var (
+			ctx context.Context
 
-		s := &gardencorev1beta1.Shoot{
-			Status: gardencorev1beta1.ShootStatus{
-				Gardener: gardencorev1beta1.Gardener{
-					Version: version,
+			gardenClient, seedClient, shootClient kubernetes.Interface
+
+			ctrl             *gomock.Controller
+			mockGardenClient *mockclient.MockClient
+			mockShootClient  *mockclient.MockClient
+
+			gardenletConfig   *config.GardenletConfiguration
+			shootedSeedConfig *gardencorev1beta1helper.ShootedSeed
+			shoot             *gardencorev1beta1.Shoot
+		)
+
+		BeforeEach(func() {
+			ctx = context.TODO()
+
+			ctrl = gomock.NewController(GinkgoT())
+
+			mockGardenClient = mockclient.NewMockClient(ctrl)
+			gardenClient = fake.NewClientSetBuilder().WithClient(mockGardenClient).Build()
+
+			seedClient = fake.NewClientSetBuilder().Build()
+
+			mockShootClient = mockclient.NewMockClient(ctrl)
+			shootClient = fake.NewClientSetBuilder().WithClient(mockShootClient).Build()
+
+			gardenletConfig = &config.GardenletConfiguration{
+				SeedConfig: &config.SeedConfig{SeedTemplate: gardencore.SeedTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-seed"},
+				}},
+			}
+			shootedSeedConfig = &gardencorev1beta1helper.ShootedSeed{}
+			shoot = &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "garden", Name: "test-shoot"},
+				Spec: gardencorev1beta1.ShootSpec{
+					SecretBindingName: "test-secretbinding",
 				},
-			},
-		}
+			}
+		})
 
-		actualAnnotations := gardenletAnnotations(s)
+		AfterEach(func() {
+			ctrl.Finish()
+		})
 
-		if added {
-			Expect(actualAnnotations).To(HaveKeyWithValue("networking.gardener.cloud/seed-sni-enabled", "true"))
-			Expect(actualAnnotations).To(HaveLen(1))
-		} else {
-			Expect(actualAnnotations).To(BeEmpty())
-		}
-	},
-		Entry("should be added for SNIEnabled release 1.14.1", true, "1.14.1", true),
-		Entry("should be added for SNIEnabled pre-release 1.14", true, "1.14-dev", true),
-		Entry("should be added for SNIEnabled pre-release 1.14.0", true, "1.14.0-dev", true),
-		Entry("should be added for SNIEnabled release 1.13.3", true, "1.13.3", true),
-		Entry("should be added for SNIEnabled pre-release 1.13", true, "1.13-dev", true),
-		Entry("should be added for SNIEnabled pre-release 1.13.0", true, "1.13.0-dev", true),
-		Entry("should not be added for SNIEnabled release 1.12.8", false, "1.12.8", true),
-		Entry("should not be added for SNIEnabled unparsable version", false, "not a semver", true),
+		It("should successfully convert config", func() {
+			mockShootClient.EXPECT().Get(gomock.Any(), kutil.Key("garden", "gardenlet-kubeconfig"), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(nil)
+			mockGardenClient.EXPECT().Get(gomock.Any(), kutil.Key("garden", shoot.Spec.SecretBindingName), gomock.AssignableToTypeOf(&gardencorev1beta1.SecretBinding{})).
+				Return(apierrors.NewNotFound(schema.GroupResource{Group: "core.gardener.cloud", Resource: "secretbindings"}, shoot.Spec.SecretBindingName))
 
-		Entry("should not be added for SNIDisabled release 1.14.1", false, "1.14.1", false),
-		Entry("should not be added for SNIDisabled pre-release 1.14", false, "1.14-dev", false),
-		Entry("should not be added for SNIDisabled pre-release 1.14.0", false, "1.14.0-dev", false),
-		Entry("should not be added for SNIDisabled release 1.13.3", false, "1.13.3", false),
-		Entry("should not be added for SNIDisabled pre-release 1.13", false, "1.13-dev", false),
-		Entry("should not be added for SNIDisabled pre-release 1.13.0", false, "1.13.0-dev", false),
-		Entry("should not be added for SNIDisabled release 1.12.8", false, "1.12.8", false),
-		Entry("should not be added for SNIDisabled unparsable version", false, "not a semver", false),
-	)
+			err := deployGardenlet(ctx, gardenClient, seedClient, shootClient, shoot, shootedSeedConfig, nil, gardenletConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err).NotTo(MatchError(ContainSubstring("unknown conversion")))
+			Expect(err).To(MatchError(ContainSubstring("\"test-secretbinding\" not found")))
+		})
+	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/priority blocker

**What this PR does / why we need it**:

Fix a bug when converting the gardenlet config's SeedConfig in the seed registration controller, that was introduced by #3477.

**Which issue(s) this PR fixes**:
```text
time="2021-02-09T05:44:44Z" level=info msg="[SHOOTED SEED REGISTRATION] Deploying gardenlet into az which will register shoot as seed" shoot=garden/az
time="2021-02-09T05:44:44Z" level=error msg="Could not deploy Gardenlet into shoot \"az\": converting (core.SeedTemplate) to (v1beta1.SeedTemplate): unknown conversion" shoot=garden/az
time="2021-02-09T05:44:44Z" level=info msg="Error syncing Shooted Seeds Registration garden/az: converting (core.SeedTemplate) to (v1beta1.SeedTemplate): unknown conversion"
```

**Special notes for your reviewer**:
/invite @rfranzke @stoyanr 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
