### PR TITLE
Fix shoot care check

### DIFF
--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -174,12 +174,12 @@ func (b *Builder) WithChartsRootPath(chartsRootPath string) *Builder {
 }
 
 // WithShootFrom sets the shootFunc attribute at the Builder which will build a new Shoot object.
-func (b *Builder) WithShootFrom(k8sGardenCoreInformers gardencoreinformers.Interface, s *gardencorev1beta1.Shoot) *Builder {
+func (b *Builder) WithShootFrom(k8sGardenCoreInformers gardencoreinformers.Interface, gardenClient kubernetes.Interface, s *gardencorev1beta1.Shoot) *Builder {
 	b.shootFunc = func(ctx context.Context, c client.Client, gardenObj *garden.Garden, seedObj *seed.Seed) (*shoot.Shoot, error) {
 		return shoot.
 			NewBuilder().
 			WithShootObject(s).
-			WithCloudProfileObjectFromLister(k8sGardenCoreInformers.CloudProfiles().Lister()).
+			WithCloudProfileObjectFromReader(gardenClient.APIReader()).
 			WithShootSecretFromSecretBindingLister(k8sGardenCoreInformers.SecretBindings().Lister()).
 			WithProjectName(gardenObj.Project.Name).
 			WithDisableDNS(!seedObj.Info.Spec.Settings.ShootDNS.Enabled).
@@ -194,10 +194,12 @@ func (b *Builder) WithShootFrom(k8sGardenCoreInformers gardencoreinformers.Inter
 // The shoot status is still taken from the passed `shoot`, though.
 func (b *Builder) WithShootFromCluster(k8sGardenCoreInformers gardencoreinformers.Interface, seedClient kubernetes.Interface, s *gardencorev1beta1.Shoot) *Builder {
 	b.shootFunc = func(ctx context.Context, c client.Client, gardenObj *garden.Garden, seedObj *seed.Seed) (*shoot.Shoot, error) {
+		shootNamespace := shoot.ComputeTechnicalID(gardenObj.Project.Name, s)
+
 		shoot, err := shoot.
 			NewBuilder().
-			WithShootObjectFromCluster(seedClient, shoot.ComputeTechnicalID(gardenObj.Project.Name, s)).
-			WithCloudProfileObjectFromLister(k8sGardenCoreInformers.CloudProfiles().Lister()).
+			WithShootObjectFromCluster(seedClient, shootNamespace).
+			WithCloudProfileObjectFromCluster(seedClient, shootNamespace).
 			WithShootSecretFromSecretBindingLister(k8sGardenCoreInformers.SecretBindings().Lister()).
 			WithProjectName(gardenObj.Project.Name).
 			WithDisableDNS(!seedObj.Info.Spec.Settings.ShootDNS.Enabled).

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -46,7 +46,7 @@ import (
 // Builder is an object that builds Shoot objects.
 type Builder struct {
 	shootObjectFunc  func(context.Context) (*gardencorev1beta1.Shoot, error)
-	cloudProfileFunc func(string) (*gardencorev1beta1.CloudProfile, error)
+	cloudProfileFunc func(context.Context, string) (*gardencorev1beta1.CloudProfile, error)
 	shootSecretFunc  func(context.Context, client.Client, string, string) (*corev1.Secret, error)
 	projectName      string
 	internalDomain   *garden.Domain


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/priority normal

**What this PR does / why we need it**:
After #3708, the gardenlet does no longer WATCH `CloudProfile`s. Hence, trying to fetch the `CloudProfile` via a lister when constructing the `Operation` in the shoot care controller does not work anymore.

**Special notes for your reviewer**:
/cc @timuthy
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
