### PR TITLE
[GEP-13] Add managed seed integration test

### DIFF
--- a/.test-defs/CreateManagedSeed.yaml
+++ b/.test-defs/CreateManagedSeed.yaml
@@ -1,0 +1,19 @@
+kind: TestDefinition
+metadata:
+  name: create-managed-seed
+spec:
+  owner: gardener-oq@listserv.sap.com
+  description: Tests the creation of a managed seed.
+  activeDeadlineSeconds: 7200
+
+  command: [bash, -c]
+  args:
+  - >-
+    go test -timeout=0 -mod=vendor ./test/system/managed_seed_creation
+    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+    -kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
+    -managed-seed-name=$MANAGED_SEED_NAME
+    -shoot-name=$SHOOT_NAME
+    -deploy-gardenlet=$DEPLOY_GARDENLET
+    -backup-provider=$BACKUP_PROVIDER
+image: golang:1.15.3

--- a/.test-defs/DeleteManagedSeed.yaml
+++ b/.test-defs/DeleteManagedSeed.yaml
@@ -1,0 +1,16 @@
+kind: TestDefinition
+metadata:
+  name: delete-managed-seed
+spec:
+  owner: gardener-oq@listserv.sap.com
+  description: Tests the deletion of a managed seed.
+  activeDeadlineSeconds: 4200
+
+  command: [bash, -c]
+  args:
+  - >-
+    go test -timeout=0 -mod=vendor ./test/system/managed_seed_deletion
+    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+    -kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
+    -managed-seed-name=$MANAGED_SEED_NAME
+  image: golang:1.15.3

--- a/test/framework/common.go
+++ b/test/framework/common.go
@@ -37,6 +37,12 @@ const (
 	// TestMachineryKubeconfigsPathEnvVarName is the name of the environment variable that holds the path to the
 	// testmachinery provided kubeconfigs.
 	TestMachineryKubeconfigsPathEnvVarName = "TM_KUBECONFIG_PATH"
+
+	// TestMachineryTestRunEnvVarName is the name of the environment variable that holds the testrun ID.
+	TestMachineryTestRunIDEnvVarName = "TM_TESTRUN_ID"
+
+	// SeedTaintTestRun is the taint used to limit shoots that can be scheduled on a seed to shoots created by the same testrun.
+	SeedTaintTestRun = "test.gardener.cloud/test-run"
 )
 
 // SearchResponse represents the response from a search query to loki

