### PR TITLE
Graceful BackupEntry deletion for specific shoot purposes

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
@@ -72,6 +72,10 @@ data:
         {{- if .Values.global.gardenlet.config.controllers.backupEntry.deletionGracePeriodHours }}
         deletionGracePeriodHours: {{ .Values.global.gardenlet.config.controllers.backupEntry.deletionGracePeriodHours }}
         {{- end }}
+        {{- if .Values.global.gardenlet.config.controllers.backupEntry.deletionGracePeriodShootPurposes }}
+        deletionGracePeriodShootPurposes:
+{{ toYaml .Values.global.gardenlet.config.controllers.backupEntry.deletionGracePeriodShootPurposes | indent 8 }}
+        {{- end }}
       {{- if .Values.global.gardenlet.config.controllers.controllerInstallation }}
       controllerInstallation:
         concurrentSyncs: {{ required ".Values.global.gardenlet.config.controllers.controllerInstallation.concurrentSyncs is required" .Values.global.gardenlet.config.controllers.controllerInstallation.concurrentSyncs }}

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -68,7 +68,9 @@ global:
           concurrentSyncs: 20
         backupEntry:
           concurrentSyncs: 20
-          deletionGracePeriodHours: 0
+        # deletionGracePeriodHours: 24
+        # deletionGracePeriodShootPurposes:
+        # - production
         seed:
           concurrentSyncs: 5
           syncPeriod: 1m

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -1,13 +1,13 @@
 # Gardenlet
 
 Gardener is implemented using the [operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/):
-It uses custom controllers that act on our own custom resources, 
-and apply Kubernetes principles to manage clusters instead of containers. 
-Following this analogy, you can recognize components of the Gardener architecture 
-as well-known Kubernetes components, for example, shoot clusters can be compared with pods, 
+It uses custom controllers that act on our own custom resources,
+and apply Kubernetes principles to manage clusters instead of containers.
+Following this analogy, you can recognize components of the Gardener architecture
+as well-known Kubernetes components, for example, shoot clusters can be compared with pods,
 and seed clusters can be seen as worker nodes.
 
-The following Gardener components play a similar role as the corresponding components 
+The following Gardener components play a similar role as the corresponding components
 in the Kubernetes architecture:
 
 | Gardener Component | Kubernetes Component |
@@ -17,22 +17,22 @@ in the Kubernetes architecture:
 | `gardener-scheduler` | `kube-scheduler` |
 | `gardenlet` | `kubelet` |
 
-Similar to how the `kube-scheduler` of Kubernetes finds an appropriate node 
-for newly created pods, the `gardener-scheduler` of Gardener finds an appropriate seed cluster 
-to host the control plane for newly ordered clusters. 
+Similar to how the `kube-scheduler` of Kubernetes finds an appropriate node
+for newly created pods, the `gardener-scheduler` of Gardener finds an appropriate seed cluster
+to host the control plane for newly ordered clusters.
 By providing multiple seed clusters for a region or provider, and distributing the workload,
 Gardener also reduces the blast radius of potential issues.
 
-Kubernetes runs a primary "agent" on every node, the kubelet, 
-which is responsible for managing pods and containers on its particular node. 
-Decentralizing the responsibility to the kubelet has the advantage that the overall system 
-is scalable. Gardener achieves the same for cluster management by using a **gardenlet** 
-as primary "agent" on every seed cluster, and is only responsible for shoot clusters 
+Kubernetes runs a primary "agent" on every node, the kubelet,
+which is responsible for managing pods and containers on its particular node.
+Decentralizing the responsibility to the kubelet has the advantage that the overall system
+is scalable. Gardener achieves the same for cluster management by using a **gardenlet**
+as primary "agent" on every seed cluster, and is only responsible for shoot clusters
 located in its particular seed cluster:
 
 ![Counterparts in the Gardener Architecture and the Kubernetes Architecture](gardenlet-architecture-similarities.png)
 
