### PR TITLE
Add CloudProfile handling to SeedAuthorizer

### DIFF
--- a/cmd/gardener-admission-controller/app/gardener_admission_controller.go
+++ b/cmd/gardener-admission-controller/app/gardener_admission_controller.go
@@ -168,7 +168,7 @@ func (o *options) run(ctx context.Context) error {
 	}
 	logSeedAuth := logf.Log.WithName(seedauthorizer.AuthorizerName)
 
-	server.Register(seedauthorizer.WebhookPath, seedauthorizer.NewHandler(logSeedAuth, seedauthorizer.NewAuthorizer(logSeedAuth)))
+	server.Register(seedauthorizer.WebhookPath, seedauthorizer.NewHandler(logSeedAuth, seedauthorizer.NewAuthorizer(logSeedAuth, graph)))
 	server.Register(seedrestriction.WebhookPath, &webhook.Admission{Handler: seedrestriction.New(logf.Log.WithName(seedrestriction.HandlerName))})
 	server.Register(namespacedeletion.WebhookPath, &webhook.Admission{Handler: namespaceValidationHandler})
 	server.Register(kubeconfigsecret.WebhookPath, &webhook.Admission{Handler: kubeconfigsecret.New(logf.Log.WithName(kubeconfigsecret.HandlerName))})

--- a/hack/local-development/local-garden/run-kube-apiserver
+++ b/hack/local-development/local-garden/run-kube-apiserver
@@ -31,7 +31,7 @@ clusters:
 - name: gardener-admission-controller
   cluster:
     insecure-skip-tls-verify: true
-    server: https://$ADMISSION_CONTROLLER_EXTERNAL_NAME:2721/webhooks/seedauthorizer
+    server: https://$ADMISSION_CONTROLLER_EXTERNAL_NAME:2721/webhooks/auth/seed
 users:
 - name: kube-apiserver
   user: {}

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
@@ -16,27 +16,88 @@ package seed
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/admissioncontroller/webhooks/auth/seed/graph"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	auth "k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
-// AuthorizerName is the name of this authorizatior.
+// AuthorizerName is the name of this authorizer.
 const AuthorizerName = "seedauthorizer"
 
 // NewAuthorizer returns a new authorizer for requests from gardenlets. It never has an opinion on the request.
