### PR TITLE
[release-v1.19] Automated cherry pick of #3741: Ensure gardenlet deployment has properly set env #3742: Fix hack/.ci/component_descriptor when chart/images.yaml does not exist

### DIFF
--- a/hack/.ci/component_descriptor
+++ b/hack/.ci/component_descriptor
@@ -8,14 +8,16 @@ descriptor_out_file="${COMPONENT_DESCRIPTOR_PATH}"
 
 echo "enriching creating component descriptor from ${BASE_DEFINITION_PATH}"
 
-# translates all images defined the images.yaml into component descriptor resources.
-# For detailed documentation see https://github.com/gardener/component-cli/blob/main/docs/reference/components-cli_image-vector_add.md
-# the konnectivity-server is temporary excluded until the component-descriptor for the replica-reloader is released
-component-cli image-vector add --comp-desc ${BASE_DEFINITION_PATH} \
-  --image-vector "$repo_root_dir/charts/images.yaml" \
-  --component-prefixes eu.gcr.io/gardener-project/gardener \
-  --exclude-component-reference konnectivity-server \
-  --generic-dependencies hyperkube,kube-apiserver,kube-controller-manager,kube-scheduler,kube-proxy
+if [[ -f "$repo_root_dir/charts/images.yaml" ]]; then
+  # translates all images defined the images.yaml into component descriptor resources.
+  # For detailed documentation see https://github.com/gardener/component-cli/blob/main/docs/reference/components-cli_image-vector_add.md
+  # the konnectivity-server is temporary excluded until the component-descriptor for the replica-reloader is released
+  component-cli image-vector add --comp-desc ${BASE_DEFINITION_PATH} \
+    --image-vector "$repo_root_dir/charts/images.yaml" \
+    --component-prefixes eu.gcr.io/gardener-project/gardener \
+    --exclude-component-reference konnectivity-server \
+    --generic-dependencies hyperkube,kube-apiserver,kube-controller-manager,kube-scheduler,kube-proxy
+fi
 
 if [[ -d "$repo_root_dir/charts/" ]]; then
   for image_tpl_path in "$repo_root_dir/charts/"*"/templates/_images.tpl"; do

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
@@ -274,8 +274,16 @@ func (a *actuator) deployGardenlet(ctx context.Context, shootClient kubernetes.I
 	}
 
 	// Prepare gardenlet chart values
-	values, err := a.prepareGardenletChartValues(ctx, shootClient, managedSeed.Spec.Gardenlet.Deployment, gardenletConfig, managedSeed.Name,
-		v1alpha1helper.GetBootstrap(managedSeed.Spec.Gardenlet.Bootstrap), utils.IsTrue(managedSeed.Spec.Gardenlet.MergeWithParent), shoot)
+	values, err := a.prepareGardenletChartValues(
+		ctx,
+		shootClient,
+		managedSeed.Spec.Gardenlet.Deployment,
+		gardenletConfig,
+		managedSeed.Name,
+		v1alpha1helper.GetBootstrap(managedSeed.Spec.Gardenlet.Bootstrap),
+		utils.IsTrue(managedSeed.Spec.Gardenlet.MergeWithParent),
+		shoot,
+	)
 	if err != nil {
 		return err
 	}
@@ -297,8 +305,15 @@ func (a *actuator) deleteGardenlet(ctx context.Context, shootClient kubernetes.I
 	}
 
 	// Prepare gardenlet chart values
-	values, err := a.prepareGardenletChartValues(ctx, shootClient, managedSeed.Spec.Gardenlet.Deployment, gardenletConfig, managedSeed.Name,
-		v1alpha1helper.GetBootstrap(managedSeed.Spec.Gardenlet.Bootstrap), utils.IsTrue(managedSeed.Spec.Gardenlet.MergeWithParent), shoot)
+	values, err := a.prepareGardenletChartValues(
+		ctx,
+		shootClient,
+		managedSeed.Spec.Gardenlet.Deployment,
+		gardenletConfig,
+		managedSeed.Name,
+		v1alpha1helper.GetBootstrap(managedSeed.Spec.Gardenlet.Bootstrap),
+		utils.IsTrue(managedSeed.Spec.Gardenlet.MergeWithParent), shoot,
+	)
 	if err != nil {
 		return err
 	}
