### PR TITLE
[GEP-13] Add ManagedSeed documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@
 
 ## Usage
 
-* [Add a Shooted Seed](usage/shooted_seed.md)
+* [Register Shoot as Seed](usage/managed_seed.md)
 * [API Server Network Proxy Reverse Tunneling](usage/reverse-tunnel.md)
 * [Audit a Kubernetes cluster](usage/shoot_auditpolicy.md)
 * [Auto-Scaling for shoot clusters](usage/shoot_autoscaling.md)

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -180,25 +180,21 @@ is available.
 However, the Gardenlet is designed to withstand such connection outages and
 retries until the connection is reestablished.
 
-## Shooted Seeds
+## Managed Seeds
 
-Gardener users can use shoot clusters as seed clusters, so-called "shooted seeds",
-by using shoot cluster annotation `shoot.gardener.cloud/use-as-seed`. 
+Gardener users can use shoot clusters as seed clusters, so-called "managed seeds" (aka "shooted seeds"),
+by creating `ManagedSeed` resources. 
 By default, the gardenlet that manages this shoot cluster then automatically 
 creates a clone of itself with the same version and the same configuration 
 that it currently has. 
-Then it deploys the gardenlet clone into the shooted seed cluster. 
+Then it deploys the gardenlet clone into the managed seed cluster. 
 
 If you want to prevent the automatic gardenlet deployment, 
-use the `no-gardenlet` value in the `shoot.gardener.cloud/use-as-seed` annotation. 
+specify the `seedTemplate` section in the `ManagedSeed` resource, and don't specify
+the `gardenlet` section. 
 In this case, you have to deploy the gardenlet on your own into the seed cluster.
 
-> For example, if you annotate the shoot cluster with 
-> `shoot.gardener.cloud/use-as-seed="true,no-gardenlet,invisible"` 
-> the shooted seed is created without gardenlet, 
-> and the `garden-scheduler` ignores it (it’s invisible).
-
-More information: [Create Shooted Seed Cluster](../usage/shooted_seed.md)
+More information: [Register Shoot as Seed](../usage/managed_seed.md)
 
 ## Migrating from Previous Gardener Versions
 
@@ -212,7 +208,7 @@ no special migration is required, but the following prerequisites must be met:
 With previous Gardener versions, you had deployed the Gardener Helm chart 
 (incorporating the API server, `controller-manager`, and scheduler).
 With v1, this stays the same, but you now have to deploy the gardenlet Helm chart as well
-into all of your seeds (if they aren’t shooted, as mentioned earlier).
+into all of your seeds (if they aren’t managed, as mentioned earlier).
 
 More information: [Deploy a Gardenlet](../deployment/deploy_gardenlet.md) for all instructions.
 

--- a/docs/deployment/deploy_gardenlet.md
+++ b/docs/deployment/deploy_gardenlet.md
@@ -11,7 +11,7 @@ To support scaleability in an automated way, gardenlets are deployed automatical
    * Deploy it manually if you have special requirements. More information: [Deploy a Gardenlet Manually](deploy_gardenlet_manually.md)
    * Let the Gardener installer deploy it automatically otherwise. More information: [Automatic Deployment of Gardenlets](deploy_gardenlet_automatically.md)
 
-1. To add additional seed clusters, it is recommended to use regular shoot clusters. The gardenlet automatically installs itself into these so-called [shooted seed clusters](../usage/shooted_seed.md). 
+1. To add additional seed clusters, it is recommended to use regular shoot clusters. You can do this by creating a `ManagedSeed` resource with a `gardenlet` section as described in [Register Shoot as Seed](../usage/managed_seed.md). 
 
 
 

--- a/docs/deployment/deploy_gardenlet_automatically.md
+++ b/docs/deployment/deploy_gardenlet_automatically.md
@@ -1,7 +1,7 @@
 # Automatic Deployment of Gardenlets
 
 The gardenlet can automatically deploy itself into shoot clusters, and register this cluster as a seed cluster. 
-These clusters are called shooted seeds. 
+These clusters are called "managed seeds" (aka "shooted seeds"). 
 This procedure is the preferred way to add additional seed clusters, because shoot clusters already come with production-grade qualities that are also demanded for seed clusters.
 
 ## Prerequisites
@@ -13,18 +13,18 @@ The only prerequisite is to register an initial cluster as a seed cluster that h
 
 > The initial cluster can be the garden cluster itself.
 
-## Self-Deployment of Gardenlets in Additional Shooted Seed Clusters
+## Self-Deployment of Gardenlets in Additional Managed Seed Clusters
 
 For a better scalability, you usually need more seed clusters that you can create as follows:
 
