### PR TITLE
[release-v1.17] Removing the finalizers from the config resources

### DIFF
--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -112,6 +112,7 @@ type Terraformer interface {
 	GetState(ctx context.Context) ([]byte, error)
 	IsStateEmpty(ctx context.Context) bool
 	CleanupConfiguration(ctx context.Context) error
+	RemoveTerraformerFinalizerFromConfig(ctx context.Context) error
 	GetStateOutputVariables(ctx context.Context, variables ...string) (map[string]string, error)
 	ConfigExists(ctx context.Context) (bool, error)
 	NumberOfResources(ctx context.Context) (int, error)

--- a/pkg/mock/gardener/extensions/terraformer/mocks.go
+++ b/pkg/mock/gardener/extensions/terraformer/mocks.go
@@ -206,6 +206,20 @@ func (mr *MockTerraformerMockRecorder) NumberOfResources(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NumberOfResources", reflect.TypeOf((*MockTerraformer)(nil).NumberOfResources), arg0)
 }
 
+// RemoveTerraformerFinalizerFromConfig mocks base method.
+func (m *MockTerraformer) RemoveTerraformerFinalizerFromConfig(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveTerraformerFinalizerFromConfig", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveTerraformerFinalizerFromConfig indicates an expected call of RemoveTerraformerFinalizerFromConfig.
+func (mr *MockTerraformerMockRecorder) RemoveTerraformerFinalizerFromConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTerraformerFinalizerFromConfig", reflect.TypeOf((*MockTerraformer)(nil).RemoveTerraformerFinalizerFromConfig), arg0)
+}
+
 // SetDeadlineCleaning mocks base method.
 func (m *MockTerraformer) SetDeadlineCleaning(arg0 time.Duration) terraformer.Terraformer {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Cherry-pick of #3556.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy dependency
The `Terraformer` interface has now a new function `RemoveTerraformerFinalizerFromConfig` which will remove the "terraformer" finalizer from the `Secret`/`ConfigMap` resources.
```