### PR TITLE
Cleanup context.TODO(), migrate from DeprecatedCreateWorker to CreateWorker (1)

### DIFF
--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -158,7 +158,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		eventController                  = eventcontroller.NewController(f.clientMap, f.cfg.Controllers.Event)
 	)
 
-	shootController, err := shootcontroller.NewShootController(f.clientMap, f.k8sGardenCoreInformers, f.k8sInformers, f.cfg, f.recorder)
+	shootController, err := shootcontroller.NewShootController(ctx, f.clientMap, f.k8sGardenCoreInformers, f.k8sInformers, f.cfg, f.recorder)
 	if err != nil {
 		return fmt.Errorf("failed initializing Shoot controller: %w", err)
 	}

--- a/pkg/controllermanager/controller/shoot/shoot.go
+++ b/pkg/controllermanager/controller/shoot/shoot.go
@@ -73,7 +73,7 @@ type Controller struct {
 
 // NewShootController takes a ClientMap, a GardenerInformerFactory, a KubernetesInformerFactory, a
 // ControllerManagerConfig struct and an EventRecorder to create a new Shoot controller.
-func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory, kubeInformerFactory kubeinformers.SharedInformerFactory, config *config.ControllerManagerConfiguration, recorder record.EventRecorder) (*Controller, error) {
+func NewShootController(ctx context.Context, clientMap clientmap.ClientMap, k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory, kubeInformerFactory kubeinformers.SharedInformerFactory, config *config.ControllerManagerConfiguration, recorder record.EventRecorder) (*Controller, error) {
 	var (
 		gardenCoreV1beta1Informer = k8sGardenCoreInformers.Core().V1beta1()
 		corev1Informer            = kubeInformerFactory.Core().V1()
@@ -132,12 +132,12 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 		UpdateFunc: shootController.configMapUpdate,
 	})
 
-	gardenClient, err := clientMap.GetClient(context.TODO(), keys.ForGarden())
+	gardenClient, err := clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
 		return nil, err
 	}
 
