### PR TITLE
Add missing unit tests for DeployControlPlane{Exposure}

### DIFF
--- a/pkg/operation/botanist/controlplane_test.go
+++ b/pkg/operation/botanist/controlplane_test.go
@@ -16,8 +16,10 @@ package botanist
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	cr "github.com/gardener/gardener/pkg/chartrenderer"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
@@ -26,11 +28,13 @@ import (
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	mockcontrolplane "github.com/gardener/gardener/pkg/operation/botanist/extensions/controlplane/mock"
 	"github.com/gardener/gardener/pkg/operation/garden"
 	"github.com/gardener/gardener/pkg/operation/shoot"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -57,17 +61,31 @@ var _ = Describe("controlplane", func() {
 	)
 
 	var (
-		b          *Botanist
-		seedClient client.Client
-		s          *runtime.Scheme
-		ctx        context.Context
+		ctrl   *gomock.Controller
+		scheme *runtime.Scheme
+		client client.Client
 
+		controlPlane         *mockcontrolplane.MockInterface
+		controlPlaneExposure *mockcontrolplane.MockInterface
+		botanist             *Botanist
+
+		ctx               = context.TODO()
+		fakeErr           = fmt.Errorf("fake err")
 		dnsEntryTTL int64 = 1234
 	)
 
 	BeforeEach(func() {
-		ctx = context.TODO()
-		b = &Botanist{
+		ctrl = gomock.NewController(GinkgoT())
+
+		scheme = runtime.NewScheme()
+		Expect(dnsv1alpha1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		Expect(corev1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		client = fake.NewFakeClientWithScheme(scheme)
+
+		controlPlane = mockcontrolplane.NewMockInterface(ctrl)
+		controlPlaneExposure = mockcontrolplane.NewMockInterface(ctrl)
+
+		botanist = &Botanist{
 			Operation: &operation.Operation{
 				Config: &config.GardenletConfiguration{
 					Controllers: &config.GardenletControllerConfiguration{
@@ -77,13 +95,15 @@ var _ = Describe("controlplane", func() {
 					},
 				},
 				Shoot: &shoot.Shoot{
-					Info: &v1beta1.Shoot{
+					Info: &gardencorev1beta1.Shoot{
 						ObjectMeta: metav1.ObjectMeta{Namespace: shootNS},
 					},
 					SeedNamespace: seedNS,
 					Components: &shoot.Components{
 						Extensions: &shoot.Extensions{
-							DNS: &shoot.DNS{},
+							DNS:                  &shoot.DNS{},
+							ControlPlane:         controlPlane,
+							ControlPlaneExposure: controlPlaneExposure,
 						},
 					},
 				},
@@ -93,30 +113,26 @@ var _ = Describe("controlplane", func() {
 			},
 		}
 
-		s = runtime.NewScheme()
-		Expect(dnsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())
-		Expect(corev1.AddToScheme(s)).NotTo(HaveOccurred())
-
-		seedClient = fake.NewFakeClientWithScheme(s)
-
 		renderer := cr.NewWithServerVersion(&version.Info{})
 		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion, dnsv1alpha1.SchemeGroupVersion})
 		mapper.Add(dnsv1alpha1.SchemeGroupVersion.WithKind("DNSOwner"), meta.RESTScopeRoot)
-		chartApplier := kubernetes.NewChartApplier(renderer, kubernetes.NewApplier(seedClient, mapper))
+		chartApplier := kubernetes.NewChartApplier(renderer, kubernetes.NewApplier(client, mapper))
 		Expect(chartApplier).NotTo(BeNil(), "should return chart applier")
 
 		fakeClientSet := fakeclientset.NewClientSetBuilder().
 			WithChartApplier(chartApplier).
-			WithDirectClient(seedClient).
+			WithDirectClient(client).
 			Build()
 
-		b.K8sSeedClient = fakeClientSet
+		botanist.K8sSeedClient = fakeClientSet
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Describe("#ValidateAuditPolicyApiGroupVersionKind", func() {
-		var (
-			kind = "Policy"
-		)
+		var kind = "Policy"
 
 		It("should return false without error because of version incompatibility", func() {
 			incompatibilityMatrix := map[string][]schema.GroupVersionKind{
@@ -222,48 +238,47 @@ var _ = Describe("controlplane", func() {
 
 	Context("setAPIServerAddress", func() {
 		It("does nothing when DNS is disabled", func() {
-			b.Shoot.DisableDNS = true
+			botanist.Shoot.DisableDNS = true
 
-			b.setAPIServerAddress("1.2.3.4", seedClient)
+			botanist.setAPIServerAddress("1.2.3.4", client)
 
-			Expect(b.Shoot.Components.Extensions.DNS.InternalOwner).To(BeNil())
-			Expect(b.Shoot.Components.Extensions.DNS.InternalEntry).To(BeNil())
-			Expect(b.Shoot.Components.Extensions.DNS.ExternalOwner).To(BeNil())
-			Expect(b.Shoot.Components.Extensions.DNS.ExternalEntry).To(BeNil())
+			Expect(botanist.Shoot.Components.Extensions.DNS.InternalOwner).To(BeNil())
+			Expect(botanist.Shoot.Components.Extensions.DNS.InternalEntry).To(BeNil())
+			Expect(botanist.Shoot.Components.Extensions.DNS.ExternalOwner).To(BeNil())
+			Expect(botanist.Shoot.Components.Extensions.DNS.ExternalEntry).To(BeNil())
 		})
 
 		It("sets owners and entries which create DNSOwner and DNSEntry", func() {
-			b.Shoot.Info.Status.ClusterIdentity = pointer.StringPtr("shoot-cluster-identity")
-			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &v1beta1.DNS{Domain: pointer.StringPtr("foo")}
-			b.Shoot.InternalClusterDomain = "bar"
-			b.Shoot.ExternalClusterDomain = pointer.StringPtr("baz")
-			b.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}
-			b.Garden.InternalDomain = &garden.Domain{Provider: "valid-provider"}
+			botanist.Shoot.Info.Status.ClusterIdentity = pointer.StringPtr("shoot-cluster-identity")
+			botanist.Shoot.DisableDNS = false
+			botanist.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.StringPtr("foo")}
+			botanist.Shoot.InternalClusterDomain = "bar"
+			botanist.Shoot.ExternalClusterDomain = pointer.StringPtr("baz")
+			botanist.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}
+			botanist.Garden.InternalDomain = &garden.Domain{Provider: "valid-provider"}
 
-			b.setAPIServerAddress("1.2.3.4", seedClient)
+			botanist.setAPIServerAddress("1.2.3.4", client)
 
-			Expect(b.Shoot.Components.Extensions.DNS.InternalOwner).ToNot(BeNil())
-			Expect(b.Shoot.Components.Extensions.DNS.InternalOwner.Deploy(ctx)).ToNot(HaveOccurred())
-			Expect(b.Shoot.Components.Extensions.DNS.InternalEntry).ToNot(BeNil())
-			Expect(b.Shoot.Components.Extensions.DNS.InternalEntry.Deploy(ctx)).ToNot(HaveOccurred())
-			Expect(b.Shoot.Components.Extensions.DNS.ExternalOwner).ToNot(BeNil())
-			Expect(b.Shoot.Components.Extensions.DNS.ExternalOwner.Deploy(ctx)).ToNot(HaveOccurred())
-			Expect(b.Shoot.Components.Extensions.DNS.ExternalEntry).ToNot(BeNil())
-			Expect(b.Shoot.Components.Extensions.DNS.ExternalEntry.Deploy(ctx)).ToNot(HaveOccurred())
+			Expect(botanist.Shoot.Components.Extensions.DNS.InternalOwner).ToNot(BeNil())
+			Expect(botanist.Shoot.Components.Extensions.DNS.InternalOwner.Deploy(ctx)).ToNot(HaveOccurred())
+			Expect(botanist.Shoot.Components.Extensions.DNS.InternalEntry).ToNot(BeNil())
+			Expect(botanist.Shoot.Components.Extensions.DNS.InternalEntry.Deploy(ctx)).ToNot(HaveOccurred())
+			Expect(botanist.Shoot.Components.Extensions.DNS.ExternalOwner).ToNot(BeNil())
+			Expect(botanist.Shoot.Components.Extensions.DNS.ExternalOwner.Deploy(ctx)).ToNot(HaveOccurred())
+			Expect(botanist.Shoot.Components.Extensions.DNS.ExternalEntry).ToNot(BeNil())
+			Expect(botanist.Shoot.Components.Extensions.DNS.ExternalEntry.Deploy(ctx)).ToNot(HaveOccurred())
 
 			internalOwner := &dnsv1alpha1.DNSOwner{}
-			err := seedClient.Get(ctx, types.NamespacedName{Name: seedNS + "-internal"}, internalOwner)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(client.Get(ctx, types.NamespacedName{Name: seedNS + "-internal"}, internalOwner)).ToNot(HaveOccurred())
+
 			internalEntry := &dnsv1alpha1.DNSEntry{}
-			err = seedClient.Get(ctx, types.NamespacedName{Name: "internal", Namespace: seedNS}, internalEntry)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(client.Get(ctx, types.NamespacedName{Name: "internal", Namespace: seedNS}, internalEntry)).ToNot(HaveOccurred())
+
 			externalOwner := &dnsv1alpha1.DNSOwner{}
-			err = seedClient.Get(ctx, types.NamespacedName{Name: seedNS + "-external"}, externalOwner)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(client.Get(ctx, types.NamespacedName{Name: seedNS + "-external"}, externalOwner)).ToNot(HaveOccurred())
+
 			externalEntry := &dnsv1alpha1.DNSEntry{}
-			err = seedClient.Get(ctx, types.NamespacedName{Name: "external", Namespace: seedNS}, externalEntry)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(client.Get(ctx, types.NamespacedName{Name: "external", Namespace: seedNS}, externalEntry)).ToNot(HaveOccurred())
 
 			Expect(internalOwner).To(DeepDerivativeEqual(&dnsv1alpha1.DNSOwner{
 				ObjectMeta: metav1.ObjectMeta{
@@ -310,30 +325,28 @@ var _ = Describe("controlplane", func() {
 				},
 			}))
 
-			Expect(b.Shoot.Components.Extensions.DNS.InternalOwner.Destroy(ctx)).ToNot(HaveOccurred())
-			Expect(b.Shoot.Components.Extensions.DNS.InternalEntry.Destroy(ctx)).ToNot(HaveOccurred())
-			Expect(b.Shoot.Components.Extensions.DNS.ExternalOwner.Destroy(ctx)).ToNot(HaveOccurred())
-			Expect(b.Shoot.Components.Extensions.DNS.ExternalEntry.Destroy(ctx)).ToNot(HaveOccurred())
+			Expect(botanist.Shoot.Components.Extensions.DNS.InternalOwner.Destroy(ctx)).ToNot(HaveOccurred())
+			Expect(botanist.Shoot.Components.Extensions.DNS.InternalEntry.Destroy(ctx)).ToNot(HaveOccurred())
+			Expect(botanist.Shoot.Components.Extensions.DNS.ExternalOwner.Destroy(ctx)).ToNot(HaveOccurred())
+			Expect(botanist.Shoot.Components.Extensions.DNS.ExternalEntry.Destroy(ctx)).ToNot(HaveOccurred())
 
 			internalOwner = &dnsv1alpha1.DNSOwner{}
-			err = seedClient.Get(ctx, types.NamespacedName{Name: seedNS + "-internal"}, internalOwner)
-			Expect(err).To(BeNotFoundError())
+			Expect(client.Get(ctx, types.NamespacedName{Name: seedNS + "-internal"}, internalOwner)).To(BeNotFoundError())
+
 			internalEntry = &dnsv1alpha1.DNSEntry{}
-			err = seedClient.Get(ctx, types.NamespacedName{Name: "internal", Namespace: seedNS}, internalEntry)
-			Expect(err).To(BeNotFoundError())
+			Expect(client.Get(ctx, types.NamespacedName{Name: "internal", Namespace: seedNS}, internalEntry)).To(BeNotFoundError())
+
 			externalOwner = &dnsv1alpha1.DNSOwner{}
-			err = seedClient.Get(ctx, types.NamespacedName{Name: seedNS + "-external"}, externalOwner)
-			Expect(err).To(BeNotFoundError())
+			Expect(client.Get(ctx, types.NamespacedName{Name: seedNS + "-external"}, externalOwner)).To(BeNotFoundError())
+
 			externalEntry = &dnsv1alpha1.DNSEntry{}
-			err = seedClient.Get(ctx, types.NamespacedName{Name: "external", Namespace: seedNS}, externalEntry)
-			Expect(err).To(BeNotFoundError())
+			Expect(client.Get(ctx, types.NamespacedName{Name: "external", Namespace: seedNS}, externalEntry)).To(BeNotFoundError())
 		})
 	})
 
 	Describe("SNIPhase", func() {
-		var (
-			svc *corev1.Service
-		)
+		var svc *corev1.Service
+
 		BeforeEach(func() {
 			gardenletfeatures.RegisterFeatureGates()
 
@@ -348,35 +361,32 @@ var _ = Describe("controlplane", func() {
 		Context("sni enabled", func() {
 			BeforeEach(func() {
 				Expect(gardenletfeatures.FeatureGate.Set("APIServerSNI=true")).ToNot(HaveOccurred())
-				b.Garden.InternalDomain = &garden.Domain{Provider: "some-provider"}
-				b.Shoot.Info.Spec.DNS = &v1beta1.DNS{Domain: pointer.StringPtr("foo")}
-				b.Shoot.ExternalClusterDomain = pointer.StringPtr("baz")
-				b.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}
+				botanist.Garden.InternalDomain = &garden.Domain{Provider: "some-provider"}
+				botanist.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.StringPtr("foo")}
+				botanist.Shoot.ExternalClusterDomain = pointer.StringPtr("baz")
+				botanist.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}
 			})
 
 			It("returns Enabled for not existing services", func() {
-				phase, err := b.SNIPhase(ctx)
-
+				phase, err := botanist.SNIPhase(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(phase).To(Equal(component.PhaseEnabled))
 			})
 
 			It("returns Enabling for service of type LoadBalancer", func() {
 				svc.Spec.Type = corev1.ServiceTypeLoadBalancer
-				Expect(seedClient.Create(ctx, svc)).NotTo(HaveOccurred())
+				Expect(client.Create(ctx, svc)).NotTo(HaveOccurred())
 
-				phase, err := b.SNIPhase(ctx)
-
+				phase, err := botanist.SNIPhase(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(phase).To(Equal(component.PhaseEnabling))
 			})
 
 			It("returns Enabled for service of type ClusterIP", func() {
 				svc.Spec.Type = corev1.ServiceTypeClusterIP
-				Expect(seedClient.Create(ctx, svc)).NotTo(HaveOccurred())
+				Expect(client.Create(ctx, svc)).NotTo(HaveOccurred())
 
-				phase, err := b.SNIPhase(ctx)
-
+				phase, err := botanist.SNIPhase(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(phase).To(Equal(component.PhaseEnabled))
 			})
@@ -385,13 +395,13 @@ var _ = Describe("controlplane", func() {
 				"return Enabled for service of type",
 				func(svcType corev1.ServiceType) {
 					svc.Spec.Type = svcType
-					Expect(seedClient.Create(ctx, svc)).NotTo(HaveOccurred())
+					Expect(client.Create(ctx, svc)).NotTo(HaveOccurred())
 
-					phase, err := b.SNIPhase(ctx)
-
+					phase, err := botanist.SNIPhase(ctx)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(phase).To(Equal(component.PhaseEnabled))
 				},
+
 				Entry("ExternalName", corev1.ServiceTypeExternalName),
 				Entry("NodePort", corev1.ServiceTypeNodePort),
 			)
@@ -403,18 +413,16 @@ var _ = Describe("controlplane", func() {
 			})
 
 			It("returns Disabled for not existing services", func() {
-				phase, err := b.SNIPhase(ctx)
-
+				phase, err := botanist.SNIPhase(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(phase).To(Equal(component.PhaseDisabled))
 			})
 
 			It("returns Disabling for service of type ClusterIP", func() {
 				svc.Spec.Type = corev1.ServiceTypeClusterIP
-				Expect(seedClient.Create(ctx, svc)).NotTo(HaveOccurred())
+				Expect(client.Create(ctx, svc)).NotTo(HaveOccurred())
 
-				phase, err := b.SNIPhase(ctx)
-
+				phase, err := botanist.SNIPhase(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(phase).To(Equal(component.PhaseDisabling))
 			})
@@ -423,17 +431,104 @@ var _ = Describe("controlplane", func() {
 				"return Disabled for service of type",
 				func(svcType corev1.ServiceType) {
 					svc.Spec.Type = svcType
-					Expect(seedClient.Create(ctx, svc)).NotTo(HaveOccurred())
+					Expect(client.Create(ctx, svc)).NotTo(HaveOccurred())
 
-					phase, err := b.SNIPhase(ctx)
-
+					phase, err := botanist.SNIPhase(ctx)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(phase).To(Equal(component.PhaseDisabled))
 				},
+
 				Entry("ExternalName", corev1.ServiceTypeExternalName),
 				Entry("LoadBalancer", corev1.ServiceTypeLoadBalancer),
 				Entry("NodePort", corev1.ServiceTypeNodePort),
 			)
+		})
+	})
+
+	Describe("#DeployControlPlane", func() {
+		var infrastructureStatus = []byte("infra-status")
+
+		BeforeEach(func() {
+			botanist.Shoot.InfrastructureStatus = infrastructureStatus
+			controlPlane.EXPECT().SetInfrastructureProviderStatus(&runtime.RawExtension{
+				Raw: infrastructureStatus,
+			})
+		})
+
+		Context("deploy", func() {
+			It("should deploy successfully", func() {
+				controlPlane.EXPECT().Deploy(ctx)
+				Expect(botanist.DeployControlPlane(ctx)).To(Succeed())
+			})
+
+			It("should return the error during deployment", func() {
+				controlPlane.EXPECT().Deploy(ctx).Return(fakeErr)
+				Expect(botanist.DeployControlPlane(ctx)).To(MatchError(fakeErr))
+			})
+		})
+
+		Context("restore", func() {
+			var shootState = &gardencorev1alpha1.ShootState{}
+
+			BeforeEach(func() {
+				botanist.ShootState = shootState
+				botanist.Shoot.Info = &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{
+						LastOperation: &gardencorev1beta1.LastOperation{
+							Type: gardencorev1beta1.LastOperationTypeRestore,
+						},
+					},
+				}
+			})
+
+			It("should restore successfully", func() {
+				controlPlane.EXPECT().Restore(ctx, shootState)
+				Expect(botanist.DeployControlPlane(ctx)).To(Succeed())
+			})
+
+			It("should return the error during restoration", func() {
+				controlPlane.EXPECT().Restore(ctx, shootState).Return(fakeErr)
+				Expect(botanist.DeployControlPlane(ctx)).To(MatchError(fakeErr))
+			})
+		})
+	})
+
+	Describe("#DeployControlPlaneExposure()", func() {
+		Context("deploy", func() {
+			It("should deploy successfully", func() {
+				controlPlaneExposure.EXPECT().Deploy(ctx)
+				Expect(botanist.DeployControlPlaneExposure(ctx)).To(Succeed())
+			})
+
+			It("should return the error during deployment", func() {
+				controlPlaneExposure.EXPECT().Deploy(ctx).Return(fakeErr)
+				Expect(botanist.DeployControlPlaneExposure(ctx)).To(MatchError(fakeErr))
+			})
+		})
+
+		Context("restore", func() {
+			var shootState = &gardencorev1alpha1.ShootState{}
+
+			BeforeEach(func() {
+				botanist.ShootState = shootState
+				botanist.Shoot.Info = &gardencorev1beta1.Shoot{
+					Status: gardencorev1beta1.ShootStatus{
+						LastOperation: &gardencorev1beta1.LastOperation{
+							Type: gardencorev1beta1.LastOperationTypeRestore,
+						},
+					},
+				}
+			})
+
+			It("should restore successfully", func() {
+				controlPlaneExposure.EXPECT().Restore(ctx, shootState)
+				Expect(botanist.DeployControlPlaneExposure(ctx)).To(Succeed())
+			})
+
+			It("should return the error during restoration", func() {
+				controlPlaneExposure.EXPECT().Restore(ctx, shootState).Return(fakeErr)
+				Expect(botanist.DeployControlPlaneExposure(ctx)).To(MatchError(fakeErr))
+			})
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind test
/priority normal

**What this PR does / why we need it**:
This PR adds missing unit tests for the `botanist.DeployControlPlane{Exposure}` functions (left-over after #3222).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
