### PR TITLE
Avoid listing all BackupEntries during care operation

### DIFF
--- a/pkg/operation/care/health.go
+++ b/pkg/operation/care/health.go
@@ -43,6 +43,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 // Health contains information needed to execute shoot health checks.
@@ -91,14 +92,51 @@ type ExtensionCondition struct {
 }
 
 func (h *Health) getAllExtensionConditions(ctx context.Context) ([]ExtensionCondition, []ExtensionCondition, []ExtensionCondition, error) {
+	objs, err := h.retrieveExtensions(ctx)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	var (
 		conditionsControlPlaneHealthy     []ExtensionCondition
 		conditionsEveryNodeReady          []ExtensionCondition
 		conditionsSystemComponentsHealthy []ExtensionCondition
 	)
 
+	for _, obj := range objs {
+		acc, err := extensions.Accessor(obj)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		gvk, err := apiutil.GVKForObject(obj, kubernetes.SeedScheme)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to identify GVK for object: %w", err)
+		}
+
+		kind := gvk.Kind
+		name := acc.GetName()
+		namespace := acc.GetNamespace()
+
+		for _, condition := range acc.GetExtensionStatus().GetConditions() {
+			switch condition.Type {
+			case gardencorev1beta1.ShootControlPlaneHealthy:
+				conditionsControlPlaneHealthy = append(conditionsControlPlaneHealthy, ExtensionCondition{condition, kind, name, namespace})
+			case gardencorev1beta1.ShootEveryNodeReady:
+				conditionsEveryNodeReady = append(conditionsEveryNodeReady, ExtensionCondition{condition, kind, name, namespace})
+			case gardencorev1beta1.ShootSystemComponentsHealthy:
+				conditionsSystemComponentsHealthy = append(conditionsSystemComponentsHealthy, ExtensionCondition{condition, kind, name, namespace})
+			}
+		}
+	}
+
+	return conditionsControlPlaneHealthy, conditionsEveryNodeReady, conditionsSystemComponentsHealthy, nil
+}
+
+func (h *Health) retrieveExtensions(ctx context.Context) ([]runtime.Object, error) {
+	extensions := []runtime.Object{}
+
 	for _, listObj := range []client.ObjectList{
-		&extensionsv1alpha1.BackupEntryList{},
 		&extensionsv1alpha1.ContainerRuntimeList{},
 		&extensionsv1alpha1.ControlPlaneList{},
 		&extensionsv1alpha1.ExtensionList{},
@@ -109,38 +147,28 @@ func (h *Health) getAllExtensionConditions(ctx context.Context) ([]ExtensionCond
 	} {
 		listKind := listObj.GetObjectKind().GroupVersionKind().Kind
 		if err := h.seedClient.Client().List(ctx, listObj, client.InNamespace(h.shoot.SeedNamespace)); err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
 
 		if err := meta.EachListItem(listObj, func(obj runtime.Object) error {
-			acc, err := extensions.Accessor(obj)
-			if err != nil {
-				return err
-			}
-
-			kind := obj.GetObjectKind().GroupVersionKind().Kind
-			name := acc.GetName()
-			namespace := acc.GetNamespace()
-
-			for _, condition := range acc.GetExtensionStatus().GetConditions() {
-				switch condition.Type {
-				case gardencorev1beta1.ShootControlPlaneHealthy:
-					conditionsControlPlaneHealthy = append(conditionsControlPlaneHealthy, ExtensionCondition{condition, kind, name, namespace})
-				case gardencorev1beta1.ShootEveryNodeReady:
-					conditionsEveryNodeReady = append(conditionsEveryNodeReady, ExtensionCondition{condition, kind, name, namespace})
-				case gardencorev1beta1.ShootSystemComponentsHealthy:
-					conditionsSystemComponentsHealthy = append(conditionsSystemComponentsHealthy, ExtensionCondition{condition, kind, name, namespace})
-				}
-			}
-
+			extensions = append(extensions, obj)
 			return nil
 		}); err != nil {
 			h.logger.Errorf("Error during evaluation of kind %q for extensions health check: %+v", listKind, err)
-			return nil, nil, nil, err
+			return nil, err
 		}
 	}
 
-	return conditionsControlPlaneHealthy, conditionsEveryNodeReady, conditionsSystemComponentsHealthy, nil
+	// Get BackupEntries separately as they are not namespaced i.e., they cannot be narrowed down
+	// to a shoot namespace like other extension resources above.
+	be := &extensionsv1alpha1.BackupEntry{}
+	beName := common.GenerateBackupEntryName(h.shoot.Info.Status.TechnicalID, h.shoot.Info.Status.UID)
+	if err := h.seedClient.Client().Get(ctx, kutil.Key(beName), be); client.IgnoreNotFound(err) != nil {
+		return nil, err
+	}
+	extensions = append(extensions, be)
+
+	return extensions, nil
 }
 
 func (h *Health) healthChecks(

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -315,7 +315,7 @@ func ReconcileServicePorts(existingPorts []corev1.ServicePort, desiredPorts []co
 func FetchEventMessages(ctx context.Context, scheme *runtime.Scheme, reader client.Reader, obj client.Object, eventType string, eventsLimit int) (string, error) {
 	gvk, err := apiutil.GVKForObject(obj, scheme)
 	if err != nil {
-		return "", fmt.Errorf("failed identify GVK for object: %w", err)
+		return "", fmt.Errorf("failed to identify GVK for object: %w", err)
 	}
 
 	apiVersion, kind := gvk.ToAPIVersionAndKind()

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -1074,7 +1074,7 @@ var _ = Describe("kubernetes", func() {
 				msg, err := FetchEventMessages(ctx, scheme, reader, &corev1.Service{}, corev1.EventTypeWarning, len(events))
 
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed identify GVK for object"))
+				Expect(err.Error()).To(ContainSubstring("failed to identify GVK for object"))
 				Expect(msg).To(BeEmpty())
 			})
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area performance
/area usability
/kind bug

**What this PR does / why we need it**:
This PR makes the shoot care operation to only retrieve the associated `BackupEntry` instead of listing all. More details can be found in the linked issue.

**Which issue(s) this PR fixes**:
Fixes #3836

**Special notes for your reviewer**:
/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Gardener care operations now only consider conditions of relevant `BackupEntries`. Earlier, the controller retrieved all entries instead of only checking the one that is associated to the processed shoot.
```
