### PR TITLE
Dynamically set replicas for seed-admission-controller deployment.

### DIFF
--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
@@ -258,7 +258,6 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 			},
 		}
 
-		minAvailable        = intstr.FromInt(1)
 		podDisruptionBudget = &policyv1beta1.PodDisruptionBudget{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Name,
@@ -266,7 +265,7 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 				Labels:    getLabels(),
 			},
 			Spec: policyv1beta1.PodDisruptionBudgetSpec{
-				MinAvailable: &minAvailable,
+				MaxUnavailable: &maxUnavailable,
 				Selector: &metav1.LabelSelector{
 					MatchLabels: getLabels(),
 				},

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
@@ -422,7 +422,9 @@ func init() {
 }
 
 func (g *gardenerSeedAdmissionController) getReplicas(ctx context.Context) (int32, error) {
-	nodeList := &corev1.NodeList{}
+	nodeList := &metav1.PartialObjectMetadataList{}
+	nodeList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("NodeList"))
+
 	err := g.client.List(ctx, nodeList)
 	if err != nil {
 		return 0, err

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
@@ -192,7 +192,7 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 			},
 			Spec: appsv1.DeploymentSpec{
 				RevisionHistoryLimit: pointer.Int32Ptr(1),
-				Replicas:             pointer.Int32Ptr(replicas),
+				Replicas:             &replicas,
 				Strategy: appsv1.DeploymentStrategy{
 					Type: appsv1.RollingUpdateDeploymentStrategyType,
 					RollingUpdate: &appsv1.RollingUpdateDeployment{

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
@@ -176,7 +176,7 @@ metadata:
   name: gardener-seed-admission-controller
   namespace: shoot--foo--bar
 spec:
-  minAvailable: 1
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: gardener

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
@@ -376,8 +376,8 @@ status: {}
 			gomock.InOrder(
 				c.EXPECT().List(ctx, gomock.Any()).DoAndReturn(
 					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-						Expect(list).To(BeAssignableToTypeOf(&corev1.NodeList{}))
-						list.(*corev1.NodeList).Items = make([]corev1.Node, 3)
+						Expect(list).To(BeAssignableToTypeOf(&metav1.PartialObjectMetadataList{}))
+						list.(*metav1.PartialObjectMetadataList).Items = make([]metav1.PartialObjectMetadata, 3)
 						return nil
 					}),
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
@@ -391,8 +391,8 @@ status: {}
 			gomock.InOrder(
 				c.EXPECT().List(ctx, gomock.Any()).DoAndReturn(
 					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-						Expect(list).To(BeAssignableToTypeOf(&corev1.NodeList{}))
-						list.(*corev1.NodeList).Items = make([]corev1.Node, 3)
+						Expect(list).To(BeAssignableToTypeOf(&metav1.PartialObjectMetadataList{}))
+						list.(*metav1.PartialObjectMetadataList).Items = make([]metav1.PartialObjectMetadata, 3)
 						return nil
 					}),
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
@@ -408,8 +408,8 @@ status: {}
 			gomock.InOrder(
 				c.EXPECT().List(ctx, gomock.Any()).DoAndReturn(
 					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-						Expect(list).To(BeAssignableToTypeOf(&corev1.NodeList{}))
-						list.(*corev1.NodeList).Items = make([]corev1.Node, 3)
+						Expect(list).To(BeAssignableToTypeOf(&metav1.PartialObjectMetadataList{}))
+						list.(*metav1.PartialObjectMetadataList).Items = make([]metav1.PartialObjectMetadata, 3)
 						return nil
 					}),
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
@@ -432,8 +432,8 @@ status: {}
 			gomock.InOrder(
 				c.EXPECT().List(ctx, gomock.Any()).DoAndReturn(
 					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-						Expect(list).To(BeAssignableToTypeOf(&corev1.NodeList{}))
-						list.(*corev1.NodeList).Items = make([]corev1.Node, 3)
+						Expect(list).To(BeAssignableToTypeOf(&metav1.PartialObjectMetadataList{}))
+						list.(*metav1.PartialObjectMetadataList).Items = make([]metav1.PartialObjectMetadata, 3)
 						return nil
 					}),
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
@@ -455,8 +455,8 @@ status: {}
 			gomock.InOrder(
 				c.EXPECT().List(ctx, gomock.Any()).DoAndReturn(
 					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-						Expect(list).To(BeAssignableToTypeOf(&corev1.NodeList{}))
-						list.(*corev1.NodeList).Items = make([]corev1.Node, 1)
+						Expect(list).To(BeAssignableToTypeOf(&metav1.PartialObjectMetadataList{}))
+						list.(*metav1.PartialObjectMetadataList).Items = make([]metav1.PartialObjectMetadata, 1)
 						return nil
 					}),
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
@@ -17,6 +17,7 @@ package seedadmissioncontroller_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
@@ -116,7 +117,10 @@ spec:
     matchLabels:
       app: gardener
       role: seed-admission-controller
-  strategy: {}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       creationTimestamp: null
@@ -370,6 +374,12 @@ status: {}
 	Describe("#Deploy", func() {
 		It("should fail because the managed resource secret cannot be updated", func() {
 			gomock.InOrder(
+				c.EXPECT().List(ctx, gomock.Any()).DoAndReturn(
+					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+						Expect(list).To(BeAssignableToTypeOf(&corev1.NodeList{}))
+						list.(*corev1.NodeList).Items = make([]corev1.Node, 3)
+						return nil
+					}),
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
 				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr),
 			)
@@ -379,6 +389,12 @@ status: {}
 
 		It("should fail because the managed resource cannot be updated", func() {
 			gomock.InOrder(
+				c.EXPECT().List(ctx, gomock.Any()).DoAndReturn(
+					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+						Expect(list).To(BeAssignableToTypeOf(&corev1.NodeList{}))
+						list.(*corev1.NodeList).Items = make([]corev1.Node, 3)
+						return nil
+					}),
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
 				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})),
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
@@ -390,6 +406,12 @@ status: {}
 
 		It("should successfully deploy all resources (k8s < 1.15)", func() {
 			gomock.InOrder(
+				c.EXPECT().List(ctx, gomock.Any()).DoAndReturn(
+					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+						Expect(list).To(BeAssignableToTypeOf(&corev1.NodeList{}))
+						list.(*corev1.NodeList).Items = make([]corev1.Node, 3)
+						return nil
+					}),
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
 				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 					Expect(obj).To(DeepEqual(managedResourceSecret))
@@ -408,6 +430,35 @@ status: {}
 			managedResourceSecret.Data["validatingwebhookconfiguration____gardener-seed-admission-controller.yaml"] = []byte(validatingWebhookConfigurationYAMLK8sGreaterEqual115)
 
 			gomock.InOrder(
+				c.EXPECT().List(ctx, gomock.Any()).DoAndReturn(
+					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+						Expect(list).To(BeAssignableToTypeOf(&corev1.NodeList{}))
+						list.(*corev1.NodeList).Items = make([]corev1.Node, 3)
+						return nil
+					}),
+				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+					Expect(obj).To(DeepEqual(managedResourceSecret))
+				}),
+				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+					Expect(obj).To(DeepEqual(managedResource))
+				}),
+			)
+
+			Expect(seedAdmission.Deploy(ctx)).To(Succeed())
+		})
+
+		It("should reduce replicas for seed clusters smaller than three nodes", func() {
+			managedResourceSecret.Data["deployment__shoot--foo--bar__gardener-seed-admission-controller.yaml"] = []byte(strings.Replace(deploymentYAML, "replicas: 3", "replicas: 1", -1))
+
+			gomock.InOrder(
+				c.EXPECT().List(ctx, gomock.Any()).DoAndReturn(
+					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+						Expect(list).To(BeAssignableToTypeOf(&corev1.NodeList{}))
+						list.(*corev1.NodeList).Items = make([]corev1.Node, 1)
+						return nil
+					}),
 				c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
 				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 					Expect(obj).To(DeepEqual(managedResourceSecret))


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:

In our test setup we can only have a single node seed cluster. However, the seed-admission-controller is deployed with strong pod anti affinity into the seed's garden namespace with a static amount of 3 replicas. This causes the managed resource for this controller to go unhealthy (the desired replica count cannot be reached).

We deal with this problem by manually adding a HPA that reduces the replica count to 1 after every seed reconciliation. This PR aims for a cleaner solution by dynamically detecting the amount of nodes in the seed cluster, reducing the number of replicas for seed clusters with less than 3 nodes.

**Which issue(s) this PR fixes**:
~

**Special notes for your reviewer**:
This is the follow-up of https://github.com/gardener/gardener/pull/3808.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Seed clusters with less than three nodes are now supported. In earlier versions of Gardener the seed-admission-controller deployment was causing unhealthy managed resources for small seed clusters, preventing seed bootstrapping from succeeding.
```
