### PR TITLE
Fix hack/.ci/component_descriptor when chart/images.yaml does not exist

### DIFF
--- a/hack/.ci/component_descriptor
+++ b/hack/.ci/component_descriptor
@@ -8,14 +8,16 @@ descriptor_out_file="${COMPONENT_DESCRIPTOR_PATH}"
 
 echo "enriching creating component descriptor from ${BASE_DEFINITION_PATH}"
 
-# translates all images defined the images.yaml into component descriptor resources.
-# For detailed documentation see https://github.com/gardener/component-cli/blob/main/docs/reference/components-cli_image-vector_add.md
-# the konnectivity-server is temporary excluded until the component-descriptor for the replica-reloader is released
-component-cli image-vector add --comp-desc ${BASE_DEFINITION_PATH} \
-  --image-vector "$repo_root_dir/charts/images.yaml" \
-  --component-prefixes eu.gcr.io/gardener-project/gardener \
-  --exclude-component-reference konnectivity-server \
-  --generic-dependencies hyperkube,kube-apiserver,kube-controller-manager,kube-scheduler,kube-proxy
+if [[ -f "$repo_root_dir/charts/images.yaml" ]]; then
+  # translates all images defined the images.yaml into component descriptor resources.
+  # For detailed documentation see https://github.com/gardener/component-cli/blob/main/docs/reference/components-cli_image-vector_add.md
+  # the konnectivity-server is temporary excluded until the component-descriptor for the replica-reloader is released
+  component-cli image-vector add --comp-desc ${BASE_DEFINITION_PATH} \
+    --image-vector "$repo_root_dir/charts/images.yaml" \
+    --component-prefixes eu.gcr.io/gardener-project/gardener \
+    --exclude-component-reference konnectivity-server \
+    --generic-dependencies hyperkube,kube-apiserver,kube-controller-manager,kube-scheduler,kube-proxy
+fi
 
 if [[ -d "$repo_root_dir/charts/" ]]; then
   for image_tpl_path in "$repo_root_dir/charts/"*"/templates/_images.tpl"; do


### PR DESCRIPTION
/area delivery
/kind bug

Currently when an extension does not have `chart/images.yaml` (all of the OS extensions), the `hack/.ci/component_descriptor` script fails with:

```
enriching creating component descriptor from /tmp/build/60e5e9b3/component_descriptor_dir/base_component_descriptor_v2
unable to open image vector file: "/tmp/build/60e5e9b3/pull-request-gardener.gardener-extension-os-gardenlinux-pr.master/.ci/../charts/images.yaml": open /tmp/build/60e5e9b3/pull-request-gardener.gardener-extension-os-gardenlinux-pr.master/.ci/../charts/images.yaml: no such file or directory
Traceback (most recent call last):
  File "<string>", line 362, in <module>
  File "/usr/lib/python3.8/subprocess.py", line 512, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/tmp/build/60e5e9b3/pull-request-gardener.gardener-extension-os-gardenlinux-pr.master/.ci/component_descriptor']' returned non-zero exit status 1.
```

Ref https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-extension-os-gardenlinux-master/jobs/master-pull-request-job/builds/2#L60573849:57

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
