### PR TITLE
Fix client.Reader injection

### DIFF
--- a/extensions/pkg/controller/infrastructure/reconciler.go
+++ b/extensions/pkg/controller/infrastructure/reconciler.go
@@ -81,7 +81,7 @@ func (r *reconciler) InjectClient(client client.Client) error {
 	return nil
 }
 
-func (r *reconciler) InjectReader(reader client.Reader) error {
+func (r *reconciler) InjectAPIReader(reader client.Reader) error {
 	r.reader = reader
 	return nil
 }

--- a/extensions/pkg/controller/network/reconciler.go
+++ b/extensions/pkg/controller/network/reconciler.go
@@ -81,7 +81,7 @@ func (r *reconciler) InjectClient(client client.Client) error {
 	return nil
 }
 
-func (r *reconciler) InjectReader(reader client.Reader) error {
+func (r *reconciler) InjectAPIReader(reader client.Reader) error {
 	r.reader = reader
 	return nil
 }

--- a/extensions/pkg/controller/operatingsystemconfig/reconciler.go
+++ b/extensions/pkg/controller/operatingsystemconfig/reconciler.go
@@ -72,7 +72,7 @@ func (r *reconciler) InjectClient(client client.Client) error {
 	return nil
 }
 
-func (r *reconciler) InjectReader(reader client.Reader) error {
+func (r *reconciler) InjectAPIReader(reader client.Reader) error {
 	r.reader = reader
 	return nil
 }


### PR DESCRIPTION
/kind bug
/kind regression

To my knowledge we should use `InjectAPIReader` (not `InjectReader`) to inject a client.Reader.

See https://github.com/kubernetes-sigs/controller-runtime/blob/v0.8.3/pkg/runtime/inject/inject.go#L47-L49

Ref https://github.com/gardener/gardener-extension-provider-alicloud/issues/252

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
An issue causing nil pointer dereference in the extension library is now fixed.
```
