### PR TITLE
Automated cherry pick of #3691: Fix istio scaling

### DIFF
--- a/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/charts/istio/istio-istiod/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
 spec:
+  replicas: 2
   revisionHistoryLimit: 1
   strategy:
     rollingUpdate:
@@ -22,7 +23,6 @@ spec:
         sidecar.istio.io/inject: "false"
         checksum/istio-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
-      replicas: 2
       serviceAccountName: istiod
       securityContext:
         fsGroup: 1337

--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -317,6 +317,8 @@ spec:
         - --cert-name=kube-apiserver.crt
         - --key-name=kube-apiserver.key
         - --port=9443
+        resources:
+{{ toYaml .Values.podMutatorResources | indent 10 }}
         volumeMounts:
         - name: kube-apiserver
           mountPath: /srv/kubernetes/apiserver

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -92,6 +92,14 @@ konnectivityTunnelResources:
       cpu: 200m
       memory: 500M
 
+podMutatorResources:
+  requests:
+    cpu: 50m
+    memory: 128M
+  limits:
+    cpu: 200m
+    memory: 500M
+
 maxReplicas: 1
 minReplicas: 1
 

--- a/pkg/operation/seed/istio/istiod.go
+++ b/pkg/operation/seed/istio/istiod.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
-	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,6 +37,7 @@ type istiod struct {
 	client    crclient.Client
 }
 
+// IstiodValues holds values for the istio-istiod chart.
 type IstiodValues struct {
 	TrustDomain string `json:"trustDomain,omitempty"`
 	Image       string `json:"image,omitempty"`
@@ -88,7 +88,6 @@ func (i *istiod) Deploy(ctx context.Context) error {
 	}
 
 	applierOptions := kubernetes.CopyApplierOptions(kubernetes.DefaultMergeFuncs)
-	applierOptions[appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind()] = kubernetes.DeploymentKeepReplicasMergeFunc
 
 	return i.Apply(ctx, i.chartPath, i.namespace, istioReleaseName, kubernetes.Values(i.values), applierOptions)
 }


### PR DESCRIPTION
Cherry pick of #3691 on release-v1.16.

#3691: Fix istio scaling

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `istiod` deployment in the `istio-system` namespace now has replicas set to 2 and can be properly scaled by its corresponding VPA.
```
```bugfix operator
Added resource requests and limits to the `apiserver-proxy-pod-mutator` container which should allow the corresponding HPA to properly read CPU metrics from the `kube-apiserver` when SNI is enabled.
```