### PR TITLE
[release-v1.16] Remove the Affinity from the Loki StatefulSet only for the intergrati…

### DIFF
--- a/test/integration/shoots/logging/seed_logging_stack.go
+++ b/test/integration/shoots/logging/seed_logging_stack.go
@@ -139,6 +139,7 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 				lokiSts.Spec.Template.Spec.Containers[index].Resources = r
 			}
 		}
+		lokiSts.Spec.Template.Spec.Affinity = nil
 		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), lokiSts))
 
 		ginkgo.By("Wait until Loki StatefulSet is ready")


### PR DESCRIPTION
…on test

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind test
/priority normal

**What this PR does / why we need it**:
This PR remove the affinity section from the Loki StatefulSet in case it is set.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The affinity section is removed from the Loki StatefulSet for the integration tests
```
