### PR TITLE
Revert "Isto is upgraded to 1.9.2"

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -252,11 +252,11 @@ images:
 - name: istio-proxy
   sourceRepository: github.com/istio/istio
   repository: docker.io/istio/proxyv2
-  tag: "1.9.2"
+  tag: "1.8.0"
 - name: istio-istiod
   sourceRepository: github.com/istio/istio
   repository: docker.io/istio/pilot
-  tag: "1.9.2"
+  tag: "1.8.0"
 
 # API Server SNI
 - name: apiserver-proxy

--- a/charts/istio/istio-crds/templates/crd-all.gen.yaml
+++ b/charts/istio/istio-crds/templates/crd-all.gen.yaml
@@ -1287,10 +1287,6 @@ spec:
                                 description: Applies only to sidecars.
                                 format: string
                                 type: string
-                              destinationPort:
-                                description: The destination_port value used by a
-                                  filter chain's match condition.
-                                type: integer
                               filter:
                                 description: The name of a specific filter to apply
                                   the patch to.
@@ -2473,8 +2469,7 @@ spec:
                         format: int32
                         type: integer
                       perTryTimeout:
-                        description: Timeout per attempt for a given request, including
-                          the initial call and any retries.
+                        description: Timeout per retry attempt for a given request.
                         type: string
                       retryOn:
                         description: Specifies the conditions under which retry takes
@@ -2822,11 +2817,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  labels:
-    app: istio-pilot
-    chart: istio
-    heritage: Tiller
-    release: istio
   name: workloadgroups.networking.istio.io
 spec:
   additionalPrinterColumns:
@@ -2894,11 +2884,11 @@ spec:
                 - exec
               properties:
                 exec:
-                  description: Health is determined by how the command that is executed
+                  description: health is determined by how the command that is executed
                     exited.
                   properties:
                     command:
-                      description: Command to run.
+                      description: command to run.
                       items:
                         format: string
                         type: string
@@ -2916,7 +2906,7 @@ spec:
                       format: string
                       type: string
                     httpHeaders:
-                      description: Headers the proxy will pass on to make the request.
+                      description: headers the proxy will pass on to make the request.
                       items:
                         properties:
                           name:
@@ -2932,7 +2922,7 @@ spec:
                       format: string
                       type: string
                     port:
-                      description: Port on which the endpoint lives.
+                      description: port on which the endpoint lives.
                       type: integer
                     scheme:
                       format: string
@@ -2953,7 +2943,7 @@ spec:
                   format: int32
                   type: integer
                 tcpSocket:
-                  description: Health is determined by if the proxy is able to connect.
+                  description: health is determined by if the proxy is able to connect.
                   properties:
                     host:
                       format: string
@@ -3254,19 +3244,6 @@ metadata:
     release: istio
   name: peerauthentications.security.istio.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.mtls.mode
-    description: Defines the mTLS mode used for peer authentication.
-    name: Mode
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: 'CreationTimestamp is a timestamp representing the server time when
-      this object was created. It is not guaranteed to be set in happens-before order
-      across separate operations. Clients may not set this value. It is represented
-      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-    name: Age
-    type: date
   group: security.istio.io
   names:
     categories:

--- a/charts/istio/istio-ingress/templates/envoy-filter.yaml
+++ b/charts/istio/istio-ingress/templates/envoy-filter.yaml
@@ -80,7 +80,7 @@ spec:
       listener:
         filterChain:
           filter:
-            name: "envoy.filters.network.tcp_proxy"
+            name: "envoy.tcp_proxy"
     patch:
       operation: INSERT_BEFORE
       value:
@@ -134,7 +134,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
-  name: tcp-stats-filter-1.9
+  name: tcp-stats-filter-1.7
   namespace: {{ .Release.Namespace }}
 spec:
   configPatches:
@@ -144,9 +144,9 @@ spec:
       listener:
         filterChain:
           filter:
-            name: envoy.filters.network.tcp_proxy
+            name: envoy.tcp_proxy
       proxy:
-        proxyVersion: ^1\.9.*
+        proxyVersion: ^1\.7.*
     patch:
       operation: INSERT_BEFORE
       value:
@@ -176,7 +176,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
-  name: tcp-metadata-exchange-1.9
+  name: tcp-metadata-exchange-1.7
   namespace: {{ .Release.Namespace }}
 spec:
   configPatches:
@@ -184,7 +184,7 @@ spec:
     match:
       context: GATEWAY
       proxy:
-        proxyVersion: '^1\.9.*'
+        proxyVersion: '^1\.7.*'
       cluster: {}
     patch:
       operation: MERGE

--- a/charts/seed-controlplane/charts/kube-apiserver-sni/templates/kube-apiserver-envoyfilter.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver-sni/templates/kube-apiserver-envoyfilter.yaml
@@ -25,7 +25,7 @@ spec:
       operation: ADD
       value:
         filters:
-        - name: envoy.filters.network.tcp_proxy
+        - name: envoy.tcp_proxy
           typed_config:
             "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy"
             stat_prefix: "outbound|443||{{ .Values.name }}.{{ .Release.Namespace }}.svc.cluster.local"

--- a/docs/proposals/08-shoot-apiserver-via-sni.md
+++ b/docs/proposals/08-shoot-apiserver-via-sni.md
@@ -336,7 +336,7 @@ spec:
       operation: ADD
       value:
         filters:
