### PR TITLE
Enhance cherry-pick-pull.sh to transport also the release notes

### DIFF
--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -79,9 +79,9 @@ Before you initiate a cherry pick, make sure that the following prerequisites ar
   - You will need to run the cherry pick script separately for each patch
     release you want to cherry pick to. Cherry picks should be applied to all
     active release branches where the fix is applicable.
-  
-  - When asked for your github password, provide the created github token 
-    rather than your actual github password. 
+
+  - When asked for your github password, provide the created github token
+    rather than your actual github password.
     Refer [https://github.com/github/hub/issues/2655#issuecomment-735836048](https://github.com/github/hub/issues/2655#issuecomment-735836048)
 
 [cherry-pick-script]: https://github.com/gardener/gardener/blob/master/hack/cherry-pick-pull.sh

--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -45,11 +45,12 @@ Please make sure you have installed the following requirements:
 - GNU Parallel
 
 Brew command:
-$ brew install coreutils gnu-tar gnu-sed jq parallel
+$ brew install coreutils gnu-sed gnu-tar grep jq parallel
 
 Please allow them to be used without their "g" prefix:
 $ export PATH=/usr/local/opt/coreutils/libexec/gnubin:\$PATH
-$ export PATH=/usr/local/opt/gnu-tar/libexec/gnubin:\$PATH
 $ export PATH=/usr/local/opt/gnu-sed/libexec/gnubin:\$PATH
+$ export PATH=/usr/local/opt/gnu-tar/libexec/gnubin:\$PATH
+$ export PATH=/usr/local/opt/grep/libexec/gnubin:\$PATH
 EOM
 fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Enhance cherry-pick-pull.sh to transport also the release notes.

**Which issue(s) this PR fixes**:
Follow up on #3674 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
