### PR TITLE
Condense code after recent refactorings

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -132,8 +132,8 @@ func (c *Controller) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			return nil
 		}),
 		errors.ToExecute("Retrieve the infrastructure resource", func() error {
-			obj := &extensionsv1alpha1.Infrastructure{}
-			if err := botanist.K8sSeedClient.DirectClient().Get(ctx, kutil.Key(o.Shoot.SeedNamespace, o.Shoot.Info.Name), obj); err != nil {
+			obj, err := botanist.Shoot.Components.Extensions.Infrastructure.Get(ctx)
+			if err != nil {
 				if apierrors.IsNotFound(err) {
 					return nil
 				}
@@ -622,12 +622,6 @@ func needsControlPlaneDeployment(ctx context.Context, o *operation.Operation, ku
 	// The infrastructure resource has not been found, no need to redeploy the control plane
 	if infrastructure == nil {
 		return false, nil
-	}
-
-	if providerStatus := infrastructure.Status.ProviderStatus; providerStatus != nil {
-		// The infrastructure resource has been found with a non-nil provider status, so redeploy the control plane
-		o.Shoot.InfrastructureStatus = providerStatus.Raw
-		return true, nil
 	}
 
 	// The infrastructure resource has been found, but its provider status is nil

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -13869,7 +13869,6 @@ func schema_pkg_apis_seedmanagement_v1alpha1_ManagedSeedSpec(ref common.Referenc
 					"shoot": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Shoot references a Shoot that should be registered as Seed.",
-							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1.Shoot"),
 						},
 					},

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -314,7 +314,7 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 		shootInfo["domain"] = *domain
 	}
 	var extensions []string
-	for extensionType := range b.Shoot.Extensions {
+	for extensionType := range b.Shoot.Components.Extensions.Extension.Extensions() {
 		extensions = append(extensions, extensionType)
 	}
 	shootInfo["extensions"] = strings.Join(extensions, ",")

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -39,8 +39,6 @@ import (
 const (
 	// DefaultInterval is the default interval for retry operations.
 	DefaultInterval = 5 * time.Second
-	// DefaultSevereThreshold  is the default threshold until an error reported by another component is treated as 'severe'.
-	DefaultSevereThreshold = 30 * time.Second
 )
 
 // New takes an operation object <o> and creates a new Botanist object. It checks whether the given Shoot DNS

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -87,7 +87,10 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	if err != nil {
 		return nil, err
 	}
-	o.Shoot.Components.Extensions.Extension = b.DefaultExtension(b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.Extension, err = b.DefaultExtension(ctx, b.K8sSeedClient.DirectClient())
+	if err != nil {
+		return nil, err
+	}
 	o.Shoot.Components.Extensions.Infrastructure = b.DefaultInfrastructure(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.Network = b.DefaultNetwork(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.OperatingSystemConfig, err = b.DefaultOperatingSystemConfig(b.K8sSeedClient.DirectClient())

--- a/pkg/operation/botanist/component/extensions/extension/mock/mocks.go
+++ b/pkg/operation/botanist/component/extensions/extension/mock/mocks.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	v1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	extension "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/extension"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -75,6 +76,20 @@ func (m *MockInterface) Destroy(arg0 context.Context) error {
 func (mr *MockInterfaceMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockInterface)(nil).Destroy), arg0)
+}
+
+// Extensions mocks base method.
+func (m *MockInterface) Extensions() map[string]extension.Extension {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Extensions")
+	ret0, _ := ret[0].(map[string]extension.Extension)
+	return ret0
+}
+
+// Extensions indicates an expected call of Extensions.
+func (mr *MockInterfaceMockRecorder) Extensions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Extensions", reflect.TypeOf((*MockInterface)(nil).Extensions))
 }
 
 // Migrate mocks base method.

--- a/pkg/operation/botanist/component/extensions/infrastructure/mock/mocks.go
+++ b/pkg/operation/botanist/component/extensions/infrastructure/mock/mocks.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	v1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	v1alpha10 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gomock "github.com/golang/mock/gomock"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -62,6 +63,21 @@ func (m *MockInterface) Destroy(arg0 context.Context) error {
 func (mr *MockInterfaceMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockInterface)(nil).Destroy), arg0)
+}
+
+// Get mocks base method.
+func (m *MockInterface) Get(arg0 context.Context) (*v1alpha10.Infrastructure, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", arg0)
+	ret0, _ := ret[0].(*v1alpha10.Infrastructure)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockInterfaceMockRecorder) Get(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockInterface)(nil).Get), arg0)
 }
 
 // Migrate mocks base method.

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -367,9 +367,7 @@ func (b *Botanist) DefaultControlPlane(seedClient client.Client, purpose extensi
 
 // DeployControlPlane deploys or restores the ControlPlane custom resource (purpose normal).
 func (b *Botanist) DeployControlPlane(ctx context.Context) error {
-	b.Shoot.Components.Extensions.ControlPlane.SetInfrastructureProviderStatus(&runtime.RawExtension{
-		Raw: b.Shoot.InfrastructureStatus,
-	})
+	b.Shoot.Components.Extensions.ControlPlane.SetInfrastructureProviderStatus(b.Shoot.Components.Extensions.Infrastructure.ProviderStatus())
 	return b.deployOrRestoreControlPlane(ctx, b.Shoot.Components.Extensions.ControlPlane)
 }
 

--- a/pkg/operation/botanist/extension.go
+++ b/pkg/operation/botanist/extension.go
@@ -16,25 +16,40 @@ package botanist
 
 import (
 	"context"
+	"fmt"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/extension"
+	"github.com/gardener/gardener/pkg/utils"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DefaultExtension creates the default deployer for the Extension custom resources.
-func (b *Botanist) DefaultExtension(seedClient client.Client) extension.Interface {
+func (b *Botanist) DefaultExtension(ctx context.Context, seedClient client.Client) (extension.Interface, error) {
+	controllerRegistrations := &gardencorev1beta1.ControllerRegistrationList{}
+	if err := b.K8sGardenClient.Client().List(ctx, controllerRegistrations); err != nil {
+		return nil, err
+	}
+
+	extensions, err := mergeExtensions(controllerRegistrations.Items, b.Shoot.Info.Spec.Extensions, b.Shoot.SeedNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("cannot calculate required extensions for shoot %s: %v", b.Shoot.Info.Name, err)
+	}
+
 	return extension.New(
 		b.Logger,
 		seedClient,
 		&extension.Values{
 			Namespace:  b.Shoot.SeedNamespace,
-			Extensions: b.Shoot.Extensions,
+			Extensions: extensions,
 		},
 		extension.DefaultInterval,
 		extension.DefaultSevereThreshold,
 		extension.DefaultTimeout,
-	)
+	), nil
 }
 
 // DeployExtensions deploys the Extension custom resources and triggers the restore operation in case
@@ -44,4 +59,60 @@ func (b *Botanist) DeployExtensions(ctx context.Context) error {
 		return b.Shoot.Components.Extensions.Extension.Restore(ctx, b.ShootState)
 	}
 	return b.Shoot.Components.Extensions.Extension.Deploy(ctx)
+}
+
+func mergeExtensions(registrations []gardencorev1beta1.ControllerRegistration, extensions []gardencorev1beta1.Extension, namespace string) (map[string]extension.Extension, error) {
+	var (
+		typeToExtension    = make(map[string]extension.Extension)
+		requiredExtensions = make(map[string]extension.Extension)
+	)
+
+	// Extensions enabled by default for all Shoot clusters.
+	for _, reg := range registrations {
+		for _, res := range reg.Spec.Resources {
+			if res.Kind != extensionsv1alpha1.ExtensionResource {
+				continue
+			}
+
+			timeout := extension.DefaultTimeout
+			if res.ReconcileTimeout != nil {
+				timeout = res.ReconcileTimeout.Duration
+			}
+
+			typeToExtension[res.Type] = extension.Extension{
+				Extension: extensionsv1alpha1.Extension{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      res.Type,
+						Namespace: namespace,
+					},
+					Spec: extensionsv1alpha1.ExtensionSpec{
+						DefaultSpec: extensionsv1alpha1.DefaultSpec{
+							Type: res.Type,
+						},
+					},
+				},
+				Timeout: timeout,
+			}
+
+			if res.GloballyEnabled != nil && *res.GloballyEnabled {
+				requiredExtensions[res.Type] = typeToExtension[res.Type]
+			}
+		}
+	}
+
+	// Extensions defined in Shoot resource.
+	for _, extension := range extensions {
+		if obj, ok := typeToExtension[extension.Type]; ok {
+			if utils.IsTrue(extension.Disabled) {
+				delete(requiredExtensions, extension.Type)
+				continue
+			}
+
+			obj.Spec.ProviderConfig = extension.ProviderConfig
+			requiredExtensions[extension.Type] = obj
+			continue
+		}
+	}
+
+	return requiredExtensions, nil
 }

