### PR TITLE
Migrate default resource lock to leases

### DIFF
--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -388,7 +388,7 @@ global:
         leaseDuration: 15s
         renewDeadline: 10s
         retryPeriod: 2s
-        resourceLock: configmapsleases
+        resourceLock: leases
       logLevel: info
       kubernetesLogLevel: 0
       server:
@@ -441,7 +441,7 @@ global:
         leaseDuration: 15s
         renewDeadline: 10s
         retryPeriod: 2s
-        resourceLock: configmapsleases
+        resourceLock: leases
       logLevel: info
       server:
         http:

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -111,7 +111,7 @@ global:
         leaseDuration: 15s
         renewDeadline: 10s
         retryPeriod: 2s
-        resourceLock: configmapsleases
+        resourceLock: leases
       logLevel: info
       kubernetesLogLevel: 0
       server:

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -49,7 +49,7 @@ leaderElection:
   leaseDuration: 15s
   renewDeadline: 10s
   retryPeriod: 2s
-  resourceLock: configmapsleases
+  resourceLock: leases
 logLevel: info
 kubernetesLogLevel: 0
 server:

--- a/example/20-componentconfig-gardener-scheduler.yaml
+++ b/example/20-componentconfig-gardener-scheduler.yaml
@@ -9,7 +9,7 @@ leaderElection:
   leaseDuration: 15s
   renewDeadline: 10s
   retryPeriod: 2s
-  resourceLock: configmapsleases
+  resourceLock: leases
 logLevel: info
 server:
   http:

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -72,7 +72,7 @@ leaderElection:
   leaseDuration: 15s
   renewDeadline: 10s
   retryPeriod: 2s
-  resourceLock: configmapsleases
+  resourceLock: leases
 logLevel: info
 kubernetesLogLevel: 0
 server:

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -140,10 +140,7 @@ func SetDefaults_ClientConnectionConfiguration(obj *componentbaseconfigv1alpha1.
 // SetDefaults_LeaderElectionConfiguration sets defaults for the leader election of the Gardener controller manager.
 func SetDefaults_LeaderElectionConfiguration(obj *LeaderElectionConfiguration) {
 	if obj.ResourceLock == "" {
-		// TODO: change default to leases after a few releases
-		// make sure, we had configmapsleases as default for a few releases before migrating to leases to ensure,
-		// all users had at least one version running with the hybrid lock to avoid split-brain scenarios when migrating.
-		obj.ResourceLock = resourcelock.ConfigMapsLeasesResourceLock
+		obj.ResourceLock = resourcelock.LeasesResourceLock
 	}
 
 	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&obj.LeaderElectionConfiguration)

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Defaults", func() {
 				Expect(obj.LeaderElection.LeaseDuration).To(Equal(metav1.Duration{Duration: 15 * time.Second}))
 				Expect(obj.LeaderElection.RenewDeadline).To(Equal(metav1.Duration{Duration: 10 * time.Second}))
 				Expect(obj.LeaderElection.RetryPeriod).To(Equal(metav1.Duration{Duration: 2 * time.Second}))
-				Expect(obj.LeaderElection.ResourceLock).To(Equal("configmapsleases"))
+				Expect(obj.LeaderElection.ResourceLock).To(Equal("leases"))
 				Expect(obj.LeaderElection.LockObjectNamespace).To(Equal("garden"))
 				Expect(obj.LeaderElection.LockObjectName).To(Equal("gardener-controller-manager-leader-election"))
 			})

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -121,10 +121,7 @@ func SetDefaults_ClientConnectionConfiguration(obj *componentbaseconfigv1alpha1.
 // SetDefaults_LeaderElectionConfiguration sets defaults for the leader election of the gardenlet.
 func SetDefaults_LeaderElectionConfiguration(obj *LeaderElectionConfiguration) {
 	if obj.ResourceLock == "" {
-		// TODO: change default to leases after a few releases
-		// make sure, we had configmapsleases as default for a few releases before migrating to leases to ensure,
-		// all users had at least one version running with the hybrid lock to avoid split-brain scenarios when migrating.
-		obj.ResourceLock = resourcelock.ConfigMapsLeasesResourceLock
+		obj.ResourceLock = resourcelock.LeasesResourceLock
 	}
 
 	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&obj.LeaderElectionConfiguration)

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Defaults", func() {
 				Expect(obj.LeaderElection.LeaseDuration).To(Equal(metav1.Duration{Duration: 15 * time.Second}))
 				Expect(obj.LeaderElection.RenewDeadline).To(Equal(metav1.Duration{Duration: 10 * time.Second}))
 				Expect(obj.LeaderElection.RetryPeriod).To(Equal(metav1.Duration{Duration: 2 * time.Second}))
-				Expect(obj.LeaderElection.ResourceLock).To(Equal("configmapsleases"))
+				Expect(obj.LeaderElection.ResourceLock).To(Equal("leases"))
 				Expect(obj.LeaderElection.LockObjectNamespace).To(PointTo(Equal("garden")))
 				Expect(obj.LeaderElection.LockObjectName).To(PointTo(Equal("gardenlet-leader-election")))
 			})

--- a/pkg/scheduler/apis/config/v1alpha1/defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults.go
@@ -81,10 +81,7 @@ func SetDefaults_ClientConnectionConfiguration(obj *componentbaseconfigv1alpha1.
 // SetDefaults_LeaderElectionConfiguration sets defaults for the leader election of the Gardener controller manager.
 func SetDefaults_LeaderElectionConfiguration(obj *LeaderElectionConfiguration) {
 	if obj.ResourceLock == "" {
-		// TODO: change default to leases after a few releases
-		// make sure, we had configmapsleases as default for a few releases before migrating to leases to ensure,
-		// all users had at least one version running with the hybrid lock to avoid split-brain scenarios when migrating.
-		obj.ResourceLock = resourcelock.ConfigMapsLeasesResourceLock
+		obj.ResourceLock = resourcelock.LeasesResourceLock
 	}
 
 	componentbaseconfigv1alpha1.RecommendedDefaultLeaderElectionConfiguration(&obj.LeaderElectionConfiguration)

--- a/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Defaults", func() {
 				Expect(obj.LeaderElection.LeaseDuration).To(Equal(metav1.Duration{Duration: 15 * time.Second}))
 				Expect(obj.LeaderElection.RenewDeadline).To(Equal(metav1.Duration{Duration: 10 * time.Second}))
 				Expect(obj.LeaderElection.RetryPeriod).To(Equal(metav1.Duration{Duration: 2 * time.Second}))
-				Expect(obj.LeaderElection.ResourceLock).To(Equal("configmapsleases"))
+				Expect(obj.LeaderElection.ResourceLock).To(Equal("leases"))
 				Expect(obj.LeaderElection.LockObjectNamespace).To(Equal("garden"))
 				Expect(obj.LeaderElection.LockObjectName).To(Equal("gardener-scheduler-leader-election"))
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:

In https://github.com/gardener/gardener/pull/3535 (included in `g/g@v1.17`) we migrated the default leader election resource lock to `configmapsleases` for all gardener components.
Now we can safely change the default resource lock for all components to `leases`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The default leader election resource lock of `gardener-controller-manager`, `gardener-scheduler` and `gardenlet` has been changed to `leases`.
Please make sure, that the components have permissions to create, get, watch and update `leases.coordination.k8s.io` in the respective clusters.
And please make sure, that you had at least `gardener@v1.17` running before upgrading to `v1.19`, so that all components have successfully required leadership with the hybrid resource lock (`configmapsleases`) at least once.
```
