### PR TITLE
Add Loki curator

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -214,11 +214,15 @@ images:
 - name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.33.0"
+  tag: "v0.34.0"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki
   tag: "1.6.0"
+- name: loki-curator
+  sourceRepository: github.com/gardener/logging
+  repository: eu.gcr.io/gardener-project/gardener/loki-curator
+  tag: "v0.34.0"
 
 # VPA
 - name: vpa-admission-controller

--- a/charts/seed-bootstrap/aggregate-prometheus-rules-tests/fluent-bit.rules.test.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules-tests/fluent-bit.rules.test.yaml
@@ -96,25 +96,3 @@ tests:
           aws.
         summary: Errors in Fluent-bit GardenerLoki plugin
 
-- interval: 1m
-  external_labels:
-    seed: aws
-  input_series:
-  # FluentBitGardenerLokiPluginDoesNotSendLogs
-  - series: 'fluentbit_loki_gardener_forwarded_logs_total{pod="fluent-bit-test"}'
-    values: '1+1x3 4+0x30'
-  alert_rule_test:
-  - eval_time: 22m
-    alertname: FluentBitGardenerLokiPluginDoesNotSendLogs
-    exp_alerts:
-    - exp_labels:
-        pod: fluent-bit-test
-        service: logging
-        severity: warning
-        type: seed
-        visibility: operator
-      exp_annotations:
-        description: >
-          fluent-bit-test GardenerLoki plugin on seed: aws
-          does not send logs.
-        summary: Fluent-bit GardenerLoki plugin does not send logs

--- a/charts/seed-bootstrap/aggregate-prometheus-rules/fluent-bit.rules.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules/fluent-bit.rules.yaml
@@ -73,22 +73,4 @@ groups:
         description: >
           There are errors in the {{$labels.pod}} GardenerLoki plugin on seed:
           {{$externalLabels.seed}}.
-  
-    - alert: FluentBitGardenerLokiPluginDoesNotSendLogs
-      expr: |
-        sum by (pod) (
-          rate(
-            fluentbit_loki_gardener_forwarded_logs_total[4m]
-          )
-        ) == 0
-      for: 15m
-      labels:
-        severity: warning
-        service: logging
-        type: seed
-        visibility: operator
-      annotations:
-        summary: Fluent-bit GardenerLoki plugin does not send logs
-        description: >
-          {{$labels.pod}} GardenerLoki plugin on seed: {{$externalLabels.seed}}
-          does not send logs.
+

--- a/charts/seed-bootstrap/charts/loki/templates/hvpa.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/hvpa.yaml
@@ -74,6 +74,8 @@ spec:
               minAllowed:
                 memory: {{ .Values.hvpa.minAllowed.memory }}
                 cpu: "{{ .Values.hvpa.minAllowed.cpu }}"
+            - containerName: curator
+              mode: "Off"
   weightBasedScalingIntervals:
     - vpaWeight: 100
       startReplicaCount: {{ .Values.replicas }}

--- a/charts/seed-bootstrap/charts/loki/templates/loki-configmap.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/loki-configmap.yaml
@@ -44,3 +44,15 @@ data:
     table_manager:
       retention_deletes_enabled: true
       retention_period: 360h
+  curator.yaml: |-
+    LogLevel: info
+    DiskPath: /data/loki/chunks
+    TriggerInterval: 1h
+    InodeConfig:
+      MinFreePercentages: 10
+      TargetFreePercentages: 15
+      PageSizeForDeletionPercentages: 1
+    StorageConfig:
+      MinFreePercentages: 10
+      TargetFreePercentages: 15
+      PageSizeForDeletionPercentages: 1

--- a/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
@@ -46,7 +46,7 @@ spec:
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources.loki | nindent 12 }}
           securityContext:
             readOnlyRootFilesystem: true
           env:
@@ -57,6 +57,21 @@ spec:
             - name: JAEGER_AGENT_HOST
               value: "{{ .Values.tracing.jaegerAgentHost }}"
             {{- end }}
