### PR TITLE
[GEP-13] Add ManagedSeedSet apiserver storage

### DIFF
--- a/hack/local-development/dev-setup-register-gardener
+++ b/hack/local-development/dev-setup-register-gardener
@@ -336,6 +336,7 @@ $ADMISSION_CONTROLLER_PORT_STRING
     - UPDATE
     resources:
     - managedseeds
+    - managedseedsets
   - apiGroups:
     - settings.gardener.cloud
     apiVersions:

--- a/hack/local-development/dev-setup-register-gardener
+++ b/hack/local-development/dev-setup-register-gardener
@@ -328,16 +328,6 @@ $ADMISSION_CONTROLLER_PORT_STRING
     - quotas
     - plants
   - apiGroups:
-    - seedmanagement.gardener.cloud
-    apiVersions:
-    - "*"
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - managedseeds
-    - managedseedsets
-  - apiGroups:
     - settings.gardener.cloud
     apiVersions:
     - "*"

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -13869,7 +13869,6 @@ func schema_pkg_apis_seedmanagement_v1alpha1_ManagedSeedSpec(ref common.Referenc
 					"shoot": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Shoot references a Shoot that should be registered as Seed.",
-							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1.Shoot"),
 						},
 					},

--- a/pkg/registry/seedmanagement/managedseed/storage/storage.go
+++ b/pkg/registry/seedmanagement/managedseed/storage/storage.go
@@ -113,5 +113,5 @@ var _ rest.ShortNamesProvider = &REST{}
 
 // ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
 func (r *REST) ShortNames() []string {
-	return []string{}
+	return []string{"ms"}
 }

--- a/pkg/registry/seedmanagement/managedseed/strategy.go
+++ b/pkg/registry/seedmanagement/managedseed/strategy.go
@@ -153,9 +153,9 @@ func ToSelectableFields(managedSeed *seedmanagement.ManagedSeed) fields.Set {
 	// amount of allocations needed to create the fields.Set. If you add any
 	// field here or the number of object-meta related fields changes, this should
 	// be adjusted.
-	shootSpecificFieldsSet := make(fields.Set, 3)
-	shootSpecificFieldsSet[seedmanagement.ManagedSeedShootName] = GetShootName(managedSeed)
-	return generic.AddObjectMetaFieldsSet(shootSpecificFieldsSet, &managedSeed.ObjectMeta, true)
+	fieldsSet := make(fields.Set, 3)
+	fieldsSet[seedmanagement.ManagedSeedShootName] = GetShootName(managedSeed)
+	return generic.AddObjectMetaFieldsSet(fieldsSet, &managedSeed.ObjectMeta, true)
 }
 
 // ShootNameTriggerFunc returns spec.shoot.name of the given ManagedSeed.

--- a/pkg/registry/seedmanagement/managedseedset/managedseedset_suite_test.go
+++ b/pkg/registry/seedmanagement/managedseedset/managedseedset_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedseedset_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestShoot(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Registry ManagedSeedSet Suite")
+}

--- a/pkg/registry/seedmanagement/managedseedset/storage/storage.go
+++ b/pkg/registry/seedmanagement/managedseedset/storage/storage.go
@@ -110,5 +110,5 @@ var _ rest.ShortNamesProvider = &REST{}
 
 // ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
 func (r *REST) ShortNames() []string {
-	return []string{}
+	return []string{"mss"}
 }

