### PR TITLE
[GEP-13] Enhance ManagedSeed controller

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
@@ -130,6 +130,8 @@ data:
       {{- if .Values.global.gardenlet.config.controllers.managedSeed }}
       managedSeed:
         concurrentSyncs: {{ required ".Values.global.gardenlet.config.controllers.managedSeed.concurrentSyncs is required" .Values.global.gardenlet.config.controllers.managedSeed.concurrentSyncs }}
+        syncPeriod: {{ required ".Values.global.gardenlet.config.controllers.managedSeed.syncPeriod is required" .Values.global.gardenlet.config.controllers.managedSeed.syncPeriod }}
+        waitSyncPeriod: {{ required ".Values.global.gardenlet.config.controllers.managedSeed.waitSyncPeriod is required" .Values.global.gardenlet.config.controllers.managedSeed.waitSyncPeriod }}
         {{- if .Values.global.gardenlet.config.controllers.managedSeed.syncJitterPeriod }}
         syncJitterPeriod: {{ .Values.global.gardenlet.config.controllers.managedSeed.syncJitterPeriod }}
         {{- end }}

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -102,6 +102,8 @@ global:
           syncPeriod: 30s
         managedSeed:
           concurrentSyncs: 5
+          syncPeriod: 1h
+          waitSyncPeriod: 15s
           syncJitterPeriod: 5m
       resources:
         capacity:

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -63,6 +63,8 @@ controllers:
     syncPeriod: 1m
   managedSeed:
     concurrentSyncs: 5
+    syncPeriod: 1h
+    waitSyncPeriod: 15s
     syncJitterPeriod: 5m
 resources:
   capacity:

--- a/landscaper/pkg/gardenlet/chart/charttest/charttest.go
+++ b/landscaper/pkg/gardenlet/chart/charttest/charttest.go
@@ -267,6 +267,12 @@ func ComputeExpectedGardenletConfiguration(componentConfigUsesTlsServerConfig, h
 			},
 			ManagedSeed: &gardenletconfigv1alpha1.ManagedSeedControllerConfiguration{
 				ConcurrentSyncs: &five,
+				SyncPeriod: &metav1.Duration{
+					Duration: 1 * time.Hour,
+				},
+				WaitSyncPeriod: &metav1.Duration{
+					Duration: 15 * time.Second,
+				},
 				SyncJitterPeriod: &metav1.Duration{
 					Duration: 300000000000,
 				},

--- a/pkg/apis/seedmanagement/types_managedseed.go
+++ b/pkg/apis/seedmanagement/types_managedseed.go
@@ -151,8 +151,6 @@ type ManagedSeedStatus struct {
 }
 
 const (
-	// ManagedSeedShootExists is a condition type for indicating whether the ManagedSeed's shoot exists.
-	ManagedSeedShootExists gardencore.ConditionType = "ShootExists"
 	// ManagedSeedShootReconciled is a condition type for indicating whether the ManagedSeed's shoot has been reconciled.
 	ManagedSeedShootReconciled gardencore.ConditionType = "ShootReconciled"
 	// ManagedSeedSeedRegistered is a condition type for indicating whether the ManagedSeed's seed has been registered,

--- a/pkg/apis/seedmanagement/v1alpha1/types_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/types_managedseed.go
@@ -181,8 +181,6 @@ type ManagedSeedStatus struct {
 }
 
 const (
-	// ManagedSeedShootExists is a condition type for indicating whether the ManagedSeed's shoot exists.
-	ManagedSeedShootExists gardencorev1beta1.ConditionType = "ShootExists"
 	// ManagedSeedShootReconciled is a condition type for indicating whether the ManagedSeed's shoot has been reconciled.
 	ManagedSeedShootReconciled gardencorev1beta1.ConditionType = "ShootReconciled"
 	// ManagedSeedSeedRegistered is a condition type for indicating whether the ManagedSeed's seed has been registered,

--- a/pkg/controllermanager/controller/managedseedset/managedseedset.go
+++ b/pkg/controllermanager/controller/managedseedset/managedseedset.go
@@ -97,7 +97,7 @@ func NewManagedSeedSetController(
 	replicaFactory := ReplicaFactoryFunc(NewReplica)
 	replicaGetter := NewReplicaGetter(gardenClient, replicaFactory)
 	actuator := NewActuator(gardenClient, replicaGetter, replicaFactory, config.Controllers.ManagedSeedSet, recorder, logger)
-	reconciler := NewReconciler(gardenClient, actuator, config.Controllers.ManagedSeedSet, recorder, logger)
+	reconciler := NewReconciler(gardenClient, actuator, config.Controllers.ManagedSeedSet, logger)
 
 	return &Controller{
 		gardenClient:           gardenClient,

--- a/pkg/controllermanager/controller/managedseedset/mock/mocks.go
+++ b/pkg/controllermanager/controller/managedseedset/mock/mocks.go
@@ -40,12 +40,13 @@ func (m *MockActuator) EXPECT() *MockActuatorMockRecorder {
 }
 
 // Reconcile mocks base method.
-func (m *MockActuator) Reconcile(arg0 context.Context, arg1 *v1alpha1.ManagedSeedSet) (*v1alpha1.ManagedSeedSetStatus, error) {
+func (m *MockActuator) Reconcile(arg0 context.Context, arg1 *v1alpha1.ManagedSeedSet) (*v1alpha1.ManagedSeedSetStatus, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Reconcile", arg0, arg1)
 	ret0, _ := ret[0].(*v1alpha1.ManagedSeedSetStatus)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Reconcile indicates an expected call of Reconcile.

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -266,6 +266,10 @@ type ManagedSeedControllerConfiguration struct {
 	// ConcurrentSyncs is the number of workers used for the controller to work on
 	// events.
 	ConcurrentSyncs *int
+	// SyncPeriod is the duration how often the existing resources are reconciled.
+	SyncPeriod *metav1.Duration
+	// WaitSyncPeriod is the duration how often an existing resource is reconciled when the controller is waiting for an event.
+	WaitSyncPeriod *metav1.Duration
 	// SyncJitterPeriod is a jitter duration for the reconciler sync that can be used to distribute the syncs randomly.
 	// If its value is greater than 0 then the managed seeds will not be enqueued immediately but only after a random
 	// duration between 0 and the configured value. It is defaulted to 5m.

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -290,6 +290,16 @@ func SetDefaults_ManagedSeedControllerConfiguration(obj *ManagedSeedControllerCo
 		obj.ConcurrentSyncs = &v
 	}
 
+	if obj.SyncPeriod == nil {
+		v := metav1.Duration{Duration: 1 * time.Hour}
+		obj.SyncPeriod = &v
+	}
+
+	if obj.WaitSyncPeriod == nil {
+		v := metav1.Duration{Duration: 15 * time.Second}
+		obj.WaitSyncPeriod = &v
+	}
+
 	if obj.SyncJitterPeriod == nil {
 		v := metav1.Duration{Duration: 5 * time.Minute}
 		obj.SyncJitterPeriod = &v

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -145,6 +145,8 @@ var _ = Describe("Defaults", func() {
 			SetDefaults_ManagedSeedControllerConfiguration(obj)
 
 			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(DefaultControllerConcurrentSyncs)))
+			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 1 * time.Hour})))
+			Expect(obj.WaitSyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 15 * time.Second})))
 			Expect(obj.SyncJitterPeriod).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
 		})
 	})

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -323,6 +323,12 @@ type ManagedSeedControllerConfiguration struct {
 	// events.
 	// +optional
 	ConcurrentSyncs *int `json:"concurrentSyncs,omitempty"`
+	// SyncPeriod is the duration how often the existing resources are reconciled.
+	// +optional
+	SyncPeriod *metav1.Duration `json:"syncPeriod,omitempty"`
+	// WaitSyncPeriod is the duration how often an existing resource is reconciled when the controller is waiting for an event.
+	// +optional
+	WaitSyncPeriod *metav1.Duration `json:"waitSyncPeriod,omitempty"`
 	// SyncJitterPeriod is a jitter duration for the reconciler sync that can be used to distribute the syncs randomly.
 	// If its value is greater than 0 then the managed seeds will not be enqueued immediately but only after a random
 	// duration between 0 and the configured value. It is defaulted to 5m.

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -892,6 +892,8 @@ func Convert_config_Loki_To_v1alpha1_Loki(in *config.Loki, out *Loki, s conversi
 
 func autoConvert_v1alpha1_ManagedSeedControllerConfiguration_To_config_ManagedSeedControllerConfiguration(in *ManagedSeedControllerConfiguration, out *config.ManagedSeedControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = (*int)(unsafe.Pointer(in.ConcurrentSyncs))
+	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
+	out.WaitSyncPeriod = (*v1.Duration)(unsafe.Pointer(in.WaitSyncPeriod))
 	out.SyncJitterPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncJitterPeriod))
 	return nil
 }
