### PR TITLE
[release-v1.17] Remove finalizers from the worker secret in the migration flow

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
@@ -73,6 +73,10 @@ func (a *genericActuator) Migrate(ctx context.Context, worker *extensionsv1alpha
 		return errors.Wrap(err, "cleaning up machine class secrets failed")
 	}
 
+	if err := a.removeFinalizerFromWorkerSecretRef(ctx, logger, worker); err != nil {
+		return errors.Wrap(err, "unable to remove the finalizers from worker`s secret")
+	}
+
 	// Wait until all machine resources have been properly deleted.
 	if err := a.waitUntilMachineResourcesDeleted(ctx, logger, worker, workerDelegate); err != nil {
 		return gardencorev1beta1helper.DetermineError(err, fmt.Sprintf("Failed while waiting for all machine resources to be deleted: '%s'", err.Error()))


### PR DESCRIPTION
Cherry-pick of #3560.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy dependency
In the generic worker actuator's migration flow, the MCM finalizer of the secret that is referenced by the `Worker` is not removed. We have now added functionality that checks that secret and removes only the MCM finalizers if necessary. 
```