### PR TITLE
Fix build after #3627 and #3796 are merged together

### DIFF
--- a/pkg/envtest/apiserver.go
+++ b/pkg/envtest/apiserver.go
@@ -269,7 +269,7 @@ func (g *GardenerAPIServer) defaultSettings() error {
 
 // prepareKubeconfigFile marshals the test environments rest config to a kubeconfig file in the CertDir.
 func (g *GardenerAPIServer) prepareKubeconfigFile() (string, error) {
-	kubeconfigBytes, err := util.MarshalKubeconfigWithClientCertificate(g.restConfig, nil, nil)
+	kubeconfigBytes, err := util.CreateGardenletKubeconfigWithClientCertificate(g.restConfig, nil, nil)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind regression

**What this PR does / why we need it**:

Fix the failing build of master after #3627 and #3796 are merged together, [ref](https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-head-update-job/builds/93#L60639b52:261:265)

```
> Check

Executing golangci-lint

WARN [runner] Can't run linter goanalysis_metalinter: S1028: failed prerequisites: [(inspect@github.com/gardener/gardener/pkg/envtest, isgenerated@github.com/gardener/gardener/pkg/envtest): analysis skipped: errors in package: [/go/src/github.com/gardener/gardener/pkg/envtest/apiserver.go:272:31: MarshalKubeconfigWithClientCertificate not declared by package util]] 

ERRO Running error: S1028: failed prerequisites: [(inspect@github.com/gardener/gardener/pkg/envtest, isgenerated@github.com/gardener/gardener/pkg/envtest): analysis skipped: errors in package: [/go/src/github.com/gardener/gardener/pkg/envtest/apiserver.go:272:31: MarshalKubeconfigWithClientCertificate not declared by package util]] 

make: *** [Makefile:179: check] Error 3

```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