--- a/pkg/registry/seedmanagement/managedseedset/storage/storage.go
+++ b/pkg/registry/seedmanagement/managedseedset/storage/storage.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+	"github.com/gardener/gardener/pkg/registry/seedmanagement/managedseedset"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/generic"
+	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
+)
+
+// REST implements a RESTStorage for ManagedSeedSet.
+type REST struct {
+	*genericregistry.Store
+}
+
+// ManagedSeedSetStorage implements the storage for ManagedSeedSets and their status subresource.
+type ManagedSeedSetStorage struct {
+	ManagedSeedSet *REST
+	Status         *StatusREST
+}
+
+// NewStorage creates a new ManagedSeedSetStorage object.
+func NewStorage(optsGetter generic.RESTOptionsGetter) ManagedSeedSetStorage {
+	managedSeedSetRest, managedSeedSetStatusRest := NewREST(optsGetter)
+
+	return ManagedSeedSetStorage{
+		ManagedSeedSet: managedSeedSetRest,
+		Status:         managedSeedSetStatusRest,
+	}
+}
+
+// NewREST returns a RESTStorage object that will work with ManagedSeedSet objects.
+func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
+	strategy := managedseedset.NewStrategy()
+	statusStrategy := managedseedset.NewStatusStrategy()
+
+	store := &genericregistry.Store{
+		NewFunc:                  func() runtime.Object { return &seedmanagement.ManagedSeedSet{} },
+		NewListFunc:              func() runtime.Object { return &seedmanagement.ManagedSeedSetList{} },
+		DefaultQualifiedResource: seedmanagement.Resource("managedseedsets"),
+		EnableGarbageCollection:  true,
+
+		CreateStrategy: strategy,
+		UpdateStrategy: strategy,
+		DeleteStrategy: strategy,
+
+		TableConvertor: newTableConvertor(),
+	}
+	options := &generic.StoreOptions{
+		RESTOptions: optsGetter,
+		AttrFunc:    managedseedset.GetAttrs,
+	}
+	if err := store.CompleteWithOptions(options); err != nil {
+		panic(err)
+	}
+
+	statusStore := *store
+	statusStore.UpdateStrategy = statusStrategy
+
+	return &REST{store}, &StatusREST{store: &statusStore}
+}
+
+// StatusREST implements the REST endpoint for changing the status of a ManagedSeedSet.
+type StatusREST struct {
+	store *genericregistry.Store
+}
+
+var (
+	_ rest.Storage = &StatusREST{}
+	_ rest.Getter  = &StatusREST{}
+	_ rest.Updater = &StatusREST{}
+)
+
+// New creates a new (empty) internal ManagedSeedSet object.
+func (r *StatusREST) New() runtime.Object {
+	return &seedmanagement.ManagedSeedSet{}
+}
+
+// Get retrieves the object from the storage. It is required to support Patch.
+func (r *StatusREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	return r.store.Get(ctx, name, options)
+}
+
+// Update alters the status subset of an object.
+func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
+}
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{}
+}

--- a/pkg/registry/seedmanagement/managedseedset/storage/tableconvertor.go
+++ b/pkg/registry/seedmanagement/managedseedset/storage/tableconvertor.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metatable "k8s.io/apimachinery/pkg/api/meta/table"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+)
+
+var swaggerMetadataDescriptions = metav1.ObjectMeta{}.SwaggerDoc()
+
+type convertor struct {
+	headers []metav1beta1.TableColumnDefinition
+}
+
+func newTableConvertor() rest.TableConvertor {
+	return &convertor{
+		headers: []metav1beta1.TableColumnDefinition{
+			{Name: "Name", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["name"]},
+			{Name: "Ready", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["ready"]},
+			{Name: "Age", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"]},
+		},
+	}
+}
+
+// ConvertToTable converts the output to a table.
+func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
+	var (
+		err   error
+		table = &metav1beta1.Table{
+			ColumnDefinitions: c.headers,
+		}
+	)
+
+	if m, err := meta.ListAccessor(obj); err == nil {
+		table.ResourceVersion = m.GetResourceVersion()
+		table.SelfLink = m.GetSelfLink()
+		table.Continue = m.GetContinue()
+	} else {
+		if m, err := meta.CommonAccessor(obj); err == nil {
+			table.ResourceVersion = m.GetResourceVersion()
+			table.SelfLink = m.GetSelfLink()
+		}
+	}
+
+	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {
+		var (
+			managedSeedSet = obj.(*seedmanagement.ManagedSeedSet)
+			cells          = []interface{}{}
+		)
+
+		cells = append(cells, managedSeedSet.Name)
+		cells = append(cells, fmt.Sprintf("%d/%d", managedSeedSet.Status.ReadyReplicas, *managedSeedSet.Spec.Replicas))
+		cells = append(cells, metatable.ConvertToHumanReadableDateType(managedSeedSet.CreationTimestamp))
+
+		return cells, nil
+	})
+
+	return table, err
+}

