### PR TITLE
[release-v1.15] [manual:component:github.com/gardener/gardener-resource-manager:v0.21.0->v0.21.1]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -24,7 +24,7 @@ images:
 - name: gardener-resource-manager
   sourceRepository: github.com/gardener/gardener-resource-manager
   repository: eu.gcr.io/gardener-project/gardener/gardener-resource-manager
-  tag: "v0.21.0"
+  tag: "v0.21.1"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog


### PR DESCRIPTION
**Release Notes*:
``` bugfix operator github.com/gardener/gardener-resource-manager #116 @rfranzke
A problem with long running ManagedResource reconciliations caused by unavailable `APIServices` was fixed.
```

``` bugfix operator github.com/gardener/gardener-resource-manager #114 @rfranzke
The `.spec.loadBalancerIP` value for `Service`s is now preserved.
```

``` improvement operator github.com/gardener/gardener-resource-manager #113 @rfranzke
The `CheckDaemonSet` function does now lead to more accurate results.
```