### PR TITLE
Add note about version requirement of the remote cluster

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -239,6 +239,8 @@ To close the tunnels and remove the locally-running Docker containers, run:
 make remote-garden-down
 ```
 
+> Note: The minimum K8S version of the remote cluster that can be used as Garden cluster is `1.19.x`.
+
 #### Prepare the Gardener
 
 Now, that you have started your local cluster, we can go ahead and register the Gardener API Server.


### PR DESCRIPTION
/area dev-productivity

For K8s < 1.19.x, the quic-lb cannot be created:
```
Events:
  Type     Reason                  Age                From                Message
  ----     ------                  ----               ----                -------
  Normal   EnsuringLoadBalancer    10s (x5 over 85s)  service-controller  Ensuring load balancer
  Warning  SyncLoadBalancerFailed  10s (x5 over 85s)  service-controller  Error syncing load balancer: failed to ensure load balancer: Only TCP LoadBalancer is supported for AWS ELB
```

NLB with UDP is only supported from K8S >= 1.19.x - ref https://github.com/kubernetes/kubernetes/pull/92109.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
