### PR TITLE
Prepare Envoy for 1.9.x Istio upgrade

### DIFF
--- a/charts/istio/istio-ingress/templates/envoy-filter.yaml
+++ b/charts/istio/istio-ingress/templates/envoy-filter.yaml
@@ -80,7 +80,7 @@ spec:
       listener:
         filterChain:
           filter:
-            name: "envoy.tcp_proxy"
+            name: envoy.filters.network.tcp_proxy
     patch:
       operation: INSERT_BEFORE
       value:
@@ -92,7 +92,7 @@ spec:
             config:
               root_id: stats_outbound
               configuration:
-                "@type": "type.googleapis.com/google.protobuf.StringValue"
+                "@type": type.googleapis.com/google.protobuf.StringValue
                 value: |
                   {
                   }
@@ -144,7 +144,7 @@ spec:
       listener:
         filterChain:
           filter:
-            name: envoy.tcp_proxy
+            name: envoy.filters.network.tcp_proxy
       proxy:
         proxyVersion: ^1\.7.*
     patch:

--- a/charts/istio/istio-proxy-protocol/templates/envoyfilter.yaml
+++ b/charts/istio/istio-proxy-protocol/templates/envoyfilter.yaml
@@ -22,4 +22,4 @@ spec:
       value:
         per_connection_buffer_limit_bytes: 32768 # 32 KiB
         listener_filters:
-        - name: envoy.listener.proxy_protocol
+        - name: envoy.filters.listener.proxy_protocol

--- a/charts/seed-controlplane/charts/kube-apiserver-sni/templates/kube-apiserver-envoyfilter.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver-sni/templates/kube-apiserver-envoyfilter.yaml
@@ -25,9 +25,9 @@ spec:
       operation: ADD
       value:
         filters:
-        - name: envoy.tcp_proxy
+        - name: envoy.filters.network.tcp_proxy
           typed_config:
-            "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy"
+            "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
             stat_prefix: "outbound|443||{{ .Values.name }}.{{ .Release.Namespace }}.svc.cluster.local"
             cluster: "outbound|443||{{ .Values.name }}.{{ .Release.Namespace }}.svc.cluster.local"
         filter_chain_match:

--- a/docs/proposals/08-shoot-apiserver-via-sni.md
+++ b/docs/proposals/08-shoot-apiserver-via-sni.md
@@ -310,7 +310,7 @@ spec:
       operation: MERGE
       value:
         listener_filters:
-        - name: envoy.listener.proxy_protocol
+        - name: envoy.filters.listener.proxy_protocol
 ```
 
 For each individual `Shoot` cluster, a dedicated [FilterChainMatch](https://www.envoyproxy.io/docs/envoy/v1.13.0/api-v2/api/v2/listener/listener_components.proto#listener-filterchainmatch) is added. It ensures that only Shoot API servers can receive traffic from this listener:
@@ -336,9 +336,9 @@ spec:
       operation: ADD
       value:
         filters:
-        - name: envoy.tcp_proxy
+        - name: envoy.filters.network.tcp_proxy
           typed_config:
-            "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy"
+            "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
             stat_prefix: outbound|443||kube-apiserver.<shoot-namespace>.svc.cluster.local
             cluster: outbound|443||kube-apiserver.<shoot-namespace>.svc.cluster.local
         filter_chain_match:

--- a/pkg/operation/botanist/component/istio/proxy_protocol_test.go
+++ b/pkg/operation/botanist/component/istio/proxy_protocol_test.go
@@ -146,14 +146,13 @@ var _ = Describe("Proxy protocol", func() {
 						Operation: v1alpha3.EnvoyFilter_Patch_MERGE,
 						Value: messageToStruct(&xdsAPI.Listener{
 							ListenerFilters: []*listenerv2.ListenerFilter{
-								{Name: "envoy.listener.proxy_protocol"},
+								{Name: "envoy.filters.listener.proxy_protocol"},
 							},
 						}),
 					},
 				}},
 			},
 		}
-
 	})
 
 	JustBeforeEach(func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

Before we upgrade istio to `1.9.x`, `EnvoyFilters` have to be upgraded to use `V3` of the API and the new fully qualified names of the filters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

See #3810

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`EnovyFilters` now use `V3` for envoy API configuration and the new fully qualified filter names.
```

/assign @vpnachev 
