### PR TITLE
Fix conflicts when bootstrapping new seeds

### DIFF
--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -17,7 +17,6 @@ package seed
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -693,8 +692,10 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 			return err
 		}
 
+		seedCopy := seed.Info.DeepCopy()
 		seed.Info.Status.ClusterIdentity = &seedClusterIdentity
-		if err := k8sGardenClient.Client().Status().Update(ctx, seed.Info); err != nil {
+
+		if err := k8sGardenClient.Client().Status().Patch(ctx, seed.Info, client.MergeFrom(seedCopy)); err != nil {
 			return err
 		}
 	}
@@ -1194,8 +1195,10 @@ func migrateIngressClassForShootIngresses(ctx context.Context, gardenClient, see
 		}
 	}
 
+	seedCopy := seed.Info.DeepCopy()
 	metav1.SetMetaDataAnnotation(&seed.Info.ObjectMeta, annotationSeedIngressClass, newClass)
-	return gardenClient.Update(ctx, seed.Info)
+
+	return gardenClient.Patch(ctx, seed.Info, client.MergeFrom(seedCopy))
 }
 
 func switchIngressClass(ctx context.Context, seedClient client.Client, ingressKey types.NamespacedName, newClass string) error {
@@ -1215,10 +1218,6 @@ func copySecretFromGardenerToSeed(ctx context.Context, gardenClient, seedClient 
 	gardenSecret := &corev1.Secret{}
 	if err := gardenClient.Get(ctx, secretKey, gardenSecret); err != nil {
 		return err
-	}
-
-	if gardenSecret == nil {
-		return errors.New("error during seed bootstrap: secret referenced in dns.provider.SecretRef not found")
 	}
 
 	_, err := controllerutil.CreateOrUpdate(ctx, seedClient, targetSecret, func() error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/priority normal

**What this PR does / why we need it**:

Even after #3506, I still see some conflicts, when boostrapping new seeds.
This PR fixes two occurrences of those conflicts by replacing an `Update` call with `Patch`.

**Which issue(s) this PR fixes**:
```text
time="2021-02-09T10:46:43+01:00" level=error msg="Seed bootstrapping failed: Operation cannot be fulfilled on seeds.core.gardener.cloud \"seed-gcp\": the object has been modified; please apply your changes to the latest version and try again" seed=seed-gcp
```

**Special notes for your reviewer**:
Should probably be cherry-picked to `v1.15` and `v1.16`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
