### PR TITLE
Increase CoreDNS memory limits to avoid OOMKill.

### DIFF
--- a/charts/shoot-core/components/charts/coredns/values.yaml
+++ b/charts/shoot-core/components/charts/coredns/values.yaml
@@ -23,7 +23,7 @@ deployment:
       resources:
         limits:
           cpu: 250m
-          memory: 100Mi
+          memory: 500Mi
         requests:
           cpu: 50m
           memory: 15Mi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Increase CoreDNS memory limits to avoid OOMKill.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Addresses the following part of https://github.tools.sap/kubernetes-canary/issues-canary/issues/605#issuecomment-184664.
> 4. If VPA is not enabled for the shoot cluster, use only HPA for CoreDNS with statically increased requests/limits.

I will raise a separate PR to address the VPA part.
> 3. If VPA is enabled for the shoot cluster, remove HPA for CoreDNS but still retain some fixed replicas (2 or 3?) and then scale only vertically.

cc @mvladev @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Increase CoreDNS memory limits to avoid OOMKill.
```
