### PR TITLE
Remove finalizers from the worker secret in the migration flow

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
@@ -73,6 +73,10 @@ func (a *genericActuator) Migrate(ctx context.Context, worker *extensionsv1alpha
 		return errors.Wrap(err, "cleaning up machine class secrets failed")
 	}
 
+	if err := a.removeFinalizerFromWorkerSecretRef(ctx, logger, worker); err != nil {
+		return errors.Wrap(err, "unable to remove the finalizers from worker`s secret")
+	}
+
 	// Wait until all machine resources have been properly deleted.
 	if err := a.waitUntilMachineResourcesDeleted(ctx, logger, worker, workerDelegate); err != nil {
 		return gardencorev1beta1helper.DetermineError(err, fmt.Sprintf("Failed while waiting for all machine resources to be deleted: '%s'", err.Error()))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug
/priority normal

**What this PR does / why we need it**:
In the migration flow the MCM finalizer of the secret that is referenced by the worker is not removed. This PR adds functionality that checks that secret and removes only the MCM finalizers if necessary. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy dependency
In the generic worker actuator's migration flow, the MCM finalizer of the secret that is referenced by the `Worker` is not removed. We have now added functionality that checks that secret and removes only the MCM finalizers if necessary. 
```
