### PR TITLE
Fix nil pointer exception when updating shootstate

### DIFF
--- a/pkg/gardenlet/controller/federatedseed/extensions/shootstate_control_test.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/shootstate_control_test.go
@@ -173,14 +173,13 @@ var _ = Describe("ShootState Control", func() {
 				},
 			},
 		}
-
-		Expect(seedClient.Create(ctx, cluster)).To(Succeed())
 	})
 
 	Describe("#CreateShootStateSyncReconcileFunc", func() {
 		It("should properly update ShootState with extension state", func() {
 			Expect(fakeGardenClient.Client().Create(ctx, shootState)).To(Succeed())
 			Expect(fakeSeedClient.Client().Create(ctx, extension)).To(Succeed())
+			Expect(fakeSeedClient.Client().Create(ctx, cluster)).To(Succeed())
 
 			reconcilerFunc := shootStateControl.CreateShootStateSyncReconcileFunc(extensionsv1alpha1.ExtensionResource, extensionObjCreator)
 			_, err := reconcilerFunc.Reconcile(ctx, reconcileRequest)
@@ -198,6 +197,7 @@ var _ = Describe("ShootState Control", func() {
 			Expect(fakeGardenClient.Client().Create(ctx, shootState)).To(Succeed())
 			Expect(fakeSeedClient.Client().Create(ctx, extension)).To(Succeed())
 			Expect(fakeSeedClient.Client().Create(ctx, secretObj)).To(Succeed())
+			Expect(fakeSeedClient.Client().Create(ctx, cluster)).To(Succeed())
 
 			reconcilerFunc := shootStateControl.CreateShootStateSyncReconcileFunc(extensionsv1alpha1.ExtensionResource, extensionObjCreator)
 			_, err := reconcilerFunc.Reconcile(ctx, reconcileRequest)
@@ -214,6 +214,7 @@ var _ = Describe("ShootState Control", func() {
 
 			Expect(fakeGardenClient.Client().Create(ctx, shootStateWithExtensionData)).To(Succeed())
 			Expect(fakeSeedClient.Client().Create(ctx, extension)).To(Succeed())
+			Expect(fakeSeedClient.Client().Create(ctx, cluster)).To(Succeed())
 
 			reconcilerFunc := shootStateControl.CreateShootStateSyncReconcileFunc(extensionsv1alpha1.ExtensionResource, extensionObjCreator)
 			_, err := reconcilerFunc.Reconcile(ctx, reconcileRequest)
@@ -237,6 +238,7 @@ var _ = Describe("ShootState Control", func() {
 			Expect(fakeGardenClient.Client().Create(ctx, shootStateWithExtensionData)).To(Succeed())
 			Expect(fakeSeedClient.Client().Create(ctx, extension)).To(Succeed())
 			Expect(fakeSeedClient.Client().Create(ctx, newSecretObj)).To(Succeed())
+			Expect(fakeSeedClient.Client().Create(ctx, cluster)).To(Succeed())
 
 			reconcilerFunc := shootStateControl.CreateShootStateSyncReconcileFunc(extensionsv1alpha1.ExtensionResource, extensionObjCreator)
 			_, err := reconcilerFunc.Reconcile(ctx, reconcileRequest)
@@ -251,6 +253,7 @@ var _ = Describe("ShootState Control", func() {
 			extension.Status.State = nil
 			Expect(fakeGardenClient.Client().Create(ctx, shootStateWithExtensionData)).To(Succeed())
 			Expect(fakeSeedClient.Client().Create(ctx, extension)).To(Succeed())
+			Expect(fakeSeedClient.Client().Create(ctx, cluster)).To(Succeed())
 
 			reconcilerFunc := shootStateControl.CreateShootStateSyncReconcileFunc(extensionsv1alpha1.ExtensionResource, extensionObjCreator)
 			_, err := reconcilerFunc.Reconcile(ctx, reconcileRequest)
@@ -268,6 +271,7 @@ var _ = Describe("ShootState Control", func() {
 
 			Expect(fakeGardenClient.Client().Create(ctx, shootStateWithExtensionData)).To(Succeed())
 			Expect(fakeSeedClient.Client().Create(ctx, extension)).To(Succeed())
+			Expect(fakeSeedClient.Client().Create(ctx, cluster)).To(Succeed())
 
 			reconcilerFunc := shootStateControl.CreateShootStateSyncReconcileFunc(extensionsv1alpha1.ExtensionResource, extensionObjCreator)
 			_, err := reconcilerFunc.Reconcile(ctx, reconcileRequest)
@@ -294,6 +298,14 @@ var _ = Describe("ShootState Control", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			ctrl.Finish()
+		})
+
+		It("should not throw any errors if Cluster resource does not exists", func() {
+			Expect(fakeSeedClient.Client().Create(ctx, extension)).To(Succeed())
+
+			reconcilerFunc := shootStateControl.CreateShootStateSyncReconcileFunc(extensionsv1alpha1.ExtensionResource, extensionObjCreator)
+			_, err := reconcilerFunc.Reconcile(ctx, reconcileRequest)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug
/priority critical

**What this PR does / why we need it**:
Fixes a nil pointer exception which occurs if there are still extension resources present in the seed but the `Cluster` resources has been deleted.

**Which issue(s) this PR fixes**:
Fixes #3621

**Special notes for your reviewer**:
This change returns the previous behaviour where if the `Cluster` is not found we do not return any error.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed nil pointer exception that occurs when there are still extension resources in the `Seed`, but the `Cluster` resource has been deleted.
```
