### PR TITLE
Introduce new error code for cloud provider request throttling

### DIFF
--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -98,6 +98,7 @@ Known error codes are:
 - `ERR_INFRA_UNAUTHORIZED` - indicates that the last error occurred due to invalid infrastructure credentials. It is classified as a non-retryable error code.
 - `ERR_INFRA_INSUFFICIENT_PRIVILEGES` - indicates that the last error occurred due to insufficient infrastructure privileges. It is classified as a non-retryable error code.
 - `ERR_INFRA_QUOTA_EXCEEDED` - indicates that the last error occurred due to infrastructure quota limits. It is classified as a non-retryable error code.
+- `ERR_INFRA_REQUEST_THROTTLING` - indicates that the last error occurred due to exceeded infrastructure API throttling limit. It is classified as a retryable error code.
 - `ERR_INFRA_DEPENDENCIES` - indicates that the last error occurred due to dependent objects on the infrastructure level. It is classified as a non-retryable error code.
 - `ERR_RETRYABLE_INFRA_DEPENDENCIES` - indicates that the last error occurred due to dependent objects on the infrastructure level, but the operation should be retried.
 - `ERR_INFRA_RESOURCES_DEPLETED` - indicates that the last error occurred due to depleted resource in the infrastructure.

--- a/pkg/apis/core/types_common.go
+++ b/pkg/apis/core/types_common.go
@@ -31,6 +31,9 @@ const (
 	// ErrorInfraQuotaExceeded indicates that the last error occurred due to infrastructure quota limits.
 	// It is classified as a non-retryable error code.
 	ErrorInfraQuotaExceeded ErrorCode = "ERR_INFRA_QUOTA_EXCEEDED"
+	// ErrorInfraRequestThrottling indicates that the last error occurred due to exceeded infrastructure API throttling limit.
+	// It is classified as a retryable error code.
+	ErrorInfraRequestThrottling ErrorCode = "ERR_INFRA_REQUEST_THROTTLING"
 	// ErrorInfraDependencies indicates that the last error occurred due to dependent objects on the infrastructure level.
 	// It is classified as a non-retryable error code.
 	ErrorInfraDependencies ErrorCode = "ERR_INFRA_DEPENDENCIES"

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -29,6 +29,9 @@ const (
 	// ErrorInfraQuotaExceeded indicates that the last error occurred due to infrastructure quota limits.
 	// It is classified as a non-retryable error code.
 	ErrorInfraQuotaExceeded ErrorCode = "ERR_INFRA_QUOTA_EXCEEDED"
+	// ErrorInfraRequestThrottling indicates that the last error occurred due to exceeded infrastructure API throttling limit.
+	// It is classified as a retryable error code.
+	ErrorInfraRequestThrottling ErrorCode = "ERR_INFRA_REQUEST_THROTTLING"
 	// ErrorInfraDependencies indicates that the last error occurred due to dependent objects on the infrastructure level.
 	// It is classified as a non-retryable error code.
 	ErrorInfraDependencies ErrorCode = "ERR_INFRA_DEPENDENCIES"

--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -204,9 +204,9 @@ func LastErrorWithTaskID(description string, taskID string, codes ...gardencorev
 	}
 }
 
-// HasNonRetryableErrorCode returns true if at least one of given list of last errors has at least one error code that
+// LastErrorsHaveNonRetryableErrorCode returns true if at least one of given list of last errors has at least one error code that
 // indicates that an automatic retry would not help fixing the problem.
-func HasNonRetryableErrorCode(lastErrors ...gardencorev1beta1.LastError) bool {
+func LastErrorsHaveNonRetryableErrorCode(lastErrors ...gardencorev1beta1.LastError) bool {
 	for _, lastError := range lastErrors {
 		for _, code := range lastError.Codes {
 			if code == gardencorev1beta1.ErrorInfraUnauthorized ||
@@ -218,5 +218,28 @@ func HasNonRetryableErrorCode(lastErrors ...gardencorev1beta1.LastError) bool {
 			}
 		}
 	}
+	return false
+}
+
+// LastErrorsHaveErrorCode checks whether at least one LastError from the given slice of LastErrors <lastErrors>
+// contains the given ErrorCode <code>.
+func LastErrorsHaveErrorCode(lastErrors []gardencorev1beta1.LastError, code gardencorev1beta1.ErrorCode) bool {
+	for _, lastError := range lastErrors {
+		if HasErrorCode(lastError.Codes, code) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// HasErrorCode checks whether the given slice of ErrorCodes <codes> contains the given ErrorCode <code>.
+func HasErrorCode(codes []gardencorev1beta1.ErrorCode, code gardencorev1beta1.ErrorCode) bool {
+	for _, current := range codes {
+		if current == code {
+			return true
+		}
+	}
+
 	return false
 }

--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -51,7 +51,8 @@ func (e *ErrorWithCodes) Error() string {
 
 var (
 	unauthorizedRegexp                  = regexp.MustCompile(`(?i)(Unauthorized|InvalidClientTokenId|InvalidAuthenticationTokenTenant|SignatureDoesNotMatch|Authentication failed|AuthFailure|AuthorizationFailed|invalid character|invalid_grant|invalid_client|Authorization Profile was not found|cannot fetch token|no active subscriptions|InvalidAccessKeyId|InvalidSecretAccessKey|query returned no results|UnauthorizedOperation|not authorized|InvalidSubscriptionId)`)
-	quotaExceededRegexp                 = regexp.MustCompile(`(?i)(LimitExceeded|Quota|Throttling|Too many requests)`)
+	quotaExceededRegexp                 = regexp.MustCompile(`(?i)(LimitExceeded|Quotas)`)
+	requestThrottlingRegexp             = regexp.MustCompile(`(?i)(Throttling|Too many requests)`)
 	insufficientPrivilegesRegexp        = regexp.MustCompile(`(?i)(AccessDenied|OperationNotAllowed|Error 403)`)
 	dependenciesRegexp                  = regexp.MustCompile(`(?i)(PendingVerification|Access Not Configured|accessNotConfigured|DependencyViolation|OptInRequired|DeleteConflict|Conflict|inactive billing state|ReadOnlyDisabledSubscription|is already being used|InUseSubnetCannotBeDeleted|VnetInUse|InUseRouteTableCannotBeDeleted|timeout while waiting for state to become|InvalidCidrBlock|already busy for|InsufficientFreeAddressesInSubnet|InternalServerError|Future#WaitForCompletion: context has been cancelled|internalerror|internal server error|A resource with the ID|VnetAddressSpaceCannotChangeDueToPeerings|InternalBillingError)`)
 	retryableDependenciesRegexp         = regexp.MustCompile(`(?i)(RetryableError)`)
@@ -99,6 +100,9 @@ func DetermineErrorCodes(err error) []gardencorev1beta1.ErrorCode {
 	}
 	if quotaExceededRegexp.MatchString(message) {
 		codes.Insert(string(gardencorev1beta1.ErrorInfraQuotaExceeded))
+	}
+	if requestThrottlingRegexp.MatchString(message) {
+		codes.Insert(string(gardencorev1beta1.ErrorInfraRequestThrottling))
 	}
 	if insufficientPrivilegesRegexp.MatchString(message) {
 		codes.Insert(string(gardencorev1beta1.ErrorInfraInsufficientPrivileges))

--- a/pkg/apis/core/v1beta1/helper/errors_test.go
+++ b/pkg/apis/core/v1beta1/helper/errors_test.go
@@ -39,6 +39,8 @@ var _ = Describe("errors", func() {
 		Entry("unauthorized with coder", NewErrorWithCodes("", gardencorev1beta1.ErrorInfraUnauthorized), "", NewErrorWithCodes("", gardencorev1beta1.ErrorInfraUnauthorized)),
 		Entry("quota exceeded", errors.New("limitexceeded"), "", NewErrorWithCodes("limitexceeded", gardencorev1beta1.ErrorInfraQuotaExceeded)),
 		Entry("quota exceeded with coder", NewErrorWithCodes("limitexceeded", gardencorev1beta1.ErrorInfraQuotaExceeded), "", NewErrorWithCodes("limitexceeded", gardencorev1beta1.ErrorInfraQuotaExceeded)),
+		Entry("request throttling", errors.New("message=cannot get hosted zones: Throttling"), "", NewErrorWithCodes("message=cannot get hosted zones: Throttling", gardencorev1beta1.ErrorInfraRequestThrottling)),
+		Entry("request throttling coder", NewErrorWithCodes("message=cannot get hosted zones: Throttling", gardencorev1beta1.ErrorInfraRequestThrottling), "", NewErrorWithCodes("message=cannot get hosted zones: Throttling", gardencorev1beta1.ErrorInfraRequestThrottling)),
 		Entry("insufficient privileges", errors.New("accessdenied"), "", NewErrorWithCodes("accessdenied", gardencorev1beta1.ErrorInfraInsufficientPrivileges)),
 		Entry("insufficient privileges with coder", NewErrorWithCodes("accessdenied", gardencorev1beta1.ErrorInfraInsufficientPrivileges), "", NewErrorWithCodes("accessdenied", gardencorev1beta1.ErrorInfraInsufficientPrivileges)),
 		Entry("infrastructure dependencies", errors.New("pendingverification"), "", NewErrorWithCodes("pendingverification", gardencorev1beta1.ErrorInfraDependencies)),

--- a/pkg/apis/core/v1beta1/types_common.go
+++ b/pkg/apis/core/v1beta1/types_common.go
@@ -29,6 +29,9 @@ const (
 	// ErrorInfraQuotaExceeded indicates that the last error occurred due to infrastructure quota limits.
 	// It is classified as a non-retryable error code.
 	ErrorInfraQuotaExceeded ErrorCode = "ERR_INFRA_QUOTA_EXCEEDED"
+	// ErrorInfraRequestThrottling indicates that the last error occurred due to exceeded infrastructure API throttling limit.
+	// It is classified as a retryable error code.
+	ErrorInfraRequestThrottling ErrorCode = "ERR_INFRA_REQUEST_THROTTLING"
 	// ErrorInfraDependencies indicates that the last error occurred due to dependent objects on the infrastructure level.
 	// It is classified as a non-retryable error code.
 	ErrorInfraDependencies ErrorCode = "ERR_INFRA_DEPENDENCIES"


### PR DESCRIPTION
/kind bug

This PR moves the cloud provider request rate limit exceeded error code handling from the `ERR_INFRA_QUOTA_EXCEEDED` error code (non-retyable) to a new error code `ERR_INFRA_REQUEST_THROTTLING` (retryable). So now all kind of rate limit errors will be automatically retried. This should fix issues like #3775 where the Shoot is marked as Failed right away (hence manual retry is needed) when a transient rate limit error occurs.

Fixes #3775

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Shoot operations that error due to cloud provider rate limit exceeded errors are now classified with the new `ERR_INFRA_REQUEST_THROTTLING` error code. Previously these errors were classified as `ERR_INFRA_QUOTA_EXCEEDED` and they were no longer retried. The new error code `ERR_INFRA_REQUEST_THROTTLING` is classified as retryable and such errors will be now automatically retried.
```
