### PR TITLE
Minimum 2 KAPI replicas for production shoots

### DIFF
--- a/docs/usage/shoot_purposes.md
+++ b/docs/usage/shoot_purposes.md
@@ -10,9 +10,10 @@ The `Shoot` resource contains a `.spec.purpose` field indicating how the shoot i
 
 ## Behavioral Differences
 
-So far, the only difference in the way the shoot cluster is set up is that
+The following enlists the differences in the way the shoot clusters are set up based on the selected purpose:
 
 * `testing` shoot clusters **do not** get a monitoring or a logging stack as part of their control planes.
+* `production` shoot clusters get at least two replicas of the `kube-apiserver` for their control planes.
 
 There are also differences with respect to how `testing` shoots are scheduled after creation, please consult the [Scheduler documentation](../concepts/scheduler.md).
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -632,6 +632,10 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 		maxReplicas = autoscaler.MaxReplicas
 	}
 
+	if b.Shoot.Purpose == gardencorev1beta1.ShootPurposeProduction {
+		minReplicas = 2
+	}
+
 	if b.ManagedSeed != nil && b.ManagedSeedAPIServer != nil && !hvpaEnabled {
 		defaultValues["replicas"] = *b.ManagedSeedAPIServer.Replicas
 		defaultValues["apiServerResources"] = map[string]interface{}{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness high-availability
/kind enhancement

**What this PR does / why we need it**:
Shoot clusters with `production` purpose have now at least two kube-apiserver replicas.

**Special notes for your reviewer**:
/cc @vlerenc @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Shoot clusters with `production` purpose have now at least two `kube-apiserver` replicas.
```
