### PR TITLE
Add some stabilisation changes  for logging Int test and dump Loki an…

### DIFF
--- a/test/framework/resources/templates/block-loki-validatingwebhookconfiguration.yaml.tpl
+++ b/test/framework/resources/templates/block-loki-validatingwebhookconfiguration.yaml.tpl
@@ -1,0 +1,42 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: block-loki-updates
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    caBundle: {{ .CABundle }}
+    service:
+    service:
+      name: unreal-service
+      namespace: unreal-namespace
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: block.loki.seed.admission.core.gardener.cloud
+  namespaceSelector:
+    matchLabels:
+      {{ .NamespaceLabelKey }}: {{ .NamespaceLabelValue }}
+  objectSelector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - loki
+    - key: role
+      operator: In
+      values:
+      - logging
+  rules:
+  - apiGroups:
+    - "apps"
+    apiVersions:
+    - v1
+    operations:
+    - UPDATE
+    resources:
+    - statefulsets
+    scope: '*'
+  sideEffects: None
+  timeoutSeconds: 10

--- a/test/framework/resources/templates/templates.go
+++ b/test/framework/resources/templates/templates.go
@@ -29,4 +29,7 @@ const (
 
 	// PodAntiAffinityDeploymentName is the name of the pod anti affinity deployment template
 	PodAntiAffinityDeploymentName = "pod-anti-affinity-deployment.yaml.tpl"
+
+	// BlockLokiValidatingWebhookConfiguration is the name of loki's ValidatingWebhookConfiguration
+	BlockLokiValidatingWebhookConfiguration = "block-loki-validatingwebhookconfiguration.yaml.tpl"
 )


### PR DESCRIPTION
Add some stabilisation changes  for logging Int test and dump Loki and Fluent-bit logs on test failure

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
1. Add Valdiating Webhook which will block Loki updates (by the hvpa) during `loki-tenant` Integration test
2. Add check for Loki status in the `loki-tenant` integration test
3. Dump Fluent-Bit and Loki logs if any of the logging tests fail

**Which issue(s) this PR fixes**:
https://github.com/gardener/gardener/issues/3548

**Special notes for your reviewer**:
@dguendisch @vlvasilev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
