### PR TITLE
[GEP-13] Reconcile managed seeds on external changes to seeds and seed secrets

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -338,6 +338,12 @@ const (
 	// `alpha.featuregates.shoot.gardener.cloud/apiserver-sni-pod-injector` annotation that disables the pod injection.
 	AnnotationShootAPIServerSNIPodInjectorDisableValue = "disable"
 
+	// AnnotationSeedIngressClass is a constant for an annotation on a Seed to specify the ingress class.
+	AnnotationSeedIngressClass = "seed.gardener.cloud/ingress-class"
+
+	// AnnotationModelChecksum is a constant for an annotation on controlled objects to detect changes by external agents.
+	AnnotationModelChecksum = "gardener.cloud/model-checksum"
+
 	// OperatingSystemConfigUnitNameKubeletService is a constant for a unit in the operating system config that contains the kubelet service.
 	OperatingSystemConfigUnitNameKubeletService = "kubelet.service"
 	// OperatingSystemConfigUnitNameDockerService is a constant for a unit in the operating system config that contains the docker service.

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -22,6 +22,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
 	"github.com/Masterminds/semver"
@@ -1340,4 +1341,14 @@ func ShootSecretResourceReferencesEqual(oldResources, newResources []gardencorev
 	}
 
 	return oldNames.Equal(newNames)
+}
+
+// GetSeedModel returns the model of the given Seed.
+func GetSeedModel(seed *gardencorev1beta1.Seed) *gardencorev1beta1.Seed {
+	model := &gardencorev1beta1.Seed{
+		ObjectMeta: *kutil.GetObjectMetaModel(&seed.ObjectMeta),
+		Spec:       seed.Spec,
+	}
+	delete(model.Annotations, v1beta1constants.AnnotationSeedIngressClass)
+	return model
 }