-The `gardener-controller-manager` has control loops to manage resources of the Gardener API. However, instead of letting the `gardener-controller-manager` talk directly to seed clusters or shoot clusters, the responsibility isn’t only delegated to the gardenlet, but also managed using a reversed control flow: It's up to the gardenlet to contact the Gardener API server, for example, to share a status for its managed seed clusters. 
+The `gardener-controller-manager` has control loops to manage resources of the Gardener API. However, instead of letting the `gardener-controller-manager` talk directly to seed clusters or shoot clusters, the responsibility isn’t only delegated to the gardenlet, but also managed using a reversed control flow: It's up to the gardenlet to contact the Gardener API server, for example, to share a status for its managed seed clusters.
 
 Reversing the control flow allows placing seed clusters or shoot clusters behind firewalls without the necessity of direct access via VPN tunnels anymore.
 
@@ -40,22 +40,22 @@ Reversing the control flow allows placing seed clusters or shoot clusters behind
 
 ## TLS Bootstrapping
 
-Kubernetes doesn’t manage worker nodes itself, and it’s also not 
+Kubernetes doesn’t manage worker nodes itself, and it’s also not
 responsible for the lifecycle of the kubelet running on the workers.
-Similarly, Gardener doesn’t manage seed clusters itself, 
-so Gardener is also not responsible for the lifecycle of the gardenlet running on the seeds. 
-As a consequence, both the gardenlet and the kubelet need to prepare 
-a trusted connection to the Gardener API server 
+Similarly, Gardener doesn’t manage seed clusters itself,
+so Gardener is also not responsible for the lifecycle of the gardenlet running on the seeds.
+As a consequence, both the gardenlet and the kubelet need to prepare
+a trusted connection to the Gardener API server
 and the Kubernetes API server correspondingly.
 
-To prepare a trusted connection between the gardenlet 
-and the Gardener API server, the gardenlet initializes 
+To prepare a trusted connection between the gardenlet
+and the Gardener API server, the gardenlet initializes
 a bootstrapping process after you deployed it into your seed clusters:
 
-1. The gardenlet starts up with a bootstrap `kubeconfig` 
+1. The gardenlet starts up with a bootstrap `kubeconfig`
    having a bootstrap token that allows to create `CertificateSigningRequest` (CSR) resources.
 
-2. After the CSR is signed, the gardenlet downloads 
+2. After the CSR is signed, the gardenlet downloads
    the created client certificate, creates a new `kubeconfig` with it,
    and stores it inside a `Secret` in the seed cluster.
 
@@ -64,51 +64,51 @@ a bootstrapping process after you deployed it into your seed clusters:
 
 4. The gardenlet starts normal operation.
 
-The `gardener-controller-manager` runs a control loop 
+The `gardener-controller-manager` runs a control loop
 that automatically signs CSRs created by gardenlets.
 