+        - name: curator
+          image: {{ index .Values.global.images "loki-curator" }}
+          args:
+            - "-config=/etc/loki/curator.yaml"
+          ports:
+          - name: metrics
+            containerPort: {{ .Values.curator.port }}
+            protocol: TCP
+          resources:
+            {{- toYaml .Values.resources.curator | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki
+            - name: loki
+              mountPath: "/data"
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
         - name: config

--- a/charts/seed-bootstrap/charts/loki/values.yaml
+++ b/charts/seed-bootstrap/charts/loki/values.yaml
@@ -1,6 +1,7 @@
 global:
   images:
     loki: image-repository:image-tag
+    loki-curator: image-repository:image-tag
   fluentbit:
     labels:
       gardener.cloud/role: logging
@@ -45,12 +46,20 @@ readinessProbe:
 replicas: 1
 
 resources:
-  limits:
-    cpu: 450m
-    memory: 512Mi
-  requests:
-    cpu: 200m
-    memory: 300Mi
+  loki:
+    limits:
+      cpu: 450m
+      memory: 512Mi
+    requests:
+      cpu: 200m
+      memory: 300Mi
+  curator:
+    limits:
+      cpu: 200m
+      memory: 200Mi
+    requests:
+      cpu: 10m
+      memory: 12Mi 
 
 securityContext:
   fsGroup: 10001
@@ -62,6 +71,8 @@ service:
   type: ClusterIP
   port: 3100
 
+curator:
+  port: 2718
 
 hvpa:
   enabled: false

--- a/charts/seed-bootstrap/dashboards/fluent-bit-dashboard.json
+++ b/charts/seed-bootstrap/dashboards/fluent-bit-dashboard.json
@@ -6,6 +6,7 @@
   "editable": true,
   "gnetId": 7752,
   "graphTooltip": 1,
+  "iteration": 1612884134921,
   "links": [],
   "panels": [
     {
@@ -64,7 +65,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(fluentbit_input_bytes_total[$__rate_interval])) by (pod, name)",
+          "expr": "sum(rate(fluentbit_input_bytes_total{pod=~\"$pod\"}[$__rate_interval])) by (pod, name)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -170,7 +171,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(fluentbit_output_proc_bytes_total[$__rate_interval])) by (pod, name)",
+          "expr": "sum(rate(fluentbit_output_proc_bytes_total{pod=~\"$pod\"}[$__rate_interval])) by (pod, name)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -199,6 +200,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:222",
           "format": "Bps",
           "label": null,
           "logBase": 1,
@@ -207,6 +209,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:223",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -274,7 +277,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(fluentbit_input_records_total[$__rate_interval])) by (pod, name)",
+          "expr": "sum(rate(fluentbit_input_records_total{pod=~\"$pod\"}[$__rate_interval])) by (pod, name)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -382,7 +385,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(fluentbit_output_proc_records_total[$__rate_interval])) by (pod, name)",
+          "expr": "sum(rate(fluentbit_output_proc_records_total{pod=~\"$pod\"}[$__rate_interval])) by (pod, name)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -411,6 +414,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:324",
           "format": "rps",
           "label": null,
           "logBase": 1,
@@ -419,6 +423,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:325",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -498,18 +503,24 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(fluentbit_loki_gardener_incoming_logs_total[$__rate_interval])) by (pod)",
+          "expr": "sum(rate(fluentbit_loki_gardener_incoming_logs_total{pod=~\"$pod\"}[$__rate_interval])) by (pod)",
           "instant": false,
           "interval": "",
-          "legendFormat": "Incoming Logs-{{pod}}",
+          "legendFormat": "Incoming logs-{{pod}}",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(fluentbit_loki_gardener_forwarded_logs_total[$__rate_interval])) by (pod)",
+          "expr": "sum(rate(fluentbit_loki_gardener_incoming_logs_with_endpoint_total{pod=~\"$pod\"}[$__rate_interval])) by (pod)",
           "instant": false,
           "interval": "",
-          "legendFormat": "Transferred to Promtail-{{pod}}",
+          "legendFormat": "Incoming logs with endpoint-{{pod}}",
           "refId": "B"
+        },
+        {
+          "expr": "sum(rate(fluentbit_loki_gardener_forwarded_logs_total{pod=~\"$pod\"}[$__rate_interval])) by (pod)",
+          "interval": "",
+          "legendFormat": "Transferred to Promtail-{{pod}}",
+          "refId": "C"
         }
       ],
       "thresholds": [],
