### PR TITLE
Fix ManagedSeed admission with shoot ingress addon

### DIFF
--- a/plugin/pkg/managedseed/validator/admission.go
+++ b/plugin/pkg/managedseed/validator/admission.go
@@ -296,9 +296,9 @@ func (v *ManagedSeed) admitSeedSpec(spec *gardencore.SeedSpec, shoot *gardencore
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("ingress", "domain"), spec.Ingress.Domain, fmt.Sprintf("seed ingress domain must be equal to shoot DNS domain %s", ingressDomain)))
 		}
 	} else {
-		if (spec.DNS.IngressDomain == nil || *spec.DNS.IngressDomain == "") && gardencorehelper.NginxIngressEnabled(shoot.Spec.Addons) {
+		if spec.DNS.IngressDomain == nil || *spec.DNS.IngressDomain == "" {
 			spec.DNS.IngressDomain = &ingressDomain
-		} else if spec.DNS.IngressDomain == nil || !strings.HasSuffix(*spec.DNS.IngressDomain, *shoot.Spec.DNS.Domain) {
+		} else if !strings.HasSuffix(*spec.DNS.IngressDomain, *shoot.Spec.DNS.Domain) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("dns", "ingressDomain"), spec.DNS.IngressDomain, fmt.Sprintf("seed ingress domain must be a subdomain of shoot DNS domain %s", *shoot.Spec.DNS.Domain)))
 		}
 	}

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -100,13 +100,6 @@ var _ = Describe("ManagedSeed", func() {
 						Type: provider,
 					},
 					Region: region,
-					Addons: &core.Addons{
-						NginxIngress: &core.NginxIngress{
-							Addon: core.Addon{
-								Enabled: true,
-							},
-						},
-					},
 				},
 			}
 
@@ -297,7 +290,6 @@ var _ = Describe("ManagedSeed", func() {
 			})
 
 			It("should allow the ManagedSeed creation if the Shoot exists and can be registered as Seed (w/ ingress)", func() {
-				shoot.Spec.Addons = nil
 				managedSeed.Spec.SeedTemplate.Spec = core.SeedSpec{
 					Backup: &core.SeedBackup{},
 					Ingress: &core.Ingress{


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug
/priority normal

**What this PR does / why we need it**:
Fixes the managed seed admission plugin to allow the shoot ingress addon to be disabled if seed ingress controller is also not used.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
During the review of the original managed seed controller PR, it was suggested by @timebertt that if seed ingress controller is not used, the shoot ingress addon must be enabled or the resource should be considered invalid. This leads to errors similar to this one for dev shooted seeds that had neither the shoot ingress addon nor the seed ingress controller:

```
time="2021-02-17T16:14:24Z" level=error msg="Could not create or update ManagedSeed object for shoot garden/sap-metal: ManagedSeed.seedmanagement.gardener.cloud \"sap-metal\" is invalid: spec.gardenlet.config.seedConfig.spec.dns.ingressDomain: Invalid value: \"null\": seed ingress domain must be a subdomain of shoot DNS domain sap-metal.seed.dev.k8s.ondemand.com" shoot=garden/sap-metal
```

For compatiblity reasons, we should for the moment at least allow such managed seeds to be reconciled successfully.

**Release note**:

```other operator
NONE
```
