### PR TITLE
Update "Features, Hotfixes, and Releases" doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,7 +72,7 @@
 * [Setting up a local development environment](development/local_setup.md)
 * [Unit Testing and Dependency Management](development/testing_and_dependencies.md)
 * [Changing the API](development/changing-the-api.md)
-* [Features, Releases and Hotfixes](development/process.md)
+* [Features, Hotfixes, and Releases](development/process.md)
 * [Adding New Cloud Providers](development/new-cloud-provider.md)
 * [Extending the Monitoring Stack](development/monitoring-stack.md)
 * [How to create log parser for container into fluent-bit](development/log_parsers.md)

--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -1,18 +1,38 @@
-# Creating a new Feature
+# Features, Hotfixes, and Releases
 
-If you want to contribute to the Gardener, please do that always on a dedicated branch on your own fork named after the purpose of the code changes, for example `feature/helm-integration`.
-Please do not forget to rebase your branch **regularly**.
+This document describes how to contribute features or hotfixes, and how new Gardener releases are usually scheduled, validated, etc.
 
-If you have finished your work, please create a pull request **based on `master`**. It will be reviewed and merged if no further changes are requested from you.
+## Contributing new Features or Fixes
 
-:warning: Please ensure that your modifications pass the lint checks, formatting checks, static code checks, and unit tests by executing
+Please refer to the [Gardener contributor guide](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md).
+Besides a lot of a general information, it also provides a checklist for newly created pull requests that may help you to prepare your changes for an efficient review process.
+
+:warning: Please ensure that your modifications pass the verification checks (linting, formatting, static code checks, tests, etc.) by executing
 
 ```bash
 make verify
 ```
 
-Please do not file your pull request unless you receive a successful response from here!
+before filing your pull request.
 
-## Creating a new Release
+The guide applies for both changes to the `master` and to any `release-*` branch.
+All changes must be submitted via a pull request and be reviewed and approved by at least one code owner.
 
-Please refer to the [Gardener contributor guide](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md).
+## Releases
+
+There is no fixed schedule for new releases of the `gardener/gardener` component.
+The [@gardener-maintainers](https://github.com/orgs/gardener/teams/gardener-maintainers) are trying to provide a new release roughly every other week (depending on their capacity and the stability/robustness of the `master` branch).
+
+Hotfixes are usually only maintained for the latest minor release as well as the minor release before that.
+
+The validation process for new releases usually takes a couple of days and includes the following steps:
+
+1. `master` (or latest `release-*` branch) is deployed to a development landscape that already hosts some existing seed and shoot clusters.
+1. An extended test suite is triggered by the "release responsible" which
+   1. executes the Gardener integration tests for different Kubernetes versions, infrastructures, and `Shoot` settings.
+   1. executes the Kubernetes conformance tests.
+   1. executes further tests like Kubernetes/OS patch/minor version upgrades.
+1. Additionally, every four hours (or on demand) more tests (e.g., including the Kubernetes e2e test suite) are executed for different infrastructures.
+1. The "release responsible" is verifying new features or other notable changes (derived of the draft release notes) in this development system.
+
+If all tests are green, all checks were successful, and the release responsible has performed all of the planned verifications then the release is triggered.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation dev-productivity open-source
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR updates the https://github.com/gardener/gardener/blob/master/docs/development/process.md document with more information as decided in the last retrospective meeting.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
