### PR TITLE
Fixing minor issues with th CP Migration integration tests

### DIFF
--- a/.test-defs/DeleteSeed.yaml
+++ b/.test-defs/DeleteSeed.yaml
@@ -1,6 +1,6 @@
 kind: TestDefinition
 metadata:
-  name: delete-shooted-seed
+  name: delete-seed
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the deletion of a shooted seed cluster.
@@ -12,7 +12,6 @@ spec:
     go test -timeout=0 -mod=vendor ./test/system/seed_deletion
     --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
     -seed-name=$SEED_NAME
-    -shoot-name=$SHOOT_NAME
     -project-namespace=$PROJECT_NAMESPACE
     -kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
   image: golang:1.15.3

--- a/.test-defs/MigrateShoot.yaml
+++ b/.test-defs/MigrateShoot.yaml
@@ -15,4 +15,5 @@ spec:
     -shoot-name=$SHOOT_NAME
     -shoot-namespace=$PROJECT_NAMESPACE
     -kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
+    -mr-exclude-list="$MR_EXCLUDE_LIST"
   image: golang:1.15.3

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -390,7 +390,7 @@ func (f *GardenerFramework) RemoveShootAnnotation(ctx context.Context, shoot *ga
 }
 
 // MigrateShoot changes the spec.Seed.Name of a shoot and waits for it to be migrated
-func (f *GardenerFramework) MigrateShoot(ctx context.Context, shoot *gardencorev1beta1.Shoot, seed *gardencorev1beta1.Seed) error {
+func (f *GardenerFramework) MigrateShoot(ctx context.Context, shoot *gardencorev1beta1.Shoot, seed *gardencorev1beta1.Seed, prerequisites func(shoot *gardencorev1beta1.Shoot) error) error {
 	if err := f.UpdateShoot(ctx, shoot, func(shoot *gardencorev1beta1.Shoot) error {
 		if err := f.GetShoot(ctx, shoot); err != nil {
 			return err
@@ -398,6 +398,12 @@ func (f *GardenerFramework) MigrateShoot(ctx context.Context, shoot *gardencorev
 
 		if _, _, err := f.GetSeed(ctx, seed.Name); err != nil {
 			return err
+		}
+
+		if prerequisites != nil {
+			if err := prerequisites(shoot); err != nil {
+				return err
+			}
 		}
 
 		shoot.Spec.SeedName = &seed.Name

--- a/test/system/shoot_cp_migration/migrate_test.go
+++ b/test/system/shoot_cp_migration/migrate_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strings"
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -48,6 +49,7 @@ var (
 	targetSeedName *string
 	shootName      *string
 	shootNamespace *string
+	mrExcludeList  *string
 	gardenerConfig *GardenerConfig
 )
 
@@ -56,6 +58,7 @@ func init() {
 	targetSeedName = flag.String("target-seed-name", "", "name of the seed to which the shoot will be migrated")
 	shootName = flag.String("shoot-name", "", "name of the shoot")
 	shootNamespace = flag.String("shoot-namespace", "", "namespace of the shoot")
+	mrExcludeList = flag.String("mr-exclude-list", "", "comma-separated values of the ManagedResources that will be exlude during the 'CreationTimestamp' check")
 }
 
 var _ = ginkgo.Describe("Shoot migration testing", func() {
@@ -220,7 +223,7 @@ func afterMigration(ctx context.Context, t *ShootMigrationTest, guestBookApp app
 	guestBookApp.Cleanup(ctx)
 
 	ginkgo.By("Checking timestamps of all resources...")
-	if err := t.CheckObjectsTimestamp(ctx); err != nil {
+	if err := t.CheckObjectsTimestamp(ctx, strings.Split(*mrExcludeList, ",")); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/area testing
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR introduces some minor improvements regarding the CP migration integration tests.
1. Fix the `DeleteSeed` test definition to match the `seed_deletion` integration test.
1. Add `prerequisites` function to the `MigrateShoot` function. This makes possible to make another changes to the shoot configuration before the migration is started. That way only one update is executed.
1. In the `CheckObjectsTimestamp(...)` function possibility to skip some resources is added as they may not be relevant to the test.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
