### PR TITLE
Cleanup context.TODO(), migrate from DeprecatedCreateWorker to CreateWorker (2)

### DIFF
--- a/pkg/controllermanager/controller/plant/plant_types.go
+++ b/pkg/controllermanager/controller/plant/plant_types.go
@@ -14,21 +14,6 @@
 
 package plant
 
-import (
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
-	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
-
-	kubecorev1listers "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/record"
-)
-
-type defaultPlantControl struct {
-	clientMap     clientmap.ClientMap
-	secretsLister kubecorev1listers.SecretLister
-	recorder      record.EventRecorder
-	config        *config.ControllerManagerConfiguration
-}
-
 // StatusCloudInfo contains the cloud info for the plant status
 type StatusCloudInfo struct {
 	CloudType  string

--- a/pkg/controllermanager/controller/project/project.go
+++ b/pkg/controllermanager/controller/project/project.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // Controller controls Projects.
@@ -40,8 +41,9 @@ type Controller struct {
 	clientMap              clientmap.ClientMap
 	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory
 
-	control      ControlInterface
 	staleControl StaleControlInterface
+
+	projectReconciler reconcile.Reconciler
 
 	config   *config.ControllerManagerConfiguration
 	recorder record.EventRecorder
@@ -99,7 +101,7 @@ func NewProjectController(clientMap clientmap.ClientMap, gardenCoreInformerFacto
 	projectController := &Controller{
 		clientMap:              clientMap,
 		k8sGardenCoreInformers: gardenCoreInformerFactory,
-		control:                NewDefaultControl(clientMap, config, gardenCoreInformerFactory, recorder, namespaceLister),
+		projectReconciler:      NewProjectReconciler(logger.Logger, config.Controllers, clientMap, gardenCoreInformerFactory, recorder, namespaceLister),
 		staleControl:           NewDefaultStaleControl(clientMap, config, shootLister, plantLister, backupEntryLister, secretBindingLister, quotaLister, namespaceLister, secretLister),
 		config:                 config,
 		recorder:               recorder,
@@ -148,7 +150,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	logger.Logger.Info("Project controller initialized.")
 
 	for i := 0; i < workers; i++ {
-		controllerutils.DeprecatedCreateWorker(ctx, c.projectQueue, "Project", c.reconcileProjectKey, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.projectQueue, "Project", c.projectReconciler, &waitGroup, c.workerCh)
 		controllerutils.DeprecatedCreateWorker(ctx, c.projectStaleQueue, "Project Stale", c.reconcileStaleProjectKey, &waitGroup, c.workerCh)
 	}
 

--- a/pkg/controllermanager/controller/project/project.go
+++ b/pkg/controllermanager/controller/project/project.go
@@ -94,7 +94,7 @@ func NewProjectController(clientMap clientmap.ClientMap, gardenCoreInformerFacto
 
 	projectController := &Controller{
 		clientMap:              clientMap,
-		projectReconciler:      NewProjectReconciler(logger.Logger, config.Controllers, clientMap, gardenCoreInformerFactory, recorder, namespaceLister),
+		projectReconciler:      NewProjectReconciler(logger.Logger, config.Controllers.Project, clientMap, recorder, namespaceLister),
 		projectStaleReconciler: NewProjectStaleReconciler(logger.Logger, config.Controllers.Project, clientMap, shootLister, plantLister, backupEntryLister, secretBindingLister, quotaLister, namespaceLister, secretLister),
 		config:                 config,
 		projectLister:          projectLister,

--- a/pkg/controllermanager/controller/project/project.go
+++ b/pkg/controllermanager/controller/project/project.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	kubeinformers "k8s.io/client-go/informers"
-	kubecorev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -38,24 +37,19 @@ import (
 
 // Controller controls Projects.
 type Controller struct {
-	clientMap              clientmap.ClientMap
-	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory
+	clientMap clientmap.ClientMap
+	config    *config.ControllerManagerConfiguration
 
-	staleControl StaleControlInterface
+	projectReconciler      reconcile.Reconciler
+	projectStaleReconciler reconcile.Reconciler
 
-	projectReconciler reconcile.Reconciler
+	projectLister gardencorelisters.ProjectLister
 
-	config   *config.ControllerManagerConfiguration
-	recorder record.EventRecorder
-
-	projectLister     gardencorelisters.ProjectLister
 	projectQueue      workqueue.RateLimitingInterface
 	projectStaleQueue workqueue.RateLimitingInterface
+
 	projectSynced     cache.InformerSynced
-
-	namespaceLister kubecorev1listers.NamespaceLister
-	namespaceSynced cache.InformerSynced
-
+	namespaceSynced   cache.InformerSynced
 	roleBindingSynced cache.InformerSynced
 
 	workerCh               chan int
@@ -100,15 +94,12 @@ func NewProjectController(clientMap clientmap.ClientMap, gardenCoreInformerFacto
 
 	projectController := &Controller{
 		clientMap:              clientMap,
-		k8sGardenCoreInformers: gardenCoreInformerFactory,
 		projectReconciler:      NewProjectReconciler(logger.Logger, config.Controllers, clientMap, gardenCoreInformerFactory, recorder, namespaceLister),
-		staleControl:           NewDefaultStaleControl(clientMap, config, shootLister, plantLister, backupEntryLister, secretBindingLister, quotaLister, namespaceLister, secretLister),
+		projectStaleReconciler: NewProjectStaleReconciler(logger.Logger, config.Controllers.Project, clientMap, shootLister, plantLister, backupEntryLister, secretBindingLister, quotaLister, namespaceLister, secretLister),
 		config:                 config,
-		recorder:               recorder,
 		projectLister:          projectLister,
 		projectQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Project"),
 		projectStaleQueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Project Stale"),
-		namespaceLister:        namespaceLister,
 		workerCh:               make(chan int),
 	}
 
@@ -151,7 +142,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 
 	for i := 0; i < workers; i++ {
 		controllerutils.CreateWorker(ctx, c.projectQueue, "Project", c.projectReconciler, &waitGroup, c.workerCh)
-		controllerutils.DeprecatedCreateWorker(ctx, c.projectStaleQueue, "Project Stale", c.reconcileStaleProjectKey, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.projectStaleQueue, "Project Stale", c.projectStaleReconciler, &waitGroup, c.workerCh)
 	}
 
 	// Shutdown handling

--- a/pkg/controllermanager/controller/project/project_control.go
+++ b/pkg/controllermanager/controller/project/project_control.go
@@ -16,12 +16,13 @@ package project
 
 import (
 	"context"
-	"time"
+	"fmt"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencore "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
+	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/logger"
 	kutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -34,6 +35,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func (c *Controller) projectAdd(obj interface{}) {
@@ -68,57 +70,51 @@ func (c *Controller) projectDelete(obj interface{}) {
 	c.projectQueue.Add(key)
 }
 
-func (c *Controller) reconcileProjectKey(key string) error {
-	_, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		return err
+// NewProjectReconciler creates a new instance of a reconciler which reconciles Projects.
+func NewProjectReconciler(l logrus.FieldLogger, config config.ControllerManagerControllerConfiguration, clientMap clientmap.ClientMap, k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory, recorder record.EventRecorder, namespaceLister kubecorev1listers.NamespaceLister) reconcile.Reconciler {
+	return &projectReconciler{
+		logger:                 l,
+		config:                 config,
+		clientMap:              clientMap,
+		k8sGardenCoreInformers: k8sGardenCoreInformers,
+		recorder:               recorder,
+		namespaceLister:        namespaceLister,
 	}
-
-	project, err := c.projectLister.Get(name)
-	if apierrors.IsNotFound(err) {
-		logger.Logger.Debugf("[PROJECT RECONCILE] %s - skipping because Project has been deleted", key)
-		return nil
-	}
-	if err != nil {
-		logger.Logger.Infof("[PROJECT RECONCILE] %s - unable to retrieve object from store: %v", key, err)
-		return err
-	}
-
-	needsRequeue, err := c.control.ReconcileProject(project)
-	if err != nil {
-		return err
-	}
-	if needsRequeue {
-		c.projectQueue.AddAfter(key, time.Minute)
-	}
-
-	return nil
 }
 
-// ControlInterface implements the control logic for updating Projects. It is implemented as an interface to allow
-// for extensions that provide different semantics. Currently, there is only one implementation.
-type ControlInterface interface {
-	// ReconcileProject implements the control logic for Project creation, update, and deletion.
-	// If an implementation returns a non-nil error, the invocation will be retried using a rate-limited strategy.
-	// Implementors should sink any errors that they do not wish to trigger a retry, and they may feel free to
-	// exit exceptionally at any point provided they wish the update to be re-run at a later point in time.
-	ReconcileProject(project *gardencorev1beta1.Project) (bool, error)
-}
-
-// NewDefaultControl returns a new instance of the default implementation ControlInterface that
-// implements the documented semantics for Projects. updater is the UpdaterInterface used
-// to update the status of Projects. You should use an instance returned from NewDefaultControl() for any
-// scenario other than testing.
-func NewDefaultControl(clientMap clientmap.ClientMap, config *config.ControllerManagerConfiguration, k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory, recorder record.EventRecorder, namespaceLister kubecorev1listers.NamespaceLister) ControlInterface {
-	return &defaultControl{clientMap, config, k8sGardenCoreInformers, recorder, namespaceLister}
-}
-
-type defaultControl struct {
+type projectReconciler struct {
+	logger                 logrus.FieldLogger
+	config                 config.ControllerManagerControllerConfiguration
 	clientMap              clientmap.ClientMap
-	config                 *config.ControllerManagerConfiguration
 	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory
 	recorder               record.EventRecorder
 	namespaceLister        kubecorev1listers.NamespaceLister
+}
+
+func (r *projectReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	gardenClient, err := r.clientMap.GetClient(ctx, keys.ForGarden())
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get garden client: %w", err)
+	}
+
+	project := &gardencorev1beta1.Project{}
+	if err := gardenClient.Client().Get(ctx, request.NamespacedName, project); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.logger.Infof("Object %q is gone, stop reconciling: %v", request.Name, err)
+			return reconcile.Result{}, nil
+		}
+		r.logger.Infof("Unable to retrieve object %q from store: %v", request.Name, err)
+		return reconcile.Result{}, err
+	}
+
+	projectLogger := newProjectLogger(project)
+	projectLogger.Infof("[PROJECT RECONCILE] %s", project.Name)
+
+	if project.DeletionTimestamp != nil {
+		return r.delete(ctx, project, gardenClient)
+	}
+
+	return r.reconcile(ctx, project, gardenClient)
 }
 
 func newProjectLogger(project *gardencorev1beta1.Project) logrus.FieldLogger {
@@ -126,22 +122,6 @@ func newProjectLogger(project *gardencorev1beta1.Project) logrus.FieldLogger {
 		return logger.Logger
 	}
 	return logger.NewFieldLogger(logger.Logger, "project", project.Name)
-}
-
-func (c *defaultControl) ReconcileProject(obj *gardencorev1beta1.Project) (bool, error) {
-	var (
-		ctx           = context.TODO()
-		project       = obj.DeepCopy()
-		projectLogger = newProjectLogger(project)
-	)
-
-	projectLogger.Infof("[PROJECT RECONCILE]")
-
-	if project.DeletionTimestamp != nil {
-		return c.delete(ctx, project)
-	}
-
-	return false, c.reconcile(ctx, project)
 }
 
 func updateProjectStatus(ctx context.Context, g gardencore.Interface, objectMeta metav1.ObjectMeta, transform func(project *gardencorev1beta1.Project) (*gardencorev1beta1.Project, error)) (*gardencorev1beta1.Project, error) {
@@ -152,7 +132,7 @@ func updateProjectStatus(ctx context.Context, g gardencore.Interface, objectMeta
 	return project, err
 }
 
-func (c *defaultControl) reportEvent(project *gardencorev1beta1.Project, isError bool, eventReason, messageFmt string, args ...interface{}) {
+func (r *projectReconciler) reportEvent(project *gardencorev1beta1.Project, isError bool, eventReason, messageFmt string, args ...interface{}) {
 	var (
 		eventType     string
 		projectLogger = newProjectLogger(project)
@@ -166,5 +146,5 @@ func (c *defaultControl) reportEvent(project *gardencorev1beta1.Project, isError
 		projectLogger.Errorf(messageFmt, args...)
 	}
 
-	c.recorder.Eventf(project, eventType, eventReason, messageFmt, args...)
+	r.recorder.Eventf(project, eventType, eventReason, messageFmt, args...)
 }

--- a/pkg/controllermanager/controller/project/project_control.go
+++ b/pkg/controllermanager/controller/project/project_control.go
@@ -20,7 +20,6 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencore "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
@@ -71,24 +70,22 @@ func (c *Controller) projectDelete(obj interface{}) {
 }
 
 // NewProjectReconciler creates a new instance of a reconciler which reconciles Projects.
-func NewProjectReconciler(l logrus.FieldLogger, config config.ControllerManagerControllerConfiguration, clientMap clientmap.ClientMap, k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory, recorder record.EventRecorder, namespaceLister kubecorev1listers.NamespaceLister) reconcile.Reconciler {
+func NewProjectReconciler(l logrus.FieldLogger, config *config.ProjectControllerConfiguration, clientMap clientmap.ClientMap, recorder record.EventRecorder, namespaceLister kubecorev1listers.NamespaceLister) reconcile.Reconciler {
 	return &projectReconciler{
-		logger:                 l,
-		config:                 config,
-		clientMap:              clientMap,
-		k8sGardenCoreInformers: k8sGardenCoreInformers,
-		recorder:               recorder,
-		namespaceLister:        namespaceLister,
+		logger:          l,
+		config:          config,
+		clientMap:       clientMap,
+		recorder:        recorder,
+		namespaceLister: namespaceLister,
 	}
 }
 
 type projectReconciler struct {
-	logger                 logrus.FieldLogger
-	config                 config.ControllerManagerControllerConfiguration
-	clientMap              clientmap.ClientMap
-	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory
-	recorder               record.EventRecorder
-	namespaceLister        kubecorev1listers.NamespaceLister
+	logger          logrus.FieldLogger
+	config          *config.ProjectControllerConfiguration
+	clientMap       clientmap.ClientMap
+	recorder        record.EventRecorder
+	namespaceLister kubecorev1listers.NamespaceLister
 }
 
 func (r *projectReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {

--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -221,12 +221,12 @@ func (r *projectReconciler) reconcileNamespaceForProject(ctx context.Context, ga
 }
 
 // quotaConfiguration returns the first matching quota configuration if one is configured for the given project.
-func quotaConfiguration(config config.ControllerManagerControllerConfiguration, project *gardencorev1beta1.Project) (*config.QuotaConfiguration, error) {
-	if config.Project == nil {
+func quotaConfiguration(config *config.ProjectControllerConfiguration, project *gardencorev1beta1.Project) (*config.QuotaConfiguration, error) {
+	if config == nil {
 		return nil, nil
 	}
 
-	for _, c := range config.Project.Quotas {
+	for _, c := range config.Quotas {
 		quotaConfig := c
 		selector, err := metav1.LabelSelectorAsSelector(quotaConfig.ProjectSelector)
 		if err != nil {

--- a/pkg/controllermanager/controller/project/project_control_reconcile_test.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile_test.go
@@ -54,7 +54,7 @@ var _ = Describe("ProjectControlReconcile", func() {
 	Describe("#quotaConfiguration", func() {
 		var (
 			project       *gardencorev1beta1.Project
-			conf          config.ControllerManagerControllerConfiguration
+			conf          *config.ProjectControllerConfiguration
 			fooSelector   *metav1.LabelSelector
 			resourceQuota *corev1.ResourceQuota
 		)
@@ -67,7 +67,6 @@ var _ = Describe("ProjectControlReconcile", func() {
 					UID:       "1",
 				},
 			}
-			conf = config.ControllerManagerControllerConfiguration{}
 			fooSelector, _ = metav1.ParseToLabelSelector("role = foo")
 			resourceQuota = &corev1.ResourceQuota{
 				Spec: corev1.ResourceQuotaSpec{
@@ -83,12 +82,12 @@ var _ = Describe("ProjectControlReconcile", func() {
 		})
 
 		It("should return no quota configuration because no quota config is specified", func() {
-			conf.Project = &config.ProjectControllerConfiguration{}
+			conf = &config.ProjectControllerConfiguration{}
 			Expect(quotaConfiguration(conf, project)).To(BeNil())
 		})
 
 		It("should return no quota configuration because label selector does not match project", func() {
-			conf.Project = &config.ProjectControllerConfiguration{
+			conf = &config.ProjectControllerConfiguration{
 				Quotas: []config.QuotaConfiguration{
 					{
 						ProjectSelector: fooSelector,
@@ -99,7 +98,7 @@ var _ = Describe("ProjectControlReconcile", func() {
 		})
 
 		It("should return no quota configuration because label selector is invalid", func() {
-			conf.Project = &config.ProjectControllerConfiguration{
+			conf = &config.ProjectControllerConfiguration{
 				Quotas: []config.QuotaConfiguration{
 					{
 						ProjectSelector: &metav1.LabelSelector{
@@ -116,7 +115,7 @@ var _ = Describe("ProjectControlReconcile", func() {
 		})
 
 		It("should return no quota configuration because label selector is nil", func() {
-			conf.Project = &config.ProjectControllerConfiguration{
+			conf = &config.ProjectControllerConfiguration{
 				Quotas: []config.QuotaConfiguration{
 					{
 						ProjectSelector: nil,
@@ -127,7 +126,7 @@ var _ = Describe("ProjectControlReconcile", func() {
 		})
 
 		It("should return the quota configuration because label selector matches project", func() {
-			conf.Project = &config.ProjectControllerConfiguration{
+			conf = &config.ProjectControllerConfiguration{
 				Quotas: []config.QuotaConfiguration{
 					{
 						Config:          nil,
@@ -139,13 +138,13 @@ var _ = Describe("ProjectControlReconcile", func() {
 					},
 				},
 			}
-			Expect(quotaConfiguration(conf, project)).To(Equal(&conf.Project.Quotas[1]))
+			Expect(quotaConfiguration(conf, project)).To(Equal(&conf.Quotas[1]))
 		})
 
 		It("should return the first matching quota configuration", func() {
 			additionalQuota := *resourceQuota
 			additionalQuota.Spec.Hard["count/bar"] = resource.MustParse("2")
-			conf.Project = &config.ProjectControllerConfiguration{
+			conf = &config.ProjectControllerConfiguration{
 				Quotas: []config.QuotaConfiguration{
 					{
 						Config:          nil,
@@ -161,7 +160,7 @@ var _ = Describe("ProjectControlReconcile", func() {
 					},
 				},
 			}
-			Expect(quotaConfiguration(conf, project)).To(Equal(&conf.Project.Quotas[1]))
+			Expect(quotaConfiguration(conf, project)).To(Equal(&conf.Quotas[1]))
 		})
 	})
 

--- a/pkg/controllermanager/controller/quota/quota.go
+++ b/pkg/controllermanager/controller/quota/quota.go
@@ -66,7 +66,7 @@ func NewQuotaController(clientMap clientmap.ClientMap, gardenCoreInformerFactory
 	quotaController := &Controller{
 		clientMap:           clientMap,
 		k8sGardenInformers:  gardenCoreInformerFactory,
-		reconciler:          NewQuotaReconciler(logger.Logger, clientMap, gardenCoreInformerFactory, recorder, secretBindingLister),
+		reconciler:          NewQuotaReconciler(logger.Logger, clientMap, recorder, secretBindingLister),
 		recorder:            recorder,
 		quotaLister:         quotaLister,
 		quotaQueue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Quota"),

--- a/pkg/controllermanager/controller/quota/quota.go
+++ b/pkg/controllermanager/controller/quota/quota.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // Controller controls Quotas.
@@ -37,8 +38,8 @@ type Controller struct {
 	clientMap          clientmap.ClientMap
 	k8sGardenInformers gardencoreinformers.SharedInformerFactory
 
-	control  ControlInterface
-	recorder record.EventRecorder
+	reconciler reconcile.Reconciler
+	recorder   record.EventRecorder
 
 	quotaLister gardencorelisters.QuotaLister
 	quotaQueue  workqueue.RateLimitingInterface
@@ -65,7 +66,7 @@ func NewQuotaController(clientMap clientmap.ClientMap, gardenCoreInformerFactory
 	quotaController := &Controller{
 		clientMap:           clientMap,
 		k8sGardenInformers:  gardenCoreInformerFactory,
-		control:             NewDefaultControl(clientMap, gardenCoreInformerFactory, recorder, secretBindingLister),
+		reconciler:          NewQuotaReconciler(logger.Logger, clientMap, gardenCoreInformerFactory, recorder, secretBindingLister),
 		recorder:            recorder,
 		quotaLister:         quotaLister,
 		quotaQueue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Quota"),
@@ -103,7 +104,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	logger.Logger.Info("Quota controller initialized.")
 
 	for i := 0; i < workers; i++ {
-		controllerutils.DeprecatedCreateWorker(ctx, c.quotaQueue, "Quota", c.reconcileQuotaKey, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.quotaQueue, "Quota", c.reconciler, &waitGroup, c.workerCh)
 	}
 
 	// Shutdown handling

--- a/pkg/controllermanager/controller/quota/quota_control.go
+++ b/pkg/controllermanager/controller/quota/quota_control.go
@@ -21,7 +21,6 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
@@ -60,22 +59,20 @@ func (c *Controller) quotaDelete(obj interface{}) {
 }
 
 // NewQuotaReconciler creates a new instance of a reconciler which reconciles Quotas.
-func NewQuotaReconciler(l logrus.FieldLogger, clientMap clientmap.ClientMap, k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory, recorder record.EventRecorder, secretBindingLister gardencorelisters.SecretBindingLister) reconcile.Reconciler {
+func NewQuotaReconciler(l logrus.FieldLogger, clientMap clientmap.ClientMap, recorder record.EventRecorder, secretBindingLister gardencorelisters.SecretBindingLister) reconcile.Reconciler {
 	return &quotaReconciler{
-		logger:                 l,
-		clientMap:              clientMap,
-		k8sGardenCoreInformers: k8sGardenCoreInformers,
-		recorder:               recorder,
-		secretBindingLister:    secretBindingLister,
+		logger:              l,
+		clientMap:           clientMap,
+		recorder:            recorder,
+		secretBindingLister: secretBindingLister,
 	}
 }
 
 type quotaReconciler struct {
-	logger                 logrus.FieldLogger
-	clientMap              clientmap.ClientMap
-	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory
-	recorder               record.EventRecorder
-	secretBindingLister    gardencorelisters.SecretBindingLister
+	logger              logrus.FieldLogger
+	clientMap           clientmap.ClientMap
+	recorder            record.EventRecorder
+	secretBindingLister gardencorelisters.SecretBindingLister
 }
 
 func (r *quotaReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {

--- a/pkg/controllermanager/controller/quota/quota_control.go
+++ b/pkg/controllermanager/controller/quota/quota_control.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -29,11 +28,13 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/logger"
 
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func (c *Controller) quotaAdd(obj interface{}) {
@@ -58,81 +59,55 @@ func (c *Controller) quotaDelete(obj interface{}) {
 	c.quotaQueue.Add(key)
 }
 
-func (c *Controller) reconcileQuotaKey(key string) error {
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		return err
+// NewQuotaReconciler creates a new instance of a reconciler which reconciles Quotas.
+func NewQuotaReconciler(l logrus.FieldLogger, clientMap clientmap.ClientMap, k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory, recorder record.EventRecorder, secretBindingLister gardencorelisters.SecretBindingLister) reconcile.Reconciler {
+	return &quotaReconciler{
+		logger:                 l,
+		clientMap:              clientMap,
+		k8sGardenCoreInformers: k8sGardenCoreInformers,
+		recorder:               recorder,
+		secretBindingLister:    secretBindingLister,
 	}
-
-	quota, err := c.quotaLister.Quotas(namespace).Get(name)
-	if apierrors.IsNotFound(err) {
-		logger.Logger.Debugf("[QUOTA RECONCILE] %s - skipping because Quota has been deleted", key)
-		return nil
-	}
-	if err != nil {
-		logger.Logger.Infof("[QUOTA RECONCILE] %s - unable to retrieve object from store: %v", key, err)
-		return err
-	}
-
-	if err := c.control.ReconcileQuota(quota); err != nil {
-		c.quotaQueue.AddAfter(key, time.Minute)
-	}
-	return nil
 }
 
-// ControlInterface implements the control logic for updating Quotas. It is implemented as an interface to allow
-// for extensions that provide different semantics. Currently, there is only one implementation.
-type ControlInterface interface {
-	// ReconcileQuota implements the control logic for Quota creation, update, and deletion.
-	// If an implementation returns a non-nil error, the invocation will be retried using a rate-limited strategy.
-	// Implementors should sink any errors that they do not wish to trigger a retry, and they may feel free to
-	// exit exceptionally at any point provided they wish the update to be re-run at a later point in time.
-	ReconcileQuota(quota *gardencorev1beta1.Quota) error
-}
-
-// NewDefaultControl returns a new instance of the default implementation ControlInterface that
-// implements the documented semantics for Quotas. You should use an instance returned from NewDefaultControl()
-// for any scenario other than testing.
-func NewDefaultControl(clientMap clientmap.ClientMap, k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory, recorder record.EventRecorder, secretBindingLister gardencorelisters.SecretBindingLister) ControlInterface {
-	return &defaultControl{clientMap, k8sGardenCoreInformers, recorder, secretBindingLister}
-}
-
-type defaultControl struct {
+type quotaReconciler struct {
+	logger                 logrus.FieldLogger
 	clientMap              clientmap.ClientMap
 	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory
 	recorder               record.EventRecorder
 	secretBindingLister    gardencorelisters.SecretBindingLister
 }
 
-func (c *defaultControl) ReconcileQuota(obj *gardencorev1beta1.Quota) error {
-	_, err := cache.MetaNamespaceKeyFunc(obj)
+func (r *quotaReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	gardenClient, err := r.clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
-		return err
+		return reconcile.Result{}, fmt.Errorf("failed to get garden client: %w", err)
 	}
 
-	var (
-		ctx         = context.TODO()
-		quota       = obj.DeepCopy()
-		quotaLogger = logger.NewFieldLogger(logger.Logger, "quota", fmt.Sprintf("%s/%s", quota.Namespace, quota.Name))
-	)
-
-	gardenClient, err := c.clientMap.GetClient(ctx, keys.ForGarden())
-	if err != nil {
-		return fmt.Errorf("failed to get garden client: %w", err)
+	quota := &gardencorev1beta1.Quota{}
+	if err := gardenClient.Client().Get(ctx, request.NamespacedName, quota); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.logger.Infof("Object %q is gone, stop reconciling: %v", request.Name, err)
+			return reconcile.Result{}, nil
+		}
+		r.logger.Infof("Unable to retrieve object %q from store: %v", request.Name, err)
+		return reconcile.Result{}, err
 	}
+
+	quotaLogger := logger.NewFieldLogger(r.logger, "quota", fmt.Sprintf("%s/%s", quota.Namespace, quota.Name))
 
 	// The deletionTimestamp labels a Quota as intended to get deleted. Before deletion,
 	// it has to be ensured that no SecretBindings are depending on the Quota anymore.
 	// When this happens the controller will remove the finalizers from the Quota so that it can be garbage collected.
 	if quota.DeletionTimestamp != nil {
 		if !sets.NewString(quota.Finalizers...).Has(gardencorev1beta1.GardenerName) {
-			return nil
+			return reconcile.Result{}, nil
 		}
 
-		associatedSecretBindings, err := controllerutils.DetermineSecretBindingAssociations(quota, c.secretBindingLister)
+		associatedSecretBindings, err := controllerutils.DetermineSecretBindingAssociations(quota, r.secretBindingLister)
 		if err != nil {
 			quotaLogger.Error(err.Error())
-			return err
+			return reconcile.Result{}, err
 		}
 
 		if len(associatedSecretBindings) == 0 {
@@ -140,23 +115,23 @@ func (c *defaultControl) ReconcileQuota(obj *gardencorev1beta1.Quota) error {
 
 			// Remove finalizer from Quota
 			if err := controllerutils.PatchRemoveFinalizers(ctx, gardenClient.Client(), quota, gardencorev1beta1.GardenerName); err != nil {
-				return fmt.Errorf("failed removing finalizer from quota: %w", err)
+				return reconcile.Result{}, fmt.Errorf("failed removing finalizer from quota: %w", err)
 			}
 
-			return nil
+			return reconcile.Result{}, nil
 		}
 
 		message := fmt.Sprintf("Can't delete Quota, because the following SecretBindings are still referencing it: %v", associatedSecretBindings)
 		quotaLogger.Info(message)
-		c.recorder.Event(quota, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, message)
+		r.recorder.Event(quota, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, message)
 
-		return errors.New("quota still has references")
+		return reconcile.Result{}, errors.New("quota still has references")
 	}
 
 	if err := controllerutils.PatchAddFinalizers(ctx, gardenClient.Client(), quota, gardencorev1beta1.GardenerName); err != nil {
 		quotaLogger.Errorf("Could not add finalizer to Quota: %s", err.Error())
-		return err
+		return reconcile.Result{}, err
 	}
 
-	return nil
+	return reconcile.Result{}, nil
 }

--- a/pkg/controllermanager/controller/secretbinding/secretbinding.go
+++ b/pkg/controllermanager/controller/secretbinding/secretbinding.go
@@ -69,7 +69,7 @@ func NewSecretBindingController(clientMap clientmap.ClientMap, gardenInformerFac
 	secretBindingController := &Controller{
 		clientMap:              clientMap,
 		k8sGardenCoreInformers: gardenInformerFactory,
-		reconciler:             NewSecretBindingReconciler(logger.Logger, clientMap, gardenInformerFactory, recorder, secretBindingLister, secretLister, shootLister),
+		reconciler:             NewSecretBindingReconciler(logger.Logger, clientMap, recorder, secretBindingLister, secretLister, shootLister),
 		recorder:               recorder,
 		secretBindingLister:    secretBindingLister,
 		secretBindingQueue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "SecretBinding"),

--- a/pkg/controllermanager/controller/secretbinding/secretbinding_control.go
+++ b/pkg/controllermanager/controller/secretbinding/secretbinding_control.go
@@ -21,7 +21,6 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
@@ -65,31 +64,28 @@ func (c *Controller) secretBindingDelete(obj interface{}) {
 func NewSecretBindingReconciler(
 	l logrus.FieldLogger,
 	clientMap clientmap.ClientMap,
-	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory,
 	recorder record.EventRecorder,
 	secretBindingLister gardencorelisters.SecretBindingLister,
 	secretLister kubecorev1listers.SecretLister,
 	shootLister gardencorelisters.ShootLister,
 ) reconcile.Reconciler {
 	return &secretBindingReconciler{
-		logger:                 l,
-		clientMap:              clientMap,
-		k8sGardenCoreInformers: k8sGardenCoreInformers,
-		recorder:               recorder,
-		secretBindingLister:    secretBindingLister,
-		secretLister:           secretLister,
-		shootLister:            shootLister,
+		logger:              l,
+		clientMap:           clientMap,
+		recorder:            recorder,
+		secretBindingLister: secretBindingLister,
+		secretLister:        secretLister,
+		shootLister:         shootLister,
 	}
 }
 
 type secretBindingReconciler struct {
-	logger                 logrus.FieldLogger
-	clientMap              clientmap.ClientMap
-	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory
-	recorder               record.EventRecorder
-	secretBindingLister    gardencorelisters.SecretBindingLister
-	secretLister           kubecorev1listers.SecretLister
-	shootLister            gardencorelisters.ShootLister
+	logger              logrus.FieldLogger
+	clientMap           clientmap.ClientMap
+	recorder            record.EventRecorder
+	secretBindingLister gardencorelisters.SecretBindingLister
+	secretLister        kubecorev1listers.SecretLister
+	shootLister         gardencorelisters.ShootLister
 }
 
 func (r *secretBindingReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {

--- a/pkg/controllermanager/controller/secretbinding/secretbinding_control.go
+++ b/pkg/controllermanager/controller/secretbinding/secretbinding_control.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -28,14 +27,16 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/logger"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	kubecorev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func (c *Controller) secretBindingAdd(obj interface{}) {
@@ -60,46 +61,29 @@ func (c *Controller) secretBindingDelete(obj interface{}) {
 	c.secretBindingQueue.Add(key)
 }
 
-func (c *Controller) reconcileSecretBindingKey(key string) error {
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		return err
+// NewSecretBindingReconciler creates a new instance of a reconciler which reconciles SecretBindings.
+func NewSecretBindingReconciler(
+	l logrus.FieldLogger,
+	clientMap clientmap.ClientMap,
+	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory,
+	recorder record.EventRecorder,
+	secretBindingLister gardencorelisters.SecretBindingLister,
+	secretLister kubecorev1listers.SecretLister,
+	shootLister gardencorelisters.ShootLister,
+) reconcile.Reconciler {
+	return &secretBindingReconciler{
+		logger:                 l,
+		clientMap:              clientMap,
+		k8sGardenCoreInformers: k8sGardenCoreInformers,
+		recorder:               recorder,
+		secretBindingLister:    secretBindingLister,
+		secretLister:           secretLister,
+		shootLister:            shootLister,
 	}
-
-	secretBinding, err := c.secretBindingLister.SecretBindings(namespace).Get(name)
-	if apierrors.IsNotFound(err) {
-		logger.Logger.Debugf("[SECRETBINDING RECONCILE] %s - skipping because SecretBinding has been deleted", key)
-		return nil
-	}
-	if err != nil {
-		logger.Logger.Infof("[SECRETBINDING RECONCILE] %s - unable to retrieve object from store: %v", key, err)
-		return err
-	}
-
-	if err := c.control.ReconcileSecretBinding(secretBinding, key); err != nil {
-		c.secretBindingQueue.AddAfter(key, time.Minute)
-	}
-	return nil
 }
 
-// ControlInterface implements the control logic for updating SecretBindings. It is implemented as an interface to allow
-// for extensions that provide different semantics. Currently, there is only one implementation.
-type ControlInterface interface {
-	// ReconcileSecretBinding implements the control logic for SecretBinding creation, update, and deletion.
-	// If an implementation returns a non-nil error, the invocation will be retried using a rate-limited strategy.
-	// Implementors should sink any errors that they do not wish to trigger a retry, and they may feel free to
-	// exit exceptionally at any point provided they wish the update to be re-run at a later point in time.
-	ReconcileSecretBinding(secretBinding *gardencorev1beta1.SecretBinding, key string) error
-}
-
-// NewDefaultControl returns a new instance of the default implementation ControlInterface that
-// implements the documented semantics for SecretBindings. You should use an instance returned from NewDefaultControl()
-// for any scenario other than testing.
-func NewDefaultControl(clientMap clientmap.ClientMap, k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory, recorder record.EventRecorder, secretBindingLister gardencorelisters.SecretBindingLister, secretLister kubecorev1listers.SecretLister, shootLister gardencorelisters.ShootLister) ControlInterface {
-	return &defaultControl{clientMap, k8sGardenCoreInformers, recorder, secretBindingLister, secretLister, shootLister}
-}
-
-type defaultControl struct {
+type secretBindingReconciler struct {
+	logger                 logrus.FieldLogger
 	clientMap              clientmap.ClientMap
 	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory
 	recorder               record.EventRecorder
@@ -108,99 +92,100 @@ type defaultControl struct {
 	shootLister            gardencorelisters.ShootLister
 }
 
-func (c *defaultControl) ReconcileSecretBinding(obj *gardencorev1beta1.SecretBinding, key string) error {
-	_, err := cache.MetaNamespaceKeyFunc(obj)
+func (r *secretBindingReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	gardenClient, err := r.clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
-		return err
+		return reconcile.Result{}, fmt.Errorf("failed to get garden client: %w", err)
 	}
 
-	var (
-		secretBinding       = obj.DeepCopy()
-		secretBindingLogger = logger.NewFieldLogger(logger.Logger, "secretbinding", fmt.Sprintf("%s/%s", secretBinding.Namespace, secretBinding.Name))
-		ctx                 = context.TODO()
-	)
-
-	gardenClient, err := c.clientMap.GetClient(ctx, keys.ForGarden())
-	if err != nil {
-		return fmt.Errorf("failed to get garden client: %w", err)
+	secretBinding := &gardencorev1beta1.SecretBinding{}
+	if err := gardenClient.Client().Get(ctx, request.NamespacedName, secretBinding); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.logger.Infof("Object %q is gone, stop reconciling: %v", request.Name, err)
+			return reconcile.Result{}, nil
+		}
+		r.logger.Infof("Unable to retrieve object %q from store: %v", request.Name, err)
+		return reconcile.Result{}, err
 	}
+
+	secretBindingLogger := logger.NewFieldLogger(r.logger, "secretbinding", fmt.Sprintf("%s/%s", secretBinding.Namespace, secretBinding.Name))
 
 	// The deletionTimestamp labels a SecretBinding as intended to get deleted. Before deletion,
 	// it has to be ensured that no Shoots are depending on the SecretBinding anymore.
 	// When this happens the controller will remove the finalizers from the SecretBinding so that it can be garbage collected.
 	if secretBinding.DeletionTimestamp != nil {
 		if !controllerutil.ContainsFinalizer(secretBinding, gardencorev1beta1.GardenerName) {
-			return nil
+			return reconcile.Result{}, nil
 		}
 
-		associatedShoots, err := controllerutils.DetermineShootsAssociatedTo(secretBinding, c.shootLister)
+		associatedShoots, err := controllerutils.DetermineShootsAssociatedTo(secretBinding, r.shootLister)
 		if err != nil {
 			secretBindingLogger.Error(err.Error())
-			return err
+			return reconcile.Result{}, err
 		}
 
 		if len(associatedShoots) == 0 {
 			secretBindingLogger.Info("No Shoots are referencing the SecretBinding. Deletion accepted.")
 
-			mayReleaseSecret, err := c.mayReleaseSecret(secretBinding.Namespace, secretBinding.Name, secretBinding.SecretRef.Namespace, secretBinding.SecretRef.Name)
+			mayReleaseSecret, err := r.mayReleaseSecret(secretBinding.Namespace, secretBinding.Name, secretBinding.SecretRef.Namespace, secretBinding.SecretRef.Name)
 			if err != nil {
 				secretBindingLogger.Error(err.Error())
-				return err
+				return reconcile.Result{}, err
 			}
 
 			if mayReleaseSecret {
 				// Remove finalizer from referenced secret
-				secret, err := c.secretLister.Secrets(secretBinding.SecretRef.Namespace).Get(secretBinding.SecretRef.Name)
+				secret, err := r.secretLister.Secrets(secretBinding.SecretRef.Namespace).Get(secretBinding.SecretRef.Name)
 				if err == nil {
 					if err2 := controllerutils.PatchRemoveFinalizers(ctx, gardenClient.Client(), secret.DeepCopy(), gardencorev1beta1.ExternalGardenerName); err2 != nil {
 						secretBindingLogger.Error(err2.Error())
-						return err2
+						return reconcile.Result{}, err2
 					}
 				} else if !apierrors.IsNotFound(err) {
-					return err
+					return reconcile.Result{}, err
 				}
 			}
 
 			// Remove finalizer from SecretBinding
 			if err := controllerutils.PatchRemoveFinalizers(ctx, gardenClient.Client(), secretBinding, gardencorev1beta1.GardenerName); err != nil {
 				secretBindingLogger.Error(err.Error())
-				return err
+				return reconcile.Result{}, err
 			}
 
-			return nil
+			return reconcile.Result{}, nil
 		}
 
 		message := fmt.Sprintf("Can't delete SecretBinding, because the following Shoots are still referencing it: %v", associatedShoots)
 		secretBindingLogger.Infof(message)
-		c.recorder.Event(secretBinding, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, message)
+		r.recorder.Event(secretBinding, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, message)
 
-		return errors.New("SecretBinding still has references")
+		return reconcile.Result{}, errors.New("SecretBinding still has references")
 	}
 
 	if err := controllerutils.PatchAddFinalizers(ctx, gardenClient.Client(), secretBinding, gardencorev1beta1.GardenerName); err != nil {
 		secretBindingLogger.Errorf("Could not add finalizer to SecretBinding: %s", err.Error())
-		return err
+		return reconcile.Result{}, err
 	}
 
 	// Add the Gardener finalizer to the referenced SecretBinding secret to protect it from deletion as long as
 	// the SecretBinding resource does exist.
-	secret, err := c.secretLister.Secrets(secretBinding.SecretRef.Namespace).Get(secretBinding.SecretRef.Name)
+	secret, err := r.secretLister.Secrets(secretBinding.SecretRef.Namespace).Get(secretBinding.SecretRef.Name)
 	if err != nil {
 		secretBindingLogger.Error(err.Error())
-		return err
+		return reconcile.Result{}, err
 	}
 
 	if err := controllerutils.PatchAddFinalizers(ctx, gardenClient.Client(), secret.DeepCopy(), gardencorev1beta1.ExternalGardenerName); err != nil {
 		secretBindingLogger.Errorf("Could not add finalizer to Secret referenced in SecretBinding: %s", err.Error())
-		return err
+		return reconcile.Result{}, err
 	}
 
-	return nil
+	return reconcile.Result{}, nil
 }
 
 // We may only release a secret if there is no other secretbinding that references it (maybe in a different namespace).
-func (c *defaultControl) mayReleaseSecret(secretBindingNamespace, secretBindingName, secretNamespace, secretName string) (bool, error) {
-	secretBindingList, err := c.secretBindingLister.List(labels.Everything())
+func (r *secretBindingReconciler) mayReleaseSecret(secretBindingNamespace, secretBindingName, secretNamespace, secretName string) (bool, error) {
+	secretBindingList, err := r.secretBindingLister.List(labels.Everything())
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controllermanager/controller/secretbinding/secretbinding_control_test.go
+++ b/pkg/controllermanager/controller/secretbinding/secretbinding_control_test.go
@@ -32,7 +32,7 @@ var _ = Describe("SecretBindingControl", func() {
 	Describe("#mayReleaseSecret", func() {
 		var (
 			gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory
-			c                         *defaultControl
+			reconciler                *secretBindingReconciler
 
 			secretBinding1Namespace = "foo"
 			secretBinding1Name      = "bar"
@@ -48,11 +48,11 @@ var _ = Describe("SecretBindingControl", func() {
 			secretBindingInformer := gardenCoreInformerFactory.Core().V1beta1().SecretBindings()
 			secretBindingLister := secretBindingInformer.Lister()
 
-			c = &defaultControl{secretBindingLister: secretBindingLister}
+			reconciler = &secretBindingReconciler{secretBindingLister: secretBindingLister}
 		})
 
 		It("should return true as no other secretbinding exists", func() {
-			allowed, err := c.mayReleaseSecret(secretBinding1Namespace, secretBinding1Name, secretNamespace, secretName)
+			allowed, err := reconciler.mayReleaseSecret(secretBinding1Namespace, secretBinding1Name, secretNamespace, secretName)
 
 			Expect(allowed).To(BeTrue())
 			Expect(err).NotTo(HaveOccurred())
@@ -72,7 +72,7 @@ var _ = Describe("SecretBindingControl", func() {
 
 			Expect(gardenCoreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(secretBinding)).To(Succeed())
 
-			allowed, err := c.mayReleaseSecret(secretBinding1Namespace, secretBinding1Name, secretNamespace, secretName)
+			allowed, err := reconciler.mayReleaseSecret(secretBinding1Namespace, secretBinding1Name, secretNamespace, secretName)
 
 			Expect(allowed).To(BeTrue())
 			Expect(err).NotTo(HaveOccurred())
@@ -92,18 +92,18 @@ var _ = Describe("SecretBindingControl", func() {
 
 			Expect(gardenCoreInformerFactory.Core().V1beta1().SecretBindings().Informer().GetStore().Add(secretBinding)).To(Succeed())
 
-			allowed, err := c.mayReleaseSecret(secretBinding1Namespace, secretBinding1Name, secretNamespace, secretName)
+			allowed, err := reconciler.mayReleaseSecret(secretBinding1Namespace, secretBinding1Name, secretNamespace, secretName)
 
 			Expect(allowed).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should return an error as the list failed", func() {
-			c.secretBindingLister = &fakeLister{
-				SecretBindingLister: c.secretBindingLister,
+			reconciler.secretBindingLister = &fakeLister{
+				SecretBindingLister: reconciler.secretBindingLister,
 			}
 
-			allowed, err := c.mayReleaseSecret(secretBinding1Namespace, secretBinding1Name, secretNamespace, secretName)
+			allowed, err := reconciler.mayReleaseSecret(secretBinding1Namespace, secretBinding1Name, secretNamespace, secretName)
 
 			Expect(allowed).To(BeFalse())
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup
/priority normal

**What this PR does / why we need it**:
Similar to #3658, this PR continues with migration a couple of our controllers from `controllerutils.DeprecatedCreateWorker` (deprecated since #1094) to `controllerutils.CreateWorker`. This helps to get rid of some remaining usages of `context.TODO()`.

**Which issue(s) this PR fixes**:
Part of #1648 

**Special notes for your reviewer**:
ℹ️ Once this PR is merged, I'll follow-up with more PRs that also cover the remaining/not-yet migrated controllers.
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
