### PR TITLE
Use separate ManagedResource for ControlPlane CRDs that are installed in the Shoot cluster

### DIFF
--- a/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -80,10 +80,7 @@ var _ = Describe("Actuator", func() {
 		providerType      = "test"
 		webhookServerPort = 443
 
-		cp = &extensionsv1alpha1.ControlPlane{
-			ObjectMeta: metav1.ObjectMeta{Name: "control-plane", Namespace: namespace},
-			Spec:       extensionsv1alpha1.ControlPlaneSpec{},
-		}
+		cp         *extensionsv1alpha1.ControlPlane
 		cpExposure = &extensionsv1alpha1.ControlPlane{
 			ObjectMeta: metav1.ObjectMeta{Name: "control-plane-exposure", Namespace: namespace},
 			Spec: extensionsv1alpha1.ControlPlaneSpec{
@@ -145,8 +142,32 @@ var _ = Describe("Actuator", func() {
 		deletedMRSecretForCPShootChart = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: ControlPlaneShootChartResourceName, Namespace: namespace},
 		}
-		deleteMRForCPShootChart = &resourcesv1alpha1.ManagedResource{
+		deletedMRForCPShootChart = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{Name: ControlPlaneShootChartResourceName, Namespace: namespace},
+		}
+
+		resourceKeyCPShootCRDsChart        = client.ObjectKey{Namespace: namespace, Name: ControlPlaneShootCRDsChartResourceName}
+		createdMRSecretForCPShootCRDsChart = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: ControlPlaneShootCRDsChartResourceName, Namespace: namespace},
+			Data:       map[string][]byte{chartName: []byte(renderedContent)},
+			Type:       corev1.SecretTypeOpaque,
+		}
+		createdMRForCPShootCRDsChart = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{Name: ControlPlaneShootCRDsChartResourceName, Namespace: namespace},
+			Spec: resourcesv1alpha1.ManagedResourceSpec{
+				SecretRefs: []corev1.LocalObjectReference{
+					{Name: ControlPlaneShootCRDsChartResourceName},
+				},
+				InjectLabels:              map[string]string{extensionscontroller.ShootNoCleanupLabel: "true"},
+				KeepObjects:               pFalse,
+				ForceOverwriteAnnotations: pFalse,
+			},
+		}
+		deletedMRSecretForCPShootCRDsChart = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: ControlPlaneShootCRDsChartResourceName, Namespace: namespace},
+		}
+		deletedMRForCPShootCRDsChart = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{Name: ControlPlaneShootCRDsChartResourceName, Namespace: namespace},
 		}
 
 		resourceKeyStorageClassesChart        = client.ObjectKey{Namespace: namespace, Name: StorageClassesChartResourceName}
@@ -169,7 +190,7 @@ var _ = Describe("Actuator", func() {
 		deletedMRSecretForStorageClassesChart = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: StorageClassesChartResourceName, Namespace: namespace},
 		}
-		deleteMRForStorageClassesChart = &resourcesv1alpha1.ManagedResource{
+		deletedMRForStorageClassesChart = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{Name: StorageClassesChartResourceName, Namespace: namespace},
 		}
 
