### PR TITLE
Scale down Loki only once per week

### DIFF
--- a/charts/seed-bootstrap/charts/loki/values.yaml
+++ b/charts/seed-bootstrap/charts/loki/values.yaml
@@ -94,7 +94,7 @@ hvpa:
         value: 300M
         percentage: 80
   scaleDownStabilization:
-    stabilizationDuration: "2h"
+    stabilizationDuration: "168h"
     minChange:
       cpu:
         value: "200m"

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -401,8 +401,17 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient, k8sSeedClient kubern
 					return err
 				}
 			} else {
-				maintenanceBegin = shootInfo.Data["maintenanceBegin"]
-				maintenanceEnd = shootInfo.Data["maintenanceEnd"]
+				shootMaintenanceBegin, err := utils.ParseMaintenanceTime(shootInfo.Data["maintenanceBegin"])
+				if err != nil {
+					return err
+				}
+				maintenanceBegin = shootMaintenanceBegin.Add(1, 0, 0).Formatted()
+
+				shootMaintenanceEnd, err := utils.ParseMaintenanceTime(shootInfo.Data["maintenanceEnd"])
+				if err != nil {
+					return err
+				}
+				maintenanceEnd = shootMaintenanceEnd.Add(1, 0, 0).Formatted()
 			}
 
 			lokiValues["hvpa"] = map[string]interface{}{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/priority normal

**What this PR does / why we need it**:
1. Configure HVPA to scale down Loki only once per week to reduce the frequent restarts.

2. Change the ScaleDown Maintenance time window to be 1 hour after the shoot's one. This will prevent Loki to be scaled down and to lose logs during the shoot update.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
