### PR TITLE
Refactor Seed (de)bootstrap to flow graph

### DIFF
--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
@@ -297,6 +297,11 @@ func computeKindTypesForSeed(
 ) sets.String {
 	var wantedKindTypeCombinations = sets.NewString()
 
+	// enable clean up of controller installations in case of seed deletion
+	if seed.DeletionTimestamp != nil {
+		return sets.NewString()
+	}
+
 	if seed.Spec.DNS.Provider != nil {
 		wantedKindTypeCombinations.Insert(common.ExtensionID(dnsv1alpha1.DNSProviderKind, seed.Spec.DNS.Provider.Type))
 	}
@@ -330,7 +335,7 @@ func computeControllerRegistrationMaps(
 // computeWantedControllerRegistrationNames computes the list of names of ControllerRegistration objects that are desired
 // to be installed. The computation is performed based on a list of required kind/type combinations and the proper mapping
 // to existing ControllerRegistration objects. Additionally, all names in the alwaysPolicyControllerRegistrationNames list
-// will be returned.
+// will be returned and all currently installed and required installations.
 func computeWantedControllerRegistrationNames(
 	wantedKindTypeCombinations sets.String,
 	controllerInstallationList *gardencorev1beta1.ControllerInstallationList,
@@ -358,27 +363,32 @@ func computeWantedControllerRegistrationNames(
 		}
 	}
 
-	for _, requiredExtension := range wantedKindTypeCombinations.UnsortedList() {
-		names, ok := kindTypeToControllerRegistrationNames[requiredExtension]
+	for _, wantedExtension := range wantedKindTypeCombinations.UnsortedList() {
+		names, ok := kindTypeToControllerRegistrationNames[wantedExtension]
 		if !ok {
-			return nil, fmt.Errorf("need to install an extension controller for %q but no appropriate ControllerRegistration found", requiredExtension)
+			return nil, fmt.Errorf("need to install an extension controller for %q but no appropriate ControllerRegistration found", wantedExtension)
 		}
-
 		wantedControllerRegistrationNames.Insert(names...)
 	}
 
+	wantedControllerRegistrationNames.Insert(installedAndRequiredRegistrationNames(controllerInstallationList, seedObjectMeta.Name).List()...)
+
+	// filter controller registrations with non-matching seed selector
+	return controllerRegistrationNamesWithMatchingSeedLabelSelector(wantedControllerRegistrationNames.UnsortedList(), controllerRegistrations, seedObjectMeta.Labels)
+}
+
+func installedAndRequiredRegistrationNames(controllerInstallationList *gardencorev1beta1.ControllerInstallationList, seedName string) sets.String {
+	requiredControllerRegistrationNames := sets.NewString()
 	for _, controllerInstallation := range controllerInstallationList.Items {
-		if controllerInstallation.Spec.SeedRef.Name != seedObjectMeta.Name {
+		if controllerInstallation.Spec.SeedRef.Name != seedName {
 			continue
 		}
 		if !gardencorev1beta1helper.IsControllerInstallationRequired(controllerInstallation) {
 			continue
 		}
-		wantedControllerRegistrationNames.Insert(controllerInstallation.Spec.RegistrationRef.Name)
+		requiredControllerRegistrationNames.Insert(controllerInstallation.Spec.RegistrationRef.Name)
 	}
-
-	// filter controller registrations with non-matching seed selector
-	return controllerRegistrationNamesWithMatchingSeedLabelSelector(wantedControllerRegistrationNames.UnsortedList(), controllerRegistrations, seedObjectMeta.Labels)
+	return requiredControllerRegistrationNames
 }
 
 // computeRegistrationNameToInstallationNameMap computes a map that maps the name of a ControllerRegistration to the name of an

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
@@ -734,7 +734,27 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 			Expect(actual).To(Equal(expected))
 		})
 
-		It("should not add an extension", func() {
+		It("should not add an extension if Seed has a deletion timestamp", func() {
+			deletionTimestamp := metav1.Now()
+			seed := &gardencorev1beta1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &deletionTimestamp,
+				},
+				Spec: gardencorev1beta1.SeedSpec{
+					DNS: gardencorev1beta1.SeedDNS{
+						Provider: &gardencorev1beta1.SeedDNSProvider{
+							Type: providerType,
+						},
+					},
+				},
+			}
+
+			expected := sets.NewString()
+			actual := computeKindTypesForSeed(seed)
+			Expect(actual).To(Equal(expected))
+		})
+
+		It("should not add an extension if no provider configured", func() {
 			seed := &gardencorev1beta1.Seed{
 				Spec: gardencorev1beta1.SeedSpec{},
 			}
@@ -794,17 +814,6 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 
 			Expect(names).To(Equal(sets.NewString(controllerRegistration7.Name)))
 			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("should fail to compute the result and return error", func() {
-			wantedKindTypeCombinations := sets.NewString(
-				extensionsv1alpha1.ExtensionResource + "/foo",
-			)
-
-			names, err := computeWantedControllerRegistrationNames(wantedKindTypeCombinations, controllerInstallationList, controllerRegistrations, len(shootList), seedObjectMeta)
-
-			Expect(names).To(BeNil())
-			Expect(err).To(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
  /area control-plane
/kind technical-debt

**What this PR does / why we need it**:
This PR addresses different issues all around seed de(bootstrap):
- Clean-up of managed Ingress DNS-related resources (DNSEntry, ControllerInstallation, DNSProvider)  when deleting a Seed
- Ensuring that the gardener resource manager gets deployed before/deleted after all components with managed resources.

We implemented a quick fix with #3543 which is reverted with this change and properly implemented using a flow graph.

**Special notes for your reviewer**

I decided to not use the DNSProvider component (used in the Shoot bootstrap) because the use case differs and forces me to  to implement around it so that the benefits of using it are minimal. The problems of the dnsProvider component were:
- it uses a fixed provider secret name which differs from the secret name currently deployed (we would need some extra clean-up logic).
- on destroy() the secret will not be updated (but it is needed in the seed destroy case)
- the secret will not be deleted upon deletion of the dnsProvider

I introduced a change to how wantedControllerRegistrationNames are calculated, see [wantedControllerRegistrationNames](https://github.com/gardener/gardener/pull/3575/files#diff-0d8996ff3546653f546482d70a198c7c4da27e0102f684a87d5e982df34896d4R350).
Except from refactoring naming I changed that In case of deletion only already installed and required installations are added. That leads to the dns-controllerinstallation being removed when it is no longer required. We can also check in  [computeKindTypesForSeed](https://github.com/gardener/gardener/pull/3575/files#diff-0d8996ff3546653f546482d70a198c7c4da27e0102f684a87d5e982df34896d4L289) and not add the kind/type if the seed is in deletion.

I moved checking associatedControllerInstallations from [from seed_control.go](https://github.com/gardener/gardener/pull/3575/files#diff-628c8891682f4a4b0f5c49cb8051057ed8a5a3bf338438659ef68ccfb66385e5R243) [to the flow graph](https://github.com/gardener/gardener/pull/3575/files#diff-8495b57b25d39744fe1b20b1e1ce695d130f730142af86ff9c5929afcdbabeb4R1001) originally this was introduced in https://github.com/gardener/gardener/pull/3653 
cc @timebertt in . I did this because the dns-controllerinstallation is needed for cleaning up the dnsentry (which was not properly cleaned up before)

**Release note**:

```other operator
On Seed deletion resources related to the managed Ingress are now properly cleaned up.
```
