### PR TITLE
Deploy GRM after KCM to prevent edge case in cluster deletion

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -333,7 +333,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployGardenerResourceManager = g.Add(flow.Task{
 			Name:         "Deploying gardener-resource-manager",
 			Fn:           flow.TaskFn(botanist.DeployGardenerResourceManager).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(initializeShootClients),
+			Dependencies: flow.NewTaskIDs(initializeShootClients, deployKubeControllerManager),
 		})
 		deployNetwork = g.Add(flow.Task{
 			Name:         "Deploying shoot network plugin",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality

/priority normal

**What this PR does / why we need it**:

In the past, we have seen edge cases when the Shoot deletion failed when
 - the Shoot was deleted during initial creation
 - no KCM was deployed yet
 - Resource Manager is already deployed and **already created e.g CSI Deamonset in the Shoot**. This is problematic, because it needs the KCM to clean up those resources during the deletion of the ControlPlane CRD.

This causes problems during the deletion flow when waiting for the ControlPlane CRD to be reconciled.

```
description: 'Flow "Shoot cluster deletion" encountered task errors: [task "Waiting
  until Shoot control plane has been reconciled" failed: Error while waiting for ControlPlane
  <> to become ready: extension encountered error
  during reconciliation: Error deleting controlplane: error while waiting for managed
  resource containing shoot chart for controlplane ''<>''
  to be deleted: retry failed with context deadline exceeded, last error: resource
  <>/extension-controlplane-shoot still exists]'
```

ManagedResource extension-controlplane-shoot still exists because there is no kcm pod that could take care of cleaning it up.

```
kg managedresources extension-controlplane-shoot -oyaml
...
status
  conditions:
  - lastTransitionTime: "2021-01-25T12:53:04Z"
    lastUpdateTime: "2021-01-25T12:53:08Z"
    message: 'Could not clean all old resources: 1 error occurred: deletion of old
      resource "apps/v1/DaemonSet/kube-system/csi-driver-node" is still pending'
    reason: DeletionPending
    status: Progressing
    type: ResourcesApplied
```

I propose as a solution to this problem to **make sure the Gardener Resource Manager is deployed after the  KCM**.
This way there is never a Gardener Resource Manager deployed without a KCM. So we cannot end up with resources in the Shoot that cannot be cleaned.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

I do understand why the described state is a problem, but I do not 100 % understand HOW this could happen.
I tried to reproduce a missing KCM deployment, but was unsuccessful. 
If someone has an idea, please let me know.

However, I think this change can improve the situation. If you think we should first be able to reproduce the issue then I would be grateful for some ideas.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Deploy the Gardener Resource Manager after the  KCM to prevent edge case during cluster deletion.
```