--- a/pkg/gardenlet/controller/managedseed/managedseed.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed.go
@@ -120,7 +120,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	c.managedSeedInformer.AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controllerutils.ManagedSeedFilterFunc(ctx, c.gardenClient.Client(), confighelper.SeedNameFromSeedConfig(c.config.SeedConfig), c.config.SeedSelector),
 		Handler: cache.ResourceEventHandlerFuncs{
-			AddFunc:    c.managedSeedAdd,
+			AddFunc:    c.managedSeedAddWithJitter,
 			UpdateFunc: c.managedSeedUpdate,
 			DeleteFunc: c.managedSeedDelete,
 		},

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
@@ -246,6 +246,9 @@ var _ = Describe("Actuator", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      backupSecretName,
 				Namespace: namespace,
+				Annotations: map[string]string{
+					v1beta1constants.AnnotationModelChecksum: "7c3c1bccfb922cfb41e1090817d10a333c40df24955da73d93313f32152b6530",
+				},
 				OwnerReferences: []metav1.OwnerReference{
 					*metav1.NewControllerRef(managedSeed, seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeed")),
 				},
@@ -257,6 +260,9 @@ var _ = Describe("Actuator", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      seedSecretName,
 				Namespace: namespace,
+				Annotations: map[string]string{
+					v1beta1constants.AnnotationModelChecksum: "e2f703ce5a4548ea38b9b75deb48ead7fd856bfa581b55837c516c4855f768ac",
+				},
 				OwnerReferences: []metav1.OwnerReference{
 					*metav1.NewControllerRef(managedSeed, seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeed")),
 				},
@@ -273,7 +279,9 @@ var _ = Describe("Actuator", func() {
 				Labels: utils.MergeStringMaps(seedTemplate.Labels, map[string]string{
 					v1beta1constants.GardenRole: v1beta1constants.GardenRoleSeed,
 				}),
-				Annotations: seedTemplate.Annotations,
+				Annotations: utils.MergeStringMaps(seedTemplate.Annotations, map[string]string{
+					v1beta1constants.AnnotationModelChecksum: "9ecec50843ed1cd9bc6108308cba18567ca8465dd08137e0437ceedd47d9ffdc",
+				}),
 				OwnerReferences: []metav1.OwnerReference{
 					*metav1.NewControllerRef(managedSeed, seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeed")),
 				},

--- a/pkg/gardenlet/controller/managedseed/managedseed_controller.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_controller.go
@@ -22,6 +22,19 @@ import (
 )
 
 func (c *Controller) managedSeedAdd(obj interface{}) {
+	_, ok := obj.(*seedmanagementv1alpha1.ManagedSeed)
+	if !ok {
+		return
+	}
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+
+	c.managedSeedQueue.Add(key)
+}
+
+func (c *Controller) managedSeedAddWithJitter(obj interface{}) {
 	managedSeed, ok := obj.(*seedmanagementv1alpha1.ManagedSeed)
 	if !ok {
 		return

--- a/pkg/gardenlet/controller/managedseed/managedseed_controller_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_controller_test.go
@@ -86,6 +86,18 @@ var _ = Describe("Controller", func() {
 
 			c.managedSeedAdd(managedSeed)
 		})
+	})
+
+	Describe("#managedSeedAddWithJitter", func() {
+		It("should do nothing because the object is not a ManagedSeed", func() {
+			c.managedSeedAddWithJitter(&gardencorev1beta1.Seed{})
+		})
+
+		It("should add the object to the queue", func() {
+			queue.EXPECT().Add(key)
+
+			c.managedSeedAddWithJitter(managedSeed)
+		})
 
 		It("should add the object to the queue (deletion)", func() {
 			now := metav1.Now()
@@ -93,7 +105,7 @@ var _ = Describe("Controller", func() {
 			managedSeed.Status.ObservedGeneration = 1
 			queue.EXPECT().Add(key)
 
-			c.managedSeedAdd(managedSeed)
+			c.managedSeedAddWithJitter(managedSeed)
 		})
 
 		It("should add the object to the queue with a jittered delay", func() {
@@ -104,7 +116,7 @@ var _ = Describe("Controller", func() {
 				},
 			)
 
-			c.managedSeedAdd(managedSeed)
+			c.managedSeedAddWithJitter(managedSeed)
 		})
 	})
 

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1269,10 +1269,8 @@ func getIngressClass(seedIngressEnabled bool) string {
 	return v1beta1constants.ShootNginxIngressClass
 }
 
-const annotationSeedIngressClass = "seed.gardener.cloud/ingress-class"
-
 func migrateIngressClassForShootIngresses(ctx context.Context, gardenClient, seedClient client.Client, seed *Seed, newClass string) error {
-	if oldClass, ok := seed.Info.Annotations[annotationSeedIngressClass]; ok && oldClass == newClass {
+	if oldClass, ok := seed.Info.Annotations[v1beta1constants.AnnotationSeedIngressClass]; ok && oldClass == newClass {
 		return nil
 	}
 
@@ -1297,7 +1295,7 @@ func migrateIngressClassForShootIngresses(ctx context.Context, gardenClient, see
 	}
 
 	seedCopy := seed.Info.DeepCopy()
-	metav1.SetMetaDataAnnotation(&seed.Info.ObjectMeta, annotationSeedIngressClass, newClass)
+	metav1.SetMetaDataAnnotation(&seed.Info.ObjectMeta, v1beta1constants.AnnotationSeedIngressClass, newClass)
 
 	return gardenClient.Patch(ctx, seed.Info, client.MergeFrom(seedCopy))
 }

--- a/pkg/utils/kubernetes/model.go
+++ b/pkg/utils/kubernetes/model.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+)
+
+// GetObjectMetaModel returns the model of the given metav1.ObjectMeta.
+func GetObjectMetaModel(meta *metav1.ObjectMeta) *metav1.ObjectMeta {
+	model := &metav1.ObjectMeta{
+		Name:            meta.Name,
+		Namespace:       meta.Namespace,
+		Labels:          meta.Labels,
+		Annotations:     meta.Annotations,
+		OwnerReferences: meta.OwnerReferences,
+	}
+	delete(model.Annotations, v1beta1constants.AnnotationModelChecksum)
+	return model
+}
+
+// GetSecretModel returns the model of the given corev1.Secret.
+func GetSecretModel(secret *corev1.Secret) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: *GetObjectMetaModel(&secret.ObjectMeta),
+		Data:       secret.Data,
+		StringData: secret.StringData,
+		Type:       secret.Type,
+	}
+}

--- a/pkg/utils/kubernetes/secretref.go
+++ b/pkg/utils/kubernetes/secretref.go
@@ -33,8 +33,8 @@ func GetSecretByReference(ctx context.Context, c client.Client, ref *corev1.Secr
 }
 
 // CreateOrUpdateSecretByReference creates or updates the secret referenced by the given secret reference
-// with the given type, data, and owner references.
-func CreateOrUpdateSecretByReference(ctx context.Context, c client.Client, ref *corev1.SecretReference, secretType corev1.SecretType, data map[string][]byte, ownerRefs []metav1.OwnerReference) error {
+// with the given mutate function.
+func CreateOrUpdateSecretByReference(ctx context.Context, c client.Client, ref *corev1.SecretReference, f func(*corev1.Secret) error) error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ref.Name,
@@ -42,10 +42,7 @@ func CreateOrUpdateSecretByReference(ctx context.Context, c client.Client, ref *
 		},
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, c, secret, func() error {
-		secret.ObjectMeta.OwnerReferences = ownerRefs
-		secret.Type = secretType
-		secret.Data = data
-		return nil
+		return f(secret)
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Introduces a mechanism for enqueueing managed seeds for reconciliation whenever external changes to controlled seeds and seed secrets are detected.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
* A checksum on the so called "model" (includes only the parts of the resource that might be changed externally) is calculated and added it as an annotation when creating / updating that resource. Upon an event, the model is checked against the checksum and if there is a difference, the MS is enqueued for reconciliation.
* At the moment this has no effect on seeds created by the `gardenlet`. The `gardenlet` code adds the checksum and the MS is enqueued correctly, the MS controller redeploys `gardenlet` but the seed is not updated since `gardenlet` is not restarted, because the deployment generated by the chart is exactly the same as before. I have some ideas how I could deal with that but I would like to discuss them first.

**Release note**:

```other operator
NONE
```
