### PR TITLE
Todo doc cleanup

### DIFF
--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -6333,7 +6333,7 @@ string
 <p>Role represents the role of this member.
 IMPORTANT: Be aware that this field will be removed in the <code>v1</code> version of this API in favor of the <code>roles</code>
 list.
-TODO: Remove this field in favor of the <code>owner</code> role in <code>v1</code>.</p>
+TODO: Remove this field in favor of the <code>roles</code> list in <code>v1</code>.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -1446,7 +1446,7 @@ message ProjectMember {
   // Role represents the role of this member.
   // IMPORTANT: Be aware that this field will be removed in the `v1` version of this API in favor of the `roles`
   // list.
-  // TODO: Remove this field in favor of the `owner` role in `v1`.
+  // TODO: Remove this field in favor of the `roles` list in `v1`.
   optional string role = 2;
 
   // Roles represents the list of roles of this member.

--- a/pkg/apis/core/v1alpha1/types_project.go
+++ b/pkg/apis/core/v1alpha1/types_project.go
@@ -106,7 +106,7 @@ type ProjectMember struct {
 	// Role represents the role of this member.
 	// IMPORTANT: Be aware that this field will be removed in the `v1` version of this API in favor of the `roles`
 	// list.
-	// TODO: Remove this field in favor of the `owner` role in `v1`.
+	// TODO: Remove this field in favor of the `roles` list in `v1`.
 	Role string `json:"role" protobuf:"bytes,2,opt,name=role"`
 	// Roles represents the list of roles of this member.
 	// +optional

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1410,7 +1410,7 @@ message ProjectMember {
   // Role represents the role of this member.
   // IMPORTANT: Be aware that this field will be removed in the `v1` version of this API in favor of the `roles`
   // list.
-  // TODO: Remove this field in favor of the `owner` role in `v1`.
+  // TODO: Remove this field in favor of the `roles` list in `v1`.
   optional string role = 2;
 
   // Roles represents the list of roles of this member.

--- a/pkg/apis/core/v1beta1/types_project.go
+++ b/pkg/apis/core/v1beta1/types_project.go
@@ -106,7 +106,7 @@ type ProjectMember struct {
 	// Role represents the role of this member.
 	// IMPORTANT: Be aware that this field will be removed in the `v1` version of this API in favor of the `roles`
 	// list.
-	// TODO: Remove this field in favor of the `roles` list in `v1`..
+	// TODO: Remove this field in favor of the `roles` list in `v1`.
 	Role string `json:"role" protobuf:"bytes,2,opt,name=role"`
 	// Roles represents the list of roles of this member.
 	// +optional

--- a/pkg/apis/core/v1beta1/types_project.go
+++ b/pkg/apis/core/v1beta1/types_project.go
@@ -106,7 +106,7 @@ type ProjectMember struct {
 	// Role represents the role of this member.
 	// IMPORTANT: Be aware that this field will be removed in the `v1` version of this API in favor of the `roles`
 	// list.
-	// TODO: Remove this field in favor of the `owner` role in `v1`.
+	// TODO: Remove this field in favor of the `roles` list in `v1`..
 	Role string `json:"role" protobuf:"bytes,2,opt,name=role"`
 	// Roles represents the list of roles of this member.
 	// +optional


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup

**What this PR does / why we need it**:

Reduce confusion around the differentiation between "role" and "roles" field changes related to v1 api.

**Which issue(s) this PR fixes**:
Fixes # N/A

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
