### PR TITLE
[release-v1.20] Automated cherry pick of #3863: set realms annotation for non-internal DNSProviders

### DIFF
--- a/pkg/operation/botanist/component/extensions/dns/dnsprovider.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsprovider.go
@@ -34,13 +34,14 @@ import (
 
 // ProviderValues contains the values used to create a DNSProvider.
 type ProviderValues struct {
-	Name       string
-	Purpose    string
-	Provider   string
-	Labels     map[string]string
-	SecretData map[string][]byte
-	Domains    *IncludeExclude
-	Zones      *IncludeExclude
+	Name        string
+	Purpose     string
+	Provider    string
+	Labels      map[string]string
+	Annotations map[string]string
+	SecretData  map[string][]byte
+	Domains     *IncludeExclude
+	Zones       *IncludeExclude
 }
 
 // IncludeExclude contain slices of excluded and included domains/zones.
@@ -96,6 +97,7 @@ func (p *provider) Deploy(ctx context.Context) error {
 
 	_, err := controllerutil.CreateOrUpdate(ctx, p.client, dnsProvider, func() error {
 		dnsProvider.Labels = p.values.Labels
+		dnsProvider.Annotations = p.values.Annotations
 
 		dnsProvider.Spec = dnsv1alpha1.DNSProviderSpec{
 			Type:      p.values.Provider,

--- a/pkg/operation/botanist/component/extensions/dns/dnsprovider_test.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsprovider_test.go
@@ -156,6 +156,10 @@ var _ = Describe("#DNSProvider", func() {
 				vals.Labels = map[string]string{"foo": "bar"}
 				expectedDNS.ObjectMeta.Labels = map[string]string{"foo": "bar"}
 			}),
+			Entry("with custom annotations", func() {
+				vals.Annotations = map[string]string{"foo": "bar"}
+				expectedDNS.ObjectMeta.Annotations = map[string]string{"foo": "bar"}
+			}),
 			Entry("with no exclude zones", func() {
 				vals.Zones.Exclude = nil
 				expectedDNS.Spec.Zones.Exclude = nil

--- a/pkg/operation/botanist/dns_test.go
+++ b/pkg/operation/botanist/dns_test.go
@@ -123,6 +123,9 @@ var _ = Describe("dns", func() {
 					Name:            "external",
 					Namespace:       seedNS,
 					ResourceVersion: "1",
+					Annotations: map[string]string{
+						"dns.gardener.cloud/realms": "test-ns,",
+					},
 				},
 				Spec: dnsv1alpha1.DNSProviderSpec{
 					Type: "valid-provider",
@@ -189,6 +192,7 @@ var _ = Describe("dns", func() {
 				},
 			}
 			Expect(found).To(DeepDerivativeEqual(expected))
+			Expect(found.Annotations).To(BeNil())
 		})
 		It("should delete when calling Deploy and dns is disabled", func() {
 			b.Shoot.DisableDNS = true
@@ -270,6 +274,9 @@ var _ = Describe("dns", func() {
 					Namespace: seedNS,
 					Labels: map[string]string{
 						"gardener.cloud/role": "managed-dns-provider",
+					},
+					Annotations: map[string]string{
+						"dns.gardener.cloud/realms": "test-ns,",
 					},
 				},
 			}


### PR DESCRIPTION
/kind bug
/kind regression

Cherry pick of #3863 on release-v1.20.

#3863: set realms annotation for non-internal DNSProviders

**Release Notes:**
```bugfix user
An issue has been fixed which prevented DNS entries being created correctly. Only requests coming from shoot clusters were affected.
```