@@ -605,33 +616,33 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(fluentbit_loki_gardener_dropped_logs_total[$__rate_interval])) by (pod)",
+          "expr": "sum(rate(fluentbit_loki_gardener_dropped_logs_total{pod=~\"$pod\"}[$__rate_interval])) by (pod)",
           "interval": "",
-          "legendFormat": "Dropped Logs-{{pod}}",
+          "legendFormat": "Dropped logs-{{pod}}",
           "refId": "C"
         },
         {
-          "expr": "sum(rate(prometheus_target_scrapes_sample_out_of_order_total[$__rate_interval])) by (pod)",
+          "expr": "sum(rate(prometheus_target_scrapes_sample_out_of_order_total{pod=~\"$pod\"}[$__rate_interval])) by (pod)",
           "interval": "",
-          "legendFormat": "OutOfOrder Logs-{{pod}}",
+          "legendFormat": "OutOfOrder logs-{{pod}}",
           "refId": "D"
         },
         {
-          "expr": "sum(rate(fluentbit_loki_gardener_logs_without_metadata_total[$__rate_interval])) by (pod)",
+          "expr": "sum(rate(fluentbit_loki_gardener_logs_without_metadata_total{pod=~\"$pod\"}[$__rate_interval])) by (pod)",
           "interval": "",
-          "legendFormat": "Missing Metadata-{{pod}}",
+          "legendFormat": "Missing metadata-{{pod}}",
           "refId": "E"
         },
         {
-          "expr": "sum(rate(fluentbit_loki_gardener_errors_total[$__rate_interval])) by (pod)",
+          "expr": "sum(rate(fluentbit_loki_gardener_errors_total{pod=~\"$pod\"}[$__rate_interval])) by (pod)",
           "interval": "",
           "legendFormat": "Errors-{{pod}}",
           "refId": "F"
         },
         {
-          "expr": "sum(rate(promtail_dropped_entries_total[$__rate_interval])) by (pod)",
+          "expr": "sum(rate(promtail_dropped_entries_total{pod=~\"$pod\"}[$__rate_interval])) by (pod)",
           "interval": "",
-          "legendFormat": "Promtail Dropped-{{pod}}",
+          "legendFormat": "Promtail dropped-{{pod}}",
           "refId": "G"
         }
       ],
@@ -705,8 +716,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 12,
+        "h": 5,
+        "w": 8,
         "x": 0,
         "y": 16
       },
