### PR TITLE
Fix promtool installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,8 @@ install-requirements:
 	@go install -mod=vendor github.com/ahmetb/gen-crd-api-reference-docs
 	@go install -mod=vendor github.com/golang/mock/mockgen
 	@go install -mod=vendor sigs.k8s.io/controller-tools/cmd/controller-gen
-	@GO111MODULE=off go get github.com/prometheus/prometheus/cmd/promtool
 	@GO111MODULE=off go get github.com/go-bindata/go-bindata/...
+	@./hack/install-promtool.sh
 	@./hack/install-requirements.sh
 
 .PHONY: revendor

--- a/hack/install-promtool.sh
+++ b/hack/install-promtool.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+echo "> Installing promtool"
+
+if which promtool &>/dev/null; then
+  echo "promtool is already installed, skipping the installation..."
+  exit 0
+fi
+
+platform=$(uname -s | tr '[:upper:]' '[:lower:]')
+version="2.24.1"
+archive_name="prometheus-${version}.${platform}-amd64"
+file_name="${archive_name}.tar.gz"
+
+temp_dir="$(mktemp -d)"
+function cleanup {
+  rm -rf "${temp_dir}"
+}
+trap cleanup EXIT ERR INT TERM
+
+curl \
+  -L \
+  --output ${temp_dir}/${file_name} \
+  "https://github.com/prometheus/prometheus/releases/download/v${version}/${file_name}"
+
+tar -xzm -C "${temp_dir}" -f "${temp_dir}/${file_name}"
+mv "${temp_dir}/${archive_name}/promtool" /usr/local/bin/
+chmod +x /usr/local/bin/promtool


### PR DESCRIPTION
/kind bug

Because of https://github.com/prometheus/client_golang/pull/828 the installation of promtool with `go get` (for unknown reasons 😞 ) fails with:
```
# github.com/prometheus/prometheus/cmd/promtool
../../prometheus/prometheus/cmd/promtool/main.go:645:35: not enough arguments in call to api.LabelValues
	have (context.Context, string, time.Time, time.Time)
	want (context.Context, string, []string, time.Time, time.Time)
make: *** [Makefile:139: install-requirements] Error 2
```

Ref https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-pull-request-job/builds/705

Many thanks to @vpnachev ❤️ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
