### PR TITLE
[release-v1.17] Automated cherry pick of #3682: VPA minAllowed configuration for metrics-server.

### DIFF
--- a/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server.go
@@ -347,8 +347,8 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("20m"),
-									corev1.ResourceMemory: resource.MustParse("100Mi"),
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("150Mi"),
 								},
 								Limits: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -403,6 +403,17 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 				},
 				UpdatePolicy: &autoscalingv1beta2.PodUpdatePolicy{
 					UpdateMode: &vpaUpdateMode,
+				},
+				ResourcePolicy: &autoscalingv1beta2.PodResourcePolicy{
+					ContainerPolicies: []autoscalingv1beta2.ContainerResourcePolicy{
+						{
+							ContainerName: autoscalingv1beta2.DefaultContainerResourcePolicy,
+							MinAllowed: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("50m"),
+								corev1.ResourceMemory: resource.MustParse("150Mi"),
+							},
+						},
+					},
 				},
 			},
 		}

--- a/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/systemcomponents/metricsserver/metrics_server_test.go
@@ -108,6 +108,12 @@ metadata:
   name: metrics-server
   namespace: kube-system
 spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        cpu: 50m
+        memory: 150Mi
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
@@ -260,8 +266,8 @@ spec:
             cpu: 100m
             memory: 1Gi
           requests:
-            cpu: 20m
-            memory: 100Mi
+            cpu: 50m
+            memory: 150Mi
         volumeMounts:
         - mountPath: /srv/metrics-server/tls
           name: metrics-server
@@ -353,8 +359,8 @@ spec:
             cpu: 80m
             memory: 400Mi
           requests:
-            cpu: 20m
-            memory: 100Mi
+            cpu: 50m
+            memory: 150Mi
         volumeMounts:
         - mountPath: /srv/metrics-server/tls
           name: metrics-server


### PR DESCRIPTION
Cherry pick of #3682 on release-v1.17.

#3682: VPA minAllowed configuration for metrics-server.

**Release Notes:**
```other operator
VPA minAllowed configuration for metrics-server.
```