@@ -903,6 +905,8 @@ func Convert_v1alpha1_ManagedSeedControllerConfiguration_To_config_ManagedSeedCo
 
 func autoConvert_config_ManagedSeedControllerConfiguration_To_v1alpha1_ManagedSeedControllerConfiguration(in *config.ManagedSeedControllerConfiguration, out *ManagedSeedControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = (*int)(unsafe.Pointer(in.ConcurrentSyncs))
+	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
+	out.WaitSyncPeriod = (*v1.Duration)(unsafe.Pointer(in.WaitSyncPeriod))
 	out.SyncJitterPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncJitterPeriod))
 	return nil
 }

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -526,6 +526,16 @@ func (in *ManagedSeedControllerConfiguration) DeepCopyInto(out *ManagedSeedContr
 		*out = new(int)
 		**out = **in
 	}
+	if in.SyncPeriod != nil {
+		in, out := &in.SyncPeriod, &out.SyncPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.WaitSyncPeriod != nil {
+		in, out := &in.WaitSyncPeriod, &out.WaitSyncPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.SyncJitterPeriod != nil {
 		in, out := &in.SyncJitterPeriod, &out.SyncJitterPeriod
 		*out = new(v1.Duration)

--- a/pkg/gardenlet/apis/config/validation/validation.go
+++ b/pkg/gardenlet/apis/config/validation/validation.go
@@ -129,6 +129,12 @@ func ValidateManagedSeedControllerConfiguration(cfg *config.ManagedSeedControlle
 	if cfg.ConcurrentSyncs != nil {
 		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*cfg.ConcurrentSyncs), fldPath.Child("concurrentSyncs"))...)
 	}
+	if cfg.SyncPeriod != nil {
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(cfg.SyncPeriod.Duration), fldPath.Child("syncPeriod"))...)
+	}
+	if cfg.WaitSyncPeriod != nil {
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(cfg.WaitSyncPeriod.Duration), fldPath.Child("waitSyncPeriod"))...)
+	}
 	if cfg.SyncJitterPeriod != nil {
 		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(cfg.SyncJitterPeriod.Duration), fldPath.Child("syncJitterPeriod"))...)
 	}

--- a/pkg/gardenlet/apis/config/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/validation/validation_test.go
@@ -55,6 +55,8 @@ var _ = Describe("GardenletConfiguration", func() {
 				},
 				ManagedSeed: &config.ManagedSeedControllerConfiguration{
 					ConcurrentSyncs:  &concurrentSyncs,
+					SyncPeriod:       &metav1.Duration{Duration: 1 * time.Hour},
+					WaitSyncPeriod:   &metav1.Duration{Duration: 15 * time.Second},
 					SyncJitterPeriod: &metav1.Duration{Duration: 5 * time.Minute},
 				},
 			},
