### PR TITLE
Fix make check on master

### DIFF
--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -51,7 +51,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/utils/pointer"

--- a/test/framework/gardenerframework.go
+++ b/test/framework/gardenerframework.go
@@ -100,6 +100,7 @@ func (f *GardenerFramework) BeforeEach() {
 func validateGardenerConfig(cfg *GardenerConfig) {
 	if cfg == nil {
 		ginkgo.Fail("no gardener framework configuration provided")
+		return // make linters happy
 	}
 	if !StringSet(cfg.GardenerKubeconfig) {
 		ginkgo.Fail("you need to specify the correct path for the kubeconfig")

--- a/test/framework/managedseedframework.go
+++ b/test/framework/managedseedframework.go
@@ -95,6 +95,7 @@ func (f *ManagedSeedFramework) AfterEach(ctx context.Context) {
 func validateManagedSeedConfig(cfg *ManagedSeedConfig) {
 	if cfg == nil {
 		ginkgo.Fail("no configuration provided")
+		return // make linters happy
 	}
 	if !StringSet(cfg.ManagedSeedName) {
 		ginkgo.Fail("You should specify a name for the managed seed")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-head-update-job/builds/61#L605a0636:258
```
> Check
Executing golangci-lint
WARN [runner] Can't run linter goanalysis_metalinter: S1028: failed prerequisites: [(inspect@github.com/gardener/gardener/pkg/apis/core/validation, isgenerated@github.com/gardener/gardener/pkg/apis/core/validation): analysis skipped: errors in package: [/go/src/github.com/gardener/gardener/pkg/apis/core/validation/shoot.go:30:2: could not import github.com/gardener/gardener/pkg/operation/botanist (/go/src/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go:54:2: "k8s.io/apimachinery/pkg/runtime" imported but not used)]] 
ERRO Running error: S1028: failed prerequisites: [(inspect@github.com/gardener/gardener/pkg/apis/core/validation, isgenerated@github.com/gardener/gardener/pkg/apis/core/validation): analysis skipped: errors in package: [/go/src/github.com/gardener/gardener/pkg/apis/core/validation/shoot.go:30:2: could not import github.com/gardener/gardener/pkg/operation/botanist (/go/src/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go:54:2: "k8s.io/apimachinery/pkg/runtime" imported but not used)]] 
```