--- a/test/framework/managedseedframework.go
+++ b/test/framework/managedseedframework.go
@@ -1,0 +1,271 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement/helper"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	configv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	"github.com/onsi/ginkgo"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+var managedSeedConfig *ManagedSeedConfig
+
+// ManagedSeedFramework is a test framework for testing managed seed creation and deletion.
+type ManagedSeedFramework struct {
+	*GardenerFramework
+	TestDescription
+	Config *ManagedSeedConfig
+
+	ManagedSeed *seedmanagementv1alpha1.ManagedSeed
+}
+
+// ManagedSeedConfig is a managed seed framework configuration.
+type ManagedSeedConfig struct {
+	GardenerConfig  *GardenerConfig
+	ManagedSeedName string
+	ShootName       string
+	DeployGardenlet bool
+	BackupProvider  string
+}
+
+// NewManagedSeedFramework creates a new managed seed framework.
+func NewManagedSeedFramework(cfg *ManagedSeedConfig) *ManagedSeedFramework {
+	var gardenerConfig *GardenerConfig
+	if cfg != nil {
+		gardenerConfig = cfg.GardenerConfig
+	}
+
+	f := &ManagedSeedFramework{
+		GardenerFramework: NewGardenerFrameworkFromConfig(gardenerConfig),
+		TestDescription:   NewTestDescription("MANAGEDSEED"),
+		Config:            cfg,
+	}
+
+	CBeforeEach(func(ctx context.Context) {
+		f.CommonFramework.BeforeEach()
+		f.GardenerFramework.BeforeEach()
+		f.BeforeEach(ctx)
+	}, 8*time.Minute)
+	CAfterEach(f.AfterEach, 10*time.Minute)
+
+	return f
+}
+
+// BeforeEach should be called in ginkgo's BeforeEach.
+// It merges and validates the managed seed framework configuration.
+func (f *ManagedSeedFramework) BeforeEach(ctx context.Context) {
+	f.Config = mergeManagedSeedConfig(f.Config, managedSeedConfig)
+	validateManagedSeedConfig(f.Config)
+}
+
+// AfterEach should be called in ginkgo's AfterEach.
+// It dumps the managed seed framework state if the test failed.
+func (f *ManagedSeedFramework) AfterEach(ctx context.Context) {
+	if ginkgo.CurrentGinkgoTestDescription().Failed {
+		f.DumpState(ctx)
+	}
+}
+
+func validateManagedSeedConfig(cfg *ManagedSeedConfig) {
+	if cfg == nil {
+		ginkgo.Fail("no configuration provided")
+	}
+	if !StringSet(cfg.ManagedSeedName) {
+		ginkgo.Fail("You should specify a name for the managed seed")
+	}
+	if !StringSet(cfg.ShootName) {
+		ginkgo.Fail("You should specify the name of the shoot to be registered as seed")
+	}
+}
+
+func mergeManagedSeedConfig(base, overwrite *ManagedSeedConfig) *ManagedSeedConfig {
+	if base == nil {
+		return overwrite
+	}
+	if overwrite == nil {
+		return base
+	}
+	if overwrite.GardenerConfig != nil {
+		base.GardenerConfig = overwrite.GardenerConfig
+	}
+	if StringSet(overwrite.ManagedSeedName) {
+		base.ManagedSeedName = overwrite.ManagedSeedName
+	}
+	if StringSet(overwrite.ShootName) {
+		base.ShootName = overwrite.ShootName
+	}
+	if overwrite.DeployGardenlet {
+		base.DeployGardenlet = overwrite.DeployGardenlet
+	}
+	if StringSet(overwrite.BackupProvider) {
+		base.BackupProvider = overwrite.BackupProvider
+	}
+	return base
+}
+
+// RegisterManagedSeedFrameworkFlags adds all flags that are needed to configure a managed seed framework.
+func RegisterManagedSeedFrameworkFlags() *ManagedSeedConfig {
+	_ = RegisterGardenerFrameworkFlags()
+
+	newCfg := &ManagedSeedConfig{}
+
+	flag.StringVar(&newCfg.ManagedSeedName, "managed-seed-name", "", "name of the managed seed")
+	flag.StringVar(&newCfg.ShootName, "shoot-name", "", "name of the shoot to be registered as seed")
+	flag.BoolVar(&newCfg.DeployGardenlet, "deploy-gardenlet", true, "indicates if gardenlet should be deployed to the shoot, default is true")
+	flag.StringVar(&newCfg.BackupProvider, "backup-provider", "", "seed backup provider")
+
+	managedSeedConfig = newCfg
+
+	return managedSeedConfig
+}
+
+// CreateManagedSeed creates a new managed seed according to the managed seed framework configuration.
+func (f *ManagedSeedFramework) CreateManagedSeed(ctx context.Context) error {
+	if f.GardenClient == nil {
+		return errors.New("no gardener client is defined")
+	}
+
+	// Get shoot
+	shoot := &gardencorev1beta1.Shoot{}
+	if err := f.GardenClient.DirectClient().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace, f.Config.ShootName), shoot); err != nil {
+		return err
+	}
+
+	// Ensure shoot VPA is enabled
+	if err := f.GardenerFramework.UpdateShoot(ctx, shoot, func(shoot *gardencorev1beta1.Shoot) error {
+		shoot.Spec.Kubernetes.VerticalPodAutoscaler = &gardencorev1beta1.VerticalPodAutoscaler{
+			Enabled: true,
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// Build managed seed object
+	var err error
+	if f.ManagedSeed, err = f.buildManagedSeed(); err != nil {
+		return err
+	}
+
+	// Create managed seed and wait until it's successfully reconciled
+	f.Logger.Infof("Creating managed seed %s", f.ManagedSeed.Name)
+	if err := PrettyPrintObject(f.ManagedSeed); err != nil {
+		return err
+	}
+	if err := f.GardenerFramework.CreateManagedSeed(ctx, f.ManagedSeed); err != nil {
+		return err
+	}
+
+	// Wait until the seed is also successfully reconciled
+	f.Logger.Infof("Waiting until seed %s is successfully reconciled", f.ManagedSeed.Name)
+	seed := gardencorev1beta1.Seed{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: f.ManagedSeed.Name,
+		},
+	}
+	return f.GardenerFramework.WaitForSeedToBeCreated(ctx, &seed)
+}
+
+func (f *ManagedSeedFramework) buildManagedSeed() (*seedmanagementv1alpha1.ManagedSeed, error) {
+	var (
+		seedTemplate *gardencorev1beta1.SeedTemplate
+		gardenlet    *seedmanagementv1alpha1.Gardenlet
+	)
+
+	// Build seed spec
+	seedSpec := f.buildSeedSpec()
+
+	if !f.Config.DeployGardenlet {
+		// Initialize seed template
+		seedTemplate = &gardencorev1beta1.SeedTemplate{
+			Spec: *seedSpec,
+		}
+	} else {
+		// Initialize gardenlet config
+		config := &configv1alpha1.GardenletConfiguration{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: configv1alpha1.SchemeGroupVersion.String(),
+				Kind:       "GardenletConfiguration",
+			},
+			SeedConfig: &configv1alpha1.SeedConfig{
+				SeedTemplate: gardencorev1beta1.SeedTemplate{
+					Spec: *seedSpec,
+				},
+			},
+		}
+
+		// Encode gardenlet config to raw extension
+		re, err := helper.EncodeGardenletConfiguration(config)
+		if err != nil {
+			return nil, err
+		}
+
+		// Initialize gardenlet configuraton and parameters
+		gardenlet = &seedmanagementv1alpha1.Gardenlet{
+			Config: *re,
+		}
+	}
+
+	return &seedmanagementv1alpha1.ManagedSeed{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      f.Config.ManagedSeedName,
+			Namespace: v1beta1constants.GardenNamespace,
+		},
+		Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+			Shoot: seedmanagementv1alpha1.Shoot{
+				Name: f.Config.ShootName,
+			},
+			SeedTemplate: seedTemplate,
+			Gardenlet:    gardenlet,
+		},
+	}, nil
+}
+
+func (f *ManagedSeedFramework) buildSeedSpec() *gardencorev1beta1.SeedSpec {
+	return &gardencorev1beta1.SeedSpec{
+		Backup: &gardencorev1beta1.SeedBackup{
+			Provider: f.Config.BackupProvider,
+		},
+		SecretRef: &corev1.SecretReference{
+			Name:      fmt.Sprintf("seed-%s", f.Config.ManagedSeedName),
+			Namespace: v1beta1constants.GardenNamespace,
+		},
+		Taints: []gardencorev1beta1.SeedTaint{
+			{
+				Key:   SeedTaintTestRun,
+				Value: pointer.StringPtr(GetTestRunID()),
+			},
+		},
+		Settings: &gardencorev1beta1.SeedSettings{
+			Scheduling: &gardencorev1beta1.SeedSettingScheduling{
+				Visible: false,
+			},
+		},
+	}
+}

