### PR TITLE
Add ConfigMap handling to SeedAuthorizer

### DIFF
--- a/docs/deployment/gardenlet_api_access.md
+++ b/docs/deployment/gardenlet_api_access.md
@@ -52,9 +52,10 @@ With the `Seed` name at hand, the authorizer checks for an **existing path** fro
 
 Today, the following rules are implemented:
 
-| Resource        | Verb        | Path                                   | Description            |
-| ----------------|-------------|----------------------------------------|------------------------|
-| `CloudProfile`  | Get         | `CloudProfile` -> `Shoot` -> `Seed`    | Allow `get` requests for CloudProfiles, referenced by `Shoot`s that are assigned to the `gardenlet`'s `Seed`. Deny `get` requests to other `CloudProfile`s. |
+| Resource       | Verb  | Path                                | Description            |
+| -------------- | ----- | ----------------------------------- | ---------------------- |
+| `CloudProfile` | `get` | `CloudProfile` -> `Shoot` -> `Seed` | Allow `get` requests for `CloudProfile`s referenced by `Shoot`s that are assigned to the `gardenlet`'s `Seed`. Deny `get` requests to other `CloudProfile`s. |
+| `ConfigMap`    | `get` | `ConfigMap` -> `Shoot` -> `Seed`    | Allow `get` requests for `ConfigMap`s referenced by `Shoot`s that are assigned to the `gardenlet`'s `Seed`. Deny `get` requests to other `ConfigMap`s. |
 
 ### Implementation Details
 

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
@@ -22,6 +22,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	auth "k8s.io/apiserver/pkg/authorization/authorizer"
 )
@@ -47,6 +48,8 @@ var _ = auth.Authorizer(&authorizer{})
 var (
 	// Only take v1beta1 because the Authorize function only checks the resource group and the resource.
 	cloudProfileResource = gardencorev1beta1.Resource("cloudprofiles")
+
+	configMapResource = corev1.Resource("configmaps")
 )
 
 // TODO: Revisit all `DecisionNoOpinion` later. Today we cannot deny the request for backwards compatibility
@@ -64,6 +67,8 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 		switch requestResource {
 		case cloudProfileResource:
 			return a.authorizeGet(seedName, graph.VertexTypeCloudProfile, attrs)
+		case configMapResource:
+			return a.authorizeGet(seedName, graph.VertexTypeConfigMap, attrs)
 		}
 	}
 

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
@@ -18,17 +18,16 @@ import (
 	"context"
 	"fmt"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-
-	"github.com/golang/mock/gomock"
-
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/gardener/gardener/pkg/admissioncontroller/webhooks/auth/seed"
 	graphpkg "github.com/gardener/gardener/pkg/admissioncontroller/webhooks/auth/seed/graph"
-	"github.com/gardener/gardener/pkg/admissioncontroller/webhooks/auth/seed/graph/mock"
+	mockgraph "github.com/gardener/gardener/pkg/admissioncontroller/webhooks/auth/seed/graph/mock"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 
 	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -42,7 +41,7 @@ var _ = Describe("Seed", func() {
 		ctrl *gomock.Controller
 
 		logger     logr.Logger
-		graph      *mock.MockInterface
+		graph      *mockgraph.MockInterface
 		authorizer auth.Authorizer
 
 		seedName                string
@@ -54,7 +53,7 @@ var _ = Describe("Seed", func() {
 		ctrl = gomock.NewController(GinkgoT())
 
 		logger = logzap.New(logzap.WriteTo(GinkgoWriter))
-		graph = mock.NewMockInterface(ctrl)
+		graph = mockgraph.NewMockInterface(ctrl)
 		authorizer = NewAuthorizer(logger, graph)
 
 		seedName = "seed"
@@ -148,6 +147,86 @@ var _ = Describe("Seed", func() {
 
 			It("should have no opinion because path to seed does not exists", func() {
 				graph.EXPECT().HasPathFrom(graphpkg.VertexTypeCloudProfile, "", cloudProfileName, graphpkg.VertexTypeSeed, "", seedName).Return(false)
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("no relationship found"))
+			})
+
+			It("should have no opinion because no get verb", func() {
+				attrs.Verb = "list"
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("can only get individual resources of this type"))
+			})
+
+			It("should have no opinion because no resources requested", func() {
+				attrs.Subresource = "status"
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("cannot get subresource"))
+			})
+
+			It("should have no opinion because no resource name is given", func() {
+				attrs.Name = ""
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("No Object name found"))
+			})
+
+			It("should allow because seed name is ambiguous", func() {
+				attrs.User = ambiguousUser
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionAllow))
+				Expect(reason).To(BeEmpty())
+			})
+		})
+
+		Context("when requested for ConfigMaps", func() {
+			var (
+				name, namespace string
+				attrs           *auth.AttributesRecord
+			)
+
+			BeforeEach(func() {
+				name, namespace = "foo", "bar"
+				attrs = &auth.AttributesRecord{
+					User:            seedUser,
+					Name:            name,
+					Namespace:       namespace,
+					APIGroup:        corev1.SchemeGroupVersion.Group,
+					Resource:        "configmaps",
+					ResourceRequest: true,
+					Verb:            "get",
+				}
+			})
+
+			It("should allow because path to seed exists", func() {
+				graph.EXPECT().HasPathFrom(graphpkg.VertexTypeConfigMap, namespace, name, graphpkg.VertexTypeSeed, "", seedName).Return(true)
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionAllow))
+				Expect(reason).To(BeEmpty())
+			})
+
+			It("should have no opinion because path to seed does not exists", func() {
+				graph.EXPECT().HasPathFrom(graphpkg.VertexTypeConfigMap, namespace, name, graphpkg.VertexTypeSeed, "", seedName).Return(false)
 
 				decision, reason, err := authorizer.Authorize(ctx, attrs)
 

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -106,7 +106,6 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		// Kubernetes core informers
 		namespaceInformer = f.k8sInformers.Core().V1().Namespaces().Informer()
 		secretInformer    = f.k8sInformers.Core().V1().Secrets().Informer()
-		configMapInformer = f.k8sInformers.Core().V1().ConfigMaps().Informer()
 	)
 
 	if err := f.clientMap.Start(ctx.Done()); err != nil {
@@ -124,7 +123,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	}
 
 	f.k8sInformers.Start(ctx.Done())
-	if !cache.WaitForCacheSync(ctx.Done(), namespaceInformer.HasSynced, secretInformer.HasSynced, configMapInformer.HasSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), namespaceInformer.HasSynced, secretInformer.HasSynced) {
 		return fmt.Errorf("timed out waiting for Kube caches to sync")
 	}
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -850,7 +850,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 
 func (b *Botanist) getAuditPolicy(ctx context.Context, name, namespace string) (string, error) {
 	auditPolicyCm := &corev1.ConfigMap{}
-	if err := b.K8sGardenClient.Client().Get(ctx, kutil.Key(namespace, name), auditPolicyCm); err != nil {
+	if err := b.K8sGardenClient.APIReader().Get(ctx, kutil.Key(namespace, name), auditPolicyCm); err != nil {
 		return "", err
 	}
 	auditPolicy, ok := auditPolicyCm.Data[auditPolicyConfigMapDataKey]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR adds handling for `ConfigMap` resource to the `SeedAuthorizer`.

**Which issue(s) this PR fixes**:
Part of #1723 

**Special notes for your reviewer**:
Similar to #3708

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
