### PR TITLE
Update release process document

### DIFF
--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -27,7 +27,10 @@ Hotfixes are usually only maintained for the latest minor release as well as the
 
 The validation process for new releases usually takes a couple of days and includes the following steps:
 
-1. `master` (or latest `release-*` branch) is deployed to a development landscape that already hosts some existing seed and shoot clusters.
+1. If a new
+   1. minor release `vX.Y.0` shall be cut then a new branch `release-vX.Y` is created based on `master`. [*]
+   1. patch release `vX.Y.Z` with `Z>0` shall be cut then the existing `release-vX.Y` branch is used.
+1. The images built from the respective branch are deployed to a development landscape that already hosts some existing seed and shoot clusters.
 1. An extended test suite is triggered by the "release responsible" which
    1. executes the Gardener integration tests for different Kubernetes versions, infrastructures, and `Shoot` settings.
    1. executes the Kubernetes conformance tests.
@@ -36,3 +39,5 @@ The validation process for new releases usually takes a couple of days and inclu
 1. The "release responsible" is verifying new features or other notable changes (derived of the draft release notes) in this development system.
 
 If all tests are green, all checks were successful, and the release responsible has performed all of the planned verifications then the release is triggered.
+
+> [*] This can be seen as "code freeze" period for the `vX.Y.0` release. The development and pull request merges to `master` can continue. Please note that you would have to pro-actively creates pull requests to the respective `release-vX.Y` branch in case you want to have your change that was already merged to `master` included in the `vX.Y.0` release.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation delivery
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR updates the release process documentation according to the latest changes.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
