### PR TITLE
[GEP-13] Add ManagedSeedSet validation

### DIFF
--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -150,7 +150,7 @@ func run(ctx context.Context, o *Options) error {
 			return fmt.Errorf("unable to read the configuration file: %v", err)
 		}
 
-		if errs := configvalidation.ValidateGardenletConfiguration(c, nil); len(errs) > 0 {
+		if errs := configvalidation.ValidateGardenletConfiguration(c, nil, false); len(errs) > 0 {
 			return fmt.Errorf("errors validating the configuration: %+v", errs)
 		}
 

--- a/pkg/apis/core/validation/seed_test.go
+++ b/pkg/apis/core/validation/seed_test.go
@@ -674,7 +674,7 @@ var _ = Describe("Seed Validation Tests", func() {
 		It("should forbid invalid metadata or spec fields", func() {
 			seedTemplate.Labels = map[string]string{"foo!": "bar"}
 			seedTemplate.Annotations = map[string]string{"foo!": "bar"}
-			seedTemplate.Spec.Provider.Type = ""
+			seedTemplate.Spec.Networks.Nodes = pointer.StringPtr("")
 
 			errorList := ValidateSeedTemplate(seedTemplate, nil)
 
@@ -688,8 +688,8 @@ var _ = Describe("Seed Validation Tests", func() {
 					"Field": Equal("metadata.annotations"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.provider.type"),
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.networks.nodes"),
 				})),
 			))
 		})

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -93,6 +93,26 @@ func ValidateShootUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 	return allErrs
 }
 
+// ValidateShootTemplate validates a ShootTemplate.
+func ValidateShootTemplate(shootTemplate *core.ShootTemplate, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, metav1validation.ValidateLabels(shootTemplate.Labels, fldPath.Child("metadata", "labels"))...)
+	allErrs = append(allErrs, apivalidation.ValidateAnnotations(shootTemplate.Annotations, fldPath.Child("metadata", "annotations"))...)
+	allErrs = append(allErrs, ValidateShootSpec(shootTemplate.ObjectMeta, &shootTemplate.Spec, fldPath.Child("spec"))...)
+
+	return allErrs
+}
+
+// ValidateShootTemplateUpdate validates a ShootTemplate before an update.
+func ValidateShootTemplateUpdate(newShootTemplate, oldShootTemplate *core.ShootTemplate, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, ValidateShootSpecUpdate(&newShootTemplate.Spec, &oldShootTemplate.Spec, newShootTemplate.ObjectMeta, fldPath.Child("spec"))...)
+
+	return allErrs
+}
+
 // ValidateShootSpec validates the specification of a Shoot object.
 func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -298,10 +298,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.maintenance"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
 					"Field": Equal("spec.provider.type"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
@@ -787,10 +783,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.provider.workers[0].machine.type"),
-					})),
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeRequired),
-						"Field": Equal("spec.provider.workers[0].machine.image"),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
@@ -1991,42 +1983,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 		})
 
 		Context("maintenance section", func() {
-			It("should forbid not specifying the maintenance section", func() {
-				shoot.Spec.Maintenance = nil
-
-				errorList := ValidateShoot(shoot)
-
-				Expect(errorList).To(HaveLen(1))
-				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.maintenance"),
-				}))
-			})
-
-			It("should forbid not specifying the auto update section", func() {
-				shoot.Spec.Maintenance.AutoUpdate = nil
-
-				errorList := ValidateShoot(shoot)
-
-				Expect(errorList).To(HaveLen(1))
-				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.maintenance.autoUpdate"),
-				}))
-			})
-
-			It("should forbid not specifying the time window section", func() {
-				shoot.Spec.Maintenance.TimeWindow = nil
-
-				errorList := ValidateShoot(shoot)
-
-				Expect(errorList).To(HaveLen(1))
-				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.maintenance.timeWindow"),
-				}))
-			})
-
 			It("should forbid invalid formats for the time window begin and end values", func() {
 				shoot.Spec.Maintenance.TimeWindow.Begin = "invalidformat"
 				shoot.Spec.Maintenance.TimeWindow.End = "invalidformat"
@@ -2217,15 +2173,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
 					"Field": Equal("machine.type"),
-				}))),
-			),
-			Entry("missing machine image",
-				core.Machine{
-					Type: "large",
-				},
-				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("machine.image"),
 				}))),
 			),
 			Entry("empty machine image name",

--- a/pkg/apis/seedmanagement/validation/managedseed_test.go
+++ b/pkg/apis/seedmanagement/validation/managedseed_test.go
@@ -176,7 +176,7 @@ var _ = Describe("ManagedSeed Validation Tests", func() {
 			It("should forbid empty or invalid fields in seed template", func() {
 				managedSeed.Spec.SeedTemplate.Name = "foo"
 				seedCopy := seed.DeepCopy()
-				seedCopy.Spec.Provider.Type = ""
+				seedCopy.Spec.Networks.Nodes = pointer.StringPtr("")
 				managedSeed.Spec.SeedTemplate.Spec = seedCopy.Spec
 
 				errorList := ValidateManagedSeed(managedSeed)
@@ -187,8 +187,8 @@ var _ = Describe("ManagedSeed Validation Tests", func() {
 						"Field": Equal("spec.seedTemplate.metadata.name"),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeRequired),
-						"Field": Equal("spec.seedTemplate.spec.provider.type"),
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.seedTemplate.spec.networks.nodes"),
 					})),
 				))
 			})
