### PR TITLE
[release-v1.19] Automated cherry pick of #3762: RetryableError should not block reconciliation attempts #3755: Add missing func in genericactuator.NoopValuesProvider #3785: test resources: replace docker.io images #3760: Prevent 'jq: not found' error on make docker-images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ EFFECTIVE_VERSION                   := $(VERSION)-$(shell git rev-parse HEAD)
 REPO_ROOT                           := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 LOCAL_GARDEN_LABEL                  := local-garden
 REMOTE_GARDEN_LABEL                 := remote-garden
-CR_VERSION                          := $(shell go mod edit -json | jq -r '.Require[] | select(.Path=="sigs.k8s.io/controller-runtime") | .Version')
+CR_VERSION                          := $(shell go list -m -f '{{ .Version }}' sigs.k8s.io/controller-runtime)
 ACTIVATE_SEEDAUTHORIZER             := false
 
 ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)

--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -99,6 +99,7 @@ Known error codes are:
 - `ERR_INFRA_INSUFFICIENT_PRIVILEGES` - indicates that the last error occurred due to insufficient infrastructure privileges. It is classified as a non-retryable error code.
 - `ERR_INFRA_QUOTA_EXCEEDED` - indicates that the last error occurred due to infrastructure quota limits. It is classified as a non-retryable error code.
 - `ERR_INFRA_DEPENDENCIES` - indicates that the last error occurred due to dependent objects on the infrastructure level. It is classified as a non-retryable error code.
+- `ERR_RETRYABLE_INFRA_DEPENDENCIES` - indicates that the last error occurred due to dependent objects on the infrastructure level, but the operation should be retried.
 - `ERR_INFRA_RESOURCES_DEPLETED` - indicates that the last error occurred due to depleted resource in the infrastructure.
 - `ERR_CLEANUP_CLUSTER_RESOURCES` - indicates that the last error occurred due to resources in the cluster that are stuck in deletion.
 - `ERR_CONFIGURATION_PROBLEM` - indicates that the last error occurred due to a configuration problem. It is classified as a non-retryable error code.

--- a/extensions/pkg/controller/controlplane/genericactuator/noopvaluesprovider.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/noopvaluesprovider.go
@@ -27,6 +27,8 @@ type NoopValuesProvider struct {
 	common.ClientContext
 }
 