-> The gardenlet bootstrapping process is based on the 
-> kubelet bootstrapping process. More information: 
+> The gardenlet bootstrapping process is based on the
+> kubelet bootstrapping process. More information:
 > [Kubelet's TLS bootstrapping](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/).
 
-If you don't want to run this bootstrap process you can create 
+If you don't want to run this bootstrap process you can create
 a `kubeconfig` pointing to the garden cluster for the gardenlet yourself,
-and use field `gardenClientConnection.kubeconfig` in the 
+and use field `gardenClientConnection.kubeconfig` in the
 gardenlet configuration to share it with the gardenlet.
 
 ## Gardenlet Certificate Rotation
 
 The certificate used to authenticate the gardenlet against the API server
-is valid for a year. 
-After about 10 months, the gardenlet tries to automatically replace 
+is valid for a year.
+After about 10 months, the gardenlet tries to automatically replace
 the current certificate with a new one (certificate rotation).
 
-To use certificate rotation, you need to specify the secret to store 
-the `kubeconfig` with the rotated certificate in field 
-`.gardenClientConnection.kubeconfigSecret` of the 
+To use certificate rotation, you need to specify the secret to store
+the `kubeconfig` with the rotated certificate in field
+`.gardenClientConnection.kubeconfigSecret` of the
 gardenlet [component configuration](#component-configuration).
 
 ### Rotate certificates using bootstrap `kubeconfig`
 
 If the gardenlet created the certificate during the initial TLS Bootstrapping
 using the Bootstrap `kubeconfig`, certificates can be rotated automatically.
-The same control loop in the `gardener-controller-manager` that signs 
-the CSRs during the initial TLS Bootstrapping also automatically signs 
+The same control loop in the `gardener-controller-manager` that signs
+the CSRs during the initial TLS Bootstrapping also automatically signs
 the CSR during a certificate rotation.
 
 ### Rotate Certificate Using Custom `kubeconfig`
 
-When trying to rotate a custom certificate that wasn’t created by gardenlet 
-as part of the TLS Bootstrap, the x509 certificate's `Subject` field 
+When trying to rotate a custom certificate that wasn’t created by gardenlet
+as part of the TLS Bootstrap, the x509 certificate's `Subject` field
 needs to conform to the following:
   - the Common Name (CN) is prefixed with `gardener.cloud:system:seed:`
   - the Organization (O) equals `gardener.cloud:system:seeds`
 
-Otherwise, the `gardener-controller-manager` doesn’t automatically 
+Otherwise, the `gardener-controller-manager` doesn’t automatically
 sign the CSR.
 In this case, an external component or user needs to approve the CSR manually,
 for example, using command  `kubectl certificate approve  seed-csr-<...>`).
-If that doesn’t happen within 15 minutes, 
+If that doesn’t happen within 15 minutes,
 the gardenlet repeats the process and creates another CSR.
 
 ## Seed Config versus Seed Selector
@@ -120,18 +120,18 @@ The usage of the gardenlet is flexible:
 | `seedConfig` | Run one gardenlet per seed cluster inside the seed cluster itself.|
 | `seedSelector` | Use one gardenlet to manage multiple seed clusters. The gardenlet can run outside of the seed cluster.|
 
-> For production use it’s recommended to go for the `seedConfig` option, 
+> For production use it’s recommended to go for the `seedConfig` option,
 > because it makes scaling easier and leads to a better distribution of responsibilities.
 
-* Provide a `seedConfig` that contains information about the seed cluster itself 
-  if you want the gardenlet in the standard way, 
-  see [the example gardenlet configuration](../../example/20-componentconfig-gardenlet.yaml). 
+* Provide a `seedConfig` that contains information about the seed cluster itself
+  if you want the gardenlet in the standard way,
+  see [the example gardenlet configuration](../../example/20-componentconfig-gardenlet.yaml).
   Once bootstrapped, the gardenlet creates and updates its `Seed` object itself.
 
 * Provide a `seedSelector` that incorporates a label selector for the
   targeted seed clusters if you want the gardenlet to manage multiple seeds,
-  see [the example gardenlet configuration](../../example/20-componentconfig-gardenlet.yaml). 
-  In this case, you have to create the `Seed` objects 
+  see [the example gardenlet configuration](../../example/20-componentconfig-gardenlet.yaml).
+  In this case, you have to create the `Seed` objects
   together with a `kubeconfig` pointing to the cluster yourself.
 
 ## Component Configuration
@@ -146,66 +146,66 @@ More information: [Example Gardenlet Component Configuration](../../example/20-c
 
 ## Heartbeats
 
-Similar to how Kubernetes uses `Lease` objects for node heart beats 
-(see [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/0009-node-heartbeat.md)), 
+Similar to how Kubernetes uses `Lease` objects for node heart beats
+(see [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/0009-node-heartbeat.md)),
 the gardenlet is using `Lease` objects for heart beats of the seed cluster.
-Every two seconds, the gardenlet checks that the seed cluster's `/healthz` 
-endpoint returns HTTP status code 200. 
-If that is the case, the gardenlet renews the lease in the Garden cluster in the `gardener-system-seed-lease` namespace and updates 
+Every two seconds, the gardenlet checks that the seed cluster's `/healthz`
+endpoint returns HTTP status code 200.
+If that is the case, the gardenlet renews the lease in the Garden cluster in the `gardener-system-seed-lease` namespace and updates
 the `GardenletReady` condition in the `status.conditions` field of the `Seed` resource(s).
 
-Similarly to the `node-lifecycle-controller` inside the `kube-controller-manager`, 
+Similarly to the `node-lifecycle-controller` inside the `kube-controller-manager`,
 the `gardener-controller-manager` features a `seed-lifecycle-controller` that sets
 the `GardenletReady` condition to `Unknown` in case the gardenlet fails to renew the lease.
 As a consequence, the `gardener-scheduler` doesn’t consider this seed cluster for newly created shoot clusters anymore.
 
 ### `/healthz` Endpoint
 
-The gardenlet includes an HTTPS server that serves a `/healthz` endpoint. 
+The gardenlet includes an HTTPS server that serves a `/healthz` endpoint.
 It’s used as a liveness probe in the `Deployment` of the gardenlet.
 If the gardenlet fails to renew its lease
 then the endpoint returns `500 Internal Server Error`, otherwise it returns `200 OK`.
 
-> ⚠️<br> In case the gardenlet is managing multiple seeds 
-> (that is, a seed selector is used) then the `/healthz` 
-> reports `500 Internal Server Error` if there is at least one seed 
-> for which it couldn’t renew its lease. Only if it can renew the lease 
+> ⚠️<br> In case the gardenlet is managing multiple seeds
+> (that is, a seed selector is used) then the `/healthz`
+> reports `500 Internal Server Error` if there is at least one seed
+> for which it couldn’t renew its lease. Only if it can renew the lease
 > for all seeds it reports `200 OK`.
 
-Please note, that the `/healthz` only indicates whether the gardenlet 
-could successfully probe the Seed's API server and renew the lease with 
+Please note, that the `/healthz` only indicates whether the gardenlet
+could successfully probe the Seed's API server and renew the lease with
 the Garden cluster.
 It does *not* show that the Gardener extension API server (with the Gardener resource groups)
-is available. 
+is available.
 However, the Gardenlet is designed to withstand such connection outages and
 retries until the connection is reestablished.
 
 ## Managed Seeds
 
 Gardener users can use shoot clusters as seed clusters, so-called "managed seeds" (aka "shooted seeds"),
-by creating `ManagedSeed` resources. 
-By default, the gardenlet that manages this shoot cluster then automatically 
-creates a clone of itself with the same version and the same configuration 
-that it currently has. 
-Then it deploys the gardenlet clone into the managed seed cluster. 
+by creating `ManagedSeed` resources.
+By default, the gardenlet that manages this shoot cluster then automatically
+creates a clone of itself with the same version and the same configuration
+that it currently has.
+Then it deploys the gardenlet clone into the managed seed cluster.
 
-If you want to prevent the automatic gardenlet deployment, 
+If you want to prevent the automatic gardenlet deployment,
 specify the `seedTemplate` section in the `ManagedSeed` resource, and don't specify
-the `gardenlet` section. 
+the `gardenlet` section.
 In this case, you have to deploy the gardenlet on your own into the seed cluster.
 
 More information: [Register Shoot as Seed](../usage/managed_seed.md)
 
 ## Migrating from Previous Gardener Versions
 
-If your Gardener version doesn’t support gardenlets yet, 
+If your Gardener version doesn’t support gardenlets yet,
 no special migration is required, but the following prerequisites must be met:
 
 * Your Gardener version is at least 0.31 before upgrading to v1.
-* You have to make sure that your garden cluster is exposed in a way 
+* You have to make sure that your garden cluster is exposed in a way
   that it’s reachable from all your seed clusters.
 
-With previous Gardener versions, you had deployed the Gardener Helm chart 
+With previous Gardener versions, you had deployed the Gardener Helm chart
 (incorporating the API server, `controller-manager`, and scheduler).
 With v1, this stays the same, but you now have to deploy the gardenlet Helm chart as well
 into all of your seeds (if they aren’t managed, as mentioned earlier).

--- a/docs/extensions/backupentry.md
+++ b/docs/extensions/backupentry.md
@@ -7,8 +7,7 @@ Now, Gardener commissions an external, provider-specific controller to take over
 
 ## What is the lifespan of `BackupEntry`?
 
-The bucket associated with `BackupEntry` will be created at using `BackupBucket` resource. The `BackupEntry` resource will be created as a part of a `Shoot` creation. But resource continue to exists post deletion of a `Shoot`. The  `deletionGracePeriod` of a `BackupEntry` resource i.e. time after the shoot deletion
-is configurable globally for Gardener via gardener-controller-manager component config. You can find the configuration option in reference.
+The bucket associated with `BackupEntry` will be created at using `BackupBucket` resource. The `BackupEntry` resource will be created as a part of a `Shoot` creation. But resource might continue to exist post deletion of a `Shoot` (see [this](../concepts/gardenlet.md#backupentry-controller) for more details).
 
 ## What needs to be implemented to support a new infrastructure provider?
 

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -16,6 +16,8 @@ controllers:
   backupEntry:
     concurrentSyncs: 20
     deletionGracePeriodHours: 0
+  # deletionGracePeriodShootPurposes:
+  # - production
   controllerInstallation:
     concurrentSyncs: 20
   controllerInstallationCare:

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -167,6 +167,8 @@ const (
 	// ShootUID is an annotation key for the shoot namespace in the seed cluster,
 	// which value will be the value of `shoot.status.uid`
 	ShootUID = "shoot.gardener.cloud/uid"
+	// ShootPurpose is a constant for the shoot purpose.
+	ShootPurpose = "shoot.gardener.cloud/purpose"
 
 	// SeedResourceManagerClass is the resource-class managed by the Gardener-Resource-Manager
 	// instance in the garden namespace on the seeds.

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -142,6 +142,9 @@ type BackupEntryControllerConfiguration struct {
 	// DeletionGracePeriodHours holds the period in number of hours to delete the BackupEntry after deletion timestamp is set.
 	// If value is set to 0 then the BackupEntryController will trigger deletion immediately.
 	DeletionGracePeriodHours *int
+	// DeletionGracePeriodShootPurposes is a list of shoot purposes for which the deletion grace period applies. All
+	// BackupEntries corresponding to Shoots with different purposes will be deleted immediately.
+	DeletionGracePeriodShootPurposes []gardencore.ShootPurpose
 }
 
 // ControllerInstallationControllerConfiguration defines the configuration of the

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -167,4 +167,20 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.DNSEntryTTLSeconds).To(PointTo(Equal(int64(120))))
 		})
 	})