-	runtimeShootInformer, err := gardenClient.Cache().GetInformer(context.TODO(), &gardencorev1beta1.Shoot{})
+	runtimeShootInformer, err := gardenClient.Cache().GetInformer(ctx, &gardencorev1beta1.Shoot{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Shoot Informer: %w", err)
 	}

--- a/pkg/controllermanager/controller/shoot/shoot_quota_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_quota_control.go
@@ -24,12 +24,14 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
-	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/operation/common"
 
+	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func (c *Controller) shootQuotaAdd(obj interface{}) {
@@ -52,63 +54,51 @@ func (c *Controller) shootQuotaDelete(obj interface{}) {
 	c.shootQuotaQueue.Done(key)
 }
 
-func (c *Controller) reconcileShootQuotaKey(key string) error {
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		return err
+// NewShootQuotaReconciler creates a new instance of a reconciler which checks handles Shoots using SecretBindings that
+// references Quotas.
+func NewShootQuotaReconciler(l logrus.FieldLogger, cfg config.ShootQuotaControllerConfiguration, clientMap clientmap.ClientMap, k8sGardenCoreInformers gardencoreinformers.Interface) reconcile.Reconciler {
+	return &shootQuotaReconciler{
+		logger:                 l,
+		cfg:                    cfg,
+		clientMap:              clientMap,
+		k8sGardenCoreInformers: k8sGardenCoreInformers,
 	}
-
-	shoot, err := c.shootLister.Shoots(namespace).Get(name)
-	if apierrors.IsNotFound(err) {
-		logger.Logger.Debugf("[SHOOT QUOTA] %s - skipping because Shoot has been deleted", key)
-		return nil
-	}
-	if err != nil {
-		logger.Logger.Infof("[SHOOT QUOTA] %s - unable to retrieve object from store: %v", key, err)
-		return err
-	}
-
-	if err := c.quotaControl.CheckQuota(shoot, key); err != nil {
-		c.shootQuotaQueue.AddAfter(key, 2*time.Minute)
-		return nil
-	}
-	c.shootQuotaQueue.AddAfter(key, c.config.Controllers.ShootQuota.SyncPeriod.Duration)
-	return nil
 }
 
-// QuotaControlInterface implements the control logic for quota management of Shoots. It is implemented as an interface to allow
-// for extensions that provide different semantics. Currently, there is only one implementation.
-type QuotaControlInterface interface {
-	CheckQuota(shoot *gardencorev1beta1.Shoot, key string) error
-}
-
-// NewDefaultQuotaControl returns a new instance of the default implementation of QuotaControlInterface
-// which implements the semantics for controlling the quota handling of Shoot resources.
-func NewDefaultQuotaControl(clientMap clientmap.ClientMap, k8sGardenCoreInformers gardencoreinformers.Interface) QuotaControlInterface {
-	return &defaultQuotaControl{clientMap, k8sGardenCoreInformers}
-}
-
-type defaultQuotaControl struct {
+type shootQuotaReconciler struct {
+	logger                 logrus.FieldLogger
+	cfg                    config.ShootQuotaControllerConfiguration
 	clientMap              clientmap.ClientMap
 	k8sGardenCoreInformers gardencoreinformers.Interface
 }
 
-func (c *defaultQuotaControl) CheckQuota(shootObj *gardencorev1beta1.Shoot, key string) error {
-	var (
-		ctx             = context.TODO()
-		clusterLifeTime *int32
-		shoot           = shootObj.DeepCopy()
-		shootLogger     = logger.NewShootLogger(logger.Logger, shoot.Name, shoot.Namespace)
-	)
-
-	secretBinding, err := c.k8sGardenCoreInformers.SecretBindings().Lister().SecretBindings(shoot.Namespace).Get(shoot.Spec.SecretBindingName)
+func (r *shootQuotaReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	gardenClient, err := r.clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
-		return err
+		return reconcile.Result{}, fmt.Errorf("failed to get garden client: %w", err)
 	}
+
+	shoot := &gardencorev1beta1.Shoot{}
+	if err := gardenClient.Client().Get(ctx, request.NamespacedName, shoot); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.logger.Infof("Object %q is gone, stop reconciling: %v", request.Name, err)
+			return reconcile.Result{}, nil
+		}
+		r.logger.Infof("Unable to retrieve object %q from store: %v", request.Name, err)
+		return reconcile.Result{}, err
+	}
+
+	secretBinding, err := r.k8sGardenCoreInformers.SecretBindings().Lister().SecretBindings(shoot.Namespace).Get(shoot.Spec.SecretBindingName)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	var clusterLifeTime *int32
+
 	for _, quotaRef := range secretBinding.Quotas {
-		quota, err := c.k8sGardenCoreInformers.Quotas().Lister().Quotas(quotaRef.Namespace).Get(quotaRef.Name)
+		quota, err := r.k8sGardenCoreInformers.Quotas().Lister().Quotas(quotaRef.Namespace).Get(quotaRef.Name)
 		if err != nil {
-			return err
+			return reconcile.Result{}, err
 		}
 
 		if quota.Spec.ClusterLifetimeDays == nil {
@@ -122,12 +112,7 @@ func (c *defaultQuotaControl) CheckQuota(shootObj *gardencorev1beta1.Shoot, key 
 	// If the Shoot has no Quotas referenced (anymore) or if the referenced Quotas does not have a clusterLifetime,
 	// then we will not check for cluster lifetime expiration, even if the Shoot has a clusterLifetime timestamp already annotated.
 	if clusterLifeTime == nil {
-		return nil
-	}
-
-	gardenClient, err := c.clientMap.GetClient(ctx, keys.ForGarden())
-	if err != nil {
-		return fmt.Errorf("failed to get garden client: %w", err)
+		return reconcile.Result{RequeueAfter: r.cfg.SyncPeriod.Duration}, nil
 	}
 
 	expirationTime, exits := shoot.Annotations[common.ShootExpirationTimestamp]
@@ -137,28 +122,29 @@ func (c *defaultQuotaControl) CheckQuota(shootObj *gardencorev1beta1.Shoot, key 
 
 		shootUpdated, err := gardenClient.GardenCore().CoreV1beta1().Shoots(shoot.Namespace).Update(ctx, shoot, kubernetes.DefaultUpdateOptions())
 		if err != nil {
-			return err
+			return reconcile.Result{}, err
 		}
 		shoot = shootUpdated
 	}
 
 	expirationTimeParsed, err := time.Parse(time.RFC3339, expirationTime)
 	if err != nil {
-		return err
+		return reconcile.Result{}, err
 	}
 
 	if time.Now().UTC().After(expirationTimeParsed.UTC()) {
-		shootLogger.Info("[SHOOT QUOTA] Shoot cluster lifetime expired. Shoot will be deleted.")
+		r.logger.Info("[SHOOT QUOTA] Shoot cluster lifetime expired. Shoot will be deleted.")
 
 		// We have to annotate the Shoot to confirm the deletion.
 		if err := common.ConfirmDeletion(ctx, gardenClient.Client(), shoot); err != nil {
-			return err
+			return reconcile.Result{}, err
 		}
 
 		// Now we are allowed to delete the Shoot (to set the deletionTimestamp).
 		if err := gardenClient.GardenCore().CoreV1beta1().Shoots(shoot.Namespace).Delete(ctx, shoot.Name, metav1.DeleteOptions{}); err != nil {
-			return err
+			return reconcile.Result{}, err
 		}
 	}
-	return nil
+
+	return reconcile.Result{RequeueAfter: r.cfg.SyncPeriod.Duration}, nil
 }

--- a/pkg/controllermanager/controller/shoot/shoot_reference_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_reference_control.go
@@ -132,10 +132,7 @@ func (r *shootReferenceReconciler) Reconcile(ctx context.Context, request reconc
 
 	r.logger.Infof("[SHOOT REFERENCE CONTROL] %s", request)
 
-	if err := r.reconcileShootReferences(ctx, gardenClient.Client(), shoot); err != nil {
-		return reconcile.Result{}, err
-	}
-	return reconcile.Result{}, nil
+	return reconcile.Result{}, r.reconcileShootReferences(ctx, gardenClient.Client(), shoot)
 }
 
 func (r *shootReferenceReconciler) reconcileShootReferences(ctx context.Context, c client.Client, shoot *gardencorev1beta1.Shoot) error {

--- a/test/framework/shootframework.go
+++ b/test/framework/shootframework.go
@@ -92,7 +92,7 @@ func NewShootFramework(cfg *ShootConfig) *ShootFramework {
 
 // NewShootFrameworkFromConfig creates a new Shoot framework from a shoot configuration without registering ginkgo
 // specific functions
-func NewShootFrameworkFromConfig(cfg *ShootConfig) (*ShootFramework, error) {
+func NewShootFrameworkFromConfig(ctx context.Context, cfg *ShootConfig) (*ShootFramework, error) {
 	var gardenerConfig *GardenerConfig
 	if cfg != nil {
 		gardenerConfig = cfg.GardenerConfig
@@ -103,7 +103,7 @@ func NewShootFrameworkFromConfig(cfg *ShootConfig) (*ShootFramework, error) {
 		Config:            cfg,
 	}
 	if cfg != nil && gardenerConfig != nil {
-		if err := f.AddShoot(context.TODO(), cfg.ShootName, cfg.GardenerConfig.ProjectNamespace); err != nil {
+		if err := f.AddShoot(ctx, cfg.ShootName, cfg.GardenerConfig.ProjectNamespace); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup
/priority normal

**What this PR does / why we need it**:
This PR starts with migration a couple of our controllers from `controllerutils.DeprecatedCreateWorker` (deprecated since #1094) to `controllerutils.CreateWorker`. This helps to get rid of some remaining usages of `context.TODO()`.

**Which issue(s) this PR fixes**:
Part of #1648 

**Special notes for your reviewer**:
ℹ️ Once this PR is merged, I'll follow-up with more PRs that also cover the remaining/not-yet migrated controllers.
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
