### PR TITLE
Fix clean.sh for vendoring repos

### DIFF
--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -30,4 +30,6 @@ for source_tree in $@; do
   grep -lr --include="*.go" "//go:generate packr2" "$(dirname "$source_tree")" | xargs -I {} packr2 clean "{}/.."
 done
 
-find ./hack/api-reference/ -type f -name "*.md" -exec rm '{}' \;
+if [ -d "$PWD/hack/api-reference" ]; then
+  find ./hack/api-reference/ -type f -name "*.md" -exec rm '{}' \;
+fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind bug
/priority normal

**What this PR does / why we need it**:

Follow-up on https://github.com/gardener/gardener/pull/3489.

Fix `clean.sh` for vendoring repos, by making the `hack/api-reference` directory optional.

**Which issue(s) this PR fixes**:
Fixes https://concourse.ci.gardener.cloud/builds/539404#L603356b3:32

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
