### PR TITLE
Let gardenlet run even without any seed resource to exist

### DIFF
--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -135,9 +135,9 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("timed out waiting for Kube caches to sync")
 	}
 
-	seeds := seedNames(f.cfg.SeedConfig, f.k8sGardenCoreInformers.Core().V1beta1().Seeds().Lister(), f.cfg.SeedSelector)
-	if len(seeds) < 1 {
-		return fmt.Errorf("no seed selected by Gardenlet")
+	gardenSecretsNamespace := v1beta1constants.GardenNamespace
+	if seeds := seedNames(f.cfg.SeedConfig, f.k8sGardenCoreInformers.Core().V1beta1().Seeds().Lister(), f.cfg.SeedSelector); len(seeds) > 0 {
+		gardenSecretsNamespace = gardenerutils.ComputeGardenNamespace(seeds[0])
 	}
 
 	// Register Seed object if desired
@@ -154,7 +154,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		ctx,
 		k8sGardenClient.Cache(),
 		f.k8sGardenCoreInformers.Core().V1beta1().Seeds().Lister(),
-		gardenerutils.ComputeGardenNamespace(seeds[0]),
+		gardenSecretsNamespace,
 	)
 	runtime.Must(err)
 

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -25,7 +25,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
-	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	gardenmetrics "github.com/gardener/gardener/pkg/controllerutils/metrics"
@@ -41,7 +40,6 @@ import (
 	shootcontroller "github.com/gardener/gardener/pkg/gardenlet/controller/shoot"
 	"github.com/gardener/gardener/pkg/healthz"
 	"github.com/gardener/gardener/pkg/logger"
-	"github.com/gardener/gardener/pkg/operation/garden"
 	"github.com/gardener/gardener/pkg/utils"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
@@ -51,7 +49,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
@@ -135,28 +132,12 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("timed out waiting for Kube caches to sync")
 	}
 
-	gardenSecretsNamespace := v1beta1constants.GardenNamespace
-	if seeds := seedNames(f.cfg.SeedConfig, f.k8sGardenCoreInformers.Core().V1beta1().Seeds().Lister(), f.cfg.SeedSelector); len(seeds) > 0 {
-		gardenSecretsNamespace = gardenerutils.ComputeGardenNamespace(seeds[0])
-	}
-
 	// Register Seed object if desired
 	if f.cfg.SeedConfig != nil {
 		if err := f.registerSeed(ctx, k8sGardenClient.Client()); err != nil {
 			return fmt.Errorf("failed to register the seed: %+v", err)
 		}
 	}
-
-	// Read Garden secrets from any seed namespace as we assume they are synced accordingly by the Gardener Controller Manager.
-	// This requires adaption if we'll decide not to sync all Secrets for all Seeds in the future.
-	// For newly created seed, this seed namespace is about to be created by the GCM.
-	_, err = garden.ReadGardenSecrets(
-		ctx,
-		k8sGardenClient.Cache(),
-		f.k8sGardenCoreInformers.Core().V1beta1().Seeds().Lister(),
-		gardenSecretsNamespace,
-	)
-	runtime.Must(err)
 
 	imageVector, err := imagevector.ReadGlobalImageVectorWithEnvOverride(filepath.Join(charts.Path, DefaultImageVector))
 	runtime.Must(err)
@@ -229,30 +210,6 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	logger.Logger.Infof("Bye Bye!")
 
 	return nil
-}
-
-// seedNames returns all seed names matching the given config or LabelSelector if no config is given.
-func seedNames(seedConfig *config.SeedConfig, seedLister gardencorelisters.SeedLister, labelSelector *metav1.LabelSelector) []string {
-	if name := confighelper.SeedNameFromSeedConfig(seedConfig); name != "" {
-		return []string{name}
-	}
-
-	var names []string
-	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
-	if err != nil || selector == labels.Nothing() {
-		return names
-	}
-
-	seeds, err := seedLister.List(selector)
-	if err != nil {
-		return names
-	}
-
-	for _, seed := range seeds {
-		names = append(names, seed.Name)
-	}
-
-	return names
 }
 
 // registerSeed create or update the seed resource if gardenlet is configured to takes care about it.

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -321,7 +321,7 @@ func readGardenSecretsFromCache(ctx context.Context, secretLister listSecretsFun
 		return nil, fmt.Errorf("can only accept at most one alerting secret, but found %d", numberOfAlertingSecrets)
 	}
 
-	logger.Logger.Infof("Found secrets: %s", strings.Join(logInfo, ", "))
+	logger.Logger.Infof("Found secrets in namespace %q: %s", namespace, strings.Join(logInfo, ", "))
 
 	return secretsMap, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Let gardenlet run even without any seed resource to exist

**Which issue(s) this PR fixes**:
Fixes #3814

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
A bug that prevented gardenlet to start-up when there is no seed in the garden cluster is now fixed.
```
