### PR TITLE
Seed name identification from user information

### DIFF
--- a/pkg/admissioncontroller/webhooks/auth/seed/identity.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/identity.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seed
+
+import (
+	"strings"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+// Identity returns the seed name and a boolean indicating whether the provided user has the
+// gardener.cloud:system:seeds group. If the seed name is ambigious then an empty string will be returned.
+func Identity(u user.Info) (string, bool) {
+	if u == nil {
+		return "", false
+	}
+
+	userName := u.GetName()
+	if !strings.HasPrefix(userName, v1beta1constants.SeedUserNamePrefix) {
+		return "", false
+	}
+
+	if !utils.ValueExists(v1beta1constants.SeedsGroup, u.GetGroups()) {
+		return "", false
+	}
+
+	var seedName string
+	if suffix := strings.TrimPrefix(userName, v1beta1constants.SeedUserNamePrefix); suffix != v1beta1constants.SeedUserNameSuffixAmbiguous {
+		seedName = suffix
+	}
+
+	return seedName, true
+}

--- a/pkg/admissioncontroller/webhooks/auth/seed/identity_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/identity_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seed_test
+
+import (
+	. "github.com/gardener/gardener/pkg/admissioncontroller/webhooks/auth/seed"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"k8s.io/apiserver/pkg/authentication/user"
+)
+
+var _ = Describe("identity", func() {
+	DescribeTable("#Identity",
+		func(u user.Info, expectedSeedName string, expectedIsSeedValue bool) {
+			seedName, isSeed := Identity(u)
+
+			Expect(seedName).To(Equal(expectedSeedName))
+			Expect(isSeed).To(Equal(expectedIsSeedValue))
+		},
+
+		Entry("nil", nil, "", false),
+		Entry("no user name prefix", &user.DefaultInfo{Name: "foo"}, "", false),
+		Entry("user name prefix but no groups", &user.DefaultInfo{Name: "gardener.cloud:system:seed:foo"}, "", false),
+		Entry("user name prefix but seed group not present", &user.DefaultInfo{Name: "gardener.cloud:system:seed:foo", Groups: []string{"bar"}}, "", false),
+		Entry("user name prefix and seed group", &user.DefaultInfo{Name: "gardener.cloud:system:seed:foo", Groups: []string{"gardener.cloud:system:seeds"}}, "foo", true),
+		Entry("user name prefix and seed group (ambiguous)", &user.DefaultInfo{Name: "gardener.cloud:system:seed:<ambiguous>", Groups: []string{"gardener.cloud:system:seeds"}}, "", true),
+	)
+})

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -333,6 +333,13 @@ const (
 	IngressKindNginx = "nginx"
 	// ShootNginxIngressClass defines the ingress class for the seed nginx ingress controller
 	ShootNginxIngressClass = "nginx"
+
+	// SeedsGroup is the identity group for gardenlets when authenticating to the API server.
+	SeedsGroup = "gardener.cloud:system:seeds"
+	// SeedUserNamePrefix is the identity user name prefix for gardenlets when authenticating to the API server.
+	SeedUserNamePrefix = "gardener.cloud:system:seed:"
+	// SeedUserNameSuffixAmbiguous is the default seed name in case the gardenlet config.SeedConfig is not set
+	SeedUserNameSuffixAmbiguous = "<ambiguous>"
 )
 
 // ControlPlaneSecretRoles contains all role values used for control plane secrets synced to the Garden cluster.

--- a/pkg/controllermanager/controller/certificatesigningrequest/csr_autoapprove_control.go
+++ b/pkg/controllermanager/controller/certificatesigningrequest/csr_autoapprove_control.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -186,7 +187,7 @@ func parseCSR(csr *certificatesv1beta1.CertificateSigningRequest) (*x509.Certifi
 }
 
 func isSeedClientCert(csr *certificatesv1beta1.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool {
-	if !reflect.DeepEqual([]string{"gardener.cloud:system:seeds"}, x509cr.Subject.Organization) {
+	if !reflect.DeepEqual([]string{v1beta1constants.SeedsGroup}, x509cr.Subject.Organization) {
 		return false
 	}
 	if (len(x509cr.DNSNames) > 0) || (len(x509cr.EmailAddresses) > 0) || (len(x509cr.IPAddresses) > 0) {
@@ -199,10 +200,7 @@ func isSeedClientCert(csr *certificatesv1beta1.CertificateSigningRequest, x509cr
 	}) {
 		return false
 	}
-	if !strings.HasPrefix(x509cr.Subject.CommonName, "gardener.cloud:system:seed:") {
-		return false
-	}
-	return true
+	return strings.HasPrefix(x509cr.Subject.CommonName, v1beta1constants.SeedUserNamePrefix)
 }
 
 func hasExactUsages(csr *certificatesv1beta1.CertificateSigningRequest, usages []certificatesv1beta1.KeyUsage) bool {

--- a/pkg/gardenlet/bootstrap/bootstrap.go
+++ b/pkg/gardenlet/bootstrap/bootstrap.go
@@ -34,6 +34,7 @@ import (
 	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/gardenlet/bootstrap/certificate"
 	bootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
@@ -44,8 +45,8 @@ import (
 // returns the kubeconfig []byte representation, the CSR name, the seed name or an error
 func RequestBootstrapKubeconfig(ctx context.Context, logger logrus.FieldLogger, seedClient client.Client, clientSet kubernetesclientset.Interface, bootstrapConfig *rest.Config, gardenClientConnection *config.GardenClientConnection, seedName, bootstrapTargetCluster string) ([]byte, string, string, error) {
 	certificateSubject := &pkix.Name{
-		Organization: []string{"gardener.cloud:system:seeds"},
-		CommonName:   "gardener.cloud:system:seed:" + seedName,
+		Organization: []string{v1beta1constants.SeedsGroup},
+		CommonName:   v1beta1constants.SeedUserNamePrefix + seedName,
 	}
 
 	certData, privateKeyData, csrName, err := certificate.RequestCertificate(ctx, logger, clientSet, certificateSubject, []string{}, []net.IP{})

--- a/pkg/gardenlet/bootstrap/util/util.go
+++ b/pkg/gardenlet/bootstrap/util/util.go
@@ -24,6 +24,7 @@ import (
 
 	certificatesv1 "k8s.io/api/certificates/v1"
 
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -155,15 +156,12 @@ func BuildBootstrapperName(name string) string {
 	return fmt.Sprintf("%s:%s", GardenerSeedBootstrapper, name)
 }
 
-// DefaultSeedName is the default seed name in case the gardenlet config.SeedConfig is not set
-const DefaultSeedName = "<ambiguous>"
-
 // GetSeedName returns the seed name from the SeedConfig or the default Seed name
 func GetSeedName(seedConfig *config.SeedConfig) string {
 	if seedConfig != nil {
 		return seedConfig.Name
 	}
-	return DefaultSeedName
+	return constants.SeedUserNameSuffixAmbiguous
 }
 
 const (

--- a/pkg/gardenlet/bootstrap/util/util_test.go
+++ b/pkg/gardenlet/bootstrap/util/util_test.go
@@ -271,7 +271,7 @@ var _ = Describe("Util", func() {
 
 		It("should return the default name", func() {
 			result := bootstraputil.GetSeedName(nil)
-			Expect(result).To(Equal(bootstraputil.DefaultSeedName))
+			Expect(result).To(Equal("<ambiguous>"))
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR adds functionality for identifying the seed name from a user information. This will be used by the `SeedAuthorizer` auth webhook in the future to check whether it needs to act on the request or not (it will only act on requests from gardenlets).

**Which issue(s) this PR fixes**:
Part of #1723 

**Special notes for your reviewer**:
/assign @timuthy 
/invite @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