-1. Use the initial cluster as the seed cluster for other shooted seed clusters. It hosts the control planes of the other seed clusters.
-1. The gardenlet deployed in the initial cluster deploys itself automatically into the shooted seed clusters.  
+1. Use the initial cluster as the seed cluster for other managed seed clusters. It hosts the control planes of the other seed clusters.
+1. The gardenlet deployed in the initial cluster deploys itself automatically into the managed seed clusters.  
 
-The advantage of this approach is that there’s only one initial gardenlet installation required. Every other shooted seed cluster has a gardenlet deployed automatically.
+The advantage of this approach is that there’s only one initial gardenlet installation required. Every other managed seed cluster has a gardenlet deployed automatically.
 
 ## Related Links
 
-[Create Shooted Seed Cluster](../usage/shooted_seed.md)
+[Register Shoot as Seed](../usage/managed_seed.md)
 
 [garden-setup](http://github.com/gardener/garden-setup)
 

--- a/docs/deployment/deploy_gardenlet_manually.md
+++ b/docs/deployment/deploy_gardenlet_manually.md
@@ -265,7 +265,7 @@ We refer to the global configuration values as _gardenlet configuration_ in the 
 A seed cluster can either be registered by manually creating 
 the [`Seed` resource](../../example/50-seed.yaml) 
 or automatically by the gardenlet.  
-This functionality is useful for shooted seed clusters, 
+This functionality is useful for managed seed clusters, 
 as the gardenlet in the garden cluster deploys a copy of itself 
 into the cluster with automatic registration of the `Seed` configured.  
 However, it can also be used to have a streamlined seed cluster registration process when manually deploying the gardenlet.

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -67,7 +67,7 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 
 * `Logging` enables logging stack for Seed clusters.
 * `HVPA` enables simultaneous horizontal and vertical scaling in Seed Clusters.
-* `HVPAForShootedSeed`  enables simultaneous horizontal and vertical scaling in shooted Seed clusters.
+* `HVPAForShootedSeed`  enables simultaneous horizontal and vertical scaling in managed seed (aka "shooted seed") clusters.
 * `ManagedIstio` enables a Gardener-tailored [Istio](https://istio.io) in each Seed cluster. Disable this feature if Istio is already installed in the cluster. Istio is not automatically removed if this feature is disabled. See the [detailed documentation](../usage/istio.md) for more information.
 * `APIServerSNI` enables only one LoadBalancer to be used for every Shoot cluster API server in a Seed. Enable this feature when `ManagedIstio` is enabled or Istio is manually deployed in Seed cluster. See [GEP-8](../proposals/08-shoot-apiserver-via-sni.md) for more details.
 * `MountHostCADirectories` enables mounting common CA certificate directories in the Shoot API server pod that might be required for webhooks or OIDC.

--- a/docs/development/seed_network_policies.md
+++ b/docs/development/seed_network_policies.md
@@ -31,7 +31,7 @@ Another network policy to be highlighted is `allow-to-seed-apiserver`.
 Some components need access to the Seed API Server. This can be allowed by labeling the pod with `networking.gardener.cloud/to-seed-apiserver=allowed`.
 This policy allows exactly the IPs of the `kube-apiserver` of the Seed.
 While all other policies have a static set of permissions (do not change during the lifecycle of the Shoot), the policy `allow-to-seed-apiserver` is reconciled to reflect the endpoints in the `default` namespace.
-This is required because endpoint IPs are not necessarily stable (think of scaling the Seed API Server pods or hibernating the Seed cluster (acting as a shooted Seed) in a local development environment).
+This is required because endpoint IPs are not necessarily stable (think of scaling the Seed API Server pods or hibernating the Seed cluster (acting as a managed seed) in a local development environment).
 
 Furthermore, the following network policies exist in the Shoot namespace.
 These policies are the same for every Shoot control plane.

--- a/docs/usage/managed_seed.md
+++ b/docs/usage/managed_seed.md
@@ -1,0 +1,74 @@
+# Register Shoot as Seed
+
+An existing shoot can be registered as a seed by creating a `ManagedSeed` resource. This resource replaces the `use-as-seed` annotation that was previously used to create [shooted seeds](shooted_seed.md). It contains:
+
+* The name of the shoot that should be registered as seed.
+* An optional `seedTemplate` section that contains the `Seed` spec and parts of its metadata, such as labels and annotations.
+* An optional `gardenlet` section that contains:
+    * `gardenlet` deployment parameters, such as the number of replicas, the image, etc.
+    * The `GardenletConfiguration` resource that contains controllers configuration, feature gates, and a `seedConfig` section that contains the `Seed` spec and parts of its metadata.
+    * Additional configuration parameters, such as the garden connection bootstrap mechanism (see [TLS Bootstrapping](../concepts/gardenlet.md#tls-bootstrapping)), and whether to merge the provided configuration with the configuration of the parent `gardenlet`.
+    
+Either the `seedTemplate` or the `gardenlet` section must be specified, but not both: 
+
+* If the `seedTemplate` section is specified, `gardenlet` is not deployed to the shoot, and a new `Seed` resource is created based on the template.
+* If the `gardenlet` section is specified, `gardenlet` is deployed to the shoot, and it registers a new seed upon startup based on the `seedConfig` section of the `GardenletConfiguration` resource.
+
+Note the following important aspects:
+
+* Unlike the `Seed` resource, the `ManagedSeed` resource is namespaced. Currently, managed seeds are restricted to the `garden` namespace.
+* The newly created `Seed` resource always has the same name as the `ManagedSeed` resource. Attempting to specify a different name in `seedTemplate` or `seedConfig` will fail. 
+* The `ManagedSeed` resource must always refer to an existing shoot. Attempting to create a `ManagedSeed` referring to a non-existing shoot will fail.
+* A shoot that is being referred to by a `ManagedSeed` cannot be deleted. Attempting to delete such a shoot will fail.  
+* You can omit practically everything from the `seedTemplate` or `gardenlet` section, including all or most of the `Seed` spec fields. Proper defaults will be supplied in all cases, based either on the most common use cases or the information already available in the `Shoot` resource.
+* Some `Seed` spec fields, for example the provider type and region, networking CIDRs for pods, services, and nodes, etc., must be the same as the corresponding `Shoot` spec fields of the shoot that is being registered as seed. Attempting to use different values (except empty ones, so that they are supplied by the defaulting mechanims) will fail.
+
+## Deploying Gardenlet to the Shoot
+
+To register a shoot as a seed and deploy `gardenlet` to the shoot using a default configuration, create a `ManagedSeed` resource similar to the following:
+
+```yaml
+apiVersion: seedmanagement.gardener.cloud/v1alpha1
+kind: ManagedSeed
+metadata:
+  name: my-managed-seed
+  namespace: garden
+spec:
+  shoot:
+    name: crazy-botany
+  gardenlet: {}
+```
+
+For an example that uses non-default configuration, see [55-managed-seed-gardenlet.yaml](../../example/55-managedseed-gardenlet.yaml)
+
+## Creating a Seed from a Template
+
+To register a shoot as a seed from a template without deploying `gardenlet` to the shoot using a default configuration, create a `ManagedSeed` resource similar to the following:
+
+```yaml
+apiVersion: seedmanagement.gardener.cloud/v1alpha1
+kind: ManagedSeed
+metadata:
+  name: my-managed-seed
+  namespace: garden
+spec:
+  shoot:
+    name: crazy-botany
+  seedTemplate:
+    metadata:
+      labels:
+        seed.gardener.cloud/gardenlet: local
+    spec:
+      dns:
+        ingressDomain: ""
+      networks:
+        pods: ""
+        services: ""
+      provider:
+        type: ""
+        region: ""
+```
+
+Note the `seed.gardener.cloud/gardenlet: local` label above. It stands for the label that is used in a `seedSelector` field of a `gardenlet` that takes care of multiple seeds. This label can be omitted if the `seedSelector` field selects all seeds. If there is no gardenlet running outside the cluster and selecting the seed, it won't be reconciled and no shoots will be scheduled on it.
+
+For an example that uses non-default configuration, see [55-managed-seed-seedtemplate.yaml](../../example/55-managedseed-seedtemplate.yaml)

--- a/docs/usage/shooted_seed.md
+++ b/docs/usage/shooted_seed.md
@@ -1,6 +1,10 @@
 # Create Shooted Seed Cluster
 
-Create shooted seed cluster with the `shoot.gardener.cloud/use-as-seed` annotation.
+Create managed seed (aka "shooted seed") cluster with the `shoot.gardener.cloud/use-as-seed` annotation.
+
+**Note:** Starting with Gardener v1.18, the `shoot.gardener.cloud/use-as-seed` annotation is deprecated. 
+It still works as described here, however behind the scenes a `ManagedSeed` resource is created and reconciled. 
+It is strongly recommended to use such resources directly to register shoots as seeds, as described in [Register Shoot as Seed](managed_seed.md).
 
 ## Procedure
 


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind test
/priority normal

**What this PR does / why we need it**:
Adds documentation for managed seeds

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```noteworthy operator
Starting with Gardener v1.18, the `shoot.gardener.cloud/use-as-seed` annotation is deprecated. The new `ManagedSeed`  resource should be used instead to register shoots as seeds.
```
