### PR TITLE
Fix KonnectivityTunnel annotation when SNI is enabled

### DIFF
--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -436,9 +436,11 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 			// shoot system components
 			metricsserver.CentralLoggingConfiguration,
 		}
-		userAllowedComponents := []string{v1beta1constants.DeploymentNameKubeAPIServer,
+		userAllowedComponents := []string{
+			v1beta1constants.DeploymentNameKubeAPIServer,
 			v1beta1constants.DeploymentNameVPAExporter, v1beta1constants.DeploymentNameVPARecommender,
-			v1beta1constants.DeploymentNameVPAAdmissionController}
+			v1beta1constants.DeploymentNameVPAAdmissionController,
+		}
 
 		// Fetch component specific logging configurations
 		for _, componentFn := range componentsFunctions {
@@ -656,14 +658,11 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 				igwConfig.Ports,
 				corev1.ServicePort{Name: "proxy", Port: 8443, TargetPort: intstr.FromInt(8443)},
 				corev1.ServicePort{Name: "tcp", Port: 443, TargetPort: intstr.FromInt(9443)},
+				// The KonnectivityTunnel feature can be enabled with annotation
+				// and it requires have this port open, even if the feature is disabled in
+				// gardenlet.
+				corev1.ServicePort{Name: "tls-tunnel", Port: 8132, TargetPort: intstr.FromInt(8132)},
 			)
-
-			if gardenletfeatures.FeatureGate.Enabled(features.KonnectivityTunnel) {
-				igwConfig.Ports = append(
-					igwConfig.Ports,
-					corev1.ServicePort{Name: "tls-tunnel", Port: 8132, TargetPort: intstr.FromInt(8132)},
-				)
-			}
 		}
 
 		igw := istio.NewIngressGateway(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area control-plane
/kind bug
/priority normal

**What this PR does / why we need it**:

The `tls-tunnel` port needs to be open all the time on `APIServerSNI`-enabled clusters as the `KonnectivityTunnel` feature can be enabled regardless of the configuration in gardenlet.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an issue with enabling `KonnectivtyTunnel` via annotation (`alpha.featuregates.shoot.gardener.cloud/konnectivity-tunnel: "false"`) on `APIServerSNI`-enabled Seed cluster causing the tunnel to not be opened.
```