@@ -225,7 +225,7 @@ var _ = Describe("ManagedSeed Validation Tests", func() {
 
 			It("should forbid empty or invalid fields in gardenlet", func() {
 				seedx.Name = "foo"
-				seedx.Spec.Provider.Type = ""
+				seedx.Spec.Networks.Nodes = pointer.StringPtr("")
 
 				managedSeed.Spec.Gardenlet.Deployment = &seedmanagement.GardenletDeployment{
 					ReplicaCount:         pointer.Int32Ptr(-1),
@@ -282,8 +282,8 @@ var _ = Describe("ManagedSeed Validation Tests", func() {
 						"Field": Equal("spec.gardenlet.config.seedConfig.metadata.name"),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeRequired),
-						"Field": Equal("spec.gardenlet.config.seedConfig.spec.provider.type"),
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.gardenlet.config.seedConfig.spec.networks.nodes"),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeNotSupported),

--- a/pkg/apis/seedmanagement/validation/managedseedset.go
+++ b/pkg/apis/seedmanagement/validation/managedseedset.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	corevalidation "github.com/gardener/gardener/pkg/apis/core/validation"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
+)
+
+// ValidateManagedSeedSet validates a ManagedSeedSet object.
+func ValidateManagedSeedSet(ManagedSeedSet *seedmanagement.ManagedSeedSet) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Ensure namespace is garden
+	if ManagedSeedSet.Namespace != v1beta1constants.GardenNamespace {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "namespace"), ManagedSeedSet.Namespace, "namespace must be garden"))
+	}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&ManagedSeedSet.ObjectMeta, true, corevalidation.ValidateName, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateManagedSeedSetSpec(&ManagedSeedSet.Spec, field.NewPath("spec"))...)
+
+	return allErrs
+}
+
+// ValidateManagedSeedSetUpdate validates a ManagedSeedSet object before an update.
+func ValidateManagedSeedSetUpdate(newManagedSeedSet, oldManagedSeedSet *seedmanagement.ManagedSeedSet) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newManagedSeedSet.ObjectMeta, &oldManagedSeedSet.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateManagedSeedSetSpecUpdate(&newManagedSeedSet.Spec, &oldManagedSeedSet.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateManagedSeedSet(newManagedSeedSet)...)
+
+	return allErrs
+}
+
+// ValidateManagedSeedStatusUpdate validates a ManagedSeedSet object before a status update.
+func ValidateManagedSeedSetStatusUpdate(newManagedSeedSet, oldManagedSeedSet *seedmanagement.ManagedSeedSet) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newManagedSeedSet.ObjectMeta, &oldManagedSeedSet.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateManagedSeedSetStatus(&newManagedSeedSet.Status, field.NewPath("status"))...)
+
+	statusPath := field.NewPath("status")
+	if newManagedSeedSet.Status.NextReplicaNumber < oldManagedSeedSet.Status.NextReplicaNumber {
+		allErrs = append(allErrs, field.Invalid(statusPath.Child("nextReplicaNumber"), newManagedSeedSet.Status.NextReplicaNumber, "cannot be decremented"))
+	}
+	if isDecremented(newManagedSeedSet.Status.CollisionCount, oldManagedSeedSet.Status.CollisionCount) {
+		value := pointer.Int32PtrDerefOr(newManagedSeedSet.Status.CollisionCount, 0)
+		allErrs = append(allErrs, field.Invalid(statusPath.Child("collisionCount"), value, "cannot be decremented"))
+	}
+
+	return allErrs
+}
+
+// ValidateManagedSeedSetSpec validates the specification of a ManagedSeed object.
+func ValidateManagedSeedSetSpec(spec *seedmanagement.ManagedSeedSetSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Ensure replicas is non-negative if specified
+	if spec.Replicas != nil {
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.Replicas), fldPath.Child("replicas"))...)
+	}
+
+	// Ensure selector is specified, non-empty and valid
+	selectorPath := fldPath.Child("selector")
+	var selector labels.Selector
+	if len(spec.Selector.MatchLabels) == 0 && len(spec.Selector.MatchExpressions) == 0 {
+		allErrs = append(allErrs, field.Invalid(selectorPath, spec.Selector, "empty selector is invalid for ManagedSeedSet"))
+	} else {
+		allErrs = append(allErrs, metav1validation.ValidateLabelSelector(&spec.Selector, selectorPath)...)
+		var err error
+		if selector, err = metav1.LabelSelectorAsSelector(&spec.Selector); err != nil {
+			allErrs = append(allErrs, field.Invalid(selectorPath, spec.Selector, err.Error()))
+		}
+	}
+
+	// Validate template and shootTemplate
+	allErrs = append(allErrs, ValidateManagedSeedTemplateForManagedSeedSet(&spec.Template, selector, fldPath.Child("template"))...)
+	allErrs = append(allErrs, ValidateShootTemplateForManagedSeedSet(&spec.ShootTemplate, selector, fldPath.Child("shootTemplate"))...)
+
+	// Ensure updateStrategy.type is RollingUpdate if specified
+	if spec.UpdateStrategy != nil && spec.UpdateStrategy.Type != nil {
+		updateStrategyPath := fldPath.Child("updateStrategy")
+
+		switch *spec.UpdateStrategy.Type {
+		case "":
+			allErrs = append(allErrs, field.Required(updateStrategyPath.Child("type"), ""))
+		case seedmanagement.RollingUpdateStrategyType:
+			// Ensure rollingUpdate.partition is non-negative if specified
+			if spec.UpdateStrategy.RollingUpdate != nil && spec.UpdateStrategy.RollingUpdate.Partition != nil {
+				allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.UpdateStrategy.RollingUpdate.Partition),
+					updateStrategyPath.Child("rollingUpdate", "partition"))...)
+			}
+		default:
+			allErrs = append(allErrs, field.NotSupported(updateStrategyPath.Child("type"),
+				*spec.UpdateStrategy.Type, []string{string(seedmanagement.RollingUpdateStrategyType)}))
+		}
+	}
+
+	// Ensure revisionHistoryLimit is non-negative if specified
+	if spec.RevisionHistoryLimit != nil {
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.RevisionHistoryLimit), fldPath.Child("revisionHistoryLimit"))...)
+	}
+
+	return allErrs
+}
+
+// ValidateManagedSeedSetSpecUpdate validates a ManagedSeedSetSpec object before an update.
+func ValidateManagedSeedSetSpecUpdate(newSpec, oldSpec *seedmanagement.ManagedSeedSetSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Ensure selector is not changed
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Selector, oldSpec.Selector, fldPath.Child("selector"))...)
+
+	// Ensure revisionHistoryLimit is not changed
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.RevisionHistoryLimit, oldSpec.RevisionHistoryLimit, fldPath.Child("revisionHistoryLimit"))...)
+
+	// Validate updates to template and shootTemplate
+	allErrs = append(allErrs, ValidateManagedSeedTemplateUpdate(&newSpec.Template, &oldSpec.Template, fldPath.Child("template"))...)
+	allErrs = append(allErrs, corevalidation.ValidateShootTemplateUpdate(&newSpec.ShootTemplate, &oldSpec.ShootTemplate, fldPath.Child("shootTemplate"))...)
+
+	return allErrs
+}
+
+// ValidateManagedSeedTemplateForManagedSeedSet validates the given ManagedSeedTemplate.
+func ValidateManagedSeedTemplateForManagedSeedSet(template *seedmanagement.ManagedSeedTemplate, selector labels.Selector, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Verify that the selector matches the labels in template.
+	if selector != nil && !selector.Empty() && !selector.Matches(labels.Set(template.Labels)) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("metadata", "labels"), template.Labels, "selector does not match template labels"))
+	}
+
+	allErrs = append(allErrs, ValidateManagedSeedTemplate(template, fldPath)...)
+
+	return allErrs
+}
+
+// ValidateShootTemplateForManagedSeedSet validates the given ShootTemplate.
+func ValidateShootTemplateForManagedSeedSet(template *gardencore.ShootTemplate, selector labels.Selector, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Verify that the selector matches the labels in template.
+	if selector != nil && !selector.Empty() && !selector.Matches(labels.Set(template.Labels)) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("metadata", "labels"), template.Labels, "selector does not match template labels"))
+	}
+
+	allErrs = append(allErrs, corevalidation.ValidateShootTemplate(template, fldPath)...)
+
+	return allErrs
+}
+
+// ValidateManagedSeedSetStatus validates the given ManagedSeedSetStatus.
+func ValidateManagedSeedSetStatus(status *seedmanagement.ManagedSeedSetStatus, fieldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Ensure integer fields are non-negative
+	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(status.ObservedGeneration, fieldPath.Child("observedGeneration"))...)
+	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(status.Replicas), fieldPath.Child("replicas"))...)
+	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(status.ReadyReplicas), fieldPath.Child("readyReplicas"))...)
+	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(status.CurrentReplicas), fieldPath.Child("currentReplicas"))...)
+	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(status.UpdatedReplicas), fieldPath.Child("updatedReplicas"))...)
+	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(status.NextReplicaNumber), fieldPath.Child("nextReplicaNumber"))...)
+	if status.CollisionCount != nil {
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*status.CollisionCount), fieldPath.Child("collisionCount"))...)
+	}
+
+	// Ensure the numbers or ready, current, and updated replicas are not greater than the number of replicas
+	if status.ReadyReplicas > status.Replicas {
+		allErrs = append(allErrs, field.Invalid(fieldPath.Child("readyReplicas"), status.ReadyReplicas, "cannot be greater than status.replicas"))
+	}
+	if status.CurrentReplicas > status.Replicas {
+		allErrs = append(allErrs, field.Invalid(fieldPath.Child("currentReplicas"), status.CurrentReplicas, "cannot be greater than status.replicas"))
+	}
+	if status.UpdatedReplicas > status.Replicas {
+		allErrs = append(allErrs, field.Invalid(fieldPath.Child("updatedReplicas"), status.UpdatedReplicas, "cannot be greater than status.replicas"))
+	}
+
+	// Ensure the next replica number is greater than or equal to the number of replicas
+	if status.NextReplicaNumber < status.Replicas {
+		allErrs = append(allErrs, field.Invalid(fieldPath.Child("nextReplicaNumber"), status.ReadyReplicas, "cannot be less than status.replicas"))
+	}
+
+	return allErrs
+}
+
+func isDecremented(new, old *int32) bool {
+	if new == nil && old != nil {
+		return true
+	}
+	if new == nil || old == nil {
+		return false
+	}
+	return *new < *old
+}

