### PR TITLE
Cleanup some more DirectClient

### DIFF
--- a/pkg/client/kubernetes/fake/builder.go
+++ b/pkg/client/kubernetes/fake/builder.go
@@ -18,9 +18,9 @@ import (
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	gardenseedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
 
 	apiextensionclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/apimachinery/pkg/api/meta"
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	apiregistrationclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
@@ -35,11 +35,12 @@ type ClientSetBuilder struct {
 	chartApplier          kubernetes.ChartApplier
 	restConfig            *rest.Config
 	client                client.Client
+	apiReader             client.Reader
 	directClient          client.Client
 	cache                 cache.Cache
-	restMapper            meta.RESTMapper
 	kubernetes            kubernetesclientset.Interface
 	gardenCore            gardencoreclientset.Interface
+	gardenSeedManagement  gardenseedmanagementclientset.Interface
 	apiextension          apiextensionclientset.Interface
 	apiregistration       apiregistrationclientset.Interface
 	restClient            rest.Interface
@@ -82,6 +83,12 @@ func (b *ClientSetBuilder) WithClient(client client.Client) *ClientSetBuilder {
 	return b
 }
 
+// WithAPIReader sets the apiReader attribute of the builder.
+func (b *ClientSetBuilder) WithAPIReader(apiReader client.Reader) *ClientSetBuilder {
+	b.apiReader = apiReader
+	return b
+}
+
 // WithDirectClient sets the directClient attribute of the builder.
 // Deprecated: kubernetes.Interface.DirectClient is also deprecated.
 func (b *ClientSetBuilder) WithDirectClient(directClient client.Client) *ClientSetBuilder {
@@ -95,12 +102,6 @@ func (b *ClientSetBuilder) WithCache(cache cache.Cache) *ClientSetBuilder {
 	return b
 }
 
-// WithRESTMapper sets the restMapper attribute of the builder.
-func (b *ClientSetBuilder) WithRESTMapper(restMapper meta.RESTMapper) *ClientSetBuilder {
-	b.restMapper = restMapper
-	return b
-}
-
 // WithKubernetes sets the kubernetes attribute of the builder.
 func (b *ClientSetBuilder) WithKubernetes(kubernetes kubernetesclientset.Interface) *ClientSetBuilder {
 	b.kubernetes = kubernetes
@@ -110,6 +111,12 @@ func (b *ClientSetBuilder) WithKubernetes(kubernetes kubernetesclientset.Interfa
 // WithGardenCore sets the gardenCore attribute of the builder.
 func (b *ClientSetBuilder) WithGardenCore(gardenCore gardencoreclientset.Interface) *ClientSetBuilder {
 	b.gardenCore = gardenCore
+	return b
+}
+
+// WithGardenSeedManagement sets the gardenSeedManagement attribute of the builder.
+func (b *ClientSetBuilder) WithGardenSeedManagement(gardenSeedManagement gardenseedmanagementclientset.Interface) *ClientSetBuilder {
+	b.gardenSeedManagement = gardenSeedManagement
 	return b
 }
 
@@ -158,10 +165,12 @@ func (b *ClientSetBuilder) Build() *ClientSet {
 		CheckForwardPodPortFn: b.checkForwardPodPortFn,
 		restConfig:            b.restConfig,
 		client:                b.client,
+		apiReader:             b.apiReader,
 		directClient:          b.directClient,
 		cache:                 b.cache,
 		kubernetes:            b.kubernetes,
 		gardenCore:            b.gardenCore,
+		gardenSeedManagement:  b.gardenSeedManagement,
 		apiextension:          b.apiextension,
 		apiregistration:       b.apiregistration,
 		restClient:            b.restClient,

--- a/pkg/client/kubernetes/fake/clientset.go
+++ b/pkg/client/kubernetes/fake/clientset.go
@@ -42,6 +42,7 @@ type ClientSet struct {
 	chartApplier         kubernetes.ChartApplier
 	restConfig           *rest.Config
 	client               client.Client
+	apiReader            client.Reader
 	directClient         client.Client
 	cache                cache.Cache
 	kubernetes           kubernetesclientset.Interface
@@ -85,7 +86,7 @@ func (c *ClientSet) Client() client.Client {
 
 // APIReader returns a client.Reader that directly reads from the API server.
 func (c *ClientSet) APIReader() client.Reader {
-	return c.directClient
+	return c.apiReader
 }
 
 // DirectClient returns a controller-runtime client, which can be used to talk to the API server directly

--- a/pkg/client/kubernetes/fake/fake_test.go
+++ b/pkg/client/kubernetes/fake/fake_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	"github.com/gardener/gardener/pkg/client/kubernetes/test"
+	gardenseedmanagementfake "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned/fake"
 	mockdiscovery "github.com/gardener/gardener/pkg/mock/client-go/discovery"
 	mockcache "github.com/gardener/gardener/pkg/mock/controller-runtime/cache"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
@@ -88,6 +89,13 @@ var _ = Describe("Fake ClientSet", func() {
 		Expect(cs.Client()).To(BeIdenticalTo(client))
 	})
 
+	It("should correctly set apiReader attribute", func() {
+		apiReader := mockclient.NewMockReader(ctrl)
+		cs := builder.WithAPIReader(apiReader).Build()
+
+		Expect(cs.APIReader()).To(BeIdenticalTo(apiReader))
+	})
+
 	It("should correctly set directClient attribute", func() {
 		directClient := mockclient.NewMockClient(ctrl)
 		cs := builder.WithDirectClient(directClient).Build()
@@ -114,6 +122,13 @@ var _ = Describe("Fake ClientSet", func() {
 		cs := builder.WithGardenCore(gardenCore).Build()
 
 		Expect(cs.GardenCore()).To(BeIdenticalTo(gardenCore))
+	})
+
+	It("should correctly set gardenSeedManagement attribute", func() {
+		gardenSeedManagement := gardenseedmanagementfake.NewSimpleClientset()
+		cs := builder.WithGardenSeedManagement(gardenSeedManagement).Build()
+
+		Expect(cs.GardenSeedManagement()).To(BeIdenticalTo(gardenSeedManagement))
 	})
 
 	It("should correctly set apiextension attribute", func() {

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -147,8 +147,8 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	}
 
 	gardenNamespace := &corev1.Namespace{}
-	// Use direct client here since we don't want to cache all namespaces of the Garden cluster.
-	runtime.Must(k8sGardenClient.DirectClient().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace), gardenNamespace))
+	// Use api reader here since we don't want to cache all namespaces of the Garden cluster.
+	runtime.Must(k8sGardenClient.APIReader().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace), gardenNamespace))
 
 	// Initialize the workqueue metrics collection.
 	gardenmetrics.RegisterWorkqueMetrics()

--- a/pkg/gardenlet/controller/managedseed/managedseed_reconciler.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_reconciler.go
@@ -170,7 +170,7 @@ func (r *reconciler) delete(ctx context.Context, managedSeed *seedmanagementv1al
 
 func (r *reconciler) ensureShootExists(ctx context.Context, managedSeed *seedmanagementv1alpha1.ManagedSeed, condition *gardencorev1beta1.Condition, logger *logrus.Entry) (*gardencorev1beta1.Shoot, error) {
 	shoot := &gardencorev1beta1.Shoot{}
-	if err := r.gardenClient.DirectClient().Get(ctx, kutil.Key(managedSeed.Namespace, managedSeed.Spec.Shoot.Name), shoot); err != nil {
+	if err := r.gardenClient.APIReader().Get(ctx, kutil.Key(managedSeed.Namespace, managedSeed.Spec.Shoot.Name), shoot); err != nil {
 		if apierrors.IsNotFound(err) {
 			message := fmt.Sprintf("Shoot %s/%s not found", managedSeed.Namespace, managedSeed.Spec.Shoot.Name)
 			updateCondition(condition, gardencorev1beta1.ConditionFalse, "ShootNotFound", message)

--- a/pkg/gardenlet/controller/managedseed/managedseed_reconciler_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_reconciler_test.go
@@ -49,6 +49,7 @@ var _ = Describe("Reconciler", func() {
 		actuator     *mockmanagedseed.MockActuator
 		recorder     *mockrecord.MockEventRecorder
 		c            *mockclient.MockClient
+		reader       *mockclient.MockReader
 		sw           *mockclient.MockStatusWriter
 
 		reconciler reconcile.Reconciler
@@ -67,10 +68,11 @@ var _ = Describe("Reconciler", func() {
 		actuator = mockmanagedseed.NewMockActuator(ctrl)
 		recorder = mockrecord.NewMockEventRecorder(ctrl)
 		c = mockclient.NewMockClient(ctrl)
+		reader = mockclient.NewMockReader(ctrl)
 		sw = mockclient.NewMockStatusWriter(ctrl)
 
 		gardenClient.EXPECT().Client().Return(c).AnyTimes()
-		gardenClient.EXPECT().DirectClient().Return(c).AnyTimes()
+		gardenClient.EXPECT().APIReader().Return(reader).AnyTimes()
 		c.EXPECT().Status().Return(sw).AnyTimes()
 
 		reconciler = newReconciler(gardenClient, actuator, recorder, gardenerlogger.NewNopLogger())
@@ -125,7 +127,7 @@ var _ = Describe("Reconciler", func() {
 						return nil
 					},
 				)
-				c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(
+				reader.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(
 					func(_ context.Context, _ client.ObjectKey, s *gardencorev1beta1.Shoot) error {
 						*s = *shoot
 						return nil
@@ -185,7 +187,7 @@ var _ = Describe("Reconciler", func() {
 						return nil
 					},
 				)
-				c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(
+				reader.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(
 					func(_ context.Context, _ client.ObjectKey, s *gardencorev1beta1.Shoot) error {
 						*s = *shoot
 						return nil

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -554,7 +554,7 @@ func removeTaskAnnotation(ctx context.Context, o *operation.Operation, generatio
 	// Check if shoot generation was changed mid-air, i.e., whether we need to wait for the next reconciliation until we
 	// can safely remove the task annotations to ensure all required tasks are executed.
 	shoot := &gardencorev1beta1.Shoot{}
-	if err := o.K8sGardenClient.DirectClient().Get(ctx, kutil.Key(o.Shoot.Info.Namespace, o.Shoot.Info.Name), shoot); err != nil {
+	if err := o.K8sGardenClient.APIReader().Get(ctx, kutil.Key(o.Shoot.Info.Namespace, o.Shoot.Info.Name), shoot); err != nil {
 		return err
 	}
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -74,7 +74,7 @@ func (b *Botanist) EnsureClusterIdentity(ctx context.Context) error {
 	}
 
 	latestShoot := &gardencorev1beta1.Shoot{}
-	if err := b.K8sGardenClient.DirectClient().Get(ctx, kutil.Key(b.Shoot.Info.Namespace, b.Shoot.Info.Name), latestShoot); err != nil {
+	if err := b.K8sGardenClient.APIReader().Get(ctx, kutil.Key(b.Shoot.Info.Namespace, b.Shoot.Info.Name), latestShoot); err != nil {
 		return err
 	}
 
@@ -923,7 +923,7 @@ func (b *Botanist) SNIPhase(ctx context.Context) (component.Phase, error) {
 		sniEnabled = b.APIServerSNIEnabled()
 	)
 
-	if err := b.K8sSeedClient.DirectClient().Get(
+	if err := b.K8sSeedClient.APIReader().Get(
 		ctx,
 		client.ObjectKey{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: b.Shoot.SeedNamespace},
 		svc,

--- a/pkg/operation/botanist/controlplane_test.go
+++ b/pkg/operation/botanist/controlplane_test.go
@@ -125,7 +125,7 @@ var _ = Describe("controlplane", func() {
 
 		fakeClientSet := fakeclientset.NewClientSetBuilder().
 			WithChartApplier(chartApplier).
-			WithDirectClient(client).
+			WithAPIReader(client).
 			Build()
 
 		botanist.K8sSeedClient = fakeClientSet

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -139,7 +139,7 @@ func (b *Botanist) ScaleETCDToOne(ctx context.Context) error {
 
 func (b *Botanist) scaleETCD(ctx context.Context, replicas int) error {
 	for _, etcd := range []string{v1beta1constants.ETCDEvents, v1beta1constants.ETCDMain} {
-		if err := kubernetes.ScaleEtcd(ctx, b.K8sSeedClient.DirectClient(), kutil.Key(b.Shoot.SeedNamespace, etcd), replicas); client.IgnoreNotFound(err) != nil {
+		if err := kubernetes.ScaleEtcd(ctx, b.K8sSeedClient.Client(), kutil.Key(b.Shoot.SeedNamespace, etcd), replicas); client.IgnoreNotFound(err) != nil {
 			return err
 		}
 	}

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -20,7 +20,8 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
@@ -50,8 +51,9 @@ import (
 var _ = Describe("Etcd", func() {
 	var (
 		ctrl             *gomock.Controller
-		kubernetesClient *mockkubernetes.MockInterface
+		kubernetesClient kubernetes.Interface
 		c                *mockclient.MockClient
+		reader           *mockclient.MockReader
 		botanist         *Botanist
 
 		ctx                   = context.TODO()
@@ -67,8 +69,12 @@ var _ = Describe("Etcd", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		kubernetesClient = mockkubernetes.NewMockInterface(ctrl)
 		c = mockclient.NewMockClient(ctrl)
+		reader = mockclient.NewMockReader(ctrl)
+		kubernetesClient = fakeclientset.NewClientSetBuilder().
+			WithClient(c).
+			WithAPIReader(reader).
+			Build()
 		botanist = &Botanist{Operation: &operation.Operation{}}
 	})
 
@@ -103,10 +109,9 @@ var _ = Describe("Etcd", func() {
 
 			It("should successfully create an etcd interface (normal class)", func() {
 				defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.HVPA, hvpaEnabled)()
-				kubernetesClient.EXPECT().Client()
 
 				validator := &newEtcdValidator{
-					expectedClient:                  BeNil(),
+					expectedClient:                  Equal(c),
 					expectedNamespace:               Equal(namespace),
 					expectedRole:                    Equal(role),
 					expectedClass:                   Equal(class),
@@ -132,10 +137,9 @@ var _ = Describe("Etcd", func() {
 				class := etcd.ClassImportant
 
 				defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.HVPA, hvpaEnabled)()
-				kubernetesClient.EXPECT().Client()
 
 				validator := &newEtcdValidator{
-					expectedClient:                  BeNil(),
+					expectedClient:                  Equal(c),
 					expectedNamespace:               Equal(namespace),
 					expectedRole:                    Equal(role),
 					expectedClass:                   Equal(class),
@@ -167,10 +171,9 @@ var _ = Describe("Etcd", func() {
 
 			It("should successfully create an etcd interface (normal class)", func() {
 				defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.HVPAForShootedSeed, hvpaForShootedSeedEnabled)()
-				kubernetesClient.EXPECT().Client()
 
 				validator := &newEtcdValidator{
-					expectedClient:                  BeNil(),
+					expectedClient:                  Equal(c),
 					expectedNamespace:               Equal(namespace),
 					expectedRole:                    Equal(role),
 					expectedClass:                   Equal(class),
@@ -196,10 +199,9 @@ var _ = Describe("Etcd", func() {
 				class := etcd.ClassImportant
 
 				defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.HVPAForShootedSeed, hvpaForShootedSeedEnabled)()
-				kubernetesClient.EXPECT().Client()
 
 				validator := &newEtcdValidator{
-					expectedClient:                  BeNil(),
+					expectedClient:                  Equal(c),
 					expectedNamespace:               Equal(namespace),
 					expectedRole:                    Equal(role),
 					expectedClass:                   Equal(class),
@@ -343,7 +345,6 @@ var _ = Describe("Etcd", func() {
 			})
 
 			It("should set the secrets and deploy", func() {
-				kubernetesClient.EXPECT().Client().Return(c)
 				c.EXPECT().Get(ctx, kutil.Key(namespace, "etcd-backup"), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					backupSecret.DeepCopyInto(obj.(*corev1.Secret))
 					return nil
@@ -362,14 +363,12 @@ var _ = Describe("Etcd", func() {
 			})
 
 			It("should fail when reading the backup secret fails", func() {
-				kubernetesClient.EXPECT().Client().Return(c)
 				c.EXPECT().Get(ctx, kutil.Key(namespace, "etcd-backup"), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
 
 				Expect(botanist.DeployEtcd(ctx)).To(MatchError(fakeErr))
 			})
 
 			It("should fail when the backup schedule cannot be determined", func() {
-				kubernetesClient.EXPECT().Client().Return(c)
 				c.EXPECT().Get(ctx, kutil.Key(namespace, "etcd-backup"), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 					backupSecret.DeepCopyInto(obj.(*corev1.Secret))
 					return nil
@@ -409,7 +408,6 @@ var _ = Describe("Etcd", func() {
 			var patch = client.RawPatch(types.MergePatchType, []byte(`{"spec":{"replicas":0}}`))
 
 			It("should scale both etcds to 0", func() {
-				kubernetesClient.EXPECT().DirectClient().Return(c).Times(2)
 				c.EXPECT().Patch(ctx, etcdEvents, patch)
 				c.EXPECT().Patch(ctx, etcdMain, patch)
 
@@ -417,14 +415,12 @@ var _ = Describe("Etcd", func() {
 			})
 
 			It("should return the error when scaling etcd-events fails", func() {
-				kubernetesClient.EXPECT().DirectClient().Return(c)
 				c.EXPECT().Patch(ctx, etcdEvents, patch).Return(fakeErr)
 
 				Expect(botanist.ScaleETCDToZero(ctx)).To(MatchError(fakeErr))
 			})
 
 			It("should return the error when scaling etcd-main fails", func() {
-				kubernetesClient.EXPECT().DirectClient().Return(c).Times(2)
 				c.EXPECT().Patch(ctx, etcdEvents, patch)
 				c.EXPECT().Patch(ctx, etcdMain, patch).Return(fakeErr)
 
@@ -436,7 +432,6 @@ var _ = Describe("Etcd", func() {
 			var patch = client.RawPatch(types.MergePatchType, []byte(`{"spec":{"replicas":1}}`))
 
 			It("should scale both etcds to 1", func() {
-				kubernetesClient.EXPECT().DirectClient().Return(c).Times(2)
 				c.EXPECT().Patch(ctx, etcdEvents, patch)
 				c.EXPECT().Patch(ctx, etcdMain, patch)
 
@@ -444,14 +439,12 @@ var _ = Describe("Etcd", func() {
 			})
 
 			It("should return the error when scaling etcd-events fails", func() {
-				kubernetesClient.EXPECT().DirectClient().Return(c)
 				c.EXPECT().Patch(ctx, etcdEvents, patch).Return(fakeErr)
 
 				Expect(botanist.ScaleETCDToOne(ctx)).To(MatchError(fakeErr))
 			})
 
 			It("should return the error when scaling etcd-main fails", func() {
-				kubernetesClient.EXPECT().DirectClient().Return(c).Times(2)
 				c.EXPECT().Patch(ctx, etcdEvents, patch)
 				c.EXPECT().Patch(ctx, etcdMain, patch).Return(fakeErr)
 

--- a/pkg/operation/botanist/kubecontrollermanager.go
+++ b/pkg/operation/botanist/kubecontrollermanager.go
@@ -74,7 +74,7 @@ func (b *Botanist) WaitForKubeControllerManagerToBeActive(ctx context.Context) e
 
 // ScaleKubeControllerManagerToOne scales kube-controller-manager replicas to one.
 func (b *Botanist) ScaleKubeControllerManagerToOne(ctx context.Context) error {
-	return kubernetes.ScaleDeployment(ctx, b.K8sSeedClient.DirectClient(), kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeControllerManager), 1)
+	return kubernetes.ScaleDeployment(ctx, b.K8sSeedClient.Client(), kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeControllerManager), 1)
 }
 
 func (b *Botanist) determineKubeControllerManagerReplicas(ctx context.Context) (int32, error) {

--- a/pkg/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/operation/botanist/kubecontrollermanager_test.go
@@ -242,7 +242,7 @@ var _ = Describe("KubeControllerManager", func() {
 				SeedNamespace: namespace,
 			}
 
-			kubernetesClient.EXPECT().DirectClient().Return(c)
+			kubernetesClient.EXPECT().Client().Return(c)
 		})
 
 		var patch = client.RawPatch(types.MergePatchType, []byte(`{"spec":{"replicas":1}}`))

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -79,7 +79,7 @@ func (b *Botanist) WaitUntilKubeAPIServerReady(ctx context.Context) error {
 	deployment := &appsv1.Deployment{}
 
 	if err := retry.UntilTimeout(ctx, 5*time.Second, 300*time.Second, func(ctx context.Context) (done bool, err error) {
-		if err := b.K8sSeedClient.DirectClient().Get(ctx, kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), deployment); err != nil {
+		if err := b.K8sSeedClient.APIReader().Get(ctx, kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), deployment); err != nil {
 			return retry.SevereError(err)
 		}
 		if deployment.Generation != deployment.Status.ObservedGeneration {
@@ -110,7 +110,7 @@ func (b *Botanist) WaitUntilKubeAPIServerReady(ctx context.Context) error {
 			return err
 		}
 
-		newestPod, err2 := kutil.NewestPodForDeployment(ctx, b.K8sSeedClient.DirectClient(), deployment)
+		newestPod, err2 := kutil.NewestPodForDeployment(ctx, b.K8sSeedClient.APIReader(), deployment)
 		if err2 != nil {
 			return errorspkg.Wrapf(err, "failure to find the newest pod for deployment to read the logs: %s", err2.Error())
 		}

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -365,8 +365,8 @@ func (o *Operation) InitializeShootClients(ctx context.Context) error {
 // IsAPIServerRunning checks if the API server of the Shoot currently running (not scaled-down/deleted).
 func (o *Operation) IsAPIServerRunning(ctx context.Context) (bool, error) {
 	deployment := &appsv1.Deployment{}
-	// use direct client here to make sure, we're not reading from a stale cache, when checking if we should initialize a shoot client (e.g. from within the care controller)
-	if err := o.K8sSeedClient.DirectClient().Get(ctx, kutil.Key(o.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), deployment); err != nil {
+	// use API reader here to make sure, we're not reading from a stale cache, when checking if we should initialize a shoot client (e.g. from within the care controller)
+	if err := o.K8sSeedClient.APIReader().Get(ctx, kutil.Key(o.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), deployment); err != nil {
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -430,7 +430,7 @@ func OwnedBy(obj client.Object, apiVersion, kind, name string, uid types.UID) bo
 // is provided then it will be applied for each object right after listing all objects. If no object remains then nil
 // is returned. The Items field in the list object will be populated with the result returned from the server after
 // applying the filter function (if provided).
-func NewestObject(ctx context.Context, c client.Client, listObj client.ObjectList, filterFn func(client.Object) bool, listOpts ...client.ListOption) (client.Object, error) {
+func NewestObject(ctx context.Context, c client.Reader, listObj client.ObjectList, filterFn func(client.Object) bool, listOpts ...client.ListOption) (client.Object, error) {
 	if err := c.List(ctx, listObj, listOpts...); err != nil {
 		return nil, err
 	}
@@ -478,7 +478,7 @@ func NewestObject(ctx context.Context, c client.Client, listObj client.ObjectLis
 }
 
 // NewestPodForDeployment returns the most recently created Pod object for the given deployment.
-func NewestPodForDeployment(ctx context.Context, c client.Client, deployment *appsv1.Deployment) (*corev1.Pod, error) {
+func NewestPodForDeployment(ctx context.Context, c client.Reader, deployment *appsv1.Deployment) (*corev1.Pod, error) {
 	listOpts := []client.ListOption{client.InNamespace(deployment.Namespace)}
 	if deployment.Spec.Selector != nil {
 		listOpts = append(listOpts, client.MatchingLabels(deployment.Spec.Selector.MatchLabels))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity scalability
/kind cleanup
/priority normal

**What this PR does / why we need it**:

This PR cleans up more usages of the `DirectClient` in order to eventually get rid of it.

It tackles
- some reading usages in gardenlet (replaced by `APIReader`)
- the fake clientset package to be able to add an `APIReader`
- `WaitUntilLoadBalancerIsReady` and `FetchEventMessages`
- usages for scaling resources (constant patch used, so now `Reader` is needed, replaced by `Client`)

**Which issue(s) this PR fixes**:
Part of #2822

**Special notes for your reviewer**:
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