@@ -222,6 +243,10 @@ var _ = Describe("Actuator", func() {
 			"foo": "bar",
 		}
 
+		controlPlaneShootCRDsChartValues = map[string]interface{}{
+			"foo": "bar",
+		}
+
 		storageClassesChartValues = map[string]interface{}{
 			"foo": "bar",
 		}
@@ -236,6 +261,11 @@ var _ = Describe("Actuator", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
+
+		cp = &extensionsv1alpha1.ControlPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "control-plane", Namespace: namespace},
+			Spec:       extensionsv1alpha1.ControlPlaneSpec{},
+		}
 	})
 
 	AfterEach(func() {
@@ -243,7 +273,7 @@ var _ = Describe("Actuator", func() {
 	})
 
 	DescribeTable("#Reconcile",
-		func(configName string, checksums map[string]string, webhooks []admissionregistrationv1beta1.MutatingWebhook) {
+		func(configName string, checksums map[string]string, webhooks []admissionregistrationv1beta1.MutatingWebhook, withShootCRDsChart bool) {
 			// Create mock client
 			client := mockclient.NewMockClient(ctrl)
 
@@ -273,6 +303,13 @@ var _ = Describe("Actuator", func() {
 			client.EXPECT().Get(ctx, resourceKeyCPShootChart, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(errNotFound)
 			client.EXPECT().Create(ctx, createdMRForCPShootChart).Return(nil)
 
+			if withShootCRDsChart {
+				client.EXPECT().Get(ctx, resourceKeyCPShootCRDsChart, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(errNotFound)
+				client.EXPECT().Create(ctx, createdMRSecretForCPShootCRDsChart).Return(nil)
+				client.EXPECT().Get(ctx, resourceKeyCPShootCRDsChart, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(errNotFound)
+				client.EXPECT().Create(ctx, createdMRForCPShootCRDsChart).Return(nil)
+			}
+
 			client.EXPECT().Get(ctx, resourceKeyStorageClassesChart, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(errNotFound)
 			client.EXPECT().Create(ctx, createdMRSecretForStorageClassesChart).Return(nil)
 			client.EXPECT().Get(ctx, resourceKeyStorageClassesChart, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(errNotFound)
@@ -293,14 +330,20 @@ var _ = Describe("Actuator", func() {
 			secrets.EXPECT().Deploy(ctx, gomock.Any(), gardenerClientset, namespace).Return(deployedSecrets, nil)
 			var configChart chart.Interface
 			if configName != "" {
-				cc := mockchartutil.NewMockInterface(ctrl)
-				cc.EXPECT().Apply(ctx, chartApplier, namespace, nil, "", "", configChartValues).Return(nil)
-				configChart = cc
+				configChartMock := mockchartutil.NewMockInterface(ctrl)
+				configChartMock.EXPECT().Apply(ctx, chartApplier, namespace, nil, "", "", configChartValues).Return(nil)
+				configChart = configChartMock
 			}
 			ccmChart := mockchartutil.NewMockInterface(ctrl)
 			ccmChart.EXPECT().Apply(ctx, chartApplier, namespace, imageVector, seedVersion, shootVersion, controlPlaneChartValues).Return(nil)
 			ccmShootChart := mockchartutil.NewMockInterface(ctrl)
 			ccmShootChart.EXPECT().Render(chartRenderer, metav1.NamespaceSystem, imageVector, shootVersion, shootVersion, controlPlaneShootChartValues).Return(chartName, []byte(renderedContent), nil)
+			var cpShootCRDsChart chart.Interface
+			if withShootCRDsChart {
+				cpShootCRDsChartMock := mockchartutil.NewMockInterface(ctrl)
+				cpShootCRDsChartMock.EXPECT().Render(chartRenderer, metav1.NamespaceSystem, imageVector, shootVersion, shootVersion, controlPlaneShootCRDsChartValues).Return(chartName, []byte(renderedContent), nil)
+				cpShootCRDsChart = cpShootCRDsChartMock
+			}
 			storageClassesChart := mockchartutil.NewMockInterface(ctrl)
 			storageClassesChart.EXPECT().Render(chartRenderer, metav1.NamespaceSystem, imageVector, shootVersion, shootVersion, storageClassesChartValues).Return(chartName, []byte(renderedContent), nil)
 
@@ -311,10 +354,13 @@ var _ = Describe("Actuator", func() {
 			}
 			vp.EXPECT().GetControlPlaneChartValues(ctx, cp, cluster, checksums, false).Return(controlPlaneChartValues, nil)
 			vp.EXPECT().GetControlPlaneShootChartValues(ctx, cp, cluster, checksums).Return(controlPlaneShootChartValues, nil)
+			if withShootCRDsChart {
+				vp.EXPECT().GetControlPlaneShootCRDsChartValues(ctx, cp, cluster).Return(controlPlaneShootCRDsChartValues, nil)
+			}
 			vp.EXPECT().GetStorageClassesChartValues(ctx, cp, cluster).Return(storageClassesChartValues, nil)
 
 			// Create actuator
-			a := NewActuator(providerName, secrets, nil, configChart, ccmChart, ccmShootChart, storageClassesChart, nil, vp, crf, imageVector, configName, webhooks, webhookServerPort, logger)
+			a := NewActuator(providerName, secrets, nil, configChart, ccmChart, ccmShootChart, cpShootCRDsChart, storageClassesChart, nil, vp, crf, imageVector, configName, webhooks, webhookServerPort, logger)
 			err := a.(inject.Client).InjectClient(client)
 			Expect(err).NotTo(HaveOccurred())
 			a.(*actuator).gardenerClientset = gardenerClientset
@@ -325,33 +371,42 @@ var _ = Describe("Actuator", func() {
 			Expect(requeue).To(Equal(false))
 			Expect(err).NotTo(HaveOccurred())
 		},
-		Entry("should deploy secrets and apply charts with correct parameters", cloudProviderConfigName, checksums, []admissionregistrationv1beta1.MutatingWebhook{{}}),
-		Entry("should deploy secrets and apply charts with correct parameters (no config)", "", checksumsNoConfig, []admissionregistrationv1beta1.MutatingWebhook{{}}),
-		Entry("should deploy secrets and apply charts with correct parameters (no webhook)", cloudProviderConfigName, checksums, nil),
+		Entry("should deploy secrets and apply charts with correct parameters", cloudProviderConfigName, checksums, []admissionregistrationv1beta1.MutatingWebhook{{}}, true),
+		Entry("should deploy secrets and apply charts with correct parameters (no config)", "", checksumsNoConfig, []admissionregistrationv1beta1.MutatingWebhook{{}}, true),
+		Entry("should deploy secrets and apply charts with correct parameters (no webhook)", cloudProviderConfigName, checksums, nil, true),
+		Entry("should deploy secrets and apply charts with correct parameters (no shoot CRDs chart)", cloudProviderConfigName, checksums, []admissionregistrationv1beta1.MutatingWebhook{{}}, false),
 	)
 
 	DescribeTable("#Delete",
-		func(configName string, webhooks []admissionregistrationv1beta1.MutatingWebhook) {
+		func(configName string, webhooks []admissionregistrationv1beta1.MutatingWebhook, withShootCRDsChart bool) {
 			// Create mock clients
 			client := mockclient.NewMockClient(ctrl)
 
-			client.EXPECT().Delete(ctx, deleteMRForStorageClassesChart).Return(nil)
+			client.EXPECT().Delete(ctx, deletedMRForStorageClassesChart).Return(nil)
 			client.EXPECT().Delete(ctx, deletedMRSecretForStorageClassesChart).Return(nil)
+			var cpShootCRDsChart chart.Interface
+			if withShootCRDsChart {
+				cpShootCRDsChartMock := mockchartutil.NewMockInterface(ctrl)
+				cpShootCRDsChart = cpShootCRDsChartMock
+				client.EXPECT().Delete(ctx, deletedMRForCPShootCRDsChart).Return(nil)
+				client.EXPECT().Delete(ctx, deletedMRSecretForCPShootCRDsChart).Return(nil)
+				client.EXPECT().Get(gomock.Any(), resourceKeyCPShootCRDsChart, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, deletedMRForCPShootCRDsChart.Name))
+			}
 
-			client.EXPECT().Delete(ctx, deleteMRForCPShootChart).Return(nil)
+			client.EXPECT().Delete(ctx, deletedMRForCPShootChart).Return(nil)
 			client.EXPECT().Delete(ctx, deletedMRSecretForCPShootChart).Return(nil)
 
-			client.EXPECT().Get(gomock.Any(), resourceKeyStorageClassesChart, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, deleteMRForStorageClassesChart.Name))
-			client.EXPECT().Get(gomock.Any(), resourceKeyCPShootChart, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, deleteMRForCPShootChart.Name))
+			client.EXPECT().Get(gomock.Any(), resourceKeyStorageClassesChart, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, deletedMRForStorageClassesChart.Name))
+			client.EXPECT().Get(gomock.Any(), resourceKeyCPShootChart, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, deletedMRForCPShootChart.Name))
 
 			// Create mock secrets and charts
 			secrets := mocksecretsutil.NewMockInterface(ctrl)
 			secrets.EXPECT().Delete(ctx, gomock.Any(), namespace).Return(nil)
 			var configChart chart.Interface
 			if configName != "" {
-				cc := mockchartutil.NewMockInterface(ctrl)
-				cc.EXPECT().Delete(ctx, client, namespace).Return(nil)
-				configChart = cc
+				configChartMock := mockchartutil.NewMockInterface(ctrl)
+				configChartMock.EXPECT().Delete(ctx, client, namespace).Return(nil)
+				configChart = configChartMock
 			}
 			ccmChart := mockchartutil.NewMockInterface(ctrl)
 			ccmChart.EXPECT().Delete(ctx, client, namespace).Return(nil)
@@ -364,7 +419,7 @@ var _ = Describe("Actuator", func() {
 			}
 
 			// Create actuator
-			a := NewActuator(providerName, secrets, nil, configChart, ccmChart, nil, nil, nil, nil, nil, nil, configName, webhooks, webhookServerPort, logger)
+			a := NewActuator(providerName, secrets, nil, configChart, ccmChart, nil, cpShootCRDsChart, nil, nil, nil, nil, nil, configName, webhooks, webhookServerPort, logger)
 			err := a.(inject.Client).InjectClient(client)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -372,9 +427,10 @@ var _ = Describe("Actuator", func() {
 			err = a.Delete(ctx, cp, cluster)
 			Expect(err).NotTo(HaveOccurred())
 		},
-		Entry("should delete secrets and charts", cloudProviderConfigName, []admissionregistrationv1beta1.MutatingWebhook{{}}),
-		Entry("should delete secrets and charts (no config)", "", []admissionregistrationv1beta1.MutatingWebhook{{}}),
-		Entry("should delete secrets and charts (no webhook)", cloudProviderConfigName, nil),
+		Entry("should delete secrets and charts", cloudProviderConfigName, []admissionregistrationv1beta1.MutatingWebhook{{}}, true),
+		Entry("should delete secrets and charts (no config)", "", []admissionregistrationv1beta1.MutatingWebhook{{}}, true),
+		Entry("should delete secrets and charts (no webhook)", cloudProviderConfigName, nil, true),
+		Entry("should delete secrets and charts (no shoot CRDs chart)", cloudProviderConfigName, []admissionregistrationv1beta1.MutatingWebhook{{}}, false),
 	)
 
 	DescribeTable("#ReconcileExposure",
@@ -395,7 +451,7 @@ var _ = Describe("Actuator", func() {
 			vp.EXPECT().GetControlPlaneExposureChartValues(ctx, cpExposure, cluster, exposureChecksums).Return(controlPlaneExposureChartValues, nil)
 
 			// Create actuator
-			a := NewActuator(providerName, nil, exposureSecrets, nil, nil, nil, nil, cpExposureChart, vp, nil, imageVector, "", nil, 0, logger)
+			a := NewActuator(providerName, nil, exposureSecrets, nil, nil, nil, nil, nil, cpExposureChart, vp, nil, imageVector, "", nil, 0, logger)
 			a.(*actuator).gardenerClientset = gardenerClientset
 			a.(*actuator).chartApplier = chartApplier
 
@@ -420,7 +476,7 @@ var _ = Describe("Actuator", func() {
 			cpExposureChart.EXPECT().Delete(ctx, client, namespace).Return(nil)
 
 			// Create actuator
-			a := NewActuator(providerName, nil, exposureSecrets, nil, nil, nil, nil, cpExposureChart, nil, nil, nil, "", nil, 0, logger)
+			a := NewActuator(providerName, nil, exposureSecrets, nil, nil, nil, nil, nil, cpExposureChart, nil, nil, nil, "", nil, 0, logger)
 			err := a.(inject.Client).InjectClient(client)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/extensions/pkg/controller/controlplane/genericactuator/mock/mocks.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/mock/mocks.go
@@ -81,6 +81,21 @@ func (mr *MockValuesProviderMockRecorder) GetControlPlaneExposureChartValues(arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControlPlaneExposureChartValues", reflect.TypeOf((*MockValuesProvider)(nil).GetControlPlaneExposureChartValues), arg0, arg1, arg2, arg3)
 }
 
+// GetControlPlaneShootCRDsChartValues mocks base method.
+func (m *MockValuesProvider) GetControlPlaneShootCRDsChartValues(arg0 context.Context, arg1 *v1alpha1.ControlPlane, arg2 *extensions.Cluster) (map[string]interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetControlPlaneShootCRDsChartValues", arg0, arg1, arg2)
+	ret0, _ := ret[0].(map[string]interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetControlPlaneShootCRDsChartValues indicates an expected call of GetControlPlaneShootCRDsChartValues.
+func (mr *MockValuesProviderMockRecorder) GetControlPlaneShootCRDsChartValues(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControlPlaneShootCRDsChartValues", reflect.TypeOf((*MockValuesProvider)(nil).GetControlPlaneShootCRDsChartValues), arg0, arg1, arg2)
+}
+
 // GetControlPlaneShootChartValues mocks base method.
 func (m *MockValuesProvider) GetControlPlaneShootChartValues(arg0 context.Context, arg1 *v1alpha1.ControlPlane, arg2 *extensions.Cluster, arg3 map[string]string) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
/area ops-productivity
/kind bug

As described in https://github.com/gardener/gardener/issues/2227#issuecomment-682468386, currently `extensions/pkg/controller/controlplane/genericactuator.Actuator` uses one ManagedResource (named `extension-controlplane-shoot`) for the resources that are installed in the Shoot cluster for the given ControlPlane. With the CSI enablement in the provider extensions this ManagedResource holds CRDs and the RBAC for controller leader election. The deletion of such ManagedResource is likely to fail (hang forever) as it can first delete the RBAC for controller leader election and the corresponding controller (`external-snapshotter`) is no longer able to acquire leadership to proceed with CR (`VolumeSnapshot`) deletions.

Part of https://github.com/gardener/gardener/issues/2227

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`extensions/pkg/controller/controlplane/genericactuator.Actuator` can now use a separate ManagedResource for ControlPlane CRDs that are installed in the Shoot cluster to separate the deletion of CRDs from the deletion of the RBAC for controller leader election.
```
