### PR TITLE
Add SecretBinding handling to SeedAuthorizer

### DIFF
--- a/docs/deployment/gardenlet_api_access.md
+++ b/docs/deployment/gardenlet_api_access.md
@@ -52,10 +52,11 @@ With the `Seed` name at hand, the authorizer checks for an **existing path** fro
 
 Today, the following rules are implemented:
 
-| Resource       | Verb  | Path                                | Description            |
-| -------------- | ----- | ----------------------------------- | ---------------------- |
-| `CloudProfile` | `get` | `CloudProfile` -> `Shoot` -> `Seed` | Allow `get` requests for `CloudProfile`s referenced by `Shoot`s that are assigned to the `gardenlet`'s `Seed`. Deny `get` requests to other `CloudProfile`s. |
-| `ConfigMap`    | `get` | `ConfigMap` -> `Shoot` -> `Seed`    | Allow `get` requests for `ConfigMap`s referenced by `Shoot`s that are assigned to the `gardenlet`'s `Seed`. Deny `get` requests to other `ConfigMap`s. |
+| Resource        | Verb  | Path                                 | Description            |
+| --------------- | ----- | ------------------------------------ | ---------------------- |
+| `CloudProfile`  | `get` | `CloudProfile` -> `Shoot` -> `Seed`  | Allow `get` requests for `CloudProfile`s referenced by `Shoot`s that are assigned to the `gardenlet`'s `Seed`. Deny `get` requests to other `CloudProfile`s. |
+| `ConfigMap`     | `get` | `ConfigMap` -> `Shoot` -> `Seed`     | Allow `get` requests for `ConfigMap`s referenced by `Shoot`s that are assigned to the `gardenlet`'s `Seed`. Deny `get` requests to other `ConfigMap`s. |
+| `SecretBinding` | `get` | `SecretBinding` -> `Shoot` -> `Seed` | Allow `get` requests for `SecretBinding`s referenced by `Shoot`s that are assigned to the `gardenlet`'s `Seed`. Deny `get` requests to other `SecretBinding`s. |
 
 ### Implementation Details
 

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
@@ -46,10 +46,11 @@ type authorizer struct {
 var _ = auth.Authorizer(&authorizer{})
 
 var (
-	// Only take v1beta1 because the Authorize function only checks the resource group and the resource.
-	cloudProfileResource = gardencorev1beta1.Resource("cloudprofiles")
-
-	configMapResource = corev1.Resource("configmaps")
+	// Only take v1beta1 for the core.gardener.cloud API group because the Authorize function only checks the resource
+	// group and the resource (but it ignores the version).
+	cloudProfileResource  = gardencorev1beta1.Resource("cloudprofiles")
+	configMapResource     = corev1.Resource("configmaps")
+	secretBindingResource = gardencorev1beta1.Resource("secretbindings")
 )
 
 // TODO: Revisit all `DecisionNoOpinion` later. Today we cannot deny the request for backwards compatibility
@@ -69,6 +70,8 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			return a.authorizeGet(seedName, graph.VertexTypeCloudProfile, attrs)
 		case configMapResource:
 			return a.authorizeGet(seedName, graph.VertexTypeConfigMap, attrs)
+		case secretBindingResource:
+			return a.authorizeGet(seedName, graph.VertexTypeSecretBinding, attrs)
 		}
 	}
 

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
@@ -275,5 +275,85 @@ var _ = Describe("Seed", func() {
 				Expect(reason).To(BeEmpty())
 			})
 		})
