### PR TITLE
Fix etcd-druid seed unbootstrap

### DIFF
--- a/pkg/operation/botanist/controlplane/etcd/bootstrap.go
+++ b/pkg/operation/botanist/controlplane/etcd/bootstrap.go
@@ -36,6 +36,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -294,7 +295,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 
 func (b *bootstrapper) Destroy(ctx context.Context) error {
 	etcdList := &druidv1alpha1.EtcdList{}
-	if err := b.client.List(ctx, etcdList); err != nil {
+	if err := b.client.List(ctx, etcdList); err != nil && !meta.IsNoMatchError(err) {
 		return err
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug
/priority normal

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #3685

**Special notes for your reviewer**:

**Release note**:

```bugfix operator
A bug preventing seed deletion to hang due to already deleted CRD `etcds.druid.gardener.cloud` is now fixed.
```
