### PR TITLE
Removing the finalizers from the Terraform config resources during cleanup

### DIFF
--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -112,6 +112,7 @@ type Terraformer interface {
 	GetState(ctx context.Context) ([]byte, error)
 	IsStateEmpty(ctx context.Context) bool
 	CleanupConfiguration(ctx context.Context) error
+	RemoveTerraformerFinalizerFromConfig(ctx context.Context) error
 	GetStateOutputVariables(ctx context.Context, variables ...string) (map[string]string, error)
 	ConfigExists(ctx context.Context) (bool, error)
 	NumberOfResources(ctx context.Context) (int, error)

--- a/pkg/mock/gardener/extensions/terraformer/mocks.go
+++ b/pkg/mock/gardener/extensions/terraformer/mocks.go
@@ -206,6 +206,20 @@ func (mr *MockTerraformerMockRecorder) NumberOfResources(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NumberOfResources", reflect.TypeOf((*MockTerraformer)(nil).NumberOfResources), arg0)
 }
 
+// RemoveTerraformerFinalizerFromConfig mocks base method.
+func (m *MockTerraformer) RemoveTerraformerFinalizerFromConfig(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveTerraformerFinalizerFromConfig", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveTerraformerFinalizerFromConfig indicates an expected call of RemoveTerraformerFinalizerFromConfig.
+func (mr *MockTerraformerMockRecorder) RemoveTerraformerFinalizerFromConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTerraformerFinalizerFromConfig", reflect.TypeOf((*MockTerraformer)(nil).RemoveTerraformerFinalizerFromConfig), arg0)
+}
+
 // SetDeadlineCleaning mocks base method.
 func (m *MockTerraformer) SetDeadlineCleaning(arg0 time.Duration) terraformer.Terraformer {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/area control-plane
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR fixes an issue that can be observed during CP migration. When `func CleanupConfiguration(...)` the finalizers of the ConfigMaps and Secrets are not removed and they can't be deleted.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy dependency
The `Terraformer` interface has now a new function `RemoveTerraformerFinalizerFromConfig` which will remove the "terraformer" finalizer from the `Secret`/`ConfigMap` resources.
```
