### PR TITLE
[release-v1.20] Automated cherry pick of #3854: Avoid listing all BackupEntries during care operation

### DIFF
--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -305,7 +305,7 @@ func ReconcileServicePorts(existingPorts []corev1.ServicePort, desiredPorts []co
 func FetchEventMessages(ctx context.Context, scheme *runtime.Scheme, reader client.Reader, obj client.Object, eventType string, eventsLimit int) (string, error) {
 	gvk, err := apiutil.GVKForObject(obj, scheme)
 	if err != nil {
-		return "", fmt.Errorf("failed identify GVK for object: %w", err)
+		return "", fmt.Errorf("failed to identify GVK for object: %w", err)
 	}
 
 	apiVersion, kind := gvk.ToAPIVersionAndKind()

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -1074,7 +1074,7 @@ var _ = Describe("kubernetes", func() {
 				msg, err := FetchEventMessages(ctx, scheme, reader, &corev1.Service{}, corev1.EventTypeWarning, len(events))
 
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed identify GVK for object"))
+				Expect(err.Error()).To(ContainSubstring("failed to identify GVK for object"))
 				Expect(msg).To(BeEmpty())
 			})
 		})


### PR DESCRIPTION
Cherry pick of #3854 on release-v1.20.

#3854: Avoid listing all BackupEntries during care operation

**Release Notes:**
```bugfix operator
Gardener care operations now only consider conditions of relevant `BackupEntries`. Earlier, the controller retrieved all entries instead of only checking the one that is associated to the processed shoot.
```