### PR TITLE
Fix failed to get key errors

### DIFF
--- a/pkg/controllermanager/controller/plant/plant_control.go
+++ b/pkg/controllermanager/controller/plant/plant_control.go
@@ -53,7 +53,7 @@ func (c *Controller) reconcilePlantForMatchingSecret(ctx context.Context, obj in
 
 	for _, plant := range plantList.Items {
 		if isPlantSecret(plant, kutil.Key(secret.Namespace, secret.Name)) {
-			key, err := cache.MetaNamespaceKeyFunc(plant)
+			key, err := cache.MetaNamespaceKeyFunc(&plant)
 			if err != nil {
 				logger.Logger.Errorf("Couldn't get key for plant %+v: %v", plant, err)
 				return

--- a/pkg/controllermanager/controller/shoot/configmap_control.go
+++ b/pkg/controllermanager/controller/shoot/configmap_control.go
@@ -88,14 +88,14 @@ func (r *configMapReconciler) Reconcile(ctx context.Context, request reconcile.R
 			shoot.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef != nil &&
 			shoot.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name == configMap.Name {
 
-			shootKey, err := cache.MetaNamespaceKeyFunc(shoot)
+			shootKey, err := cache.MetaNamespaceKeyFunc(&shoot)
 			if err != nil {
 				logger.Logger.Errorf("[SHOOT CONFIGMAP controller] failed to get key for shoot. err=%+v", err)
 				continue
 			}
 
 			if shoot.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.ResourceVersion != configMap.ResourceVersion {
-				logger.Logger.Infof("[SHOOT CONFIGMAP controller] schedule for reconciliation shoot %v ", shootKey)
+				logger.Logger.Infof("[SHOOT CONFIGMAP controller] schedule for reconciliation shoot %v", shootKey)
 				// send empty patch to let the admission webhook in GAC add or update the config map resource version
 				if err := kubernetes.SubmitEmptyPatch(ctx, r.gardenClient, &shoot); err != nil {
 					return reconcile.Result{}, err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind regression
/priority 1

**What this PR does / why we need it**:

This PR fixes to regressions in `g/g@v1.20.0` introduced by https://github.com/gardener/gardener/pull/3768, that led to the following issues when updating Plant secrets and AuditPolicy ConfigMaps:
```
# logs from gardener-controller-manager
time="2021-04-08T08:41:02Z" level=error msg="Couldn't get key for plant {TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:e2e-tq978 GenerateName:e2e- Namespace:garden-it SelfLink: UID:1178ca35-1b17-4078-9bda-52b34e295252 ResourceVersion:2732784924 Generation:2 CreationTimestamp:2021-04-08 08:40:29 +0000 UTC DeletionTimestamp:2021-04-08 08:41:01 +0000 UTC DeletionGracePeriodSeconds:0xc0047b4400 Labels:map[] Annotations:map[gardener.cloud/created-by:virtual-garden:client:admin] OwnerReferences:[] Finalizers:[core.gardener.cloud/plant] ClusterName: ManagedFields:[{Manager:shoot.test Operation:Update APIVersion:core.gardener.cloud/v1beta1 Time:2021-04-08 08:40:29 +0000 UTC FieldsType:FieldsV1 FieldsV1:{\"f:metadata\":{\"f:generateName\":{}},\"f:spec\":{\"f:secretRef\":{\"f:name\":{}}}}} {Manager:gardener-controller-manager Operation:Update APIVersion:core.gardener.cloud/v1beta1 Time:2021-04-08 08:40:30 +0000 UTC FieldsType:FieldsV1 FieldsV1:{\"f:metadata\":{\"f:finalizers\":{\".\":{},\"v:\\\"core.gardener.cloud/plant\\\"\":{}}},\"f:status\":{\"f:clusterInfo\":{\".\":{},\"f:cloud\":{\".\":{},\"f:region\":{},\"f:type\":{}},\"f:kubernetes\":{\".\":{},\"f:version\":{}}},\"f:conditions\":{\".\":{},\"k:{\\\"type\\\":\\\"APIServerAvailable\\\"}\":{\".\":{},\"f:lastTransitionTime\":{},\"f:lastUpdateTime\":{},\"f:message\":{},\"f:reason\":{},\"f:status\":{},\"f:type\":{}},\"k:{\\\"type\\\":\\\"EveryNodeReady\\\"}\":{\".\":{},\"f:lastTransitionTime\":{},\"f:lastUpdateTime\":{},\"f:message\":{},\"f:reason\":{},\"f:status\":{},\"f:type\":{}}}}}}]} Spec:{SecretRef:{Name:test-secret-plant-xfztv} Endpoints:[]} Status:{Conditions:[{Type:APIServerAvailable Status:True LastTransitionTime:2021-04-08 08:41:00 +0000 UTC LastUpdateTime:2021-04-08 08:41:00 +0000 UTC Reason:HealthzRequestSucceeded Message:API server /healthz endpoint responded with success status code. Codes:[]} {Type:EveryNodeReady Status:True LastTransitionTime:2021-04-08 08:41:00 +0000 UTC LastUpdateTime:2021-04-08 08:41:00 +0000 UTC Reason:EveryNodeReady Message:Every node registered to the cluster is ready. Codes:[]}] ObservedGeneration:<nil> ClusterInfo:&ClusterInfo{Cloud:CloudInfo{Type:aws,Region:eu-central-1,},Kubernetes:KubernetesInfo{Version:v1.20.5,},}}}: object has no meta: object does not implement the Object interfaces"
...
time="2021-04-08T09:12:50Z" level=error msg="[SHOOT CONFIGMAP controller] failed to get key for shoot. err=object has no meta: object does not implement the Object interfaces"
```

Both regressions caused gcm to not be able to enqueue the referencing Shoots/Plants and thus they were not immediately reconciled after updating the referenced Secret/ConfigMap.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fixed which led to Shoots not being reconciled immediately after changing the referenced AuditPolicy ConfigMap.
```