-func NewAuthorizer(logger logr.Logger) *authorizer {
+func NewAuthorizer(logger logr.Logger, graph graph.Interface) *authorizer {
 	return &authorizer{
 		logger: logger,
+		graph:  graph,
 	}
 }
 
 type authorizer struct {
 	logger logr.Logger
+	graph  graph.Interface
 }
 
 var _ = auth.Authorizer(&authorizer{})
 
-func (a *authorizer) Authorize(_ context.Context, _ auth.Attributes) (auth.Decision, string, error) {
+var (
+	// Only take v1beta1 because the Authorize function only checks the resource group and the resource.
+	cloudProfileResource = gardencorev1beta1.Resource("cloudprofiles")
+)
+
+// TODO: Revisit all `DecisionNoOpinion` later. Today we cannot deny the request for backwards compatibility
+// because older Gardenlet versions might not be compatible at the time this authorization plugin is enabled.
+// With `DecisionNoOpinion`, RBAC will be respected in the authorization chain afterwards.
+func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.Decision, string, error) {
+	seedName, isSeed := Identity(attrs.GetUser())
+	if !isSeed {
+		// reject requests from non-seeds
+		return auth.DecisionNoOpinion, "", nil
+	}
+
+	if attrs.IsResourceRequest() {
+		requestResource := schema.GroupResource{Group: attrs.GetAPIGroup(), Resource: attrs.GetResource()}
+		switch requestResource {
+		case cloudProfileResource:
+			return a.authorizeGet(seedName, graph.VertexTypeCloudProfile, attrs)
+		}
+	}
+
 	return auth.DecisionNoOpinion, "", nil
+}
+
+// authorizeGet authorizes "get" requests to objects of the specified type if they are related to the specified seed
+func (a *authorizer) authorizeGet(seedName string, fromType graph.VertexType, attrs auth.Attributes) (auth.Decision, string, error) {
+	if attrs.GetVerb() != "get" {
+		a.logger.Info(fmt.Sprintf("SEED DENY: '%s' %#v", seedName, attrs))
+		return auth.DecisionNoOpinion, "can only get individual resources of this type", nil
+	}
+	if len(attrs.GetSubresource()) > 0 {
+		a.logger.Info(fmt.Sprintf("SEED DENY: '%s' %#v", seedName, attrs))
+		return auth.DecisionNoOpinion, "cannot get subresource", nil
+	}
+	return a.authorize(seedName, fromType, attrs)
+}
+
+func (a *authorizer) authorize(seedName string, fromType graph.VertexType, attrs auth.Attributes) (auth.Decision, string, error) {
+	if len(attrs.GetName()) == 0 {
+		a.logger.Info(fmt.Sprintf("SEED DENY: '%s' %#v", seedName, attrs))
+		return auth.DecisionNoOpinion, "No Object name found", nil
+	}
+
+	// Allow request if seed name is not known because a target seed cannot be used to find a path.
+	if seedName == "" {
+		return auth.DecisionAllow, "", nil
+	}
+
+	if !a.graph.HasPathFrom(fromType, attrs.GetNamespace(), attrs.GetName(), graph.VertexTypeSeed, "", seedName) {
+		a.logger.Info(fmt.Sprintf("SEED DENY: '%s' %#v", seedName, attrs))
+		return auth.DecisionNoOpinion, fmt.Sprintf("no relationship found between seed '%s' and this object", seedName), nil
+	}
+
+	return auth.DecisionAllow, "", nil
 }

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
@@ -16,36 +16,185 @@ package seed_test
 
 import (
 	"context"
+	"fmt"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	"github.com/golang/mock/gomock"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 
 	. "github.com/gardener/gardener/pkg/admissioncontroller/webhooks/auth/seed"
+	graphpkg "github.com/gardener/gardener/pkg/admissioncontroller/webhooks/auth/seed/graph"
+	"github.com/gardener/gardener/pkg/admissioncontroller/webhooks/auth/seed/graph/mock"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/authentication/user"
+	auth "k8s.io/apiserver/pkg/authorization/authorizer"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 var _ = Describe("Seed", func() {
 	var (
-		ctx = context.TODO()
+		ctx  context.Context
+		ctrl *gomock.Controller
 
-		logger logr.Logger
-		auth   authorizer.Authorizer
+		logger     logr.Logger
+		graph      *mock.MockInterface
+		authorizer auth.Authorizer
+
+		seedName                string
+		seedUser, ambiguousUser user.Info
 	)
 
 	BeforeEach(func() {
+		ctx = context.Background()
+		ctrl = gomock.NewController(GinkgoT())
+
 		logger = logzap.New(logzap.WriteTo(GinkgoWriter))
-		auth = NewAuthorizer(logger)
+		graph = mock.NewMockInterface(ctrl)
+		authorizer = NewAuthorizer(logger, graph)
+
+		seedName = "seed"
+		seedUser = &user.DefaultInfo{
+			Name:   fmt.Sprintf("%s%s", v1beta1constants.SeedUserNamePrefix, seedName),
+			Groups: []string{v1beta1constants.SeedsGroup},
+		}
+		ambiguousUser = &user.DefaultInfo{
+			Name:   fmt.Sprintf("%s%s", v1beta1constants.SeedUserNamePrefix, v1beta1constants.SeedUserNameSuffixAmbiguous),
+			Groups: []string{v1beta1constants.SeedsGroup},
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
 	})
 
 	Describe("#Authorize", func() {
-		It("should have no opinion", func() {
-			decision, reason, err := auth.Authorize(ctx, nil)
+		Context("when cases are unhandled", func() {
+			It("should have no opinion because no seed", func() {
+				attrs := auth.AttributesRecord{
+					User: &user.DefaultInfo{
+						Name: "foo",
+					},
+				}
 
-			Expect(err).NotTo(HaveOccurred())
-			Expect(decision).To(Equal(authorizer.DecisionNoOpinion))
-			Expect(reason).To(BeEmpty())
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(BeEmpty())
+			})
+
+			It("should have no opinion because no resource request", func() {
+				attrs := auth.AttributesRecord{
+					User:     seedUser,
+					APIGroup: "",
+					Resource: "",
+				}
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(BeEmpty())
+			})
+
+			It("should have no opinion because resource is irrelevant", func() {
+				attrs := auth.AttributesRecord{
+					User:            seedUser,
+					APIGroup:        "",
+					Resource:        "",
+					ResourceRequest: true,
+				}
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(BeEmpty())
+			})
+		})
+
+		Context("when requested for CloudProfiles", func() {
+			var (
+				cloudProfileName string
+				attrs            *auth.AttributesRecord
+			)
+
+			BeforeEach(func() {
+				cloudProfileName = "fooCloud"
+				attrs = &auth.AttributesRecord{
+					User:            seedUser,
+					Name:            cloudProfileName,
+					APIGroup:        gardencorev1beta1.SchemeGroupVersion.Group,
+					Resource:        "cloudprofiles",
+					ResourceRequest: true,
+					Verb:            "get",
+				}
+			})
+
+			It("should allow because path to seed exists", func() {
+				graph.EXPECT().HasPathFrom(graphpkg.VertexTypeCloudProfile, "", cloudProfileName, graphpkg.VertexTypeSeed, "", seedName).Return(true)
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionAllow))
+				Expect(reason).To(BeEmpty())
+			})
+
+			It("should have no opinion because path to seed does not exists", func() {
+				graph.EXPECT().HasPathFrom(graphpkg.VertexTypeCloudProfile, "", cloudProfileName, graphpkg.VertexTypeSeed, "", seedName).Return(false)
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("no relationship found"))
+			})
+
+			It("should have no opinion because no get verb", func() {
+				attrs.Verb = "list"
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("can only get individual resources of this type"))
+			})
+
+			It("should have no opinion because no resources requested", func() {
+				attrs.Subresource = "status"
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("cannot get subresource"))
+			})
+
+			It("should have no opinion because no resource name is given", func() {
+				attrs.Name = ""
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("No Object name found"))
+			})
+
+			It("should allow because seed name is ambiguous", func() {
+				attrs.User = ambiguousUser
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionAllow))
+				Expect(reason).To(BeEmpty())
+			})
 		})
 	})
 })

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -96,7 +96,6 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		// Garden core informers
 		backupBucketInformer           = f.k8sGardenCoreInformers.Core().V1beta1().BackupBuckets().Informer()
 		backupEntryInformer            = f.k8sGardenCoreInformers.Core().V1beta1().BackupEntries().Informer()
