### PR TITLE
Add VPA resources for istiod

### DIFF
--- a/charts/istio/istio-istiod/templates/autoscale.yaml
+++ b/charts/istio/istio-istiod/templates/autoscale.yaml
@@ -1,19 +1,20 @@
-apiVersion: {{ include "hpaversion" . }}
-kind: HorizontalPodAutoscaler
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
 metadata:
   name: istiod
   namespace: {{ .Release.Namespace }}
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 spec:
-  maxReplicas: 5
-  minReplicas: 2
-  scaleTargetRef:
+  targetRef:
     apiVersion: {{ include "deploymentversion" . }}
     kind: Deployment
     name: istiod
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      targetAverageUtilization: 80
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+      - containerName: discovery
+        minAllowed:
+          memory: 128Mi
+          cpu: 100m

--- a/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/charts/istio/istio-istiod/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         sidecar.istio.io/inject: "false"
         checksum/istio-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
+      replicas: 2
       serviceAccountName: istiod
       securityContext:
         fsGroup: 1337
@@ -96,7 +97,7 @@ spec:
         resources:
           requests:
             cpu: 250m
-            memory: 128Mi
+            memory: 256Mi
           limits:
             cpu: 1000m
             memory: 2048Mi

--- a/pkg/operation/seed/istio/istiod.go
+++ b/pkg/operation/seed/istio/istiod.go
@@ -22,9 +22,11 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -72,6 +74,16 @@ func (i *istiod) Deploy(ctx context.Context) error {
 			},
 		},
 	); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	// TODO (mvladev): Remove this in next release
+	if err := client.IgnoreNotFound(i.client.Delete(ctx, &autoscalingv1.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "istiod",
+			Namespace: i.namespace,
+		},
+	})); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Secrets size can cause OOMKills of the istiod in big Seed clusters. The VPA solves that problem.

**Which issue(s) this PR fixes**:

Fixes #3595 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`istiod` is now scaled automatically by `VerticalPodAutoscaler` instead of `HorizontalPodAutoscaler`. This fixes OOMKilled issues on big Seed clusters.
```
