### PR TITLE
Prevent overlaps in seed/shoot networks with vpn default network range.

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -375,6 +375,9 @@ const (
 	// should not be deleted if the corresponding `Project` gets deleted. Please note that all project related labels
 	// from the namespace will be removed when the project is being deleted.
 	NamespaceKeepAfterProjectDeletion = "namespace.gardener.cloud/keep-after-project-deletion"
+
+	// DefaultVpnRange is the default network range for the vpn between seed and shoot cluster.
+	DefaultVpnRange = "192.168.123.0/24"
 )
 
 // ControlPlaneSecretRoles contains all role values used for control plane secrets synced to the Garden cluster.

--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -114,6 +114,10 @@ func ValidateSeedSpec(seedSpec *core.SeedSpec, fldPath *field.Path, inTemplate b
 	allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(networks...)...)
 	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(networks, networks, false)...)
 
+	vpnDefaultRanges := []cidrvalidation.CIDR{cidrvalidation.NewCIDR(v1beta1constants.DefaultVpnRange, field.NewPath(""))}
+	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(vpnDefaultRanges, networks, false)...)
+	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(networks, vpnDefaultRanges, false)...)
+
 	if seedSpec.Backup != nil {
 		if len(seedSpec.Backup.Provider) == 0 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("backup", "provider"), "must provide a backup cloud provider name"))

--- a/pkg/utils/validation/cidr/disjoint.go
+++ b/pkg/utils/validation/cidr/disjoint.go
@@ -15,8 +15,10 @@
 package cidr
 
 import (
+	"fmt"
 	"net"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -33,6 +35,9 @@ func ValidateNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPods, s
 	if shootNodes != nil && seedNodes != nil && NetworksIntersect(*shootNodes, *seedNodes) {
 		allErrs = append(allErrs, field.Invalid(pathNodes, *shootNodes, "shoot node network intersects with seed node network"))
 	}
+	if shootNodes != nil && NetworksIntersect(*shootNodes, v1beta1constants.DefaultVpnRange) {
+		allErrs = append(allErrs, field.Invalid(pathNodes, *shootNodes, fmt.Sprintf("shoot node network intersects with default vpn network (%s)", v1beta1constants.DefaultVpnRange)))
+	}
 
 	if shootServices != nil {
 		if NetworksIntersect(seedServices, *shootServices) {
@@ -40,6 +45,9 @@ func ValidateNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPods, s
 		}
 		if NetworksIntersect(seedPods, *shootServices) {
 			allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, "shoot service network intersects with seed pod network"))
+		}
+		if NetworksIntersect(v1beta1constants.DefaultVpnRange, *shootServices) {
+			allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, fmt.Sprintf("shoot service network intersects with default vpn network (%s)", v1beta1constants.DefaultVpnRange)))
 		}
 	} else {
 		allErrs = append(allErrs, field.Required(pathServices, "services is required"))
@@ -51,6 +59,9 @@ func ValidateNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPods, s
 		}
 		if NetworksIntersect(seedServices, *shootPods) {
 			allErrs = append(allErrs, field.Invalid(pathPods, *shootPods, "shoot pod network intersects with seed service network"))
+		}
+		if NetworksIntersect(v1beta1constants.DefaultVpnRange, *shootPods) {
+			allErrs = append(allErrs, field.Invalid(pathPods, *shootPods, fmt.Sprintf("shoot pod network intersects with default vpn network (%s)", v1beta1constants.DefaultVpnRange)))
 		}
 	} else {
 		allErrs = append(allErrs, field.Required(pathPods, "pods is required"))

--- a/pkg/utils/validation/cidr/disjoint_test.go
+++ b/pkg/utils/validation/cidr/disjoint_test.go
@@ -130,6 +130,75 @@ var _ = Describe("utils", func() {
 				})),
 			))
 		})
+
+		It("should fail due to default vpn range overlap in pod cidr", func() {
+			var (
+				podsCIDR     = "192.168.123.0/24"
+				servicesCIDR = "10.242.0.0/17"
+				nodesCIDR    = "10.241.0.0/16"
+			)
+
+			errorList := ValidateNetworkDisjointedness(
+				field.NewPath(""),
+				&nodesCIDR,
+				&podsCIDR,
+				&servicesCIDR,
+				&seedNodesCIDR,
+				seedPodsCIDR,
+				seedServicesCIDR,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].pods"),
+			}))))
+		})
+
+		It("should fail due to default vpn range overlap in services cidr", func() {
+			var (
+				podsCIDR     = "10.242.128.0/17"
+				servicesCIDR = "192.168.123.64/26"
+				nodesCIDR    = "10.241.0.0/16"
+			)
+
+			errorList := ValidateNetworkDisjointedness(
+				field.NewPath(""),
+				&nodesCIDR,
+				&podsCIDR,
+				&servicesCIDR,
+				&seedNodesCIDR,
+				seedPodsCIDR,
+				seedServicesCIDR,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].services"),
+			}))))
+		})
+
+		It("should fail due to default vpn range overlap in nodes cidr", func() {
+			var (
+				podsCIDR     = "10.242.128.0/17"
+				servicesCIDR = "10.242.0.0/17"
+				nodesCIDR    = "192.168.0.0/16"
+			)
+
+			errorList := ValidateNetworkDisjointedness(
+				field.NewPath(""),
+				&nodesCIDR,
+				&podsCIDR,
+				&servicesCIDR,
+				&seedNodesCIDR,
+				seedPodsCIDR,
+				seedServicesCIDR,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].nodes"),
+			}))))
+		})
 	})
 
 	Describe("#ValidateNetworkDisjointedness IPv6", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area usability
/kind technical-debt

**What this PR does / why we need it**:
Gardener uses a solution based on openvpn for the communication from the shoot control plane in the seed cluster to the shoot cluster (nodes, pods, services). The openvpn network uses the network range 192.168.123.0/24. To prevent hard to debug situations when either seed or shoot clusters have networks overlapping the vpn range, this pull request prevents any seed/shoot overlap in the relevant network specifications.

**Which issue(s) this PR fixes**:
No bug is fixed, but it addresses a recommendation from the review of #3771 .

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
