### PR TITLE
Clean up some migration code

### DIFF
--- a/extensions/pkg/controller/backupentry/mapper.go
+++ b/extensions/pkg/controller/backupentry/mapper.go
@@ -83,10 +83,7 @@ func (m *namespaceToBackupEntryMapper) Map(obj client.Object) []reconcile.Reques
 		return nil
 	}
 
-	shootUID, ok := getDeprecatedAnnotation(namespace.Annotations, v1beta1constants.ShootUID, v1beta1constants.DeprecatedShootUID)
-	if !ok {
-		return nil
-	}
+	shootUID := namespace.Annotations[v1beta1constants.ShootUID]
 
 	var requests []reconcile.Request
 	for _, backupEntry := range backupEntryList.Items {
@@ -110,13 +107,4 @@ func (m *namespaceToBackupEntryMapper) Map(obj client.Object) []reconcile.Reques
 // associated Shoot's seed namespace have been modified.
 func NamespaceToBackupEntryMapper(client client.Client, predicates []predicate.Predicate) extensionshandler.Mapper {
 	return &namespaceToBackupEntryMapper{client, predicates}
-}
-
-func getDeprecatedAnnotation(annotations map[string]string, annotationKey, deprecatedAnnotationKey string) (string, bool) {
-	val, ok := annotations[annotationKey]
-	if !ok {
-		val, ok = annotations[deprecatedAnnotationKey]
-	}
-
-	return val, ok
 }

--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -128,11 +128,6 @@ const (
 	// GardenRoleOptionalAddon is the value of the GardenRole key indicating type 'optional-addon'.
 	GardenRoleOptionalAddon = "optional-addon"
 
-	// DeprecatedShootUID is an annotation key for the shoot namespace in the seed cluster,
-	// which value will be the value of `shoot.status.uid`
-	//
-	// Deprecated: Use the `Cluster` resource or the annotation key from the new API group `ShootUID`.
-	DeprecatedShootUID = "shoot.garden.sapcloud.io/uid"
 	// ShootUID is an annotation key for the shoot namespace in the seed cluster,
 	// which value will be the value of `shoot.status.uid`
 	ShootUID = "shoot.gardener.cloud/uid"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -177,11 +177,6 @@ const (
 	// It refers to a wildcard tls certificate which can be used for services exposed under the corresponding domain.
 	GardenRoleControlPlaneWildcardCert = "controlplane-cert"
 
-	// DeprecatedShootUID is an annotation key for the shoot namespace in the seed cluster,
-	// which value will be the value of `shoot.status.uid`
-	//
-	// Deprecated: Use the `Cluster` resource or the annotation key from the new API group `ShootUID`.
-	DeprecatedShootUID = "shoot.garden.sapcloud.io/uid"
 	// ShootUID is an annotation key for the shoot namespace in the seed cluster,
 	// which value will be the value of `shoot.status.uid`
 	ShootUID = "shoot.gardener.cloud/uid"

--- a/pkg/operation/botanist/component/istio/istiod.go
+++ b/pkg/operation/botanist/component/istio/istiod.go
@@ -21,11 +21,9 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -74,16 +72,6 @@ func (i *istiod) Deploy(ctx context.Context) error {
 			},
 		},
 	); err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
-	}
-
-	// TODO (mvladev): Remove this in next release
-	if err := client.IgnoreNotFound(i.client.Delete(ctx, &autoscalingv1.HorizontalPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "istiod",
-			Namespace: i.namespace,
-		},
-	})); err != nil {
 		return err
 	}
 

--- a/pkg/operation/botanist/component/istio/istiod_test.go
+++ b/pkg/operation/botanist/component/istio/istiod_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/istio"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -194,24 +193,6 @@ var _ = Describe("istiod", func() {
 					corev1.ResourceCPU:    resource.MustParse("100m"),
 				},
 			}))
