### PR TITLE
[release-v1.16] Deploy Loki's PriorityClass into the integration test

### DIFF
--- a/test/integration/shoots/logging/seed_logging_stack.go
+++ b/test/integration/shoots/logging/seed_logging_stack.go
@@ -77,6 +77,7 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 	lokiServiceAccount := &corev1.ServiceAccount{}
 	lokiService := &corev1.Service{}
 	lokiConfMap := &corev1.ConfigMap{}
+	lokiPriorityClass := &schedulingv1.PriorityClass{}
 
 	framework.CBeforeEach(func(ctx context.Context) {
 		checkRequiredResources(ctx, f.SeedClient)
@@ -92,6 +93,7 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 		framework.ExpectNoError(f.SeedClient.Client().Get(ctx, types.NamespacedName{Namespace: v1beta1constants.GardenNamespace, Name: lokiName}, lokiServiceAccount))
 		framework.ExpectNoError(f.SeedClient.Client().Get(ctx, types.NamespacedName{Namespace: v1beta1constants.GardenNamespace, Name: lokiName}, lokiService))
 		framework.ExpectNoError(f.SeedClient.Client().Get(ctx, types.NamespacedName{Namespace: v1beta1constants.GardenNamespace, Name: lokiConfigMapName}, lokiConfMap))
+		framework.ExpectNoError(f.SeedClient.Client().Get(ctx, types.NamespacedName{Namespace: v1beta1constants.GardenNamespace, Name: lokiName}, lokiPriorityClass))
 	}, initializationTimeout)
 
 	f.Beta().Serial().CIt("should get container logs from loki for all namespaces", func(ctx context.Context) {
@@ -108,6 +110,7 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), lokiConfMap))
 		lokiService.Spec.ClusterIP = ""
 		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), lokiService))
+		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), lokiPriorityClass))
 		// Remove the Loki PVC as it is no needed for the test
 		lokiSts.Spec.VolumeClaimTemplates = nil
 		// Instead use an empty dir volume
@@ -231,6 +234,12 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 			fluentBitClusterRoleBinding,
 			fluentBitServiceAccount,
 			fluentBitPriorityClass,
+			lokiSts,
+			lokiServiceAccount,
+			lokiService,
+			lokiConfMap,
+			lokiPriorityClass,
+			clusterCRD,
 			gardenNamespace,
 		}
 		for _, object := range objectsToDelete {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug
/priority normal

**What this PR does / why we need it**:
Cherry pick of #3483 on release-v1.16.

#3483: Deploy Loki's PriorityClass in the logging integration test

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
