### PR TITLE
Set istiod admission webhook to use 10 seconds timeout.

### DIFF
--- a/charts/istio/istio-istiod/templates/validatingwebhookconfiguration.yaml
+++ b/charts/istio/istio-istiod/templates/validatingwebhookconfiguration.yaml
@@ -6,6 +6,7 @@ metadata:
 {{ .Values.labels | toYaml | indent 4 }}
 webhooks:
   - name: validation.istio.io
+    timeoutSeconds: 10
     clientConfig:
       service:
         name: istiod


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement 

**What this PR does / why we need it**:
Set istiod admission webhook to use 10 seconds timeout.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The timeout seconds for the `istiod` webhook in the seed clusters managed by Gardener when `ManagedIstio` feature gate is enabled, is now set to 10s.
```