+
+		Context("when requested for SecretBindings", func() {
+			var (
+				name, namespace string
+				attrs           *auth.AttributesRecord
+			)
+
+			BeforeEach(func() {
+				name, namespace = "foo", "bar"
+				attrs = &auth.AttributesRecord{
+					User:            seedUser,
+					Name:            name,
+					Namespace:       namespace,
+					APIGroup:        gardencorev1beta1.SchemeGroupVersion.Group,
+					Resource:        "secretbindings",
+					ResourceRequest: true,
+					Verb:            "get",
+				}
+			})
+
+			It("should allow because path to seed exists", func() {
+				graph.EXPECT().HasPathFrom(graphpkg.VertexTypeSecretBinding, namespace, name, graphpkg.VertexTypeSeed, "", seedName).Return(true)
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionAllow))
+				Expect(reason).To(BeEmpty())
+			})
+
+			It("should have no opinion because path to seed does not exists", func() {
+				graph.EXPECT().HasPathFrom(graphpkg.VertexTypeSecretBinding, namespace, name, graphpkg.VertexTypeSeed, "", seedName).Return(false)
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("no relationship found"))
+			})
+
+			It("should have no opinion because no get verb", func() {
+				attrs.Verb = "list"
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("can only get individual resources of this type"))
+			})
+
+			It("should have no opinion because no resources requested", func() {
+				attrs.Subresource = "status"
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("cannot get subresource"))
+			})
+
+			It("should have no opinion because no resource name is given", func() {
+				attrs.Name = ""
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("No Object name found"))
+			})
+
+			It("should allow because seed name is ambiguous", func() {
+				attrs.User = ambiguousUser
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionAllow))
+				Expect(reason).To(BeEmpty())
+			})
+		})
 	})
 })

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -103,7 +103,6 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		controllerRegistrationInformer = f.k8sGardenCoreInformers.Core().V1beta1().ControllerRegistrations().Informer()
 		controllerInstallationInformer = f.k8sGardenCoreInformers.Core().V1beta1().ControllerInstallations().Informer()
 		projectInformer                = f.k8sGardenCoreInformers.Core().V1beta1().Projects().Informer()
-		secretBindingInformer          = f.k8sGardenCoreInformers.Core().V1beta1().SecretBindings().Informer()
 		seedInformer                   = f.k8sGardenCoreInformers.Core().V1beta1().Seeds().Informer()
 		shootInformer                  = f.k8sGardenCoreInformers.Core().V1beta1().Shoots().Informer()
 		// Kubernetes core informers
@@ -121,7 +120,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	}
 
 	f.k8sGardenCoreInformers.Start(ctx.Done())
