### PR TITLE
[release-v1.17] Automated cherry pick of #3670: Increase BackupBucket controller test timeouts

### DIFF
--- a/extensions/pkg/controller/backupbucket/backupbucket_test.go
+++ b/extensions/pkg/controller/backupbucket/backupbucket_test.go
@@ -48,8 +48,8 @@ import (
 
 const (
 	pollInterval        = time.Second
-	pollSevereThreshold = 10 * time.Second
-	pollTimeout         = 15 * time.Second
+	pollSevereThreshold = 30 * time.Second
+	pollTimeout         = time.Minute
 )
 
 var _ = Describe("BackupBucket", func() {


### PR DESCRIPTION
Cherry pick of #3670 on release-v1.17.

#3670: Increase BackupBucket controller test timeouts

**Release Notes:**
```other operator
NONE
```