### PR TITLE
Changing the image version of the test definitions

### DIFF
--- a/.test-defs/CreateManagedSeed.yaml
+++ b/.test-defs/CreateManagedSeed.yaml
@@ -16,4 +16,4 @@ spec:
     -shoot-name=$SHOOT_NAME
     -deploy-gardenlet=$DEPLOY_GARDENLET
     -backup-provider=$BACKUP_PROVIDER
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/CreateManagedSeed.yaml
+++ b/.test-defs/CreateManagedSeed.yaml
@@ -16,4 +16,4 @@ spec:
     -shoot-name=$SHOOT_NAME
     -deploy-gardenlet=$DEPLOY_GARDENLET
     -backup-provider=$BACKUP_PROVIDER
-image: golang:1.16.2
+  image: golang:1.16.2

--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -39,4 +39,4 @@ spec:
 #    -machine-type=$MACHINE_TYPE
 #    -external-domain=
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/DeleteManagedSeed.yaml
+++ b/.test-defs/DeleteManagedSeed.yaml
@@ -13,4 +13,4 @@ spec:
     --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
     -kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
     -managed-seed-name=$MANAGED_SEED_NAME
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/DeleteShoot.yaml
+++ b/.test-defs/DeleteShoot.yaml
@@ -14,5 +14,4 @@ spec:
     --shoot-name=$SHOOT_NAME
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
-
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/HibernateShoot.yaml
+++ b/.test-defs/HibernateShoot.yaml
@@ -15,4 +15,4 @@ spec:
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/MigrateShoot.yaml
+++ b/.test-defs/MigrateShoot.yaml
@@ -16,4 +16,4 @@ spec:
     -shoot-namespace=$PROJECT_NAMESPACE
     -kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
     -mr-exclude-list="$MR_EXCLUDE_LIST"
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/ReconcileShoots.yaml
+++ b/.test-defs/ReconcileShoots.yaml
@@ -15,4 +15,4 @@ spec:
     -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
     -version=$GARDENER_VERSION
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/ShootKubernetesUpdateTest.yaml
+++ b/.test-defs/ShootKubernetesUpdateTest.yaml
@@ -17,4 +17,4 @@ spec:
     -shoot-name=$SHOOT_NAME
     -project-namespace=$PROJECT_NAMESPACE
     -version=$K8S_VERSION
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/TestSuiteGardenerBeta.yaml
+++ b/.test-defs/TestSuiteGardenerBeta.yaml
@@ -19,4 +19,4 @@ spec:
       -ginkgo.focus="\[BETA\]"
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/TestSuiteGardenerBetaSerial.yaml
+++ b/.test-defs/TestSuiteGardenerBetaSerial.yaml
@@ -21,4 +21,4 @@ spec:
       -ginkgo.focus="\[BETA\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/TestSuiteGardenerDefault.yaml
+++ b/.test-defs/TestSuiteGardenerDefault.yaml
@@ -19,4 +19,4 @@ spec:
       -ginkgo.focus="\[DEFAULT\]"
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/TestSuiteGardenerDefaultSerial.yaml
+++ b/.test-defs/TestSuiteGardenerDefaultSerial.yaml
@@ -21,4 +21,4 @@ spec:
       -ginkgo.focus="\[DEFAULT\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/TestSuiteGardenerRelease.yaml
+++ b/.test-defs/TestSuiteGardenerRelease.yaml
@@ -19,4 +19,4 @@ spec:
       -ginkgo.focus="\[RELEASE\]"
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/TestSuiteGardenerReleaseSerial.yaml
+++ b/.test-defs/TestSuiteGardenerReleaseSerial.yaml
@@ -21,4 +21,4 @@ spec:
       -ginkgo.focus="\[RELEASE\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/TestSuiteShootBeta.yaml
+++ b/.test-defs/TestSuiteShootBeta.yaml
@@ -21,4 +21,4 @@ spec:
       -ginkgo.focus="\[BETA\]"
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/TestSuiteShootBetaDisruptive.yaml
+++ b/.test-defs/TestSuiteShootBetaDisruptive.yaml
@@ -23,4 +23,4 @@ spec:
       -ginkgo.focus="\[BETA\].*\[DISRUPTIVE\]"
       -ginkgo.skip="\[SERIAL\]"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/TestSuiteShootBetaSerial.yaml
+++ b/.test-defs/TestSuiteShootBetaSerial.yaml
@@ -23,4 +23,4 @@ spec:
       -ginkgo.focus="\[BETA\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/TestSuiteShootDefault.yaml
+++ b/.test-defs/TestSuiteShootDefault.yaml
@@ -21,4 +21,4 @@ spec:
       -ginkgo.focus="\[DEFAULT\]"
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/TestSuiteShootDefaultDisruptive.yaml
+++ b/.test-defs/TestSuiteShootDefaultDisruptive.yaml
@@ -23,4 +23,4 @@ spec:
       -ginkgo.focus="\[DEFAULT\].*\[DISRUPTIVE\]"
       -ginkgo.skip="\[SERIAL\]"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/TestSuiteShootDefaultSerial.yaml
+++ b/.test-defs/TestSuiteShootDefaultSerial.yaml
@@ -23,4 +23,4 @@ spec:
       -ginkgo.focus="\[DEFAULT\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/TestSuiteShootRelease.yaml
+++ b/.test-defs/TestSuiteShootRelease.yaml
@@ -21,4 +21,4 @@ spec:
       -ginkgo.focus="\[RELEASE\]"
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/TestSuiteShootReleaseDisruptive.yaml
+++ b/.test-defs/TestSuiteShootReleaseDisruptive.yaml
@@ -23,4 +23,4 @@ spec:
       -ginkgo.focus="\[RELEASE\].*\[DISRUPTIVE\]"
       -ginkgo.skip="\[SERIAL\]"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/TestSuiteShootReleaseSerial.yaml
+++ b/.test-defs/TestSuiteShootReleaseSerial.yaml
@@ -23,4 +23,4 @@ spec:
       -ginkgo.focus="\[RELEASE\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2

--- a/.test-defs/WakeUpShoot.yaml
+++ b/.test-defs/WakeUpShoot.yaml
@@ -15,4 +15,4 @@ spec:
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
 
-  image: golang:1.16.2
+  image: eu.gcr.io/gardener-project/3rd/golang:1.16.2


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
This PR is fixing the indentation of the `image` property of the CreateManagedSeed test definition.
Also the image of the test definitions is changed to `eu.gcr.io/gardener-project/3rd/golang:1.16.2`
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
