### PR TITLE
[release-v1.17] Automated cherry pick of #3732: increase istio-ingressgateway memory limits

### DIFF
--- a/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/charts/istio/istio-ingress/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
             memory: 128Mi
           limits:
             cpu: 2000m
-            memory: 1024Mi
+            memory: 2048Mi
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
Cherry pick of #3732 on release-v1.17.

#3732: increase istio-ingressgateway memory limits

**Release Notes:**
```other operator
`istio-ingressgateway` memory limit is increased to `2048Mi`
```

/invite @mvladev 