### PR TITLE
Minor improvements to health check messages and formatting

### DIFF
--- a/extensions/pkg/controller/healthcheck/controller.go
+++ b/extensions/pkg/controller/healthcheck/controller.go
@@ -70,9 +70,9 @@ type DefaultAddArgs struct {
 }
 
 // RegisteredExtension is a registered extensions that the HealthCheck Controller watches.
-// The field extension  contains any extension object
+// The field extension contains any extension object
 // The field healthConditionTypes contains all distinct healthCondition types (extracted from the healthCheck).
-// They are being used as the .type field of the Condition that the HealthCheck controller writes to the extension Resource.
+// They are used as the .type field of the Condition that the HealthCheck controller writes to the extension resource.
 // The field groupVersionKind stores the GroupVersionKind of the extension resource
 type RegisteredExtension struct {
 	extension            extensionsv1alpha1.Object

--- a/extensions/pkg/controller/healthcheck/healthcheck_suite_test.go
+++ b/extensions/pkg/controller/healthcheck/healthcheck_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestWorker(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Extension health check Suite")
+}

--- a/extensions/pkg/controller/healthcheck/message_util.go
+++ b/extensions/pkg/controller/healthcheck/message_util.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"fmt"
+	"strings"
+)
+
+// getUnsuccessfulDetailMessage returns a message depending on the number of
+// unsuccessful and pending checks
+func getUnsuccessfulDetailMessage(unsuccessfulChecks, progressingChecks int, details string) string {
+	if progressingChecks > 0 && unsuccessfulChecks > 0 {
+		return fmt.Sprintf("%d failing and %d progressing %s: %s", unsuccessfulChecks, progressingChecks, getSingularOrPlural("check", progressingChecks), details)
+	}
+
+	return details
+}
+
+// getSingularOrPlural returns the given verb in either singular or plural
+func getSingularOrPlural(verb string, count int) string {
+	if count > 1 {
+		return fmt.Sprintf("%ss", verb)
+	}
+	return verb
+}
+
+// appendUnsuccessfulChecksDetails appends a formatted detail message to the given string builder
+func (h *checkResultForConditionType) appendUnsuccessfulChecksDetails(details *strings.Builder) {
+	if len(h.unsuccessfulChecks) > 0 && (len(h.progressingChecks) != 0 || len(h.failedChecks) != 0) {
+		details.WriteString(fmt.Sprintf("Failed %s: ", getSingularOrPlural("check", len(h.unsuccessfulChecks))))
+	}
+
+	if len(h.unsuccessfulChecks) == 1 {
+		details.WriteString(fmt.Sprintf("%s ", ensureTrailingDot(h.unsuccessfulChecks[0].detail)))
+		return
+	}
+
+	for index, check := range h.unsuccessfulChecks {
+		details.WriteString(fmt.Sprintf("%d) %s ", index+1, ensureTrailingDot(check.detail)))
+	}
+}
+
+// appendProgressingChecksDetails appends a formatted detail message to the given string builder
+func (h *checkResultForConditionType) appendProgressingChecksDetails(details *strings.Builder) {
+	if len(h.progressingChecks) > 0 && (len(h.unsuccessfulChecks) != 0 || len(h.failedChecks) != 0) {
+		details.WriteString(fmt.Sprintf("Progressing %s: ", getSingularOrPlural("check", len(h.progressingChecks))))
+	}
+
+	if len(h.progressingChecks) == 1 {
+		details.WriteString(fmt.Sprintf("%s ", ensureTrailingDot(h.progressingChecks[0].detail)))
+		return
+	}
+
+	for index, check := range h.progressingChecks {
+		details.WriteString(fmt.Sprintf("%d) %s ", index+1, ensureTrailingDot(check.detail)))
+	}
+}
+
+// appendFailedChecksDetails appends a formatted detail message to the given string builder
+func (h *checkResultForConditionType) appendFailedChecksDetails(details *strings.Builder) {
+	if len(h.failedChecks) > 0 && (len(h.unsuccessfulChecks) != 0 || len(h.progressingChecks) != 0) {
+		details.WriteString(fmt.Sprintf("Unable to execute %s: ", getSingularOrPlural("check", len(h.failedChecks))))
+	}
+
+	if len(h.failedChecks) == 1 {
+		details.WriteString(fmt.Sprintf("%s ", ensureTrailingDot(h.failedChecks[0].Error())))
+		return
+	}
+
+	for index, check := range h.failedChecks {
+		details.WriteString(fmt.Sprintf("%d) %s ", index+1, ensureTrailingDot(check.Error())))
+	}
+}
+
+// ensureTrailingDot adds a trailing dot if it does not exist
+func ensureTrailingDot(details string) string {
+	if !strings.HasSuffix(details, ".") {
+		return fmt.Sprintf("%s.", details)
+	}
+	return details
+}
+
+// trimTrailingWhitespace removes a trailing whitespace character
+func trimTrailingWhitespace(details string) string {
+	return strings.TrimSuffix(details, " ")
+}

