### PR TITLE
Cleanup usage of PartialObjectMetadataList

### DIFF
--- a/pkg/admissioncontroller/webhooks/validate_namespace_deletion.go
+++ b/pkg/admissioncontroller/webhooks/validate_namespace_deletion.go
@@ -152,7 +152,7 @@ func (h *namespaceDeletionHandler) admitNamespace(ctx context.Context, request a
 // isNamespaceEmpty checks if there are no more Shoots left inside the given namespace.
 func (h *namespaceDeletionHandler) isNamespaceEmpty(ctx context.Context, namespace string) (bool, error) {
 	shoots := &metav1.PartialObjectMetadataList{}
-	shoots.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"))
+	shoots.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("ShootList"))
 	if err := h.apiReader.List(ctx, shoots, client.InNamespace(namespace), client.Limit(1)); err != nil {
 		return false, err
 	}

--- a/pkg/admissioncontroller/webhooks/validate_namespace_deletion_test.go
+++ b/pkg/admissioncontroller/webhooks/validate_namespace_deletion_test.go
@@ -61,7 +61,7 @@ var _ = Describe("namespaceDeletionHandler", func() {
 		mockReader = mockclient.NewMockReader(ctrl)
 
 		shootMetadataList = &metav1.PartialObjectMetadataList{}
-		shootMetadataList.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"))
+		shootMetadataList.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("ShootList"))
 
 		mockCache.EXPECT().GetInformer(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Project{}))
 		validator, err = webhooks.NewValidateNamespaceDeletionHandler(ctx, mockCache)

--- a/pkg/controllermanager/controller/project/project_control_delete.go
+++ b/pkg/controllermanager/controller/project/project_control_delete.go
@@ -70,7 +70,7 @@ func (c *defaultControl) delete(ctx context.Context, project *gardencorev1beta1.
 // isNamespaceEmpty checks if there are no more Shoots left inside the given namespace.
 func isNamespaceEmpty(ctx context.Context, reader client.Reader, namespace string) (bool, error) {
 	shoots := &metav1.PartialObjectMetadataList{}
-	shoots.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"))
+	shoots.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("ShootList"))
 	if err := reader.List(ctx, shoots, client.InNamespace(namespace), client.Limit(1)); err != nil {
 		return false, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority normal

**What this PR does / why we need it**:

I just noticed, the gvk of `PartialObjectMetadataList` is supposed to be set to `*List` instead.
Otherwise, if the reader is cached, it returns an error like this:
```
non-list type *v1.PartialObjectMetadataList (kind \"core.gardener.cloud/v1beta1, Kind=Shoot\") passed as output
```

Consequently, this PR cleans up our usages of `PartialObjectMetadataList`.

**Special notes for your reviewer**:

Actually, we don't have any usages of `PartialObjectMetadataList` in conjunction with cached readers.
Nevertheless, correcting this now, before someone runs into the trap...