--- a/pkg/operation/botanist/extension_test.go
+++ b/pkg/operation/botanist/extension_test.go
@@ -17,47 +17,265 @@ package botanist_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/botanist"
+	extensionpkg "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/extension"
 	mockextension "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/extension/mock"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	gomegatypes "github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Extensions", func() {
 	var (
-		ctrl      *gomock.Controller
-		extension *mockextension.MockInterface
-		botanist  *Botanist
+		ctrl                  *gomock.Controller
+		extension             *mockextension.MockInterface
+		gardenClientInterface *mockkubernetes.MockInterface
+		gardenClient          *mockclient.MockClient
+		botanist              *Botanist
 
 		ctx        = context.TODO()
 		fakeErr    = fmt.Errorf("fake")
 		shootState = &gardencorev1alpha1.ShootState{}
+		namespace  = "shoot--name--space"
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		extension = mockextension.NewMockInterface(ctrl)
+		gardenClientInterface = mockkubernetes.NewMockInterface(ctrl)
+		gardenClient = mockclient.NewMockClient(ctrl)
 		botanist = &Botanist{Operation: &operation.Operation{
+			K8sGardenClient: gardenClientInterface,
 			Shoot: &shootpkg.Shoot{
 				Components: &shootpkg.Components{
 					Extensions: &shootpkg.Extensions{
 						Extension: extension,
 					},
 				},
+				Info:          &gardencorev1beta1.Shoot{},
+				SeedNamespace: namespace,
 			},
 			ShootState: shootState,
 		}}
+
+		gardenClientInterface.EXPECT().Client().Return(gardenClient).AnyTimes()
 	})
 
 	AfterEach(func() {
 		ctrl.Finish()
+	})
+
+	Describe("#DefaultExtension", func() {
+		var (
+			extensionKind  = extensionsv1alpha1.ExtensionResource
+			providerConfig = runtime.RawExtension{
+				Raw: []byte("key: value"),
+			}
+
+			fooExtensionType         = "foo"
+			fooReconciliationTimeout = metav1.Duration{Duration: 5 * time.Minute}
+			fooRegistration          = gardencorev1beta1.ControllerRegistration{
+				Spec: gardencorev1beta1.ControllerRegistrationSpec{
+					Resources: []gardencorev1beta1.ControllerResource{
+						{
+							Kind:             extensionKind,
+							Type:             fooExtensionType,
+							ReconcileTimeout: &fooReconciliationTimeout,
+						},
+					},
+				},
+			}
+			fooExtension = gardencorev1beta1.Extension{
+				Type:           fooExtensionType,
+				ProviderConfig: &providerConfig,
+			}
+
+			barExtensionType = "bar"
+			barRegistration  = gardencorev1beta1.ControllerRegistration{
+				Spec: gardencorev1beta1.ControllerRegistrationSpec{
+					Resources: []gardencorev1beta1.ControllerResource{
+						{
+							Kind:            extensionKind,
+							Type:            barExtensionType,
+							GloballyEnabled: pointer.BoolPtr(true),
+						},
+					},
+				},
+			}
+			barExtension = gardencorev1beta1.Extension{
+				Type:           barExtensionType,
+				ProviderConfig: &providerConfig,
+			}
+			barExtensionDisabled = gardencorev1beta1.Extension{
+				Type:           barExtensionType,
+				ProviderConfig: &providerConfig,
+				Disabled:       pointer.BoolPtr(true),
+			}
+		)
+
+		It("should return the error because listing failed", func() {
+			gardenClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistrationList{})).Return(fakeErr)
+
+			ext, err := botanist.DefaultExtension(ctx, nil)
+			Expect(ext).To(BeNil())
+			Expect(err).To(MatchError(fakeErr))
+		})
+
+		DescribeTable("#DefaultExtension",
+			func(registrations []gardencorev1beta1.ControllerRegistration, extensions []gardencorev1beta1.Extension, conditionMatcher gomegatypes.GomegaMatcher) {
+				botanist.Shoot.Info.Spec.Extensions = extensions
+				gardenClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistrationList{})).DoAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+					(&gardencorev1beta1.ControllerRegistrationList{Items: registrations}).DeepCopyInto(list.(*gardencorev1beta1.ControllerRegistrationList))
+					return nil
+				})
+
+				ext, err := botanist.DefaultExtension(ctx, nil)
+				Expect(err).To(BeNil())
+				Expect(ext.Extensions()).To(conditionMatcher)
+			},
+
+			Entry(
+				"No extensions",
+				nil,
+				nil,
+				BeEmpty(),
+			),
+			Entry(
+				"Extension w/o registration",
+				nil,
+				[]gardencorev1beta1.Extension{{Type: fooExtensionType}},
+				BeEmpty(),
+			),
+			Entry(
+				"Extensions w/ registration",
+				[]gardencorev1beta1.ControllerRegistration{fooRegistration},
+				[]gardencorev1beta1.Extension{fooExtension},
+				HaveKeyWithValue(
+					Equal(fooExtensionType),
+					MatchAllFields(
+						Fields{
+							"Extension": MatchFields(IgnoreExtras, Fields{
+								"Spec": MatchFields(IgnoreExtras, Fields{
+									"DefaultSpec": MatchAllFields(Fields{
+										"Type":           Equal(fooExtensionType),
+										"ProviderConfig": PointTo(Equal(providerConfig)),
+									}),
+								}),
+							}),
+							"Timeout": Equal(fooReconciliationTimeout.Duration),
+						},
+					),
+				),
+			),
+			Entry(
+				"Registration w/o extension",
+				[]gardencorev1beta1.ControllerRegistration{fooRegistration},
+				nil,
+				BeEmpty(),
+			),
+			Entry(
+				"Globally enabled extension registration, w/o extension",
+				[]gardencorev1beta1.ControllerRegistration{barRegistration},
+				nil,
+				HaveKeyWithValue(
+					Equal(barExtensionType),
+					MatchAllFields(
+						Fields{
+							"Extension": MatchFields(IgnoreExtras, Fields{
+								"Spec": MatchAllFields(Fields{
+									"DefaultSpec": MatchAllFields(Fields{
+										"Type":           Equal(barExtensionType),
+										"ProviderConfig": BeNil(),
+									}),
+								}),
+							}),
+							"Timeout": Equal(extensionpkg.DefaultTimeout),
+						},
+					),
+				),
+			),
+			Entry(
+				"Globally enabled extension registration but explicitly disabled",
+				[]gardencorev1beta1.ControllerRegistration{barRegistration},
+				[]gardencorev1beta1.Extension{barExtensionDisabled},
+				BeEmpty(),
+			),
+			Entry(
+				"Multiple registration but a globally one is explicitly disabled",
+				[]gardencorev1beta1.ControllerRegistration{fooRegistration, barRegistration},
+				[]gardencorev1beta1.Extension{fooExtension, barExtensionDisabled},
+				SatisfyAll(
+					HaveLen(1),
+					HaveKeyWithValue(
+						Equal(fooExtensionType),
+						MatchAllFields(
+							Fields{
+								"Extension": MatchFields(IgnoreExtras, Fields{
+									"Spec": MatchFields(IgnoreExtras, Fields{
+										"DefaultSpec": MatchAllFields(Fields{
+											"Type":           Equal(fooExtensionType),
+											"ProviderConfig": PointTo(Equal(providerConfig)),
+										}),
+									}),
+								}),
+								"Timeout": Equal(fooReconciliationTimeout.Duration),
+							},
+						),
+					),
+				),
+			),
+			Entry(
+				"Multiple registrations, w/ one extension",
+				[]gardencorev1beta1.ControllerRegistration{
+					fooRegistration,
+					barRegistration,
+					{
+						Spec: gardencorev1beta1.ControllerRegistrationSpec{
+							Resources: []gardencorev1beta1.ControllerResource{
+								{
+									Kind: "kind",
+									Type: "type",
+								},
+							},
+						},
+					},
+				},
+				[]gardencorev1beta1.Extension{barExtension},
+				HaveKeyWithValue(
+					Equal(barExtensionType),
+					MatchAllFields(
+						Fields{
+							"Extension": MatchFields(IgnoreExtras, Fields{
+								"Spec": MatchAllFields(Fields{
+									"DefaultSpec": MatchAllFields(Fields{
+										"Type":           Equal(barExtensionType),
+										"ProviderConfig": PointTo(Equal(providerConfig)),
+									}),
+								}),
+							}),
+							"Timeout": Equal(extensionpkg.DefaultTimeout),
+						},
+					),
+				),
+			),
+		)
 	})
 
 	Describe("#DeployExtensions", func() {

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -64,10 +64,6 @@ func (b *Botanist) WaitForInfrastructure(ctx context.Context) error {
 		return err
 	}
 
-	if providerStatus := b.Shoot.Components.Extensions.Infrastructure.ProviderStatus(); providerStatus != nil {
-		b.Shoot.InfrastructureStatus = providerStatus.Raw
-	}
-
 	if nodesCIDR := b.Shoot.Components.Extensions.Infrastructure.NodesCIDR(); nodesCIDR != nil {
 		shootCopy := b.Shoot.Info.DeepCopy()
 		return b.UpdateShootAndCluster(ctx, shootCopy, func() error {

--- a/pkg/operation/botanist/infrastructure_test.go
+++ b/pkg/operation/botanist/infrastructure_test.go
@@ -33,7 +33,6 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 )
 
@@ -118,11 +117,10 @@ var _ = Describe("Infrastructure", func() {
 			kubernetesSeedInterface   *mockkubernetes.MockInterface
 			kubernetesSeedClient      *mockclient.MockClient
 
-			namespace      = "namespace"
-			name           = "name"
-			providerStatus = &runtime.RawExtension{Raw: []byte(`{"some": "status"}"`)}
-			nodesCIDR      = pointer.StringPtr("1.2.3.4/5")
-			shoot          = &gardencorev1beta1.Shoot{
+			namespace = "namespace"
+			name      = "name"
+			nodesCIDR = pointer.StringPtr("1.2.3.4/5")
+			shoot     = &gardencorev1beta1.Shoot{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: namespace,
@@ -143,7 +141,6 @@ var _ = Describe("Infrastructure", func() {
 
 		It("should successfully wait (w/ provider status, w/ nodes cidr)", func() {
 			infrastructure.EXPECT().Wait(ctx)
-			infrastructure.EXPECT().ProviderStatus().Return(providerStatus)
 			infrastructure.EXPECT().NodesCIDR().Return(nodesCIDR)
 
 			kubernetesGardenInterface.EXPECT().DirectClient().Return(kubernetesGardenClient)
@@ -155,17 +152,14 @@ var _ = Describe("Infrastructure", func() {
 			kubernetesSeedInterface.EXPECT().Client().Return(kubernetesSeedClient)
 
 			Expect(botanist.WaitForInfrastructure(ctx)).To(Succeed())
-			Expect(botanist.Shoot.InfrastructureStatus).To(Equal(providerStatus.Raw))
 			Expect(botanist.Shoot.Info).To(Equal(updatedShoot))
 		})
 
 		It("should successfully wait (w/o provider status, w/o nodes cidr)", func() {
 			infrastructure.EXPECT().Wait(ctx)
-			infrastructure.EXPECT().ProviderStatus()
 			infrastructure.EXPECT().NodesCIDR()
 
 			Expect(botanist.WaitForInfrastructure(ctx)).To(Succeed())
-			Expect(botanist.Shoot.InfrastructureStatus).To(BeNil())
 			Expect(botanist.Shoot.Info).To(Equal(shoot))
 		})
 
@@ -173,13 +167,11 @@ var _ = Describe("Infrastructure", func() {
 			infrastructure.EXPECT().Wait(ctx).Return(fakeErr)
 
 			Expect(botanist.WaitForInfrastructure(ctx)).To(MatchError(fakeErr))
-			Expect(botanist.Shoot.InfrastructureStatus).To(BeNil())
 			Expect(botanist.Shoot.Info).To(Equal(shoot))
 		})
 
 		It("should return the error during nodes cidr update", func() {
 			infrastructure.EXPECT().Wait(ctx)
-			infrastructure.EXPECT().ProviderStatus()
 			infrastructure.EXPECT().NodesCIDR().Return(nodesCIDR)
 
 			kubernetesGardenInterface.EXPECT().DirectClient().Return(kubernetesGardenClient)
@@ -189,7 +181,6 @@ var _ = Describe("Infrastructure", func() {
 			kubernetesGardenClient.EXPECT().Update(ctx, updatedShoot).Return(fakeErr)
 
 			Expect(botanist.WaitForInfrastructure(ctx)).To(MatchError(fakeErr))
-			Expect(botanist.Shoot.InfrastructureStatus).To(BeNil())
 			Expect(botanist.Shoot.Info).To(Equal(shoot))
 		})
 	})

--- a/pkg/operation/botanist/resources.go
+++ b/pkg/operation/botanist/resources.go
@@ -35,14 +35,14 @@ const (
 func (b *Botanist) DeployReferencedResources(ctx context.Context) error {
 	// Read referenced objects into a slice of unstructured objects
 	var unstructuredObjs []*unstructured.Unstructured
-	for _, resourceRef := range b.Shoot.ResourceRefs {
+	for _, resource := range b.Shoot.Info.Spec.Resources {
 		// Read the resource from the Garden cluster
-		obj, err := utils.GetObjectByRef(ctx, b.K8sGardenClient.Client(), &resourceRef, b.Shoot.Info.Namespace)
+		obj, err := utils.GetObjectByRef(ctx, b.K8sGardenClient.Client(), &resource.ResourceRef, b.Shoot.Info.Namespace)
 		if err != nil {
 			return err
 		}
 		if obj == nil {
-			return fmt.Errorf("object not found %v", resourceRef)
+			return fmt.Errorf("object not found %v", resource.ResourceRef)
 		}
 
 		// Create an unstructured object and append it to the slice

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -30,7 +30,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -57,7 +56,7 @@ func (b *Botanist) DefaultWorker(seedClient client.Client) worker.Interface {
 // the Shoot is in the restore phase of the control plane migration
 func (b *Botanist) DeployWorker(ctx context.Context) error {
 	b.Shoot.Components.Extensions.Worker.SetSSHPublicKey(b.Secrets[v1beta1constants.SecretNameSSHKeyPair].Data[secrets.DataKeySSHAuthorizedKeys])
-	b.Shoot.Components.Extensions.Worker.SetInfrastructureProviderStatus(&runtime.RawExtension{Raw: b.Shoot.InfrastructureStatus})
+	b.Shoot.Components.Extensions.Worker.SetInfrastructureProviderStatus(b.Shoot.Components.Extensions.Infrastructure.ProviderStatus())
 	b.Shoot.Components.Extensions.Worker.SetWorkerNameToOperatingSystemConfigsMap(b.Shoot.Components.Extensions.OperatingSystemConfig.WorkerNameToOperatingSystemConfigsMap())
 
 	if b.isRestorePhase() {

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -239,7 +239,6 @@ func (b *Builder) Build(ctx context.Context, c client.Client) (*Shoot, error) {
 	}
 	shoot.Networks = networks
 
-	shoot.ResourceRefs = getResourceRefs(shootObject)
 	shoot.NodeLocalDNSEnabled = gardenletfeatures.FeatureGate.Enabled(features.NodeLocalDNS)
 	shoot.Purpose = gardencorev1beta1helper.GetPurpose(shootObject)
 
@@ -619,13 +618,4 @@ func ComputeRequiredExtensions(shoot *gardencorev1beta1.Shoot, seed *gardencorev
 	}
 
 	return requiredExtensions
-}
-
-// getResourceRefs returns resource references from the Shoot spec as map[string]autoscalingv1.CrossVersionObjectReference.
-func getResourceRefs(shoot *gardencorev1beta1.Shoot) map[string]autoscalingv1.CrossVersionObjectReference {
-	resourceRefs := make(map[string]autoscalingv1.CrossVersionObjectReference)
-	for _, r := range shoot.Spec.Resources {
-		resourceRefs[r.Name] = r.ResourceRef
-	}
-	return resourceRefs
 }

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/extension"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/garden"
 	"github.com/gardener/gardener/pkg/utils"
@@ -40,9 +39,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -195,12 +192,6 @@ func (b *Builder) Build(ctx context.Context, c client.Client) (*Shoot, error) {
 		SystemComponents: &SystemComponents{},
 	}
 
-	extensions, err := calculateExtensions(ctx, c, shootObject, shoot.SeedNamespace)
-	if err != nil {
-		return nil, fmt.Errorf("cannot calculate required extensions for shoot %s: %v", shootObject.Name, err)
-	}
-	shoot.Extensions = extensions
-
 	// Determine information about external domain for shoot cluster.
 	externalDomain, err := ConstructExternalDomain(ctx, c, shootObject, secret, b.defaultDomains)
 	if err != nil {
@@ -243,14 +234,6 @@ func (b *Builder) Build(ctx context.Context, c client.Client) (*Shoot, error) {
 	shoot.Purpose = gardencorev1beta1helper.GetPurpose(shootObject)
 
 	return shoot, nil
-}
-
-func calculateExtensions(ctx context.Context, gardenClient client.Client, shoot *gardencorev1beta1.Shoot, seedNamespace string) (map[string]extension.Extension, error) {
-	controllerRegistrations := &gardencorev1beta1.ControllerRegistrationList{}
-	if err := gardenClient.List(ctx, controllerRegistrations); err != nil {
-		return nil, err
-	}
-	return MergeExtensions(controllerRegistrations.Items, shoot.Spec.Extensions, seedNamespace)
 }
 
 // GetExtensionComponents returns a list of component.DeployMigrateWaiters of all extension components.
@@ -449,65 +432,6 @@ func ConstructExternalDomain(ctx context.Context, client client.Client, shoot *g
 	}
 
 	return externalDomain, nil
-}
-
-// MergeExtensions merges the given controller registrations with the given extensions, expecting that each type in
-// extensions is also represented in the registration. It ignores all extensions that were explicitly disabled in the
-// shoot spec.
-func MergeExtensions(registrations []gardencorev1beta1.ControllerRegistration, extensions []gardencorev1beta1.Extension, namespace string) (map[string]extension.Extension, error) {
-	var (
-		typeToExtension    = make(map[string]extension.Extension)
-		requiredExtensions = make(map[string]extension.Extension)
-	)
-
-	// Extensions enabled by default for all Shoot clusters.
-	for _, reg := range registrations {
-		for _, res := range reg.Spec.Resources {
-			if res.Kind != extensionsv1alpha1.ExtensionResource {
-				continue
-			}
-
-			timeout := extension.DefaultTimeout
-			if res.ReconcileTimeout != nil {
-				timeout = res.ReconcileTimeout.Duration
-			}
-
-			typeToExtension[res.Type] = extension.Extension{
-				Extension: extensionsv1alpha1.Extension{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      res.Type,
-						Namespace: namespace,
-					},
-					Spec: extensionsv1alpha1.ExtensionSpec{
-						DefaultSpec: extensionsv1alpha1.DefaultSpec{
-							Type: res.Type,
-						},
-					},
-				},
-				Timeout: timeout,
-			}
-
-			if res.GloballyEnabled != nil && *res.GloballyEnabled {
-				requiredExtensions[res.Type] = typeToExtension[res.Type]
-			}
-		}
-	}
-
-	// Extensions defined in Shoot resource.
-	for _, extension := range extensions {
-		if obj, ok := typeToExtension[extension.Type]; ok {
-			if utils.IsTrue(extension.Disabled) {
-				delete(requiredExtensions, extension.Type)
-				continue
-			}
-
-			obj.Spec.ProviderConfig = extension.ProviderConfig
-			requiredExtensions[extension.Type] = obj
-			continue
-		}
-	}
-
-	return requiredExtensions, nil
 }
 
 // ToNetworks return a network with computed cidrs and ClusterIPs

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -80,7 +80,6 @@ type Shoot struct {
 
 	Components *Components
 
-	Extensions           map[string]extension.Extension
 	InfrastructureStatus []byte
 
 	ETCDEncryption *etcdencryption.EncryptionConfig

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -78,10 +78,7 @@ type Shoot struct {
 	NodeLocalDNSEnabled        bool
 	Networks                   *Networks
 
-	Components *Components
-
-	InfrastructureStatus []byte
-
+	Components     *Components
 	ETCDEncryption *etcdencryption.EncryptionConfig
 }
 

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -38,7 +38,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/garden"
 
 	"github.com/Masterminds/semver"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -85,8 +84,6 @@ type Shoot struct {
 	InfrastructureStatus []byte
 
 	ETCDEncryption *etcdencryption.EncryptionConfig
-
-	ResourceRefs map[string]autoscalingv1.CrossVersionObjectReference
 }
 
 // Components contains different components deployed in the Shoot cluster.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup
/priority normal

**What this PR does / why we need it**:
After the many recent refactorings, let's condense the code a little bit and move parts that belong together to the same place for easier future maintenance.

**Special notes for your reviewer**:
I suggest to use the dedicated commits for an easier review.
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