-		cloudProfileInformer           = f.k8sGardenCoreInformers.Core().V1beta1().CloudProfiles().Informer()
 		controllerRegistrationInformer = f.k8sGardenCoreInformers.Core().V1beta1().ControllerRegistrations().Informer()
 		controllerInstallationInformer = f.k8sGardenCoreInformers.Core().V1beta1().ControllerInstallations().Informer()
 		projectInformer                = f.k8sGardenCoreInformers.Core().V1beta1().Projects().Informer()
@@ -119,7 +118,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	}
 
 	f.k8sGardenCoreInformers.Start(ctx.Done())
-	if !cache.WaitForCacheSync(ctx.Done(), backupBucketInformer.HasSynced, backupEntryInformer.HasSynced, cloudProfileInformer.HasSynced, controllerRegistrationInformer.HasSynced, controllerInstallationInformer.HasSynced, projectInformer.HasSynced, secretBindingInformer.HasSynced, seedInformer.HasSynced, shootInformer.HasSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), backupBucketInformer.HasSynced, backupEntryInformer.HasSynced, controllerRegistrationInformer.HasSynced, controllerInstallationInformer.HasSynced, projectInformer.HasSynced, secretBindingInformer.HasSynced, seedInformer.HasSynced, shootInformer.HasSynced) {
 		return fmt.Errorf("timed out waiting for Garden core caches to sync")
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/priority normal

**What this PR does / why we need it**:
After #3571 and #3631 this PR adds the first check for `CloudProfile`s to the `SeedAuthorizer`. Please take a look at the enclosed documentation for more information.

Co-authored-by: Rafael Franzke <rafael.franzke@sap.com>

**Which issue(s) this PR fixes**:
Part of #1723

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
NONE
```
