### PR TITLE
Add Project handling to SeedAuthorizer

### DIFF
--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -294,10 +294,11 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 	}
 
 	gardenClientMapBuilder := clientmapbuilder.NewGardenClientMapBuilder().
-		WithRESTConfig(restCfg)
+		WithRESTConfig(restCfg).
+		WithUncached(&gardencorev1beta1.Project{}) // gardenlet is not allowed to list/watch Project resources
 
 	if seedConfig := cfg.SeedConfig; seedConfig != nil {
-		gardenClientMapBuilder.ForSeed(seedConfig.Name)
+		gardenClientMapBuilder = gardenClientMapBuilder.ForSeed(seedConfig.Name)
 	}
 
 	seedClientMapBuilder := clientmapbuilder.NewSeedClientMapBuilder().

--- a/docs/deployment/gardenlet_api_access.md
+++ b/docs/deployment/gardenlet_api_access.md
@@ -52,11 +52,13 @@ With the `Seed` name at hand, the authorizer checks for an **existing path** fro
 
 Today, the following rules are implemented:
 
-| Resource        | Verb  | Path                                 | Description            |
-| --------------- | ----- | ------------------------------------ | ---------------------- |
-| `CloudProfile`  | `get` | `CloudProfile` -> `Shoot` -> `Seed`  | Allow `get` requests for `CloudProfile`s referenced by `Shoot`s that are assigned to the `gardenlet`'s `Seed`. Deny `get` requests to other `CloudProfile`s. |
-| `ConfigMap`     | `get` | `ConfigMap` -> `Shoot` -> `Seed`     | Allow `get` requests for `ConfigMap`s referenced by `Shoot`s that are assigned to the `gardenlet`'s `Seed`. Deny `get` requests to other `ConfigMap`s. |
-| `SecretBinding` | `get` | `SecretBinding` -> `Shoot` -> `Seed` | Allow `get` requests for `SecretBinding`s referenced by `Shoot`s that are assigned to the `gardenlet`'s `Seed`. Deny `get` requests to other `SecretBinding`s. |
+| Resource        | Verb  | Path                                          | Description            |
+| --------------- | ----- | --------------------------------------------- | ---------------------- |
+| `CloudProfile`  | `get` | `CloudProfile` -> `Shoot` -> `Seed`           | Allow `get` requests for `CloudProfile`s referenced by `Shoot`s that are assigned to the `gardenlet`'s `Seed`. Deny `get` requests to other `CloudProfile`s. |
+| `ConfigMap`     | `get` | `ConfigMap` -> `Shoot` -> `Seed`              | Allow `get` requests for `ConfigMap`s referenced by `Shoot`s that are assigned to the `gardenlet`'s `Seed`. Deny `get` requests to other `ConfigMap`s. |
+| `Namespace`     | `get` | `Namespace` -> `Shoot` -> `Seed`              | Allow `get` requests for `Namespace`s of `Shoot`s that are assigned to the `gardenlet`'s `Seed`. Deny `get` requests to other `Namespace`s. |
+| `Project`       | `get` | `Project` -> `Namespace` -> `Shoot` -> `Seed` | Allow `get` requests for `Project`s referenced by the `Namespace` of `Shoot`s that are assigned to the `gardenlet`'s `Seed`. Deny `get` requests to other `Project`s. |
+| `SecretBinding` | `get` | `SecretBinding` -> `Shoot` -> `Seed`          | Allow `get` requests for `SecretBinding`s referenced by `Shoot`s that are assigned to the `gardenlet`'s `Seed`. Deny `get` requests to other `SecretBinding`s. |
 
 ### Implementation Details
 

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
@@ -50,6 +50,8 @@ var (
 	// group and the resource (but it ignores the version).
 	cloudProfileResource  = gardencorev1beta1.Resource("cloudprofiles")
 	configMapResource     = corev1.Resource("configmaps")
+	namespaceResource     = corev1.Resource("namespaces")
+	projectResource       = gardencorev1beta1.Resource("projects")
 	secretBindingResource = gardencorev1beta1.Resource("secretbindings")
 )
 
@@ -70,6 +72,10 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			return a.authorizeGet(seedName, graph.VertexTypeCloudProfile, attrs)
 		case configMapResource:
 			return a.authorizeGet(seedName, graph.VertexTypeConfigMap, attrs)
+		case namespaceResource:
+			return a.authorizeGet(seedName, graph.VertexTypeNamespace, attrs)
+		case projectResource:
+			return a.authorizeGet(seedName, graph.VertexTypeProject, attrs)
 		case secretBindingResource:
 			return a.authorizeGet(seedName, graph.VertexTypeSecretBinding, attrs)
 		}

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
@@ -355,5 +355,163 @@ var _ = Describe("Seed", func() {
 				Expect(reason).To(BeEmpty())
 			})
 		})
+
+		Context("when requested for Namespaces", func() {
+			var (
+				name  string
+				attrs *auth.AttributesRecord
+			)
+
+			BeforeEach(func() {
+				name = "foo"
+				attrs = &auth.AttributesRecord{
+					User:            seedUser,
+					Name:            name,
+					APIGroup:        corev1.SchemeGroupVersion.Group,
+					Resource:        "namespaces",
+					ResourceRequest: true,
+					Verb:            "get",
+				}
+			})
+
+			It("should allow because path to seed exists", func() {
+				graph.EXPECT().HasPathFrom(graphpkg.VertexTypeNamespace, "", name, graphpkg.VertexTypeSeed, "", seedName).Return(true)
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionAllow))
+				Expect(reason).To(BeEmpty())
+			})
+
+			It("should have no opinion because path to seed does not exists", func() {
+				graph.EXPECT().HasPathFrom(graphpkg.VertexTypeNamespace, "", name, graphpkg.VertexTypeSeed, "", seedName).Return(false)
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("no relationship found"))
+			})
+
+			It("should have no opinion because no get verb", func() {
+				attrs.Verb = "list"
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("can only get individual resources of this type"))
+			})
+
+			It("should have no opinion because no resources requested", func() {
+				attrs.Subresource = "status"
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("cannot get subresource"))
+			})
+
+			It("should have no opinion because no resource name is given", func() {
+				attrs.Name = ""
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("No Object name found"))
+			})
+
+			It("should allow because seed name is ambiguous", func() {
+				attrs.User = ambiguousUser
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionAllow))
+				Expect(reason).To(BeEmpty())
+			})
+		})
+
+		Context("when requested for Projects", func() {
+			var (
+				name  string
+				attrs *auth.AttributesRecord
+			)
+
+			BeforeEach(func() {
+				name = "foo"
+				attrs = &auth.AttributesRecord{
+					User:            seedUser,
+					Name:            name,
+					APIGroup:        gardencorev1beta1.SchemeGroupVersion.Group,
+					Resource:        "projects",
+					ResourceRequest: true,
+					Verb:            "get",
+				}
+			})
+
+			It("should allow because path to seed exists", func() {
+				graph.EXPECT().HasPathFrom(graphpkg.VertexTypeProject, "", name, graphpkg.VertexTypeSeed, "", seedName).Return(true)
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionAllow))
+				Expect(reason).To(BeEmpty())
+			})
+
+			It("should have no opinion because path to seed does not exists", func() {
+				graph.EXPECT().HasPathFrom(graphpkg.VertexTypeProject, "", name, graphpkg.VertexTypeSeed, "", seedName).Return(false)
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("no relationship found"))
+			})
+
+			It("should have no opinion because no get verb", func() {
+				attrs.Verb = "list"
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("can only get individual resources of this type"))
+			})
+
+			It("should have no opinion because no resources requested", func() {
+				attrs.Subresource = "status"
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("cannot get subresource"))
+			})
+
+			It("should have no opinion because no resource name is given", func() {
+				attrs.Name = ""
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionNoOpinion))
+				Expect(reason).To(ContainSubstring("No Object name found"))
+			})
+
+			It("should allow because seed name is ambiguous", func() {
+				attrs.User = ambiguousUser
+
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionAllow))
+				Expect(reason).To(BeEmpty())
+			})
+		})
 	})
 })