--- a/pkg/registry/seedmanagement/managedseedset/strategy.go
+++ b/pkg/registry/seedmanagement/managedseedset/strategy.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedseedset
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/api"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement/validation"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/apiserver/pkg/storage/names"
+)
+
+// Strategy defines the strategy for storing managedseedsets.
+type Strategy struct {
+	runtime.ObjectTyper
+	names.NameGenerator
+}
+
+// NewStrategy defines the storage strategy for ManagedSeedSets.
+func NewStrategy() Strategy {
+	return Strategy{api.Scheme, names.SimpleNameGenerator}
+}
+
+// NamespaceScoped returns true if the object must be within a namespace.
+func (Strategy) NamespaceScoped() bool {
+	return true
+}
+
+// PrepareForCreate mutates some fields in the object before it's created.
+func (s Strategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
+	managedSeedSet := obj.(*seedmanagement.ManagedSeedSet)
+
+	managedSeedSet.Generation = 1
+	managedSeedSet.Status = seedmanagement.ManagedSeedSetStatus{}
+}
+
+// PrepareForUpdate is invoked on update before validation to normalize
+// the object.  For example: remove fields that are not to be persisted,
+// sort order-insensitive list fields, etc.  This should not remove fields
+// whose presence would be considered a validation error.
+func (s Strategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	newManagedSeedSet := obj.(*seedmanagement.ManagedSeedSet)
+	oldManagedSeedSet := old.(*seedmanagement.ManagedSeedSet)
+	newManagedSeedSet.Status = oldManagedSeedSet.Status
+
+	if !apiequality.Semantic.DeepEqual(oldManagedSeedSet.Spec, newManagedSeedSet.Spec) ||
+		oldManagedSeedSet.DeletionTimestamp == nil && newManagedSeedSet.DeletionTimestamp != nil {
+		newManagedSeedSet.Generation = oldManagedSeedSet.Generation + 1
+	}
+}
+
+// Validate validates the given object.
+func (Strategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	managedSeedSet := obj.(*seedmanagement.ManagedSeedSet)
+	return validation.ValidateManagedSeedSet(managedSeedSet)
+}
+
+// Canonicalize allows an object to be mutated into a canonical form. This
+// ensures that code that operates on these objects can rely on the common
+// form for things like comparison.  Canonicalize is invoked after
+// validation has succeeded but before the object has been persisted.
+// This method may mutate the object.
+func (Strategy) Canonicalize(obj runtime.Object) {
+}
+
+// AllowCreateOnUpdate returns true if the object can be created by a PUT.
+func (Strategy) AllowCreateOnUpdate() bool {
+	return false
+}
+
+// AllowUnconditionalUpdate returns true if the object can be updated
+// unconditionally (irrespective of the latest resource version), when
+// there is no resource version specified in the object.
+func (Strategy) AllowUnconditionalUpdate() bool {
+	return false
+}
+
+// ValidateUpdate validates the update on the given old and new object.
+func (Strategy) ValidateUpdate(ctx context.Context, newObj, oldObj runtime.Object) field.ErrorList {
+	oldManagedSeedSet, newManagedSeedSet := oldObj.(*seedmanagement.ManagedSeedSet), newObj.(*seedmanagement.ManagedSeedSet)
+	return validation.ValidateManagedSeedSetUpdate(newManagedSeedSet, oldManagedSeedSet)
+}
+
+// StatusStrategy defines the strategy for storing seeds statuses.
+type StatusStrategy struct {
+	Strategy
+}
+
+// NewStatusStrategy defines the storage strategy for the status subresource of ManagedSeedSets.
+func NewStatusStrategy() StatusStrategy {
+	return StatusStrategy{NewStrategy()}
+}
+
+// PrepareForUpdate is invoked on update before validation to normalize
+// the object.  For example: remove fields that are not to be persisted,
+// sort order-insensitive list fields, etc.  This should not remove fields
+// whose presence would be considered a validation error.
+func (s StatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+	newManagedSeedSet := obj.(*seedmanagement.ManagedSeedSet)
+	oldManagedSeedSet := old.(*seedmanagement.ManagedSeedSet)
+	newManagedSeedSet.Spec = oldManagedSeedSet.Spec
+}
+
+// ValidateUpdate validates the update on the given old and new object.
+func (StatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+	return validation.ValidateManagedSeedSetStatusUpdate(obj.(*seedmanagement.ManagedSeedSet), old.(*seedmanagement.ManagedSeedSet))
+}
+
+// MatchManagedSeedSet returns a generic matcher for a given label and field selector.
+func MatchManagedSeedSet(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+	return storage.SelectionPredicate{
+		Label:    label,
+		Field:    field,
+		GetAttrs: GetAttrs,
+	}
+}
+
+// GetAttrs returns labels and fields of a given object for filtering purposes.
+func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
+	managedSeedSet, ok := obj.(*seedmanagement.ManagedSeedSet)
+	if !ok {
+		return nil, nil, fmt.Errorf("not a ManagedSeedSet")
+	}
+	return labels.Set(managedSeedSet.ObjectMeta.Labels), ToSelectableFields(managedSeedSet), nil
+}
+
+// ToSelectableFields returns a field set that represents the object.
+func ToSelectableFields(managedSeedSet *seedmanagement.ManagedSeedSet) fields.Set {
+	// The purpose of allocation with a given number of elements is to reduce
+	// amount of allocations needed to create the fields.Set. If you add any
+	// field here or the number of object-meta related fields changes, this should
+	// be adjusted.
+	shootSpecificFieldsSet := make(fields.Set, 3)
+	return generic.AddObjectMetaFieldsSet(shootSpecificFieldsSet, &managedSeedSet.ObjectMeta, true)
+}

