### PR TITLE
Fix ManagedSeed merging of seedConfig with parent

### DIFF
--- a/pkg/gardenlet/controller/managedseed/managedseed_valueshelper.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_valueshelper.go
@@ -108,8 +108,12 @@ func (vp *valuesHelper) MergeGardenletConfiguration(config *configv1alpha1.Garde
 		return nil, err
 	}
 
-	// Delete seedClientConnection.kubeconfig in parent config values
+	// Delete seedClientConnection.kubeconfig and seedConfig in parent config values
 	parentConfigValues, err = utils.DeleteFromValuesMap(parentConfigValues, "seedClientConnection", "kubeconfig")
+	if err != nil {
+		return nil, err
+	}
+	parentConfigValues, err = utils.DeleteFromValuesMap(parentConfigValues, "seedConfig")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gardenlet/controller/managedseed/managedseed_valueshelper_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_valueshelper_test.go
@@ -15,6 +15,7 @@
 package managedseed
 
 import (
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
@@ -108,6 +109,13 @@ var _ = Describe("ValuesHelper", func() {
 			FeatureGates: map[string]bool{
 				string(features.Logging): true,
 				string(features.HVPA):    true,
+			},
+			SeedConfig: &config.SeedConfig{
+				SeedTemplate: gardencore.SeedTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "bar",
+					},
+				},
 			},
 		}
 		imageVector = []*imagevector.ImageSource{


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug
/priority normal

**What this PR does / why we need it**:
Fixes the managed seed merging with parent to ensure that `seedConfig` is never merged.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
`seedConfig` was never supposed to be merged with parent but it somehow got buggy. I fixed it now and modified the unit tests to test for it.

**Release note**:

```other operator
NONE
```
