### PR TITLE
Disable etcd scale down.

### DIFF
--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -352,11 +352,11 @@ func (e *etcd) Deploy(ctx context.Context) error {
 
 	if e.hvpaConfig != nil && e.hvpaConfig.Enabled {
 		var (
-			hpaLabels                   = map[string]string{v1beta1constants.LabelRole: "etcd-hpa-" + e.role}
-			vpaLabels                   = map[string]string{v1beta1constants.LabelRole: "etcd-vpa-" + e.role}
-			updateModeAuto              = hvpav1alpha1.UpdateModeAuto
-			updateModeMaintenanceWindow = hvpav1alpha1.UpdateModeMaintenanceWindow
-			containerPolicyOff          = autoscalingv1beta2.ContainerScalingModeOff
+			hpaLabels          = map[string]string{v1beta1constants.LabelRole: "etcd-hpa-" + e.role}
+			vpaLabels          = map[string]string{v1beta1constants.LabelRole: "etcd-vpa-" + e.role}
+			updateModeAuto     = hvpav1alpha1.UpdateModeAuto
+			updateModeOff      = hvpav1alpha1.UpdateModeOff
+			containerPolicyOff = autoscalingv1beta2.ContainerScalingModeOff
 		)
 
 		if _, err := controllerutil.CreateOrUpdate(ctx, e.client, hvpa, func() error {
@@ -418,7 +418,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 				},
 				ScaleDown: hvpav1alpha1.ScaleType{
 					UpdatePolicy: hvpav1alpha1.UpdatePolicy{
-						UpdateMode: &updateModeMaintenanceWindow,
+						UpdateMode: &updateModeOff,
 					},
 					StabilizationDuration: pointer.StringPtr("15m"),
 					MinChange: hvpav1alpha1.ScaleParams{

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -89,13 +89,13 @@ var _ = Describe("Etcd", func() {
 			Begin: "1234",
 			End:   "5678",
 		}
-		now                         = time.Time{}
-		quota                       = resource.MustParse("8Gi")
-		garbageCollectionPolicy     = druidv1alpha1.GarbageCollectionPolicy(druidv1alpha1.GarbageCollectionPolicyExponential)
-		garbageCollectionPeriod     = metav1.Duration{Duration: 12 * time.Hour}
-		updateModeAuto              = hvpav1alpha1.UpdateModeAuto
-		updateModeMaintenanceWindow = hvpav1alpha1.UpdateModeMaintenanceWindow
-		containerPolicyOff          = autoscalingv1beta2.ContainerScalingModeOff
+		now                     = time.Time{}
+		quota                   = resource.MustParse("8Gi")
+		garbageCollectionPolicy = druidv1alpha1.GarbageCollectionPolicy(druidv1alpha1.GarbageCollectionPolicyExponential)
+		garbageCollectionPeriod = metav1.Duration{Duration: 12 * time.Hour}
+		updateModeAuto          = hvpav1alpha1.UpdateModeAuto
+		updateModeOff           = hvpav1alpha1.UpdateModeOff
+		containerPolicyOff      = autoscalingv1beta2.ContainerScalingModeOff
 
 		networkPolicyName = "allow-etcd"
 		etcdName          = "etcd-" + testRole
@@ -380,7 +380,7 @@ var _ = Describe("Etcd", func() {
 						},
 						ScaleDown: hvpav1alpha1.ScaleType{
 							UpdatePolicy: hvpav1alpha1.UpdatePolicy{
-								UpdateMode: &updateModeMaintenanceWindow,
+								UpdateMode: &updateModeOff,
 							},
 							StabilizationDuration: pointer.StringPtr("15m"),
 							MinChange: hvpav1alpha1.ScaleParams{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane auto-scaling high-availability cost
/kind post-mortem

**What this PR does / why we need it**:
Disable etcd scale down.

**Which issue(s) this PR fixes**:
Fixes https://github.tools.sap/kubernetes-live/issues-live/issues/250

**Special notes for your reviewer**:
There is a risk of longer downtime (also, possibly corrupted WAL files) during maintenance window in bigger clusters (if they have large fluctuations in usage pattern during `24h` period) which is triggered by too drastic a scale down during maintenance window followed by sub-optimal subsequent scale ups.

Please see here for more details -> https://github.tools.sap/kubernetes-live/issues-live/issues/250#issuecomment-202646

cc @vlerenc @istvanballok @mliepold @ialidzhikov @rfranzke @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Disable etcd scale down to avoid potential long down time during maintenance window.
```
