### PR TITLE
IgnoreNotFound when removing plant finalizer

### DIFF
--- a/pkg/controllermanager/controller/plant/plant_control.go
+++ b/pkg/controllermanager/controller/plant/plant_control.go
@@ -254,7 +254,7 @@ func (c *defaultPlantControl) delete(ctx context.Context, plant *gardencorev1bet
 		return fmt.Errorf("failed to get plant secret '%s/%s': %w", plant.Namespace, plant.Spec.SecretRef.Name, err)
 	}
 
-	if err := controllerutils.PatchRemoveFinalizers(ctx, gardenClient.Client(), plant, FinalizerName); err != nil {
+	if err := controllerutils.PatchRemoveFinalizers(ctx, gardenClient.Client(), plant, FinalizerName); client.IgnoreNotFound(err) != nil {
 		return fmt.Errorf("failed to remove finalizer from plant: %w", err)
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug
/priority normal

**What this PR does / why we need it**:

IgnoreNotFound when removing plant finalizer, to not spam the logs of gcm with messages like these:
```
time="2021-03-05T02:29:59Z" level=info msg="Error syncing plant garden-it/e2e-xgdww: failed to remove finalizer from plant: plants.core.gardener.cloud \"e2e-xgdww\" not found"
time="2021-03-05T02:29:59Z" level=info msg="Error syncing plant garden-it/e2e-xgdww: failed to remove finalizer from plant: plants.core.gardener.cloud \"e2e-xgdww\" not found"
time="2021-03-05T02:29:59Z" level=info msg="Error syncing plant garden-it/e2e-xgdww: failed to remove finalizer from plant: plants.core.gardener.cloud \"e2e-xgdww\" not found"
time="2021-03-05T02:29:59Z" level=info msg="Error syncing plant garden-it/e2e-xgdww: failed to remove finalizer from plant: plants.core.gardener.cloud \"e2e-xgdww\" not found"
time="2021-03-05T02:29:59Z" level=info msg="Error syncing plant garden-it/e2e-xgdww: failed to remove finalizer from plant: plants.core.gardener.cloud \"e2e-xgdww\" not found"
time="2021-03-05T02:29:59Z" level=info msg="Error syncing plant garden-it/e2e-xgdww: failed to remove finalizer from plant: plants.core.gardener.cloud \"e2e-xgdww\" not found"
time="2021-03-05T02:30:05Z" level=info msg="Error syncing plant garden-it/e2e-2wswf: failed to remove finalizer from plant: plants.core.gardener.cloud \"e2e-2wswf\" not found"
time="2021-03-05T02:30:05Z" level=info msg="Error syncing plant garden-it/e2e-2wswf: failed to remove finalizer from plant: plants.core.gardener.cloud \"e2e-2wswf\" not found"
time="2021-03-05T02:30:05Z" level=info msg="Error syncing plant garden-it/e2e-2wswf: failed to remove finalizer from plant: plants.core.gardener.cloud \"e2e-2wswf\" not found"
time="2021-03-05T02:30:05Z" level=info msg="Error syncing plant garden-it/e2e-2wswf: failed to remove finalizer from plant: plants.core.gardener.cloud \"e2e-2wswf\" not found"
time="2021-03-05T02:30:05Z" level=info msg="Error syncing plant garden-it/e2e-2wswf: failed to remove finalizer from plant: plants.core.gardener.cloud \"e2e-2wswf\" not found"
time="2021-03-05T02:30:06Z" level=info msg="Error syncing plant garden-it/e2e-2wswf: failed to remove finalizer from plant: plants.core.gardener.cloud \"e2e-2wswf\" not found"
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