--- a/pkg/apis/seedmanagement/validation/managedseedset_test.go
+++ b/pkg/apis/seedmanagement/validation/managedseedset_test.go
@@ -1,0 +1,524 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+	. "github.com/gardener/gardener/pkg/apis/seedmanagement/validation"
+)
+
+var _ = Describe("ManagedSeedSet Validation Tests", func() {
+	var (
+		seed = &core.Seed{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+			},
+			Spec: core.SeedSpec{
+				DNS: core.SeedDNS{
+					IngressDomain: pointer.StringPtr("ingress.test.example.com"),
+				},
+				Networks: core.SeedNetworks{
+					Pods:     "100.96.0.0/11",
+					Services: "100.64.0.0/13",
+				},
+				Provider: core.SeedProvider{
+					Type:   "foo",
+					Region: "some-region",
+				},
+			},
+		}
+		shoot = &core.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+			},
+			Spec: core.ShootSpec{
+				CloudProfileName: "foo",
+				DNS: &core.DNS{
+					Domain: pointer.StringPtr("test.example.com"),
+				},
+				Kubernetes: core.Kubernetes{
+					Version: "1.18.14",
+				},
+				Networking: core.Networking{
+					Type:     "foo",
+					Nodes:    pointer.StringPtr("10.250.0.0/16"),
+					Pods:     pointer.StringPtr("100.96.0.0/11"),
+					Services: pointer.StringPtr("100.64.0.0/13"),
+				},
+				Maintenance: &core.Maintenance{
+					AutoUpdate: &core.MaintenanceAutoUpdate{
+						KubernetesVersion:   true,
+						MachineImageVersion: true,
+					},
+					TimeWindow: &core.MaintenanceTimeWindow{
+						Begin: "200000+0000",
+						End:   "210000+0000",
+					},
+				},
+				Provider: core.Provider{
+					Type: "foo",
+					Workers: []core.Worker{
+						{
+							Name: "some-worker",
+							Machine: core.Machine{
+								Type: "some-machine-type",
+								Image: &core.ShootMachineImage{
+									Name:    "some-machine-image",
+									Version: "1.0",
+								},
+							},
+							Maximum:        2,
+							Minimum:        1,
+							MaxSurge:       intstrPtr(intstr.FromInt(1)),
+							MaxUnavailable: intstrPtr(intstr.FromInt(0)),
+							SystemComponents: &core.WorkerSystemComponents{
+								Allow: true,
+							},
+						},
+					},
+				},
+				Region:            "some-region",
+				SecretBindingName: "shoot-operator-foo",
+			},
+		}
+
+		managedSeedSet *seedmanagement.ManagedSeedSet
+	)
+
+	BeforeEach(func() {
+		managedSeedSet = &seedmanagement.ManagedSeedSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       name,
+				Namespace:  namespace,
+				Generation: 1,
+			},
+			Spec: seedmanagement.ManagedSeedSetSpec{
+				Replicas: pointer.Int32Ptr(1),
+				Selector: *metav1.SetAsLabelSelector(labels.Set{
+					"foo": "bar",
+				}),
+				Template: seedmanagement.ManagedSeedTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					},
+					Spec: seedmanagement.ManagedSeedSpec{
+						SeedTemplate: &core.SeedTemplate{
+							ObjectMeta: seed.ObjectMeta,
+							Spec:       seed.Spec,
+						},
+					},
+				},
+				ShootTemplate: core.ShootTemplate{
+					ObjectMeta: shoot.ObjectMeta,
+					Spec:       shoot.Spec,
+				},
+				UpdateStrategy: &seedmanagement.UpdateStrategy{
+					Type: updateStrategyTypePtr(seedmanagement.RollingUpdateStrategyType),
+					RollingUpdate: &seedmanagement.RollingUpdateStrategy{
+						Partition: pointer.Int32Ptr(0),
+					},
+				},
+				RevisionHistoryLimit: pointer.Int32Ptr(10),
+			},
+			Status: seedmanagement.ManagedSeedSetStatus{
+				ObservedGeneration: 1,
+				Replicas:           1,
+				ReadyReplicas:      1,
+				NextReplicaNumber:  2,
+				CurrentReplicas:    0,
+				UpdatedReplicas:    1,
+				CollisionCount:     pointer.Int32Ptr(1),
+			},
+		}
+	})
+
+	Describe("#ValidateManagedSeedSet", func() {
+		It("should allow valid resources", func() {
+			errorList := ValidateManagedSeedSet(managedSeedSet)
+
+			Expect(errorList).To(HaveLen(0))
+		})
+
+		It("should forbid empty metadata", func() {
+			managedSeedSet.ObjectMeta = metav1.ObjectMeta{}
+
+			errorList := ValidateManagedSeedSet(managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("metadata.name"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("metadata.namespace"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("metadata.namespace"),
+				})),
+			))
+		})
+
+		It("should forbid namespace different from garden", func() {
+			managedSeedSet.Namespace = "foo"
+
+			errorList := ValidateManagedSeedSet(managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("metadata.namespace"),
+				})),
+			))
+		})
+
+		It("should forbid negative replicas, updateStrategy.rollingUpdate.partition, and revisionHistoryLimit", func() {
+			managedSeedSet.Spec.Replicas = pointer.Int32Ptr(-1)
+			managedSeedSet.Spec.UpdateStrategy.RollingUpdate.Partition = pointer.Int32Ptr(-1)
+			managedSeedSet.Spec.RevisionHistoryLimit = pointer.Int32Ptr(-1)
+
+			errorList := ValidateManagedSeedSet(managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.replicas"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.updateStrategy.rollingUpdate.partition"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.revisionHistoryLimit"),
+				})),
+			))
+		})
+
+		It("should forbid empty selector", func() {
+			managedSeedSet.Spec.Selector = metav1.LabelSelector{}
+
+			errorList := ValidateManagedSeedSet(managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.selector"),
+				})),
+			))
+		})
+
+		It("should forbid empty updateStrategy.type", func() {
+			managedSeedSet.Spec.UpdateStrategy.Type = updateStrategyTypePtr("")
+
+			errorList := ValidateManagedSeedSet(managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.updateStrategy.type"),
+				})),
+			))
+		})
+
+		It("should forbid unsupported updateStrategy.type", func() {
+			managedSeedSet.Spec.UpdateStrategy.Type = updateStrategyTypePtr("OnDelete")
+
+			errorList := ValidateManagedSeedSet(managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeNotSupported),
+					"Field": Equal("spec.updateStrategy.type"),
+				})),
+			))
+		})
+
+		It("should forbid templates if labels don't match selector", func() {
+			managedSeedSet.Spec.Selector = *metav1.SetAsLabelSelector(labels.Set{
+				"bar": "baz",
+			})
+
+			errorList := ValidateManagedSeedSet(managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.template.metadata.labels"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.shootTemplate.metadata.labels"),
+				})),
+			))
+		})
+
+		It("should forbid empty or invalid fields in template", func() {
+			managedSeedSet.Spec.Template.Spec.SeedTemplate.Name = "foo"
+			seedCopy := seed.DeepCopy()
+			seedCopy.Spec.Provider.Type = ""
+			managedSeedSet.Spec.Template.Spec.SeedTemplate.Spec = seedCopy.Spec
+
+			errorList := ValidateManagedSeedSet(managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeForbidden),
+					"Field": Equal("spec.template.spec.seedTemplate.metadata.name"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.template.spec.seedTemplate.spec.provider.type"),
+				})),
+			))
+		})
+
+		It("should forbid empty or invalid fields in shootTemplate", func() {
+			shootCopy := shoot.DeepCopy()
+			shootCopy.Spec.Maintenance = nil
+			managedSeedSet.Spec.ShootTemplate.Spec = shootCopy.Spec
+
+			errorList := ValidateManagedSeedSet(managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.shootTemplate.spec.maintenance"),
+				})),
+			))
+		})
+	})
+
+	Describe("#ValidateManagedSeedSetUpdate", func() {
+		var (
+			newManagedSeedSet *seedmanagement.ManagedSeedSet
+		)
+
+		BeforeEach(func() {
+			newManagedSeedSet = managedSeedSet.DeepCopy()
+			newManagedSeedSet.ResourceVersion = "1"
+		})
+
+		It("should allow valid updates", func() {
+			errorList := ValidateManagedSeedSetUpdate(newManagedSeedSet, managedSeedSet)
+
+			Expect(errorList).To(HaveLen(0))
+		})
+
+		It("should forbid changes to immutable metadata fields", func() {
+			newManagedSeedSet.Name = name + "x"
+
+			errorList := ValidateManagedSeedSetUpdate(newManagedSeedSet, managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("metadata.name"),
+					"Detail": Equal("field is immutable"),
+				})),
+			))
+		})
+
+		It("should forbid changes to immutable spec fields", func() {
+			newManagedSeedSet.Spec.Selector = *metav1.SetAsLabelSelector(labels.Set{
+				"bar": "baz",
+			})
+			newManagedSeedSet.Spec.RevisionHistoryLimit = pointer.Int32Ptr(20)
+
+			errorList := ValidateManagedSeedSetUpdate(newManagedSeedSet, managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.selector"),
+					"Detail": Equal("field is immutable"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.revisionHistoryLimit"),
+					"Detail": Equal("field is immutable"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.template.metadata.labels"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.shootTemplate.metadata.labels"),
+				})),
+			))
+		})
+
+		It("should forbid changes to immutable fields in template", func() {
+			newManagedSeedSet.Spec.Template.Spec.SeedTemplate = nil
+			newManagedSeedSet.Spec.Template.Spec.Gardenlet = &seedmanagement.Gardenlet{}
+
+			errorList := ValidateManagedSeedSetUpdate(newManagedSeedSet, managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.template.spec"),
+					"Detail": Equal("changing from seed template to gardenlet and vice versa is not allowed"),
+				})),
+			))
+		})
+
+		It("should forbid changes to immutable fields in shootTemplate", func() {
+			shootCopy := shoot.DeepCopy()
+			shootCopy.Spec.Region = "other-region"
+			newManagedSeedSet.Spec.ShootTemplate.Spec = shootCopy.Spec
+
+			errorList := ValidateManagedSeedSetUpdate(newManagedSeedSet, managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.shootTemplate.spec.region"),
+					"Detail": Equal("field is immutable"),
+				})),
+			))
+		})
+	})
+
+	Describe("#ValidateManagedSeedSetStatusUpdate", func() {
+		var (
+			newManagedSeedSet *seedmanagement.ManagedSeedSet
+		)
+
+		BeforeEach(func() {
+			newManagedSeedSet = managedSeedSet.DeepCopy()
+			newManagedSeedSet.ResourceVersion = "1"
+		})
+
+		It("should allow valid status updates", func() {
+			errorList := ValidateManagedSeedSetStatusUpdate(newManagedSeedSet, managedSeedSet)
+
+			Expect(errorList).To(HaveLen(0))
+		})
+
+		It("should forbid negative integer fields", func() {
+			newManagedSeedSet.Status.ObservedGeneration = -1
+			newManagedSeedSet.Status.Replicas = -1
+			newManagedSeedSet.Status.ReadyReplicas = -1
+			newManagedSeedSet.Status.CurrentReplicas = -1
+			newManagedSeedSet.Status.UpdatedReplicas = -1
+
+			errorList := ValidateManagedSeedSetStatusUpdate(newManagedSeedSet, managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("status.observedGeneration"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("status.replicas"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("status.readyReplicas"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("status.currentReplicas"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("status.updatedReplicas"),
+				})),
+			))
+		})
+
+		It("should forbid invalid number of ready, current, or update replicas", func() {
+			newManagedSeedSet.Status.ReadyReplicas = 2
+			newManagedSeedSet.Status.CurrentReplicas = 2
+			newManagedSeedSet.Status.UpdatedReplicas = 2
+
+			errorList := ValidateManagedSeedSetStatusUpdate(newManagedSeedSet, managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("status.readyReplicas"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("status.currentReplicas"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("status.updatedReplicas"),
+				})),
+			))
+		})
+
+		It("should forbid invalid next replica number", func() {
+			newManagedSeedSet.Status.Replicas = 3
+
+			errorList := ValidateManagedSeedSetStatusUpdate(newManagedSeedSet, managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("status.nextReplicaNumber"),
+				})),
+			))
+		})
+
+		It("should forbid decrementing the next replica number or the collision count", func() {
+			newManagedSeedSet.Status.NextReplicaNumber = 1
+			newManagedSeedSet.Status.CollisionCount = pointer.Int32Ptr(0)
+
+			errorList := ValidateManagedSeedSetStatusUpdate(newManagedSeedSet, managedSeedSet)
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("status.nextReplicaNumber"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("status.collisionCount"),
+				})),
+			))
+		})
+	})
+})
+
+func updateStrategyTypePtr(v seedmanagement.UpdateStrategyType) *seedmanagement.UpdateStrategyType {
+	return &v
+}
+
+func intstrPtr(v intstr.IntOrString) *intstr.IntOrString {
+	return &v
+}