+
+	Describe("#SetDefaults_BackupEntryControllerConfiguration", func() {
+		var obj *BackupEntryControllerConfiguration
+
+		BeforeEach(func() {
+			obj = &BackupEntryControllerConfiguration{}
+		})
+
+		It("should default the configuration", func() {
+			SetDefaults_BackupEntryControllerConfiguration(obj)
+
+			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(20)))
+			Expect(obj.DeletionGracePeriodHours).To(PointTo(Equal(0)))
+			Expect(obj.DeletionGracePeriodShootPurposes).To(BeEmpty())
+		})
+	})
 })

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -176,6 +176,10 @@ type BackupEntryControllerConfiguration struct {
 	// If value is set to 0 then the BackupEntryController will trigger deletion immediately.
 	// +optional
 	DeletionGracePeriodHours *int `json:"deletionGracePeriodHours,omitempty"`
+	// DeletionGracePeriodShootPurposes is a list of shoot purposes for which the deletion grace period applies. All
+	// BackupEntries corresponding to Shoots with different purposes will be deleted immediately.
+	// +optional
+	DeletionGracePeriodShootPurposes []gardencorev1beta1.ShootPurpose `json:"deletionGracePeriodShootPurposes,omitempty"`
 }
 
 // ControllerInstallationControllerConfiguration defines the configuration of the

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -23,6 +23,8 @@ package v1alpha1
 import (
 	unsafe "unsafe"
 
+	core "github.com/gardener/gardener/pkg/apis/core"
+	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	config "github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -355,6 +357,7 @@ func Convert_config_BackupBucketControllerConfiguration_To_v1alpha1_BackupBucket
 func autoConvert_v1alpha1_BackupEntryControllerConfiguration_To_config_BackupEntryControllerConfiguration(in *BackupEntryControllerConfiguration, out *config.BackupEntryControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = (*int)(unsafe.Pointer(in.ConcurrentSyncs))
 	out.DeletionGracePeriodHours = (*int)(unsafe.Pointer(in.DeletionGracePeriodHours))
+	out.DeletionGracePeriodShootPurposes = *(*[]core.ShootPurpose)(unsafe.Pointer(&in.DeletionGracePeriodShootPurposes))
 	return nil
 }
 
@@ -366,6 +369,7 @@ func Convert_v1alpha1_BackupEntryControllerConfiguration_To_config_BackupEntryCo
 func autoConvert_config_BackupEntryControllerConfiguration_To_v1alpha1_BackupEntryControllerConfiguration(in *config.BackupEntryControllerConfiguration, out *BackupEntryControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = (*int)(unsafe.Pointer(in.ConcurrentSyncs))
 	out.DeletionGracePeriodHours = (*int)(unsafe.Pointer(in.DeletionGracePeriodHours))
+	out.DeletionGracePeriodShootPurposes = *(*[]v1beta1.ShootPurpose)(unsafe.Pointer(&in.DeletionGracePeriodShootPurposes))
 	return nil
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -60,6 +61,11 @@ func (in *BackupEntryControllerConfiguration) DeepCopyInto(out *BackupEntryContr
 		in, out := &in.DeletionGracePeriodHours, &out.DeletionGracePeriodHours
 		*out = new(int)
 		**out = **in
+	}
+	if in.DeletionGracePeriodShootPurposes != nil {
+		in, out := &in.DeletionGracePeriodShootPurposes, &out.DeletionGracePeriodShootPurposes
+		*out = make([]v1beta1.ShootPurpose, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/pkg/gardenlet/apis/config/validation/validation.go
+++ b/pkg/gardenlet/apis/config/validation/validation.go
@@ -17,10 +17,12 @@ package validation
 import (
 	"fmt"
 
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	corevalidation "github.com/gardener/gardener/pkg/apis/core/validation"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -134,12 +136,26 @@ func ValidateManagedSeedControllerConfiguration(cfg *config.ManagedSeedControlle
 	return allErrs
 }
 
+var availableShootPurposes = sets.NewString(
+	string(gardencore.ShootPurposeEvaluation),
+	string(gardencore.ShootPurposeTesting),
+	string(gardencore.ShootPurposeDevelopment),
+	string(gardencore.ShootPurposeInfrastructure),
+	string(gardencore.ShootPurposeProduction),
+)
+
 // ValidateBackupEntryControllerConfiguration validates the BackupEntry controller configuration.
 func ValidateBackupEntryControllerConfiguration(cfg *config.BackupEntryControllerConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(cfg.DeletionGracePeriodShootPurposes) > 0 && (cfg.DeletionGracePeriodHours == nil || *cfg.DeletionGracePeriodHours <= 0) {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("deletionGracePeriodShootPurposes"), "must specify grace period hours > 0 when specifying purposes"))
+	}
+
+	for i, purpose := range cfg.DeletionGracePeriodShootPurposes {
+		if !availableShootPurposes.Has(string(purpose)) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("deletionGracePeriodShootPurposes").Index(i), purpose, availableShootPurposes.List()))
+		}
 	}
 
 	return allErrs

--- a/pkg/gardenlet/apis/config/validation/validation.go
+++ b/pkg/gardenlet/apis/config/validation/validation.go
@@ -29,6 +29,9 @@ func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath 
 	allErrs := field.ErrorList{}
 
 	if cfg.Controllers != nil {
+		if cfg.Controllers.BackupEntry != nil {
+			allErrs = append(allErrs, ValidateBackupEntryControllerConfiguration(cfg.Controllers.BackupEntry, fldPath.Child("controllers", "backupEntry"))...)
+		}
 		if cfg.Controllers.Shoot != nil {
 			allErrs = append(allErrs, ValidateShootControllerConfiguration(cfg.Controllers.Shoot, fldPath.Child("controllers", "shoot"))...)
 		}
@@ -126,6 +129,17 @@ func ValidateManagedSeedControllerConfiguration(cfg *config.ManagedSeedControlle
 	}
 	if cfg.SyncJitterPeriod != nil {
 		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(cfg.SyncJitterPeriod.Duration), fldPath.Child("syncJitterPeriod"))...)
+	}
+
+	return allErrs
+}
+
+// ValidateBackupEntryControllerConfiguration validates the BackupEntry controller configuration.
+func ValidateBackupEntryControllerConfiguration(cfg *config.BackupEntryControllerConfiguration, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(cfg.DeletionGracePeriodShootPurposes) > 0 && (cfg.DeletionGracePeriodHours == nil || *cfg.DeletionGracePeriodHours <= 0) {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("deletionGracePeriodShootPurposes"), "must specify grace period hours > 0 when specifying purposes"))
 	}
 
 	return allErrs

