### PR TITLE
Automated cherry pick of #3677: Fix debootstrap of Seed

### DIFF
--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -270,14 +270,18 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 						Namespace: seed.Spec.SecretRef.Namespace,
 					},
 				}
-				if err := controllerutils.PatchRemoveFinalizers(ctx, gardenClient.Client(), secret, gardencorev1beta1.ExternalGardenerName); err != nil {
-					seedLogger.Error(err.Error())
-					return err
+				err = gardenClient.Client().Get(ctx, client.ObjectKeyFromObject(secret), secret)
+				if err == nil {
+					if err2 := controllerutils.PatchRemoveFinalizers(ctx, gardenClient.Client(), secret, gardencorev1beta1.ExternalGardenerName); err2 != nil {
+						return fmt.Errorf("failed to remove finalizer from Seed secret '%s/%s': %w", secret.Namespace, secret.Name, err2)
+					}
+				} else if !apierrors.IsNotFound(err) {
+					return fmt.Errorf("failed to get Seed secret '%s/%s': %w", secret.Namespace, secret.Name, err)
 				}
 			}
 
 			// Remove finalizer from Seed
-			if err := controllerutils.PatchRemoveFinalizers(ctx, gardenClient.Client(), seed); err != nil {
+			if err := controllerutils.PatchRemoveFinalizers(ctx, gardenClient.Client(), seed, gardencorev1beta1.GardenerName); err != nil {
 				seedLogger.Error(err.Error())
 				return err
 			}


### PR DESCRIPTION
/kind bug
/kind regression

Cherry pick of #3677 on release-v1.18.

#3677: Fix debootstrap of Seed

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing gardenlet to fail to remove the finalizer of the Seed Secret (`.spec.secretRef`) is now fixed.
```