--- a/extensions/pkg/controller/healthcheck/message_util_test.go
+++ b/extensions/pkg/controller/healthcheck/message_util_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("message_util", func() {
+	var details = "details"
+	Describe("#getUnsuccessfulDetailMessage", func() {
+		It("should return message when progressing checks > 0 && unsuccessful checks > 0", func() {
+			Expect(getUnsuccessfulDetailMessage(2, 2, details)).To(Equal("2 failing and 2 progressing checks: details"))
+		})
+		It("should return message when unsuccessful checks > 1", func() {
+			Expect(getUnsuccessfulDetailMessage(2, 0, details)).To(Equal("details"))
+		})
+		It("should return message when unsuccessful checks == 1", func() {
+			Expect(getUnsuccessfulDetailMessage(1, 0, details)).To(Equal("details"))
+		})
+		It("should return message when progressing checks > 1", func() {
+			Expect(getUnsuccessfulDetailMessage(0, 2, details)).To(Equal("details"))
+		})
+		It("should return message when progressing checks == 1", func() {
+			Expect(getUnsuccessfulDetailMessage(0, 1, details)).To(Equal("details"))
+		})
+	})
+
+	DescribeTable("#append_ChecksDetails",
+		func(input checkResultForConditionType, expected string) {
+			var details strings.Builder
+			input.appendFailedChecksDetails(&details)
+			input.appendUnsuccessfulChecksDetails(&details)
+			input.appendProgressingChecksDetails(&details)
+			Expect(trimTrailingWhitespace(details.String())).To(Equal(expected))
+		},
+		Entry("no unsuccessful checks", checkResultForConditionType{}, ""),
+		Entry("Only one unsuccessful check",
+			checkResultForConditionType{
+				unsuccessfulChecks: []healthCheckUnsuccessful{
+					{
+						detail: "MyBad",
+					}},
+			},
+			"MyBad."),
+		Entry("Only one failed check",
+			checkResultForConditionType{
+				failedChecks: []error{fmt.Errorf("fail")},
+			},
+			"fail."),
+		Entry("Only one progressing check",
+			checkResultForConditionType{
+				progressingChecks: []healthCheckProgressing{
+					{
+						detail: "fail again",
+					},
+				},
+			},
+			"fail again."),
+		Entry("One unsuccessful check and one progressing check",
+			checkResultForConditionType{
+				unsuccessfulChecks: []healthCheckUnsuccessful{
+					{
+						detail: "MyBad",
+					}},
+				progressingChecks: []healthCheckProgressing{
+					{
+						detail: "xyz",
+					},
+				},
+			},
+			"Failed check: MyBad. Progressing check: xyz."),
+		Entry("Two unsuccessful check and two progressing check",
+			checkResultForConditionType{
+				unsuccessfulChecks: []healthCheckUnsuccessful{
+					{
+						detail: "MyBad",
+					},
+					{
+						detail: "MyBad2",
+					},
+				},
+				progressingChecks: []healthCheckProgressing{
+					{
+						detail: "xyz",
+					},
+					{
+						detail: "xtc",
+					},
+				},
+			},
+			"Failed checks: 1) MyBad. 2) MyBad2. Progressing checks: 1) xyz. 2) xtc."),
+		Entry("One unsuccessful check and two progressing checks",
+			checkResultForConditionType{
+				unsuccessfulChecks: []healthCheckUnsuccessful{
+					{
+						detail: "MyBad",
+					}},
+				progressingChecks: []healthCheckProgressing{
+					{
+						detail: "xyz",
+					},
+					{
+						detail: "abc",
+					},
+				},
+			},
+			"Failed check: MyBad. Progressing checks: 1) xyz. 2) abc."),
+		Entry("One unsuccessful check and one failed check",
+			checkResultForConditionType{
+				unsuccessfulChecks: []healthCheckUnsuccessful{
+					{
+						detail: "MyBad",
+					}},
+				failedChecks: []error{fmt.Errorf("super bad")},
+			},
+			"Unable to execute check: super bad. Failed check: MyBad."),
+		Entry("One unsuccessful check and two failed checks",
+			checkResultForConditionType{
+				unsuccessfulChecks: []healthCheckUnsuccessful{
+					{
+						detail: "MyBad",
+					}},
+				failedChecks: []error{fmt.Errorf("super bad"), fmt.Errorf("super bad2")},
+			},
+			"Unable to execute checks: 1) super bad. 2) super bad2. Failed check: MyBad."),
+	)
+
+})

