### PR TITLE
Use GCS instead of bitnami as helm repo for redis chart for integration tests

### DIFF
--- a/test/framework/resources/repository/repositories.yaml
+++ b/test/framework/resources/repository/repositories.yaml
@@ -5,5 +5,5 @@ repositories:
     keyFile: ""
     name: stable
     password: ""
-    url: https://charts.bitnami.com/bitnami
+    url: https://storage.googleapis.com/gardener-public/integrationtests-charts
     username: ""


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
I've noted that our guestbook tests fail occasionally with network errors while trying to pull the redis helm charts from bitnami.
In the spirit of replicating docker images into GCR for improved reliability, I now created a new public GCS bucket and replicated the resp. helm chart into a new helm repository at https://storage.googleapis.com/gardener-public/integrationtests-charts for improved reliability.
This PR just reconfigures the test to the new GCS location.

**Which issue(s) this PR fixes**:
Sporadic network errors on downloading the redis helm chart during integration tests.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
/cc @schrodit 