--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
@@ -168,6 +169,8 @@ func CreateShootTestArtifacts(cfg *ShootCreationConfig, projectNamespace string,
 
 	setShootNetworkingSettings(shoot, cfg, clearDNS)
 
+	setShootTolerations(shoot)
+
 	return shoot.Name, shoot, nil
 }
 
@@ -292,6 +295,16 @@ func setShootNetworkingSettings(shoot *gardencorev1beta1.Shoot, cfg *ShootCreati
 
 	if clearDNS {
 		shoot.Spec.DNS = &gardencorev1beta1.DNS{}
+	}
+}
+
+// setShootTolerations sets the Shoot's tolerations
+func setShootTolerations(shoot *gardencorev1beta1.Shoot) {
+	shoot.Spec.Tolerations = []gardencorev1beta1.Toleration{
+		{
+			Key:   SeedTaintTestRun,
+			Value: pointer.StringPtr(GetTestRunID()),
+		},
 	}
 }
 

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -156,24 +156,24 @@ func validateShootCreationConfig(cfg *ShootCreationConfig) {
 	}
 
 	if !FileExists(cfg.infrastructureProviderConfig) {
-		ginkgo.Fail("path to the infrastructureProviderConfig of the Shoot is invalid")
+		ginkgo.Fail(fmt.Sprintf("path to the infrastructureProviderConfig of the Shoot is invalid: %s", cfg.infrastructureProviderConfig))
 	}
 
 	if StringSet(cfg.controlPlaneProviderConfig) {
 		if !FileExists(cfg.controlPlaneProviderConfig) {
-			ginkgo.Fail("path to the controlPlaneProviderConfig of the Shoot is invalid")
+			ginkgo.Fail(fmt.Sprintf("path to the controlPlaneProviderConfig of the Shoot is invalid: %s", cfg.controlPlaneProviderConfig))
 		}
 	}
 
 	if StringSet(cfg.networkingProviderConfig) {
 		if !FileExists(cfg.networkingProviderConfig) {
-			ginkgo.Fail("path to the networkingProviderConfig of the Shoot is invalid")
+			ginkgo.Fail(fmt.Sprintf("path to the networkingProviderConfig of the Shoot is invalid: %s", cfg.networkingProviderConfig))
 		}
 	}
 
 	if StringSet(cfg.workersConfig) {
 		if !FileExists(cfg.workersConfig) {
-			ginkgo.Fail("path to the worker config of the Shoot is invalid")
+			ginkgo.Fail(fmt.Sprintf("path to the worker config of the Shoot is invalid: %s", cfg.workersConfig))
 		}
 	}
 }