-        - name: envoy.filters.network.tcp_proxy
+        - name: envoy.tcp_proxy
           typed_config:
             "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy"
             stat_prefix: outbound|443||kube-apiserver.<shoot-namespace>.svc.cluster.local

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -28,7 +28,6 @@ import (
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	resourcesscheme "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
-	istionetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
@@ -108,7 +107,6 @@ func init() {
 		druidv1alpha1.AddToScheme,
 		apiextensionsscheme.AddToScheme,
 		istionetworkingv1beta1.AddToScheme,
-		istionetworkingv1alpha3.AddToScheme,
 	)
 	utilruntime.Must(seedSchemeBuilder.AddToScheme(SeedScheme))
 

--- a/pkg/operation/botanist/component/istio/crds.go
+++ b/pkg/operation/botanist/component/istio/crds.go
@@ -21,13 +21,16 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type crds struct {
 	kubernetes.ChartApplier
-	chartPath string
-	client    crclient.Client
+	chartPath      string
+	client         crclient.Client
+	deprecatedCRDs []apiextensionsv1.CustomResourceDefinition
 }
 
 // NewIstioCRD can be used to deploy istio CRDs.
@@ -41,10 +44,32 @@ func NewIstioCRD(
 		ChartApplier: applier,
 		chartPath:    filepath.Join(chartsRootPath, "istio", "istio-crds"),
 		client:       client,
+		deprecatedCRDs: []apiextensionsv1.CustomResourceDefinition{
+			{ObjectMeta: metav1.ObjectMeta{Name: "attributemanifests.config.istio.io"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "clusterrbacconfigs.rbac.istio.io"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "handlers.config.istio.io"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "httpapispecbindings.config.istio.io"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "httpapispecs.config.istio.io"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "instances.config.istio.io"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "meshpolicies.authentication.istio.io"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "policies.authentication.istio.io"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "quotaspecbindings.config.istio.io"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "quotaspecs.config.istio.io"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "rbacconfigs.rbac.istio.io"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "rules.config.istio.io"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "servicerolebindings.rbac.istio.io"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "serviceroles.rbac.istio.io"}},
+		},
 	}
 }
 
 func (c *crds) Deploy(ctx context.Context) error {
+	for _, deprecatedCRD := range c.deprecatedCRDs {
+		if err := crclient.IgnoreNotFound(c.client.Delete(ctx, &deprecatedCRD)); err != nil {
+			return err
+		}
+	}
+
 	return c.Apply(ctx, c.chartPath, "", "istio")
 }
 

--- a/pkg/operation/botanist/component/istio/ingress_gateway.go
+++ b/pkg/operation/botanist/component/istio/ingress_gateway.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
-	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -69,15 +68,6 @@ func NewIngressGateway(
 }
 
 func (i *ingress) Deploy(ctx context.Context) error {
-	// TODO(mvladev): Rotate this on on every istio version upgrade.
-	for _, filterName := range []string{"tcp-metadata-exchange-1.7", "tcp-stats-filter-1.7"} {
-		if err := crclient.IgnoreNotFound(i.client.Delete(ctx, &networkingv1alpha3.EnvoyFilter{
-			ObjectMeta: metav1.ObjectMeta{Name: filterName, Namespace: i.namespace},
-		})); err != nil {
-			return err
-		}
-	}
-
 	if err := i.client.Create(
 		ctx,
 		&corev1.Namespace{

--- a/pkg/operation/botanist/component/istio/ingress_gateway_test.go
+++ b/pkg/operation/botanist/component/istio/ingress_gateway_test.go
@@ -30,7 +30,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
@@ -66,7 +65,6 @@ var _ = Describe("ingress", func() {
 		s := runtime.NewScheme()
 		Expect(corev1.AddToScheme(s)).ToNot(HaveOccurred())
 		Expect(appsv1.AddToScheme(s)).ToNot(HaveOccurred())
-		Expect(networkingv1alpha3.AddToScheme(s)).ToNot(HaveOccurred())
 		Expect(policyv1beta1.AddToScheme(s)).ToNot(HaveOccurred())
 		c = fake.NewFakeClientWithScheme(s)
 		renderer := cr.NewWithServerVersion(&version.Info{})

--- a/pkg/operation/botanist/component/istio/istiod.go
+++ b/pkg/operation/botanist/component/istio/istiod.go
@@ -21,9 +21,11 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -72,6 +74,16 @@ func (i *istiod) Deploy(ctx context.Context) error {
 			},
 		},
 	); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	// TODO (mvladev): Remove this in next release
+	if err := client.IgnoreNotFound(i.client.Delete(ctx, &autoscalingv1.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "istiod",
+			Namespace: i.namespace,
+		},
+	})); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Reverts gardener/gardener#3806

Envoy filters have to be updated to use `v3` of the API before we upgrade.

```
2021-04-01T08:36:00.570017Z     warning envoy config    gRPC config for type.googleapis.com/envoy.config.listener.v3.Listener rejected: Error adding/updating listener(s) 0.0.0.0_8443: The v2 xDS major version is deprecated and disabled by default. Support for v2 will be removed from Envoy at the start of Q1 2021. You may make use of v2 in Q4 2020 by following the advice in https://www.envoyproxy.io/docs/envoy/latest/faq/api/transition. (envoy.config.filter.network.tcp_proxy.v2.TcpProxy)
```