--- a/pkg/apis/core/field_constants.go
+++ b/pkg/apis/core/field_constants.go
@@ -24,6 +24,10 @@ const (
 	// the Seed cluster of a core.gardener.cloud/v1beta1 BackupEntry.
 	BackupEntrySeedName = "spec.seedName"
 
+	// ProjectNamespace is the field selector path for filtering by namespace
+	// for core.gardener.cloud/{v1beta1,v1beta1} Project.
+	ProjectNamespace = "spec.namespace"
+
 	// RegistrationRefName is the field selector path for finding
 	// the ControllerRegistration name of a core.gardener.cloud/{v1beta1,v1beta1} ControllerInstallation.
 	RegistrationRefName = "spec.registrationRef.name"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -362,6 +362,19 @@ const (
 	SeedUserNamePrefix = "gardener.cloud:system:seed:"
 	// SeedUserNameSuffixAmbiguous is the default seed name in case the gardenlet config.SeedConfig is not set
 	SeedUserNameSuffixAmbiguous = "<ambiguous>"
+
+	// ProjectName is the key of a label on namespaces whose value holds the project name.
+	ProjectName = "project.gardener.cloud/name"
+	// ProjectSkipStaleCheck is the key of an annotation on a project namespace that marks the associated Project to be
+	// skipped by the stale project controller. If the project has already configured stale timestamps in its status
+	// then they will be reset.
+	ProjectSkipStaleCheck = "project.gardener.cloud/skip-stale-check"
+	// NamespaceProject is the key of an annotation on namespace whose value holds the project uid.
+	NamespaceProject = "namespace.gardener.cloud/project"
+	// NamespaceKeepAfterProjectDeletion is a constant for an annotation on a `Namespace` resource that states that it
+	// should not be deleted if the corresponding `Project` gets deleted. Please note that all project related labels
+	// from the namespace will be removed when the project is being deleted.
+	NamespaceKeepAfterProjectDeletion = "namespace.gardener.cloud/keep-after-project-deletion"
 )
 
 // ControlPlaneSecretRoles contains all role values used for control plane secrets synced to the Garden cluster.

--- a/pkg/apis/core/v1beta1/conversions.go
+++ b/pkg/apis/core/v1beta1/conversions.go
@@ -70,7 +70,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 		SchemeGroupVersion.WithKind("Project"),
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "metadata.name", "metadata.namespace", core.ProjectNamespace:
+			case "metadata.name", core.ProjectNamespace:
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)

