### PR TITLE
Increase BackupBucket controller test timeouts

### DIFF
--- a/extensions/pkg/controller/backupbucket/backupbucket_test.go
+++ b/extensions/pkg/controller/backupbucket/backupbucket_test.go
@@ -48,8 +48,8 @@ import (
 
 const (
 	pollInterval        = time.Second
-	pollSevereThreshold = 10 * time.Second
-	pollTimeout         = 15 * time.Second
+	pollSevereThreshold = 30 * time.Second
+	pollTimeout         = time.Minute
 )
 
 var _ = Describe("BackupBucket", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug
/priority normal

**What this PR does / why we need it**:

Increases the test timeouts in the `Extensions Controller BackupBucket Test Suite` to hopefully circumvent some flakes in g/g's pipelines.

**Which issue(s) this PR fixes**:
Related to https://github.com/gardener/gardener/issues/2915

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
