### PR TITLE
Fix scaling of some istio (and SNI) components

### DIFF
--- a/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/charts/istio/istio-istiod/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 spec:
+  replicas: 2
   revisionHistoryLimit: 1
   strategy:
     rollingUpdate:
@@ -22,7 +23,6 @@ spec:
         sidecar.istio.io/inject: "false"
         checksum/istio-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
-      replicas: 2
       serviceAccountName: istiod
       securityContext:
         fsGroup: 1337

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -322,6 +322,8 @@ spec:
         - --cert-name=kube-apiserver.crt
         - --key-name=kube-apiserver.key
         - --port=9443
+        resources:
+{{ toYaml .Values.podMutatorResources | indent 10 }}
         volumeMounts:
         - name: kube-apiserver
           mountPath: /srv/kubernetes/apiserver

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -92,6 +92,14 @@ konnectivityTunnelResources:
       cpu: 200m
       memory: 500M
 
+podMutatorResources:
+  requests:
+    cpu: 50m
+    memory: 128M
+  limits:
+    cpu: 200m
+    memory: 500M
+
 maxReplicas: 1
 minReplicas: 1
 

--- a/pkg/operation/botanist/component/istio/istiod.go
+++ b/pkg/operation/botanist/component/istio/istiod.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
-	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,6 +37,7 @@ type istiod struct {
 	client    crclient.Client
 }
 
+// IstiodValues holds values for the istio-istiod chart.
 type IstiodValues struct {
 	TrustDomain string `json:"trustDomain,omitempty"`
 	Image       string `json:"image,omitempty"`
@@ -88,7 +88,6 @@ func (i *istiod) Deploy(ctx context.Context) error {
 	}
 
 	applierOptions := kubernetes.CopyApplierOptions(kubernetes.DefaultMergeFuncs)
-	applierOptions[appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind()] = kubernetes.DeploymentKeepReplicasMergeFunc
 
 	return i.Apply(ctx, i.chartPath, i.namespace, istioReleaseName, kubernetes.Values(i.values), applierOptions)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR fixes 2 issues related to istio components in `Seed` clusters:
1. After `gardenlet` is updated to 1.17.1 there can be a problem with scaling the `istiod` deployment in `istio-system` namespace if its replicas were set to 1 before the update by the respective HPA (which gets removed in 1.17.1). There is a PDB that prevents the `istiod` pod to get recreated and updated with new resource limits. With this PR the replicas are now set to 2 and are correctly specified in the `istio-istiod` chart. The management of replicas in go code has also been removed (otherwise replicas would remain at 1 forever as the HPA no longer exists).

1. When SNI is enabled the `apiserver-proxy-pod-mutator` container in the `kube-apiserver` pod now specifies resource requests and limits. Previously the `resources` entry was missing which was preventing the respective HPA to read the CPU requests for the kube-apiserver pod and therefore preventing scaling operations.

**Which issue(s) this PR fixes**:
Fixes part of [#3619](https://github.com/gardener/gardener/issues/3619#issuecomment-795227380) and #3613

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `istiod` deployment in the `istio-system` namespace now has replicas set to 2 and can be properly scaled by its corresponding VPA.
```
```bugfix operator
Added resource requests and limits to the `apiserver-proxy-pod-mutator` container which should allow the corresponding HPA to properly read CPU metrics from the `kube-apiserver` when SNI is enabled.
```