--- a/pkg/gardenlet/apis/config/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/validation/validation_test.go
@@ -179,12 +179,33 @@ var _ = Describe("GardenletConfiguration", func() {
 			It("should forbid specifying purposes when not specifying hours", func() {
 				cfg.Controllers.BackupEntry.DeletionGracePeriodHours = nil
 
-				errorList := ValidateGardenletConfiguration(cfg, nil)
-
-				Expect(errorList).To(ConsistOf(
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(ConsistOf(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeForbidden),
 						"Field": Equal("controllers.backupEntry.deletionGracePeriodShootPurposes"),
+					})),
+				))
+			})
+
+			It("should allow valid purposes", func() {
+				cfg.Controllers.BackupEntry.DeletionGracePeriodShootPurposes = []gardencore.ShootPurpose{
+					gardencore.ShootPurposeEvaluation,
+					gardencore.ShootPurposeTesting,
+					gardencore.ShootPurposeDevelopment,
+					gardencore.ShootPurposeInfrastructure,
+					gardencore.ShootPurposeProduction,
+				}
+
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(BeEmpty())
+			})
+
+			It("should forbid invalid purposes", func() {
+				cfg.Controllers.BackupEntry.DeletionGracePeriodShootPurposes = []gardencore.ShootPurpose{"does-not-exist"}
+
+				Expect(ValidateGardenletConfiguration(cfg, nil)).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeNotSupported),
+						"Field": Equal("controllers.backupEntry.deletionGracePeriodShootPurposes[0]"),
 					})),
 				))
 			})