--- a/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/extensions/pkg/controller/healthcheck/reconciler.go
@@ -140,7 +140,7 @@ func (r *reconciler) performHealthCheck(ctx context.Context, request reconcile.R
 				return reconcile.Result{}, buildErr
 			}
 
-			conditions = append(conditions, extensionConditionFailedToExecute(conditionBuilder, healthConditionType, r.registeredExtension.groupVersionKind.Kind, err))
+			conditions = append(conditions, extensionConditionFailedToExecute(conditionBuilder, healthConditionType, err))
 		}
 		if updateErr := r.updateExtensionConditions(ctx, extension, conditions...); updateErr != nil {
 			return reconcile.Result{}, updateErr
@@ -162,20 +162,20 @@ func (r *reconciler) performHealthCheck(ctx context.Context, request reconcile.R
 			logger = r.logger
 		}
 
-		if healthCheckResult.Status == gardencorev1beta1.ConditionProgressing || healthCheckResult.Status == gardencorev1beta1.ConditionFalse {
-			if healthCheckResult.FailedChecks > 0 {
-				r.logger.Info("Updating HealthCheckCondition for extension resource to ConditionCheckError.", "kind", r.registeredExtension.groupVersionKind.Kind, "health condition type", healthCheckResult.HealthConditionType, "name", request.Name, "namespace", request.Namespace)
-				conditions = append(conditions, extensionConditionCheckError(conditionBuilder, healthCheckResult.HealthConditionType, r.registeredExtension.groupVersionKind.Kind, healthCheckResult))
-				continue
-			}
-
-			logger.Info("Health check for extension resource progressing or unsuccessful.", "kind", fmt.Sprintf("%s.%s.%s", r.registeredExtension.groupVersionKind.Kind, r.registeredExtension.groupVersionKind.Group, r.registeredExtension.groupVersionKind.Version), "name", request.Name, "namespace", request.Namespace, "failed", healthCheckResult.FailedChecks, "progressing", healthCheckResult.ProgressingChecks, "successful", healthCheckResult.SuccessfulChecks, "details", healthCheckResult.GetDetails())
-			conditions = append(conditions, extensionConditionUnsuccessful(conditionBuilder, healthCheckResult.HealthConditionType, extension, healthCheckResult))
+		if healthCheckResult.Status == gardencorev1beta1.ConditionTrue {
+			logger.Info("Health check for extension resource successful.", "kind", r.registeredExtension.groupVersionKind.Kind, "health condition type", healthCheckResult.HealthConditionType, "name", request.Name, "namespace", request.Namespace)
+			conditions = append(conditions, extensionConditionSuccessful(conditionBuilder, healthCheckResult.HealthConditionType, healthCheckResult))
 			continue
 		}
 
-		logger.Info("Health check for extension resource successful.", "kind", r.registeredExtension.groupVersionKind.Kind, "health condition type", healthCheckResult.HealthConditionType, "name", request.Name, "namespace", request.Namespace)
-		conditions = append(conditions, extensionConditionSuccessful(conditionBuilder, healthCheckResult.HealthConditionType, healthCheckResult))
+		if healthCheckResult.FailedChecks > 0 {
+			r.logger.Info("Updating HealthCheckCondition for extension resource to ConditionCheckError.", "kind", r.registeredExtension.groupVersionKind.Kind, "health condition type", healthCheckResult.HealthConditionType, "name", request.Name, "namespace", request.Namespace)
+			conditions = append(conditions, extensionConditionCheckError(conditionBuilder, healthCheckResult.HealthConditionType, healthCheckResult))
+			continue
+		}
+
+		logger.Info("Health check for extension resource progressing or unsuccessful.", "kind", fmt.Sprintf("%s.%s.%s", r.registeredExtension.groupVersionKind.Kind, r.registeredExtension.groupVersionKind.Group, r.registeredExtension.groupVersionKind.Version), "name", request.Name, "namespace", request.Namespace, "failed", healthCheckResult.FailedChecks, "progressing", healthCheckResult.ProgressingChecks, "successful", healthCheckResult.SuccessfulChecks, "details", healthCheckResult.GetDetails())
+		conditions = append(conditions, extensionConditionUnsuccessful(conditionBuilder, healthCheckResult.HealthConditionType, extension, healthCheckResult))
 	}
 
 	if err := r.updateExtensionConditions(ctx, extension, conditions...); err != nil {
@@ -185,22 +185,22 @@ func (r *reconciler) performHealthCheck(ctx context.Context, request reconcile.R
 	return r.resultWithRequeue(), nil
 }
 
-func extensionConditionFailedToExecute(conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, kind string, executionError error) condition {
+func extensionConditionFailedToExecute(conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, executionError error) condition {
 	conditionBuilder.
 		WithStatus(gardencorev1beta1.ConditionUnknown).
 		WithReason(gardencorev1beta1.ConditionCheckError).
-		WithMessage(fmt.Sprintf("failed to execute health checks for '%s': %v", kind, executionError.Error()))
+		WithMessage(fmt.Sprintf("unable to execute any health check: %v", executionError.Error()))
 	return condition{
 		builder:             conditionBuilder,
 		healthConditionType: healthConditionType,
 	}
 }
 
-func extensionConditionCheckError(conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, kind string, healthCheckResult Result) condition {
+func extensionConditionCheckError(conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, healthCheckResult Result) condition {
 	conditionBuilder.
 		WithStatus(gardencorev1beta1.ConditionUnknown).
 		WithReason(gardencorev1beta1.ConditionCheckError).
-		WithMessage(fmt.Sprintf("failed to execute %d/%d health checks for '%s': %v", healthCheckResult.FailedChecks, healthCheckResult.SuccessfulChecks+healthCheckResult.UnsuccessfulChecks+healthCheckResult.FailedChecks, kind, healthCheckResult.GetDetails()))
+		WithMessage(fmt.Sprintf("failed to execute %d health %s: %v", healthCheckResult.FailedChecks, getSingularOrPlural("check", healthCheckResult.FailedChecks), healthCheckResult.GetDetails()))
 	return condition{
 		builder:             conditionBuilder,
 		healthConditionType: healthConditionType,
@@ -209,10 +209,9 @@ func extensionConditionCheckError(conditionBuilder gardencorev1beta1helper.Condi
 
 func extensionConditionUnsuccessful(conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, extension extensionsv1alpha1.Object, healthCheckResult Result) condition {
 	var (
-		numberOfChecks = healthCheckResult.UnsuccessfulChecks + healthCheckResult.ProgressingChecks + healthCheckResult.SuccessfulChecks
-		detail         = fmt.Sprintf("Health check summary: %d/%d unsuccessful, %d/%d progressing, %d/%d successful. %v", healthCheckResult.UnsuccessfulChecks, numberOfChecks, healthCheckResult.ProgressingChecks, numberOfChecks, healthCheckResult.SuccessfulChecks, numberOfChecks, healthCheckResult.GetDetails())
-		status         = gardencorev1beta1.ConditionFalse
-		reason         = ReasonUnsuccessful
+		detail = getUnsuccessfulDetailMessage(healthCheckResult.UnsuccessfulChecks, healthCheckResult.ProgressingChecks, healthCheckResult.GetDetails())
+		status = gardencorev1beta1.ConditionFalse
+		reason = ReasonUnsuccessful
 	)
 
 	if healthCheckResult.ProgressingChecks > 0 && healthCheckResult.ProgressingThreshold != nil {
@@ -243,7 +242,7 @@ func extensionConditionSuccessful(conditionBuilder gardencorev1beta1helper.Condi
 	conditionBuilder.
 		WithStatus(gardencorev1beta1.ConditionTrue).
 		WithReason(ReasonSuccessful).
-		WithMessage(fmt.Sprintf("(%d/%d) Health checks successful", healthCheckResult.SuccessfulChecks, healthCheckResult.SuccessfulChecks))
+		WithMessage("All health checks successful")
 	return condition{
 		builder:             conditionBuilder,
 		healthConditionType: healthConditionType,

--- a/extensions/pkg/controller/healthcheck/worker/helpers_test.go
+++ b/extensions/pkg/controller/healthcheck/worker/helpers_test.go
@@ -103,18 +103,16 @@ var _ = Describe("health", func() {
 
 	Describe("#checkMachineDeploymentsHealthy", func() {
 		It("should  return true for nil", func() {
-			isHealthy, reason, err := checkMachineDeploymentsHealthy(nil)
+			isHealthy, err := checkMachineDeploymentsHealthy(nil)
 
 			Expect(isHealthy).To(BeTrue())
-			Expect(reason).To(BeEmpty())
 			Expect(err).To(Succeed())
 		})
 
 		It("should  return true for an empty list", func() {
-			isHealthy, reason, err := checkMachineDeploymentsHealthy([]machinev1alpha1.MachineDeployment{})
+			isHealthy, err := checkMachineDeploymentsHealthy([]machinev1alpha1.MachineDeployment{})
 
 			Expect(isHealthy).To(BeTrue())
-			Expect(reason).To(BeEmpty())
 			Expect(err).To(Succeed())
 		})
 
@@ -136,10 +134,9 @@ var _ = Describe("health", func() {
 				},
 			}
 
-			isHealthy, reason, err := checkMachineDeploymentsHealthy(machineDeployments)
+			isHealthy, err := checkMachineDeploymentsHealthy(machineDeployments)
 
 			Expect(isHealthy).To(BeTrue())
-			Expect(reason).To(BeEmpty())
 			Expect(err).To(Succeed())
 		})
 
@@ -161,10 +158,9 @@ var _ = Describe("health", func() {
 				}
 			)
 
-			isHealthy, reason, err := checkMachineDeploymentsHealthy(machineDeployments)
+			isHealthy, err := checkMachineDeploymentsHealthy(machineDeployments)
 
 			Expect(isHealthy).To(BeFalse())
-			Expect(reason).To(Equal("MachineDeploymentHasFailedMachines"))
 			Expect(err).ToNot(Succeed())
 		})
 
@@ -182,28 +178,25 @@ var _ = Describe("health", func() {
 				},
 			}
 
-			isHealthy, reason, err := checkMachineDeploymentsHealthy(machineDeployments)
+			isHealthy, err := checkMachineDeploymentsHealthy(machineDeployments)
 
 			Expect(isHealthy).To(BeFalse())
-			Expect(reason).To(Equal("MachineDeploymentUnhealthy"))
 			Expect(err).ToNot(Succeed())
 		})
 	})
 
 	Describe("#checkNodesScalingUp", func() {
 		It("should return true if number of ready nodes equal number of desired machines", func() {
-			status, reason, err := checkNodesScalingUp(nil, 1, 1)
+			status, err := checkNodesScalingUp(nil, 1, 1)
 
 			Expect(status).To(Equal(gardencorev1beta1.ConditionTrue))
-			Expect(reason).To(BeEmpty())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should return an error if not enough machine objects as desired were created", func() {
-			status, reason, err := checkNodesScalingUp(&machinev1alpha1.MachineList{}, 0, 1)
+			status, err := checkNodesScalingUp(&machinev1alpha1.MachineList{}, 0, 1)
 
 			Expect(status).To(Equal(gardencorev1beta1.ConditionFalse))
-			Expect(reason).To(Equal("MissingMachines"))
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -218,10 +211,9 @@ var _ = Describe("health", func() {
 				},
 			}
 
-			status, reason, err := checkNodesScalingUp(machineList, 0, 1)
+			status, err := checkNodesScalingUp(machineList, 0, 1)
 
 			Expect(status).To(Equal(gardencorev1beta1.ConditionFalse))
-			Expect(reason).To(Equal("ErroneousMachines"))
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -236,10 +228,9 @@ var _ = Describe("health", func() {
 				},
 			}
 
-			status, reason, err := checkNodesScalingUp(machineList, 0, 1)
+			status, err := checkNodesScalingUp(machineList, 0, 1)
 
 			Expect(status).To(Equal(gardencorev1beta1.ConditionFalse))
-			Expect(reason).To(Equal("MissingNodes"))
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -254,10 +245,9 @@ var _ = Describe("health", func() {
 				},
 			}
 
-			status, reason, err := checkNodesScalingUp(machineList, 0, 1)
+			status, err := checkNodesScalingUp(machineList, 0, 1)
 
 			Expect(status).To(Equal(gardencorev1beta1.ConditionProgressing))
-			Expect(reason).To(Equal("PendingMachines"))
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -268,20 +258,18 @@ var _ = Describe("health", func() {
 				},
 			}
 
-			status, reason, err := checkNodesScalingUp(machineList, 0, 1)
+			status, err := checkNodesScalingUp(machineList, 0, 1)
 
 			Expect(status).To(Equal(gardencorev1beta1.ConditionProgressing))
-			Expect(reason).To(Equal("PendingMachines"))
 			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	Describe("#checkNodesScalingDown", func() {
 		It("should return true if number of registered nodes equal number of desired machines", func() {
-			status, reason, err := checkNodesScalingDown(nil, nil, 1, 1)
+			status, err := checkNodesScalingDown(nil, nil, 1, 1)
 
 			Expect(status).To(Equal(gardencorev1beta1.ConditionTrue))
-			Expect(reason).To(BeEmpty())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -292,10 +280,9 @@ var _ = Describe("health", func() {
 				},
 			}
 
-			status, reason, err := checkNodesScalingDown(&machinev1alpha1.MachineList{}, nodeList, 2, 1)
+			status, err := checkNodesScalingDown(&machinev1alpha1.MachineList{}, nodeList, 2, 1)
 
 			Expect(status).To(Equal(gardencorev1beta1.ConditionFalse))
-			Expect(reason).To(Equal("MachineNotFound"))
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -318,18 +305,16 @@ var _ = Describe("health", func() {
 				}
 			)
 
-			status, reason, err := checkNodesScalingDown(machineList, nodeList, 2, 1)
+			status, err := checkNodesScalingDown(machineList, nodeList, 2, 1)
 
 			Expect(status).To(Equal(gardencorev1beta1.ConditionFalse))
-			Expect(reason).To(Equal("NodeUnexpectedlyCordoned"))
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return an error if there are more nodes then machines", func() {
-			status, reason, err := checkNodesScalingDown(&machinev1alpha1.MachineList{}, &corev1.NodeList{Items: []corev1.Node{{}}}, 2, 1)
+			status, err := checkNodesScalingDown(&machinev1alpha1.MachineList{}, &corev1.NodeList{Items: []corev1.Node{{}}}, 2, 1)
 
 			Expect(status).To(Equal(gardencorev1beta1.ConditionFalse))
-			Expect(reason).To(Equal("TooManyNodes"))
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -353,10 +338,9 @@ var _ = Describe("health", func() {
 				}
 			)
 
-			status, reason, err := checkNodesScalingDown(machineList, nodeList, 2, 1)
+			status, err := checkNodesScalingDown(machineList, nodeList, 2, 1)
 
 			Expect(status).To(Equal(gardencorev1beta1.ConditionProgressing))
-			Expect(reason).To(Equal("DrainingMachines"))
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/pkg/controllermanager/controller/plant/plant_health.go
+++ b/pkg/controllermanager/controller/plant/plant_health.go
@@ -54,7 +54,7 @@ func (h *HealthChecker) CheckPlantClusterNodes(ctx context.Context, condition ga
 		return exitCondition
 	}
 
-	updatedCondition := gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionTrue, string(gardencorev1beta1.PlantEveryNodeReady), "Every node registered to the cluster is ready.")
+	updatedCondition := gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionTrue, string(gardencorev1beta1.PlantEveryNodeReady), "All nodes are ready.")
 	return updatedCondition
 }
 

--- a/pkg/operation/care/health.go
+++ b/pkg/operation/care/health.go
@@ -352,6 +352,6 @@ func (h *Health) checkClusterNodes(
 		return exitCondition, nil
 	}
 
-	c := gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionTrue, "EveryNodeReady", "Every node registered to the cluster is ready.")
+	c := gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionTrue, "EveryNodeReady", "All nodes are ready.")
 	return &c, nil
 }

--- a/pkg/operation/care/health_check_test.go
+++ b/pkg/operation/care/health_check_test.go
@@ -584,7 +584,7 @@ var _ = Describe("health check", func() {
 					},
 				},
 				cloudConfigSecretChecksums,
-				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "NodeUnhealthy", fmt.Sprintf("Node '%s' in worker group '%s' is unhealthy", nodeName, workerPoolName1)))),
+				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "NodeUnhealthy", fmt.Sprintf("Node %q in worker group %q is unhealthy", nodeName, workerPoolName1)))),
 			Entry("node not healthy with error codes",
 				[]corev1.Node{
 					{
@@ -633,7 +633,7 @@ var _ = Describe("health check", func() {
 					},
 				},
 				cloudConfigSecretChecksums,
-				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "MissingNodes", fmt.Sprintf("Not enough worker nodes registered in worker pool '%s' to meet minimum desired machine count. (%d/%d).", workerPoolName2, 0, 1)))),
+				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "MissingNodes", fmt.Sprintf("Not enough worker nodes registered in worker pool %q to meet minimum desired machine count. (%d/%d).", workerPoolName2, 0, 1)))),
 			Entry("not enough nodes in worker pool",
 				[]corev1.Node{
 					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1}, nil, kubernetesVersion.Original()),
