### PR TITLE
Delay the deletion of the external DNS

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -508,7 +508,7 @@ func (c *Controller) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		destroyExternalDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Destroying external domain DNS record",
 			Fn:           flow.TaskFn(botanist.DestroyExternalDNS),
-			Dependencies: flow.NewTaskIDs(syncPointCleaned),
+			Dependencies: flow.NewTaskIDs(syncPointCleaned, deleteKubeAPIServer),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deleting shoot monitoring stack in Seed",

--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -189,8 +189,7 @@ func (b *Botanist) CleanExtendedAPIs(ctx context.Context) error {
 		c           = b.K8sShootClient.Client()
 		ensurer     = utilclient.GoneBeforeEnsurer(b.Shoot.Info.GetDeletionTimestamp().Time)
 		defaultOps  = utilclient.NewCleanOps(utilclient.DefaultCleaner(), ensurer)
-		crdCleaner  = utilclient.NewCRDCleaner()
-		crdCleanOps = utilclient.NewCleanOps(crdCleaner, ensurer)
+		crdCleanOps = utilclient.NewCleanOps(utilclient.NewCRDCleaner(), ensurer)
 	)
 
 	return flow.Parallel(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Delay the deletion of the external DNS record to allow shoot owners to clean-up resources in case they cannot be deleted by Gardener or a Gardener extension.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The external DNS record for the kubernetes API server is now deleted after the kubernetes API server. This is useful for shoot cluster owners that need to clean some kubernetes resources that can cause the shoot cluster deletion to stuck.
```