--- a/pkg/gardenlet/apis/config/validation/validation.go
+++ b/pkg/gardenlet/apis/config/validation/validation.go
@@ -27,7 +27,7 @@ import (
 )
 
 // ValidateGardenletConfiguration validates a GardenletConfiguration object.
-func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath *field.Path) field.ErrorList {
+func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath *field.Path, inTemplate bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if cfg.Controllers != nil {
@@ -42,7 +42,7 @@ func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath 
 		}
 	}
 
-	if (cfg.SeedConfig == nil && cfg.SeedSelector == nil) || (cfg.SeedConfig != nil && cfg.SeedSelector != nil) {
+	if !inTemplate && (cfg.SeedConfig == nil && cfg.SeedSelector == nil) || (cfg.SeedConfig != nil && cfg.SeedSelector != nil) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("seedConfig"), cfg, "either seed config or seed selector is required"))
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Adds validation for `ManagedSeedSet` resources.

* `ManagedSeedSet` validation code
* Changes to `Shoot`, `Seed`, and `ManagedSeed` validation code to relax validation checks for their spec when they are specified in a template. This is needed to avoid having to specify fields in `ManagedSeedSet`  templates that are otherwise optional and are defaulted when the corresponding resources are actually created.

The new validation code is not testable (except by unit tests), since the `ManagedSeedSet` resource is not yet registered in the API server. This is on purpose, to make this PR easier to review.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Based on #3638, marked as "Draft" until that one is merged.

**Release note**:

```improvement operator
NONE
```