### PR TITLE
Prevent deadlock when Terraform configuration cleanup fails 

### DIFF
--- a/extensions/pkg/terraformer/config.go
+++ b/extensions/pkg/terraformer/config.go
@@ -111,11 +111,16 @@ func (t *terraformer) initializerConfig(ctx context.Context) *InitializerConfig 
 // Initializer to correctly create all the resources as specified in the given InitializerConfig.
 // A default implementation can be found in DefaultInitializer.
 func (t *terraformer) InitializeWith(ctx context.Context, initializer Initializer) Terraformer {
-	if err := initializer.Initialize(ctx, t.initializerConfig(ctx), t.ownerRef); err != nil {
+	config := t.initializerConfig(ctx)
+
+	if err := initializer.Initialize(ctx, config, t.ownerRef); err != nil {
 		t.logger.Error(err, "Could not create Terraformer ConfigMaps/Secrets")
 		return t
 	}
-	t.configurationDefined = true
+
+	t.configurationInitialized = true
+	t.stateInitialized = config.InitializeState
+
 	return t
 }
 

--- a/extensions/pkg/terraformer/config.go
+++ b/extensions/pkg/terraformer/config.go
@@ -250,6 +250,11 @@ func (t *terraformer) ConfigExists(ctx context.Context) (bool, error) {
 func (t *terraformer) CleanupConfiguration(ctx context.Context) error {
 	t.logger.Info("Cleaning up all terraformer configuration")
 
+	t.logger.V(1).Info("Deleting Terraform state ConfigMap", "name", t.stateName)
+	if err := t.client.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: t.namespace, Name: t.stateName}}); client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
 	t.logger.V(1).Info("Deleting Terraform variables Secret", "name", t.variablesName)
 	if err := t.client.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: t.namespace, Name: t.variablesName}}); client.IgnoreNotFound(err) != nil {
 		return err
@@ -257,11 +262,6 @@ func (t *terraformer) CleanupConfiguration(ctx context.Context) error {
 
 	t.logger.V(1).Info("Deleting Terraform configuration ConfigMap", "name", t.configName)
 	if err := t.client.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: t.namespace, Name: t.configName}}); client.IgnoreNotFound(err) != nil {
-		return err
-	}
-
-	t.logger.V(1).Info("Deleting Terraform state ConfigMap", "name", t.stateName)
-	if err := t.client.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: t.namespace, Name: t.stateName}}); client.IgnoreNotFound(err) != nil {
 		return err
 	}
 

