### PR TITLE
exclude the konnectivity-server image from the component-references

### DIFF
--- a/hack/.ci/component_descriptor
+++ b/hack/.ci/component_descriptor
@@ -10,9 +10,11 @@ echo "enriching creating component descriptor from ${BASE_DEFINITION_PATH}"
 
 # translates all images defined the images.yaml into component descriptor resources.
 # For detailed documentation see https://github.com/gardener/component-cli/blob/main/docs/reference/components-cli_image-vector_add.md
+# the konnectivity-server is temporary excluded until the component-descriptor for the replica-reloader is released
 component-cli image-vector add --comp-desc ${BASE_DEFINITION_PATH} \
   --image-vector "$repo_root_dir/charts/images.yaml" \
   --component-prefixes eu.gcr.io/gardener-project/gardener \
+  --exclude-component-reference konnectivity-server \
   --generic-dependencies hyperkube,kube-apiserver,kube-controller-manager,kube-scheduler,kube-proxy
 
 if [[ -d "$repo_root_dir/charts/" ]]; then


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind bug
/priority normal

**What this PR does / why we need it**:

fixes the component-descriptor to exclude the konnectivity-server image as component-reference and include it as default oci resource.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