@@ -158,6 +160,8 @@ var _ = Describe("GardenletConfiguration", func() {
 				invalidConcurrentSyncs := -1
 
 				cfg.Controllers.ManagedSeed.ConcurrentSyncs = &invalidConcurrentSyncs
+				cfg.Controllers.ManagedSeed.SyncPeriod = &metav1.Duration{Duration: -1}
+				cfg.Controllers.ManagedSeed.WaitSyncPeriod = &metav1.Duration{Duration: -1}
 				cfg.Controllers.ManagedSeed.SyncJitterPeriod = &metav1.Duration{Duration: -1}
 
 				errorList := ValidateGardenletConfiguration(cfg, nil, false)
@@ -166,6 +170,14 @@ var _ = Describe("GardenletConfiguration", func() {
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
 						"Field": Equal("controllers.managedSeed.concurrentSyncs"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("controllers.managedSeed.syncPeriod"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("controllers.managedSeed.waitSyncPeriod"),
 					})),
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -526,6 +526,16 @@ func (in *ManagedSeedControllerConfiguration) DeepCopyInto(out *ManagedSeedContr
 		*out = new(int)
 		**out = **in
 	}
+	if in.SyncPeriod != nil {
+		in, out := &in.SyncPeriod, &out.SyncPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.WaitSyncPeriod != nil {
+		in, out := &in.WaitSyncPeriod, &out.WaitSyncPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.SyncJitterPeriod != nil {
 		in, out := &in.SyncJitterPeriod, &out.SyncJitterPeriod
 		*out = new(v1.Duration)

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
@@ -44,6 +44,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -51,9 +52,9 @@ import (
 // Actuator acts upon ManagedSeed resources.
 type Actuator interface {
 	// Reconcile reconciles ManagedSeed creation or update.
-	Reconcile(context.Context, *seedmanagementv1alpha1.ManagedSeed, *gardencorev1beta1.Shoot) error
+	Reconcile(context.Context, *seedmanagementv1alpha1.ManagedSeed) (*seedmanagementv1alpha1.ManagedSeedStatus, bool, error)
 	// Delete reconciles ManagedSeed deletion.
-	Delete(context.Context, *seedmanagementv1alpha1.ManagedSeed, *gardencorev1beta1.Shoot) error
+	Delete(context.Context, *seedmanagementv1alpha1.ManagedSeed) (*seedmanagementv1alpha1.ManagedSeedStatus, bool, bool, error)
 }
 
 // actuator is a concrete implementation of Actuator.
@@ -61,93 +62,232 @@ type actuator struct {
 	gardenClient kubernetes.Interface
 	clientMap    clientmap.ClientMap
 	vp           ValuesHelper
+	recorder     record.EventRecorder
 	logger       *logrus.Logger
 }
 
 // newActuator creates a new Actuator with the given clients, ValuesHelper, and logger.
-func newActuator(gardenClient kubernetes.Interface, clientMap clientmap.ClientMap, vp ValuesHelper, logger *logrus.Logger) Actuator {
+func newActuator(gardenClient kubernetes.Interface, clientMap clientmap.ClientMap, vp ValuesHelper, recorder record.EventRecorder, logger *logrus.Logger) Actuator {
 	return &actuator{
 		gardenClient: gardenClient,
 		clientMap:    clientMap,
 		vp:           vp,
+		recorder:     recorder,
 		logger:       logger,
 	}
 }
 
 // Reconcile reconciles ManagedSeed creation or update.
-func (a *actuator) Reconcile(ctx context.Context, managedSeed *seedmanagementv1alpha1.ManagedSeed, shoot *gardencorev1beta1.Shoot) error {
-	managedSeedLogger := logger.NewFieldLogger(a.logger, "managedSeed", kutil.ObjectName(managedSeed))
+func (a *actuator) Reconcile(ctx context.Context, ms *seedmanagementv1alpha1.ManagedSeed) (status *seedmanagementv1alpha1.ManagedSeedStatus, wait bool, err error) {
+	// Initialize status
+	status = ms.Status.DeepCopy()
+	status.ObservedGeneration = ms.Generation
+
+	defer func() {
+		if err != nil {
+			a.reconcileErrorEventf(ms, err.Error())
+			updateCondition(status, seedmanagementv1alpha1.ManagedSeedSeedRegistered, gardencorev1beta1.ConditionFalse, gardencorev1beta1.EventReconcileError, err.Error())
+		}
+	}()
+
+	// Get shoot
+	shoot := &gardencorev1beta1.Shoot{}
+	if err := a.gardenClient.APIReader().Get(ctx, kutil.Key(ms.Namespace, ms.Spec.Shoot.Name), shoot); err != nil {
+		return status, false, fmt.Errorf("could not get shoot %s/%s: %w", ms.Namespace, ms.Spec.Shoot.Name, err)
+	}
+
+	// Check if shoot is reconciled and update ShootReconciled condition
+	if !shootReconciled(shoot) {
+		a.reconcilingInfoEventf(ms, "Waiting for shoot %s to be reconciled", kutil.ObjectName(shoot))
+		updateCondition(status, seedmanagementv1alpha1.ManagedSeedShootReconciled, gardencorev1beta1.ConditionFalse, gardencorev1beta1.EventReconciling, "")
+		return status, true, nil
+	}
+	updateCondition(status, seedmanagementv1alpha1.ManagedSeedShootReconciled, gardencorev1beta1.ConditionTrue, gardencorev1beta1.EventReconciled, "")
+
+	// Update SeedRegistered condition
+	updateCondition(status, seedmanagementv1alpha1.ManagedSeedSeedRegistered, gardencorev1beta1.ConditionProgressing, gardencorev1beta1.EventReconciling, "")
 
 	// Get shoot client
 	shootClient, err := a.clientMap.GetClient(ctx, keys.ForShoot(shoot))
 	if err != nil {
-		return fmt.Errorf("could not get shoot client for shoot %s: %w", kutil.ObjectName(shoot), err)
+		return status, false, fmt.Errorf("could not get shoot client for shoot %s: %w", kutil.ObjectName(shoot), err)
+	}
+
+	// Decode gardenlet configuration
+	var gardenletConfig *configv1alpha1.GardenletConfiguration
+	if ms.Spec.Gardenlet != nil {
+		gardenletConfig, err = helper.DecodeGardenletConfiguration(&ms.Spec.Gardenlet.Config, false)
+		if err != nil {
+			return status, false, fmt.Errorf("could not decode gardenlet configuration: %w", err)
+		}
+	}
+
+	// Determine seed template
+	var seedTemplate *gardencorev1beta1.SeedTemplate
+	switch {
+	case ms.Spec.SeedTemplate != nil:
+		seedTemplate = ms.Spec.SeedTemplate
+	case ms.Spec.Gardenlet != nil:
+		seedTemplate = &gardenletConfig.SeedConfig.SeedTemplate
+	default:
+		return status, false, fmt.Errorf("could not determine seed template")
+	}
+
+	// Check seed spec
+	if err := a.checkSeedSpec(ctx, &seedTemplate.Spec, shoot); err != nil {
+		return status, false, err
 	}
 
 	// Create or update garden namespace in the shoot
-	managedSeedLogger.Infof("Creating or updating garden namespace in shoot %s", kutil.ObjectName(shoot))
+	a.reconcilingInfoEventf(ms, "Creating or updating garden namespace in shoot %s", kutil.ObjectName(shoot))
 	if err := a.createOrUpdateGardenNamespace(ctx, shootClient); err != nil {
-		return fmt.Errorf("could not create or update garden namespace in shoot %s: %w", kutil.ObjectName(shoot), err)
+		return status, false, fmt.Errorf("could not create or update garden namespace in shoot %s: %w", kutil.ObjectName(shoot), err)
 	}
 
-	switch {
-	case managedSeed.Spec.SeedTemplate != nil:
-		// Register the shoot as seed
-		managedSeedLogger.Infof("Registering shoot %s as seed", kutil.ObjectName(shoot))
-		if err := a.registerAsSeed(ctx, managedSeed, shoot); err != nil {
-			return fmt.Errorf("could not register shoot %s as seed: %w", kutil.ObjectName(shoot), err)
-		}
+	// Create or update seed secrets
+	a.reconcilingInfoEventf(ms, "Creating or updating seed %s secrets", ms.Name)
+	if err := a.createOrUpdateSeedSecrets(ctx, &seedTemplate.Spec, ms, shoot); err != nil {
+		return status, false, fmt.Errorf("could not create or update seed %s secrets: %w", ms.Name, err)
+	}
 
-	case managedSeed.Spec.Gardenlet != nil:
+	if ms.Spec.SeedTemplate != nil {
+		// Create or update seed
+		a.reconcilingInfoEventf(ms, "Creating or updating seed %s", ms.Name)
+		if err := a.createOrUpdateSeed(ctx, ms); err != nil {
+			return status, false, fmt.Errorf("could not create or update seed %s: %w", ms.Name, err)
+		}
+	} else if ms.Spec.Gardenlet != nil {
 		// Deploy gardenlet into the shoot, it will register the seed automatically
-		managedSeedLogger.Infof("Deploying gardenlet into shoot %s", kutil.ObjectName(shoot))
-		if err := a.deployGardenlet(ctx, shootClient, managedSeed, shoot); err != nil {
-			return fmt.Errorf("could not deploy gardenlet into shoot %s: %w", kutil.ObjectName(shoot), err)
+		a.reconcilingInfoEventf(ms, "Deploying gardenlet into shoot %s", kutil.ObjectName(shoot))
+		if err := a.deployGardenlet(ctx, shootClient, ms, gardenletConfig, shoot); err != nil {
+			return status, false, fmt.Errorf("could not deploy gardenlet into shoot %s: %w", kutil.ObjectName(shoot), err)
 		}
 	}
 
-	return nil
+	updateCondition(status, seedmanagementv1alpha1.ManagedSeedSeedRegistered, gardencorev1beta1.ConditionTrue, gardencorev1beta1.EventReconciled, "")
+	return status, false, nil
 }
 
 // Delete reconciles ManagedSeed deletion.
-func (a *actuator) Delete(ctx context.Context, managedSeed *seedmanagementv1alpha1.ManagedSeed, shoot *gardencorev1beta1.Shoot) error {
-	managedSeedLogger := logger.NewFieldLogger(a.logger, "managedSeed", kutil.ObjectName(managedSeed))
+func (a *actuator) Delete(ctx context.Context, ms *seedmanagementv1alpha1.ManagedSeed) (status *seedmanagementv1alpha1.ManagedSeedStatus, wait, removeFinalizer bool, err error) {
+	// Initialize status
+	status = ms.Status.DeepCopy()
+	status.ObservedGeneration = ms.Generation
+
+	defer func() {
+		if err != nil {
+			a.deleteErrorEventf(ms, err.Error())
+			updateCondition(status, seedmanagementv1alpha1.ManagedSeedSeedRegistered, gardencorev1beta1.ConditionFalse, gardencorev1beta1.EventDeleteError, err.Error())
+		}
+	}()
+
+	// Update SeedRegistered condition
+	updateCondition(status, seedmanagementv1alpha1.ManagedSeedSeedRegistered, gardencorev1beta1.ConditionFalse, gardencorev1beta1.EventDeleting, "")
+
+	// Get shoot
+	shoot := &gardencorev1beta1.Shoot{}
+	if err := a.gardenClient.APIReader().Get(ctx, kutil.Key(ms.Namespace, ms.Spec.Shoot.Name), shoot); err != nil {
+		return status, false, false, fmt.Errorf("could not get shoot %s/%s: %w", ms.Namespace, ms.Spec.Shoot.Name, err)
+	}
 
 	// Get shoot client
 	shootClient, err := a.clientMap.GetClient(ctx, keys.ForShoot(shoot))
 	if err != nil {
-		return fmt.Errorf("could not get shoot client for shoot %s: %w", kutil.ObjectName(shoot), err)
+		return status, false, false, fmt.Errorf("could not get shoot client for shoot %s: %w", kutil.ObjectName(shoot), err)
 	}
 
+	// Decode gardenlet configuration
+	var gardenletConfig *configv1alpha1.GardenletConfiguration
+	if ms.Spec.Gardenlet != nil {
+		gardenletConfig, err = helper.DecodeGardenletConfiguration(&ms.Spec.Gardenlet.Config, false)
+		if err != nil {
+			return status, false, false, fmt.Errorf("could not decode gardenlet configuration: %w", err)
+		}
+	}
+
+	// Determine seed template
+	var seedTemplate *gardencorev1beta1.SeedTemplate
 	switch {
-	case managedSeed.Spec.SeedTemplate != nil:
-		// Unregister the shoot as seed
-		managedSeedLogger.Infof("Unregistering shoot %s as seed", kutil.ObjectName(shoot))
-		if err := a.unregisterAsSeed(ctx, managedSeed); err != nil {
-			return fmt.Errorf("could not unregister shoot %s as seed: %w", kutil.ObjectName(shoot), err)
-		}
+	case ms.Spec.SeedTemplate != nil:
+		seedTemplate = ms.Spec.SeedTemplate
+	case ms.Spec.Gardenlet != nil:
+		seedTemplate = &gardenletConfig.SeedConfig.SeedTemplate
+	default:
+		return status, false, false, fmt.Errorf("could not determine seed template")
+	}
 
-	case managedSeed.Spec.Gardenlet != nil:
-		// Ensure the seed is deleted
-		managedSeedLogger.Infof("Ensuring seed %s is deleted", managedSeed.Name)
-		if err := a.ensureSeedDeleted(ctx, managedSeed); err != nil {
-			return fmt.Errorf("could not ensure seed %s is deleted: %w", managedSeed.Name, err)
+	// Delete seed if it still exists and is not already deleting
+	seed, err := a.getSeed(ctx, ms)
+	if err != nil {
+		return status, false, false, fmt.Errorf("could not get seed %s: %w", ms.Name, err)
+	}
+	if seed != nil {
+		if seed.DeletionTimestamp == nil {
+			a.deletingInfoEventf(ms, "Deleting seed %s", ms.Name)
+			if err := a.deleteSeed(ctx, ms); err != nil {
+				return status, false, false, fmt.Errorf("could not delete seed %s: %w", ms.Name, err)
+			}
+		} else {
+			a.deletingInfoEventf(ms, "Waiting for seed %s to be deleted", ms.Name)
 		}
+		return status, false, false, nil
+	}
 
-		// Delete gardenlet from the shoot
-		managedSeedLogger.Infof("Deleting gardenlet from shoot %s", kutil.ObjectName(shoot))
-		if err := a.deleteGardenlet(ctx, shootClient, managedSeed, shoot); err != nil {
-			return fmt.Errorf("could not delete gardenlet from shoot %s: %w", kutil.ObjectName(shoot), err)
+	if ms.Spec.Gardenlet != nil {
+		// Delete gardenlet from the shoot if it still exists and is not already deleting
+		gardenletDeployment, err := a.getGardenletDeployment(ctx, shootClient)
+		if err != nil {
+			return status, false, false, fmt.Errorf("could not get gardenlet deployment in shoot %s: %w", kutil.ObjectName(shoot), err)
+		}
+		if gardenletDeployment != nil {
+			if gardenletDeployment.DeletionTimestamp == nil {
+				a.deletingInfoEventf(ms, "Deleting gardenlet from shoot %s", kutil.ObjectName(shoot))
+				if err := a.deleteGardenlet(ctx, shootClient, ms, gardenletConfig, shoot); err != nil {
+					return status, false, false, fmt.Errorf("could delete gardenlet from shoot %s: %w", kutil.ObjectName(shoot), err)
+				}
+			} else {
+				a.deletingInfoEventf(ms, "Waiting for gardenlet to be deleted from shoot %s", kutil.ObjectName(shoot))
+			}
+			return status, true, false, nil
 		}
 	}
 
-	// Ensure garden namespace is deleted from the shoot
-	managedSeedLogger.Infof("Ensuring garden namespace is deleted from shoot %s", kutil.ObjectName(shoot))
-	if err := a.ensureGardenNamespaceDeleted(ctx, shootClient); err != nil {
-		return fmt.Errorf("could not ensure garden namespace is deleted from shoot %s: %w", kutil.ObjectName(shoot), err)
+	// Delete seed secrets if any of them still exists and is not already deleting
+	secret, backupSecret, err := a.getSeedSecrets(ctx, &seedTemplate.Spec, ms)
+	if err != nil {
+		return status, false, false, fmt.Errorf("could not get seed %s secrets: %w", ms.Name, err)
+	}
+	if secret != nil || backupSecret != nil {
+		if (secret != nil && secret.DeletionTimestamp == nil) || (backupSecret != nil && backupSecret.DeletionTimestamp == nil) {
+			a.deletingInfoEventf(ms, "Deleting seed %s secrets", ms.Name)
+			if err := a.deleteSeedSecrets(ctx, &seedTemplate.Spec, ms); err != nil {
+				return status, false, false, fmt.Errorf("could not delete seed %s secrets: %w", ms.Name, err)
+			}
+		} else {
+			a.deletingInfoEventf(ms, "Waiting for seed %s secrets to be deleted", ms.Name)
+		}
+		return status, false, false, nil
 	}
 
-	return nil
+	// Delete garden namespace from the shoot if it still exists and is not already deleting
+	gardenNamespace, err := a.getGardenNamespace(ctx, shootClient)
+	if err != nil {
+		return status, false, false, fmt.Errorf("could not check if garden namespace exists in shoot %s: %w", kutil.ObjectName(shoot), err)
+	}
+	if gardenNamespace != nil {
+		if gardenNamespace.DeletionTimestamp == nil {
+			a.deletingInfoEventf(ms, "Deleting garden namespace from shoot %s", kutil.ObjectName(shoot))
+			if err := a.deleteGardenNamespace(ctx, shootClient); err != nil {
+				return status, false, false, fmt.Errorf("could not delete garden namespace from shoot %s: %w", kutil.ObjectName(shoot), err)
+			}
+		} else {
+			a.deletingInfoEventf(ms, "Waiting for garden namespace to be deleted from shoot %s", kutil.ObjectName(shoot))
+		}
+		return status, true, false, nil
+	}
+
+	updateCondition(status, seedmanagementv1alpha1.ManagedSeedSeedRegistered, gardencorev1beta1.ConditionFalse, gardencorev1beta1.EventDeleted, "")
+	return status, false, true, nil
 }
 
 func (a *actuator) createOrUpdateGardenNamespace(ctx context.Context, shootClient kubernetes.Interface) error {
@@ -162,52 +302,24 @@ func (a *actuator) createOrUpdateGardenNamespace(ctx context.Context, shootClien
 	return err
 }
 
-func (a *actuator) ensureGardenNamespaceDeleted(ctx context.Context, shootClient kubernetes.Interface) error {
-	// Delete garden namespace
+func (a *actuator) deleteGardenNamespace(ctx context.Context, shootClient kubernetes.Interface) error {
 	gardenNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: v1beta1constants.GardenNamespace,
 		},
 	}
-	if err := shootClient.Client().Delete(ctx, gardenNamespace); client.IgnoreNotFound(err) != nil {
-		return err
-	}
-
-	// Check if garden namespace still exists
-	err := shootClient.Client().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace), &corev1.Namespace{})
-	if client.IgnoreNotFound(err) != nil {
-		return err
-	}
-	if err == nil {
-		return fmt.Errorf("namespace %s still exists", v1beta1constants.GardenNamespace)
-	}
-
-	return nil
+	return client.IgnoreNotFound(shootClient.Client().Delete(ctx, gardenNamespace))
 }
 
-func (a *actuator) registerAsSeed(ctx context.Context, managedSeed *seedmanagementv1alpha1.ManagedSeed, shoot *gardencorev1beta1.Shoot) error {
-	// Check seed spec
-	if err := a.checkSeedSpec(ctx, &managedSeed.Spec.SeedTemplate.Spec, shoot); err != nil {
-		return err
+func (a *actuator) getGardenNamespace(ctx context.Context, shootClient kubernetes.Interface) (*corev1.Namespace, error) {
+	ns := &corev1.Namespace{}
+	if err := shootClient.Client().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace), ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
 	}
-
-	// Create or update seed secrets
-	if err := a.createOrUpdateSeedSecrets(ctx, &managedSeed.Spec.SeedTemplate.Spec, managedSeed, shoot); err != nil {
-		return err
-	}
-
-	// Create or update the seed
-	return a.createOrUpdateSeed(ctx, managedSeed)
-}
-
-func (a *actuator) unregisterAsSeed(ctx context.Context, managedSeed *seedmanagementv1alpha1.ManagedSeed) error {
-	// Ensure the seed is deleted
-	if err := a.ensureSeedDeleted(ctx, managedSeed); err != nil {
-		return err
-	}
-
-	// Ensure seed secrets are deleted
-	return a.ensureSeedSecretsDeleted(ctx, &managedSeed.Spec.SeedTemplate.Spec, managedSeed)
+	return ns, nil
 }
 
 func (a *actuator) createOrUpdateSeed(ctx context.Context, managedSeed *seedmanagementv1alpha1.ManagedSeed) error {
@@ -230,46 +342,33 @@ func (a *actuator) createOrUpdateSeed(ctx context.Context, managedSeed *seedmana
 	return err
 }
 
-func (a *actuator) ensureSeedDeleted(ctx context.Context, managedSeed *seedmanagementv1alpha1.ManagedSeed) error {
-	// Delete the seed
+func (a *actuator) deleteSeed(ctx context.Context, managedSeed *seedmanagementv1alpha1.ManagedSeed) error {
 	seed := &gardencorev1beta1.Seed{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: managedSeed.Name,
 		},
 	}
-	if err := a.gardenClient.Client().Delete(ctx, seed); client.IgnoreNotFound(err) != nil {
-		return err
-	}
-
-	// Check if the seed still exists
-	err := a.gardenClient.Client().Get(ctx, kutil.Key(managedSeed.Name), &gardencorev1beta1.Seed{})
-	if client.IgnoreNotFound(err) != nil {
-		return err
-	}
-	if err == nil {
-		return fmt.Errorf("seed %s still exists", managedSeed.Name)
-	}
-
-	return nil
+	return client.IgnoreNotFound(a.gardenClient.Client().Delete(ctx, seed))
 }
 
-func (a *actuator) deployGardenlet(ctx context.Context, shootClient kubernetes.Interface, managedSeed *seedmanagementv1alpha1.ManagedSeed, shoot *gardencorev1beta1.Shoot) error {
-	// Decode gardenlet configuration
-	gardenletConfig, err := helper.DecodeGardenletConfiguration(&managedSeed.Spec.Gardenlet.Config, false)
-	if err != nil {
-		return err
+func (a *actuator) getSeed(ctx context.Context, managedSeed *seedmanagementv1alpha1.ManagedSeed) (*gardencorev1beta1.Seed, error) {
+	seed := &gardencorev1beta1.Seed{}
+	if err := a.gardenClient.Client().Get(ctx, kutil.Key(managedSeed.Name), seed); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
 	}
+	return seed, nil
+}
 
-	// Check seed spec
-	if err := a.checkSeedSpec(ctx, &gardenletConfig.SeedConfig.SeedTemplate.Spec, shoot); err != nil {
-		return err
-	}
-
-	// Create or update seed secrets
-	if err := a.createOrUpdateSeedSecrets(ctx, &gardenletConfig.SeedConfig.SeedTemplate.Spec, managedSeed, shoot); err != nil {
-		return err
-	}
-
+func (a *actuator) deployGardenlet(
+	ctx context.Context,
+	shootClient kubernetes.Interface,
+	managedSeed *seedmanagementv1alpha1.ManagedSeed,
+	gardenletConfig *configv1alpha1.GardenletConfiguration,
+	shoot *gardencorev1beta1.Shoot,
+) error {
 	// Prepare gardenlet chart values
 	values, err := a.prepareGardenletChartValues(
 		ctx,
@@ -289,18 +388,13 @@ func (a *actuator) deployGardenlet(ctx context.Context, shootClient kubernetes.I
 	return shootClient.ChartApplier().Apply(ctx, filepath.Join(charts.Path, "gardener", "gardenlet"), v1beta1constants.GardenNamespace, "gardenlet", kubernetes.Values(values))
 }
 
-func (a *actuator) deleteGardenlet(ctx context.Context, shootClient kubernetes.Interface, managedSeed *seedmanagementv1alpha1.ManagedSeed, shoot *gardencorev1beta1.Shoot) error {
-	// Decode gardenlet configuration
-	gardenletConfig, err := helper.DecodeGardenletConfiguration(&managedSeed.Spec.Gardenlet.Config, false)
-	if err != nil {
-		return err
-	}
-
-	// Ensure seed secrets are deleted
-	if err := a.ensureSeedSecretsDeleted(ctx, &gardenletConfig.SeedConfig.SeedTemplate.Spec, managedSeed); err != nil {
-		return err
-	}
-
+func (a *actuator) deleteGardenlet(
+	ctx context.Context,
+	shootClient kubernetes.Interface,
+	managedSeed *seedmanagementv1alpha1.ManagedSeed,
+	gardenletConfig *configv1alpha1.GardenletConfiguration,
+	shoot *gardencorev1beta1.Shoot,
+) error {
 	// Prepare gardenlet chart values
 	values, err := a.prepareGardenletChartValues(
 		ctx,
@@ -309,7 +403,8 @@ func (a *actuator) deleteGardenlet(ctx context.Context, shootClient kubernetes.I
 		gardenletConfig,
 		managedSeed.Name,
 		v1alpha1helper.GetBootstrap(managedSeed.Spec.Gardenlet.Bootstrap),
-		utils.IsTrue(managedSeed.Spec.Gardenlet.MergeWithParent), shoot,
+		utils.IsTrue(managedSeed.Spec.Gardenlet.MergeWithParent),
+		shoot,
 	)
 	if err != nil {
 		return err
@@ -317,6 +412,17 @@ func (a *actuator) deleteGardenlet(ctx context.Context, shootClient kubernetes.I
 
 	// Delete gardenlet chart
 	return shootClient.ChartApplier().Delete(ctx, filepath.Join(charts.Path, "gardener", "gardenlet"), v1beta1constants.GardenNamespace, "gardenlet", kubernetes.Values(values))
+}
+
+func (a *actuator) getGardenletDeployment(ctx context.Context, shootClient kubernetes.Interface) (*appsv1.Deployment, error) {
+	deployment := &appsv1.Deployment{}
+	if err := shootClient.Client().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace, v1beta1constants.DeploymentNameGardenlet), deployment); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return deployment, nil
 }
 
 func (a *actuator) checkSeedSpec(ctx context.Context, spec *gardencorev1beta1.SeedSpec, shoot *gardencorev1beta1.Shoot) error {
@@ -401,7 +507,7 @@ func (a *actuator) createOrUpdateSeedSecrets(ctx context.Context, spec *gardenco
 	return nil
 }
 
-func (a *actuator) ensureSeedSecretsDeleted(ctx context.Context, spec *gardencorev1beta1.SeedSpec, managedSeed *seedmanagementv1alpha1.ManagedSeed) error {
+func (a *actuator) deleteSeedSecrets(ctx context.Context, spec *gardencorev1beta1.SeedSpec, managedSeed *seedmanagementv1alpha1.ManagedSeed) error {
 	// If backup is specified, delete the backup secret if it exists and is owned by the managed seed
 	if spec.Backup != nil {
 		backupSecret, err := kutil.GetSecretByReference(ctx, a.gardenClient.Client(), &spec.Backup.SecretRef)
@@ -422,29 +528,33 @@ func (a *actuator) ensureSeedSecretsDeleted(ctx context.Context, spec *gardencor
 		}
 	}
 
-	// If backup is specified, check if the backup secret still exists and is owned by the managed seed
-	if spec.Backup != nil {
-		backupSecret, err := kutil.GetSecretByReference(ctx, a.gardenClient.Client(), &spec.Backup.SecretRef)
-		if client.IgnoreNotFound(err) != nil {
-			return err
-		}
-		if err == nil && metav1.IsControlledBy(backupSecret, managedSeed) {
-			return fmt.Errorf("backup secret %s still exists", kutil.ObjectName(backupSecret))
-		}
-	}
-
-	// If secret reference is specified, check if the corresponding secret still exists
-	if spec.SecretRef != nil {
-		secret, err := kutil.GetSecretByReference(ctx, a.gardenClient.Client(), spec.SecretRef)
-		if client.IgnoreNotFound(err) != nil {
-			return err
-		}
-		if err == nil {
-			return fmt.Errorf("seed secret %s still exists", kutil.ObjectName(secret))
-		}
-	}
-
 	return nil
+}
+
+func (a *actuator) getSeedSecrets(ctx context.Context, spec *gardencorev1beta1.SeedSpec, managedSeed *seedmanagementv1alpha1.ManagedSeed) (*corev1.Secret, *corev1.Secret, error) {
+	var secret, backupSecret *corev1.Secret
+	var err error
+
+	// If backup is specified, get the backup secret if it exists and is owned by the managed seed
+	if spec.Backup != nil {
+		backupSecret, err = kutil.GetSecretByReference(ctx, a.gardenClient.Client(), &spec.Backup.SecretRef)
+		if client.IgnoreNotFound(err) != nil {
+			return nil, nil, err
+		}
+		if backupSecret != nil && !metav1.IsControlledBy(backupSecret, managedSeed) {
+			backupSecret = nil
+		}
+	}
+
+	// If secret reference is specified, get the corresponding secret if it exists
+	if spec.SecretRef != nil {
+		secret, err = kutil.GetSecretByReference(ctx, a.gardenClient.Client(), spec.SecretRef)
+		if client.IgnoreNotFound(err) != nil {
+			return nil, nil, err
+		}
+	}
+
+	return secret, backupSecret, nil
 }
 
 func (a *actuator) getShootSecret(ctx context.Context, shoot *gardencorev1beta1.Shoot) (*corev1.Secret, error) {
@@ -676,4 +786,39 @@ func (a *actuator) prepareGardenClientRestConfig(address *string, caCert []byte)
 		}
 	}
 	return gardenClientRestConfig
+}
+
+func (a *actuator) reconcilingInfoEventf(ms *seedmanagementv1alpha1.ManagedSeed, fmt string, args ...interface{}) {
+	a.recorder.Eventf(ms, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, fmt, args...)
+	a.getLogger(ms).Infof(fmt, args...)
+}
+
+func (a *actuator) deletingInfoEventf(ms *seedmanagementv1alpha1.ManagedSeed, fmt string, args ...interface{}) {
+	a.recorder.Eventf(ms, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, fmt, args...)
+	a.getLogger(ms).Infof(fmt, args...)
+}
+
+func (a *actuator) reconcileErrorEventf(ms *seedmanagementv1alpha1.ManagedSeed, fmt string, args ...interface{}) {
+	a.recorder.Eventf(ms, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, fmt, args...)
+	a.getLogger(ms).Errorf(fmt, args...)
+}
+
+func (a *actuator) deleteErrorEventf(ms *seedmanagementv1alpha1.ManagedSeed, fmt string, args ...interface{}) {
+	a.recorder.Eventf(ms, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, fmt, args...)
+	a.getLogger(ms).Errorf(fmt, args...)
+}
+
+func (a *actuator) getLogger(ms *seedmanagementv1alpha1.ManagedSeed) *logrus.Entry {
+	return logger.NewFieldLogger(a.logger, "managedSeed", kutil.ObjectName(ms))
+}
+
+func shootReconciled(shoot *gardencorev1beta1.Shoot) bool {
+	lastOp := shoot.Status.LastOperation
+	return shoot.Generation == shoot.Status.ObservedGeneration && lastOp != nil && lastOp.State == gardencorev1beta1.LastOperationStateSucceeded
+}
+
+func updateCondition(status *seedmanagementv1alpha1.ManagedSeedStatus, ct gardencorev1beta1.ConditionType, cs gardencorev1beta1.ConditionStatus, reason, message string) {
+	condition := gardencorev1beta1helper.GetOrInitCondition(status.Conditions, ct)
+	condition = gardencorev1beta1helper.UpdatedCondition(condition, cs, reason, message)
+	status.Conditions = gardencorev1beta1helper.MergeConditions(status.Conditions, condition)
 }

--- a/pkg/gardenlet/controller/managedseed/managedseed_predicates.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_predicates.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedseed
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+func (c *Controller) filterSeed(obj, _, controller client.Object, deleted bool) bool {
+	seed, ok := obj.(*gardencorev1beta1.Seed)
+	if !ok {
+		return false
+	}
+	ms, ok := controller.(*seedmanagementv1alpha1.ManagedSeed)
+	if !ok {
+		return false
+	}
+
+	// TODO Return true if the seed was deleted or updated and metadata / spec don't match its checksum
+
+	if ms.DeletionTimestamp != nil && deleted {
+		c.logger.Debugf("Managed seed %s is deleting and seed %s no longer exists", kutil.ObjectName(ms), kutil.ObjectName(seed))
+		return true
+	}
+	return false
+}
+
+func (c *Controller) filterSecret(obj, _, controller client.Object, deleted bool) bool {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		return false
+	}
+	ms, ok := controller.(*seedmanagementv1alpha1.ManagedSeed)
+	if !ok {
+		return false
+	}
+
+	// TODO Return true if the secret was deleted or updated and metadata / data don't match its checksum
+
+	if ms.DeletionTimestamp != nil && deleted {
+		c.logger.Debugf("Managed seed %s is deleting and secret %s no longer exists", kutil.ObjectName(ms), kutil.ObjectName(secret))
+		return true
+	}
+	return false
+}

--- a/pkg/gardenlet/controller/managedseed/managedseed_reconciler.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_reconciler.go
@@ -17,21 +17,17 @@ package managedseed
 import (
 	"context"
 	"fmt"
-	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/logger"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -41,23 +37,23 @@ import (
 type reconciler struct {
 	gardenClient kubernetes.Interface
 	actuator     Actuator
-	recorder     record.EventRecorder
+	cfg          *config.ManagedSeedControllerConfiguration
 	logger       *logrus.Logger
 }
 
-// newReconciler creates a new ManagedSeed reconciler with the given clients, actuator, recorder, and logger.
-func newReconciler(gardenClient kubernetes.Interface, actuator Actuator, recorder record.EventRecorder, logger *logrus.Logger) reconcile.Reconciler {
+// newReconciler creates a new ManagedSeed reconciler with the given parameters.
+func newReconciler(gardenClient kubernetes.Interface, actuator Actuator, cfg *config.ManagedSeedControllerConfiguration, logger *logrus.Logger) reconcile.Reconciler {
 	return &reconciler{
 		gardenClient: gardenClient,
 		actuator:     actuator,
-		recorder:     recorder,
+		cfg:          cfg,
 		logger:       logger,
 	}
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
-	if err := r.gardenClient.Client().Get(ctx, request.NamespacedName, managedSeed); err != nil {
+	ms := &seedmanagementv1alpha1.ManagedSeed{}
+	if err := r.gardenClient.Client().Get(ctx, request.NamespacedName, ms); err != nil {
 		if apierrors.IsNotFound(err) {
 			r.logger.Debugf("Skipping ManagedSeed %s because it has been deleted", request.NamespacedName)
 			return reconcile.Result{}, nil
@@ -66,151 +62,93 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	managedSeedLogger := logger.NewFieldLogger(r.logger, "managedSeed", kutil.ObjectName(managedSeed))
-
-	if managedSeed.DeletionTimestamp != nil {
-		return r.delete(ctx, managedSeed, managedSeedLogger)
+	if ms.DeletionTimestamp != nil {
+		return r.delete(ctx, ms)
 	}
-	return r.reconcile(ctx, managedSeed, managedSeedLogger)
+	return r.reconcile(ctx, ms)
 }
 
-func (r *reconciler) reconcile(ctx context.Context, managedSeed *seedmanagementv1alpha1.ManagedSeed, logger *logrus.Entry) (result reconcile.Result, err error) {
-
+func (r *reconciler) reconcile(ctx context.Context, ms *seedmanagementv1alpha1.ManagedSeed) (result reconcile.Result, err error) {
 	// Ensure gardener finalizer
-	if err := controllerutils.PatchAddFinalizers(ctx, r.gardenClient.Client(), managedSeed, gardencorev1beta1.GardenerName); err != nil {
+	r.getLogger(ms).Debug("Ensuring finalizer")
+	if err := controllerutils.PatchAddFinalizers(ctx, r.gardenClient.Client(), ms, gardencorev1beta1.GardenerName); err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not ensure gardener finalizer: %w", err)
 	}
 
-	conditionShootExists := gardencorev1beta1helper.GetOrInitCondition(managedSeed.Status.Conditions, seedmanagementv1alpha1.ManagedSeedShootExists)
-	conditionShootReconciled := gardencorev1beta1helper.GetOrInitCondition(managedSeed.Status.Conditions, seedmanagementv1alpha1.ManagedSeedShootReconciled)
-	conditionSeedRegistered := gardencorev1beta1helper.GetOrInitCondition(managedSeed.Status.Conditions, seedmanagementv1alpha1.ManagedSeedSeedRegistered)
-
+	var status *seedmanagementv1alpha1.ManagedSeedStatus
 	defer func() {
 		// Update status, on failure return the update error unless there is another error
-		if updateErr := updateStatus(ctx, r.gardenClient.Client(), managedSeed, conditionShootExists, conditionShootReconciled, conditionSeedRegistered); updateErr != nil && err == nil {
+		if updateErr := r.updateStatus(ctx, ms, status); updateErr != nil && err == nil {
 			err = fmt.Errorf("could not update status: %w", updateErr)
 		}
 	}()
 
-	// Ensure the shoot exists and update the ShootExists condition
-	shoot, err := r.ensureShootExists(ctx, managedSeed, &conditionShootExists, logger)
-	if err != nil {
-		return reconcile.Result{}, err
+	// Reconcile creation or update
+	r.getLogger(ms).Debug("Reconciling creation or update")
+	var wait bool
+	if status, wait, err = r.actuator.Reconcile(ctx, ms); err != nil {
+		return reconcile.Result{}, fmt.Errorf("could not reconcile ManagedSeed %s creation or update: %w", kutil.ObjectName(ms), err)
 	}
+	r.getLogger(ms).Debug("Creation or update reconciled")
 
-	// Check if the shoot is reconciled and update the ShootReconciled condition
-	// If the shoot is not reconciled yet, requeue for another check in 10s
-	if shoot.Generation != shoot.Status.ObservedGeneration || shoot.Status.LastOperation == nil || shoot.Status.LastOperation.State != gardencorev1beta1.LastOperationStateSucceeded {
-		message := fmt.Sprintf("Shoot %s is still reconciling", kutil.ObjectName(shoot))
-		updateCondition(&conditionShootReconciled, gardencorev1beta1.ConditionFalse, "ShootStillReconciling", message)
-		r.recordAndLog(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, logger, logrus.InfoLevel, message)
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	// If waiting, requeue after WaitSyncPeriod
+	if wait {
+		return reconcile.Result{RequeueAfter: r.cfg.WaitSyncPeriod.Duration}, nil
 	}
-	message := fmt.Sprintf("Shoot %s is reconciled", kutil.ObjectName(shoot))
-	updateCondition(&conditionShootReconciled, gardencorev1beta1.ConditionTrue, "ShootReconciled", message)
-	r.recordAndLog(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, logger, logrus.InfoLevel, message)
-
-	// Reconcile creation or update and update the SeedRegistered condition
-	if err := r.actuator.Reconcile(ctx, managedSeed, shoot); err != nil {
-		message := fmt.Sprintf("Could not register shoot %s as seed: %+v", kutil.ObjectName(shoot), err)
-		updateCondition(&conditionSeedRegistered, gardencorev1beta1.ConditionFalse, "SeedRegistrationFailed", message)
-		r.recordAndLog(managedSeed, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, logger, logrus.ErrorLevel, message)
-		return reconcile.Result{}, fmt.Errorf("could not register shoot %s as seed: %w", kutil.ObjectName(shoot), err)
-	}
-	message = fmt.Sprintf("Shoot %s registered as seed", kutil.ObjectName(shoot))
-	updateCondition(&conditionSeedRegistered, gardencorev1beta1.ConditionTrue, "SeedRegistered", message)
-	r.recordAndLog(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciled, logger, logrus.InfoLevel, message)
 
 	// Return success result
-	return reconcile.Result{}, nil
+	return reconcile.Result{RequeueAfter: r.cfg.SyncPeriod.Duration}, nil
 }
 
-func (r *reconciler) delete(ctx context.Context, managedSeed *seedmanagementv1alpha1.ManagedSeed, logger *logrus.Entry) (result reconcile.Result, err error) {
+func (r *reconciler) delete(ctx context.Context, ms *seedmanagementv1alpha1.ManagedSeed) (result reconcile.Result, err error) {
 	// Check gardener finalizer
-	if !controllerutil.ContainsFinalizer(managedSeed, gardencorev1beta1.GardenerName) {
-		logger.Debug("Skipping ManagedSeed as it does not have a finalizer")
+	if !controllerutil.ContainsFinalizer(ms, gardencorev1beta1.GardenerName) {
+		r.getLogger(ms).Debug("Skipping as it does not have a finalizer")
 		return reconcile.Result{}, nil
 	}
 
-	conditionShootExists := gardencorev1beta1helper.GetOrInitCondition(managedSeed.Status.Conditions, seedmanagementv1alpha1.ManagedSeedShootExists)
-	conditionSeedRegistered := gardencorev1beta1helper.GetOrInitCondition(managedSeed.Status.Conditions, seedmanagementv1alpha1.ManagedSeedSeedRegistered)
-
+	var status *seedmanagementv1alpha1.ManagedSeedStatus
 	defer func() {
 		// Update status, on failure return the update error unless there is another error
-		if updateErr := updateStatus(ctx, r.gardenClient.Client(), managedSeed, conditionShootExists, conditionSeedRegistered); updateErr != nil && err == nil {
+		if updateErr := r.updateStatus(ctx, ms, status); updateErr != nil && err == nil {
 			err = fmt.Errorf("could not update status: %w", updateErr)
 		}
 	}()
 
-	// Ensure the shoot exists and update the ShootExists condition
-	shoot, err := r.ensureShootExists(ctx, managedSeed, &conditionShootExists, logger)
-	if err != nil {
-		return reconcile.Result{}, err
+	// Reconcile deletion
+	r.getLogger(ms).Debug("Reconciling deletion")
+	var wait, removeFinalizer bool
+	if status, wait, removeFinalizer, err = r.actuator.Delete(ctx, ms); err != nil {
+		return reconcile.Result{}, fmt.Errorf("could not reconcile ManagedSeed %s deletion: %w", kutil.ObjectName(ms), err)
+	}
+	r.getLogger(ms).Debug("Deletion reconciled")
+
+	// If waiting, requeue after WaitSyncPeriod
+	if wait {
+		return reconcile.Result{RequeueAfter: r.cfg.WaitSyncPeriod.Duration}, nil
 	}
 
-	// Reconcile deletion and update the SeedRegistered condition
-	if err := r.actuator.Delete(ctx, managedSeed, shoot); err != nil {
-		message := fmt.Sprintf("Could not unregister shoot %s seed: %+v", kutil.ObjectName(shoot), err)
-		updateCondition(&conditionSeedRegistered, gardencorev1beta1.ConditionUnknown, "SeedUnregistrationFailed", message)
-		r.recordAndLog(managedSeed, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, logger, logrus.ErrorLevel, message)
-		return reconcile.Result{}, fmt.Errorf("could not unregister shoot %s as seed: %w", kutil.ObjectName(shoot), err)
-	}
-	message := fmt.Sprintf("Shoot %s unregistered as seed", kutil.ObjectName(shoot))
-	updateCondition(&conditionSeedRegistered, gardencorev1beta1.ConditionFalse, "SeedUnregistered", message)
-	r.recordAndLog(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciled, logger, logrus.InfoLevel, message)
-
-	// Remove gardener finalizer
-	if err := controllerutils.PatchRemoveFinalizers(ctx, r.gardenClient.Client(), managedSeed, gardencorev1beta1.GardenerName); err != nil {
-		return reconcile.Result{}, fmt.Errorf("could not remove gardener finalizer: %w", err)
+	// Remove gardener finalizer if requested by the actuator
+	if removeFinalizer {
+		if err := controllerutils.PatchRemoveFinalizers(ctx, r.gardenClient.Client(), ms, gardencorev1beta1.GardenerName); err != nil {
+			return reconcile.Result{}, fmt.Errorf("could not remove gardener finalizer: %w", err)
+		}
+		return reconcile.Result{}, nil
 	}
 
 	// Return success result
-	return reconcile.Result{}, nil
+	return reconcile.Result{RequeueAfter: r.cfg.SyncPeriod.Duration}, nil
 }
 
-func (r *reconciler) ensureShootExists(ctx context.Context, managedSeed *seedmanagementv1alpha1.ManagedSeed, condition *gardencorev1beta1.Condition, logger *logrus.Entry) (*gardencorev1beta1.Shoot, error) {
-	shoot := &gardencorev1beta1.Shoot{}
-	if err := r.gardenClient.APIReader().Get(ctx, kutil.Key(managedSeed.Namespace, managedSeed.Spec.Shoot.Name), shoot); err != nil {
-		if apierrors.IsNotFound(err) {
-			message := fmt.Sprintf("Shoot %s/%s not found", managedSeed.Namespace, managedSeed.Spec.Shoot.Name)
-			updateCondition(condition, gardencorev1beta1.ConditionFalse, "ShootNotFound", message)
-			r.recordAndLog(managedSeed, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, logger, logrus.ErrorLevel, message)
-			return nil, fmt.Errorf("shoot %s/%s not found", managedSeed.Namespace, managedSeed.Spec.Shoot.Name)
-		}
-		message := fmt.Sprintf("Could not get shoot %s/%s: %+v", managedSeed.Namespace, managedSeed.Spec.Shoot.Name, err)
-		updateCondition(condition, gardencorev1beta1.ConditionUnknown, "CouldNotGetShoot", message)
-		r.recordAndLog(managedSeed, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, logger, logrus.ErrorLevel, message)
-		return nil, fmt.Errorf("could not get shoot %s/%s: %w", managedSeed.Namespace, managedSeed.Spec.Shoot.Name, err)
-	}
-	message := fmt.Sprintf("Shoot %s found", kutil.ObjectName(shoot))
-	updateCondition(condition, gardencorev1beta1.ConditionTrue, "ShootFound", message)
-
-	return shoot, nil
+func (r *reconciler) getLogger(ms *seedmanagementv1alpha1.ManagedSeed) *logrus.Entry {
+	return logger.NewFieldLogger(r.logger, "managedSeed", kutil.ObjectName(ms))
 }
 
-func (r *reconciler) recordAndLog(managedSeed *seedmanagementv1alpha1.ManagedSeed, eventType, eventReason string, logger *logrus.Entry, logLevel logrus.Level, message string) {
-	r.recorder.Eventf(managedSeed, eventType, eventReason, "%s", message)
-	logger.Log(logLevel, message)
-}
-
-func updateCondition(condition *gardencorev1beta1.Condition, status gardencorev1beta1.ConditionStatus, reason, message string) {
-	*condition = gardencorev1beta1helper.UpdatedCondition(*condition, status, reason, message)
-}
-
-func updateStatus(ctx context.Context, c client.Client, managedSeed *seedmanagementv1alpha1.ManagedSeed, conditions ...gardencorev1beta1.Condition) error {
-	return kutil.TryPatchStatus(ctx, retry.DefaultBackoff, c, managedSeed, func() error {
-		managedSeed.Status.Conditions = gardencorev1beta1helper.MergeConditions(managedSeed.Status.Conditions, getUpdatedConditions(conditions)...)
-		managedSeed.Status.ObservedGeneration = managedSeed.Generation
+func (r *reconciler) updateStatus(ctx context.Context, ms *seedmanagementv1alpha1.ManagedSeed, status *seedmanagementv1alpha1.ManagedSeedStatus) error {
+	if status == nil {
 		return nil
-	})
-}
-
-func getUpdatedConditions(conditions []gardencorev1beta1.Condition) []gardencorev1beta1.Condition {
-	var updatedConditions []gardencorev1beta1.Condition
-	for _, condition := range conditions {
-		if condition.Reason != "ConditionInitialized" {
-			updatedConditions = append(updatedConditions, condition)
-		}
 	}
-	return updatedConditions
+	patch := client.StrategicMergeFrom(ms.DeepCopy())
+	ms.Status = *status
+	return r.gardenClient.Client().Status().Patch(ctx, ms, patch)
 }

--- a/pkg/gardenlet/controller/managedseed/mock/mocks.go
+++ b/pkg/gardenlet/controller/managedseed/mock/mocks.go
@@ -38,31 +38,36 @@ func (m *MockActuator) EXPECT() *MockActuatorMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockActuator) Delete(arg0 context.Context, arg1 *v1alpha1.ManagedSeed, arg2 *v1beta1.Shoot) error {
+func (m *MockActuator) Delete(arg0 context.Context, arg1 *v1alpha1.ManagedSeed) (*v1alpha1.ManagedSeedStatus, bool, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
+	ret0, _ := ret[0].(*v1alpha1.ManagedSeedStatus)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(bool)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockActuatorMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockActuatorMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockActuator)(nil).Delete), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockActuator)(nil).Delete), arg0, arg1)
 }
 
 // Reconcile mocks base method.
-func (m *MockActuator) Reconcile(arg0 context.Context, arg1 *v1alpha1.ManagedSeed, arg2 *v1beta1.Shoot) error {
+func (m *MockActuator) Reconcile(arg0 context.Context, arg1 *v1alpha1.ManagedSeed) (*v1alpha1.ManagedSeedStatus, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Reconcile", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "Reconcile", arg0, arg1)
+	ret0, _ := ret[0].(*v1alpha1.ManagedSeedStatus)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Reconcile indicates an expected call of Reconcile.
-func (mr *MockActuatorMockRecorder) Reconcile(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockActuatorMockRecorder) Reconcile(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockActuator)(nil).Reconcile), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockActuator)(nil).Reconcile), arg0, arg1)
 }
 
 // MockValuesHelper is a mock of ValuesHelper interface.

--- a/pkg/utils/kubernetes/eventhandler.go
+++ b/pkg/utils/kubernetes/eventhandler.go
@@ -224,7 +224,9 @@ func (h *ControlledResourceEventHandler) getControllerOf(obj client.Object, inde
 	if controllerRef != nil {
 		return h.getControllerByRef(obj.GetNamespace(), controllerRef, index)
 	} else if ct.NameFunc != nil {
-		return h.getControllerByName(obj.GetNamespace(), ct.NameFunc(obj), index)
+		if name := ct.NameFunc(obj); name != "" {
+			return h.getControllerByName(obj.GetNamespace(), name, index)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
* Enhances the `ManagedSeed` controller to take advantage of events on controlled objects (seeds, seed secrets).
* Improves the deletion of `ManagedSeed` objects to avoid relying on requeue-on-error for situations that are not really errors.
* Introduces `SyncPeriod` (defaults to 1 hour) and `WaitSyncPeriod` (defaults to 15 sec) configuration options for the `ManagedSeed` controller.
* Refactors the `ManagedSeed` controller, reconciler, and actuator types to make them more similar to the corresponding `ManagedSeedSet` types.
* Refactors also the `ManagedSeedSet` reconciler and actuator type to achieve better distribution of responsibilities between the two.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
There are two TODOs for events caused by external changes to seeds and seed secrets. Such events are not properly handled right now. I intend to add this handling in a separate PR.

**Release note**:

```other operator
NONE
```
