### PR TITLE
test resources: replace docker.io images

### DIFF
--- a/test/framework/resources/templates/logger-app.yaml.tpl
+++ b/test/framework/resources/templates/logger-app.yaml.tpl
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: logger
-        image: k8s.gcr.io/logs-generator:v0.1.1
+        image: eu.gcr.io/gardener-project/3rd/k8s_gcr_io/logs-generator:v0.1.1
         args:
           - /bin/sh
           - -c

--- a/test/framework/resources/templates/network-nginx-deamonset.yaml.tpl
+++ b/test/framework/resources/templates/network-nginx-deamonset.yaml.tpl
@@ -14,11 +14,11 @@ spec:
         app: net-nginx
     spec:
       containers:
-      - image: nginx:1.17.5
+      - image: eu.gcr.io/gardener-project/3rd/nginx:1.17.5
         name: net-nginx
         ports:
         - containerPort: 80
-      - image: curlimages/curl:7.67.0
+      - image: eu.gcr.io/gardener-project/3rd/curlimages/curl:7.67.0
         name: net-curl
         command: ["sh", "-c"]
         args: ["sleep 300"]

--- a/test/framework/resources/templates/simple-load-deployment.yaml.tpl
+++ b/test/framework/resources/templates/simple-load-deployment.yaml.tpl
@@ -14,7 +14,7 @@ spec:
         app: load
     spec:
       containers:
-      - image: alpine:3.11
+      - image: eu.gcr.io/gardener-project/3rd/alpine:3.13
         name: load
         command: ["sh", "-c"]
         {{ if .nodeName }}


### PR DESCRIPTION
…/3rd images

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind technical-debt

**What this PR does / why we need it**:
Some deployment templates of the test framework still use images from docker.io which can lead to test failures because of pull rate limits. These images are replaced with copies from `eu.gcr.io/gardener-project/3rd`

Example:
```
event for os-loadtest-7f4d6df99b-bjtqp: {kubelet shoot--it--tmpsj-50g-worker-1-z1-7c4d9-t8lf4} Failed: Failed to pull image \"alpine:3.11\": rpc error: code = Unknown desc = Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit"
``` 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