-		})
-	})
-
-	// TODO (mvladev): Remove after 1 release
-	Describe("HPA", func() {
-		BeforeEach(func() {
-			Expect(c.Create(ctx, &autoscalingv1.HorizontalPodAutoscaler{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "istiod",
-					Namespace: deployNS,
-				},
-			})).To(Succeed())
-		})
-
-		It("removes leftover HPA", func() {
-			Expect(
-				c.Get(ctx, client.ObjectKey{Name: "istio", Namespace: deployNS}, &autoscalingv1.HorizontalPodAutoscaler{}),
-			).To(BeNotFoundError())
 		})
 	})
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -99,18 +99,6 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 		return common.DeleteVpa(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, true)
 	}
 
-	// .spec.selector of a Deployment is immutable. If Deployment's .spec.selector contains
-	// the deprecated role label key, we delete it and let it to be re-created below with the chart apply.
-	// TODO: remove in a future version
-	deploymentKeys := []client.ObjectKey{
-		kutil.Key(b.Shoot.SeedNamespace, "vpa-updater"),
-		kutil.Key(b.Shoot.SeedNamespace, "vpa-recommender"),
-		kutil.Key(b.Shoot.SeedNamespace, "vpa-admission-controller"),
-	}
-	if err := common.DeleteDeploymentsHavingDeprecatedRoleLabelKey(ctx, b.K8sSeedClient.Client(), deploymentKeys); err != nil {
-		return err
-	}
-
 	var (
 		podLabels = map[string]interface{}{
 			v1beta1constants.LabelNetworkPolicyToDNS:            "allowed",

--- a/pkg/operation/botanist/namespaces.go
+++ b/pkg/operation/botanist/namespaces.go
@@ -44,8 +44,7 @@ func (b *Botanist) DeploySeedNamespace(ctx context.Context) error {
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, b.K8sSeedClient.Client(), namespace, func() error {
 		namespace.Annotations = map[string]string{
-			v1beta1constants.ShootUID:           string(b.Shoot.Info.Status.UID),
-			v1beta1constants.DeprecatedShootUID: string(b.Shoot.Info.Status.UID),
+			v1beta1constants.ShootUID: string(b.Shoot.Info.Status.UID),
 		}
 		namespace.Labels = map[string]string{
 			v1beta1constants.GardenRole:              v1beta1constants.GardenRoleShoot,

--- a/pkg/operation/botanist/namespaces_test.go
+++ b/pkg/operation/botanist/namespaces_test.go
@@ -108,8 +108,7 @@ var _ = Describe("Namespaces", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namespace,
 					Annotations: map[string]string{
-						"shoot.gardener.cloud/uid":     string(uid),
-						"shoot.garden.sapcloud.io/uid": string(uid),
+						"shoot.gardener.cloud/uid": string(uid),
 					},
 					Labels: map[string]string{
 						"gardener.cloud/role":                      "shoot",

--- a/pkg/operation/care/health.go
+++ b/pkg/operation/care/health.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/konnectivity"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/metricsserver"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -174,7 +173,7 @@ func (h *Health) healthChecks(
 	}
 
 	var (
-		checker               = NewHealthChecker(thresholdMappings, healthCheckOutdatedThreshold, h.shoot.Info.Status.LastOperation, h.shoot.KubernetesVersion, h.shoot.GardenerVersion)
+		checker               = NewHealthChecker(thresholdMappings, healthCheckOutdatedThreshold, h.shoot.Info.Status.LastOperation, h.shoot.KubernetesVersion)
 		seedDeploymentLister  = makeDeploymentLister(ctx, h.seedClient.Client(), h.shoot.SeedNamespace, controlPlaneMonitoringLoggingSelector)
 		seedStatefulSetLister = makeStatefulSetLister(ctx, h.seedClient.Client(), h.shoot.SeedNamespace, controlPlaneMonitoringLoggingSelector)
 		seedEtcdLister        = makeEtcdLister(ctx, h.seedClient.Client(), h.shoot.SeedNamespace)
@@ -267,12 +266,7 @@ func (h *Health) checkSystemComponents(
 	condition gardencorev1beta1.Condition,
 	extensionConditions []ExtensionCondition,
 ) (*gardencorev1beta1.Condition, error) {
-	managedResources := managedResourcesShoot.List()
-	if versionConstraintGreaterEqual113.Check(checker.gardenerVersion) {
-		managedResources = append(managedResources, metricsserver.ManagedResourceName)
-	}
-
-	for _, name := range managedResources {
+	for name := range managedResourcesShoot {
 		mr := &resourcesv1alpha1.ManagedResource{}
 		if err := h.seedClient.Client().Get(ctx, kutil.Key(h.shoot.SeedNamespace, name), mr); err != nil {
 			return nil, err

--- a/pkg/operation/care/health_check_test.go
+++ b/pkg/operation/care/health_check_test.go
@@ -223,7 +223,6 @@ var _ = Describe("health check", func() {
 
 		seedNamespace     = "shoot--foo--bar"
 		kubernetesVersion = semver.MustParse("1.19.3")
-		gardenerVersion   = semver.MustParse("1.12.3")
 
 		// control plane deployments
 		gardenerResourceManagerDeployment = newDeployment(seedNamespace, v1beta1constants.DeploymentNameGardenerResourceManager, v1beta1constants.GardenRoleControlPlane, true)
@@ -289,7 +288,7 @@ var _ = Describe("health check", func() {
 				deploymentLister = constDeploymentLister(deployments)
 				etcdLister       = constEtcdLister(etcds)
 				workerLister     = constWorkerLister(workers)
-				checker          = care.NewHealthChecker(map[gardencorev1beta1.ConditionType]time.Duration{}, nil, nil, kubernetesVersion, gardenerVersion)
+				checker          = care.NewHealthChecker(map[gardencorev1beta1.ConditionType]time.Duration{}, nil, nil, kubernetesVersion)
 			)
 
 			exitCondition, err := checker.CheckControlPlane(shoot, seedNamespace, condition, deploymentLister, etcdLister, workerLister)
@@ -406,7 +405,7 @@ var _ = Describe("health check", func() {
 		func(conditions []resourcesv1alpha1.ManagedResourceCondition, upToDate bool, conditionMatcher types.GomegaMatcher) {
 			var (
 				mr      = new(resourcesv1alpha1.ManagedResource)
-				checker = care.NewHealthChecker(map[gardencorev1beta1.ConditionType]time.Duration{}, nil, nil, kubernetesVersion, gardenerVersion)
+				checker = care.NewHealthChecker(map[gardencorev1beta1.ConditionType]time.Duration{}, nil, nil, kubernetesVersion)
 			)
 
 			if !upToDate {
@@ -554,7 +553,7 @@ var _ = Describe("health check", func() {
 					return nil
 				})
 
-				checker := care.NewHealthChecker(map[gardencorev1beta1.ConditionType]time.Duration{}, nil, nil, kubernetesVersion, gardenerVersion)
+				checker := care.NewHealthChecker(map[gardencorev1beta1.ConditionType]time.Duration{}, nil, nil, kubernetesVersion)
 
 				exitCondition, err := checker.CheckClusterNodes(ctx, c, workerPools, condition)
 				Expect(err).NotTo(HaveOccurred())
@@ -741,7 +740,7 @@ var _ = Describe("health check", func() {
 			var (
 				deploymentLister  = constDeploymentLister(deployments)
 				statefulSetLister = constStatefulSetLister(statefulSets)
-				checker           = care.NewHealthChecker(map[gardencorev1beta1.ConditionType]time.Duration{}, nil, nil, kubernetesVersion, gardenerVersion)
+				checker           = care.NewHealthChecker(map[gardencorev1beta1.ConditionType]time.Duration{}, nil, nil, kubernetesVersion)
 			)
 
 			exitCondition, err := checker.CheckMonitoringControlPlane(seedNamespace, isTestingShoot, wantsAlertmanager, condition, deploymentLister, statefulSetLister)
@@ -801,7 +800,7 @@ var _ = Describe("health check", func() {
 		func(statefulSets []*appsv1.StatefulSet, isTestingShoot bool, conditionMatcher types.GomegaMatcher) {
 			var (
 				statefulSetLister = constStatefulSetLister(statefulSets)
-				checker           = care.NewHealthChecker(map[gardencorev1beta1.ConditionType]time.Duration{}, nil, nil, kubernetesVersion, gardenerVersion)
+				checker           = care.NewHealthChecker(map[gardencorev1beta1.ConditionType]time.Duration{}, nil, nil, kubernetesVersion)
 			)
 
 			exitCondition, err := checker.CheckLoggingControlPlane(seedNamespace, isTestingShoot, condition, statefulSetLister)
@@ -830,7 +829,7 @@ var _ = Describe("health check", func() {
 
 	DescribeTable("#FailedCondition",
 		func(thresholds map[gardencorev1beta1.ConditionType]time.Duration, lastOperation *gardencorev1beta1.LastOperation, transitionTime metav1.Time, now time.Time, condition gardencorev1beta1.Condition, reason, message string, expected types.GomegaMatcher) {
-			checker := care.NewHealthChecker(thresholds, nil, lastOperation, kubernetesVersion, gardenerVersion)
+			checker := care.NewHealthChecker(thresholds, nil, lastOperation, kubernetesVersion)
 			tmp1, tmp2 := care.Now, gardencorev1beta1helper.Now
 			defer func() {
 				care.Now, gardencorev1beta1helper.Now = tmp1, tmp2
@@ -1009,7 +1008,7 @@ var _ = Describe("health check", func() {
 	// CheckExtensionCondition
 	DescribeTable("#CheckExtensionCondition - HealthCheckReport",
 		func(healthCheckOutdatedThreshold *metav1.Duration, condition gardencorev1beta1.Condition, extensionsConditions []care.ExtensionCondition, expected types.GomegaMatcher) {
-			checker := care.NewHealthChecker(nil, healthCheckOutdatedThreshold, nil, kubernetesVersion, gardenerVersion)
+			checker := care.NewHealthChecker(nil, healthCheckOutdatedThreshold, nil, kubernetesVersion)
 			updatedCondition := checker.CheckExtensionCondition(condition, extensionsConditions)
 			if expected == nil {
 				Expect(updatedCondition).To(BeNil())

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -743,23 +743,6 @@ func RunReconcileSeedFlow(
 		}
 	}
 
-	// .spec.selector of a Deployment is immutable. If Deployment's .spec.selector contains
-	// the deprecated role label key, we delete it and let it to be re-created below with the chart apply.
-	// TODO: remove in a future version
-	deploymentKeys := []client.ObjectKey{
-		kutil.Key(v1beta1constants.GardenNamespace, "vpa-exporter"),
-	}
-	if vpaEnabled {
-		deploymentKeys = append(deploymentKeys,
-			kutil.Key(v1beta1constants.GardenNamespace, "vpa-updater"),
-			kutil.Key(v1beta1constants.GardenNamespace, "vpa-recommender"),
-			kutil.Key(v1beta1constants.GardenNamespace, "vpa-admission-controller"),
-		)
-	}
-	if err := common.DeleteDeploymentsHavingDeprecatedRoleLabelKey(ctx, k8sSeedClient.Client(), deploymentKeys); err != nil {
-		return err
-	}
-
 	values := kubernetes.Values(map[string]interface{}{
 		"priorityClassName": v1beta1constants.PriorityClassNameShootControlPlane,
 		"global": map[string]interface{}{

--- a/pkg/utils/validation/cidr/helper.go
+++ b/pkg/utils/validation/cidr/helper.go
@@ -53,7 +53,7 @@ func ValidateCIDRIsCanonical(fldPath *field.Path, cidrToValidate string) field.E
 		return allErrs
 	}
 	// CIDR parse error already validated
-	ipAdress, ipNet, _ := net.ParseCIDR(string(cidrToValidate))
+	ipAdress, ipNet, _ := net.ParseCIDR(cidrToValidate)
 	if ipNet != nil {
 		if !ipNet.IP.Equal(ipAdress) {
 			allErrs = append(allErrs, field.Invalid(fldPath, cidrToValidate, "must be valid canonical CIDR"))


### PR DESCRIPTION
/kind cleanup
/merge squash

fc744cd - Cleanup the version check in the HealthChecker for the metrics-server ManagedResource - ref https://github.com/gardener/gardener/pull/3183
e595897 - Clean up the deletion of the stale istiod HPA - ref https://github.com/gardener/gardener/pull/3613
e80c979 - Clean up the deletion of VPA components having deprecated label key - ref https://github.com/gardener/gardener/pull/3264
013daf1 - Clean up the deprecated Shoot uid annotation from the Shoot namespace in the Seed - ref #3322

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
