### PR TITLE
Cleanup more usages of DirectClient

### DIFF
--- a/cmd/gardenlet/app/bootstrap.go
+++ b/cmd/gardenlet/app/bootstrap.go
@@ -66,7 +66,7 @@ func bootstrapKubeconfig(
 		return nil, "", "", nil
 	}
 
-	clientSet, err := kubernetes.NewClientFromBytes(bootstrapKubeconfig)
+	bootstrapClientSet, err := kubernetes.NewClientFromBytes(bootstrapKubeconfig)
 	if err != nil {
 		return nil, "", "", fmt.Errorf("unable to bootstrap client from bootstrap kubeconfig: %w", err)
 	}
@@ -76,5 +76,5 @@ func bootstrapKubeconfig(
 
 	logger.Info("Using provided bootstrap kubeconfig to request signed certificate.")
 
-	return bootstrap.RequestBootstrapKubeconfig(ctx, logger, seedClient, clientSet.Kubernetes(), clientSet.RESTConfig(), config.GardenClientConnection, seedName, bootstrapTargetCluster)
+	return bootstrap.RequestBootstrapKubeconfig(ctx, logger, seedClient, bootstrapClientSet, config.GardenClientConnection, seedName, bootstrapTargetCluster)
 }

--- a/pkg/client/kubernetes/fake/builder.go
+++ b/pkg/client/kubernetes/fake/builder.go
@@ -83,6 +83,7 @@ func (b *ClientSetBuilder) WithClient(client client.Client) *ClientSetBuilder {
 }
 
 // WithDirectClient sets the directClient attribute of the builder.
+// Deprecated: kubernetes.Interface.DirectClient is also deprecated.
 func (b *ClientSetBuilder) WithDirectClient(directClient client.Client) *ClientSetBuilder {
 	b.directClient = directClient
 	return b

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_control_test.go
@@ -291,7 +291,7 @@ var _ = Describe("ControllerRegistrationControl", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		k8sGardenRuntimeClient = mockclient.NewMockClient(ctrl)
-		k8sGardenClient := fakeclientset.NewClientSetBuilder().WithClient(k8sGardenRuntimeClient).WithDirectClient(k8sGardenRuntimeClient).Build()
+		k8sGardenClient := fakeclientset.NewClientSetBuilder().WithClient(k8sGardenRuntimeClient).Build()
 
 		clientMap = fake.NewClientMap().AddClient(keys.ForGarden(), k8sGardenClient)
 

--- a/pkg/controllermanager/controller/controllerregistration/seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed_control_test.go
@@ -237,7 +237,7 @@ var _ = Describe("SeedControl", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		k8sGardenRuntimeClient = mockclient.NewMockClient(ctrl)
-		k8sGardenClient := fakeclientset.NewClientSetBuilder().WithClient(k8sGardenRuntimeClient).WithDirectClient(k8sGardenRuntimeClient).Build()
+		k8sGardenClient := fakeclientset.NewClientSetBuilder().WithClient(k8sGardenRuntimeClient).Build()
 
 		clientMap = fake.NewClientMap().AddClient(keys.ForGarden(), k8sGardenClient)
 

--- a/pkg/controllermanager/controller/project/project_control_delete.go
+++ b/pkg/controllermanager/controller/project/project_control_delete.go
@@ -35,7 +35,7 @@ import (
 
 func (r *projectReconciler) delete(ctx context.Context, project *gardencorev1beta1.Project, gardenClient kubernetes.Interface) (reconcile.Result, error) {
 	if namespace := project.Spec.Namespace; namespace != nil {
-		isEmpty, err := isNamespaceEmpty(ctx, gardenClient.DirectClient(), *namespace)
+		isEmpty, err := isNamespaceEmpty(ctx, gardenClient.APIReader(), *namespace)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to check if namespace is empty: %w", err)
 		}

--- a/pkg/utils/kubernetes/object.go
+++ b/pkg/utils/kubernetes/object.go
@@ -30,7 +30,7 @@ func ObjectName(obj client.Object) string {
 }
 
 // DeleteObjects deletes a list of Kubernetes objects.
-func DeleteObjects(ctx context.Context, c client.Client, objects ...client.Object) error {
+func DeleteObjects(ctx context.Context, c client.Writer, objects ...client.Object) error {
 	for _, obj := range objects {
 		if err := DeleteObject(ctx, c, obj); err != nil {
 			return err
@@ -40,7 +40,7 @@ func DeleteObjects(ctx context.Context, c client.Client, objects ...client.Objec
 }
 
 // DeleteObject deletes a Kubernetes object. It ignores 'not found' and 'no match' errors.
-func DeleteObject(ctx context.Context, c client.Client, object client.Object) error {
+func DeleteObject(ctx context.Context, c client.Writer, object client.Object) error {
 	if err := c.Delete(ctx, object); client.IgnoreNotFound(err) != nil && !meta.IsNoMatchError(err) {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity scalability
/kind cleanup
/priority normal

**What this PR does / why we need it**:

This PR cleans up more usages of the `DirectClient` in order to eventually get rid of it.

It tackles usages in 
- gardenlet bootstrap code
- gardener-controller-manager project controller
- gardener-controller-manager plant controller (switches to strategic merge patches for updating the status)

**Which issue(s) this PR fixes**:
Part of #2822

**Special notes for your reviewer**:
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
