### PR TITLE
[GCM] Use DirectClient when creating seed Namespace and syncing garden secrets

### DIFF
--- a/pkg/controllermanager/controller/seed/seed_reconcile.go
+++ b/pkg/controllermanager/controller/seed/seed_reconcile.go
@@ -88,7 +88,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		},
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, gardenClient.Client(), namespace, func() error {
+	if _, err := controllerutil.CreateOrUpdate(ctx, gardenClient.DirectClient(), namespace, func() error {
 		namespace.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(seedObj, gardencorev1beta1.SchemeGroupVersion.WithKind("Seed"))}
 		return nil
 	}); err != nil {
@@ -160,7 +160,7 @@ func (r *reconciler) syncGardenSecrets(ctx context.Context, gardenClient kuberne
 				},
 			}
 
-			if _, err := controllerutil.CreateOrUpdate(ctx, gardenClient.Client(), seedSecret, func() error {
+			if _, err := controllerutil.CreateOrUpdate(ctx, gardenClient.DirectClient(), seedSecret, func() error {
 				seedSecret.Annotations = secret.Annotations
 				seedSecret.Labels = secret.Labels
 				seedSecret.Data = secret.Data

--- a/pkg/controllermanager/controller/seed/seed_reconcile_test.go
+++ b/pkg/controllermanager/controller/seed/seed_reconcile_test.go
@@ -101,6 +101,7 @@ var _ = Describe("SeedReconciler", func() {
 			fakeGardenClientSet := fakeclientset.NewClientSetBuilder().
 				WithKubernetes(k).
 				WithClient(cl).
+				WithDirectClient(cl).
 				Build()
 			cm = fakeclientmap.NewClientMapBuilder().WithClientSetForKey(keys.ForGarden(), fakeGardenClientSet).Build()
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind regression

**What this PR does / why we need it**:
Use DirectClient when creating seed Namespace and syncing garden secrets.
On a landscape that was recently upgraded to v1.20.0, I see that the memory usage of GCM has increased 3 times.

**Which issue(s) this PR fixes**:
See https://github.com/gardener/gardener/pull/3821#issuecomment-815030639

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Use `DirectClient` in the GCM to reduce memory usage.
```
