### PR TITLE
Prevent 'jq: not found' error on make docker-images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ EFFECTIVE_VERSION                   := $(VERSION)-$(shell git rev-parse HEAD)
 REPO_ROOT                           := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 LOCAL_GARDEN_LABEL                  := local-garden
 REMOTE_GARDEN_LABEL                 := remote-garden
-CR_VERSION                          := $(shell go mod edit -json | jq -r '.Require[] | select(.Path=="sigs.k8s.io/controller-runtime") | .Version')
+CR_VERSION                          := $(shell go list -m -f '{{ .Version }}' sigs.k8s.io/controller-runtime)
 ACTIVATE_SEEDAUTHORIZER             := false
 
 ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)


### PR DESCRIPTION
Currently on `make docker-images` there is always one annoying error `/bin/sh: 1: jq: not found` that is being shown:

```
$ make docker-images
Step 1/12 : ARG GCR_PULL_URL=eu.gcr.io/gardener-project/3rd/
Step 2/12 : FROM ${GCR_PULL_URL}golang:1.15.9 AS builder
 ---> 7ab2ba72cb2d
Step 3/12 : WORKDIR /go/src/github.com/gardener/gardener
 ---> Using cache
 ---> e052fdcf5cc7
Step 4/12 : COPY . .
 ---> fc40e498dc97
Step 5/12 : ARG EFFECTIVE_VERSION
 ---> Running in 0805e8ad8ddd
Removing intermediate container 0805e8ad8ddd
 ---> 09c8aaada9f6
Step 6/12 : RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
 ---> Running in 3c8c3c59b901
/bin/sh: 1: jq: not found
> Install
```

This PR updates the Makefile to do not require jq, hence `/bin/sh: 1: jq: not found`  is no longer shown on docker build:

```
Step 1/12 : ARG GCR_PULL_URL=eu.gcr.io/gardener-project/3rd/
Step 2/12 : FROM ${GCR_PULL_URL}golang:1.15.9 AS builder
 ---> 7ab2ba72cb2d
Step 3/12 : WORKDIR /go/src/github.com/gardener/gardener
 ---> Using cache
 ---> e052fdcf5cc7
Step 4/12 : COPY . .
 ---> Using cache
 ---> d25515146857
Step 5/12 : ARG EFFECTIVE_VERSION
 ---> Running in 7045e9f79fb1
Removing intermediate container 7045e9f79fb1
 ---> 1d790f99964a
Step 6/12 : RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
 ---> Running in 538860f15523
> Install
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
