### PR TITLE
Allow ingress traffic to coredns from a pod running with hostNetwork

### DIFF
--- a/charts/shoot-core/components/charts/coredns/templates/coredns-networkpolicy.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-networkpolicy.yaml
@@ -36,6 +36,8 @@ spec:
       podSelector: {}
     - ipBlock:
         cidr: {{ .Values.global.podNetwork }}
+    - ipBlock:
+        cidr: {{ .Values.nodeNetwork }}
   policyTypes:
   - Egress
   - Ingress

--- a/charts/shoot-core/components/charts/coredns/values.yaml
+++ b/charts/shoot-core/components/charts/coredns/values.yaml
@@ -3,6 +3,7 @@
 
 global:
   podNetwork: 1.2.3.4/24
+nodeNetwork: 2.3.4.5/24
 service:
   type: "ClusterIP"
   clusterDNS: 100.64.0.10

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -226,6 +226,7 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 			"vpaEnabled":        b.Shoot.WantsVerticalPodAutoscaler,
 		}
 		coreDNSConfig = map[string]interface{}{
+			"nodeNetwork": b.Shoot.GetNodeNetwork(),
 			"service": map[string]interface{}{
 				"clusterDNS": b.Shoot.Networks.CoreDNS.String(),
 				// TODO: resolve conformance test issue before changing:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/priority normal

**What this PR does / why we need it**:
Allow ingress traffic to coredns from a pod running with `hostNetwork: true` and `dnsPolicy: ClusterFirstWithHostNet`.
This was denied in the past.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow ingress traffic to coredns from a pod running with `hostNetwork: true` and `dnsPolicy: ClusterFirstWithHostNet`
```

/cc: @mandelsoft @vlerenc 
