### PR TITLE
Update RBAC for GAC

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-system.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-system.yaml
@@ -102,20 +102,34 @@ metadata:
     heritage: "{{ .Release.Service }}"
 rules:
 - apiGroups:
-    - core.gardener.cloud
+  - core.gardener.cloud
   resources:
-    - shoots
-    - projects
+  - backupbuckets
+  - backupentries
+  - controllerinstallations
+  - secretbindings
+  - seed
+  - shoots
+  - shootstates
+  - projects
   verbs:
-    - get
-    - list
-    - watch
+  - get
+  - list
+  - watch
 - apiGroups:
-    - ""
+  - seedmanagement.gardener.cloud
   resources:
-    - namespaces
+  - managedseeds
   verbs:
-    - get
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug
/priority normal

**What this PR does / why we need it**:
With #3631 the GAC watches many more resources but we didn't update its RBAC role accordingly.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