--- a/test/framework/utils.go
+++ b/test/framework/utils.go
@@ -157,6 +157,11 @@ func ParseFileAsWorkers(filepath string) ([]gardencorev1beta1.Worker, error) {
 	return workers, nil
 }
 
+// GetTestRunID returns the current testmachinery testrun ID.
+func GetTestRunID() string {
+	return os.Getenv(TestMachineryTestRunIDEnvVarName)
+}
+
 // TextValidation is a map of regular expression to description
 // that is used to validate texts based on allowed or denied regexps.
 type TextValidation map[string]string

--- a/test/system/managed_seed_creation/create_suite_test.go
+++ b/test/system/managed_seed_creation/create_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managed_seed_creation
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestManagedSeedCreation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ManagedSeed Creation Test Suite")
+}

--- a/test/system/managed_seed_creation/create_test.go
+++ b/test/system/managed_seed_creation/create_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managed_seed_creation
+
+import (
+	"context"
+	"time"
+
+	"github.com/gardener/gardener/test/framework"
+
+	. "github.com/onsi/ginkgo"
+)
+
+const (
+	CreateAndReconcileTimeout = 2 * time.Hour
+)
+
+func init() {
+	framework.RegisterManagedSeedFrameworkFlags()
+}
+
+var _ = Describe("ManagedSeed creation testing", func() {
+
+	f := framework.NewManagedSeedFramework(&framework.ManagedSeedConfig{
+		GardenerConfig: &framework.GardenerConfig{
+			CommonConfig: &framework.CommonConfig{
+				ResourceDir: "../../framework/resources",
+			},
+		},
+	})
+
+	f.CIt("Create and reconcile ManagedSeed", func(ctx context.Context) {
+		err := f.CreateManagedSeed(ctx)
+		framework.ExpectNoError(err)
+	}, CreateAndReconcileTimeout)
+})

--- a/test/system/managed_seed_deletion/delete_suite_test.go
+++ b/test/system/managed_seed_deletion/delete_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managed_seed_deletion
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestManagedSeedDeletion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ManagedSeed Deletion Test Suite")
+}

--- a/test/system/managed_seed_deletion/delete_test.go
+++ b/test/system/managed_seed_deletion/delete_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managed_seed_deletion
+
+import (
+	"context"
+	"flag"
+	"os"
+	"time"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	"github.com/gardener/gardener/test/framework"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var managedSeedName = flag.String("managed-seed-name", "", "name of the managed seed")
+
+func init() {
+	framework.RegisterGardenerFrameworkFlags()
+}
+
+func validateFlags() {
+	if !framework.StringSet(*managedSeedName) {
+		Fail("flag '-managed-seed-name' needs to be specified")
+	}
+}
+
+var _ = Describe("ManagedSeed deletion testing", func() {
+	f := framework.NewGardenerFramework(nil)
+
+	framework.CIt("Delete ManagedSeed", func(ctx context.Context) {
+		validateFlags()
+
+		managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
+		if err := f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: v1beta1constants.GardenNamespace, Name: *managedSeedName}, managedSeed); err != nil {
+			if apierrors.IsNotFound(err) {
+				Skip("managed seed is already deleted")
+			}
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		// Dump gardener state if delete managed seed is in exit handler
+		if os.Getenv("TM_PHASE") == "Exit" {
+			f.DumpState(ctx)
+		}
+
+		if err := f.DeleteManagedSeed(ctx, managedSeed); err != nil && !apierrors.IsNotFound(err) {
+			f.Logger.Fatalf("Could not delete managed seed %s: %s", *managedSeedName, err.Error())
+		}
+	}, 1*time.Hour)
+})


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind test
/priority normal

**What this PR does / why we need it**:
Adds integration tests for `ManagedSeed` creation and deletion

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
* Intended to eventually replace `seed_registration` and `seed_deletion` tests. Currently these tests are only executed as part of the CP migration integration test flow. Once they are not needed anymore, they will be removed in a separate PR.

**Release note**:

```other operator
NONE
```