@@ -525,7 +540,45 @@ func (a *actuator) prepareGardenletChartValues(
 	gardenletConfig.SeedSelector = nil
 
 	// Get gardenlet chart values
-	return a.vp.GetGardenletChartValues(deployment, gardenletConfig, bootstrapKubeconfig)
+	return a.vp.GetGardenletChartValues(
+		ensureGardenletEnvironment(deployment, shoot.Spec.DNS),
+		gardenletConfig,
+		bootstrapKubeconfig,
+	)
+}
+
+// ensureGardenletEnvironment sets the KUBERNETES_SERVICE_HOST to the API of the ManagedSeed cluster.
+// This is needed so that the deployed gardenlet can properly set the network policies allowing
+// access of control plane components of the hosted shoots to the API server of the (managed) seed.
+func ensureGardenletEnvironment(deployment *seedmanagementv1alpha1.GardenletDeployment, dns *gardencorev1beta1.DNS) *seedmanagementv1alpha1.GardenletDeployment {
+	const kubernetesServiceHost = "KUBERNETES_SERVICE_HOST"
+	var shootDomain = ""
+
+	if deployment.Env == nil {
+		deployment.Env = []corev1.EnvVar{}
+	}
+
+	for _, env := range deployment.Env {
+		if env.Name == kubernetesServiceHost {
+			return deployment
+		}
+	}
+
+	if dns != nil && dns.Domain != nil && len(*dns.Domain) != 0 {
+		shootDomain = common.GetAPIServerDomain(*dns.Domain)
+	}
+
+	if len(shootDomain) != 0 {
+		deployment.Env = append(
+			deployment.Env,
+			corev1.EnvVar{
+				Name:  kubernetesServiceHost,
+				Value: shootDomain,
+			},
+		)
+	}
+
+	return deployment
 }
 
 const (

--- a/pkg/gardenlet/controller/managedseed/managedseed_valueshelper_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_valueshelper_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/test"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -171,7 +170,6 @@ var _ = Describe("ValuesHelper", func() {
 			},
 			PodAnnotations: map[string]string{
 				"foo": "bar",
-				"networking.gardener.cloud/seed-sni-enabled": "true",
 			},
 			VPA: pointer.BoolPtr(true),
 		}
@@ -252,7 +250,6 @@ var _ = Describe("ValuesHelper", func() {
 						},
 						"podAnnotations": map[string]interface{}{
 							"foo": "bar",
-							"networking.gardener.cloud/seed-sni-enabled": "true",
 						},
 						"vpa":                            true,
 						"imageVectorOverwrite":           "image vector overwrite",
@@ -351,44 +348,4 @@ var _ = Describe("ValuesHelper", func() {
 		})
 	})
 
-	Describe("#getParentPodAnnotations", func() {
-		DescribeTable("seed-sni-enabled annotation", func(enabled bool, version string, added bool) {
-			Expect(gardenletfeatures.FeatureGate.SetFromMap(map[string]bool{"APIServerSNI": enabled})).To(Succeed())
-
-			shoot := &gardencorev1beta1.Shoot{
-				Status: gardencorev1beta1.ShootStatus{
-					Gardener: gardencorev1beta1.Gardener{
-						Version: version,
-					},
-				},
-			}
-
-			actualAnnotations := getParentPodAnnotations(shoot)
-
-			if added {
-				Expect(actualAnnotations).To(HaveKeyWithValue("networking.gardener.cloud/seed-sni-enabled", "true"))
-				Expect(actualAnnotations).To(HaveLen(1))
-			} else {
-				Expect(actualAnnotations).To(BeEmpty())
-			}
-		},
-			Entry("should be added for SNI enabled and release 1.14.1", true, "1.14.1", true),
-			Entry("should be added for SNI enabled and pre-release 1.14", true, "1.14-dev", true),
-			Entry("should be added for SNI enabled and pre-release 1.14.0", true, "1.14.0-dev", true),
-			Entry("should be added for SNI enabled and release 1.13.3", true, "1.13.3", true),
-			Entry("should be added for SNI enabled and pre-release 1.13", true, "1.13-dev", true),
-			Entry("should be added for SNI enabled and pre-release 1.13.0", true, "1.13.0-dev", true),
-			Entry("should not be added for SNI enabled and release 1.12.8", true, "1.12.8", false),
-			Entry("should not be added for SNI enabled and unparsable version", true, "not a semver", false),
-
-			Entry("should not be added for SNI disabled and release 1.14.1", false, "1.14.1", false),
-			Entry("should not be added for SNI disabled and pre-release 1.14", false, "1.14-dev", false),
-			Entry("should not be added for SNI disabled and pre-release 1.14.0", false, "1.14.0-dev", false),
-			Entry("should not be added for SNI disabled and release 1.13.3", false, "1.13.3", false),
-			Entry("should not be added for SNI disabled and pre-release 1.13", false, "1.13-dev", false),
-			Entry("should not be added for SNI disabled and pre-release 1.13.0", false, "1.13.0-dev", false),
-			Entry("should not be added for SNI disabled and release 1.12.8", false, "1.12.8", false),
-			Entry("should not be added for SNI disabled and unparsable version", false, "not a semver", false),
-		)
-	})
 })


### PR DESCRIPTION
Cherry pick of #3741 #3742 on release-v1.19.

#3741: Ensure gardenlet deployment has properly set env
#3742: Fix hack/.ci/component_descriptor when chart/images.yaml does not exist

**Release Notes:**
```bugfix operator
Fix a bug where the `gardenlet` was not updating the `allow-to-seed-apiserver` network policy with the IP address of the seed's API server when the `APIServerSNI` feature gate is just enabled.
```