### PR TITLE
[release-v1.15] Fix potential nil pointer when validating pid reservations

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1096,7 +1096,7 @@ func validateKubeletConfigReserved(reserved *core.KubeletConfigReserved, fldPath
 		allErrs = append(allErrs, validateResourceQuantityValue("ephemeralStorage", *reserved.EphemeralStorage, fldPath.Child("ephemeralStorage"))...)
 	}
 	if reserved.PID != nil {
-		allErrs = append(allErrs, validateResourceQuantityValue("pid", *reserved.EphemeralStorage, fldPath.Child("pid"))...)
+		allErrs = append(allErrs, validateResourceQuantityValue("pid", *reserved.PID, fldPath.Child("pid"))...)
 	}
 	return allErrs
 }


### PR DESCRIPTION
/kind bug

Cherry pick of #3632 on release-v1.15.

#3632: Fix potential nil pointer when validating pid reservations

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A potential `nil` pointer exception in the `Shoot` validation (leading to `503` responses from `gardener-apiserver`) when validating PID reservations (e.g., in `kubeReserved` or `systemReserved`) has been fixed.
```
