### PR TITLE
Remove redundancy in shoot_autoscaling.md

### DIFF
--- a/docs/usage/shoot_autoscaling.md
+++ b/docs/usage/shoot_autoscaling.md
@@ -17,7 +17,7 @@ Consequently, please refer to the [offical documentation](https://github.com/kub
 
 The `Shoot` API allows to configure a few flags of the `cluster-autoscaler`:
 * `.spec.kubernetes.clusterAutoscaler.ScaleDownDelayAfterAdd` defines how long after scale up that scale down evaluation resumes (default: `1h`).
-* `.spec.kubernetes.clusterAutoscaler.ScaleDownDelayAfterDelete` defines how long after node deletion that scale down evaluation resumes, defaults to scanInterval (defaults to `ScanInterval`).
+* `.spec.kubernetes.clusterAutoscaler.ScaleDownDelayAfterDelete` defines how long after node deletion that scale down evaluation resumes (defaults to `ScanInterval`).
 * `.spec.kubernetes.clusterAutoscaler.ScaleDownDelayAfterFailure` defines how long after scale down failure that scale down evaluation resumes (default: `3m`).
 * `.spec.kubernetes.clusterAutoscaler.ScaleDownUnneededTime` defines how long a node should be unneeded before it is eligible for scale down (default: `30m`).
 * `.spec.kubernetes.clusterAutoscaler.ScaleDownUtilizationThreshold` defines the threshold in % under which a node is being removed.


### PR DESCRIPTION
**How to categorize this PR?**

/area documentation
/kind cleanup

**What this PR does / why we need it**:

It removes a duplication of default value explanation.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc operator
NONE
```