+var _ ValuesProvider = &NoopValuesProvider{}
+
 // GetConfigChartValues returns the values for the config chart applied by this actuator.
 func (vp *NoopValuesProvider) GetConfigChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) (map[string]interface{}, error) {
 	return nil, nil
@@ -39,6 +41,11 @@ func (vp *NoopValuesProvider) GetControlPlaneChartValues(context.Context, *exten
 
 // GetControlPlaneShootChartValues returns the values for the control plane shoot chart applied by this actuator.
 func (vp *NoopValuesProvider) GetControlPlaneShootChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster, map[string]string) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+// GetControlPlaneShootCRDsChartValues returns the values for the control plane shoot CRDs chart applied by this actuator.
+func (vp *NoopValuesProvider) GetControlPlaneShootCRDsChartValues(context.Context, *extensionsv1alpha1.ControlPlane, *extensionscontroller.Cluster) (map[string]interface{}, error) {
 	return nil, nil
 }
 

--- a/pkg/apis/core/types_common.go
+++ b/pkg/apis/core/types_common.go
@@ -34,6 +34,8 @@ const (
 	// ErrorInfraDependencies indicates that the last error occurred due to dependent objects on the infrastructure level.
 	// It is classified as a non-retryable error code.
 	ErrorInfraDependencies ErrorCode = "ERR_INFRA_DEPENDENCIES"
+	// ErrorRetryableInfraDependencies indicates that the last error occurred due to dependent objects on the infrastructure level, but operation should be retried.
+	ErrorRetryableInfraDependencies ErrorCode = "ERR_RETRYABLE_INFRA_DEPENDENCIES"
 	// ErrorInfraResourcesDepleted indicates that the last error occurred due to depleted resource in the infrastructure.
 	ErrorInfraResourcesDepleted ErrorCode = "ERR_INFRA_RESOURCES_DEPLETED"
 	// ErrorCleanupClusterResources indicates that the last error occurred due to resources in the cluster that are stuck in deletion.

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -32,6 +32,8 @@ const (
 	// ErrorInfraDependencies indicates that the last error occurred due to dependent objects on the infrastructure level.
 	// It is classified as a non-retryable error code.
 	ErrorInfraDependencies ErrorCode = "ERR_INFRA_DEPENDENCIES"
+	// ErrorRetryableInfraDependencies indicates that the last error occurred due to dependent objects on the infrastructure level, but operation should be retried.
+	ErrorRetryableInfraDependencies ErrorCode = "ERR_RETRYABLE_INFRA_DEPENDENCIES"
 	// ErrorInfraResourcesDepleted indicates that the last error occurred due to depleted resource in the infrastructure.
 	ErrorInfraResourcesDepleted ErrorCode = "ERR_INFRA_RESOURCES_DEPLETED"
 	// ErrorCleanupClusterResources indicates that the last error occurred due to resources in the cluster that are stuck in deletion.

--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -53,7 +53,8 @@ var (
 	unauthorizedRegexp                  = regexp.MustCompile(`(?i)(Unauthorized|InvalidClientTokenId|InvalidAuthenticationTokenTenant|SignatureDoesNotMatch|Authentication failed|AuthFailure|AuthorizationFailed|invalid character|invalid_grant|invalid_client|Authorization Profile was not found|cannot fetch token|no active subscriptions|InvalidAccessKeyId|InvalidSecretAccessKey|query returned no results|UnauthorizedOperation|not authorized)`)
 	quotaExceededRegexp                 = regexp.MustCompile(`(?i)(LimitExceeded|Quota|Throttling|Too many requests)`)
 	insufficientPrivilegesRegexp        = regexp.MustCompile(`(?i)(AccessDenied|OperationNotAllowed|Error 403)`)
-	dependenciesRegexp                  = regexp.MustCompile(`(?i)(PendingVerification|Access Not Configured|accessNotConfigured|DependencyViolation|OptInRequired|DeleteConflict|Conflict|inactive billing state|ReadOnlyDisabledSubscription|is already being used|InUseSubnetCannotBeDeleted|VnetInUse|InUseRouteTableCannotBeDeleted|timeout while waiting for state to become|InvalidCidrBlock|already busy for|InsufficientFreeAddressesInSubnet|InternalServerError|RetryableError|Future#WaitForCompletion: context has been cancelled|internalerror|internal server error|A resource with the ID|VnetAddressSpaceCannotChangeDueToPeerings)`)
+	dependenciesRegexp                  = regexp.MustCompile(`(?i)(PendingVerification|Access Not Configured|accessNotConfigured|DependencyViolation|OptInRequired|DeleteConflict|Conflict|inactive billing state|ReadOnlyDisabledSubscription|is already being used|InUseSubnetCannotBeDeleted|VnetInUse|InUseRouteTableCannotBeDeleted|timeout while waiting for state to become|InvalidCidrBlock|already busy for|InsufficientFreeAddressesInSubnet|InternalServerError|Future#WaitForCompletion: context has been cancelled|internalerror|internal server error|A resource with the ID|VnetAddressSpaceCannotChangeDueToPeerings)`)
+	retryableDependenciesRegexp         = regexp.MustCompile(`(?i)(RetryableError)`)
 	resourcesDepletedRegexp             = regexp.MustCompile(`(?i)(not available in the current hardware cluster|InsufficientInstanceCapacity|SkuNotAvailable|ZonalAllocationFailed|out of stock)`)
 	configurationProblemRegexp          = regexp.MustCompile(`(?i)(AzureBastionSubnet|not supported in your requested Availability Zone|InvalidParameter|InvalidParameterValue|notFound|NetcfgInvalidSubnet|InvalidSubnet|Invalid value|KubeletHasInsufficientMemory|KubeletHasDiskPressure|KubeletHasInsufficientPID|violates constraint|no attached internet gateway found|Your query returned no results|PrivateEndpointNetworkPoliciesCannotBeEnabledOnPrivateEndpointSubnet|invalid VPC attributes|PrivateLinkServiceNetworkPoliciesCannotBeEnabledOnPrivateLinkServiceSubnet|unrecognized feature gate|runtime-config invalid key|LoadBalancingRuleMustDisableSNATSinceSameFrontendIPConfigurationIsReferencedByOutboundRule)`)
 	retryableConfigurationProblemRegexp = regexp.MustCompile(`(?i)(is misconfigured and requires zero voluntary evictions)`)
@@ -104,6 +105,9 @@ func DetermineErrorCodes(err error) []gardencorev1beta1.ErrorCode {
 	}
 	if dependenciesRegexp.MatchString(message) {
 		codes.Insert(string(gardencorev1beta1.ErrorInfraDependencies))
+	}
+	if retryableDependenciesRegexp.MatchString(message) {
+		codes.Insert(string(gardencorev1beta1.ErrorRetryableInfraDependencies))
 	}
 	if resourcesDepletedRegexp.MatchString(message) {
 		codes.Insert(string(gardencorev1beta1.ErrorInfraResourcesDepleted))

--- a/pkg/apis/core/v1beta1/helper/errors_test.go
+++ b/pkg/apis/core/v1beta1/helper/errors_test.go
@@ -49,6 +49,8 @@ var _ = Describe("errors", func() {
 		Entry("configuration problem with coder", NewErrorWithCodes("InvalidParameterValue", gardencorev1beta1.ErrorConfigurationProblem), "error occurred: InvalidParameterValue", NewErrorWithCodes("error occurred: InvalidParameterValue", gardencorev1beta1.ErrorConfigurationProblem)),
 		Entry("retryable configuration problem", errors.New("pod disruption budget default/pdb is misconfigured and requires zero voluntary evictions"), "", NewErrorWithCodes("pod disruption budget default/pdb is misconfigured and requires zero voluntary evictions", gardencorev1beta1.ErrorRetryableConfigurationProblem)),
 		Entry("retryable configuration problem with coder", NewErrorWithCodes("pod disruption budget default/pdb is misconfigured and requires zero voluntary evictions", gardencorev1beta1.ErrorRetryableConfigurationProblem), "", NewErrorWithCodes("pod disruption budget default/pdb is misconfigured and requires zero voluntary evictions", gardencorev1beta1.ErrorRetryableConfigurationProblem)),
+		Entry("retryable infrastructure dependencies", errors.New("Code=\"RetryableError\" Message=\"A retryable error occurred"), "", NewErrorWithCodes("Code=\"RetryableError\" Message=\"A retryable error occurred", gardencorev1beta1.ErrorRetryableInfraDependencies)),
+		Entry("retryable infrastructure dependencies with coder", NewErrorWithCodes("Code=\"RetryableError\" Message=\"A retryable error occurred", gardencorev1beta1.ErrorRetryableInfraDependencies), "", NewErrorWithCodes("Code=\"RetryableError\" Message=\"A retryable error occurred", gardencorev1beta1.ErrorRetryableInfraDependencies)),
 	)
 
 	DescribeTable("#ExtractErrorCodes",

--- a/pkg/apis/core/v1beta1/types_common.go
+++ b/pkg/apis/core/v1beta1/types_common.go
@@ -32,6 +32,8 @@ const (
 	// ErrorInfraDependencies indicates that the last error occurred due to dependent objects on the infrastructure level.
 	// It is classified as a non-retryable error code.
 	ErrorInfraDependencies ErrorCode = "ERR_INFRA_DEPENDENCIES"
+	// ErrorRetryableInfraDependencies indicates that the last error occurred due to dependent objects on the infrastructure level, but operation should be retried.
+	ErrorRetryableInfraDependencies ErrorCode = "ERR_RETRYABLE_INFRA_DEPENDENCIES"
 	// ErrorInfraResourcesDepleted indicates that the last error occurred due to depleted resource in the infrastructure.
 	ErrorInfraResourcesDepleted ErrorCode = "ERR_INFRA_RESOURCES_DEPLETED"
 	// ErrorCleanupClusterResources indicates that the last error occurred due to resources in the cluster that are stuck in deletion.

--- a/test/framework/resources/templates/logger-app.yaml.tpl
+++ b/test/framework/resources/templates/logger-app.yaml.tpl
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: logger
-        image: k8s.gcr.io/logs-generator:v0.1.1
+        image: eu.gcr.io/gardener-project/3rd/k8s_gcr_io/logs-generator:v0.1.1
         args:
           - /bin/sh
           - -c

--- a/test/framework/resources/templates/network-nginx-deamonset.yaml.tpl
+++ b/test/framework/resources/templates/network-nginx-deamonset.yaml.tpl
@@ -14,11 +14,11 @@ spec:
         app: net-nginx
     spec:
       containers:
-      - image: nginx:1.17.5
+      - image: eu.gcr.io/gardener-project/3rd/nginx:1.17.5
         name: net-nginx
         ports:
         - containerPort: 80
-      - image: curlimages/curl:7.67.0
+      - image: eu.gcr.io/gardener-project/3rd/curlimages/curl:7.67.0
         name: net-curl
         command: ["sh", "-c"]
         args: ["sleep 300"]

--- a/test/framework/resources/templates/simple-load-deployment.yaml.tpl
+++ b/test/framework/resources/templates/simple-load-deployment.yaml.tpl
@@ -14,7 +14,7 @@ spec:
         app: load
     spec:
       containers:
-      - image: alpine:3.11
+      - image: eu.gcr.io/gardener-project/3rd/alpine:3.13
         name: load
         command: ["sh", "-c"]
         {{ if .nodeName }}


### PR DESCRIPTION
merge/keep-commits 

Cherry pick of #3762 #3755 #3785 #3760 on release-v1.19.

#3762: RetryableError should not block reconciliation attempts
#3755: Add missing func in genericactuator.NoopValuesProvider
#3785: test resources: replace docker.io images
#3760: Prevent 'jq: not found' error on make docker-images

**Release Notes:**
```other operator
Infrastructure dependency errors containing the `RetryableError` will not stop automatic reconciliation attempts.
```