@@ -651,7 +651,7 @@ var _ = Describe("health check", func() {
 					},
 				},
 				cloudConfigSecretChecksums,
-				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "MissingNodes", fmt.Sprintf("Not enough worker nodes registered in worker pool '%s' to meet minimum desired machine count. (%d/%d).", workerPoolName2, 0, 1)))),
+				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "MissingNodes", fmt.Sprintf("Not enough worker nodes registered in worker pool %q to meet minimum desired machine count. (%d/%d).", workerPoolName2, 0, 1)))),
 			Entry("too old Kubernetes patch version",
 				[]corev1.Node{
 					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1}, nil, "v1.19.2"),

--- a/pkg/utils/kubernetes/health/pod_health.go
+++ b/pkg/utils/kubernetes/health/pod_health.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Coppied from https://github.com/kubernetes/kubernetes/blob/a93f803f8e400f1d42dc812bc51932ff3b31798a/pkg/api/pod/util.go#L181-L211
+// Copied from https://github.com/kubernetes/kubernetes/blob/a93f803f8e400f1d42dc812bc51932ff3b31798a/pkg/api/pod/util.go#L181-L211
 
 package health
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind technical-debt

**What this PR does / why we need it**:

Includes multiple minor improvements to health check detail messages by the Gardenlet and also in the Extension health check library.
- consistently use quotation marks instead of 'xyz' to indicate values

- make failing condition status more human readable. Exclude the type (Available) and the expected status (True).
  - ` condition "Available" has invalid status False (expected True) due to MinimumReplicasUnavailable: Deployment does not have minimum availability`
    becomes `Deployment does not have minimum availability (MinimumReplicasUnavailable)`
- replace health check summary with reader-friendlier alternative 
  - `Health check summary: 1/3 unsuccessful, 0/3 progressing, 2/3 successful `
    becomes `1 failing health check`.
- `"Worker" CRD reports failed ...`. --> `Worker extension reports failed ...`


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
