### PR TITLE
Extend list of non-retryable error codes

### DIFF
--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -97,7 +97,7 @@ Known error codes are:
 
 - `ERR_INFRA_UNAUTHORIZED` - indicates that the last error occurred due to invalid infrastructure credentials. It is classified as a non-retryable error code.
 - `ERR_INFRA_INSUFFICIENT_PRIVILEGES` - indicates that the last error occurred due to insufficient infrastructure privileges. It is classified as a non-retryable error code.
-- `ERR_INFRA_QUOTA_EXCEEDED` - indicates that the last error occurred due to infrastructure quota limits.
+- `ERR_INFRA_QUOTA_EXCEEDED` - indicates that the last error occurred due to infrastructure quota limits. It is classified as a non-retryable error code.
 - `ERR_INFRA_DEPENDENCIES` - indicates that the last error occurred due to dependent objects on the infrastructure level. It is classified as a non-retryable error code.
 - `ERR_INFRA_RESOURCES_DEPLETED` - indicates that the last error occurred due to depleted resource in the infrastructure.
 - `ERR_CLEANUP_CLUSTER_RESOURCES` - indicates that the last error occurred due to resources in the cluster that are stuck in deletion.

--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -96,10 +96,10 @@ The Shoot status also contains information about the last occurred error(s) (if 
 Known error codes are:
 
 - `ERR_INFRA_UNAUTHORIZED` - indicates that the last error occurred due to invalid infrastructure credentials. It is classified as a non-retryable error code.
-- `ERR_INFRA_INSUFFICIENT_PRIVILEGES` - indicates that the last error occurred due to insufficient infrastructure privileges
-- `ERR_INFRA_QUOTA_EXCEEDED` - indicates that the last error occurred due to infrastructure quota limits
-- `ERR_INFRA_DEPENDENCIES` - indicates that the last error occurred due to dependent objects on the infrastructure level
-- `ERR_INFRA_RESOURCES_DEPLETED` - indicates that the last error occurred due to depleted resource in the infrastructure
-- `ERR_CLEANUP_CLUSTER_RESOURCES` - indicates that the last error occurred due to resources in the cluster that are stuck in deletion
+- `ERR_INFRA_INSUFFICIENT_PRIVILEGES` - indicates that the last error occurred due to insufficient infrastructure privileges. It is classified as a non-retryable error code.
+- `ERR_INFRA_QUOTA_EXCEEDED` - indicates that the last error occurred due to infrastructure quota limits.
+- `ERR_INFRA_DEPENDENCIES` - indicates that the last error occurred due to dependent objects on the infrastructure level. It is classified as a non-retryable error code.
+- `ERR_INFRA_RESOURCES_DEPLETED` - indicates that the last error occurred due to depleted resource in the infrastructure.
+- `ERR_CLEANUP_CLUSTER_RESOURCES` - indicates that the last error occurred due to resources in the cluster that are stuck in deletion.
 - `ERR_CONFIGURATION_PROBLEM` - indicates that the last error occurred due to a configuration problem. It is classified as a non-retryable error code.
 - `ERR_RETRYABLE_CONFIGURATION_PROBLEM` - indicates that the last error occurred due to a retryable configuration problem. "Retryable" means that the occurred error is likely to be resolved in a ungraceful manner after given period of time.

--- a/pkg/apis/core/types_common.go
+++ b/pkg/apis/core/types_common.go
@@ -26,10 +26,12 @@ const (
 	// It is classified as a non-retryable error code.
 	ErrorInfraUnauthorized ErrorCode = "ERR_INFRA_UNAUTHORIZED"
 	// ErrorInfraInsufficientPrivileges indicates that the last error occurred due to insufficient infrastructure privileges.
+	// It is classified as a non-retryable error code.
 	ErrorInfraInsufficientPrivileges ErrorCode = "ERR_INFRA_INSUFFICIENT_PRIVILEGES"
 	// ErrorInfraQuotaExceeded indicates that the last error occurred due to infrastructure quota limits.
 	ErrorInfraQuotaExceeded ErrorCode = "ERR_INFRA_QUOTA_EXCEEDED"
 	// ErrorInfraDependencies indicates that the last error occurred due to dependent objects on the infrastructure level.
+	// It is classified as a non-retryable error code.
 	ErrorInfraDependencies ErrorCode = "ERR_INFRA_DEPENDENCIES"
 	// ErrorInfraResourcesDepleted indicates that the last error occurred due to depleted resource in the infrastructure.
 	ErrorInfraResourcesDepleted ErrorCode = "ERR_INFRA_RESOURCES_DEPLETED"

--- a/pkg/apis/core/types_common.go
+++ b/pkg/apis/core/types_common.go
@@ -29,6 +29,7 @@ const (
 	// It is classified as a non-retryable error code.
 	ErrorInfraInsufficientPrivileges ErrorCode = "ERR_INFRA_INSUFFICIENT_PRIVILEGES"
 	// ErrorInfraQuotaExceeded indicates that the last error occurred due to infrastructure quota limits.
+	// It is classified as a non-retryable error code.
 	ErrorInfraQuotaExceeded ErrorCode = "ERR_INFRA_QUOTA_EXCEEDED"
 	// ErrorInfraDependencies indicates that the last error occurred due to dependent objects on the infrastructure level.
 	// It is classified as a non-retryable error code.

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -27,6 +27,7 @@ const (
 	// It is classified as a non-retryable error code.
 	ErrorInfraInsufficientPrivileges ErrorCode = "ERR_INFRA_INSUFFICIENT_PRIVILEGES"
 	// ErrorInfraQuotaExceeded indicates that the last error occurred due to infrastructure quota limits.
+	// It is classified as a non-retryable error code.
 	ErrorInfraQuotaExceeded ErrorCode = "ERR_INFRA_QUOTA_EXCEEDED"
 	// ErrorInfraDependencies indicates that the last error occurred due to dependent objects on the infrastructure level.
 	// It is classified as a non-retryable error code.

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -24,10 +24,12 @@ const (
 	// It is classified as a non-retryable error code.
 	ErrorInfraUnauthorized ErrorCode = "ERR_INFRA_UNAUTHORIZED"
 	// ErrorInfraInsufficientPrivileges indicates that the last error occurred due to insufficient infrastructure privileges.
+	// It is classified as a non-retryable error code.
 	ErrorInfraInsufficientPrivileges ErrorCode = "ERR_INFRA_INSUFFICIENT_PRIVILEGES"
 	// ErrorInfraQuotaExceeded indicates that the last error occurred due to infrastructure quota limits.
 	ErrorInfraQuotaExceeded ErrorCode = "ERR_INFRA_QUOTA_EXCEEDED"
 	// ErrorInfraDependencies indicates that the last error occurred due to dependent objects on the infrastructure level.
+	// It is classified as a non-retryable error code.
 	ErrorInfraDependencies ErrorCode = "ERR_INFRA_DEPENDENCIES"
 	// ErrorInfraResourcesDepleted indicates that the last error occurred due to depleted resource in the infrastructure.
 	ErrorInfraResourcesDepleted ErrorCode = "ERR_INFRA_RESOURCES_DEPLETED"

--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -203,8 +203,9 @@ func HasNonRetryableErrorCode(lastErrors ...gardencorev1beta1.LastError) bool {
 		for _, code := range lastError.Codes {
 			if code == gardencorev1beta1.ErrorInfraUnauthorized ||
 				code == gardencorev1beta1.ErrorInfraInsufficientPrivileges ||
-				code == gardencorev1beta1.ErrorConfigurationProblem ||
-				code == gardencorev1beta1.ErrorInfraDependencies {
+				code == gardencorev1beta1.ErrorInfraDependencies ||
+				code == gardencorev1beta1.ErrorInfraQuotaExceeded ||
+				code == gardencorev1beta1.ErrorConfigurationProblem {
 				return true
 			}
 		}

--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -201,7 +201,10 @@ func LastErrorWithTaskID(description string, taskID string, codes ...gardencorev
 func HasNonRetryableErrorCode(lastErrors ...gardencorev1beta1.LastError) bool {
 	for _, lastError := range lastErrors {
 		for _, code := range lastError.Codes {
-			if code == gardencorev1beta1.ErrorInfraUnauthorized || code == gardencorev1beta1.ErrorConfigurationProblem {
+			if code == gardencorev1beta1.ErrorInfraUnauthorized ||
+				code == gardencorev1beta1.ErrorInfraInsufficientPrivileges ||
+				code == gardencorev1beta1.ErrorConfigurationProblem ||
+				code == gardencorev1beta1.ErrorInfraDependencies {
 				return true
 			}
 		}

--- a/pkg/apis/core/v1beta1/helper/errors_test.go
+++ b/pkg/apis/core/v1beta1/helper/errors_test.go
@@ -80,8 +80,8 @@ var _ = Describe("errors", func() {
 		},
 
 		Entry("no error given", nil, BeFalse()),
-		Entry("only errors with non-retryable error codes", []gardencorev1beta1.LastError{unauthorizedError, infraInsufficientPrivilegesError, infraDependenciesError, configurationProblemError}, BeTrue()),
-		Entry("only errors with retryable error codes", []gardencorev1beta1.LastError{infraQuotaExceededError, infraResourcesDepletedError, cleanupClusterResourcesError}, BeFalse()),
+		Entry("only errors with non-retryable error codes", []gardencorev1beta1.LastError{unauthorizedError, infraInsufficientPrivilegesError, infraQuotaExceededError, infraDependenciesError, configurationProblemError}, BeTrue()),
+		Entry("only errors with retryable error codes", []gardencorev1beta1.LastError{infraResourcesDepletedError, cleanupClusterResourcesError}, BeFalse()),
 		Entry("errors with both retryable and not retryable error codes", []gardencorev1beta1.LastError{unauthorizedError, configurationProblemError, infraInsufficientPrivilegesError, infraQuotaExceededError, infraDependenciesError, infraResourcesDepletedError, cleanupClusterResourcesError}, BeTrue()),
 		Entry("errors without error codes", []gardencorev1beta1.LastError{errorWithoutCodes}, BeFalse()),
 	)

--- a/pkg/apis/core/v1beta1/helper/errors_test.go
+++ b/pkg/apis/core/v1beta1/helper/errors_test.go
@@ -80,8 +80,8 @@ var _ = Describe("errors", func() {
 		},
 
 		Entry("no error given", nil, BeFalse()),
-		Entry("only errors with non-retryable error codes", []gardencorev1beta1.LastError{unauthorizedError, configurationProblemError}, BeTrue()),
-		Entry("only errors with retryable error codes", []gardencorev1beta1.LastError{infraInsufficientPrivilegesError, infraQuotaExceededError, infraDependenciesError, infraResourcesDepletedError, cleanupClusterResourcesError}, BeFalse()),
+		Entry("only errors with non-retryable error codes", []gardencorev1beta1.LastError{unauthorizedError, infraInsufficientPrivilegesError, infraDependenciesError, configurationProblemError}, BeTrue()),
+		Entry("only errors with retryable error codes", []gardencorev1beta1.LastError{infraQuotaExceededError, infraResourcesDepletedError, cleanupClusterResourcesError}, BeFalse()),
 		Entry("errors with both retryable and not retryable error codes", []gardencorev1beta1.LastError{unauthorizedError, configurationProblemError, infraInsufficientPrivilegesError, infraQuotaExceededError, infraDependenciesError, infraResourcesDepletedError, cleanupClusterResourcesError}, BeTrue()),
 		Entry("errors without error codes", []gardencorev1beta1.LastError{errorWithoutCodes}, BeFalse()),
 	)

--- a/pkg/apis/core/v1beta1/types_common.go
+++ b/pkg/apis/core/v1beta1/types_common.go
@@ -27,6 +27,7 @@ const (
 	// It is classified as a non-retryable error code.
 	ErrorInfraInsufficientPrivileges ErrorCode = "ERR_INFRA_INSUFFICIENT_PRIVILEGES"
 	// ErrorInfraQuotaExceeded indicates that the last error occurred due to infrastructure quota limits.
+	// It is classified as a non-retryable error code.
 	ErrorInfraQuotaExceeded ErrorCode = "ERR_INFRA_QUOTA_EXCEEDED"
 	// ErrorInfraDependencies indicates that the last error occurred due to dependent objects on the infrastructure level.
 	// It is classified as a non-retryable error code.

--- a/pkg/apis/core/v1beta1/types_common.go
+++ b/pkg/apis/core/v1beta1/types_common.go
@@ -24,10 +24,12 @@ const (
 	// It is classified as a non-retryable error code.
 	ErrorInfraUnauthorized ErrorCode = "ERR_INFRA_UNAUTHORIZED"
 	// ErrorInfraInsufficientPrivileges indicates that the last error occurred due to insufficient infrastructure privileges.
+	// It is classified as a non-retryable error code.
 	ErrorInfraInsufficientPrivileges ErrorCode = "ERR_INFRA_INSUFFICIENT_PRIVILEGES"
 	// ErrorInfraQuotaExceeded indicates that the last error occurred due to infrastructure quota limits.
 	ErrorInfraQuotaExceeded ErrorCode = "ERR_INFRA_QUOTA_EXCEEDED"
 	// ErrorInfraDependencies indicates that the last error occurred due to dependent objects on the infrastructure level.
+	// It is classified as a non-retryable error code.
 	ErrorInfraDependencies ErrorCode = "ERR_INFRA_DEPENDENCIES"
 	// ErrorInfraResourcesDepleted indicates that the last error occurred due to depleted resource in the infrastructure.
 	ErrorInfraResourcesDepleted ErrorCode = "ERR_INFRA_RESOURCES_DEPLETED"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
To prevent "spamming" an infrastructure provider's API, we are now extending list of non-retryable error codes with `ERR_INFRA_INSUFFICIENT_PRIVILEGES`, `ERR_INFRA_QUOTA_EXCEEDED`, and `ERR_INFRA_DEPENDENCIES`.

**Special notes for your reviewer**:
`ERR_INFRA_RESOURCES_DEPLETED` was not added because it usually resolves automatically after some time.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
When a shoot is erroring with `ERR_INFRA_INSUFFICIENT_PRIVILEGES`, `ERR_INFRA_QUOTA_EXCEEDED` or `ERR_INFRA_DEPENDENCIES` then it is now immediately set to the `Failed` status (this already happens also for `ERR_INFRA_UNAUTHORIZED` or `ERR_CONFIGURATION_PROBLEM`). This prevents Gardener from automatically retrying the operation. If you are hit by it, please manually retry the operation once you have resolved the issue.
```
