### PR TITLE
Automated cherry pick of #3684: Ensure kubelet CSRs get approved after one year

### DIFF
--- a/pkg/operation/botanist/extensions/operatingsystemconfig/downloader/downloader.go
+++ b/pkg/operation/botanist/extensions/operatingsystemconfig/downloader/downloader.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Masterminds/sprig"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
 	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
 	"k8s.io/utils/pointer"
 )
@@ -275,7 +276,7 @@ func GenerateRBACResourcesData(secretNames []string) (map[string][]byte, error) 
 			Subjects: []rbacv1.Subject{{
 				APIGroup: rbacv1.SchemeGroupVersion.Group,
 				Kind:     rbacv1.GroupKind,
-				Name:     bootstraptokenapi.BootstrapDefaultGroup,
+				Name:     user.NodesGroup,
 			}},
 		}
 	)

--- a/pkg/operation/botanist/extensions/operatingsystemconfig/downloader/downloader.go
+++ b/pkg/operation/botanist/extensions/operatingsystemconfig/downloader/downloader.go
@@ -262,6 +262,22 @@ func GenerateRBACResourcesData(secretNames []string) (map[string][]byte, error) 
 				Name:     bootstraptokenapi.BootstrapDefaultGroup,
 			}},
 		}
+
+		clusterRoleBindingSelfNodeClient = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient",
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     "ClusterRole",
+				Name:     "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient",
+			},
+			Subjects: []rbacv1.Subject{{
+				APIGroup: rbacv1.SchemeGroupVersion.Group,
+				Kind:     rbacv1.GroupKind,
+				Name:     bootstraptokenapi.BootstrapDefaultGroup,
+			}},
+		}
 	)
 
 	return managedresources.
@@ -271,5 +287,6 @@ func GenerateRBACResourcesData(secretNames []string) (map[string][]byte, error) 
 			roleBinding,
 			clusterRoleBindingNodeBootstrapper,
 			clusterRoleBindingNodeClient,
+			clusterRoleBindingSelfNodeClient,
 		)
 }

--- a/pkg/operation/botanist/extensions/operatingsystemconfig/downloader/downloader_test.go
+++ b/pkg/operation/botanist/extensions/operatingsystemconfig/downloader/downloader_test.go
@@ -170,7 +170,7 @@ roleRef:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
-  name: system:bootstrappers
+  name: system:nodes
 `
 		)
 

--- a/pkg/operation/botanist/extensions/operatingsystemconfig/downloader/downloader_test.go
+++ b/pkg/operation/botanist/extensions/operatingsystemconfig/downloader/downloader_test.go
@@ -158,16 +158,31 @@ subjects:
   kind: Group
   name: system:bootstrappers
 `
+			clusterRoleBindingSelfNodeClientYAML = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: system:certificates.k8s.io:certificatesigningrequests:selfnodeclient
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:certificates.k8s.io:certificatesigningrequests:selfnodeclient
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:bootstrappers
+`
 		)
 
 		It("should generate the expected RBAC resources", func() {
 			data, err := GenerateRBACResourcesData([]string{secretName1, secretName2})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(data).To(HaveLen(4))
+			Expect(data).To(HaveLen(5))
 			Expect(string(data["role__kube-system__cloud-config-downloader.yaml"])).To(Equal(roleYAML))
 			Expect(string(data["rolebinding__kube-system__cloud-config-downloader.yaml"])).To(Equal(roleBindingYAML))
 			Expect(string(data["clusterrolebinding____system_node-bootstrapper.yaml"])).To(Equal(clusterRoleBindingNodeBootstrapperYAML))
 			Expect(string(data["clusterrolebinding____system_certificates.k8s.io_certificatesigningrequests_nodeclient.yaml"])).To(Equal(clusterRoleBindingNodeClientYAML))
+			Expect(string(data["clusterrolebinding____system_certificates.k8s.io_certificatesigningrequests_selfnodeclient.yaml"])).To(Equal(clusterRoleBindingSelfNodeClientYAML))
 		})
 	})
 })


### PR DESCRIPTION
Cherry pick of #3684 on release-v1.17.

#3684: Ensure kubelet CSRs get approved after one year

**Release note**:
```bugfix operator
An issue preventing kube-controller-manager to approve the CSR for kubelet certificate renewal is now fixed.
```