### PR TITLE
Enable replicasets collector

### DIFF
--- a/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - /kube-state-metrics
         - --port=8080
         - --telemetry-port=8081
-        - --collectors=deployments,pods,statefulsets,nodes,horizontalpodautoscalers
+        - --collectors=deployments,pods,statefulsets,nodes,horizontalpodautoscalers,replicasets
         ports:
         - name: metrics
           containerPort: 8080

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/deployment.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - --telemetry-port=8081
         - --kubeconfig=/etc/kube-state-metrics/config/kubeconfig
         - --namespace=kube-system
-        - --collectors=daemonsets,deployments,nodes,pods,statefulsets,verticalpodautoscalers
+        - --collectors=daemonsets,deployments,nodes,pods,statefulsets,verticalpodautoscalers,replicasets
         volumeMounts:
         - name: kubeconfig
           mountPath: /etc/kube-state-metrics/config


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug
/priority critical

**What this PR does / why we need it**:

Enable replicasets collector in both ksm-seed and ksm-shoot.
Was missing in https://github.com/gardener/gardener/pull/3503

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
