### PR TITLE
Ensure ManagedSeed VPA is not enabled if shoot VPA is enabled

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -311,6 +311,11 @@ func NginxIngressEnabled(addons *core.Addons) bool {
 	return addons != nil && addons.NginxIngress != nil && addons.NginxIngress.Enabled
 }
 
+// ShootWantsVerticalPodAutoscaler checks if the given Shoot needs a VPA.
+func ShootWantsVerticalPodAutoscaler(shoot *core.Shoot) bool {
+	return shoot.Spec.Kubernetes.VerticalPodAutoscaler != nil && shoot.Spec.Kubernetes.VerticalPodAutoscaler.Enabled
+}
+
 var scheme *runtime.Scheme
 
 func init() {

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -856,6 +856,11 @@ func ShootUsesUnmanagedDNS(shoot *gardencorev1beta1.Shoot) bool {
 	return shoot.Spec.DNS != nil && len(shoot.Spec.DNS.Providers) > 0 && shoot.Spec.DNS.Providers[0].Type != nil && *shoot.Spec.DNS.Providers[0].Type == "unmanaged"
 }
 
+// SeedSettingVerticalPodAutoscalerEnabled returns true if the 'verticalPodAutoscaler' setting is enabled.
+func SeedSettingVerticalPodAutoscalerEnabled(settings *gardencorev1beta1.SeedSettings) bool {
+	return settings == nil || settings.VerticalPodAutoscaler == nil || settings.VerticalPodAutoscaler.Enabled
+}
+
 // DetermineMachineImageForName finds the cloud specific machine images in the <cloudProfile> for the given <name> and
 // region. In case it does not find the machine image with the <name>, it returns false. Otherwise, true and the
 // cloud-specific machine image will be returned.

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
@@ -22,6 +22,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/helper"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	v1alpha1helper "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/helper"
@@ -313,7 +314,7 @@ func (a *actuator) checkSeedSpec(ctx context.Context, spec *gardencorev1beta1.Se
 	}
 
 	// If VPA is enabled, check if the shoot namespace in the seed contains a vpa-admission-controller deployment
-	if spec.Settings != nil && spec.Settings.VerticalPodAutoscaler != nil && spec.Settings.VerticalPodAutoscaler.Enabled {
+	if gardencorev1beta1helper.SeedSettingVerticalPodAutoscalerEnabled(spec.Settings) {
 		seedVPAAdmissionControllerExists, err := a.seedVPADeploymentExists(ctx, seedClient, shoot)
 		if err != nil {
 			return err

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -91,6 +91,11 @@ var _ = Describe("ManagedSeed", func() {
 					DNS: &core.DNS{
 						Domain: pointer.StringPtr(domain),
 					},
+					Kubernetes: core.Kubernetes{
+						VerticalPodAutoscaler: &core.VerticalPodAutoscaler{
+							Enabled: true,
+						},
+					},
 					Networking: core.Networking{
 						Pods:     pointer.StringPtr("100.96.0.0/11"),
 						Nodes:    pointer.StringPtr("10.250.0.0/16"),
@@ -162,6 +167,11 @@ var _ = Describe("ManagedSeed", func() {
 						Provider: core.SeedProvider{
 							Type:   provider,
 							Region: region,
+						},
+						Settings: &core.SeedSettings{
+							VerticalPodAutoscaler: &core.SeedSettingVerticalPodAutoscaler{
+								Enabled: false,
+							},
 						},
 						Ingress: ingress,
 					},
@@ -325,6 +335,11 @@ var _ = Describe("ManagedSeed", func() {
 						Type:   "bar-provider",
 						Region: "bar-region",
 					},
+					Settings: &core.SeedSettings{
+						VerticalPodAutoscaler: &core.SeedSettingVerticalPodAutoscaler{
+							Enabled: true,
+						},
+					},
 				}
 
 				coreClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
@@ -357,6 +372,10 @@ var _ = Describe("ManagedSeed", func() {
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
 						"Field": Equal("spec.seedTemplate.spec.provider.region"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.seedTemplate.spec.settings.verticalPodAutoscaler.enabled"),
 					})),
 				))
 			})


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug
/priority normal

**What this PR does / why we need it**:
Ensures ManagedSeed VPA is not enabled if shoot VPA is enabled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I chose to fix the issue in the admission plugin, rather than in the (deprecated) seed registration controller (handling the `use-as-seed` annotation).
* If the seed VPA is not explicitly enabled or disabled - set it to the opposite of the shoot VPA setting
* If the seed VPA is explicitly enabled and the shoot VPA is also enabled - error
* If the seed VPA is explicitly disabled and the shoot VPA is also disabled - ok, the user might want to use their own VPA

In addition, the safety check in the managed seed controller is also fixed to properly take into account the fact that the seed VPA is enabled by default, similarly to all other seed settings.

**Release note**:

```other operator
NONE
```