--- a/extensions/pkg/terraformer/terraform_test.go
+++ b/extensions/pkg/terraformer/terraform_test.go
@@ -607,11 +607,11 @@ var _ = Describe("terraformer", func() {
 
 			gomock.InOrder(
 				c.EXPECT().
+					Delete(gomock.Any(), state.DeepCopy()),
+				c.EXPECT().
 					Delete(gomock.Any(), secret.DeepCopy()),
 				c.EXPECT().
 					Delete(gomock.Any(), config.DeepCopy()),
-				c.EXPECT().
-					Delete(gomock.Any(), state.DeepCopy()),
 			)
 
 			Expect(t.CleanupConfiguration(ctx)).NotTo(HaveOccurred())

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -128,17 +128,24 @@ func New(
 	}
 }
 
+const (
+	// CommandApply is a constant for the "apply" command.
+	CommandApply = "apply"
+	// CommandDestroy is a constant for the "destroy" command.
+	CommandDestroy = "destroy"
+)
+
 // Apply executes a Terraform Pod by running the 'terraform apply' command.
 func (t *terraformer) Apply(ctx context.Context) error {
 	if !t.configurationDefined {
 		return errors.New("terraformer configuration has not been defined, cannot execute Terraformer")
 	}
-	return t.execute(ctx, "apply")
+	return t.execute(ctx, CommandApply)
 }
 
 // Destroy executes a Terraform Pod by running the 'terraform destroy' command.
 func (t *terraformer) Destroy(ctx context.Context) error {
-	if err := t.execute(ctx, "destroy"); err != nil {
+	if err := t.execute(ctx, CommandDestroy); err != nil {
 		return err
 	}
 	return t.CleanupConfiguration(ctx)
@@ -214,7 +221,7 @@ func (t *terraformer) execute(ctx context.Context, command string) error {
 	// something at all. If it does not contain anything, then the 'apply' could never be executed, probably
 	// because of syntax errors. In this case, we want to skip the Terraform destroy pod (as it wouldn't do anything
 	// anyway) and just delete the related ConfigMaps/Secrets.
-	if command == "destroy" {
+	if command == CommandDestroy {
 		deployNewPod = !t.IsStateEmpty(ctx)
 	}
 

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -137,7 +137,7 @@ const (
 
 // Apply executes a Terraform Pod by running the 'terraform apply' command.
 func (t *terraformer) Apply(ctx context.Context) error {
-	if !t.configurationDefined {
+	if !t.configurationInitialized {
 		return errors.New("terraformer configuration has not been defined, cannot execute Terraformer")
 	}
 	return t.execute(ctx, CommandApply)

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -36,7 +36,6 @@ import (
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/retry"
 )
 
 const (
@@ -156,31 +155,29 @@ func (t *terraformer) Destroy(ctx context.Context) error {
 func (t *terraformer) execute(ctx context.Context, command string) error {
 	logger := t.logger.WithValues("command", command)
 
-	var allConfigurationResourcesExist = false
-	logger.V(1).Info("Waiting until all configuration resources exist")
-
-	// We should retry the preparation check in order to allow the kube-apiserver to actually create the ConfigMaps.
-	if err := retry.UntilTimeout(ctx, 5*time.Second, 30*time.Second, func(ctx context.Context) (done bool, err error) {
+	// When not both configuration and state were freshly initialized then we should check whether all configuration
+	// resources still exist. If yes then we can safely continue. If nothing exists then we exit early and don't run the
+	// pod. Otherwise, we might return an error in case we don't tolerate that resources are missing. We only tolerate
+	// this when the command is 'destroy'. This is because the CleanupConfiguration() function could have already
+	// deleted some of the resources (but not all). Hence, without the toleration we would end up in a deadlock and
+	// manual action would be required.
+	if !(t.configurationInitialized && t.stateInitialized) {
 		numberOfExistingResources, err := t.NumberOfResources(ctx)
 		if err != nil {
-			return retry.SevereError(err)
+			return err
 		}
-		if numberOfExistingResources == 0 {
-			logger.Info("All ConfigMaps and Secrets missing, can not execute Terraformer pod")
-			return retry.Ok()
-		} else if numberOfExistingResources == numberOfConfigResources {
+
+		switch {
+		case numberOfExistingResources == numberOfConfigResources:
 			logger.Info("All ConfigMaps and Secrets exist, will execute Terraformer pod")
-			allConfigurationResourcesExist = true
-			return retry.Ok()
-		} else {
-			logger.Error(fmt.Errorf("ConfigMaps or Secrets are missing"), "Cannot execute Terraformer pod")
-			return retry.MinorError(fmt.Errorf("%d/%d Terraform resources are missing", numberOfConfigResources-numberOfExistingResources, numberOfConfigResources))
+		case numberOfExistingResources == 0:
+			logger.Info("All ConfigMaps and Secrets missing, can not execute Terraformer pod")
+			return nil
+		case command != CommandDestroy:
+			errResourcesMissing := fmt.Errorf("%d/%d Terraform resources are missing", numberOfConfigResources-numberOfExistingResources, numberOfConfigResources)
+			logger.Error(errResourcesMissing, "Cannot execute Terraformer pod")
+			return errResourcesMissing
 		}
-	}); err != nil {
-		return err
-	}
-	if !allConfigurationResourcesExist {
-		return nil
 	}
 
 	// Check if an existing Terraformer pod is still running. If yes, then adopt it. If no, then deploy a new pod (if

--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -38,8 +38,9 @@ import (
 // * envVars is a list of environment variables which will be injected in the resulting
 //   Terraform pod. These variables can contain Terraform variables (i.e., must be prefixed
 //   with TF_VAR_).
-// * configurationDefined indicates whether the required configuration ConfigMaps/Secrets have been
+// * configurationInitialized indicates whether the Terraform variables secret and Terraform script ConfigMap have been
 //   successfully defined.
+// * stateInitialized indicates whether the Terraform state ConfigMap has been successfully defined.
 // * logLevel configures the log level for the Terraformer Pod (only compatible with terraformer@v2,
 //   defaults to "info")
 // * terminationGracePeriodSeconds is the respective Pod spec field passed to Terraformer Pods.
@@ -58,11 +59,13 @@ type terraformer struct {
 	image     string
 	ownerRef  *metav1.OwnerReference
 
-	configName           string
-	variablesName        string
-	stateName            string
-	envVars              []corev1.EnvVar
-	configurationDefined bool
+	configName    string
+	variablesName string
+	stateName     string
+	envVars       []corev1.EnvVar
+
+	configurationInitialized bool
+	stateInitialized         bool
 
 	logLevel                      string
 	terminationGracePeriodSeconds int64


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
In rare cases we see `Shoot`s stuck in deletion because of the following error:

```
Error deleting infrastructure: 1 error occurred: * 2/3 Terraform resources are missing
```

The reason is that the `CleanupConfiguration()` function deletes the two `ConfigMap`s and the one `Secret` one-by-one. Hence, when it fails in between then the "all TF config resources exist"-check in the next `Destroy()` execution fails forever.
This deadlock is now prevented as follows:

1. The `CleanupConfiguration()` function first deletes the state `ConfigMap` (this only happens after a successful `terraform destroy` run), i.e., it's safe to delete the state now.
2. This enables us to improve the "all TF config resources exist"-check in a way that tolerations missing resources when the command is `destroy` (because we know that this can only mean that the state (and maybe more) is missing, but this also means that `terraform destroy` succeeded already in a previous run).

Also, I got rid of the retry behaviour. I *think* the rationale behind it was to prevent transient errors when a new `Infrastructure` is created. In this case, it could have happened that the TF config resources are created, but when the `execute()` function tries to read them again then, due to stale caches, this could lead to cache misses and undesired error messages that potentially would be populated to the end-user. Now, I don't even execute this check when both config + state were freshly initialized (this is also the only situation in which such cache misses are undesired/unexpected). Otherwise, it is only checked once whether all resources exist, and if not, then the error is directly returned.

/cc @timebertt 
/invite @timebertt 

**Special notes for your reviewer**:
Along the road, I introduced some constants for the Terraform commands.
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A rare issue with the `Infrastructure` destruction that may result in `Shoot` resources stuck in deletion has been fixed.
```
