### PR TITLE
Add correct path to landscaper component in dev-setup script

### DIFF
--- a/hack/local-development/dev-setup
+++ b/hack/local-development/dev-setup
@@ -22,7 +22,7 @@ LANDSCAPER_DIR=$(dirname "${0}")/../../landscaper
 
 source $(dirname "${0}")/common/helpers
 kubernetes_env="$(k8s_env)"
-PLATFORM='-'$( uname -m ); case $PLATFORM in -ppc64le|-arm64) ;; *) PLATFORM=;; esac 
+PLATFORM='-'$( uname -m ); case $PLATFORM in -ppc64le|-arm64) ;; *) PLATFORM=;; esac
 
 # test if we are running against a Minikube, Docker or kind Kubernetes local setup
 case "${kubernetes_env}" in
@@ -57,8 +57,8 @@ case "${kubernetes_env}" in
 mkdir -p ${DEV_DIR}/landscaper
 
 cp ${EXAMPLE_DIR}/20-componentconfig-*.yaml ${DEV_DIR}/
-cp ${LANDSCAPER_DIR}/gardenlet/example/gardenlet-landscaper-imports.yaml ${DEV_DIR}/landscaper
-cp ${LANDSCAPER_DIR}/gardenlet/example/run-locally/gardenlet-landscaper-component-descriptor-list.yaml ${DEV_DIR}/landscaper
+cp ${LANDSCAPER_DIR}/pkg/gardenlet/example/gardenlet-landscaper-imports.yaml ${DEV_DIR}/landscaper
+cp ${LANDSCAPER_DIR}/pkg/gardenlet/example/run-locally/gardenlet-landscaper-component-descriptor-list.yaml ${DEV_DIR}/landscaper
 
 kubectl apply -f ${EXAMPLE_DIR}/00-namespace-garden.yaml
 kubectl apply -f ${EXAMPLE_DIR}/00-namespace-garden-dev.yaml


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Fix an incorrect path in the dev-setup script that prevented it from working.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
