### PR TITLE
Add validation of image vectors

### DIFF
--- a/pkg/utils/imagevector/imagevector.go
+++ b/pkg/utils/imagevector/imagevector.go
@@ -24,6 +24,7 @@ import (
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
 	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 const (
@@ -42,6 +43,11 @@ func Read(r io.Reader) (ImageVector, error) {
 	if err := yaml.NewDecoder(r).Decode(&vector); err != nil {
 		return nil, err
 	}
+
+	if errs := ValidateImageVector(vector.Images, field.NewPath("images")); len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+
 	return vector.Images, nil
 }
 

--- a/pkg/utils/imagevector/imagevector_components.go
+++ b/pkg/utils/imagevector/imagevector_components.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 const (
@@ -37,12 +38,16 @@ func ReadComponentOverwrite(r io.Reader) (ComponentImageVectors, error) {
 		return nil, err
 	}
 
-	out := make(ComponentImageVectors, len(data.Components))
+	componentImageVectors := make(ComponentImageVectors, len(data.Components))
 	for _, component := range data.Components {
-		out[component.Name] = component.ImageVectorOverwrite
+		componentImageVectors[component.Name] = component.ImageVectorOverwrite
 	}
 
-	return out, nil
+	if errs := ValidateComponentImageVectors(componentImageVectors, field.NewPath("components")); len(errs) > 0 {
+		return nil, errs.ToAggregate()
+	}
+
+	return componentImageVectors, nil
 }
 
 // ReadComponentOverwriteFile reads an ComponentImageVector from the file with the given name.

--- a/pkg/utils/imagevector/imagevector_components_test.go
+++ b/pkg/utils/imagevector/imagevector_components_test.go
@@ -28,10 +28,10 @@ var _ = Describe("imagevector", func() {
 	Describe("#ComponentImageVectors", func() {
 		var (
 			component1     = "foo"
-			componentData1 = "some-data"
+			componentData1 = "images: []"
 
 			component2     = "bar"
-			componentData2 = "some-other-data"
+			componentData2 = "images: []"
 
 			componentImageVectors = ComponentImageVectors{
 				component1: componentData1,
@@ -55,13 +55,13 @@ var _ = Describe("imagevector", func() {
 			componentImagesYAML = fmt.Sprintf(`
 components:
 - name: %s
-  imageVectorOverwrite: %s
+  imageVectorOverwrite: "%s"
 - name: %s
-  imageVectorOverwrite: %s
+  imageVectorOverwrite: "%s"
 `, component1, componentData1, component2, componentData2)
 		)
 
-		Describe("#Read", func() {
+		Describe("#ReadComponentOverwrite", func() {
 			It("should successfully read a JSON image vector", func() {
 				vector, err := ReadComponentOverwrite(strings.NewReader(componentImagesJSON))
 				Expect(err).NotTo(HaveOccurred())
@@ -75,7 +75,7 @@ components:
 			})
 		})
 
-		Describe("#ReadFile", func() {
+		Describe("#ReadComponentOverwriteFile", func() {
 			It("should successfully read the file and close it", func() {
 				tmpFile, cleanup := withTempFile("component imagevector", []byte(componentImagesJSON))
 				defer cleanup()

--- a/pkg/utils/imagevector/imagevector_validation.go
+++ b/pkg/utils/imagevector/imagevector_validation.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package imagevector
+
+import (
+	"strings"
+
+	"github.com/Masterminds/semver"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateImageVector validates the given ImageVector.
+func ValidateImageVector(imageVector ImageVector, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	for i, imageSource := range imageVector {
+		allErrs = append(allErrs, validateImageSource(imageSource, fldPath.Index(i))...)
+	}
+
+	return allErrs
+}
+
+// ValidateComponentImageVectors validates the given ComponentImageVectors.
+func ValidateComponentImageVectors(componentImageVectors ComponentImageVectors, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	for key, value := range componentImageVectors {
+		componentImageVector := &ComponentImageVector{
+			Name:                 key,
+			ImageVectorOverwrite: value,
+		}
+		allErrs = append(allErrs, validateComponentImageVector(componentImageVector, fldPath.Key(key))...)
+	}
+
+	return allErrs
+}
+
+func validateImageSource(imageSource *ImageSource, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Ensure name and repository are non-empty
+	if imageSource.Name == "" {
+		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "image name is required"))
+	}
+	if imageSource.Repository == "" {
+		allErrs = append(allErrs, field.Required(fldPath.Child("repository"), "image repository is required"))
+	}
+
+	// Ensure tag is non-empty if specified
+	if imageSource.Tag != nil && *imageSource.Tag == "" {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("tag"), *imageSource.Tag, "image tag must not be empty if specified"))
+	}
+
+	// Ensure runtimeVersion and targetVersion are valid semver constraints if specified
+	if imageSource.RuntimeVersion != nil {
+		if _, err := semver.NewConstraint(*imageSource.RuntimeVersion); err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("runtimeVersion"), imageSource.RuntimeVersion, err.Error()))
+		}
+	}
+	if imageSource.TargetVersion != nil {
+		if _, err := semver.NewConstraint(*imageSource.TargetVersion); err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("targetVersion"), imageSource.TargetVersion, err.Error()))
+		}
+	}
+
+	return allErrs
+}
+
+func validateComponentImageVector(componentImageVector *ComponentImageVector, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Ensure name is non-empty
+	if componentImageVector.Name == "" {
+		allErrs = append(allErrs, field.Required(fldPath.Child("name"), "component name is required"))
+	}
+
+	// Read (and validate) imageVectorOverwrite as image vector
+	imageVector, err := Read(strings.NewReader(componentImageVector.ImageVectorOverwrite))
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("imageVectorOverwrite"), imageVector, err.Error()))
+	}
+
+	return allErrs
+}

--- a/pkg/utils/imagevector/imagevector_validation_test.go
+++ b/pkg/utils/imagevector/imagevector_validation_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package imagevector_test
+
+import (
+	"bytes"
+	"io"
+
+	. "github.com/gardener/gardener/pkg/utils/imagevector"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("validation", func() {
+	var (
+		imageVector           func(string, string, string, string, string) ImageVector
+		componentImageVectors func(string, ImageVector) ComponentImageVectors
+	)
+
+	BeforeEach(func() {
+		imageVector = func(name, repository, tag, runtimeVersion, targetVersion string) ImageVector {
+			return ImageVector{
+				{
+					Name:           name,
+					Repository:     repository,
+					Tag:            pointer.StringPtr(tag),
+					RuntimeVersion: pointer.StringPtr(runtimeVersion),
+					TargetVersion:  pointer.StringPtr(targetVersion),
+				},
+			}
+		}
+
+		componentImageVectors = func(name string, imageVector ImageVector) ComponentImageVectors {
+			var buf bytes.Buffer
+			err := write(&buf, imageVector)
+			Expect(err).NotTo(HaveOccurred())
+
+			return ComponentImageVectors{
+				name: buf.String(),
+			}
+		}
+	})
+
+	Describe("#ValidateImageVector", func() {
+		It("should allow valid image vectors", func() {
+			errorList := ValidateImageVector(imageVector("test-image1", "test-repo", "test-tag", ">= 1.6, < 1.8", ">= 1.8"), field.NewPath("images"))
+
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should forbid invalid image vectors", func() {
+			errorList := ValidateImageVector(imageVector("", "", "", "", "!@#"), field.NewPath("images"))
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("images[0].name"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("images[0].repository"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("images[0].tag"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("images[0].runtimeVersion"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("images[0].targetVersion"),
+				})),
+			))
+		})
+	})
+
+	Describe("#ValidateComponentImageVectors", func() {
+		It("should allow valid component image vectors", func() {
+			errorList := ValidateComponentImageVectors(componentImageVectors("test-component1", imageVector("test-image1", "test-repo", "test-tag", ">= 1.6, < 1.8", ">= 1.8")), field.NewPath("components"))
+
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should forbid invalid component image vectors", func() {
+			errorList := ValidateComponentImageVectors(componentImageVectors("", ImageVector{{}}), field.NewPath("components"))
+
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("components[].name"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("components[].imageVectorOverwrite"),
+				})),
+			))
+		})
+	})
+})
+
+func write(w io.Writer, imageVector ImageVector) error {
+	vector := struct {
+		Images ImageVector `json:"images" yaml:"images"`
+	}{
+		Images: imageVector,
+	}
+
+	if err := yaml.NewEncoder(w).Encode(&vector); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Adds validation of image vectors, as agreed before closing #3656.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```breaking operator
Invalid image vectors and component image vector overwrites will cause validation errors upon reading. If you encounter such errors, make sure image vectors specified in `ConfigMap` or `ComponentRegistration` resources are valid.
```
