### PR TITLE
set realms annotation for non-internal DNSProviders

### DIFF
--- a/pkg/operation/botanist/component/extensions/dns/dnsprovider.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsprovider.go
@@ -34,13 +34,14 @@ import (
 
 // ProviderValues contains the values used to create a DNSProvider.
 type ProviderValues struct {
-	Name       string
-	Purpose    string
-	Provider   string
-	Labels     map[string]string
-	SecretData map[string][]byte
-	Domains    *IncludeExclude
-	Zones      *IncludeExclude
+	Name        string
+	Purpose     string
+	Provider    string
+	Labels      map[string]string
+	Annotations map[string]string
+	SecretData  map[string][]byte
+	Domains     *IncludeExclude
+	Zones       *IncludeExclude
 }
 
 // IncludeExclude contain slices of excluded and included domains/zones.
@@ -96,6 +97,7 @@ func (p *provider) Deploy(ctx context.Context) error {
 
 	_, err := controllerutil.CreateOrUpdate(ctx, p.client, dnsProvider, func() error {
 		dnsProvider.Labels = p.values.Labels
+		dnsProvider.Annotations = p.values.Annotations
 
 		dnsProvider.Spec = dnsv1alpha1.DNSProviderSpec{
 			Type:      p.values.Provider,

--- a/pkg/operation/botanist/component/extensions/dns/dnsprovider_test.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsprovider_test.go
@@ -156,6 +156,10 @@ var _ = Describe("#DNSProvider", func() {
 				vals.Labels = map[string]string{"foo": "bar"}
 				expectedDNS.ObjectMeta.Labels = map[string]string{"foo": "bar"}
 			}),
+			Entry("with custom annotations", func() {
+				vals.Annotations = map[string]string{"foo": "bar"}
+				expectedDNS.ObjectMeta.Annotations = map[string]string{"foo": "bar"}
+			}),
 			Entry("with no exclude zones", func() {
 				vals.Zones.Exclude = nil
 				expectedDNS.Spec.Zones.Exclude = nil

--- a/pkg/operation/botanist/dns_test.go
+++ b/pkg/operation/botanist/dns_test.go
@@ -123,6 +123,9 @@ var _ = Describe("dns", func() {
 					Name:            "external",
 					Namespace:       seedNS,
 					ResourceVersion: "1",
+					Annotations: map[string]string{
+						"dns.gardener.cloud/realms": "test-ns,",
+					},
 				},
 				Spec: dnsv1alpha1.DNSProviderSpec{
 					Type: "valid-provider",
@@ -189,6 +192,7 @@ var _ = Describe("dns", func() {
 				},
 			}
 			Expect(found).To(DeepDerivativeEqual(expected))
+			Expect(found.Annotations).To(BeNil())
 		})
 		It("should delete when calling Deploy and dns is disabled", func() {
 			b.Shoot.DisableDNS = true
@@ -270,6 +274,9 @@ var _ = Describe("dns", func() {
 					Namespace: seedNS,
 					Labels: map[string]string{
 						"gardener.cloud/role": "managed-dns-provider",
+					},
+					Annotations: map[string]string{
+						"dns.gardener.cloud/realms": "test-ns,",
 					},
 				},
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind regression

**What this PR does / why we need it**:
On refactoring the seed-dns Helm charts the annotation `dns.gardener.cloud/realms` in the non-internal DNS providers has gone lost. But it is still needed to enable DNS entries from the shoot-dns-service.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue has been fixed which prevented DNS entries being created correctly. Only requests coming from shoot clusters were affected.
```