### PR TITLE
clarify how worker group kubelet configuration behaves

### DIFF
--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -9266,7 +9266,8 @@ KubeletConfig
 </td>
 <td>
 <em>(Optional)</em>
-<p>Kubelet contains configuration settings for all kubelets of this worker pool.</p>
+<p>Kubelet contains configuration settings for all kubelets of this worker pool.
+If set, all <code>spec.kubernetes.kubelet</code> settings will be overwritten for this worker pool (no merge of settings).</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -834,6 +834,7 @@ type WorkerSystemComponents struct {
 // WorkerKubernetes contains configuration for Kubernetes components related to this worker pool.
 type WorkerKubernetes struct {
 	// Kubelet contains configuration settings for all kubelets of this worker pool.
+	// If set, all `spec.kubernetes.kubelet` settings will be overwritten for this worker pool (no merge of settings).
 	Kubelet *KubeletConfig
 }
 

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -2332,6 +2332,7 @@ message Worker {
 // WorkerKubernetes contains configuration for Kubernetes components related to this worker pool.
 message WorkerKubernetes {
   // Kubelet contains configuration settings for all kubelets of this worker pool.
+  // If set, all `spec.kubernetes.kubelet` settings will be overwritten for this worker pool (no merge of settings).
   // +optional
   optional KubeletConfig kubelet = 1;
 }

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -1038,6 +1038,7 @@ type WorkerSystemComponents struct {
 // WorkerKubernetes contains configuration for Kubernetes components related to this worker pool.
 type WorkerKubernetes struct {
 	// Kubelet contains configuration settings for all kubelets of this worker pool.
+	// If set, all `spec.kubernetes.kubelet` settings will be overwritten for this worker pool (no merge of settings).
 	// +optional
 	Kubelet *KubeletConfig `json:"kubelet,omitempty" protobuf:"bytes,1,opt,name=kubelet"`
 }

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2266,6 +2266,7 @@ message Worker {
 // WorkerKubernetes contains configuration for Kubernetes components related to this worker pool.
 message WorkerKubernetes {
   // Kubelet contains configuration settings for all kubelets of this worker pool.
+  // If set, all `spec.kubernetes.kubelet` settings will be overwritten for this worker pool (no merge of settings).
   // +optional
   optional KubeletConfig kubelet = 1;
 }

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1035,6 +1035,7 @@ type WorkerSystemComponents struct {
 // WorkerKubernetes contains configuration for Kubernetes components related to this worker pool.
 type WorkerKubernetes struct {
 	// Kubelet contains configuration settings for all kubelets of this worker pool.
+	// If set, all `spec.kubernetes.kubelet` settings will be overwritten for this worker pool (no merge of settings).
 	// +optional
 	Kubelet *KubeletConfig `json:"kubelet,omitempty" protobuf:"bytes,1,opt,name=kubelet"`
 }

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -6778,7 +6778,7 @@ func schema_pkg_apis_core_v1alpha1_WorkerKubernetes(ref common.ReferenceCallback
 				Properties: map[string]spec.Schema{
 					"kubelet": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kubelet contains configuration settings for all kubelets of this worker pool.",
+							Description: "Kubelet contains configuration settings for all kubelets of this worker pool. If set, all `spec.kubernetes.kubelet` settings will be overwritten for this worker pool (no merge of settings).",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.KubeletConfig"),
 						},
 					},
@@ -12741,7 +12741,7 @@ func schema_pkg_apis_core_v1beta1_WorkerKubernetes(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"kubelet": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kubelet contains configuration settings for all kubelets of this worker pool.",
+							Description: "Kubelet contains configuration settings for all kubelets of this worker pool. If set, all `spec.kubernetes.kubelet` settings will be overwritten for this worker pool (no merge of settings).",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.KubeletConfig"),
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**

/area quality
/priority normal

**What this PR does / why we need it**:
Clarify how worker group kubelet setting behaves with toplevel kubelet settings.

I looked for other places in the documentation I should adapt but found only this place.

**Release note**:

```other operator
NONE
```