### PR TITLE
Increase initialDelaySeconds to 40 for nginx-ingress probes

### DIFF
--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -81,7 +81,7 @@ spec:
               path: /healthz
               port: 10254
               scheme: HTTP
-            initialDelaySeconds: 10
+            initialDelaySeconds: 40
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -94,6 +94,7 @@ spec:
               protocol: TCP
           readinessProbe:
             failureThreshold: 3
+            initialDelaySeconds: 40
             httpGet:
               path: /healthz
               port: 10254
@@ -104,10 +105,10 @@ spec:
           resources:
             limits:
               cpu: 400m
-              memory: 2048Mi
+              memory: 1500Mi
             requests:
               cpu: 100m
-              memory: 512Mi
+              memory: 375Mi
       hostNetwork: false
       serviceAccountName: nginx-ingress
       terminationGracePeriodSeconds: 60


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
In larger seed clusters (>100 shoot control planes) the nginx-ingress-controller is sometimes crash-looping because it's unable to start. The VPA scales down its resources, however, during start-up time the nginx-ingress-controller takes a lot of CPU because it syncs its caches (afterwards, its CPU consumption goes down again by a lot). Due to the fact that the `initialDelaySeconds` are set quite low, if the VPA was too optimistic, the nginx-ingress-controller is no longer able to start up. The VPA does not understand that the following crash-loop is due to CPU-throttling (from its perspective, the pods get killed by kubelet because they are not ready/healthy for whatever reason).
Let's increase this delay to give the `nginx-ingress-controller` more time to start-up until we get to a more sophisticated VPA recommender.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
NONE
```
