### PR TITLE
Fix update of generatedSecretRef in status of backupBucket

### DIFF
--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
@@ -269,12 +269,11 @@ func (a *actuator) waitUntilBackupBucketExtensionReconciled(ctx context.Context)
 			}
 
 			if generatedSecretRef != nil || backupBucket.Status.ProviderStatus != nil {
-				_, err := controllerutil.CreateOrUpdate(ctx, a.gardenClient.Client(), a.backupBucket, func() error {
+				return kutil.TryUpdateStatus(ctx, kretry.DefaultBackoff, a.gardenClient.Client(), a.backupBucket, func() error {
 					a.backupBucket.Status.GeneratedSecretRef = generatedSecretRef
 					a.backupBucket.Status.ProviderStatus = backupBucket.Status.ProviderStatus
 					return nil
 				})
-				return err
 			}
 
 			return nil

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
@@ -269,7 +269,7 @@ func (a *actuator) waitUntilBackupBucketExtensionReconciled(ctx context.Context)
 			}
 
 			if generatedSecretRef != nil || backupBucket.Status.ProviderStatus != nil {
-				return kutil.TryUpdateStatus(ctx, kretry.DefaultBackoff, a.gardenClient.Client(), a.backupBucket, func() error {
+				return kutil.TryUpdateStatus(ctx, kretry.DefaultBackoff, a.gardenClient.DirectClient(), a.backupBucket, func() error {
 					a.backupBucket.Status.GeneratedSecretRef = generatedSecretRef
 					a.backupBucket.Status.ProviderStatus = backupBucket.Status.ProviderStatus
 					return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority normal

**What this PR does / why we need it**:
On creating a new Azure seed, the status of backupbucket in the virtual garden cluster was not updated with the `generatedSecretRef`. As the status of the backupbucket is an own object, using `CreateOrUpdate` on the backupbucket object itself ignores changes to status fields. Instead the status must be updated explicitly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue preventing the status of the BackupBucket to be properly updated is now fixed.
```