--- a/pkg/registry/seedmanagement/managedseedset/strategy.go
+++ b/pkg/registry/seedmanagement/managedseedset/strategy.go
@@ -152,6 +152,6 @@ func ToSelectableFields(managedSeedSet *seedmanagement.ManagedSeedSet) fields.Se
 	// amount of allocations needed to create the fields.Set. If you add any
 	// field here or the number of object-meta related fields changes, this should
 	// be adjusted.
-	shootSpecificFieldsSet := make(fields.Set, 3)
-	return generic.AddObjectMetaFieldsSet(shootSpecificFieldsSet, &managedSeedSet.ObjectMeta, true)
+	fieldsSet := make(fields.Set, 2)
+	return generic.AddObjectMetaFieldsSet(fieldsSet, &managedSeedSet.ObjectMeta, true)
 }

--- a/pkg/registry/seedmanagement/managedseedset/strategy_test.go
+++ b/pkg/registry/seedmanagement/managedseedset/strategy_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedseedset_test
+
+import (
+	"context"
+
+	"k8s.io/utils/pointer"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
+	. "github.com/gardener/gardener/pkg/registry/seedmanagement/managedseedset"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var _ = Describe("Strategy", func() {
+	var (
+		ctx      = context.TODO()
+		strategy = Strategy{}
+	)
+
+	Describe("#PrepareForUpdate", func() {
+		var oldManagedSeedSet, newManagedSeedSet *seedmanagement.ManagedSeedSet
+
+		BeforeEach(func() {
+			oldManagedSeedSet = &seedmanagement.ManagedSeedSet{}
+			newManagedSeedSet = &seedmanagement.ManagedSeedSet{}
+		})
+
+		It("should increase the generation if the spec has changed", func() {
+			newManagedSeedSet.Spec.Replicas = pointer.Int32Ptr(1)
+
+			strategy.PrepareForUpdate(ctx, newManagedSeedSet, oldManagedSeedSet)
+			Expect(newManagedSeedSet.Generation).To(Equal(oldManagedSeedSet.Generation + 1))
+		})
+
+		It("should increase the generation if the deletion timestamp is set", func() {
+			deletionTimestamp := metav1.Now()
+			newManagedSeedSet.DeletionTimestamp = &deletionTimestamp
+
+			strategy.PrepareForUpdate(ctx, newManagedSeedSet, oldManagedSeedSet)
+			Expect(newManagedSeedSet.Generation).To(Equal(oldManagedSeedSet.Generation + 1))
+		})
+
+		It("should not increase the generation if neither the spec has changed nor the deletion timestamp is set", func() {
+			strategy.PrepareForUpdate(ctx, newManagedSeedSet, oldManagedSeedSet)
+			Expect(newManagedSeedSet.Generation).To(Equal(oldManagedSeedSet.Generation))
+		})
+	})
+})
+
+var _ = Describe("ToSelectableFields", func() {
+	It("should return correct fields", func() {
+		result := ToSelectableFields(newManagedSeedSet("foo"))
+
+		Expect(result).To(HaveLen(2))
+	})
+})
+
+var _ = Describe("GetAttrs", func() {
+	It("should return error when object is not ManagedSeedSet", func() {
+		_, _, err := GetAttrs(&core.Seed{})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return correct result", func() {
+		ls, _, err := GetAttrs(newManagedSeedSet("foo"))
+
+		Expect(ls).To(HaveLen(1))
+		Expect(ls.Get("foo")).To(Equal("bar"))
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("MatchManagedSeedSet", func() {
+	It("should return correct predicate", func() {
+		ls, _ := labels.Parse("app=test")
+
+		result := MatchManagedSeedSet(ls, nil)
+
+		Expect(result.Label).To(Equal(ls))
+	})
+})
+
+func newManagedSeedSet(shootName string) *seedmanagement.ManagedSeedSet {
+	return &seedmanagement.ManagedSeedSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-namespace",
+			Labels:    map[string]string{"foo": "bar"},
+		},
+		Spec: seedmanagement.ManagedSeedSetSpec{},
+	}
+}

--- a/pkg/registry/seedmanagement/rest/storage_seedmanagement.go
+++ b/pkg/registry/seedmanagement/rest/storage_seedmanagement.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	managedseedstore "github.com/gardener/gardener/pkg/registry/seedmanagement/managedseed/storage"
+	managedseedsetstore "github.com/gardener/gardener/pkg/registry/seedmanagement/managedseedset/storage"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/registry/generic"
@@ -45,9 +46,12 @@ func (p StorageProvider) v1alpha1Storage(restOptionsGetter generic.RESTOptionsGe
 	storage := map[string]rest.Storage{}
 
 	managedSeedStorage := managedseedstore.NewStorage(restOptionsGetter)
+	managedSeedSetStorage := managedseedsetstore.NewStorage(restOptionsGetter)
 
 	storage["managedseeds"] = managedSeedStorage.ManagedSeed
 	storage["managedseeds/status"] = managedSeedStorage.Status
+	storage["managedseedsets"] = managedSeedSetStorage.ManagedSeedSet
+	storage["managedseedsets/status"] = managedSeedSetStorage.Status
 
 	return storage
 }


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Adds `gardener-apiserver` registration and storage for `ManagedSeedSet` resources.

Creating, updating, and deleting `ManagedSeedSet` resources can now be tested, although admission plugins / controllers are still missing. This is on purpose, to make this PR easier to review. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```improvement operator
NONE
```