### PR TITLE
Do not retry shoot status updates on conflict when starting a reconcile, restore or migrate operation

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -59,8 +59,7 @@ func (c *Controller) prepareShootForMigration(ctx context.Context, logger *logru
 
 	c.recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventPrepareMigration, "Prepare Shoot cluster for migration")
 	shootNamespace := shootpkg.ComputeTechnicalID(project.Name, shoot)
-	shoot, err = c.updateShootStatusOperationStart(ctx, gardenClient.GardenCore(), shoot, shootNamespace, gardencorev1beta1.LastOperationTypeMigrate)
-	if err != nil {
+	if err = c.updateShootStatusOperationStart(ctx, gardenClient.Client(), shoot, shootNamespace, gardencorev1beta1.LastOperationTypeMigrate); err != nil {
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
There is a possibility that the Shoot can be reconciled/restored while it's lastOperation is still `Migrate` which then causes the extension resources to not be annotated with `gardener.cloud/operation=restore` as that actually requires the lastOperation to be `Restore`. Instead they will be annotated with `gardener.cloud/operation=reconcile`. 

**Which issue(s) this PR fixes**:
Part of #1631 

**Special notes for your reviewer**:
Generally this is the expected flow:
1. The migrate flow is started (this removes the control plane of the Shoot in the __Source Seed__)
2. At the end of the migrate flow the Shoot.Status is updated to contain:
```
lastOperation:
  type: Restore
  status: Pending
seedName: nil
```
3. This update causes the generation of the Shoot to increase and it is requeued for reconciliation
4. The shoot controller should then properly read the new status and Restore the Shoot's control plane in the __Destination Seed__

However during the migration flow the Shoot can be added to the reconciliation queue. Once the migration flow finishes and the Shoot is popped from the queue to be reconciled again, outdated data for the Shoot resource can be retrieved (perhaps due to caching) which leads to the following differences between what the client sees and what is actually on the server

1. The shoot controller starts the migration flow and updates the Shoot with
```
lastOperation
  type: Migrate
  status: Processing
seedName: oldSeed
```
2. The shoot controller finishes the migration flow and updates the Shoot with
```
lastOperation
  type: Restore
  status: Pending
seedName: nil
```
3. The shoot is popped for reconciliation but now the controller sees the following old value
```
lastOperation
   type: Migrate
   status: Processing
seedName: oldSeed
```
4. This causes the migration flow to be executed again
During this when the `TryUpdateStatus` at the start of the migration flow tries to update the `Shoot.Status` it first fetches the Shoot and actually gets the most recent one with the `Restore Pending` lastOperation. However, that is overwritten with the following (basically [the code after this line](https://github.com/gardener/gardener/blob/453b70ed9a40c0eb72694452d55d54b9d074ea29/pkg/gardenlet/controller/shoot/shoot_control.go#L587)):
```
lastOperation:
  type: Migrate
  status: Processing
seedName: nil
```
Notice that during this update the seedName is kept to nil as we do not change it when a Migration operation starts.
5. At the end of the migration the Status is again updated with
```
lastOperation:
   type: Restore
   status: Pending
seedName: nil
```
6. During this time, It can happen that the Shoot is again requeued for reconciliation and the controller fetches old information again where the status is:
```
lastOperation:
  type: Migrate
  status: Processing
seedName: nil
```
Due to the `Status.seedName`=nil, [this check](https://github.com/gardener/gardener/blob/453b70ed9a40c0eb72694452d55d54b9d074ea29/pkg/gardenlet/controller/shoot/shoot_control.go#L218) is skipped and the shoot is Reconciled instead of being restored.

By returning an error we force the shoot to be reconciled again until it fetches the correct data from about the Shoot's status.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes a possible caching issue by directly returning an error when updating the `Shoot.Status` to reflect the start of a reconcile, restore or migrate operation, instead of retrying the update on conflict.
```
