### PR TITLE
Migrate default resource lock to configmapsleases

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-system.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-system.yaml
@@ -191,6 +191,22 @@ rules:
     - list
     - watch
     - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - gardener-scheduler-leader-election
+  verbs:
+  - get
+  - watch
+  - update
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -377,7 +377,7 @@ global:
         leaseDuration: 15s
         renewDeadline: 10s
         retryPeriod: 2s
-        resourceLock: configmaps
+        resourceLock: configmapsleases
       logLevel: info
       kubernetesLogLevel: 0
       server:
@@ -430,7 +430,7 @@ global:
         leaseDuration: 15s
         renewDeadline: 10s
         retryPeriod: 2s
-        resourceLock: configmaps
+        resourceLock: configmapsleases
       logLevel: info
       server:
         http:

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -108,7 +108,7 @@ global:
         leaseDuration: 15s
         renewDeadline: 10s
         retryPeriod: 2s
-        resourceLock: configmaps
+        resourceLock: configmapsleases
       logLevel: info
       kubernetesLogLevel: 0
       server:

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -48,7 +48,7 @@ leaderElection:
   leaseDuration: 15s
   renewDeadline: 10s
   retryPeriod: 2s
-  resourceLock: configmaps
+  resourceLock: configmapsleases
 logLevel: info
 kubernetesLogLevel: 0
 server:

--- a/example/20-componentconfig-gardener-scheduler.yaml
+++ b/example/20-componentconfig-gardener-scheduler.yaml
@@ -9,7 +9,7 @@ leaderElection:
   leaseDuration: 15s
   renewDeadline: 10s
   retryPeriod: 2s
-  resourceLock: configmaps
+  resourceLock: configmapsleases
 logLevel: info
 server:
   http:

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -69,7 +69,7 @@ leaderElection:
   leaseDuration: 15s
   renewDeadline: 10s
   retryPeriod: 2s
-  resourceLock: configmaps
+  resourceLock: configmapsleases
 logLevel: info
 kubernetesLogLevel: 0
 server:

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -139,9 +139,14 @@ func SetDefaults_ClientConnectionConfiguration(obj *componentbaseconfigv1alpha1.
 
 // SetDefaults_LeaderElectionConfiguration sets defaults for the leader election of the Gardener controller manager.
 func SetDefaults_LeaderElectionConfiguration(obj *LeaderElectionConfiguration) {
-	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&obj.LeaderElectionConfiguration)
+	if obj.ResourceLock == "" {
+		// TODO: change default to leases after a few releases
+		// make sure, we had configmapsleases as default for a few releases before migrating to leases to ensure,
+		// all users had at least one version running with the hybrid lock to avoid split-brain scenarios when migrating.
+		obj.ResourceLock = resourcelock.ConfigMapsLeasesResourceLock
+	}
 
-	obj.ResourceLock = resourcelock.ConfigMapsResourceLock
+	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&obj.LeaderElectionConfiguration)
 
 	if len(obj.LockObjectNamespace) == 0 {
 		obj.LockObjectNamespace = ControllerManagerDefaultLockObjectNamespace

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -121,9 +121,14 @@ func SetDefaults_ClientConnectionConfiguration(obj *componentbaseconfigv1alpha1.
 
 // SetDefaults_LeaderElectionConfiguration sets defaults for the leader election of the gardenlet.
 func SetDefaults_LeaderElectionConfiguration(obj *LeaderElectionConfiguration) {
-	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&obj.LeaderElectionConfiguration)
+	if obj.ResourceLock == "" {
+		// TODO: change default to leases after a few releases
+		// make sure, we had configmapsleases as default for a few releases before migrating to leases to ensure,
+		// all users had at least one version running with the hybrid lock to avoid split-brain scenarios when migrating.
+		obj.ResourceLock = resourcelock.ConfigMapsLeasesResourceLock
+	}
 
-	obj.ResourceLock = resourcelock.ConfigMapsResourceLock
+	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&obj.LeaderElectionConfiguration)
 
 	if obj.LockObjectNamespace == nil {
 		v := GardenletDefaultLockObjectNamespace

--- a/pkg/scheduler/apis/config/v1alpha1/defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults.go
@@ -80,9 +80,14 @@ func SetDefaults_ClientConnectionConfiguration(obj *componentbaseconfigv1alpha1.
 
 // SetDefaults_LeaderElectionConfiguration sets defaults for the leader election of the Gardener controller manager.
 func SetDefaults_LeaderElectionConfiguration(obj *LeaderElectionConfiguration) {
-	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&obj.LeaderElectionConfiguration)
+	if obj.ResourceLock == "" {
+		// TODO: change default to leases after a few releases
+		// make sure, we had configmapsleases as default for a few releases before migrating to leases to ensure,
+		// all users had at least one version running with the hybrid lock to avoid split-brain scenarios when migrating.
+		obj.ResourceLock = resourcelock.ConfigMapsLeasesResourceLock
+	}
 
-	obj.ResourceLock = resourcelock.ConfigMapsResourceLock
+	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&obj.LeaderElectionConfiguration)
 
 	if len(obj.LockObjectNamespace) == 0 {
 		obj.LockObjectNamespace = SchedulerDefaultLockObjectNamespace


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:

This PR migrates the default leader election resource lock of all gardener components to `configmapsleases`.
This is a preparation to eventually migrate to `leases` after a few releases.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The default leader election resource lock of `gardener-controller-manager`, `gardener-scheduler` and `gardenlet` has been changed to `configmapsleases`. This is a preparation to eventually migrate to `leases` after a few releases. Please make sure, that the components have permissions to create, get, watch and update `leases.coordination.k8s.io` in the respective clusters.
```
