### PR TITLE
Restart CoreDNS on each maintenance

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/configmap-componentconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/configmap-componentconfig.yaml
@@ -95,6 +95,9 @@ data:
         {{- if .Values.global.controller.config.controllers.shootMaintenance.enableShootControlPlaneRestarter }}
         enableShootControlPlaneRestarter: {{ .Values.global.controller.config.controllers.shootMaintenance.enableShootControlPlaneRestarter }}
         {{- end }}
+        {{- if .Values.global.controller.config.controllers.shootMaintenance.enableShootCoreAddonRestarter }}
+        enableShootCoreAddonRestarter: {{ .Values.global.controller.config.controllers.shootMaintenance.enableShootCoreAddonRestarter }}
+        {{- end }}
       shootQuota:
         concurrentSyncs: {{ required ".Values.global.controller.config.controllers.shootQuota.concurrentSyncs is required" .Values.global.controller.config.controllers.shootQuota.concurrentSyncs }}
         syncPeriod: {{ required ".Values.global.controller.config.controllers.shootQuota.syncPeriod is required" .Values.global.controller.config.controllers.shootQuota.syncPeriod }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -372,6 +372,7 @@ global:
         shootMaintenance:
           concurrentSyncs: 5
           enableShootControlPlaneRestarter: true
+          enableShootCoreAddonRestarter: true
         shootQuota:
           concurrentSyncs: 5
           syncPeriod: 60m

--- a/charts/shoot-core/components/charts/coredns/templates/coredns-deployment.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-deployment.yaml
@@ -12,7 +12,7 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       k8s-app: kube-dns
@@ -20,6 +20,9 @@ spec:
     metadata:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
+        {{- if .Values.deployment.spec.podAnnotations }}
+{{ toYaml .Values.deployment.spec.podAnnotations | indent 8 }}
+        {{- end }}
       labels:
         origin: gardener
         gardener.cloud/role: system-component
@@ -101,6 +104,7 @@ spec:
             path: /ready
             port: 8181
             scheme: HTTP
+          initialDelaySeconds: 5
       dnsPolicy: Default
       volumes:
         - name: config-volume

--- a/charts/shoot-core/components/charts/coredns/values.yaml
+++ b/charts/shoot-core/components/charts/coredns/values.yaml
@@ -17,6 +17,7 @@ images:
    coredns: image-repository:image-tag
 deployment:
   spec:
+    podAnnotations: {}
     containers:
       imagePullPolicy: IfNotPresent
       resources:

--- a/docs/usage/shoot_maintenance.md
+++ b/docs/usage/shoot_maintenance.md
@@ -94,3 +94,10 @@ Please note that these are exceptional cases but they are observed from time to 
 Gardener, for example, takes this precautionary measure for `kube-controller-manager` pods.
 
 See [this document](../extensions/shoot-maintenance.md) to see how extension developers can extend this behaviour.
+
+### Restart Some Core Addons
+
+Gardener operators can make Gardener restart some core addons, at the moment only CoreDNS, during a shoot maintenance.
+
+CoreDNS benefits from this feature as it automatically solve problems with clients stuck to single replica of the deployment and thus overloading it.
+Please note that these are exceptional cases but they are observed from time to time.

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -16,6 +16,7 @@ controllers:
   shootMaintenance:
     concurrentSyncs: 5
   # enableShootControlPlaneRestarter: true
+  # enableShootCoreAddonRestarter: true
   shootHibernation:
     concurrentSyncs: 5
   shootQuota:

--- a/pkg/controllermanager/apis/config/types.go
+++ b/pkg/controllermanager/apis/config/types.go
@@ -180,6 +180,8 @@ type ShootMaintenanceControllerConfiguration struct {
 	ConcurrentSyncs int
 	// EnableShootControlPlaneRestarter configures whether adequate pods of the shoot control plane are restarted during maintenance.
 	EnableShootControlPlaneRestarter *bool
+	// EnableShootCoreAddonRestarter configures whether some core addons to be restarted during maintenance.
+	EnableShootCoreAddonRestarter *bool
 }
 
 // ShootQuotaControllerConfiguration defines the configuration of the

--- a/pkg/controllermanager/apis/config/v1alpha1/types.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/types.go
@@ -203,6 +203,9 @@ type ShootMaintenanceControllerConfiguration struct {
 	// EnableShootControlPlaneRestarter configures whether adequate pods of the shoot control plane are restarted during maintenance.
 	// +optional
 	EnableShootControlPlaneRestarter *bool `json:"enableShootControlPlaneRestarter"`
+	// EnableShootCoreAddonRestarter configures whether some core addons to be restarted during maintenance.
+	// +optional
+	EnableShootCoreAddonRestarter *bool `json:"enableShootCoreAddonRestarter"`
 }
 
 // ShootQuotaControllerConfiguration defines the configuration of the

--- a/pkg/controllermanager/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/zz_generated.conversion.go
@@ -713,6 +713,7 @@ func Convert_config_ShootHibernationControllerConfiguration_To_v1alpha1_ShootHib
 func autoConvert_v1alpha1_ShootMaintenanceControllerConfiguration_To_config_ShootMaintenanceControllerConfiguration(in *ShootMaintenanceControllerConfiguration, out *config.ShootMaintenanceControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = in.ConcurrentSyncs
 	out.EnableShootControlPlaneRestarter = (*bool)(unsafe.Pointer(in.EnableShootControlPlaneRestarter))
+	out.EnableShootCoreAddonRestarter = (*bool)(unsafe.Pointer(in.EnableShootCoreAddonRestarter))
 	return nil
 }
 
@@ -724,6 +725,7 @@ func Convert_v1alpha1_ShootMaintenanceControllerConfiguration_To_config_ShootMai
 func autoConvert_config_ShootMaintenanceControllerConfiguration_To_v1alpha1_ShootMaintenanceControllerConfiguration(in *config.ShootMaintenanceControllerConfiguration, out *ShootMaintenanceControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = in.ConcurrentSyncs
 	out.EnableShootControlPlaneRestarter = (*bool)(unsafe.Pointer(in.EnableShootControlPlaneRestarter))
+	out.EnableShootCoreAddonRestarter = (*bool)(unsafe.Pointer(in.EnableShootCoreAddonRestarter))
 	return nil
 }
 

--- a/pkg/controllermanager/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -412,6 +412,11 @@ func (in *ShootMaintenanceControllerConfiguration) DeepCopyInto(out *ShootMainte
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableShootCoreAddonRestarter != nil {
+		in, out := &in.EnableShootCoreAddonRestarter, &out.EnableShootCoreAddonRestarter
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controllermanager/apis/config/zz_generated.deepcopy.go
+++ b/pkg/controllermanager/apis/config/zz_generated.deepcopy.go
@@ -414,6 +414,11 @@ func (in *ShootMaintenanceControllerConfiguration) DeepCopyInto(out *ShootMainte
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableShootCoreAddonRestarter != nil {
+		in, out := &in.EnableShootCoreAddonRestarter, &out.EnableShootCoreAddonRestarter
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -200,6 +200,10 @@ func (c *defaultMaintenanceControl) Maintain(shootObj *gardencorev1beta1.Shoot, 
 			controllerutils.AddTasks(s.Annotations, common.ShootTaskRestartControlPlanePods)
 		}
 
+		if utils.IsTrue(c.config.EnableShootCoreAddonRestarter) {
+			controllerutils.AddTasks(s.Annotations, common.ShootTaskRestartCoreAddons)
+		}
+
 		if updatedMachineImages != nil {
 			gardencorev1beta1helper.UpdateMachineImages(s.Spec.Provider.Workers, updatedMachineImages)
 		}

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -268,6 +268,9 @@ const (
 	// ShootTaskRestartControlPlanePods is a name for a Shoot task which is dedicated to restart related control plane pods.
 	ShootTaskRestartControlPlanePods = "restartControlPlanePods"
 
+	// ShootTaskRestartCoreAddons is a name for a Shoot task which is dedicated to restart some core addons.
+	ShootTaskRestartCoreAddons = "restartCoreAddons"
+
 	// ShootOperationRetry is a constant for an annotation on a Shoot indicating that a failed Shoot reconciliation shall be retried.
 	ShootOperationRetry = "retry"
 


### PR DESCRIPTION
**How to categorize this PR?**
/area networking
/kind discussion
/priority normal

**What this PR does / why we need it**:
Restart CoreDNS on each maintenance.
The reason for this change is that we have seen several times shoot cluster with broken networking because all of the dns traffic is going only to one of the all CoreDNS replicas, even though the HPA has scaled it up to the maximum 5 replicas. In these cases just a plain restart of the CoreDNS pods resolved the networking issues in the cluster.

#### Session Affinity
I tried to set `sessionAffinity` https://github.com/gardener/gardener/commit/46afca976623aae4b8784e189da3cbea4438dc01 to the `kube-dns` service and used the command `watch -n 0.1 dig google.com` from a pod running in the cluster to verify whether there is an improvement or not. It got worse :open_mouth:. I found that the client was always stuck to the same backend pod. Reducing the timeout to 5 seconds had no effect.
![coredns-session-affinity-with-description](https://user-images.githubusercontent.com/6798531/108558652-e55ae400-7302-11eb-955b-2c7ced5a30c4.png)

Based on the above, I think the session affinity will affect negatively all clusters in a landscape, so I prefer to not implement it.

#### Restarting the CoreDNS
It is influenced by the control plane restarted. It is optional feature of the maintenance controller disabled by default.
Firstly, I implemented direct coredns deployment patching https://github.com/gardener/gardener/commit/0132b981f32122a2de1de4ced7873849203ae9e2, but It has the disadvantage that the timestamp is not preserved in the managed resource and GRM revert the deployment spec almost immediately. Thus it cannot guarantee that all pods will be restarted.
Then I switched to injecting the timestamp in the chart values https://github.com/gardener/gardener/commit/f24c5a7ee7a1f89bb0bf868d0e12f8629031e059 which is working exactly as it is required. I just not like so much how the task is removed from the shoot.

#### General improvements
- added initial delay to the readiness probe of CoreDNS.
- decreased `maxUnavailable` for the CoreDNS deployment from 1 to 0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I am opening this PR as draft and to collect some initial feedback. 
I will squash/remove commits before to make it `ready`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
CoreDNS deployment of shoot clusters can now be automatically restarted during the shoot's maintenance time window. This is used to solve problems with clients stuck to single replica of the deployment and thus overloading it. The feature can be enabled via the `ControllerManagerConfiguration` under `.controllers.shootMaintecance.enableShootCoreAddonRestarter` (see `example/20-componentconfig-gardener-controller-manager.yaml`).
```
