### PR TITLE
[release-v1.18] Automated cherry pick of #3675: Increase CoreDNS memory limits to avoid OOMKill.

### DIFF
--- a/charts/shoot-core/components/charts/coredns/values.yaml
+++ b/charts/shoot-core/components/charts/coredns/values.yaml
@@ -23,7 +23,7 @@ deployment:
       resources:
         limits:
           cpu: 250m
-          memory: 100Mi
+          memory: 500Mi
         requests:
           cpu: 50m
           memory: 15Mi


### PR DESCRIPTION
Cherry pick of #3675 on release-v1.18.

#3675: Increase CoreDNS memory limits to avoid OOMKill.

**Release Notes:**
```bugfix operator
Increase CoreDNS memory limits to avoid OOMKill.
```