### PR TITLE
[release-v1.20] Automated cherry pick of #3857: [GCM] Use DirectClient when creating seed Namespace and syncing garden secrets

### DIFF
--- a/pkg/controllermanager/controller/seed/seed_reconcile.go
+++ b/pkg/controllermanager/controller/seed/seed_reconcile.go
@@ -88,7 +88,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		},
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, gardenClient.Client(), namespace, func() error {
+	if _, err := controllerutil.CreateOrUpdate(ctx, gardenClient.DirectClient(), namespace, func() error {
 		namespace.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(seedObj, gardencorev1beta1.SchemeGroupVersion.WithKind("Seed"))}
 		return nil
 	}); err != nil {
@@ -160,7 +160,7 @@ func (r *reconciler) syncGardenSecrets(ctx context.Context, gardenClient kuberne
 				},
 			}
 
-			if _, err := controllerutil.CreateOrUpdate(ctx, gardenClient.Client(), seedSecret, func() error {
+			if _, err := controllerutil.CreateOrUpdate(ctx, gardenClient.DirectClient(), seedSecret, func() error {
 				seedSecret.Annotations = secret.Annotations
 				seedSecret.Labels = secret.Labels
 				seedSecret.Data = secret.Data

--- a/pkg/controllermanager/controller/seed/seed_reconcile_test.go
+++ b/pkg/controllermanager/controller/seed/seed_reconcile_test.go
@@ -101,6 +101,7 @@ var _ = Describe("SeedReconciler", func() {
 			fakeGardenClientSet := fakeclientset.NewClientSetBuilder().
 				WithKubernetes(k).
 				WithClient(cl).
+				WithDirectClient(cl).
 				Build()
 			cm = fakeclientmap.NewClientMapBuilder().WithClientSetForKey(keys.ForGarden(), fakeGardenClientSet).Build()
 


### PR DESCRIPTION
Cherry pick of #3857 on release-v1.20.

#3857: [GCM] Use DirectClient when creating seed Namespace and syncing garden secrets

**Release Notes:**
```other operator
Use `DirectClient` in the GCM to reduce memory usage.
```