@@ -721,7 +732,7 @@
       "pluginVersion": "7.2.1",
       "targets": [
         {
-          "expr": "sum(increase(fluentbit_loki_gardener_incoming_logs_total[$__rate_interval]) != 0) by (host)",
+          "expr": "sum(increase(fluentbit_loki_gardener_incoming_logs_total{pod=~\"$pod\"}[$__rate_interval]) != 0) by (host)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -731,7 +742,98 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "[Output Plugin] Incoming logs",
+      "title": "[Output Plugin] Incoming Logs",
+      "transformations": [
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "delta"
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Delta": "Total number of logs",
+              "Field": "Namespace",
+              "Last": "Dropped logs from last 1h",
+              "Mean": "Average number of incoming logs per hour",
+              "Total": ""
+            }
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Namespace": {
+                "aggregations": [],
+                "operation": "aggregate"
+              }
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": null,
+      "description": "Table which shows the total incoming logs with attached endpoint and are ready to be forwarded to the Promtail client",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "filterable": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "hideTimeOverride": true,
+      "id": 63,
+      "interval": "",
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "7.2.1",
+      "targets": [
+        {
+          "expr": "sum(increase(fluentbit_loki_gardener_incoming_logs_with_endpoint_total{pod=~\"$pod\"}[$__rate_interval])  != 0) by (host)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{host}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "[Output Plugin] Incoming Logs With Endpoint",
       "transformations": [
         {
           "id": "reduce",
@@ -796,9 +898,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 12,
+        "h": 5,
+        "w": 8,
+        "x": 16,
         "y": 16
       },
       "id": 49,
@@ -809,7 +911,7 @@
       "pluginVersion": "7.2.1",
       "targets": [
         {
-          "expr": "sum(increase(fluentbit_loki_gardener_forwarded_logs_total[$__rate_interval]) != 0) by (host)",
+          "expr": "sum(increase(fluentbit_loki_gardener_forwarded_logs_total{pod=~\"$pod\"}[$__rate_interval]) != 0) by (host)",
           "instant": false,
           "interval": "",
           "legendFormat": "{{host}}",
@@ -887,7 +989,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 22
+        "y": 21
       },
       "hideTimeOverride": true,
       "id": 58,
@@ -899,7 +1001,7 @@
       "pluginVersion": "7.2.1",
       "targets": [
         {
-          "expr": "sum(increase(promtail_dropped_entries_total[$__rate_interval]) != 0) by (host)",
+          "expr": "sum(increase(promtail_dropped_entries_total{pod=~\"$pod\"}[$__rate_interval]) != 0) by (host)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -966,7 +1068,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 22
+        "y": 21
       },
       "hideTimeOverride": true,
       "id": 53,
@@ -978,7 +1080,7 @@
       "pluginVersion": "7.2.1",
       "targets": [
         {
-          "expr": "sum(increase(fluentbit_loki_gardener_dropped_logs_total[$__rate_interval]) != 0) by (host)",
+          "expr": "sum(increase(fluentbit_loki_gardener_dropped_logs_total{pod=~\"$pod\"}[$__rate_interval]) != 0) by (host)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1042,7 +1144,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 28
+        "y": 27
       },
       "hideTimeOverride": true,
       "id": 52,
@@ -1053,7 +1155,7 @@
       "pluginVersion": "7.2.1",
       "targets": [
         {
-          "expr": "sum(increase(fluentbit_loki_gardener_logs_without_metadata_total[$__rate_interval]) != 0) by (host)",
+          "expr": "sum(increase(fluentbit_loki_gardener_logs_without_metadata_total{pod=~\"$pod\"}[$__rate_interval]) != 0) by (host)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1106,7 +1208,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 28
+        "y": 27
       },
       "hideTimeOverride": true,
       "id": 54,
@@ -1117,7 +1219,7 @@
       "pluginVersion": "7.2.1",
       "targets": [
         {
-          "expr": "sum(increase(fluentbit_loki_gardener_errors_total[$__rate_interval]) != 0) by (host)",
+          "expr": "sum(increase(fluentbit_loki_gardener_errors_total{pod=~\"$pod\"}[$__rate_interval]) != 0) by (host)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1146,10 +1248,42 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": "fluent-bit.+",
+        "current": {
+          "selected": true,
+          "tags": [],
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "prometheus",
+        "definition": "label_values(pod)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": "label_values(pod)",
+        "refresh": 1,
+        "regex": "fluent-bit.+",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -116,6 +116,7 @@ allowedMetrics:
   - fluentbit_loki_gardener_errors_total
   - fluentbit_loki_gardener_logs_without_metadata_total
   - fluentbit_loki_gardener_incoming_logs_total
+  - fluentbit_loki_gardener_incoming_logs_with_endpoint_total
   - fluentbit_loki_gardener_forwarded_logs_total
   - fluentbit_loki_gardener_dropped_logs_total
 

--- a/hack/.ci/set_dependency_version
+++ b/hack/.ci/set_dependency_version
@@ -108,7 +108,7 @@ elif name == 'vpn':
 elif name == 'external-dns-management':
     names = ['dns-controller-manager']
 elif name == 'logging':
-    names = ['fluent-bit-plugin-installer']
+    names = ['fluent-bit-plugin-installer', 'loki-curator']
 elif name == 'etcd-custom-image':
     names = ['etcd']
 else:

--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -35,6 +35,7 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 
 	images, err := b.InjectSeedSeedImages(map[string]interface{}{},
 		common.LokiImageName,
+		common.CuratorImageName,
 	)
 	if err != nil {
 		return err
@@ -59,8 +60,10 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		if len(currentResources) != 0 && currentResources[0] != nil {
-			lokiValues["resources"] = currentResources[0]
+		if len(currentResources) != 0 && currentResources["loki"] != nil {
+			lokiValues["resources"] = map[string]interface{}{
+				"loki": currentResources["loki"],
+			}
 		}
 	}
 

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -381,6 +381,9 @@ const (
 	// LokiImageName is the name of the Loki image used for logging
 	LokiImageName = "loki"
 
+	// CuratorImageName is the image of the curator responsible for Loki Disk
+	CuratorImageName = "loki-curator"
+
 	// FluentBitImageName is the image of Fluent-bit image
 	FluentBitImageName = "fluent-bit"
 

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -366,14 +366,14 @@ func DeleteSeedLoggingStack(ctx context.Context, k8sClient client.Client) error 
 }
 
 // GetContainerResourcesInStatefulSet  returns the containers resources in StatefulSet
-func GetContainerResourcesInStatefulSet(ctx context.Context, k8sClient client.Client, key client.ObjectKey) ([]*corev1.ResourceRequirements, error) {
+func GetContainerResourcesInStatefulSet(ctx context.Context, k8sClient client.Client, key client.ObjectKey) (map[string]*corev1.ResourceRequirements, error) {
 	statefulSet := &appsv1.StatefulSet{}
-	resourcesPerContainer := make([]*corev1.ResourceRequirements, 0)
+	resourcesPerContainer := make(map[string]*corev1.ResourceRequirements)
 	if err := k8sClient.Get(ctx, key, statefulSet); client.IgnoreNotFound(err) != nil {
 		return nil, err
 	} else if !apierrors.IsNotFound(err) {
 		for _, container := range statefulSet.Spec.Template.Spec.Containers {
-			resourcesPerContainer = append(resourcesPerContainer, container.Resources.DeepCopy())
+			resourcesPerContainer[container.Name] = container.Resources.DeepCopy()
 		}
 		return resourcesPerContainer, nil
 	}

--- a/pkg/operation/common/utils_test.go
+++ b/pkg/operation/common/utils_test.go
@@ -553,7 +553,7 @@ var _ = Describe("common", func() {
 
 			statefulSet.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:      "contaienr-1",
+					Name:      "container-1",
 					Resources: *expectedResources,
 				},
 			}
@@ -563,7 +563,7 @@ var _ = Describe("common", func() {
 			rr, err := GetContainerResourcesInStatefulSet(ctx, c, kutil.Key(testNamespace, testStatefulset))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rr).To(HaveLen(len(statefulSet.Spec.Template.Spec.Containers)))
-			Expect(rr[0]).To(Equal(expectedResources))
+			Expect(rr["container-1"]).To(Equal(expectedResources))
 		})
 
 		It("should return all container resources when statefulset contains two containers", func() {
@@ -587,8 +587,8 @@ var _ = Describe("common", func() {
 			rr, err := GetContainerResourcesInStatefulSet(ctx, c, kutil.Key(testNamespace, testStatefulset))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rr).To(HaveLen(len(statefulSet.Spec.Template.Spec.Containers)))
-			Expect(rr[0]).To(Equal(expectedResources))
-			Expect(rr[1]).To(Equal(expectedResources))
+			Expect(rr["container-1"]).To(Equal(expectedResources))
+			Expect(rr["container-2"]).To(Equal(expectedResources))
 		})
 
 		It("should return error if statefulSet is not found", func() {

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -307,6 +307,7 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 			common.AlpineImageName,
 			common.ConfigMapReloaderImageName,
 			common.LokiImageName,
+			common.CuratorImageName,
 			common.FluentBitImageName,
 			common.FluentBitPluginInstaller,
 			common.GardenerResourceManagerImageName,
@@ -416,8 +417,10 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 			if err != nil {
 				return err
 			}
-			if len(currentResources) != 0 && currentResources[0] != nil {
-				lokiValues["resources"] = currentResources[0]
+			if len(currentResources) != 0 && currentResources["loki"] != nil {
+				lokiValues["resources"] = map[string]interface{}{
+					"loki": currentResources["loki"],
+				}
 			}
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
1. Adds Loki curator which will ensure that Loki's Inodes and Storage limits are not reached.
2. Adds new fluent-bit metric `incoming_logs_with_endpoint_total` and includes it into the FluentBit dashboard
3. Removes the irrelevant  `FluentBitGardenerLokiPluginDoesNotSendLogs ` which does not show correct feedback.

**Which issue(s) this PR fixes**:
https://github.com/gardener/logging/issues/72

**Special notes for your reviewer**:
@vlvasilev @vpnachev @wyb1 @amshuman-kr 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`incoming_logs_with_endpoint_total` metric is added to count the number of logs with endpoints which are going to be forwarded to Promtail client.
```
```other operator
Loki curator will ensure that Loki's Inodes and Storage limits are not reached
```