--- a/pkg/apis/core/v1beta1/conversions.go
+++ b/pkg/apis/core/v1beta1/conversions.go
@@ -67,6 +67,20 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	}
 
 	if err := scheme.AddFieldLabelConversionFunc(
+		SchemeGroupVersion.WithKind("Project"),
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name", "metadata.namespace", core.ProjectNamespace:
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		},
+	); err != nil {
+		return err
+	}
+
+	if err := scheme.AddFieldLabelConversionFunc(
 		SchemeGroupVersion.WithKind("Shoot"),
 		func(label, value string) (string, string, error) {
 			switch label {

--- a/pkg/client/kubernetes/clientmap/builder/garden_builder_test.go
+++ b/pkg/client/kubernetes/clientmap/builder/garden_builder_test.go
@@ -15,24 +15,29 @@
 package builder
 
 import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/logger"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("GardenClientMapBuilder", func() {
 
 	var (
-		fakeLogger logrus.FieldLogger
-		restConfig *rest.Config
+		fakeLogger      logrus.FieldLogger
+		restConfig      *rest.Config
+		uncachedObjects []client.Object
 	)
 
 	BeforeEach(func() {
 		fakeLogger = logger.NewNopLogger()
 		restConfig = &rest.Config{}
+		uncachedObjects = []client.Object{&corev1.ConfigMap{}, &gardencorev1beta1.Shoot{}}
 	})
 
 	Context("#logger", func() {
@@ -46,6 +51,13 @@ var _ = Describe("GardenClientMapBuilder", func() {
 		It("should be set correctly by WithRESTConfig", func() {
 			builder := NewGardenClientMapBuilder().WithRESTConfig(restConfig)
 			Expect(builder.restConfig).To(BeIdenticalTo(restConfig))
+		})
+	})
+
+	Context("#uncachedObjects", func() {
+		It("should be set correctly by WithUncached", func() {
+			builder := NewGardenClientMapBuilder().WithUncached(uncachedObjects...)
+			Expect(builder.uncachedObjects).To(Equal(uncachedObjects))
 		})
 	})
 

--- a/pkg/client/kubernetes/clientmap/internal/alias.go
+++ b/pkg/client/kubernetes/clientmap/internal/alias.go
@@ -18,7 +18,7 @@ import (
 	"net"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/operation/common"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 // github.com/gardener/gardener/pkg/client/kubernetes aliases
@@ -33,8 +33,8 @@ var (
 
 // github.com/gardener/gardener/pkg/operation/common aliases
 var (
-	// ProjectForNamespaceWithClient is an alias to common.ProjectForNamespaceWithClient which allows it to be mocked for testing.
-	ProjectForNamespaceWithClient = common.ProjectForNamespaceWithClient
+	// ProjectAndNamespaceFromReader is an alias to gutil.ProjectAndNamespaceFromReader which allows it to be mocked for testing.
+	ProjectAndNamespaceFromReader = gutil.ProjectAndNamespaceFromReader
 )
 
 // net aliases

--- a/pkg/client/kubernetes/clientmap/internal/alias.go
+++ b/pkg/client/kubernetes/clientmap/internal/alias.go
@@ -31,10 +31,10 @@ var (
 	NewClientSetWithConfig = kubernetes.NewWithConfig
 )
 
-// github.com/gardener/gardener/pkg/operation/common aliases
+// github.com/gardener/gardener/pkg/utils/gardener aliases
 var (
-	// ProjectAndNamespaceFromReader is an alias to gutil.ProjectAndNamespaceFromReader which allows it to be mocked for testing.
-	ProjectAndNamespaceFromReader = gutil.ProjectAndNamespaceFromReader
+	// ProjectForNamespaceFromReader is an alias to gutil.ProjectForNamespaceFromReader which allows it to be mocked for testing.
+	ProjectForNamespaceFromReader = gutil.ProjectForNamespaceFromReader
 )
 
 // net aliases

--- a/pkg/client/kubernetes/clientmap/internal/garden_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/internal/garden_clientmap_test.go
@@ -35,11 +35,12 @@ import (
 
 var _ = Describe("GardenClientMap", func() {
 	var (
-		ctx        context.Context
-		cm         clientmap.ClientMap
-		key        clientmap.ClientSetKey
-		factory    *internal.GardenClientSetFactory
-		restConfig *rest.Config
+		ctx             context.Context
+		cm              clientmap.ClientMap
+		key             clientmap.ClientSetKey
+		factory         *internal.GardenClientSetFactory
+		restConfig      *rest.Config
+		uncachedObjects []client.Object
 	)
 
 	BeforeEach(func() {
@@ -47,8 +48,10 @@ var _ = Describe("GardenClientMap", func() {
 		key = keys.ForGarden()
 
 		restConfig = &rest.Config{}
+		uncachedObjects = []client.Object{&corev1.ConfigMap{}}
 		factory = &internal.GardenClientSetFactory{
-			RESTConfig: restConfig,
+			RESTConfig:      restConfig,
+			UncachedObjects: uncachedObjects,
 		}
 		cm = internal.NewGardenClientMap(factory, logger.NewNopLogger())
 	})
@@ -78,6 +81,7 @@ var _ = Describe("GardenClientMap", func() {
 				Expect(fns).To(ConsistOfConfigFuncs(
 					kubernetes.WithRESTConfig(restConfig),
 					kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.GardenScheme}),
+					kubernetes.WithUncached(&corev1.ConfigMap{}),
 					kubernetes.WithUncached(&corev1.Secret{}),
 				))
 				return fakeCS, nil

--- a/pkg/client/kubernetes/clientmap/internal/shoot_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/shoot_clientmap.go
@@ -192,7 +192,7 @@ func (f *ShootClientSetFactory) getSeedNamespace(ctx context.Context, key ShootC
 	if len(shoot.Status.TechnicalID) > 0 {
 		namespace = shoot.Status.TechnicalID
 	} else {
-		project, err := ProjectForNamespaceWithClient(ctx, gardenClient.Client(), shoot.Namespace)
+		project, _, err := ProjectAndNamespaceFromReader(ctx, gardenClient.Client(), shoot.Namespace)
 		if err != nil {
 			return "", seedClient, fmt.Errorf("failed to get Project for Shoot %q: %w", key.Key(), err)
 		}

--- a/pkg/client/kubernetes/clientmap/internal/shoot_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/shoot_clientmap.go
@@ -192,7 +192,7 @@ func (f *ShootClientSetFactory) getSeedNamespace(ctx context.Context, key ShootC
 	if len(shoot.Status.TechnicalID) > 0 {
 		namespace = shoot.Status.TechnicalID
 	} else {
-		project, _, err := ProjectAndNamespaceFromReader(ctx, gardenClient.Client(), shoot.Namespace)
+		project, err := ProjectForNamespaceFromReader(ctx, gardenClient.Client(), shoot.Namespace)
 		if err != nil {
 			return "", seedClient, fmt.Errorf("failed to get Project for Shoot %q: %w", key.Key(), err)
 		}

--- a/pkg/client/kubernetes/clientmap/internal/shoot_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/internal/shoot_clientmap_test.go
@@ -78,14 +78,14 @@ var _ = Describe("ShootClientMap", func() {
 			},
 		}
 
-		internal.ProjectAndNamespaceFromReader = func(ctx context.Context, c client.Reader, namespaceName string) (*gardencorev1beta1.Project, *corev1.Namespace, error) {
+		internal.ProjectForNamespaceFromReader = func(ctx context.Context, c client.Reader, namespaceName string) (*gardencorev1beta1.Project, error) {
 			return &gardencorev1beta1.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "eden",
 				},
 				Spec: gardencorev1beta1.ProjectSpec{
 					Namespace: pointer.StringPtr("garden-eden"),
-				}}, nil, nil
+				}}, nil
 		}
 		internal.LookupHost = func(host string) ([]string, error) {
 			Expect(host).To(Equal("kube-apiserver." + shoot.Status.TechnicalID + ".svc"))
@@ -177,7 +177,7 @@ var _ = Describe("ShootClientMap", func() {
 			Expect(err).To(MatchError(ContainSubstring("failed to get seed client: fake")))
 		})
 
-		It("should fail if ProjectAndNamespaceFromReader fails", func() {
+		It("should fail if ProjectForNamespaceFromReader fails", func() {
 			shoot.Status.TechnicalID = "" // trigger retrieval of project instead of relying on shoot status
 
 			fakeErr := fmt.Errorf("fake")
@@ -186,8 +186,8 @@ var _ = Describe("ShootClientMap", func() {
 					shoot.DeepCopyInto(obj.(*gardencorev1beta1.Shoot))
 					return nil
 				})
-			internal.ProjectAndNamespaceFromReader = func(ctx context.Context, c client.Reader, namespaceName string) (*gardencorev1beta1.Project, *corev1.Namespace, error) {
-				return nil, nil, fakeErr
+			internal.ProjectForNamespaceFromReader = func(ctx context.Context, c client.Reader, namespaceName string) (*gardencorev1beta1.Project, error) {
+				return nil, fakeErr
 			}
 
 			cs, err := cm.GetClient(ctx, key)

--- a/pkg/client/kubernetes/clientmap/internal/shoot_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/internal/shoot_clientmap_test.go
@@ -78,14 +78,14 @@ var _ = Describe("ShootClientMap", func() {
 			},
 		}
 
-		internal.ProjectForNamespaceWithClient = func(ctx context.Context, c client.Reader, namespaceName string) (*gardencorev1beta1.Project, error) {
+		internal.ProjectAndNamespaceFromReader = func(ctx context.Context, c client.Reader, namespaceName string) (*gardencorev1beta1.Project, *corev1.Namespace, error) {
 			return &gardencorev1beta1.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "eden",
 				},
 				Spec: gardencorev1beta1.ProjectSpec{
 					Namespace: pointer.StringPtr("garden-eden"),
-				}}, nil
+				}}, nil, nil
 		}
 		internal.LookupHost = func(host string) ([]string, error) {
 			Expect(host).To(Equal("kube-apiserver." + shoot.Status.TechnicalID + ".svc"))
@@ -177,7 +177,7 @@ var _ = Describe("ShootClientMap", func() {
 			Expect(err).To(MatchError(ContainSubstring("failed to get seed client: fake")))
 		})
 
-		It("should fail if ProjectForNamespaceWithClient fails", func() {
+		It("should fail if ProjectAndNamespaceFromReader fails", func() {
 			shoot.Status.TechnicalID = "" // trigger retrieval of project instead of relying on shoot status
 
 			fakeErr := fmt.Errorf("fake")
@@ -186,8 +186,8 @@ var _ = Describe("ShootClientMap", func() {
 					shoot.DeepCopyInto(obj.(*gardencorev1beta1.Shoot))
 					return nil
 				})
-			internal.ProjectForNamespaceWithClient = func(ctx context.Context, c client.Reader, namespaceName string) (*gardencorev1beta1.Project, error) {
-				return nil, fakeErr
+			internal.ProjectAndNamespaceFromReader = func(ctx context.Context, c client.Reader, namespaceName string) (*gardencorev1beta1.Project, *corev1.Namespace, error) {
+				return nil, nil, fakeErr
 			}
 
 			cs, err := cm.GetClient(ctx, key)

--- a/pkg/controllermanager/controller/project/project_control_delete.go
+++ b/pkg/controllermanager/controller/project/project_control_delete.go
@@ -30,7 +30,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/operation/common"
 )
 
 func (r *projectReconciler) delete(ctx context.Context, project *gardencorev1beta1.Project, gardenClient client.Client, gardenAPIReader client.Reader) (reconcile.Result, error) {
@@ -98,14 +97,14 @@ func (r *projectReconciler) releaseNamespace(ctx context.Context, gardenClient c
 	// If the user wants to keep the namespace in the system even if the project gets deleted then we remove the related
 	// labels, annotations, and owner references and only delete the project.
 	var keepNamespace bool
-	if val, ok := namespace.Annotations[common.NamespaceKeepAfterProjectDeletion]; ok {
+	if val, ok := namespace.Annotations[v1beta1constants.NamespaceKeepAfterProjectDeletion]; ok {
 		keepNamespace, _ = strconv.ParseBool(val)
 	}
 
 	if keepNamespace {
-		delete(namespace.Annotations, common.NamespaceProject)
-		delete(namespace.Annotations, common.NamespaceKeepAfterProjectDeletion)
-		delete(namespace.Labels, common.ProjectName)
+		delete(namespace.Annotations, v1beta1constants.NamespaceProject)
+		delete(namespace.Annotations, v1beta1constants.NamespaceKeepAfterProjectDeletion)
+		delete(namespace.Labels, v1beta1constants.ProjectName)
 		delete(namespace.Labels, v1beta1constants.GardenRole)
 		for i := len(namespace.OwnerReferences) - 1; i >= 0; i-- {
 			if ownerRef := namespace.OwnerReferences[i]; ownerRef.APIVersion == gardencorev1beta1.SchemeGroupVersion.String() &&

--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -20,11 +20,11 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/projectrbac"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
@@ -190,7 +190,7 @@ func (r *projectReconciler) reconcileNamespaceForProject(ctx context.Context, ga
 			return fmt.Errorf("namespace cannot be used as it needs the project labels %#v", projectLabels)
 		}
 
-		if metav1.HasAnnotation(namespace.ObjectMeta, common.NamespaceProject) && !apiequality.Semantic.DeepDerivative(projectAnnotations, namespace.Annotations) {
+		if metav1.HasAnnotation(namespace.ObjectMeta, v1beta1constants.NamespaceProject) && !apiequality.Semantic.DeepDerivative(projectAnnotations, namespace.Annotations) {
 			return fmt.Errorf("namespace is already in-use by another project")
 		}
 
@@ -201,7 +201,7 @@ func (r *projectReconciler) reconcileNamespaceForProject(ctx context.Context, ga
 		// If the project is reconciled for the first time then its observed generation is 0. Only in this case we want
 		// to add the "keep-after-project-deletion" annotation to the namespace when we adopt it.
 		if project.Status.ObservedGeneration == 0 {
-			namespace.Annotations[common.NamespaceKeepAfterProjectDeletion] = "true"
+			namespace.Annotations[v1beta1constants.NamespaceKeepAfterProjectDeletion] = "true"
 		}
 
 		return nil

--- a/pkg/controllermanager/controller/project/project_stale_control.go
+++ b/pkg/controllermanager/controller/project/project_stale_control.go
@@ -20,9 +20,9 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
-	"github.com/gardener/gardener/pkg/operation/common"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 
 	"github.com/sirupsen/logrus"
@@ -118,12 +118,12 @@ func (r *projectStaleReconciler) reconcile(ctx context.Context, project *gardenc
 	}
 
 	var skipStaleCheck bool
-	if value, ok := namespace.Annotations[common.ProjectSkipStaleCheck]; ok {
+	if value, ok := namespace.Annotations[v1beta1constants.ProjectSkipStaleCheck]; ok {
 		skipStaleCheck, _ = strconv.ParseBool(value)
 	}
 
 	if skipStaleCheck {
-		projectLogger.Infof("[STALE PROJECT RECONCILE] Namespace %q is annotated with %s, skipping the check and considering the project as 'not stale'", *project.Spec.Namespace, common.ProjectSkipStaleCheck)
+		projectLogger.Infof("[STALE PROJECT RECONCILE] Namespace %q is annotated with %s, skipping the check and considering the project as 'not stale'", *project.Spec.Namespace, v1beta1constants.ProjectSkipStaleCheck)
 		return r.markProjectAsNotStale(ctx, r.gardenClient, project)
 	}
 

--- a/pkg/controllermanager/controller/project/project_stale_control_test.go
+++ b/pkg/controllermanager/controller/project/project_stale_control_test.go
@@ -25,7 +25,6 @@ import (
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/project"
 	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	"github.com/gardener/gardener/pkg/operation/common"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -164,7 +163,7 @@ var _ = Describe("ProjectStaleControl", func() {
 				}
 				defer test.WithVar(&NowFunc, nowFunc)
 
-				namespace.Annotations = map[string]string{common.ProjectSkipStaleCheck: "true"}
+				namespace.Annotations = map[string]string{v1beta1constants.ProjectSkipStaleCheck: "true"}
 				Expect(kubeCoreInformerFactory.Core().V1().Namespaces().Informer().GetStore().Update(namespace)).To(Succeed())
 
 				expectNonStaleMarking(k8sGardenRuntimeClient, k8sGardenRuntimeStatusWriter, project, nowFunc)

--- a/pkg/controllermanager/controller/project/project_utils.go
+++ b/pkg/controllermanager/controller/project/project_utils.go
@@ -17,18 +17,17 @@ package project
 import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/operation/common"
 )
 
 func namespaceLabelsFromProject(project *gardencorev1beta1.Project) map[string]string {
 	return map[string]string{
-		v1beta1constants.GardenRole: v1beta1constants.GardenRoleProject,
-		common.ProjectName:          project.Name,
+		v1beta1constants.GardenRole:  v1beta1constants.GardenRoleProject,
+		v1beta1constants.ProjectName: project.Name,
 	}
 }
 
 func namespaceAnnotationsFromProject(project *gardencorev1beta1.Project) map[string]string {
 	return map[string]string{
-		common.NamespaceProject: string(project.UID),
+		v1beta1constants.NamespaceProject: string(project.UID),
 	}
 }

--- a/pkg/controllermanager/controller/project/rolebinding_control.go
+++ b/pkg/controllermanager/controller/project/rolebinding_control.go
@@ -47,7 +47,7 @@ func (c *Controller) roleBindingDelete(ctx context.Context, obj interface{}) {
 
 		logger.Logger.Debugf("[PROJECT RECONCILE] %q rolebinding modified", key)
 
-		project, _, err := gutil.ProjectAndNamespaceFromReader(ctx, c.gardenClient, namespace)
+		project, err := gutil.ProjectForNamespaceFromReader(ctx, c.gardenClient, namespace)
 		if err != nil {
 			logger.Logger.Errorf("Couldn't get list keys for object %+v: %v", obj, err)
 			return

--- a/pkg/controllermanager/controller/project/rolebinding_control.go
+++ b/pkg/controllermanager/controller/project/rolebinding_control.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/gardener/gardener/pkg/logger"
-	"github.com/gardener/gardener/pkg/operation/common"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
 func (c *Controller) roleBindingUpdate(ctx context.Context, _, new interface{}) {
@@ -47,7 +47,7 @@ func (c *Controller) roleBindingDelete(ctx context.Context, obj interface{}) {
 
 		logger.Logger.Debugf("[PROJECT RECONCILE] %q rolebinding modified", key)
 
-		project, err := common.ProjectForNamespaceWithClient(ctx, c.gardenClient, namespace)
+		project, _, err := gutil.ProjectAndNamespaceFromReader(ctx, c.gardenClient, namespace)
 		if err != nil {
 			logger.Logger.Errorf("Couldn't get list keys for object %+v: %v", obj, err)
 			return

--- a/pkg/controllermanager/controller/project/rolebinding_control_test.go
+++ b/pkg/controllermanager/controller/project/rolebinding_control_test.go
@@ -84,7 +84,7 @@ var _ = Describe("#roleBindingDelete", func() {
 		func(roleBindingName string) {
 			rolebinding.Name = roleBindingName
 
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ProjectList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ProjectList, _ ...client.ListOption) error {
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ProjectList{}), client.MatchingFields{"spec.namespace": ns}).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ProjectList, _ ...client.ListOption) error {
 				(&gardencorev1beta1.ProjectList{Items: []gardencorev1beta1.Project{*proj}}).DeepCopyInto(list)
 				return nil
 			})
@@ -107,7 +107,7 @@ var _ = Describe("#roleBindingDelete", func() {
 			proj.DeletionTimestamp = &now
 			rolebinding.Name = roleBindingName
 
-			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ProjectList{})).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ProjectList, _ ...client.ListOption) error {
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ProjectList{}), client.MatchingFields{"spec.namespace": ns}).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.ProjectList, _ ...client.ListOption) error {
 				(&gardencorev1beta1.ProjectList{Items: []gardencorev1beta1.Project{*proj}}).DeepCopyInto(list)
 				return nil
 			})

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -108,12 +108,10 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		backupEntryInformer            = f.k8sGardenCoreInformers.Core().V1beta1().BackupEntries().Informer()
 		controllerRegistrationInformer = f.k8sGardenCoreInformers.Core().V1beta1().ControllerRegistrations().Informer()
 		controllerInstallationInformer = f.k8sGardenCoreInformers.Core().V1beta1().ControllerInstallations().Informer()
-		projectInformer                = f.k8sGardenCoreInformers.Core().V1beta1().Projects().Informer()
 		seedInformer                   = f.k8sGardenCoreInformers.Core().V1beta1().Seeds().Informer()
 		shootInformer                  = f.k8sGardenCoreInformers.Core().V1beta1().Shoots().Informer()
 		// Kubernetes core informers
-		namespaceInformer = f.k8sInformers.Core().V1().Namespaces().Informer()
-		secretInformer    = f.k8sInformers.Core().V1().Secrets().Informer()
+		secretInformer = f.k8sInformers.Core().V1().Secrets().Informer()
 	)
 
 	if err := f.clientMap.Start(ctx.Done()); err != nil {
@@ -126,12 +124,12 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	}
 
 	f.k8sGardenCoreInformers.Start(ctx.Done())
-	if !cache.WaitForCacheSync(ctx.Done(), backupBucketInformer.HasSynced, backupEntryInformer.HasSynced, controllerRegistrationInformer.HasSynced, controllerInstallationInformer.HasSynced, projectInformer.HasSynced, seedInformer.HasSynced, shootInformer.HasSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), backupBucketInformer.HasSynced, backupEntryInformer.HasSynced, controllerRegistrationInformer.HasSynced, controllerInstallationInformer.HasSynced, seedInformer.HasSynced, shootInformer.HasSynced) {
 		return fmt.Errorf("timed out waiting for Garden core caches to sync")
 	}
 
 	f.k8sInformers.Start(ctx.Done())
-	if !cache.WaitForCacheSync(ctx.Done(), namespaceInformer.HasSynced, secretInformer.HasSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), secretInformer.HasSynced) {
 		return fmt.Errorf("timed out waiting for Kube caches to sync")
 	}
 

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
@@ -115,7 +115,7 @@ var defaultNewOperationFunc = func(
 		WithGardenClusterIdentity(gardenClusterIdentity).
 		WithSecrets(secrets).
 		WithImageVector(imageVector).
-		WithGardenFrom(gardenClient.APIReader(), shoot.Namespace).
+		WithGardenFrom(gardenClient.Client(), shoot.Namespace).
 		WithSeedFrom(k8sGardenCoreInformers, *shoot.Spec.SeedName).
 		WithShootFromCluster(gardenClient, seedClient, shoot).
 		Build(ctx, clientMap)

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
@@ -115,7 +115,7 @@ var defaultNewOperationFunc = func(
 		WithGardenClusterIdentity(gardenClusterIdentity).
 		WithSecrets(secrets).
 		WithImageVector(imageVector).
-		WithGardenFrom(k8sGardenCoreInformers, shoot.Namespace).
+		WithGardenFrom(gardenClient.APIReader(), shoot.Namespace).
 		WithSeedFrom(k8sGardenCoreInformers, *shoot.Spec.SeedName).
 		WithShootFromCluster(gardenClient, seedClient, shoot).
 		Build(ctx, clientMap)

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -188,7 +188,7 @@ func (c *Controller) reconcileShootRequest(ctx context.Context, req reconcile.Re
 	}
 
 	// fetch related objects required for shoot operation
-	project, err := common.ProjectForNamespace(c.k8sGardenCoreInformers.Core().V1beta1().Projects().Lister(), shoot.Namespace)
+	project, err := gutil.ProjectForNamespaceFromLister(c.k8sGardenCoreInformers.Core().V1beta1().Projects().Lister(), shoot.Namespace)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -193,7 +193,7 @@ func (c *Controller) reconcileShootRequest(ctx context.Context, req reconcile.Re
 	}
 
 	// fetch related objects required for shoot operation
-	project, err := gutil.ProjectForNamespaceFromReader(ctx, gardenClient.APIReader(), shoot.Namespace)
+	project, err := gutil.ProjectForNamespaceFromReader(ctx, gardenClient.Client(), shoot.Namespace)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -193,7 +193,7 @@ func (c *Controller) reconcileShootRequest(ctx context.Context, req reconcile.Re
 	}
 
 	// fetch related objects required for shoot operation
-	project, _, err := gutil.ProjectAndNamespaceFromReader(ctx, gardenClient.APIReader(), shoot.Namespace)
+	project, err := gutil.ProjectForNamespaceFromReader(ctx, gardenClient.APIReader(), shoot.Namespace)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/operation/botanist/component/projectrbac/projectrbac.go
+++ b/pkg/operation/botanist/component/projectrbac/projectrbac.go
@@ -22,7 +22,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
@@ -364,8 +363,8 @@ func (p *projectRBAC) deleteExtensionRolesResources(ctx context.Context, wantedE
 
 func (p *projectRBAC) getExtensionRolesResourceLabels() map[string]string {
 	return map[string]string{
-		v1beta1constants.GardenRole: v1beta1constants.LabelExtensionProjectRole,
-		common.ProjectName:          p.project.Name,
+		v1beta1constants.GardenRole:  v1beta1constants.LabelExtensionProjectRole,
+		v1beta1constants.ProjectName: p.project.Name,
 	}
 }
 

--- a/pkg/operation/botanist/component/projectrbac/projectrbac_test.go
+++ b/pkg/operation/botanist/component/projectrbac/projectrbac_test.go
@@ -22,7 +22,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/projectrbac"
-	"github.com/gardener/gardener/pkg/operation/common"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	"github.com/golang/mock/gomock"
@@ -76,8 +75,8 @@ var _ = Describe("ProjectRBAC", func() {
 		extensionRoleListOptions = []client.ListOption{
 			client.InNamespace(namespace),
 			client.MatchingLabels{
-				v1beta1constants.GardenRole: v1beta1constants.LabelExtensionProjectRole,
-				common.ProjectName:          projectName,
+				v1beta1constants.GardenRole:  v1beta1constants.LabelExtensionProjectRole,
+				v1beta1constants.ProjectName: projectName,
 			},
 		}
 

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -106,22 +106,6 @@ const (
 	// VPASecretName is the name of the secret used by VPA
 	VPASecretName = "vpa-tls-certs"
 
-	// ProjectName is the key of a label on namespaces whose value holds the project name.
-	ProjectName = "project.gardener.cloud/name"
-
-	// ProjectSkipStaleCheck is the key of an annotation on a project namespace that marks the associated Project to be
-	// skipped by the stale project controller. If the project has already configured stale timestamps in its status
-	// then they will be reset.
-	ProjectSkipStaleCheck = "project.gardener.cloud/skip-stale-check"
-
-	// NamespaceProject is the key of an annotation on namespace whose value holds the project uid.
-	NamespaceProject = "namespace.gardener.cloud/project"
-
-	// NamespaceKeepAfterProjectDeletion is a constant for an annotation on a `Namespace` resource that states that it
-	// should not be deleted if the corresponding `Project` gets deleted. Please note that all project related labels
-	// from the namespace will be removed when the project is being deleted.
-	NamespaceKeepAfterProjectDeletion = "namespace.gardener.cloud/keep-after-project-deletion"
-
 	// ShootAlphaScalingAPIServerClass is a constant for an annotation on the shoot stating the initial API server class.
 	// It influences the size of the initial resource requests/limits.
 	// Possible values are [small, medium, large, xlarge, 2xlarge].

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -24,7 +24,6 @@ import (
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/logger"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
@@ -56,7 +55,7 @@ func (b *Builder) WithProject(project *gardencorev1beta1.Project) *Builder {
 // WithProjectFromLister sets the projectFunc attribute after fetching it from the lister.
 func (b *Builder) WithProjectFromLister(projectLister gardencorelisters.ProjectLister, namespace string) *Builder {
 	b.projectFunc = func() (*gardencorev1beta1.Project, error) {
-		return common.ProjectForNamespace(projectLister, namespace)
+		return gutil.ProjectForNamespaceFromLister(projectLister, namespace)
 	}
 	return b
 }

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -57,8 +57,7 @@ func (b *Builder) WithProject(project *gardencorev1beta1.Project) *Builder {
 // WithProjectFromReader sets the projectFunc attribute after fetching it from the lister.
 func (b *Builder) WithProjectFromReader(reader client.Reader, namespace string) *Builder {
 	b.projectFunc = func(ctx context.Context) (*gardencorev1beta1.Project, error) {
-		project, _, err := gutil.ProjectAndNamespaceFromReader(ctx, reader, namespace)
-		return project, err
+		return gutil.ProjectForNamespaceFromReader(ctx, reader, namespace)
 	}
 	return b
 }

--- a/pkg/operation/garden/types.go
+++ b/pkg/operation/garden/types.go
@@ -15,12 +15,14 @@
 package garden
 
 import (
+	"context"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
 
 // Builder is an object that builds Garden objects.
 type Builder struct {
-	projectFunc        func() (*gardencorev1beta1.Project, error)
+	projectFunc        func(context.Context) (*gardencorev1beta1.Project, error)
 	internalDomainFunc func() (*Domain, error)
 	defaultDomainsFunc func() ([]*Domain, error)
 }

--- a/pkg/operation/types.go
+++ b/pkg/operation/types.go
@@ -38,7 +38,7 @@ import (
 // Builder is an object that builds Operation objects.
 type Builder struct {
 	configFunc                func() (*config.GardenletConfiguration, error)
-	gardenFunc                func(map[string]*corev1.Secret) (*garden.Garden, error)
+	gardenFunc                func(context.Context, map[string]*corev1.Secret) (*garden.Garden, error)
 	gardenerInfoFunc          func() (*gardencorev1beta1.Gardener, error)
 	gardenClusterIdentityFunc func() (string, error)
 	imageVectorFunc           func() (imagevector.ImageVector, error)

--- a/pkg/registry/core/project/storage/storage.go
+++ b/pkg/registry/core/project/storage/storage.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/storage"
 )
 
 // REST implements a RESTStorage for Project
@@ -62,7 +63,11 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 
 		TableConvertor: newTableConvertor(),
 	}
-	options := &generic.StoreOptions{RESTOptions: optsGetter}
+	options := &generic.StoreOptions{
+		RESTOptions: optsGetter,
+		AttrFunc:    project.GetAttrs,
+		TriggerFunc: map[string]storage.IndexerFunc{core.ProjectNamespace: project.NamespaceTriggerFunc},
+	}
 	if err := store.CompleteWithOptions(options); err != nil {
 		panic(err)
 	}

--- a/pkg/registry/core/project/strategy.go
+++ b/pkg/registry/core/project/strategy.go
@@ -16,6 +16,7 @@ package project
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -23,8 +24,12 @@ import (
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 )
 
@@ -150,4 +155,51 @@ func (projectStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runt
 
 func (projectStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	return validation.ValidateProjectStatusUpdate(obj.(*core.Project), old.(*core.Project))
+}
+
+// ToSelectableFields returns a field set that represents the object
+// TODO: fields are not labels, and the validation rules for them do not apply.
+func ToSelectableFields(project *core.Project) fields.Set {
+	// The purpose of allocation with a given number of elements is to reduce
+	// amount of allocations needed to create the fields.Set. If you add any
+	// field here or the number of object-meta related fields changes, this should
+	// be adjusted.
+	projectSpecificFieldsSet := make(fields.Set, 3)
+	projectSpecificFieldsSet[core.ProjectNamespace] = getNamespace(project)
+	return generic.AddObjectMetaFieldsSet(projectSpecificFieldsSet, &project.ObjectMeta, true)
+}
+
+// GetAttrs returns labels and fields of a given object for filtering purposes.
+func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
+	project, ok := obj.(*core.Project)
+	if !ok {
+		return nil, nil, fmt.Errorf("not a project")
+	}
+	return project.ObjectMeta.Labels, ToSelectableFields(project), nil
+}
+
+// MatchProject returns a generic matcher for a given label and field selector.
+func MatchProject(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+	return storage.SelectionPredicate{
+		Label:       label,
+		Field:       field,
+		GetAttrs:    GetAttrs,
+		IndexFields: []string{core.ProjectNamespace},
+	}
+}
+
+// NamespaceTriggerFunc returns spec.seedName of given Project.
+func NamespaceTriggerFunc(obj runtime.Object) string {
+	project, ok := obj.(*core.Project)
+	if !ok {
+		return ""
+	}
+	return getNamespace(project)
+}
+
+func getNamespace(project *core.Project) string {
+	if project.Spec.Namespace == nil {
+		return ""
+	}
+	return *project.Spec.Namespace
 }

--- a/pkg/registry/core/project/strategy.go
+++ b/pkg/registry/core/project/strategy.go
@@ -164,9 +164,9 @@ func ToSelectableFields(project *core.Project) fields.Set {
 	// amount of allocations needed to create the fields.Set. If you add any
 	// field here or the number of object-meta related fields changes, this should
 	// be adjusted.
-	projectSpecificFieldsSet := make(fields.Set, 3)
+	projectSpecificFieldsSet := make(fields.Set, 2)
 	projectSpecificFieldsSet[core.ProjectNamespace] = getNamespace(project)
-	return generic.AddObjectMetaFieldsSet(projectSpecificFieldsSet, &project.ObjectMeta, true)
+	return generic.AddObjectMetaFieldsSet(projectSpecificFieldsSet, &project.ObjectMeta, false)
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.
@@ -188,7 +188,7 @@ func MatchProject(label labels.Selector, field fields.Selector) storage.Selectio
 	}
 }
 
-// NamespaceTriggerFunc returns spec.seedName of given Project.
+// NamespaceTriggerFunc returns spec.namespace of given Project.
 func NamespaceTriggerFunc(obj runtime.Object) string {
 	project, ok := obj.(*core.Project)
 	if !ok {

--- a/pkg/registry/core/project/strategy_test.go
+++ b/pkg/registry/core/project/strategy_test.go
@@ -23,6 +23,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/pointer"
 )
 
@@ -170,3 +173,61 @@ var _ = Describe("Strategy", func() {
 		})
 	})
 })
+
+var _ = Describe("ToSelectableFields", func() {
+	It("should return correct fields", func() {
+		result := ToSelectableFields(newProject("foo"))
+
+		Expect(result).To(HaveLen(3))
+		Expect(result.Has(core.ProjectNamespace)).To(BeTrue())
+		Expect(result.Get(core.ProjectNamespace)).To(Equal("foo"))
+	})
+})
+
+var _ = Describe("GetAttrs", func() {
+	It("should return error when object is not Project", func() {
+		_, _, err := GetAttrs(&core.Seed{})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return correct result", func() {
+		ls, fs, err := GetAttrs(newProject("foo"))
+
+		Expect(ls).To(HaveLen(1))
+		Expect(ls.Get("foo")).To(Equal("bar"))
+		Expect(fs.Get(core.ProjectNamespace)).To(Equal("foo"))
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("NamespaceTriggerFunc", func() {
+	It("should return spec.namespace", func() {
+		actual := NamespaceTriggerFunc(newProject("foo"))
+		Expect(actual).To(Equal("foo"))
+	})
+})
+
+var _ = Describe("MatchProject", func() {
+	It("should return correct predicate", func() {
+		ls, _ := labels.Parse("app=test")
+		fs := fields.OneTermEqualSelector(core.ProjectNamespace, "foo")
+
+		result := MatchProject(ls, fs)
+
+		Expect(result.Label).To(Equal(ls))
+		Expect(result.Field).To(Equal(fs))
+		Expect(result.IndexFields).To(ConsistOf(core.ProjectNamespace))
+	})
+})
+
+func newProject(namespace string) *core.Project {
+	return &core.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test",
+			Labels: map[string]string{"foo": "bar"},
+		},
+		Spec: core.ProjectSpec{
+			Namespace: &namespace,
+		},
+	}
+}

--- a/pkg/registry/core/project/strategy_test.go
+++ b/pkg/registry/core/project/strategy_test.go
@@ -178,7 +178,7 @@ var _ = Describe("ToSelectableFields", func() {
 	It("should return correct fields", func() {
 		result := ToSelectableFields(newProject("foo"))
 
-		Expect(result).To(HaveLen(3))
+		Expect(result).To(HaveLen(2))
 		Expect(result.Has(core.ProjectNamespace)).To(BeTrue())
 		Expect(result.Get(core.ProjectNamespace)).To(Equal("foo"))
 	})

--- a/pkg/utils/gardener/project.go
+++ b/pkg/utils/gardener/project.go
@@ -66,6 +66,21 @@ func ProjectForNamespaceFromInternalLister(projectLister gardencoreinternalliste
 	return nil, apierrors.NewNotFound(gardencore.Resource("Project"), namespaceName)
 }
 
+// ProjectForNamespaceFromReader returns the Project responsible for a given <namespace>. It reads the namespace and
+// fetches the project name label. Then it will read the project with the respective name.
+func ProjectForNamespaceFromReader(ctx context.Context, reader client.Reader, namespaceName string) (*gardencorev1beta1.Project, error) {
+	projectList := &gardencorev1beta1.ProjectList{}
+	if err := reader.List(ctx, projectList, client.MatchingFields{gardencore.ProjectNamespace: namespaceName}); err != nil {
+		return nil, err
+	}
+
+	if len(projectList.Items) == 0 {
+		return nil, apierrors.NewNotFound(gardencorev1beta1.Resource("Project"), "<unknown>")
+	}
+
+	return &projectList.Items[0], nil
+}
+
 // ProjectAndNamespaceFromReader returns the Project responsible for a given <namespace>. It reads the namespace and
 // fetches the project name label. Then it will read the project with the respective name.
 func ProjectAndNamespaceFromReader(ctx context.Context, reader client.Reader, namespaceName string) (*gardencorev1beta1.Project, *corev1.Namespace, error) {

--- a/pkg/utils/gardener/project.go
+++ b/pkg/utils/gardener/project.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardener
+
+import (
+	"context"
+
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardencoreinternallisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
+	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ProjectForNamespaceFromLister returns the Project responsible for a given <namespace>. It lists all Projects
+// via the given lister, iterates over them and tries to identify the Project by looking for the namespace name
+// in the project spec.
+func ProjectForNamespaceFromLister(projectLister gardencorelisters.ProjectLister, namespaceName string) (*gardencorev1beta1.Project, error) {
+	projectList, err := projectLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, project := range projectList {
+		if project.Spec.Namespace != nil && *project.Spec.Namespace == namespaceName {
+			return project, nil
+		}
+	}
+
+	return nil, apierrors.NewNotFound(gardencorev1beta1.Resource("Project"), namespaceName)
+}
+
+// ProjectForNamespaceFromInternalLister returns the Project responsible for a given <namespace>. It lists all Projects
+// via the given lister, iterates over them and tries to identify the Project by looking for the namespace name
+// in the project spec.
+func ProjectForNamespaceFromInternalLister(projectLister gardencoreinternallisters.ProjectLister, namespaceName string) (*gardencore.Project, error) {
+	projectList, err := projectLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, project := range projectList {
+		if project.Spec.Namespace != nil && *project.Spec.Namespace == namespaceName {
+			return project, nil
+		}
+	}
+
+	return nil, apierrors.NewNotFound(gardencore.Resource("Project"), namespaceName)
+}
+
+// ProjectAndNamespaceFromReader returns the Project responsible for a given <namespace>. It reads the namespace and
+// fetches the project name label. Then it will read the project with the respective name.
+func ProjectAndNamespaceFromReader(ctx context.Context, reader client.Reader, namespaceName string) (*gardencorev1beta1.Project, *corev1.Namespace, error) {
+	namespace := &corev1.Namespace{}
+	if err := reader.Get(ctx, kutil.Key(namespaceName), namespace); err != nil {
+		return nil, nil, err
+	}
+
+	projectName := namespace.Labels[v1beta1constants.ProjectName]
+	if projectName == "" {
+		return nil, namespace, nil
+	}
+
+	project := &gardencorev1beta1.Project{}
+	if err := reader.Get(ctx, kutil.Key(projectName), project); err != nil {
+		return nil, namespace, err
+	}
+
+	return project, namespace, nil
+}

--- a/pkg/utils/gardener/project_test.go
+++ b/pkg/utils/gardener/project_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardener_test
+
+import (
+	"context"
+	"fmt"
+
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencoreinternallisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
+	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	. "github.com/gardener/gardener/pkg/utils/gardener"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Project", func() {
+	var (
+		ctrl *gomock.Controller
+		c    *mockclient.MockClient
+
+		ctx     = context.TODO()
+		fakeErr = fmt.Errorf("fake err")
+
+		namespaceName = "foo"
+		namespace     = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespaceName,
+			},
+		}
+
+		projectName = "bar"
+		project     = &gardencorev1beta1.Project{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: projectName,
+			},
+			Spec: gardencorev1beta1.ProjectSpec{
+				Namespace: &namespaceName,
+			},
+		}
+		projectInternal = &gardencore.Project{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: projectName,
+			},
+			Spec: gardencore.ProjectSpec{
+				Namespace: &namespaceName,
+			},
+		}
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		c = mockclient.NewMockClient(ctrl)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#ProjectForNamespaceFromLister", func() {
+		var lister *fakeLister
+
+		BeforeEach(func() {
+			lister = &fakeLister{}
+		})
+
+		It("should return an error because listing failed", func() {
+			lister.err = fakeErr
+
+			result, err := ProjectForNamespaceFromLister(lister, namespaceName)
+			Expect(err).To(MatchError(fakeErr))
+			Expect(result).To(BeNil())
+		})
+
+		It("should return the found project", func() {
+			lister.projects = []*gardencorev1beta1.Project{project}
+
+			result, err := ProjectForNamespaceFromLister(lister, namespaceName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(project))
+		})
+
+		It("should return a 'not found' error", func() {
+			result, err := ProjectForNamespaceFromLister(lister, namespaceName)
+			Expect(err).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: "core.gardener.cloud", Resource: "Project"}, namespaceName)))
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Describe("#ProjectForNamespaceFromInternalLister", func() {
+		var lister *fakeInternalLister
+
+		BeforeEach(func() {
+			lister = &fakeInternalLister{}
+		})
+
+		It("should return an error because listing failed", func() {
+			lister.err = fakeErr
+
+			result, err := ProjectForNamespaceFromInternalLister(lister, namespaceName)
+			Expect(err).To(MatchError(fakeErr))
+			Expect(result).To(BeNil())
+		})
+
+		It("should return the found project", func() {
+			lister.projects = []*gardencore.Project{projectInternal}
+
+			result, err := ProjectForNamespaceFromInternalLister(lister, namespaceName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(projectInternal))
+		})
+
+		It("should return a 'not found' error", func() {
+			result, err := ProjectForNamespaceFromInternalLister(lister, namespaceName)
+			Expect(err).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: "core.gardener.cloud", Resource: "Project"}, namespaceName)))
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Describe("#ProjectAndNamespaceFromReader", func() {
+		It("should return an error because getting the namespace failed", func() {
+			c.EXPECT().Get(ctx, kutil.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).Return(fakeErr)
+
+			projectResult, namespaceResult, err := ProjectAndNamespaceFromReader(ctx, c, namespaceName)
+			Expect(err).To(MatchError(fakeErr))
+			Expect(namespaceResult).To(BeNil())
+			Expect(projectResult).To(BeNil())
+		})
+
+		It("should return the namespace but no project beacuse labels missing", func() {
+			c.EXPECT().Get(ctx, kutil.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj *corev1.Namespace) error {
+				namespace.DeepCopyInto(obj)
+				return nil
+			})
+
+			projectResult, namespaceResult, err := ProjectAndNamespaceFromReader(ctx, c, namespaceName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(namespaceResult).To(Equal(namespace))
+			Expect(projectResult).To(BeNil())
+		})
+
+		It("should return an error because getting the project failed", func() {
+			namespace.Labels = map[string]string{"project.gardener.cloud/name": projectName}
+
+			c.EXPECT().Get(ctx, kutil.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj *corev1.Namespace) error {
+				namespace.DeepCopyInto(obj)
+				return nil
+			})
+			c.EXPECT().Get(ctx, kutil.Key(projectName), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).Return(fakeErr)
+
+			projectResult, namespaceResult, err := ProjectAndNamespaceFromReader(ctx, c, namespaceName)
+			Expect(err).To(MatchError(fakeErr))
+			Expect(namespaceResult).To(Equal(namespace))
+			Expect(projectResult).To(BeNil())
+		})
+
+		It("should return both namespace and project", func() {
+			namespace.Labels = map[string]string{"project.gardener.cloud/name": projectName}
+
+			c.EXPECT().Get(ctx, kutil.Key(namespaceName), gomock.AssignableToTypeOf(&corev1.Namespace{})).DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj *corev1.Namespace) error {
+				namespace.DeepCopyInto(obj)
+				return nil
+			})
+			c.EXPECT().Get(ctx, kutil.Key(projectName), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{})).DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj *gardencorev1beta1.Project) error {
+				project.DeepCopyInto(obj)
+				return nil
+			})
+
+			projectResult, namespaceResult, err := ProjectAndNamespaceFromReader(ctx, c, namespaceName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(namespaceResult).To(Equal(namespace))
+			Expect(projectResult).To(Equal(project))
+		})
+	})
+})
+
+type fakeLister struct {
+	gardencorelisters.ProjectLister
+	projects []*gardencorev1beta1.Project
+	err      error
+}
+
+func (c *fakeLister) List(labels.Selector) ([]*gardencorev1beta1.Project, error) {
+	return c.projects, c.err
+}
+
+type fakeInternalLister struct {
+	gardencoreinternallisters.ProjectLister
+	projects []*gardencore.Project
+	err      error
+}
+
+func (c *fakeInternalLister) List(labels.Selector) ([]*gardencore.Project, error) {
+	return c.projects, c.err
+}

--- a/plugin/pkg/plant/admission.go
+++ b/plugin/pkg/plant/admission.go
@@ -25,6 +25,7 @@ import (
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
 	"github.com/gardener/gardener/pkg/operation/common"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -173,7 +174,7 @@ func (a *Handler) validate(plant *core.Plant, attrs admission.Attributes) error 
 		return err
 	}
 
-	project, err := admissionutils.GetProject(plant.Namespace, a.projectLister)
+	project, err := gutil.ProjectForNamespaceFromInternalLister(a.projectLister, plant.Namespace)
 	if err != nil {
 		return apierrors.NewBadRequest(fmt.Sprintf("could not find referenced project: %+v", err.Error()))
 	}

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -30,7 +30,6 @@ import (
 	corelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
 	gardenerutils "github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
-	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -317,7 +316,7 @@ func seedDisablesDNS(seedLister corelisters.SeedLister, seedName string) (bool, 
 // and sets it in the shoot resource in the `spec.dns.domain` field.
 // If for any reason no domain can be generated, no domain is assigned to the Shoot.
 func assignDefaultDomainIfNeeded(shoot *core.Shoot, projectLister corelisters.ProjectLister, defaultDomains []string) error {
-	project, err := admissionutils.GetProject(shoot.Namespace, projectLister)
+	project, err := gutil.ProjectForNamespaceFromInternalLister(projectLister, shoot.Namespace)
 	if err != nil {
 		return apierrors.NewInternalError(err)
 	}

--- a/plugin/pkg/shoot/dns/admission_test.go
+++ b/plugin/pkg/shoot/dns/admission_test.go
@@ -627,7 +627,7 @@ var _ = Describe("dns", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(MatchError(apierrors.NewInternalError(fmt.Errorf("no project found for namespace %q", shoot.Namespace))))
+				Expect(err).To(MatchError(apierrors.NewInternalError(fmt.Errorf("Project.core.gardener.cloud %q not found", shoot.Namespace))))
 			})
 
 			It("should reject because no domain was configured for the shoot and default domain secret is missing", func() {

--- a/plugin/pkg/shoot/tolerationrestriction/admission.go
+++ b/plugin/pkg/shoot/tolerationrestriction/admission.go
@@ -20,20 +20,19 @@ import (
 	"fmt"
 	"io"
 
-	"k8s.io/apimachinery/pkg/util/validation/field"
-
 	"github.com/gardener/gardener/pkg/apis/core"
 	corevalidation "github.com/gardener/gardener/pkg/apis/core/validation"
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	corelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
 	"github.com/gardener/gardener/pkg/utils"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/plugin/pkg/shoot/tolerationrestriction/apis/shoottolerationrestriction"
 	"github.com/gardener/gardener/plugin/pkg/shoot/tolerationrestriction/apis/shoottolerationrestriction/validation"
-	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
 )
 
@@ -155,7 +154,7 @@ func (t *TolerationRestriction) Admit(ctx context.Context, a admission.Attribute
 }
 
 func (t *TolerationRestriction) admitShoot(shoot *core.Shoot) error {
-	project, err := admissionutils.GetProject(shoot.Namespace, t.projectLister)
+	project, err := gutil.ProjectForNamespaceFromInternalLister(t.projectLister, shoot.Namespace)
 	if err != nil {
 		return apierrors.NewBadRequest(fmt.Sprintf("could not find referenced project: %+v", err.Error()))
 	}
@@ -216,7 +215,7 @@ func (t *TolerationRestriction) validateShoot(shoot, oldShoot *core.Shoot) error
 		tolerationsToValidate = getNewOrChangedTolerations(shoot, oldShoot)
 	}
 
-	project, err := admissionutils.GetProject(shoot.Namespace, t.projectLister)
+	project, err := gutil.ProjectForNamespaceFromInternalLister(t.projectLister, shoot.Namespace)
 	if err != nil {
 		return apierrors.NewBadRequest(fmt.Sprintf("could not find referenced project: %+v", err.Error()))
 	}

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -193,7 +193,7 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 		}
 	}
 
-	project, err := admissionutils.GetProject(shoot.Namespace, v.projectLister)
+	project, err := gutil.ProjectForNamespaceFromInternalLister(v.projectLister, shoot.Namespace)
 	if err != nil {
 		return apierrors.NewBadRequest(fmt.Sprintf("could not find referenced project: %+v", err.Error()))
 	}

--- a/plugin/pkg/utils/miscellaneous.go
+++ b/plugin/pkg/utils/miscellaneous.go
@@ -15,35 +15,15 @@
 package utils
 
 import (
-	"fmt"
-
 	"github.com/gardener/gardener/pkg/apis/core"
-	corelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/admission"
 )
 
 // SkipVerification is a common function to skip object verification during admission
 func SkipVerification(operation admission.Operation, metadata metav1.ObjectMeta) bool {
 	return operation == admission.Update && metadata.DeletionTimestamp != nil
-}
-
-// GetProject retrieves the project with the corresponding namespace
-func GetProject(namespace string, projectLister corelisters.ProjectLister) (*core.Project, error) {
-	projects, err := projectLister.List(labels.Everything())
-	if err != nil {
-		return nil, err
-	}
-
-	for _, project := range projects {
-		if project.Spec.Namespace != nil && *project.Spec.Namespace == namespace {
-			return project, nil
-		}
-	}
-
-	return nil, fmt.Errorf("no project found for namespace %q", namespace)
 }
 
 // IsSeedUsedByShoot checks whether there is a shoot cluster referencing the provided seed name

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -20,13 +20,10 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/utils/pointer"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/scheduler/apis/config"
 	schedulerconfigv1alpha1 "github.com/gardener/gardener/pkg/scheduler/apis/config/v1alpha1"
 	scheduler "github.com/gardener/gardener/pkg/scheduler/controller/shoot"
@@ -42,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -92,7 +90,7 @@ func (f *GardenerFramework) GetShootProject(ctx context.Context, shootNamespace 
 	if ns.Labels == nil {
 		return nil, fmt.Errorf("namespace %q does not have any labels", ns.Name)
 	}
-	projectName, ok := ns.Labels[common.ProjectName]
+	projectName, ok := ns.Labels[v1beta1constants.ProjectName]
 	if !ok {
 		return nil, fmt.Errorf("namespace %q did not contain a project label", ns.Name)
 	}
@@ -166,7 +164,7 @@ func (f *GardenerFramework) DeleteShootAndWaitForDeletion(ctx context.Context, s
 // DeleteShoot deletes the test shoot
 func (f *GardenerFramework) DeleteShoot(ctx context.Context, shoot *gardencorev1beta1.Shoot) error {
 	err := retry.UntilTimeout(ctx, 20*time.Second, 5*time.Minute, func(ctx context.Context) (done bool, err error) {
-		err = f.RemoveShootAnnotation(ctx, shoot, gardencorev1beta1constants.ShootIgnore)
+		err = f.RemoveShootAnnotation(ctx, shoot, v1beta1constants.ShootIgnore)
 		if err != nil {
 			return retry.MinorError(err)
 		}
@@ -595,12 +593,12 @@ func ParseSchedulerConfiguration(configuration *corev1.ConfigMap) (*config.Sched
 
 // ScaleGardenerScheduler scales the gardener-scheduler to the desired replicas
 func ScaleGardenerScheduler(setupContextTimeout time.Duration, client client.Client, desiredReplicas *int32) (*int32, error) {
-	return ScaleDeployment(setupContextTimeout, client, desiredReplicas, "gardener-scheduler", gardencorev1beta1constants.GardenNamespace)
+	return ScaleDeployment(setupContextTimeout, client, desiredReplicas, "gardener-scheduler", v1beta1constants.GardenNamespace)
 }
 
 // ScaleGardenerControllerManager scales the gardener-controller-manager to the desired replicas
 func ScaleGardenerControllerManager(setupContextTimeout time.Duration, client client.Client, desiredReplicas *int32) (*int32, error) {
-	return ScaleDeployment(setupContextTimeout, client, desiredReplicas, "gardener-controller-manager", gardencorev1beta1constants.GardenNamespace)
+	return ScaleDeployment(setupContextTimeout, client, desiredReplicas, "gardener-controller-manager", v1beta1constants.GardenNamespace)
 }
 
 // CreateSeed creates a seed from a seed Object and waits until it is successfully reconciled
@@ -754,7 +752,7 @@ func BuildSeedSpecForTestrun(name string, backupProvider *string) *gardencorev1b
 	seedSpec := &gardencorev1beta1.SeedSpec{
 		SecretRef: &corev1.SecretReference{
 			Name:      name,
-			Namespace: gardencorev1beta1constants.GardenNamespace,
+			Namespace: v1beta1constants.GardenNamespace,
 		},
 		Taints: []gardencorev1beta1.SeedTaint{
 			{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR adds handling for `Project` resource to the `SeedAuthorizer`.

**Which issue(s) this PR fixes**:
Part of #1723 

**Special notes for your reviewer**:
Similar to #3708
/squash

On the way (not directly required for the PR), I added a field selector for `.spec.namespace`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
