### PR TITLE
Remove DirectClient usage in integration tests

### DIFF
--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -231,7 +231,7 @@ func (t *GuestBookTest) Cleanup(ctx context.Context) {
 	// Clean up shoot
 	ginkgo.By("Cleaning up guestbook app resources")
 	deleteResource := func(ctx context.Context, resource client.Object) error {
-		err := t.framework.ShootClient.DirectClient().Delete(ctx, resource)
+		err := t.framework.ShootClient.Client().Delete(ctx, resource)
 		if apierrors.IsNotFound(err) {
 			return nil
 		}

--- a/test/framework/dump.go
+++ b/test/framework/dump.go
@@ -41,7 +41,7 @@ const (
 // DumpDefaultResourcesInAllNamespaces dumps all default k8s resources of a namespace
 func (f *CommonFramework) DumpDefaultResourcesInAllNamespaces(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface) error {
 	namespaces := &corev1.NamespaceList{}
-	if err := k8sClient.DirectClient().List(ctx, namespaces); err != nil {
+	if err := k8sClient.Client().List(ctx, namespaces); err != nil {
 		return err
 	}
 
@@ -127,7 +127,7 @@ func (f *GardenerFramework) dumpGardenerExtensionsInNamespace(ctx context.Contex
 
 	f.Logger.Infof("%s [EXTENSIONS] [INFRASTRUCTURE]", ctxIdentifier)
 	infrastructures := &v1alpha1.InfrastructureList{}
-	err := k8sClient.DirectClient().List(ctx, infrastructures, client.InNamespace(namespace))
+	err := k8sClient.Client().List(ctx, infrastructures, client.InNamespace(namespace))
 	result = multierror.Append(result, err)
 	if err != nil {
 		for _, infra := range infrastructures.Items {
@@ -138,7 +138,7 @@ func (f *GardenerFramework) dumpGardenerExtensionsInNamespace(ctx context.Contex
 
 	f.Logger.Infof("%s [EXTENSIONS] [CONTROLPLANE]", ctxIdentifier)
 	controlplanes := &v1alpha1.ControlPlaneList{}
-	err = k8sClient.DirectClient().List(ctx, controlplanes, client.InNamespace(namespace))
+	err = k8sClient.Client().List(ctx, controlplanes, client.InNamespace(namespace))
 	if err != nil {
 		for _, cp := range controlplanes.Items {
 			f.dumpGardenerExtension(&cp)
@@ -148,7 +148,7 @@ func (f *GardenerFramework) dumpGardenerExtensionsInNamespace(ctx context.Contex
 
 	f.Logger.Infof("%s [EXTENSIONS] [OS]", ctxIdentifier)
 	operatingSystems := &v1alpha1.OperatingSystemConfigList{}
-	err = k8sClient.DirectClient().List(ctx, operatingSystems, client.InNamespace(namespace))
+	err = k8sClient.Client().List(ctx, operatingSystems, client.InNamespace(namespace))
 	result = multierror.Append(result, err)
 	if err == nil {
 		for _, os := range operatingSystems.Items {
@@ -159,7 +159,7 @@ func (f *GardenerFramework) dumpGardenerExtensionsInNamespace(ctx context.Contex
 
 	f.Logger.Infof("%s [EXTENSIONS] [WORKER]", ctxIdentifier)
 	workers := &v1alpha1.WorkerList{}
-	err = k8sClient.DirectClient().List(ctx, workers, client.InNamespace(namespace))
+	err = k8sClient.Client().List(ctx, workers, client.InNamespace(namespace))
 	result = multierror.Append(result, err)
 	if err == nil {
 		for _, worker := range workers.Items {
@@ -170,7 +170,7 @@ func (f *GardenerFramework) dumpGardenerExtensionsInNamespace(ctx context.Contex
 
 	f.Logger.Infof("%s [EXTENSIONS] [BACKUPBUCKET]", ctxIdentifier)
 	backupBuckets := &v1alpha1.BackupBucketList{}
-	err = k8sClient.DirectClient().List(ctx, backupBuckets, client.InNamespace(namespace))
+	err = k8sClient.Client().List(ctx, backupBuckets, client.InNamespace(namespace))
 	result = multierror.Append(result, err)
 	if err == nil {
 		for _, bucket := range backupBuckets.Items {
@@ -181,7 +181,7 @@ func (f *GardenerFramework) dumpGardenerExtensionsInNamespace(ctx context.Contex
 
 	f.Logger.Infof("%s [EXTENSIONS] [BACKUPENTRY]", ctxIdentifier)
 	backupEntries := &v1alpha1.BackupEntryList{}
-	err = k8sClient.DirectClient().List(ctx, backupEntries, client.InNamespace(namespace))
+	err = k8sClient.Client().List(ctx, backupEntries, client.InNamespace(namespace))
 	result = multierror.Append(result, err)
 	if err == nil {
 		for _, entry := range backupEntries.Items {
@@ -192,7 +192,7 @@ func (f *GardenerFramework) dumpGardenerExtensionsInNamespace(ctx context.Contex
 
 	f.Logger.Infof("%s [EXTENSIONS] [NETWORK]", ctxIdentifier)
 	networks := &v1alpha1.NetworkList{}
-	err = k8sClient.DirectClient().List(ctx, networks, client.InNamespace(namespace))
+	err = k8sClient.Client().List(ctx, networks, client.InNamespace(namespace))
 	result = multierror.Append(result, err)
 	if err == nil {
 		for _, network := range networks.Items {
@@ -220,7 +220,7 @@ func (f *GardenerFramework) dumpGardenerExtension(extension v1alpha1.Object) {
 func (f *CommonFramework) DumpLogsForPodsWithLabelsInNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string, opts ...client.ListOption) error {
 	pods := &corev1.PodList{}
 	opts = append(opts, client.InNamespace(namespace))
-	if err := k8sClient.DirectClient().List(ctx, pods, opts...); err != nil {
+	if err := k8sClient.Client().List(ctx, pods, opts...); err != nil {
 		return err
 	}
 
@@ -252,7 +252,7 @@ func (f *CommonFramework) DumpLogsForPodInNamespace(ctx context.Context, ctxIden
 func (f *CommonFramework) dumpDeploymentInfoForNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string) error {
 	f.Logger.Infof("%s [NAMESPACE %s] [DEPLOYMENTS]", ctxIdentifier, namespace)
 	deployments := &appsv1.DeploymentList{}
-	if err := k8sClient.DirectClient().List(ctx, deployments, client.InNamespace(namespace)); err != nil {
+	if err := k8sClient.Client().List(ctx, deployments, client.InNamespace(namespace)); err != nil {
 		return err
 	}
 	for _, deployment := range deployments.Items {
@@ -270,7 +270,7 @@ func (f *CommonFramework) dumpDeploymentInfoForNamespace(ctx context.Context, ct
 func (f *CommonFramework) dumpStatefulSetInfoForNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string) error {
 	f.Logger.Infof("%s [NAMESPACE %s] [STATEFULSETS]", ctxIdentifier, namespace)
 	statefulSets := &appsv1.StatefulSetList{}
-	if err := k8sClient.DirectClient().List(ctx, statefulSets, client.InNamespace(namespace)); err != nil {
+	if err := k8sClient.Client().List(ctx, statefulSets, client.InNamespace(namespace)); err != nil {
 		return err
 	}
 	for _, statefulSet := range statefulSets.Items {
@@ -288,7 +288,7 @@ func (f *CommonFramework) dumpStatefulSetInfoForNamespace(ctx context.Context, c
 func (f *CommonFramework) dumpDaemonSetInfoForNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string) error {
 	f.Logger.Infof("%s [NAMESPACE %s] [DAEMONSETS]", ctxIdentifier, namespace)
 	daemonSets := &appsv1.DaemonSetList{}
-	if err := k8sClient.DirectClient().List(ctx, daemonSets, client.InNamespace(namespace)); err != nil {
+	if err := k8sClient.Client().List(ctx, daemonSets, client.InNamespace(namespace)); err != nil {
 		return err
 	}
 	for _, ds := range daemonSets.Items {
@@ -306,7 +306,7 @@ func (f *CommonFramework) dumpDaemonSetInfoForNamespace(ctx context.Context, ctx
 func (f *CommonFramework) dumpNamespaceResource(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string) error {
 	f.Logger.Infof("%s [NAMESPACE RESOURCE %s]", ctxIdentifier, namespace)
 	ns := &corev1.Namespace{}
-	if err := k8sClient.DirectClient().Get(ctx, client.ObjectKey{Name: namespace}, ns); err != nil {
+	if err := k8sClient.Client().Get(ctx, client.ObjectKey{Name: namespace}, ns); err != nil {
 		return err
 	}
 	f.Logger.Printf("Namespace %s - Spec %+v - Status %+v", namespace, ns.Spec, ns.Status)
@@ -318,7 +318,7 @@ func (f *CommonFramework) dumpNamespaceResource(ctx context.Context, ctxIdentifi
 func (f *CommonFramework) dumpServiceInfoForNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string) error {
 	f.Logger.Infof("%s [NAMESPACE %s] [SERVICES]", ctxIdentifier, namespace)
 	services := &corev1.ServiceList{}
-	if err := k8sClient.DirectClient().List(ctx, services, client.InNamespace(namespace)); err != nil {
+	if err := k8sClient.Client().List(ctx, services, client.InNamespace(namespace)); err != nil {
 		return err
 	}
 	for _, service := range services.Items {
@@ -356,7 +356,7 @@ func (f *CommonFramework) dumpVolumeInfoForNamespace(ctx context.Context, ctxIde
 func (f *CommonFramework) dumpNodes(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface) error {
 	f.Logger.Infof("%s [NODES]", ctxIdentifier)
 	nodes := &corev1.NodeList{}
-	if err := k8sClient.DirectClient().List(ctx, nodes); err != nil {
+	if err := k8sClient.Client().List(ctx, nodes); err != nil {
 		return err
 	}
 	for _, node := range nodes.Items {
@@ -368,7 +368,7 @@ func (f *CommonFramework) dumpNodes(ctx context.Context, ctxIdentifier string, k
 		f.Logger.Printf("Node %s has a capacity of %s cpu, %s memory", node.Name, node.Status.Capacity.Cpu().String(), node.Status.Capacity.Memory().String())
 
 		nodeMetric := &metricsv1beta1.NodeMetrics{}
-		if err := k8sClient.DirectClient().Get(ctx, client.ObjectKey{Name: node.Name}, nodeMetric); err != nil {
+		if err := k8sClient.Client().Get(ctx, client.ObjectKey{Name: node.Name}, nodeMetric); err != nil {
 			f.Logger.Errorf("unable to receive metrics for node %s: %s", node.Name, err.Error())
 			continue
 		}
@@ -382,7 +382,7 @@ func (f *CommonFramework) dumpNodes(ctx context.Context, ctxIdentifier string, k
 func (f *CommonFramework) dumpPodInfoForNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string) error {
 	f.Logger.Infof("%s [NAMESPACE %s] [PODS]", ctxIdentifier, namespace)
 	pods := &corev1.PodList{}
-	if err := k8sClient.DirectClient().List(ctx, pods, client.InNamespace(namespace)); err != nil {
+	if err := k8sClient.Client().List(ctx, pods, client.InNamespace(namespace)); err != nil {
 		return err
 	}
 	for _, pod := range pods.Items {
@@ -396,7 +396,7 @@ func (f *CommonFramework) dumpPodInfoForNamespace(ctx context.Context, ctxIdenti
 func (f *CommonFramework) dumpEventsInNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string, filters ...EventFilterFunc) error {
 	f.Logger.Infof("%s [NAMESPACE %s] [EVENTS]", ctxIdentifier, namespace)
 	events := &corev1.EventList{}
-	if err := k8sClient.DirectClient().List(ctx, events, client.InNamespace(namespace)); err != nil {
+	if err := k8sClient.Client().List(ctx, events, client.InNamespace(namespace)); err != nil {
 		return err
 	}
 

--- a/test/framework/managedseedframework.go
+++ b/test/framework/managedseedframework.go
@@ -153,7 +153,7 @@ func (f *ManagedSeedFramework) CreateManagedSeed(ctx context.Context) error {
 
 	// Get shoot
 	shoot := &gardencorev1beta1.Shoot{}
-	if err := f.GardenClient.DirectClient().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace, f.Config.ShootName), shoot); err != nil {
+	if err := f.GardenClient.Client().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace, f.Config.ShootName), shoot); err != nil {
 		return err
 	}
 

--- a/test/framework/plant_utils.go
+++ b/test/framework/plant_utils.go
@@ -35,7 +35,7 @@ func (f *GardenerFramework) CreatePlantSecret(ctx context.Context, namespace str
 	plantSecret.Data = make(map[string][]byte)
 	plantSecret.Data["kubeconfig"] = kubeConfigContent
 
-	err := f.GardenClient.DirectClient().Create(ctx, plantSecret)
+	err := f.GardenClient.Client().Create(ctx, plantSecret)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (f *GardenerFramework) CreatePlantSecret(ctx context.Context, namespace str
 
 // CreatePlant Creates a plant from a plant Object
 func (f *GardenerFramework) CreatePlant(ctx context.Context, plant *gardencorev1beta1.Plant) error {
-	err := f.GardenClient.DirectClient().Create(ctx, plant)
+	err := f.GardenClient.Client().Create(ctx, plant)
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func (f *GardenerFramework) CreatePlant(ctx context.Context, plant *gardencorev1
 
 // DeletePlant deletes the test plant
 func (f *GardenerFramework) DeletePlant(ctx context.Context, plant *gardencorev1beta1.Plant) error {
-	err := f.GardenClient.DirectClient().Delete(ctx, plant)
+	err := f.GardenClient.Client().Delete(ctx, plant)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func (f *GardenerFramework) DeletePlant(ctx context.Context, plant *gardencorev1
 func (f *GardenerFramework) WaitForPlantToBeCreated(ctx context.Context, plant *gardencorev1beta1.Plant) error {
 	return retry.Until(ctx, 2*time.Second, func(ctx context.Context) (done bool, err error) {
 		newPlant := &gardencorev1beta1.Plant{}
-		err = f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: plant.GetNamespace(), Name: plant.GetName()}, newPlant)
+		err = f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: plant.GetNamespace(), Name: plant.GetName()}, newPlant)
 		if err != nil {
 			return retry.SevereError(err)
 		}
@@ -94,7 +94,7 @@ func (f *GardenerFramework) WaitForPlantToBeCreated(ctx context.Context, plant *
 func (f *GardenerFramework) WaitForPlantToBeReconciledSuccessfully(ctx context.Context, plant *gardencorev1beta1.Plant) error {
 	return retry.Until(ctx, 2*time.Second, func(ctx context.Context) (done bool, err error) {
 		newPlant := &gardencorev1beta1.Plant{}
-		err = f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: plant.GetNamespace(), Name: plant.GetName()}, newPlant)
+		err = f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: plant.GetNamespace(), Name: plant.GetName()}, newPlant)
 		if err != nil {
 			return retry.SevereError(err)
 		}
@@ -113,7 +113,7 @@ func (f *GardenerFramework) WaitForPlantToBeReconciledSuccessfully(ctx context.C
 func (f *GardenerFramework) WaitForPlantToBeDeleted(ctx context.Context, plant *gardencorev1beta1.Plant) error {
 	return retry.Until(ctx, 2*time.Second, func(ctx context.Context) (done bool, err error) {
 		newPlant := &gardencorev1beta1.Plant{}
-		err = f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: plant.GetNamespace(), Name: plant.GetName()}, newPlant)
+		err = f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: plant.GetNamespace(), Name: plant.GetName()}, newPlant)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return retry.Ok()
@@ -132,7 +132,7 @@ func (f *GardenerFramework) WaitForPlantToBeDeleted(ctx context.Context, plant *
 func (f *GardenerFramework) WaitForPlantToBeReconciledWithUnknownStatus(ctx context.Context, plant *gardencorev1beta1.Plant) error {
 	return retry.Until(ctx, 2*time.Second, func(ctx context.Context) (done bool, err error) {
 		newPlant := &gardencorev1beta1.Plant{}
-		err = f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: plant.GetNamespace(), Name: plant.GetName()}, newPlant)
+		err = f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: plant.GetNamespace(), Name: plant.GetName()}, newPlant)
 		if err != nil {
 			return retry.SevereError(err)
 		}

--- a/test/framework/rootpod_executor.go
+++ b/test/framework/rootpod_executor.go
@@ -95,7 +95,7 @@ func (e *rootPodExecutor) Execute(ctx context.Context, command string) ([]byte, 
 
 // deploy deploys a root pod on the specified node and waits until it is running
 func (e *rootPodExecutor) deploy(ctx context.Context) error {
-	rootPod, err := DeployRootPod(ctx, e.client.DirectClient(), e.namespace, e.nodeName)
+	rootPod, err := DeployRootPod(ctx, e.client.Client(), e.namespace, e.nodeName)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func (e *rootPodExecutor) checkPodRunning(ctx context.Context) (bool, error) {
 	}
 
 	pod := e.Pod.DeepCopy()
-	if err := e.client.DirectClient().Get(ctx, client.ObjectKeyFromObject(e.Pod), pod); err != nil {
+	if err := e.client.Client().Get(ctx, client.ObjectKeyFromObject(e.Pod), pod); err != nil {
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}

--- a/test/framework/seedregistrationframework.go
+++ b/test/framework/seedregistrationframework.go
@@ -232,7 +232,7 @@ func (f *SeedRegistrationFramework) AddSeed(ctx context.Context, seed *gardencor
 	if f.GardenClient == nil {
 		return errors.New("no gardener client is defined")
 	}
-	if err := f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Name: seed.Name}, seed); err != nil {
+	if err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Name: seed.Name}, seed); err != nil {
 		return err
 	}
 	f.Seed = seed
@@ -247,7 +247,7 @@ func (f *SeedRegistrationFramework) RegisterSeed(ctx context.Context) (err error
 	}
 
 	refShoot := &gardencorev1beta1.Shoot{}
-	if err = f.GardenClient.DirectClient().Get(ctx, kutil.Key(f.Config.ShootedSeedNamespace, f.Config.ShootedSeedName), refShoot); err != nil {
+	if err = f.GardenClient.Client().Get(ctx, kutil.Key(f.Config.ShootedSeedNamespace, f.Config.ShootedSeedName), refShoot); err != nil {
 		return err
 	}
 
@@ -256,7 +256,7 @@ func (f *SeedRegistrationFramework) RegisterSeed(ctx context.Context) (err error
 	}
 
 	secretBinding := &gardencorev1beta1.SecretBinding{}
-	if err = f.GardenClient.DirectClient().Get(ctx, kutil.Key(f.Config.ShootedSeedNamespace, f.Config.SecretBinding), secretBinding); err != nil {
+	if err = f.GardenClient.Client().Get(ctx, kutil.Key(f.Config.ShootedSeedNamespace, f.Config.SecretBinding), secretBinding); err != nil {
 		return err
 	}
 
@@ -268,7 +268,7 @@ func (f *SeedRegistrationFramework) RegisterSeed(ctx context.Context) (err error
 	}
 	f.Logger.Infof("Creating seed secret %s in namespace %s", f.Secret.GetName(), f.Secret.GetNamespace())
 	// Apply secret to the cluster
-	if err = f.GardenClient.DirectClient().Create(ctx, f.Secret); err != nil {
+	if err = f.GardenClient.Client().Create(ctx, f.Secret); err != nil {
 		f.Logger.Errorf("Cannot create seed secret %s: %s", f.Secret.GetName(), err)
 		return err
 	}
@@ -357,13 +357,13 @@ func (f *SeedRegistrationFramework) buildSeedSecret(ctx context.Context, secretB
 	}
 
 	kubeconfigSecret := &corev1.Secret{}
-	if err := f.GardenClient.DirectClient().Get(ctx, kutil.Key(f.Config.ShootedSeedNamespace, (f.Config.ShootedSeedName+".kubeconfig")), kubeconfigSecret); err != nil {
+	if err := f.GardenClient.Client().Get(ctx, kutil.Key(f.Config.ShootedSeedNamespace, (f.Config.ShootedSeedName+".kubeconfig")), kubeconfigSecret); err != nil {
 		return err
 	}
 	kubecfgData := kubeconfigSecret.Data["kubeconfig"]
 
 	referenceSecret := &corev1.Secret{}
-	if err := f.GardenClient.DirectClient().Get(ctx, kutil.Key(secretBinding.SecretRef.Namespace, secretBinding.SecretRef.Name), referenceSecret); err != nil {
+	if err := f.GardenClient.Client().Get(ctx, kutil.Key(secretBinding.SecretRef.Namespace, secretBinding.SecretRef.Name), referenceSecret); err != nil {
 		return err
 	}
 	secret.Data = referenceSecret.Data

--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -135,7 +135,7 @@ func (f *ShootFramework) DumpState(ctx context.Context) {
 		// dump seed status if seed is available
 		if f.Shoot.Spec.SeedName != nil {
 			seed := &gardencorev1beta1.Seed{}
-			if err := f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Name: *f.Shoot.Spec.SeedName}, seed); err != nil {
+			if err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Name: *f.Shoot.Spec.SeedName}, seed); err != nil {
 				f.Logger.Errorf("unable to get seed %s: %s", *f.Shoot.Spec.SeedName, err.Error())
 				return
 			}

--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -199,7 +199,7 @@ func (t *ShootMigrationTest) CompareElementsAfterMigration() error {
 // The timestamp should not be after the ShootMigrationTest.MigrationTime
 func (t *ShootMigrationTest) CheckObjectsTimestamp(ctx context.Context, mrExcludeList []string) error {
 	mrList := &resourcesv1alpha1.ManagedResourceList{}
-	if err := t.TargetSeedClient.DirectClient().List(
+	if err := t.TargetSeedClient.Client().List(
 		ctx,
 		mrList,
 		client.InNamespace(t.SeedShootNamespace),
@@ -236,7 +236,7 @@ func (t *ShootMigrationTest) CheckObjectsTimestamp(ctx context.Context, mrExclud
 // CheckForOrphanedNonNamespacedResources checks if there are orphaned resources left on the target seed after the shoot migration.
 // The function checks for Cluster, DNSOwner, BackupEntry, ClusterRoleBinding, ClusterRole and PersistentVolume
 func (t *ShootMigrationTest) CheckForOrphanedNonNamespacedResources(ctx context.Context) error {
-	seedClientScheme := t.SourceSeedClient.DirectClient().Scheme()
+	seedClientScheme := t.SourceSeedClient.Client().Scheme()
 
 	if err := extensionsv1alpha1.AddToScheme(seedClientScheme); err != nil {
 		return err

--- a/test/integration/gardener/scheduler/scheduler_test.go
+++ b/test/integration/gardener/scheduler/scheduler_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Scheduler testing", func() {
 		framework.ExpectNoError(err)
 
 		schedulerConfigurationConfigMap := &corev1.ConfigMap{}
-		err = hostClusterClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: schedulerconfigv1alpha1.SchedulerDefaultConfigurationConfigMapNamespace, Name: schedulerconfigv1alpha1.SchedulerDefaultConfigurationConfigMapName}, schedulerConfigurationConfigMap)
+		err = hostClusterClient.Client().Get(ctx, client.ObjectKey{Namespace: schedulerconfigv1alpha1.SchedulerDefaultConfigurationConfigMapNamespace, Name: schedulerconfigv1alpha1.SchedulerDefaultConfigurationConfigMapName}, schedulerConfigurationConfigMap)
 		framework.ExpectNoError(err)
 
 		schedulerConfiguration, err = framework.ParseSchedulerConfiguration(schedulerConfigurationConfigMap)
@@ -138,7 +138,7 @@ var _ = Describe("Scheduler testing", func() {
 
 		if testMachineryRun != nil && *testMachineryRun {
 			f.Logger.Info("Running in test Machinery")
-			replicas, err := framework.ScaleGardenerControllerManager(setupContextTimeout, f.GardenClient.DirectClient(), pointer.Int32Ptr(0))
+			replicas, err := framework.ScaleGardenerControllerManager(setupContextTimeout, f.GardenClient.Client(), pointer.Int32Ptr(0))
 			Expect(err).To(BeNil())
 			gardenerSchedulerReplicaCount = replicas
 			f.Logger.Info("Environment for test-machinery run is prepared")
@@ -154,7 +154,7 @@ var _ = Describe("Scheduler testing", func() {
 		}
 		if testMachineryRun != nil && *testMachineryRun {
 			// Scale up ControllerManager again to restore state before this test.
-			_, err := framework.ScaleGardenerControllerManager(restoreCtxTimeout, f.GardenClient.DirectClient(), gardenerSchedulerReplicaCount)
+			_, err := framework.ScaleGardenerControllerManager(restoreCtxTimeout, f.GardenClient.Client(), gardenerSchedulerReplicaCount)
 			framework.ExpectNoError(err)
 			f.Logger.Infof("Environment is restored")
 		}
@@ -219,7 +219,7 @@ var _ = Describe("Scheduler testing", func() {
 
 		// retrieve valid shoot
 		alreadyScheduledShoot := &gardencorev1beta1.Shoot{}
-		err = f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: f.Shoot.Namespace, Name: f.Shoot.Name}, alreadyScheduledShoot)
+		err = f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: f.Shoot.Namespace, Name: f.Shoot.Name}, alreadyScheduledShoot)
 		framework.ExpectNoError(err)
 
 		err = f.ScheduleShoot(ctx, alreadyScheduledShoot, invalidSeed)
@@ -227,7 +227,7 @@ var _ = Describe("Scheduler testing", func() {
 
 		// double check that invalid seed is not set
 		currentShoot := &gardencorev1beta1.Shoot{}
-		err = f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: f.Shoot.Namespace, Name: f.Shoot.Name}, currentShoot)
+		err = f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: f.Shoot.Namespace, Name: f.Shoot.Name}, currentShoot)
 		framework.ExpectNoError(err)
 		Expect(*currentShoot.Spec.SeedName).NotTo(Equal(invalidSeed.Name))
 

--- a/test/integration/gardener/security/rbac.go
+++ b/test/integration/gardener/security/rbac.go
@@ -77,15 +77,15 @@ var _ = ginkgo.Describe("RBAC testing", func() {
 			},
 		}
 
-		err := f.GardenClient.DirectClient().Create(ctx, serviceAccount)
+		err := f.GardenClient.Client().Create(ctx, serviceAccount)
 		framework.ExpectNoError(err)
 		defer func() {
-			framework.ExpectNoError(f.GardenClient.DirectClient().Delete(ctx, serviceAccount))
+			framework.ExpectNoError(f.GardenClient.Client().Delete(ctx, serviceAccount))
 		}()
 
 		err = retry.UntilTimeout(ctx, 10*time.Second, serviceAccountPermissionTimeout, func(ctx context.Context) (bool, error) {
 			newServiceAccount := &corev1.ServiceAccount{}
-			if err := f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: serviceAccount.Namespace, Name: serviceAccount.Name}, newServiceAccount); err != nil {
+			if err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: serviceAccount.Namespace, Name: serviceAccount.Name}, newServiceAccount); err != nil {
 				return retry.MinorError(err)
 			}
 			serviceAccount = newServiceAccount
@@ -100,7 +100,7 @@ var _ = ginkgo.Describe("RBAC testing", func() {
 		framework.ExpectNoError(err)
 
 		shoots := &gardencorev1beta1.ShootList{}
-		err = saClient.DirectClient().List(ctx, shoots, client.InNamespace(v1beta1constants.GardenNamespace))
+		err = saClient.Client().List(ctx, shoots, client.InNamespace(v1beta1constants.GardenNamespace))
 		g.Expect(err).To(g.HaveOccurred())
 		g.Expect(errors.IsForbidden(err)).To(g.BeTrue())
 	}, serviceAccountPermissionTimeout)

--- a/test/integration/plants/plant.go
+++ b/test/integration/plants/plant.go
@@ -61,7 +61,7 @@ const (
 )
 
 func cleanPlant(ctx context.Context, f *framework.ShootFramework, plant *gardencorev1beta1.Plant, secret *corev1.Secret) error {
-	if err := f.GardenClient.DirectClient().Delete(ctx, secret); err != nil {
+	if err := f.GardenClient.Client().Delete(ctx, secret); err != nil {
 		return err
 	}
 	return f.DeletePlant(ctx, plant)

--- a/test/integration/shoots/applications/metrics.go
+++ b/test/integration/shoots/applications/metrics.go
@@ -73,7 +73,7 @@ var _ = ginkgo.Describe("Shoot application metrics testing", func() {
 		framework.ExpectNoError(err)
 
 		pods := &corev1.PodList{}
-		err = f.ShootClient.DirectClient().List(ctx, pods, client.InNamespace(f.Namespace), client.MatchingLabels{"app": "load"})
+		err = f.ShootClient.Client().List(ctx, pods, client.InNamespace(f.Namespace), client.MatchingLabels{"app": "load"})
 		framework.ExpectNoError(err)
 
 		if len(pods.Items) == 0 {
@@ -85,7 +85,7 @@ var _ = ginkgo.Describe("Shoot application metrics testing", func() {
 		framework.ExpectNoError(
 			retry.Until(ctx, 30*time.Second, func(ctx context.Context) (bool, error) {
 				podMetrics := &metricsv1beta1.PodMetrics{}
-				if err := f.ShootClient.DirectClient().Get(ctx, kutil.Key(f.Namespace, podName), podMetrics); err != nil {
+				if err := f.ShootClient.Client().Get(ctx, kutil.Key(f.Namespace, podName), podMetrics); err != nil {
 					if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 						f.Logger.Infof("No metrics for pod %s/%s available yet: %v", f.Namespace, podName, err)
 						return retry.MinorError(err)
@@ -110,7 +110,7 @@ var _ = ginkgo.Describe("Shoot application metrics testing", func() {
 		)
 	}, metricsTestTimeout, framework.WithCAfterTest(func(ctx context.Context) {
 		ginkgo.By("cleanup metrics test deployment")
-		err := f.ShootClient.DirectClient().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: f.Namespace}})
+		err := f.ShootClient.Client().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: f.Namespace}})
 		framework.ExpectNoError(client.IgnoreNotFound(err))
 	}, cleanupTimeout))
 

--- a/test/integration/shoots/applications/networking.go
+++ b/test/integration/shoots/applications/networking.go
@@ -69,11 +69,11 @@ var _ = ginkgo.Describe("Shoot network testing", func() {
 		err := f.RenderAndDeployTemplate(ctx, f.ShootClient, templates.NginxDaemonSetName, templateParams)
 		framework.ExpectNoError(err)
 
-		err = f.WaitUntilDaemonSetIsRunning(ctx, f.ShootClient.DirectClient(), name, f.Namespace)
+		err = f.WaitUntilDaemonSetIsRunning(ctx, f.ShootClient.Client(), name, f.Namespace)
 		framework.ExpectNoError(err)
 
 		pods := &corev1.PodList{}
-		err = f.ShootClient.DirectClient().List(ctx, pods, client.InNamespace(f.Namespace), client.MatchingLabels{"app": "net-nginx"})
+		err = f.ShootClient.Client().List(ctx, pods, client.InNamespace(f.Namespace), client.MatchingLabels{"app": "net-nginx"})
 		framework.ExpectNoError(err)
 
 		podExecutor := framework.NewPodExecutor(f.ShootClient)
@@ -100,7 +100,7 @@ var _ = ginkgo.Describe("Shoot network testing", func() {
 		framework.ExpectNoError(err)
 	}, networkTestTimeout, framework.WithCAfterTest(func(ctx context.Context) {
 		ginkgo.By("cleanup network test daemonset")
-		err := f.ShootClient.DirectClient().Delete(ctx, &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: f.Namespace}})
+		err := f.ShootClient.Client().Delete(ctx, &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: f.Namespace}})
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
 				framework.ExpectNoError(err)

--- a/test/integration/shoots/care/shoot_care.go
+++ b/test/integration/shoots/care/shoot_care.go
@@ -55,7 +55,7 @@ var _ = ginkgo.Describe("Shoot Care testing", func() {
 		gomega.Expect(cond.Status).To(gomega.Equal(gardencorev1beta1.ConditionTrue))
 
 		zero := int32(0)
-		origReplicas, err = framework.ScaleDeployment(timeout, f.SeedClient.DirectClient(), &zero, gardencorev1beta1constants.DeploymentNameKubeAPIServer, f.ShootSeedNamespace())
+		origReplicas, err = framework.ScaleDeployment(timeout, f.SeedClient.Client(), &zero, gardencorev1beta1constants.DeploymentNameKubeAPIServer, f.ShootSeedNamespace())
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 		// wait for unhealthy condition
@@ -64,7 +64,7 @@ var _ = ginkgo.Describe("Shoot Care testing", func() {
 	}, timeout, framework.WithCAfterTest(func(ctx context.Context) {
 		if origReplicas != nil {
 			f.Logger.Infof("Test cleanup: Scale API Server to '%d' replicas again", *origReplicas)
-			origReplicas, err = framework.ScaleDeployment(timeout, f.SeedClient.DirectClient(), origReplicas, gardencorev1beta1constants.DeploymentNameKubeAPIServer, f.ShootSeedNamespace())
+			origReplicas, err = framework.ScaleDeployment(timeout, f.SeedClient.Client(), origReplicas, gardencorev1beta1constants.DeploymentNameKubeAPIServer, f.ShootSeedNamespace())
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 			// wait for healthy condition

--- a/test/integration/shoots/logging/seed_logging_stack.go
+++ b/test/integration/shoots/logging/seed_logging_stack.go
@@ -174,7 +174,7 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 
 			cluster := getCluster(i)
 			ginkgo.By(fmt.Sprintf("Deploy cluster %s", cluster.Name))
-			framework.ExpectNoError(create(ctx, f.ShootClient.DirectClient(), cluster))
+			framework.ExpectNoError(create(ctx, f.ShootClient.Client(), cluster))
 
 			ginkgo.By(fmt.Sprintf("Deploy the loki service in namespace %s", shootNamespace.Name))
 			lokiShootService := getLokiShootService(i)

--- a/test/integration/shoots/logging/utils.go
+++ b/test/integration/shoots/logging/utils.go
@@ -42,12 +42,12 @@ import (
 // If not, probably the logging feature gate is not enabled.
 func hasRequiredResources(ctx context.Context, k8sSeedClient kubernetes.Interface) (bool, error) {
 	fluentBit := &appsv1.DaemonSet{}
-	if err := k8sSeedClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: garden, Name: fluentBitName}, fluentBit); err != nil {
+	if err := k8sSeedClient.Client().Get(ctx, client.ObjectKey{Namespace: garden, Name: fluentBitName}, fluentBit); err != nil {
 		return false, err
 	}
 
 	loki := &appsv1.StatefulSet{}
-	if err := k8sSeedClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: garden, Name: lokiName}, loki); err != nil {
+	if err := k8sSeedClient.Client().Get(ctx, client.ObjectKey{Namespace: garden, Name: lokiName}, loki); err != nil {
 		return false, err
 	}
 

--- a/test/integration/shoots/operatingsystem/os.go
+++ b/test/integration/shoots/operatingsystem/os.go
@@ -52,7 +52,7 @@ var _ = ginkgo.Describe("Operating system testing", func() {
 		f.Default().Serial().CIt("should not segfault", func(ctx context.Context) {
 			// choose random node
 			nodes := &corev1.NodeList{}
-			err := f.ShootClient.DirectClient().List(ctx, nodes)
+			err := f.ShootClient.Client().List(ctx, nodes)
 			framework.ExpectNoError(err)
 
 			if len(nodes.Items) == 0 {

--- a/test/integration/shoots/operations/clusterautoscaler.go
+++ b/test/integration/shoots/operations/clusterautoscaler.go
@@ -114,7 +114,7 @@ var _ = ginkgo.Describe("Shoot clusterautoscaler testing", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("scaling up pod-anti-affinity deployment")
-		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.DirectClient(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, origMinWorkers+1)
+		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.Client(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, origMinWorkers+1)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("one node should be added to the worker pool")
@@ -126,7 +126,7 @@ var _ = ginkgo.Describe("Shoot clusterautoscaler testing", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("scaling down pod-anti-affinity deployment")
-		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.DirectClient(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, origMinWorkers)
+		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.Client(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, origMinWorkers)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("one node should be removed from the worker pool")
@@ -211,7 +211,7 @@ var _ = ginkgo.Describe("Shoot clusterautoscaler testing", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("scaling up pod-anti-affinity deployment")
-		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.DirectClient(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, 1)
+		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.Client(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, 1)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("one node should be added to the worker pool")
@@ -223,7 +223,7 @@ var _ = ginkgo.Describe("Shoot clusterautoscaler testing", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("scaling down pod-anti-affinity deployment")
-		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.DirectClient(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, 0)
+		err = kubernetes.ScaleDeployment(ctx, f.ShootClient.Client(), client.ObjectKey{Namespace: values.Namespace, Name: values.Name}, 0)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("worker pool should be scaled-down to 0")

--- a/test/system/complete_reconcile/gardener_reconcile_test.go
+++ b/test/system/complete_reconcile/gardener_reconcile_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Shoot reconciliation testing", func() {
 
 		err := retry.UntilTimeout(ctx, 30*time.Second, ReconcileShootsTimeout, func(ctx context.Context) (bool, error) {
 			shoots := &gardencorev1beta1.ShootList{}
-			err := f.GardenClient.DirectClient().List(ctx, shoots)
+			err := f.GardenClient.Client().List(ctx, shoots)
 			if err != nil {
 				f.Logger.Debug(err.Error())
 				return retry.MinorError(err)

--- a/test/system/managed_seed_deletion/delete_test.go
+++ b/test/system/managed_seed_deletion/delete_test.go
@@ -49,7 +49,7 @@ var _ = Describe("ManagedSeed deletion testing", func() {
 		validateFlags()
 
 		managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
-		if err := f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: v1beta1constants.GardenNamespace, Name: *managedSeedName}, managedSeed); err != nil {
+		if err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: v1beta1constants.GardenNamespace, Name: *managedSeedName}, managedSeed); err != nil {
 			if apierrors.IsNotFound(err) {
 				Skip("managed seed is already deleted")
 			}

--- a/test/system/seed_deletion/delete_test.go
+++ b/test/system/seed_deletion/delete_test.go
@@ -95,7 +95,7 @@ func deleteSeed(ctx context.Context, f *framework.GardenerFramework) error {
 
 	f.Logger.Info("Deleting secret...")
 	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: seed.Spec.SecretRef.Name, Namespace: seed.Spec.SecretRef.Namespace}}
-	if err := f.GardenClient.DirectClient().Delete(ctx, secret); client.IgnoreNotFound(err) != nil {
+	if err := f.GardenClient.Client().Delete(ctx, secret); client.IgnoreNotFound(err) != nil {
 		err = errors.Wrapf(err, "Secret %s/%s can't be deleted", seed.Spec.SecretRef.Namespace, seed.Spec.SecretRef.Name)
 		return err
 	}
@@ -106,14 +106,14 @@ func deleteSeed(ctx context.Context, f *framework.GardenerFramework) error {
 func deleteBackupbucket(ctx context.Context, f *framework.GardenerFramework, seedName string) error {
 	backupbuckets := &gardencorev1beta1.BackupBucketList{}
 
-	if err := f.GardenClient.DirectClient().List(ctx, backupbuckets); err != nil {
+	if err := f.GardenClient.Client().List(ctx, backupbuckets); err != nil {
 		return err
 	}
 
 	for _, backupbucket := range backupbuckets.Items {
 		if backupbucket.Spec.SeedName != nil && *backupbucket.Spec.SeedName == seedName {
 			f.Logger.Infof("Backupbucket found: %s", backupbucket.Name)
-			return f.GardenClient.DirectClient().Delete(ctx, &backupbucket)
+			return f.GardenClient.Client().Delete(ctx, &backupbucket)
 		}
 	}
 	return nil

--- a/test/system/shoot_cp_migration/migrate_test.go
+++ b/test/system/shoot_cp_migration/migrate_test.go
@@ -122,13 +122,13 @@ func initShootAndClient(ctx context.Context, t *ShootMigrationTest) (err error) 
 	}
 
 	kubecfgSecret := corev1.Secret{}
-	if err := t.GardenerFramework.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Name: shoot.Name + ".kubeconfig", Namespace: shoot.Namespace}, &kubecfgSecret); err != nil {
+	if err := t.GardenerFramework.GardenClient.Client().Get(ctx, client.ObjectKey{Name: shoot.Name + ".kubeconfig", Namespace: shoot.Namespace}, &kubecfgSecret); err != nil {
 		t.GardenerFramework.Logger.Errorf("Unable to get kubeconfig from secret: %s", err.Error())
 		return err
 	}
 	t.GardenerFramework.Logger.Info("Shoot kubeconfig secret was fetched successfully")
 
-	t.ShootClient, err = kubernetes.NewClientFromSecret(ctx, t.GardenerFramework.GardenClient.DirectClient(), kubecfgSecret.Namespace, kubecfgSecret.Name, kubernetes.WithClientOptions(client.Options{
+	t.ShootClient, err = kubernetes.NewClientFromSecret(ctx, t.GardenerFramework.GardenClient.Client(), kubecfgSecret.Namespace, kubecfgSecret.Name, kubernetes.WithClientOptions(client.Options{
 		Scheme: kubernetes.ShootScheme,
 	}))
 	t.Shoot = *shoot
@@ -172,11 +172,11 @@ func beforeMigration(ctx context.Context, t *ShootMigrationTest, guestBookApp *a
 	}
 
 	ginkgo.By("Creating test Secret and Service Account")
-	if err := t.ShootClient.DirectClient().Create(ctx, testSecret); err != nil {
+	if err := t.ShootClient.Client().Create(ctx, testSecret); err != nil {
 		return err
 	}
 	t.GardenerFramework.Logger.Infof("Secret resource %s/%s was created!", testSecret.Namespace, testSecret.Name)
-	if err := t.ShootClient.DirectClient().Create(ctx, testServiceAccount); err != nil {
+	if err := t.ShootClient.Client().Create(ctx, testServiceAccount); err != nil {
 		return err
 	}
 	t.GardenerFramework.Logger.Infof("ServiceAccount resource %s/%s was created!", testServiceAccount.Namespace, testServiceAccount.Name)
@@ -204,11 +204,11 @@ func afterMigration(ctx context.Context, t *ShootMigrationTest, guestBookApp app
 	}
 
 	ginkgo.By("Checking if the test Secret and Service Account are migrated and cleaning them up...")
-	if err := t.ShootClient.DirectClient().Delete(ctx, testSecret); err != nil {
+	if err := t.ShootClient.Client().Delete(ctx, testSecret); err != nil {
 		return err
 	}
 	t.GardenerFramework.Logger.Infof("Secret resource %s/%s was deleted!", testSecret.Namespace, testSecret.Name)
-	if err := t.ShootClient.DirectClient().Delete(ctx, testServiceAccount); err != nil {
+	if err := t.ShootClient.Client().Delete(ctx, testServiceAccount); err != nil {
 		return err
 	}
 	t.GardenerFramework.Logger.Infof("ServiceAccount resource %s/%s was deleted!", testServiceAccount.Namespace, testServiceAccount.Name)

--- a/test/system/shoot_deletion/delete_test.go
+++ b/test/system/shoot_deletion/delete_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Shoot deletion testing", func() {
 		validateFlags()
 
 		shoot := &gardencorev1beta1.Shoot{ObjectMeta: metav1.ObjectMeta{Namespace: f.ProjectNamespace, Name: *shootName}}
-		if err := f.GardenClient.DirectClient().Get(ctx, client.ObjectKey{Namespace: f.ProjectNamespace, Name: *shootName}, shoot); err != nil {
+		if err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: f.ProjectNamespace, Name: *shootName}, shoot); err != nil {
 			if apierrors.IsNotFound(err) {
 				Skip("shoot is already deleted")
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority normal

**What this PR does / why we need it**:

This PR removes all `DirectClient` usages under `test/`. The clients constructed there are anyways uncached and read directly from the API server.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2822

**Special notes for your reviewer**:

No other change, just a good old "find+replace all".

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
