### PR TITLE
Fix ControlPlane deployment on Shoot deletion

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -623,6 +623,11 @@ func needsControlPlaneDeployment(ctx context.Context, o *operation.Operation, ku
 		return false, nil
 	}
 
+	if providerStatus := infrastructure.Status.ProviderStatus; providerStatus != nil {
+		// The infrastructure resource has been found with a non-nil provider status, so redeploy the control plane
+		return true, nil
+	}
+
 	// The infrastructure resource has been found, but its provider status is nil
 	// In this case the control plane could not have been created at all, so no need to redeploy it
 	return false, nil


### PR DESCRIPTION
/kind bug
/kind regression

https://github.com/gardener/gardener/pull/3683 introduces a regression in the `needsControlPlaneDeployment` func. It removes:

```diff 
-	if providerStatus := infrastructure.Status.ProviderStatus; providerStatus != nil {
-		// The infrastructure resource has been found with a non-nil provider status, so redeploy the control plane
-		o.Shoot.InfrastructureStatus = providerStatus.Raw
-		return true, nil
-	}
```

After this changes there is no way for the `needsControlPlaneDeployment` to return `true`. Hence on current master `needsControlPlaneDeployment` always returns `false` -> the ControlPlane resource is never re-deployed on Shoot deletion -> cloud-controller-manager, csi-driver-controller are not scaled up on Shoot deletion.

To reproduce this issue:
1. Create a Shoot
2. Hibernated it
3. Delete the hibernated Shoot
4. Make sure that the ControlPlane is not redeployed -> cloud-controller-manager, csi-driver are not scaled up on Shoot deletion

Hence such Shoot deletion fails with:

```yaml
status:
  lastErrors:
    - description: >-
        task "Waiting until managed resources have been deleted" failed: retry
        failed with context deadline exceeded, last error: not all managed
        resources have been deleted in the shoot cluster (still existing:
        [shoot-core])
      taskID: Waiting until managed resources have been deleted
```

(as the cloud-controller-manager is not scaled up and the deletion of the vpn-shoot LoadBalancer hangs forever)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue causing the deletion of hibernated Shoot to fail is now fixed.
```
