### PR TITLE
Remove the Affinity from the Loki StatefulSet only for int. tests

### DIFF
--- a/test/integration/shoots/logging/seed_logging_stack.go
+++ b/test/integration/shoots/logging/seed_logging_stack.go
@@ -139,6 +139,7 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 				lokiSts.Spec.Template.Spec.Containers[index].Resources = r
 			}
 		}
+		lokiSts.Spec.Template.Spec.Affinity = nil
 		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), lokiSts))
 
 		ginkgo.By("Wait until Loki StatefulSet is ready")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind test
/priority normal

**What this PR does / why we need it**:
By moving the garden/loki-0 pod into the etcd worker pool the  [Loki StatefulSet](https://github.com/gardener/gardener/blob/master/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml) received a affinity configuration by the [kupid](https://github.com/gardener/kupid). When logging integration test is run a seed is simulate on a shoot cluster, but the shoots don't have etcd worker pool and Loki can't be scale up. With this PR the affinity section is remove only for the integration tests.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
``` bugfix operator
The affinity section is removed from the Loki StatefulSet for the integration tests
```
