### PR TITLE
Node exporter: enable uname collector

### DIFF
--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -84,6 +84,7 @@ spec:
         - --collector.filesystem.ignored-mount-points=^/.+$
         - --collector.loadavg
         - --collector.meminfo
+        - --collector.uname
         ports:
         - containerPort: {{ .Values.ports.metrics }}
           protocol: TCP


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area mon
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Enables the uname collector of the node-exporter.
It provides the metric ```node_uname_info```

**Which issue(s) this PR fixes**:
Fixes several dashboards

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Node exporter provides the metric node_uname_info
```