--- a/pkg/gardenlet/apis/config/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/validation/validation_test.go
@@ -35,12 +35,17 @@ var _ = Describe("GardenletConfiguration", func() {
 	var (
 		cfg *config.GardenletConfiguration
 
-		concurrentSyncs = 20
+		deletionGracePeriodHours = 1
+		concurrentSyncs          = 20
 	)
 
 	BeforeEach(func() {
 		cfg = &config.GardenletConfiguration{
 			Controllers: &config.GardenletControllerConfiguration{
+				BackupEntry: &config.BackupEntryControllerConfiguration{
+					DeletionGracePeriodHours:         &deletionGracePeriodHours,
+					DeletionGracePeriodShootPurposes: []gardencore.ShootPurpose{gardencore.ShootPurposeDevelopment},
+				},
 				Shoot: &config.ShootControllerConfiguration{
 					ConcurrentSyncs:      &concurrentSyncs,
 					ProgressReportPeriod: &metav1.Duration{Duration: time.Hour},
@@ -165,6 +170,21 @@ var _ = Describe("GardenletConfiguration", func() {
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
 						"Field": Equal("controllers.managedSeed.syncJitterPeriod"),
+					})),
+				))
+			})
+		})
+
+		Context("backup entry controller", func() {
+			It("should forbid specifying purposes when not specifying hours", func() {
+				cfg.Controllers.BackupEntry.DeletionGracePeriodHours = nil
+
+				errorList := ValidateGardenletConfiguration(cfg, nil)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeForbidden),
+						"Field": Equal("controllers.backupEntry.deletionGracePeriodShootPurposes"),
 					})),
 				))
 			})

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package config
 
 import (
+	core "github.com/gardener/gardener/pkg/apis/core"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -60,6 +61,11 @@ func (in *BackupEntryControllerConfiguration) DeepCopyInto(out *BackupEntryContr
 		in, out := &in.DeletionGracePeriodHours, &out.DeletionGracePeriodHours
 		*out = new(int)
 		**out = **in
+	}
+	if in.DeletionGracePeriodShootPurposes != nil {
+		in, out := &in.DeletionGracePeriodShootPurposes, &out.DeletionGracePeriodShootPurposes
+		*out = make([]core.ShootPurpose, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/pkg/operation/botanist/backupentry.go
+++ b/pkg/operation/botanist/backupentry.go
@@ -37,6 +37,7 @@ func (b *Botanist) DefaultCoreBackupEntry(gardenClient client.Client) component.
 		&corebackupentry.Values{
 			Namespace:         b.Shoot.Info.Namespace,
 			Name:              common.GenerateBackupEntryName(b.Shoot.Info.Status.TechnicalID, b.Shoot.Info.Status.UID),
+			ShootPurpose:      b.Shoot.Info.Spec.Purpose,
 			OwnerReference:    ownerRef,
 			SeedName:          pointer.StringPtr(b.Seed.Info.Name),
 			OverwriteSeedName: b.isRestorePhase(),

--- a/pkg/operation/botanist/backupentry/backupentry.go
+++ b/pkg/operation/botanist/backupentry/backupentry.go
@@ -50,6 +50,8 @@ type Values struct {
 	Namespace string
 	// Name is the name of the BackupEntry resource.
 	Name string
+	// ShootPurpose is the purpose of the shoot.
+	ShootPurpose *gardencorev1beta1.ShootPurpose
 	// OwnerReference is a reference to an owner for BackupEntry resource.
 	OwnerReference *metav1.OwnerReference
 	// SeedName is the name of the seed to which the BackupEntry shall be scheduled.
@@ -116,6 +118,9 @@ func (b *backupEntry) Deploy(ctx context.Context) error {
 	_, err := controllerutil.CreateOrUpdate(ctx, b.client, backupEntry, func() error {
 		metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
 		metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		if b.values.ShootPurpose != nil {
+			metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.ShootPurpose, string(*b.values.ShootPurpose))
+		}
 
 		finalizers := sets.NewString(backupEntry.GetFinalizers()...)
 		finalizers.Insert(gardencorev1beta1.GardenerName)

--- a/pkg/operation/botanist/backupentry/backupentry_test.go
+++ b/pkg/operation/botanist/backupentry/backupentry_test.go
@@ -52,9 +52,10 @@ var _ = Describe("BackupEntry", func() {
 		mockNow *mocktime.MockNow
 		now     time.Time
 
-		name      = "be"
-		namespace = "namespace"
-		ownerRef  = metav1.NewControllerRef(&corev1.Namespace{}, corev1.SchemeGroupVersion.WithKind("Namespace"))
+		name         = "be"
+		namespace    = "namespace"
+		shootPurpose = gardencorev1beta1.ShootPurposeDevelopment
+		ownerRef     = metav1.NewControllerRef(&corev1.Namespace{}, corev1.SchemeGroupVersion.WithKind("Namespace"))
 
 		seedName            = "seed"
 		bucketName          = "bucket"
@@ -78,6 +79,7 @@ var _ = Describe("BackupEntry", func() {
 		values = &Values{
 			Name:           name,
 			Namespace:      namespace,
+			ShootPurpose:   &shootPurpose,
 			OwnerReference: ownerRef,
 			SeedName:       &seedName,
 			BucketName:     bucketName,
@@ -94,6 +96,7 @@ var _ = Describe("BackupEntry", func() {
 				Annotations: map[string]string{
 					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
 					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+					v1beta1constants.ShootPurpose:      string(shootPurpose),
 				},
 				Finalizers:      []string{"gardener"},
 				OwnerReferences: []metav1.OwnerReference{*ownerRef},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR allows to configure for which shoot purposes the `BackupEntry` deletion grace period applies.

**Which issue(s) this PR fixes**:
Fixes #3630

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
It is now configurable for which shoot purposes the `BackupEntry` deletion grace period applies. An empty list (default) means that it applies for all shoot purposes (as it was earlier). If you want to only select specific purposes then please configure `.controllers.backupEntry.deletionGracePeriodShootPurposes[]` in the gardenlet's component configuration.
```
