### PR TITLE
Deserialize custom resources with EnableStrict

### DIFF
--- a/extensions/pkg/controller/common/context.go
+++ b/extensions/pkg/controller/common/context.go
@@ -37,7 +37,7 @@ type ClientContext struct {
 // NewClientConntext offers the possibility to create a ClientContext without injection.
 func NewClientContext(client client.Client, scheme *runtime.Scheme, decoder runtime.Decoder) ClientContext {
 	if decoder == nil && scheme != nil {
-		decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
+		decoder = serializer.NewCodecFactory(scheme, serializer.EnableStrict).UniversalDecoder()
 	}
 	return ClientContext{client: client, scheme: scheme, decoder: decoder}
 }
@@ -46,7 +46,7 @@ func NewClientContext(client client.Client, scheme *runtime.Scheme, decoder runt
 func (cc *ClientContext) InjectScheme(scheme *runtime.Scheme) error {
 	cc.scheme = scheme
 	if scheme != nil {
-		cc.decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
+		cc.decoder = serializer.NewCodecFactory(scheme, serializer.EnableStrict).UniversalDecoder()
 	}
 	return nil
 }

--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -27,7 +27,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -64,7 +63,6 @@ type genericActuator struct {
 	clientset            kubernetes.Interface
 	reader               client.Reader
 	scheme               *runtime.Scheme
-	decoder              runtime.Decoder
 	gardenerClientset    gardenerkubernetes.Interface
 	chartApplier         gardenerkubernetes.ChartApplier
 	chartRendererFactory extensionscontroller.ChartRendererFactory
@@ -102,7 +100,6 @@ func (a *genericActuator) InjectAPIReader(reader client.Reader) error {
 
 func (a *genericActuator) InjectScheme(scheme *runtime.Scheme) error {
 	a.scheme = scheme
-	a.decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/priority 3

**What this PR does / why we need it**:
Adds the `EnableStrict` option to the codec factory of the client context used by extension controllers, to ensure that extension resource configs such as `ControlPlaneConfig` and `WorkerConfig` are always deserialized in "strict" mode. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-azure/pull/270 for `ControlPlaneConfig` and `WorkerConfig` resources, see also https://github.com/gardener/gardener-extension-provider-azure/pull/271

**Special notes for your reviewer**:

**Release note**:

```breaking user
Extension resources configs, namely `ControlPlaneConfig` and `WorkerConfig`, are now deserialized in "strict" mode. This means that deserializing resources with fields that are not allowed by the API schema will result in errors. Shoots containing such resources will fail with an appropriate error until you manually update the shoot to make sure any extension resources contained in it are valid. Note that due to other changes will not be able to create new shoots containing such resources, since they will be rejected by validation.
```
