### PR TITLE
Switch dependency-watchdog to use 'gardener.cloud/role' label key

### DIFF
--- a/charts/seed-bootstrap/charts/dependency-watchdog/templates/endpoint-configmap.yaml
+++ b/charts/seed-bootstrap/charts/dependency-watchdog/templates/endpoint-configmap.yaml
@@ -14,7 +14,7 @@ data:
           - name: controlplane
             selector:
               matchExpressions:
-              - key: garden.sapcloud.io/role
+              - key: gardener.cloud/role
                 operator: In
                 values:
                 - controlplane

--- a/docs/usage/seed_bootstrapping.md
+++ b/docs/usage/seed_bootstrapping.md
@@ -56,4 +56,4 @@ This is exactly the situation in which the DWD will become active:
 If it detects that a certain `Service` is available again (e.g., after the `etcd` was temporarily down while being moved to another seed node) then DWD will restart all crash-looping dependant pods.
 These dependant pods are detected via a pre-configured label selector.
 
-As of today, the DWD is configured to restart a crash-looping `kube-apiserver` after `etcd` became available again, or any pod depending on the `kube-apiserver` that has a `garden.sapcloud.io/role=controlplane` label (e.g., `kube-controller-manager`, `kube-scheduler`, etc.).
+As of today, the DWD is configured to restart a crash-looping `kube-apiserver` after `etcd` became available again, or any pod depending on the `kube-apiserver` that has a `gardener.cloud/role=controlplane` label (e.g., `kube-controller-manager`, `kube-scheduler`, etc.).

--- a/pkg/operation/botanist/component/etcd/dependency_watchdog.go
+++ b/pkg/operation/botanist/component/etcd/dependency_watchdog.go
@@ -26,7 +26,7 @@ func DependencyWatchdogConfiguration(role string) (string, error) {
   - name: ` + v1beta1constants.GardenRoleControlPlane + `
     selector:
       matchExpressions:
-      - key: ` + v1beta1constants.DeprecatedGardenRole + `
+      - key: ` + v1beta1constants.GardenRole + `
         operator: In
         values:
         - ` + v1beta1constants.GardenRoleControlPlane + `

--- a/pkg/operation/botanist/component/etcd/dependency_watchdog_test.go
+++ b/pkg/operation/botanist/component/etcd/dependency_watchdog_test.go
@@ -37,7 +37,7 @@ const (
   - name: controlplane
     selector:
       matchExpressions:
-      - key: garden.sapcloud.io/role
+      - key: gardener.cloud/role
         operator: In
         values:
         - controlplane


### PR DESCRIPTION
/kind cleanup

Part of #1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
