### PR TITLE
Reconcile managed seeds via the operation annotation

### DIFF
--- a/pkg/registry/seedmanagement/managedseed/strategy_test.go
+++ b/pkg/registry/seedmanagement/managedseed/strategy_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	. "github.com/gardener/gardener/pkg/registry/seedmanagement/managedseed"
 
@@ -55,6 +56,16 @@ var _ = Describe("Strategy", func() {
 
 			strategy.PrepareForUpdate(ctx, newManagedSeed, oldManagedSeed)
 			Expect(newManagedSeed.Generation).To(Equal(oldManagedSeed.Generation + 1))
+		})
+
+		It("should increase the generation if the operation annotation with value reconcile was added", func() {
+			newManagedSeed.Annotations = map[string]string{
+				v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+			}
+
+			strategy.PrepareForUpdate(ctx, newManagedSeed, oldManagedSeed)
+			Expect(newManagedSeed.Generation).To(Equal(oldManagedSeed.Generation + 1))
+			Expect(newManagedSeed.Annotations).To(BeEmpty())
 		})
 
 		It("should not increase the generation if neither the spec has changed nor the deletion timestamp is set", func() {


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Adds support for reconciling `ManagedSeeds` via the `operation` annotation

**Which issue(s) this PR fixes**:
Fixes #3724

**Special notes for your reviewer**:

**Release note**:

```other operator
It is now possible to trigger an immediate reconciliation of a `ManagedSeed` (and therefore a rollout of its `gardenlet`) by adding the annotation `gardener.cloud/operation=reconcile`.
```