-	if !cache.WaitForCacheSync(ctx.Done(), backupBucketInformer.HasSynced, backupEntryInformer.HasSynced, controllerRegistrationInformer.HasSynced, controllerInstallationInformer.HasSynced, projectInformer.HasSynced, secretBindingInformer.HasSynced, seedInformer.HasSynced, shootInformer.HasSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), backupBucketInformer.HasSynced, backupEntryInformer.HasSynced, controllerRegistrationInformer.HasSynced, controllerInstallationInformer.HasSynced, projectInformer.HasSynced, seedInformer.HasSynced, shootInformer.HasSynced) {
 		return fmt.Errorf("timed out waiting for Garden core caches to sync")
 	}
 

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -290,6 +290,7 @@ func (c *defaultCareControl) Care(shootObj *gardencorev1beta1.Shoot, key string)
 
 	operation, err := NewOperation(
 		ctx,
+		gardenClient,
 		seedClient,
 		c.config,
 		c.identity,

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_test.go
@@ -710,6 +710,7 @@ func opFunc(op *operation.Operation, err error) NewOperationFunc {
 	return func(
 		_ context.Context,
 		_ kubernetes.Interface,
+		_ kubernetes.Interface,
 		_ *config.GardenletConfiguration,
 		_ *gardencorev1beta1.Gardener,
 		_ string,

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
@@ -74,6 +74,7 @@ var defaultNewGarbageCollector = func(op *operation.Operation, init care.ShootCl
 // NewOperationFunc is a function used to create a new `operation.Operation` instance.
 type NewOperationFunc func(
 	ctx context.Context,
+	gardenClient kubernetes.Interface,
 	seedClient kubernetes.Interface,
 	config *config.GardenletConfiguration,
 	gardenerInfo *gardencorev1beta1.Gardener,
@@ -84,10 +85,14 @@ type NewOperationFunc func(
 	clientMap clientmap.ClientMap,
 	shoot *gardencorev1beta1.Shoot,
 	logger *logrus.Entry,
-) (*operation.Operation, error)
+) (
+	*operation.Operation,
+	error,
+)
 
 var defaultNewOperationFunc = func(
 	ctx context.Context,
+	gardenClient kubernetes.Interface,
 	seedClient kubernetes.Interface,
 	config *config.GardenletConfiguration,
 	gardenerInfo *gardencorev1beta1.Gardener,
@@ -98,7 +103,10 @@ var defaultNewOperationFunc = func(
 	clientMap clientmap.ClientMap,
 	shoot *gardencorev1beta1.Shoot,
 	logger *logrus.Entry,
-) (*operation.Operation, error) {
+) (
+	*operation.Operation,
+	error,
+) {
 	return operation.
 		NewBuilder().
 		WithLogger(logger).
@@ -109,6 +117,6 @@ var defaultNewOperationFunc = func(
 		WithImageVector(imageVector).
 		WithGardenFrom(k8sGardenCoreInformers, shoot.Namespace).
 		WithSeedFrom(k8sGardenCoreInformers, *shoot.Spec.SeedName).
-		WithShootFromCluster(k8sGardenCoreInformers, seedClient, shoot).
+		WithShootFromCluster(gardenClient, seedClient, shoot).
 		Build(ctx, clientMap)
 }

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -291,7 +291,7 @@ func (c *Controller) initializeOperation(ctx context.Context, logger *logrus.Ent
 		NewBuilder().
 		WithShootObject(shoot).
 		WithCloudProfileObject(cloudProfile).
-		WithShootSecretFromSecretBindingLister(c.k8sGardenCoreInformers.Core().V1beta1().SecretBindings().Lister()).
+		WithShootSecretFromReader(gardenClient.APIReader()).
 		WithProjectName(project.Name).
 		WithDisableDNS(!seedObj.Info.Spec.Settings.ShootDNS.Enabled).
 		WithInternalDomain(gardenObj.InternalDomain).

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -181,7 +181,7 @@ func (b *Builder) WithShootFrom(k8sGardenCoreInformers gardencoreinformers.Inter
 			NewBuilder().
 			WithShootObject(s).
 			WithCloudProfileObjectFromReader(gardenClient.APIReader()).
-			WithShootSecretFromSecretBindingLister(k8sGardenCoreInformers.SecretBindings().Lister()).
+			WithShootSecretFromReader(gardenClient.APIReader()).
 			WithProjectName(gardenObj.Project.Name).
 			WithDisableDNS(!seedObj.Info.Spec.Settings.ShootDNS.Enabled).
 			WithInternalDomain(gardenObj.InternalDomain).
@@ -193,7 +193,7 @@ func (b *Builder) WithShootFrom(k8sGardenCoreInformers gardencoreinformers.Inter
 
 // WithShootFromCluster sets the shootFunc attribute at the Builder which will build a new Shoot object constructed from the cluster resource.
 // The shoot status is still taken from the passed `shoot`, though.
-func (b *Builder) WithShootFromCluster(k8sGardenCoreInformers gardencoreinformers.Interface, seedClient kubernetes.Interface, s *gardencorev1beta1.Shoot) *Builder {
+func (b *Builder) WithShootFromCluster(gardenClient, seedClient kubernetes.Interface, s *gardencorev1beta1.Shoot) *Builder {
 	b.shootFunc = func(ctx context.Context, c client.Client, gardenObj *garden.Garden, seedObj *seed.Seed) (*shoot.Shoot, error) {
 		shootNamespace := shoot.ComputeTechnicalID(gardenObj.Project.Name, s)
 
@@ -201,7 +201,7 @@ func (b *Builder) WithShootFromCluster(k8sGardenCoreInformers gardencoreinformer
 			NewBuilder().
 			WithShootObjectFromCluster(seedClient, shootNamespace).
 			WithCloudProfileObjectFromCluster(seedClient, shootNamespace).
-			WithShootSecretFromSecretBindingLister(k8sGardenCoreInformers.SecretBindings().Lister()).
+			WithShootSecretFromReader(gardenClient.APIReader()).
 			WithProjectName(gardenObj.Project.Name).
 			WithDisableDNS(!seedObj.Info.Spec.Settings.ShootDNS.Enabled).
 			WithInternalDomain(gardenObj.InternalDomain).

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -39,14 +39,13 @@ import (
 
 	"github.com/Masterminds/semver"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Builder is an object that builds Shoot objects.
 type Builder struct {
 	shootObjectFunc  func(context.Context) (*gardencorev1beta1.Shoot, error)
 	cloudProfileFunc func(context.Context, string) (*gardencorev1beta1.CloudProfile, error)
-	shootSecretFunc  func(context.Context, client.Client, string, string) (*corev1.Secret, error)
+	shootSecretFunc  func(context.Context, string, string) (*corev1.Secret, error)
 	projectName      string
 	internalDomain   *garden.Domain
 	defaultDomains   []*garden.Domain


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR adds handling for `SecretBinding` resource to the `SeedAuthorizer`.

**Which issue(s) this PR fixes**:
Part of #1723 

**Special notes for your reviewer**:
Similar to #3708

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
