### PR TITLE
[release-v1.20] Automated cherry pick of #3848: Fix failed to get key errors

### DIFF
--- a/pkg/controllermanager/controller/plant/plant_control.go
+++ b/pkg/controllermanager/controller/plant/plant_control.go
@@ -53,7 +53,7 @@ func (c *Controller) reconcilePlantForMatchingSecret(ctx context.Context, obj in
 
 	for _, plant := range plantList.Items {
 		if isPlantSecret(plant, kutil.Key(secret.Namespace, secret.Name)) {
-			key, err := cache.MetaNamespaceKeyFunc(plant)
+			key, err := cache.MetaNamespaceKeyFunc(&plant)
 			if err != nil {
 				logger.Logger.Errorf("Couldn't get key for plant %+v: %v", plant, err)
 				return

--- a/pkg/controllermanager/controller/shoot/configmap_control.go
+++ b/pkg/controllermanager/controller/shoot/configmap_control.go
@@ -88,14 +88,14 @@ func (r *configMapReconciler) Reconcile(ctx context.Context, request reconcile.R
 			shoot.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef != nil &&
 			shoot.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.Name == configMap.Name {
 
-			shootKey, err := cache.MetaNamespaceKeyFunc(shoot)
+			shootKey, err := cache.MetaNamespaceKeyFunc(&shoot)
 			if err != nil {
 				logger.Logger.Errorf("[SHOOT CONFIGMAP controller] failed to get key for shoot. err=%+v", err)
 				continue
 			}
 
 			if shoot.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.ResourceVersion != configMap.ResourceVersion {
-				logger.Logger.Infof("[SHOOT CONFIGMAP controller] schedule for reconciliation shoot %v ", shootKey)
+				logger.Logger.Infof("[SHOOT CONFIGMAP controller] schedule for reconciliation shoot %v", shootKey)
 				// send empty patch to let the admission webhook in GAC add or update the config map resource version
 				if err := kubernetes.SubmitEmptyPatch(ctx, r.gardenClient, &shoot); err != nil {
 					return reconcile.Result{}, err


### PR DESCRIPTION
/kind regression

Cherry pick of #3848 on release-v1.20.

#3848: Fix failed to get key errors

**Release Notes:**
```bugfix operator
An issue has been fixed which led to Shoots not being reconciled immediately after changing the referenced AuditPolicy ConfigMap.
```