### PR TITLE
Decouple gardener-apiserver from pkg/operation/*

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -113,6 +113,9 @@ const (
 	// GardenerDescription is a constant for a key in an annotation describing what the resource is used for.
 	GardenerDescription = "gardener.cloud/description"
 
+	// GardenCreatedBy is the key for an annotation of a Shoot cluster whose value indicates contains the username
+	// of the user that created the resource.
+	GardenCreatedBy = "gardener.cloud/created-by"
 	// GardenerOperation is a constant for an annotation on a resource that describes a desired operation.
 	GardenerOperation = "gardener.cloud/operation"
 	// GardenerOperationReconcile is a constant for the value of the operation annotation describing a reconcile
@@ -194,6 +197,38 @@ const (
 	// ShootNoCleanup is a constant for a label on a resource indicating that the Gardener cleaner should not delete this
 	// resource when cleaning a shoot during the deletion flow.
 	ShootNoCleanup = "shoot.gardener.cloud/no-cleanup"
+	// ShootAlphaScalingAPIServerClass is a constant for an annotation on the shoot stating the initial API server class.
+	// It influences the size of the initial resource requests/limits.
+	// Possible values are [small, medium, large, xlarge, 2xlarge].
+	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
+	// what you do.
+	ShootAlphaScalingAPIServerClass = "alpha.kube-apiserver.scaling.shoot.gardener.cloud/class"
+	// ShootExpirationTimestamp is an annotation on a Shoot resource whose value represents the time when the Shoot lifetime
+	// is expired. The lifetime can be extended, but at most by the minimal value of the 'clusterLifetimeDays' property
+	// of referenced quotas.
+	ShootExpirationTimestamp = "shoot.gardener.cloud/expiration-timestamp"
+	// ShootStatus is a constant for a label on a Shoot resource indicating that the Shoot's health.
+	ShootStatus = "shoot.gardener.cloud/status"
+	// FailedShootNeedsRetryOperation is a constant for an annotation on a Shoot in a failed state indicating that a retry operation should be triggered during the next maintenance time window.
+	FailedShootNeedsRetryOperation = "maintenance.shoot.gardener.cloud/needs-retry-operation"
+	// ShootTasks is a constant for an annotation on a Shoot which states that certain tasks should be done.
+	ShootTasks = "shoot.gardener.cloud/tasks"
+	// ShootTaskDeployInfrastructure is a name for a Shoot's infrastructure deployment task. It indicates that the
+	// Infrastructure extension resource shall be reconciled.
+	ShootTaskDeployInfrastructure = "deployInfrastructure"
+	// ShootTaskRestartControlPlanePods is a name for a Shoot task which is dedicated to restart related control plane pods.
+	ShootTaskRestartControlPlanePods = "restartControlPlanePods"
+	// ShootTaskRestartCoreAddons is a name for a Shoot task which is dedicated to restart some core addons.
+	ShootTaskRestartCoreAddons = "restartCoreAddons"
+	// ShootOperationMaintain is a constant for an annotation on a Shoot indicating that the Shoot maintenance shall be
+	// executed as soon as possible.
+	ShootOperationMaintain = "maintain"
+	// ShootOperationRetry is a constant for an annotation on a Shoot indicating that a failed Shoot reconciliation shall be
+	// retried.
+	ShootOperationRetry = "retry"
+	// ShootOperationRotateKubeconfigCredentials is a constant for an annotation on a Shoot indicating that the credentials
+	// contained in the kubeconfig that is handed out to the user shall be rotated.
+	ShootOperationRotateKubeconfigCredentials = "rotate-kubeconfig-credentials"
 
 	// SeedResourceManagerClass is the resource-class managed by the Gardener-Resource-Manager
 	// instance in the garden namespace on the seeds.

--- a/pkg/apis/core/validation/controllerregistration.go
+++ b/pkg/apis/core/validation/controllerregistration.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/extensions"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
@@ -71,7 +71,7 @@ func ValidateControllerRegistrationSpec(spec *core.ControllerRegistrationSpec, f
 			allErrs = append(allErrs, field.Required(idxPath.Child("type"), "field is required"))
 		}
 		if t, ok := resources[resource.Kind]; ok && t == resource.Type {
-			allErrs = append(allErrs, field.Duplicate(idxPath, common.ExtensionID(resource.Kind, resource.Type)))
+			allErrs = append(allErrs, field.Duplicate(idxPath, extensions.Id(resource.Kind, resource.Type)))
 		}
 		if resource.Kind != extensionsv1alpha1.ExtensionResource {
 			if resource.GloballyEnabled != nil {

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -27,8 +27,8 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/features"
-	"github.com/gardener/gardener/pkg/operation/botanist"
 	"github.com/gardener/gardener/pkg/utils"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
@@ -451,7 +451,7 @@ func validateDNS(dns *core.DNS, fldPath *field.Path) field.ErrorList {
 		idxPath := fldPath.Child("providers").Index(i)
 
 		if provider.SecretName != nil && provider.Type != nil {
-			providerName := botanist.GenerateDNSProviderName(*provider.SecretName, *provider.Type)
+			providerName := gutil.GenerateDNSProviderName(*provider.SecretName, *provider.Type)
 			if names.Has(providerName) {
 				allErrs = append(allErrs, field.Invalid(idxPath, providerName, "combination of .secretName and .type must be unique across dns providers"))
 				continue

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
@@ -28,6 +28,7 @@ import (
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
+	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation/common"
 	gardenpkg "github.com/gardener/gardener/pkg/operation/garden"
@@ -208,7 +209,7 @@ func computeKindTypesForBackupBuckets(
 			continue
 		}
 
-		wantedKindTypeCombinations.Insert(common.ExtensionID(extensionsv1alpha1.BackupBucketResource, backupBucket.Spec.Provider.Type))
+		wantedKindTypeCombinations.Insert(extensions.Id(extensionsv1alpha1.BackupBucketResource, backupBucket.Spec.Provider.Type))
 	}
 
 	return wantedKindTypeCombinations, buckets
@@ -235,7 +236,7 @@ func computeKindTypesForBackupEntries(
 			continue
 		}
 
-		wantedKindTypeCombinations.Insert(common.ExtensionID(extensionsv1alpha1.BackupEntryResource, bucket.Spec.Provider.Type))
+		wantedKindTypeCombinations.Insert(extensions.Id(extensionsv1alpha1.BackupEntryResource, bucket.Spec.Provider.Type))
 	}
 
 	return wantedKindTypeCombinations
@@ -303,7 +304,7 @@ func computeKindTypesForSeed(
 	}
 
 	if seed.Spec.DNS.Provider != nil {
-		wantedKindTypeCombinations.Insert(common.ExtensionID(dnsv1alpha1.DNSProviderKind, seed.Spec.DNS.Provider.Type))
+		wantedKindTypeCombinations.Insert(extensions.Id(dnsv1alpha1.DNSProviderKind, seed.Spec.DNS.Provider.Type))
 	}
 
 	return wantedKindTypeCombinations
@@ -358,7 +359,7 @@ func computeWantedControllerRegistrationNames(
 		}
 
 		for _, resource := range controllerRegistration.obj.Spec.Resources {
-			id := common.ExtensionID(resource.Kind, resource.Type)
+			id := extensions.Id(resource.Kind, resource.Type)
 			kindTypeToControllerRegistrationNames[id] = append(kindTypeToControllerRegistrationNames[id], name)
 		}
 	}

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
@@ -21,6 +21,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation/common"
@@ -729,7 +730,7 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 				},
 			}
 
-			expected := sets.NewString(common.ExtensionID(dnsv1alpha1.DNSProviderKind, providerType))
+			expected := sets.NewString(extensions.Id(dnsv1alpha1.DNSProviderKind, providerType))
 			actual := computeKindTypesForSeed(seed)
 			Expect(actual).To(Equal(expected))
 		})

--- a/pkg/controllermanager/controller/managedseedset/managedseedset_replica.go
+++ b/pkg/controllermanager/controller/managedseedset/managedseedset_replica.go
@@ -22,12 +22,11 @@ import (
 	"strings"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	seedmanagementhelper "github.com/gardener/gardener/pkg/apis/seedmanagement/helper"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	seedmanagementv1alpha1constants "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/constants"
-	"github.com/gardener/gardener/pkg/operation/common"
 	operationshoot "github.com/gardener/gardener/pkg/operation/shoot"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -285,7 +284,7 @@ func (r *replica) RetryShoot(ctx context.Context, c client.Client) error {
 	if r.shoot == nil {
 		return nil
 	}
-	if err := kutil.SetAnnotationAndUpdate(ctx, c, r.shoot, gardencorev1beta1constants.GardenerOperation, common.ShootOperationRetry); err != nil {
+	if err := kutil.SetAnnotationAndUpdate(ctx, c, r.shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationRetry); err != nil {
 		return err
 	}
 	return nil
@@ -329,7 +328,7 @@ func seedReady(seed *gardencorev1beta1.Seed) bool {
 }
 
 func shootHealthStatus(shoot *gardencorev1beta1.Shoot) operationshoot.Status {
-	if value, ok := shoot.Labels[common.ShootStatus]; ok {
+	if value, ok := shoot.Labels[v1beta1constants.ShootStatus]; ok {
 		return operationshoot.Status(value)
 	}
 	return operationshoot.StatusProgressing

--- a/pkg/controllermanager/controller/managedseedset/managedseedset_replica_test.go
+++ b/pkg/controllermanager/controller/managedseedset/managedseedset_replica_test.go
@@ -27,13 +27,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	seedmanagementv1alpha1constants "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1/constants"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/managedseedset"
 	configv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	"github.com/gardener/gardener/pkg/operation/common"
 	operationshoot "github.com/gardener/gardener/pkg/operation/shoot"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 )
@@ -119,7 +118,7 @@ var _ = Describe("Replica", func() {
 		) *gardencorev1beta1.Shoot {
 			labels := make(map[string]string)
 			if shs != "" {
-				labels[common.ShootStatus] = string(shs)
+				labels[v1beta1constants.ShootStatus] = string(shs)
 			}
 			annotations := make(map[string]string)
 			if protected {
@@ -423,7 +422,7 @@ var _ = Describe("Replica", func() {
 			shoot := shoot(nil, "", "", "", false)
 			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{}), gomock.Any()).DoAndReturn(
 				func(_ context.Context, s *gardencorev1beta1.Shoot, _ client.Patch) error {
-					Expect(s.Annotations).To(HaveKeyWithValue(gardencorev1beta1constants.GardenerOperation, common.ShootOperationRetry))
+					Expect(s.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationRetry))
 					return nil
 				},
 			)

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/logger"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -165,26 +164,26 @@ func (r *shootMaintenanceReconciler) reconcile(ctx context.Context, shoot *garde
 
 		// do not add reconcile annotation if shoot was once set to failed or if shoot is already in an ongoing reconciliation
 		if s.Status.LastOperation != nil && s.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded {
-			metav1.SetMetaDataAnnotation(&s.ObjectMeta, v1beta1constants.GardenerOperation, common.ShootOperationReconcile)
+			metav1.SetMetaDataAnnotation(&s.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
 		}
 
 		var needsRetry bool
-		if val, ok := s.Annotations[common.FailedShootNeedsRetryOperation]; ok {
+		if val, ok := s.Annotations[v1beta1constants.FailedShootNeedsRetryOperation]; ok {
 			needsRetry, _ = strconv.ParseBool(val)
 		}
-		delete(s.Annotations, common.FailedShootNeedsRetryOperation)
+		delete(s.Annotations, v1beta1constants.FailedShootNeedsRetryOperation)
 
 		if needsRetry {
-			metav1.SetMetaDataAnnotation(&s.ObjectMeta, v1beta1constants.GardenerOperation, common.ShootOperationRetry)
+			metav1.SetMetaDataAnnotation(&s.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationRetry)
 		}
 
-		controllerutils.AddTasks(s.Annotations, common.ShootTaskDeployInfrastructure)
+		controllerutils.AddTasks(s.Annotations, v1beta1constants.ShootTaskDeployInfrastructure)
 		if utils.IsTrue(r.config.EnableShootControlPlaneRestarter) {
-			controllerutils.AddTasks(s.Annotations, common.ShootTaskRestartControlPlanePods)
+			controllerutils.AddTasks(s.Annotations, v1beta1constants.ShootTaskRestartControlPlanePods)
 		}
 
 		if utils.IsTrue(r.config.EnableShootCoreAddonRestarter) {
-			controllerutils.AddTasks(s.Annotations, common.ShootTaskRestartCoreAddons)
+			controllerutils.AddTasks(s.Annotations, v1beta1constants.ShootTaskRestartCoreAddons)
 		}
 
 		if updatedMachineImages != nil {
@@ -289,7 +288,7 @@ func mustMaintainNow(shoot *gardencorev1beta1.Shoot) bool {
 
 func hasMaintainNowAnnotation(shoot *gardencorev1beta1.Shoot) bool {
 	operation, ok := shoot.Annotations[v1beta1constants.GardenerOperation]
-	return ok && operation == common.ShootOperationMaintain
+	return ok && operation == v1beta1constants.ShootOperationMaintain
 }
 
 // MaintainMachineImages determines if a shoots machine images have to be maintained and in case returns the target images

--- a/pkg/controllermanager/controller/shoot/shoot_quota_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_quota_control.go
@@ -19,9 +19,9 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions/core/v1beta1"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
-	"github.com/gardener/gardener/pkg/operation/common"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 
 	"github.com/sirupsen/logrus"
@@ -108,10 +108,10 @@ func (r *shootQuotaReconciler) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{RequeueAfter: r.cfg.SyncPeriod.Duration}, nil
 	}
 
-	expirationTime, exits := shoot.Annotations[common.ShootExpirationTimestamp]
+	expirationTime, exits := shoot.Annotations[v1beta1constants.ShootExpirationTimestamp]
 	if !exits {
 		expirationTime = shoot.CreationTimestamp.Add(time.Duration(*clusterLifeTime*24) * time.Hour).Format(time.RFC3339)
-		metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, common.ShootExpirationTimestamp, expirationTime)
+		metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, v1beta1constants.ShootExpirationTimestamp, expirationTime)
 
 		if err := r.gardenClient.Update(ctx, shoot); err != nil {
 			return reconcile.Result{}, err

--- a/pkg/controllerutils/miscellaneous.go
+++ b/pkg/controllerutils/miscellaneous.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/operation/common"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +30,7 @@ const separator = ","
 // GetTasks returns the list of tasks in the ShootTasks annotation.
 func GetTasks(annotations map[string]string) []string {
 	var tasks []string
-	if val := annotations[common.ShootTasks]; len(val) > 0 {
+	if val := annotations[v1beta1constants.ShootTasks]; len(val) > 0 {
 		tasks = strings.Split(val, separator)
 	}
 	return tasks
@@ -73,7 +73,7 @@ func RemoveTasks(annotations map[string]string, tasksToRemove ...string) {
 
 // RemoveAllTasks removes the ShootTasks annotation from the passed map.
 func RemoveAllTasks(annotations map[string]string) {
-	delete(annotations, common.ShootTasks)
+	delete(annotations, v1beta1constants.ShootTasks)
 }
 
 func setTaskAnnotations(annotations map[string]string, tasks []string) {
@@ -82,7 +82,7 @@ func setTaskAnnotations(annotations map[string]string, tasks []string) {
 		return
 	}
 
-	annotations[common.ShootTasks] = strings.Join(tasks, separator)
+	annotations[v1beta1constants.ShootTasks] = strings.Join(tasks, separator)
 }
 
 var (

--- a/pkg/controllerutils/miscellaneous_test.go
+++ b/pkg/controllerutils/miscellaneous_test.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/operation/common"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -37,9 +37,9 @@ var _ = Describe("controller", func() {
 			},
 
 			Entry("absent task annotation", map[string]string{}, nil),
-			Entry("empty task list", map[string]string{common.ShootTasks: ""}, nil),
-			Entry("task list", map[string]string{common.ShootTasks: "some-task" + "," + common.ShootTaskDeployInfrastructure},
-				[]string{"some-task", common.ShootTaskDeployInfrastructure}),
+			Entry("empty task list", map[string]string{v1beta1constants.ShootTasks: ""}, nil),
+			Entry("task list", map[string]string{v1beta1constants.ShootTasks: "some-task" + "," + v1beta1constants.ShootTaskDeployInfrastructure},
+				[]string{"some-task", v1beta1constants.ShootTaskDeployInfrastructure}),
 		)
 
 		DescribeTable("#AddTasks",
@@ -47,28 +47,28 @@ var _ = Describe("controller", func() {
 				AddTasks(existingTasks, tasks...)
 
 				if expectedTasks == nil {
-					Expect(existingTasks[common.ShootTasks]).To(BeEmpty())
+					Expect(existingTasks[v1beta1constants.ShootTasks]).To(BeEmpty())
 				} else {
-					Expect(strings.Split(existingTasks[common.ShootTasks], ",")).To(Equal(expectedTasks))
+					Expect(strings.Split(existingTasks[v1beta1constants.ShootTasks], ",")).To(Equal(expectedTasks))
 				}
 			},
 
 			Entry("task to absent annotation", map[string]string{},
-				[]string{common.ShootTaskDeployInfrastructure}, []string{common.ShootTaskDeployInfrastructure}),
+				[]string{v1beta1constants.ShootTaskDeployInfrastructure}, []string{v1beta1constants.ShootTaskDeployInfrastructure}),
 			Entry("tasks to empty list", map[string]string{},
-				[]string{common.ShootTaskDeployInfrastructure}, []string{common.ShootTaskDeployInfrastructure}),
+				[]string{v1beta1constants.ShootTaskDeployInfrastructure}, []string{v1beta1constants.ShootTaskDeployInfrastructure}),
 			Entry("task to empty list", map[string]string{"foo": "bar"},
-				[]string{common.ShootTaskDeployInfrastructure}, []string{common.ShootTaskDeployInfrastructure}),
+				[]string{v1beta1constants.ShootTaskDeployInfrastructure}, []string{v1beta1constants.ShootTaskDeployInfrastructure}),
 			Entry("no task to empty list", map[string]string{},
 				[]string{}, nil),
 			Entry("no task to empty list", map[string]string{"foo": "bar"},
 				[]string{}, nil),
 			Entry("task to empty list twice", map[string]string{},
-				[]string{common.ShootTaskDeployInfrastructure, common.ShootTaskDeployInfrastructure}, []string{common.ShootTaskDeployInfrastructure}),
-			Entry("tasks to filled list", map[string]string{common.ShootTasks: common.ShootTaskDeployInfrastructure},
-				[]string{"some-task"}, []string{common.ShootTaskDeployInfrastructure, "some-task"}),
-			Entry("tasks already in list", map[string]string{common.ShootTasks: common.ShootTaskDeployInfrastructure},
-				[]string{"some-task", common.ShootTaskDeployInfrastructure}, []string{common.ShootTaskDeployInfrastructure, "some-task"}),
+				[]string{v1beta1constants.ShootTaskDeployInfrastructure, v1beta1constants.ShootTaskDeployInfrastructure}, []string{v1beta1constants.ShootTaskDeployInfrastructure}),
+			Entry("tasks to filled list", map[string]string{v1beta1constants.ShootTasks: v1beta1constants.ShootTaskDeployInfrastructure},
+				[]string{"some-task"}, []string{v1beta1constants.ShootTaskDeployInfrastructure, "some-task"}),
+			Entry("tasks already in list", map[string]string{v1beta1constants.ShootTasks: v1beta1constants.ShootTaskDeployInfrastructure},
+				[]string{"some-task", v1beta1constants.ShootTaskDeployInfrastructure}, []string{v1beta1constants.ShootTaskDeployInfrastructure, "some-task"}),
 		)
 
 		DescribeTable("#RemoveTasks",
@@ -76,30 +76,30 @@ var _ = Describe("controller", func() {
 				RemoveTasks(existingTasks, tasks...)
 
 				if expectedTasks == nil {
-					Expect(existingTasks[common.ShootTasks]).To(BeEmpty())
+					Expect(existingTasks[v1beta1constants.ShootTasks]).To(BeEmpty())
 				} else {
-					Expect(strings.Split(existingTasks[common.ShootTasks], ",")).To(Equal(expectedTasks))
+					Expect(strings.Split(existingTasks[v1beta1constants.ShootTasks], ",")).To(Equal(expectedTasks))
 				}
 			},
 
 			Entry("task from absent annotation", map[string]string{},
-				[]string{common.ShootTaskDeployInfrastructure}, nil),
+				[]string{v1beta1constants.ShootTaskDeployInfrastructure}, nil),
 			Entry("task from empty list", map[string]string{"foo": "bar"},
-				[]string{common.ShootTaskDeployInfrastructure}, nil),
+				[]string{v1beta1constants.ShootTaskDeployInfrastructure}, nil),
 			Entry("no task from empty list", map[string]string{},
 				[]string{}, nil),
 			Entry("task from empty list", map[string]string{"foo": "bar"},
 				[]string{}, nil),
 			Entry("task from empty list twice", map[string]string{},
-				[]string{common.ShootTaskDeployInfrastructure, common.ShootTaskDeployInfrastructure}, nil),
-			Entry("non-existing tasks from filled list", map[string]string{common.ShootTasks: common.ShootTaskDeployInfrastructure},
-				[]string{"some-task"}, []string{common.ShootTaskDeployInfrastructure}),
-			Entry("existing task from filled list", map[string]string{common.ShootTasks: common.ShootTaskDeployInfrastructure + ",foo"},
-				[]string{common.ShootTaskDeployInfrastructure}, []string{"foo"}),
-			Entry("all existing tasks from filled list", map[string]string{common.ShootTasks: common.ShootTaskDeployInfrastructure + ",foo"},
-				[]string{"foo", common.ShootTaskDeployInfrastructure}, nil),
-			Entry("all occurances of a task", map[string]string{common.ShootTasks: common.ShootTaskDeployInfrastructure + "," + common.ShootTaskDeployInfrastructure},
-				[]string{common.ShootTaskDeployInfrastructure}, nil),
+				[]string{v1beta1constants.ShootTaskDeployInfrastructure, v1beta1constants.ShootTaskDeployInfrastructure}, nil),
+			Entry("non-existing tasks from filled list", map[string]string{v1beta1constants.ShootTasks: v1beta1constants.ShootTaskDeployInfrastructure},
+				[]string{"some-task"}, []string{v1beta1constants.ShootTaskDeployInfrastructure}),
+			Entry("existing task from filled list", map[string]string{v1beta1constants.ShootTasks: v1beta1constants.ShootTaskDeployInfrastructure + ",foo"},
+				[]string{v1beta1constants.ShootTaskDeployInfrastructure}, []string{"foo"}),
+			Entry("all existing tasks from filled list", map[string]string{v1beta1constants.ShootTasks: v1beta1constants.ShootTaskDeployInfrastructure + ",foo"},
+				[]string{"foo", v1beta1constants.ShootTaskDeployInfrastructure}, nil),
+			Entry("all occurances of a task", map[string]string{v1beta1constants.ShootTasks: v1beta1constants.ShootTaskDeployInfrastructure + "," + v1beta1constants.ShootTaskDeployInfrastructure},
+				[]string{v1beta1constants.ShootTaskDeployInfrastructure}, nil),
 		)
 
 		DescribeTable("#HasTask",
@@ -108,10 +108,10 @@ var _ = Describe("controller", func() {
 				Expect(result).To(Equal(expectedResult))
 			},
 
-			Entry("absent task annotation", map[string]string{}, common.ShootTaskDeployInfrastructure, false),
-			Entry("empty task list", map[string]string{common.ShootTasks: ""}, common.ShootTaskDeployInfrastructure, false),
-			Entry("task not in list", map[string]string{common.ShootTasks: "some-task" + "," + "dummyTask"}, common.ShootTaskDeployInfrastructure, false),
-			Entry("task in list", map[string]string{common.ShootTasks: "some-task" + "," + common.ShootTaskDeployInfrastructure}, "some-task", true),
+			Entry("absent task annotation", map[string]string{}, v1beta1constants.ShootTaskDeployInfrastructure, false),
+			Entry("empty task list", map[string]string{v1beta1constants.ShootTasks: ""}, v1beta1constants.ShootTaskDeployInfrastructure, false),
+			Entry("task not in list", map[string]string{v1beta1constants.ShootTasks: "some-task" + "," + "dummyTask"}, v1beta1constants.ShootTaskDeployInfrastructure, false),
+			Entry("task in list", map[string]string{v1beta1constants.ShootTasks: "some-task" + "," + v1beta1constants.ShootTaskDeployInfrastructure}, "some-task", true),
 		)
 	})
 

--- a/pkg/extensions/id.go
+++ b/pkg/extensions/id.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	"fmt"
+)
+
+// Id returns an identifier for the given extension kind/type.
+func Id(extensionKind, extensionType string) string {
+	return fmt.Sprintf("%s/%s", extensionKind, extensionType)
+}

--- a/pkg/extensions/id_test.go
+++ b/pkg/extensions/id_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/gardener/gardener/pkg/extensions"
+)
+
+var _ = Describe("id", func() {
+	Describe("#Id", func() {
+		It("should return the expected identifier", func() {
+			Expect(Id("foo", "bar")).To(Equal("foo/bar"))
+		})
+	})
+})

--- a/pkg/gardenlet/bootstrap/util/util.go
+++ b/pkg/gardenlet/bootstrap/util/util.go
@@ -23,22 +23,20 @@ import (
 	"fmt"
 	"time"
 
-	certificatesv1 "k8s.io/api/certificates/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
-	bootstraptokenutil "k8s.io/cluster-bootstrap/token/util"
-
-	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
+	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	bootstraptokenapi "k8s.io/cluster-bootstrap/token/api"
+	bootstraptokenutil "k8s.io/cluster-bootstrap/token/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -64,7 +62,7 @@ func GetSeedName(seedConfig *config.SeedConfig) string {
 	if seedConfig != nil {
 		return seedConfig.Name
 	}
-	return gardencorev1beta1constants.SeedUserNameSuffixAmbiguous
+	return v1beta1constants.SeedUserNameSuffixAmbiguous
 }
 
 // GetTargetClusterName returns the target cluster of the gardenlet based on the SeedClientConnection.
@@ -231,7 +229,7 @@ func ComputeGardenletKubeconfigWithServiceAccountToken(ctx context.Context, gard
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceAccountName,
-			Namespace: gardencorev1beta1constants.GardenNamespace,
+			Namespace: v1beta1constants.GardenNamespace,
 		},
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, gardenClient, sa, func() error { return nil }); err != nil {
@@ -243,7 +241,7 @@ func ComputeGardenletKubeconfigWithServiceAccountToken(ctx context.Context, gard
 		return nil, fmt.Errorf("service account token controller has not yet created a secret for the service account")
 	}
 	saSecret := &corev1.Secret{}
-	if err := gardenClient.Get(ctx, kutil.Key(gardencorev1beta1constants.GardenNamespace, sa.Secrets[0].Name), saSecret); err != nil {
+	if err := gardenClient.Get(ctx, kutil.Key(v1beta1constants.GardenNamespace, sa.Secrets[0].Name), saSecret); err != nil {
 		return nil, err
 	}
 
@@ -263,7 +261,7 @@ func ComputeGardenletKubeconfigWithServiceAccountToken(ctx context.Context, gard
 			{
 				Kind:      rbacv1.ServiceAccountKind,
 				Name:      serviceAccountName,
-				Namespace: gardencorev1beta1constants.GardenNamespace,
+				Namespace: v1beta1constants.GardenNamespace,
 			},
 		}
 		return nil

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
@@ -170,7 +169,7 @@ func (a *actuator) emptyExtensionSecret() *corev1.Secret {
 }
 
 func (a *actuator) deployBackupBucketExtensionSecret(ctx context.Context) error {
-	coreSecret, err := common.GetSecretFromSecretRef(ctx, a.gardenClient.Client(), &a.backupBucket.Spec.SecretRef)
+	coreSecret, err := kutil.GetSecretByReference(ctx, a.gardenClient.Client(), &a.backupBucket.Spec.SecretRef)
 	if err != nil {
 		return err
 	}
@@ -238,7 +237,7 @@ func (a *actuator) waitUntilBackupBucketExtensionReconciled(ctx context.Context)
 			var generatedSecretRef *corev1.SecretReference
 
 			if backupBucket.Status.GeneratedSecretRef != nil {
-				generatedSecret, err := common.GetSecretFromSecretRef(ctx, a.seedClient.Client(), backupBucket.Status.GeneratedSecretRef)
+				generatedSecret, err := kutil.GetSecretByReference(ctx, a.seedClient.Client(), backupBucket.Status.GeneratedSecretRef)
 				if err != nil {
 					return err
 				}

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/logger"
-	"github.com/gardener/gardener/pkg/operation/common"
 	utilerrors "github.com/gardener/gardener/pkg/utils/errors"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
@@ -103,7 +102,7 @@ func (r *reconciler) reconcileBackupBucket(ctx context.Context, gardenClient kub
 		return reconcile.Result{}, updateErr
 	}
 
-	secret, err := common.GetSecretFromSecretRef(ctx, gardenClient.Client(), &backupBucket.Spec.SecretRef)
+	secret, err := kutil.GetSecretByReference(ctx, gardenClient.Client(), &backupBucket.Spec.SecretRef)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to get backup secret (%s/%s): %+v", backupBucket.Spec.SecretRef.Namespace, backupBucket.Spec.SecretRef.Name, err)
 		backupBucketLogger.Error(msg)
@@ -209,7 +208,7 @@ func (r *reconciler) deleteBackupBucket(ctx context.Context, gardenClient kubern
 
 	backupBucketLogger.Infof("Successfully deleted backup bucket %q", backupBucket.Name)
 
-	secret, err := common.GetSecretFromSecretRef(ctx, gardenClient.Client(), &backupBucket.Spec.SecretRef)
+	secret, err := kutil.GetSecretByReference(ctx, gardenClient.Client(), &backupBucket.Spec.SecretRef)
 	if err != nil {
 		backupBucketLogger.Errorf("Failed to get referred secret: %+v", err)
 		return reconcile.Result{}, err

--- a/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/extensions"
 	extensionsbackupentry "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/backupentry"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
@@ -230,7 +229,7 @@ func (a *actuator) deployBackupEntryExtensionSecret(ctx context.Context) error {
 		coreSecretRef = a.backupBucket.Status.GeneratedSecretRef
 	}
 
-	coreSecret, err := common.GetSecretFromSecretRef(ctx, a.gardenClient.Client(), coreSecretRef)
+	coreSecret, err := kutil.GetSecretByReference(ctx, a.gardenClient.Client(), coreSecretRef)
 	if err != nil {
 		return errors.Wrapf(err, "could not get secret referred in core backup bucket")
 	}

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -31,7 +31,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/logger"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/garden"
 	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
@@ -336,7 +335,7 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 	// Add the Gardener finalizer to the referenced Seed secret to protect it from deletion as long as the Seed resource
 	// does exist.
 	if seed.Spec.SecretRef != nil {
-		secret, err := common.GetSecretFromSecretRef(ctx, gardenClient.Client(), seed.Spec.SecretRef)
+		secret, err := kutil.GetSecretByReference(ctx, gardenClient.Client(), seed.Spec.SecretRef)
 		if err != nil {
 			seedLogger.Error(err.Error())
 			return err

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	gardencore "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions/core/v1beta1"
@@ -32,7 +33,6 @@ import (
 	confighelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/garden"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils"
@@ -371,7 +371,7 @@ func (s *careReconciler) care(ctx context.Context, shootObj *gardencorev1beta1.S
 
 	// Mark Shoot as healthy/unhealthy
 	oldObj := shoot.DeepCopy()
-	kutil.SetMetaDataLabel(&shoot.ObjectMeta, common.ShootStatus, string(shootpkg.ComputeStatus(
+	kutil.SetMetaDataLabel(&shoot.ObjectMeta, v1beta1constants.ShootStatus, string(shootpkg.ComputeStatus(
 		shoot.Status.LastOperation,
 		shoot.Status.LastErrors,
 		updatedConditions...,

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_test.go
@@ -38,7 +38,6 @@ import (
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/care"
-	"github.com/gardener/gardener/pkg/operation/common"
 	operationshoot "github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
@@ -333,7 +332,7 @@ var _ = Describe("Shoot Care Control", func() {
 					Expect(careControl.Reconcile(ctx, req)).To(Equal(reconcile.Result{RequeueAfter: careSyncPeriod}))
 					Expect(updatedShoot.Status.Conditions).To(BeEmpty())
 					Expect(updatedShoot.Status.Constraints).To(BeEmpty())
-					Expect(updatedShoot.ObjectMeta.Labels).Should(HaveKeyWithValue(common.ShootStatus, string(operationshoot.StatusHealthy)))
+					Expect(updatedShoot.ObjectMeta.Labels).Should(HaveKeyWithValue(v1beta1constants.ShootStatus, string(operationshoot.StatusHealthy)))
 				})
 				It("should remove conditions / constraints", func() {
 					apiServerCondition := gardencorev1beta1.Condition{
@@ -362,7 +361,7 @@ var _ = Describe("Shoot Care Control", func() {
 					Expect(careControl.Reconcile(ctx, req)).To(Equal(reconcile.Result{RequeueAfter: careSyncPeriod}))
 					Expect(updatedShoot.Status.Conditions).To(BeEmpty())
 					Expect(updatedShoot.Status.Constraints).To(BeEmpty())
-					Expect(updatedShoot.ObjectMeta.Labels).Should(HaveKeyWithValue(common.ShootStatus, string(operationshoot.StatusHealthy)))
+					Expect(updatedShoot.ObjectMeta.Labels).Should(HaveKeyWithValue(v1beta1constants.ShootStatus, string(operationshoot.StatusHealthy)))
 				})
 			})
 
@@ -399,7 +398,7 @@ var _ = Describe("Shoot Care Control", func() {
 						})
 					Expect(careControl.Reconcile(ctx, req)).To(Equal(reconcile.Result{RequeueAfter: careSyncPeriod}))
 					Expect(updatedShoot.Status.Conditions).To(BeEmpty())
-					Expect(updatedShoot.ObjectMeta.Labels).Should(HaveKeyWithValue(common.ShootStatus, string(operationshoot.StatusHealthy)))
+					Expect(updatedShoot.ObjectMeta.Labels).Should(HaveKeyWithValue(v1beta1constants.ShootStatus, string(operationshoot.StatusHealthy)))
 				})
 				It("should not amend existing conditions / constraints", func() {
 					apiServerCondition := gardencorev1beta1.Condition{
@@ -428,7 +427,7 @@ var _ = Describe("Shoot Care Control", func() {
 					Expect(careControl.Reconcile(ctx, req)).To(Equal(reconcile.Result{RequeueAfter: careSyncPeriod}))
 					Expect(updatedShoot.Status.Conditions).To(ConsistOf(apiServerCondition))
 					Expect(updatedShoot.Status.Constraints).To(ConsistOf(hibernationConstraint))
-					Expect(updatedShoot.ObjectMeta.Labels).Should(HaveKeyWithValue(common.ShootStatus, string(operationshoot.StatusHealthy)))
+					Expect(updatedShoot.ObjectMeta.Labels).Should(HaveKeyWithValue(v1beta1constants.ShootStatus, string(operationshoot.StatusHealthy)))
 				})
 			})
 
@@ -548,7 +547,7 @@ var _ = Describe("Shoot Care Control", func() {
 						Expect(careControl.Reconcile(ctx, req)).To(Equal(reconcile.Result{RequeueAfter: careSyncPeriod}))
 						Expect(updatedShoot.Status.Conditions).To(ConsistOf(append(conditions, seedConditions...)))
 						Expect(updatedShoot.Status.Constraints).To(ConsistOf(constraints))
-						Expect(updatedShoot.ObjectMeta.Labels).Should(HaveKeyWithValue(common.ShootStatus, string(operationshoot.StatusHealthy)))
+						Expect(updatedShoot.ObjectMeta.Labels).Should(HaveKeyWithValue(v1beta1constants.ShootStatus, string(operationshoot.StatusHealthy)))
 					})
 				})
 
@@ -580,7 +579,7 @@ var _ = Describe("Shoot Care Control", func() {
 						Expect(careControl.Reconcile(ctx, req)).To(Equal(reconcile.Result{RequeueAfter: careSyncPeriod}))
 						Expect(updatedShoot.Status.Conditions).To(ConsistOf(conditions))
 						Expect(updatedShoot.Status.Constraints).To(ConsistOf(constraints))
-						Expect(updatedShoot.ObjectMeta.Labels).Should(HaveKeyWithValue(common.ShootStatus, string(operationshoot.StatusHealthy)))
+						Expect(updatedShoot.ObjectMeta.Labels).Should(HaveKeyWithValue(v1beta1constants.ShootStatus, string(operationshoot.StatusHealthy)))
 					})
 				})
 
@@ -603,7 +602,7 @@ var _ = Describe("Shoot Care Control", func() {
 						Expect(careControl.Reconcile(ctx, req)).To(Equal(reconcile.Result{RequeueAfter: careSyncPeriod}))
 						Expect(updatedShoot.Status.Conditions).To(ConsistOf(conditions))
 						Expect(updatedShoot.Status.Constraints).To(ConsistOf(constraints))
-						Expect(updatedShoot.ObjectMeta.Labels).Should(HaveKeyWithValue(common.ShootStatus, string(operationshoot.StatusUnhealthy)))
+						Expect(updatedShoot.ObjectMeta.Labels).Should(HaveKeyWithValue(v1beta1constants.ShootStatus, string(operationshoot.StatusUnhealthy)))
 					})
 				})
 
@@ -691,7 +690,7 @@ var _ = Describe("Shoot Care Control", func() {
 							})
 						Expect(careControl.Reconcile(ctx, req)).To(Equal(reconcile.Result{RequeueAfter: careSyncPeriod}))
 						Expect(updatedShoot.Status.Conditions).To(ConsistOf(conditions))
-						Expect(updatedShoot.ObjectMeta.Labels).Should(HaveKeyWithValue(common.ShootStatus, string(operationshoot.StatusHealthy)))
+						Expect(updatedShoot.ObjectMeta.Labels).Should(HaveKeyWithValue(v1beta1constants.ShootStatus, string(operationshoot.StatusHealthy)))
 					})
 				})
 

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardencore "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
@@ -32,7 +33,6 @@ import (
 	gardenerextensions "github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/garden"
 	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
@@ -711,7 +711,7 @@ func (c *Controller) updateShootStatusOperationError(ctx context.Context, garden
 	}
 
 	oldObj := newShoot.DeepCopy()
-	kutil.SetMetaDataLabel(&newShoot.ObjectMeta, common.ShootStatus, string(shootpkg.StatusUnhealthy))
+	kutil.SetMetaDataLabel(&newShoot.ObjectMeta, v1beta1constants.ShootStatus, string(shootpkg.StatusUnhealthy))
 	if err := gardenClient.Client().Patch(ctx, newShoot, client.MergeFrom(oldObj)); err != nil {
 		return nil, err
 	}

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -20,13 +20,13 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/operation/botanist"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils/errors"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -86,7 +86,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		useSNI                         = botanist.APIServerSNIEnabled()
 		generation                     = o.Shoot.Info.Generation
 		sniPhase                       = botanist.Shoot.Components.ControlPlane.KubeAPIServerSNIPhase
-		requestControlPlanePodsRestart = controllerutils.HasTask(o.Shoot.Info.Annotations, common.ShootTaskRestartControlPlanePods)
+		requestControlPlanePodsRestart = controllerutils.HasTask(o.Shoot.Info.Annotations, v1beta1constants.ShootTaskRestartControlPlanePods)
 
 		g                      = flow.NewGraph("Shoot cluster reconciliation")
 		ensureShootStateExists = g.Add(flow.Task{
@@ -173,7 +173,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				if err := botanist.WaitForInfrastructure(ctx); err != nil {
 					return err
 				}
-				return removeTaskAnnotation(ctx, o, generation, common.ShootTaskDeployInfrastructure)
+				return removeTaskAnnotation(ctx, o, generation, v1beta1constants.ShootTaskDeployInfrastructure)
 			},
 			Dependencies: flow.NewTaskIDs(deployInfrastructure),
 		})
@@ -355,8 +355,8 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				if err := botanist.DeployManagedResourceForAddons(ctx); err != nil {
 					return err
 				}
-				if controllerutils.HasTask(o.Shoot.Info.Annotations, common.ShootTaskRestartCoreAddons) {
-					return removeTaskAnnotation(ctx, o, generation, common.ShootTaskRestartCoreAddons)
+				if controllerutils.HasTask(o.Shoot.Info.Annotations, v1beta1constants.ShootTaskRestartCoreAddons) {
+					return removeTaskAnnotation(ctx, o, generation, v1beta1constants.ShootTaskRestartCoreAddons)
 				}
 				return nil
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout).SkipIf(o.Shoot.HibernationEnabled),
@@ -501,7 +501,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				if err := botanist.RestartControlPlanePods(ctx); err != nil {
 					return err
 				}
-				return removeTaskAnnotation(ctx, o, generation, common.ShootTaskRestartControlPlanePods)
+				return removeTaskAnnotation(ctx, o, generation, v1beta1constants.ShootTaskRestartControlPlanePods)
 			}).DoIf(requestControlPlanePodsRestart),
 			Dependencies: flow.NewTaskIDs(deployKubeControllerManager, deployControlPlane, deployControlPlaneExposure),
 		})

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dns"
 	"github.com/gardener/gardener/pkg/operation/common"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
@@ -424,7 +425,7 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 		values["konnectivity-agent"] = common.GenerateAddonConfig(konnectivityAgent, true)
 
 		// TODO: remove when konnectivity tunnel is the default tunneling method for all shoots.
-		secret, err := common.GetSecretFromSecretRef(ctx, shootClient, &corev1.SecretReference{Namespace: metav1.NamespaceSystem, Name: "vpn-shoot"})
+		secret, err := kutil.GetSecretByReference(ctx, shootClient, &corev1.SecretReference{Namespace: metav1.NamespaceSystem, Name: "vpn-shoot"})
 		if err != nil && !apierrors.IsNotFound(err) {
 			return nil, err
 		}

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -525,7 +525,7 @@ func (b *Botanist) outOfClusterAPIServerFQDN() string {
 
 // getCoreDNSRestartTimestamp returns a timestamp that can potentially restart the CoreDNS deployment.
 func (b *Botanist) getCoreDNSRestartTimestamp(ctx context.Context) (string, error) {
-	if controllerutils.HasTask(b.Shoot.Info.Annotations, common.ShootTaskRestartCoreAddons) {
+	if controllerutils.HasTask(b.Shoot.Info.Annotations, v1beta1constants.ShootTaskRestartCoreAddons) {
 		return time.Now().UTC().Format(time.RFC3339), nil
 	}
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -623,9 +623,9 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 
 		var cpuRequest, memoryRequest, cpuLimit, memoryLimit string
 		if hvpaEnabled {
-			cpuRequest, memoryRequest, cpuLimit, memoryLimit = getResourcesForAPIServer(b.Shoot.GetMinNodeCount(), b.Shoot.Info.Annotations[common.ShootAlphaScalingAPIServerClass])
+			cpuRequest, memoryRequest, cpuLimit, memoryLimit = getResourcesForAPIServer(b.Shoot.GetMinNodeCount(), b.Shoot.Info.Annotations[v1beta1constants.ShootAlphaScalingAPIServerClass])
 		} else {
-			cpuRequest, memoryRequest, cpuLimit, memoryLimit = getResourcesForAPIServer(b.Shoot.GetMaxNodeCount(), b.Shoot.Info.Annotations[common.ShootAlphaScalingAPIServerClass])
+			cpuRequest, memoryRequest, cpuLimit, memoryLimit = getResourcesForAPIServer(b.Shoot.GetMaxNodeCount(), b.Shoot.Info.Annotations[v1beta1constants.ShootAlphaScalingAPIServerClass])
 		}
 		defaultValues["apiServerResources"] = map[string]interface{}{
 			"limits": map[string]interface{}{

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -26,6 +26,7 @@ import (
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dns"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
@@ -44,20 +45,6 @@ const (
 	// DNSRealmAnnotation is the annotation key for restricting provider access for shoot DNS entries
 	DNSRealmAnnotation = "dns.gardener.cloud/realms"
 )
-
-// GenerateDNSProviderName creates a name for the dns provider out of the passed `secretName` and `providerType`.
-func GenerateDNSProviderName(secretName, providerType string) string {
-	switch {
-	case secretName != "" && providerType != "":
-		return fmt.Sprintf("%s-%s", providerType, secretName)
-	case secretName != "":
-		return secretName
-	case providerType != "":
-		return providerType
-	default:
-		return ""
-	}
-}
 
 // DeployExternalDNS deploys the external DNSOwner, DNSProvider, and DNSEntry resources.
 func (b *Botanist) DeployExternalDNS(ctx context.Context) error {
@@ -286,7 +273,7 @@ func (b *Botanist) AdditionalDNSProviders(ctx context.Context, gardenClient, see
 			); err != nil {
 				return nil, fmt.Errorf("could not get dns provider secret %q: %+v", *secretName, err)
 			}
-			providerName := GenerateDNSProviderName(*secretName, *providerType)
+			providerName := gutil.GenerateDNSProviderName(*secretName, *providerType)
 
 			additionalProviders[providerName] = dns.NewProvider(
 				b.Logger,

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -20,7 +20,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/infrastructure"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,7 +36,7 @@ func (b *Botanist) DefaultInfrastructure(seedClient client.Client) infrastructur
 			Type:              b.Shoot.Info.Spec.Provider.Type,
 			ProviderConfig:    b.Shoot.Info.Spec.Provider.InfrastructureConfig,
 			Region:            b.Shoot.Info.Spec.Region,
-			AnnotateOperation: controllerutils.HasTask(b.Shoot.Info.Annotations, common.ShootTaskDeployInfrastructure) || b.isRestorePhase(),
+			AnnotateOperation: controllerutils.HasTask(b.Shoot.Info.Annotations, v1beta1constants.ShootTaskDeployInfrastructure) || b.isRestorePhase(),
 		},
 		infrastructure.DefaultInterval,
 		infrastructure.DefaultSevereThreshold,

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -46,7 +46,7 @@ import (
 func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 	gardenerResourceDataList := gardencorev1alpha1helper.GardenerResourceDataList(b.ShootState.Spec.Gardener).DeepCopy()
 
-	if val, ok := b.Shoot.Info.Annotations[v1beta1constants.GardenerOperation]; ok && val == common.ShootOperationRotateKubeconfigCredentials {
+	if val, ok := b.Shoot.Info.Annotations[v1beta1constants.GardenerOperation]; ok && val == v1beta1constants.ShootOperationRotateKubeconfigCredentials {
 		if err := b.rotateKubeconfigSecrets(ctx, &gardenerResourceDataList); err != nil {
 			return err
 		}

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -57,10 +57,6 @@ const (
 	// ETCDEncryptionConfigDataName is the name of ShootState data entry holding the current key and encryption state used to encrypt shoot resources
 	ETCDEncryptionConfigDataName = "etcdEncryptionConfiguration"
 
-	// GardenCreatedBy is the key for an annotation of a Shoot cluster whose value indicates contains the username
-	// of the user that created the resource.
-	GardenCreatedBy = "gardener.cloud/created-by"
-
 	// GrafanaOperatorsPrefix is a constant for a prefix used for the operators Grafana instance.
 	GrafanaOperatorsPrefix = "go"
 
@@ -106,54 +102,8 @@ const (
 	// VPASecretName is the name of the secret used by VPA
 	VPASecretName = "vpa-tls-certs"
 
-	// ShootAlphaScalingAPIServerClass is a constant for an annotation on the shoot stating the initial API server class.
-	// It influences the size of the initial resource requests/limits.
-	// Possible values are [small, medium, large, xlarge, 2xlarge].
-	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
-	// what you do.
-	ShootAlphaScalingAPIServerClass = "alpha.kube-apiserver.scaling.shoot.gardener.cloud/class"
-
-	// ShootExpirationTimestamp is an annotation on a Shoot resource whose value represents the time when the Shoot lifetime
-	// is expired. The lifetime can be extended, but at most by the minimal value of the 'clusterLifetimeDays' property
-	// of referenced quotas.
-	ShootExpirationTimestamp = "shoot.gardener.cloud/expiration-timestamp"
-
-	// ShootStatus is a constant for a label on a Shoot resource indicating that the Shoot's health.
-	ShootStatus = "shoot.gardener.cloud/status"
-
-	// ShootOperationMaintain is a constant for an annotation on a Shoot indicating that the Shoot maintenance shall be executed as soon as
-	// possible.
-	ShootOperationMaintain = "maintain"
-
-	// FailedShootNeedsRetryOperation is a constant for an annotation on a Shoot in a failed state indicating that a retry operation should be triggered during the next maintenance time window.
-	FailedShootNeedsRetryOperation = "maintenance.shoot.gardener.cloud/needs-retry-operation"
-
-	// ShootOperationRotateKubeconfigCredentials is a constant for an annotation on a Shoot indicating that the credentials contained in the
-	// kubeconfig that is handed out to the user shall be rotated.
-	ShootOperationRotateKubeconfigCredentials = "rotate-kubeconfig-credentials"
-
-	// ShootTasks is a constant for an annotation on a Shoot which states that certain tasks should be done.
-	ShootTasks = "shoot.gardener.cloud/tasks"
-
-	// ShootTaskDeployInfrastructure is a name for a Shoot's infrastructure deployment task. It indicates that the
-	// Infrastructure extension resource shall be reconciled.
-	ShootTaskDeployInfrastructure = "deployInfrastructure"
-
-	// ShootTaskRestartControlPlanePods is a name for a Shoot task which is dedicated to restart related control plane pods.
-	ShootTaskRestartControlPlanePods = "restartControlPlanePods"
-
-	// ShootTaskRestartCoreAddons is a name for a Shoot task which is dedicated to restart some core addons.
-	ShootTaskRestartCoreAddons = "restartCoreAddons"
-
-	// ShootOperationRetry is a constant for an annotation on a Shoot indicating that a failed Shoot reconciliation shall be retried.
-	ShootOperationRetry = "retry"
-
-	// ShootOperationReconcile is a constant for an annotation on a Shoot indicating that a Shoot reconciliation shall be triggered.
-	ShootOperationReconcile = "reconcile"
-
 	// ManagedResourceShootCoreName is the name of the shoot core managed resource.
 	ManagedResourceShootCoreName = "shoot-core"
-
 	// ManagedResourceAddonsName is the name of the addons managed resource.
 	ManagedResourceAddonsName = "addons"
 

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -415,15 +415,6 @@ func GetServiceAccountSigningKeySecret(ctx context.Context, c client.Client, sho
 	return ReadServiceAccountSigningKeySecret(secret)
 }
 
-// GetSecretFromSecretRef gets the Secret object from <secretRef>.
-func GetSecretFromSecretRef(ctx context.Context, c client.Client, secretRef *corev1.SecretReference) (*corev1.Secret, error) {
-	secret := &corev1.Secret{}
-	if err := c.Get(ctx, kutil.Key(secretRef.Namespace, secretRef.Name), secret); err != nil {
-		return nil, err
-	}
-	return secret, nil
-}
-
 // ExtensionID returns an identifier for the given extension kind/type.
 func ExtensionID(extensionKind, extensionType string) string {
 	return fmt.Sprintf("%s/%s", extensionKind, extensionType)

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -415,11 +415,6 @@ func GetServiceAccountSigningKeySecret(ctx context.Context, c client.Client, sho
 	return ReadServiceAccountSigningKeySecret(secret)
 }
 
-// ExtensionID returns an identifier for the given extension kind/type.
-func ExtensionID(extensionKind, extensionType string) string {
-	return fmt.Sprintf("%s/%s", extensionKind, extensionType)
-}
-
 // DeleteDeploymentsHavingDeprecatedRoleLabelKey deletes the Deployments with the passed object keys if
 // the corresponding Deployment .spec.selector contains the deprecated "garden.sapcloud.io/role" label key.
 func DeleteDeploymentsHavingDeprecatedRoleLabelKey(ctx context.Context, c client.Client, keys []client.ObjectKey) error {

--- a/pkg/operation/common/utils_test.go
+++ b/pkg/operation/common/utils_test.go
@@ -215,12 +215,6 @@ var _ = Describe("common", func() {
 		Entry("with special characters", "foo", "P+*4", `P*$8uOkv6+4`),
 	)
 
-	Describe("#ExtensionID", func() {
-		It("should return the expected identifier", func() {
-			Expect(ExtensionID("foo", "bar")).To(Equal("foo/bar"))
-		})
-	})
-
 	Describe("#DeleteDeploymentsHavingDeprecatedRoleLabelKey", func() {
 		var (
 			ctrl *gomock.Controller

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -449,7 +449,7 @@ func (o *Operation) CleanShootTaskErrorAndUpdateStatusLabel(ctx context.Context,
 
 	if len(o.Shoot.Info.Status.LastErrors) == 0 {
 		oldObj := o.Shoot.Info.DeepCopy()
-		kutil.SetMetaDataLabel(&o.Shoot.Info.ObjectMeta, common.ShootStatus, string(shoot.ComputeStatus(
+		kutil.SetMetaDataLabel(&o.Shoot.Info.ObjectMeta, v1beta1constants.ShootStatus, string(shoot.ComputeStatus(
 			o.Shoot.Info.Status.LastOperation,
 			o.Shoot.Info.Status.LastErrors,
 			o.Shoot.Info.Status.Conditions...,

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -497,22 +497,22 @@ func ComputeRequiredExtensions(shoot *gardencorev1beta1.Shoot, seed *gardencorev
 	requiredExtensions := sets.NewString()
 
 	if seed.Spec.Backup != nil {
-		requiredExtensions.Insert(common.ExtensionID(extensionsv1alpha1.BackupBucketResource, seed.Spec.Backup.Provider))
-		requiredExtensions.Insert(common.ExtensionID(extensionsv1alpha1.BackupEntryResource, seed.Spec.Backup.Provider))
+		requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.BackupBucketResource, seed.Spec.Backup.Provider))
+		requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.BackupEntryResource, seed.Spec.Backup.Provider))
 	}
 	// Hint: This is actually a temporary work-around to request the control plane extension of the seed provider type as
 	// it might come with webhooks that are configuring the exposure of shoot control planes. The ControllerRegistration resource
 	// does not reflect this today.
-	requiredExtensions.Insert(common.ExtensionID(extensionsv1alpha1.ControlPlaneResource, seed.Spec.Provider.Type))
+	requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.ControlPlaneResource, seed.Spec.Provider.Type))
 
-	requiredExtensions.Insert(common.ExtensionID(extensionsv1alpha1.ControlPlaneResource, shoot.Spec.Provider.Type))
-	requiredExtensions.Insert(common.ExtensionID(extensionsv1alpha1.InfrastructureResource, shoot.Spec.Provider.Type))
-	requiredExtensions.Insert(common.ExtensionID(extensionsv1alpha1.NetworkResource, shoot.Spec.Networking.Type))
-	requiredExtensions.Insert(common.ExtensionID(extensionsv1alpha1.WorkerResource, shoot.Spec.Provider.Type))
+	requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.ControlPlaneResource, shoot.Spec.Provider.Type))
+	requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.InfrastructureResource, shoot.Spec.Provider.Type))
+	requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.NetworkResource, shoot.Spec.Networking.Type))
+	requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.WorkerResource, shoot.Spec.Provider.Type))
 
 	var disabledExtensions = sets.NewString()
 	for _, extension := range shoot.Spec.Extensions {
-		id := common.ExtensionID(extensionsv1alpha1.ExtensionResource, extension.Type)
+		id := gardenerextensions.Id(extensionsv1alpha1.ExtensionResource, extension.Type)
 
 		if utils.IsTrue(extension.Disabled) {
 			disabledExtensions.Insert(id)
@@ -523,11 +523,11 @@ func ComputeRequiredExtensions(shoot *gardencorev1beta1.Shoot, seed *gardencorev
 
 	for _, pool := range shoot.Spec.Provider.Workers {
 		if pool.Machine.Image != nil {
-			requiredExtensions.Insert(common.ExtensionID(extensionsv1alpha1.OperatingSystemConfigResource, pool.Machine.Image.Name))
+			requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, pool.Machine.Image.Name))
 		}
 		if pool.CRI != nil {
 			for _, cr := range pool.CRI.ContainerRuntimes {
-				requiredExtensions.Insert(common.ExtensionID(extensionsv1alpha1.ContainerRuntimeResource, cr.Type))
+				requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.ContainerRuntimeResource, cr.Type))
 			}
 		}
 	}
@@ -536,23 +536,23 @@ func ComputeRequiredExtensions(shoot *gardencorev1beta1.Shoot, seed *gardencorev
 		if shoot.Spec.DNS != nil {
 			for _, provider := range shoot.Spec.DNS.Providers {
 				if provider.Type != nil && *provider.Type != core.DNSUnmanaged {
-					requiredExtensions.Insert(common.ExtensionID(dnsv1alpha1.DNSProviderKind, *provider.Type))
+					requiredExtensions.Insert(gardenerextensions.Id(dnsv1alpha1.DNSProviderKind, *provider.Type))
 				}
 			}
 		}
 
 		if internalDomain != nil && internalDomain.Provider != core.DNSUnmanaged {
-			requiredExtensions.Insert(common.ExtensionID(dnsv1alpha1.DNSProviderKind, internalDomain.Provider))
+			requiredExtensions.Insert(gardenerextensions.Id(dnsv1alpha1.DNSProviderKind, internalDomain.Provider))
 		}
 
 		if externalDomain != nil && externalDomain.Provider != core.DNSUnmanaged {
-			requiredExtensions.Insert(common.ExtensionID(dnsv1alpha1.DNSProviderKind, externalDomain.Provider))
+			requiredExtensions.Insert(gardenerextensions.Id(dnsv1alpha1.DNSProviderKind, externalDomain.Provider))
 		}
 	}
 
 	for _, controllerRegistration := range controllerRegistrationList {
 		for _, resource := range controllerRegistration.Spec.Resources {
-			id := common.ExtensionID(extensionsv1alpha1.ExtensionResource, resource.Type)
+			id := gardenerextensions.Id(extensionsv1alpha1.ExtensionResource, resource.Type)
 			if resource.Kind == extensionsv1alpha1.ExtensionResource && resource.GloballyEnabled != nil && *resource.GloballyEnabled && !disabledExtensions.Has(id) {
 				requiredExtensions.Insert(id)
 			}

--- a/pkg/operation/shoot/shoot_test.go
+++ b/pkg/operation/shoot/shoot_test.go
@@ -21,8 +21,8 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/extensions"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/garden"
 	. "github.com/gardener/gardener/pkg/operation/shoot"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -481,20 +481,20 @@ var _ = Describe("shoot", func() {
 			result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
 
 			Expect(result).To(Equal(sets.NewString(
-				common.ExtensionID(extensionsv1alpha1.BackupBucketResource, backupProvider),
-				common.ExtensionID(extensionsv1alpha1.BackupEntryResource, backupProvider),
-				common.ExtensionID(extensionsv1alpha1.ControlPlaneResource, seedProvider),
-				common.ExtensionID(extensionsv1alpha1.ControlPlaneResource, shootProvider),
-				common.ExtensionID(extensionsv1alpha1.InfrastructureResource, shootProvider),
-				common.ExtensionID(extensionsv1alpha1.NetworkResource, networkingType),
-				common.ExtensionID(extensionsv1alpha1.WorkerResource, shootProvider),
-				common.ExtensionID(extensionsv1alpha1.ExtensionResource, extensionType1),
-				common.ExtensionID(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
-				common.ExtensionID(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
-				common.ExtensionID(dnsv1alpha1.DNSProviderKind, dnsProviderType1),
-				common.ExtensionID(dnsv1alpha1.DNSProviderKind, dnsProviderType2),
-				common.ExtensionID(dnsv1alpha1.DNSProviderKind, dnsProviderType3),
-				common.ExtensionID(extensionsv1alpha1.ExtensionResource, extensionType2),
+				extensions.Id(extensionsv1alpha1.BackupBucketResource, backupProvider),
+				extensions.Id(extensionsv1alpha1.BackupEntryResource, backupProvider),
+				extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
+				extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.NetworkResource, networkingType),
+				extensions.Id(extensionsv1alpha1.WorkerResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType1),
+				extensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
+				extensions.Id(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
+				extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType1),
+				extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType2),
+				extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType3),
+				extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType2),
 			)))
 		})
 
@@ -504,18 +504,18 @@ var _ = Describe("shoot", func() {
 			result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
 
 			Expect(result).To(Equal(sets.NewString(
-				common.ExtensionID(extensionsv1alpha1.ControlPlaneResource, seedProvider),
-				common.ExtensionID(extensionsv1alpha1.ControlPlaneResource, shootProvider),
-				common.ExtensionID(extensionsv1alpha1.InfrastructureResource, shootProvider),
-				common.ExtensionID(extensionsv1alpha1.NetworkResource, networkingType),
-				common.ExtensionID(extensionsv1alpha1.WorkerResource, shootProvider),
-				common.ExtensionID(extensionsv1alpha1.ExtensionResource, extensionType1),
-				common.ExtensionID(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
-				common.ExtensionID(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
-				common.ExtensionID(dnsv1alpha1.DNSProviderKind, dnsProviderType1),
-				common.ExtensionID(dnsv1alpha1.DNSProviderKind, dnsProviderType2),
-				common.ExtensionID(dnsv1alpha1.DNSProviderKind, dnsProviderType3),
-				common.ExtensionID(extensionsv1alpha1.ExtensionResource, extensionType2),
+				extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
+				extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.NetworkResource, networkingType),
+				extensions.Id(extensionsv1alpha1.WorkerResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType1),
+				extensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
+				extensions.Id(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
+				extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType1),
+				extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType2),
+				extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType3),
+				extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType2),
 			)))
 		})
 
@@ -525,17 +525,17 @@ var _ = Describe("shoot", func() {
 			result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
 
 			Expect(result).To(Equal(sets.NewString(
-				common.ExtensionID(extensionsv1alpha1.BackupBucketResource, backupProvider),
-				common.ExtensionID(extensionsv1alpha1.BackupEntryResource, backupProvider),
-				common.ExtensionID(extensionsv1alpha1.ControlPlaneResource, seedProvider),
-				common.ExtensionID(extensionsv1alpha1.ControlPlaneResource, shootProvider),
-				common.ExtensionID(extensionsv1alpha1.InfrastructureResource, shootProvider),
-				common.ExtensionID(extensionsv1alpha1.NetworkResource, networkingType),
-				common.ExtensionID(extensionsv1alpha1.WorkerResource, shootProvider),
-				common.ExtensionID(extensionsv1alpha1.ExtensionResource, extensionType1),
-				common.ExtensionID(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
-				common.ExtensionID(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
-				common.ExtensionID(extensionsv1alpha1.ExtensionResource, extensionType2),
+				extensions.Id(extensionsv1alpha1.BackupBucketResource, backupProvider),
+				extensions.Id(extensionsv1alpha1.BackupEntryResource, backupProvider),
+				extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
+				extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.NetworkResource, networkingType),
+				extensions.Id(extensionsv1alpha1.WorkerResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType1),
+				extensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
+				extensions.Id(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
+				extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType2),
 			)))
 		})
 
@@ -548,19 +548,19 @@ var _ = Describe("shoot", func() {
 			result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
 
 			Expect(result).To(Equal(sets.NewString(
-				common.ExtensionID(extensionsv1alpha1.BackupBucketResource, backupProvider),
-				common.ExtensionID(extensionsv1alpha1.BackupEntryResource, backupProvider),
-				common.ExtensionID(extensionsv1alpha1.ControlPlaneResource, seedProvider),
-				common.ExtensionID(extensionsv1alpha1.ControlPlaneResource, shootProvider),
-				common.ExtensionID(extensionsv1alpha1.InfrastructureResource, shootProvider),
-				common.ExtensionID(extensionsv1alpha1.NetworkResource, networkingType),
-				common.ExtensionID(extensionsv1alpha1.WorkerResource, shootProvider),
-				common.ExtensionID(extensionsv1alpha1.ExtensionResource, extensionType1),
-				common.ExtensionID(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
-				common.ExtensionID(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
-				common.ExtensionID(dnsv1alpha1.DNSProviderKind, dnsProviderType1),
-				common.ExtensionID(dnsv1alpha1.DNSProviderKind, dnsProviderType2),
-				common.ExtensionID(dnsv1alpha1.DNSProviderKind, dnsProviderType3),
+				extensions.Id(extensionsv1alpha1.BackupBucketResource, backupProvider),
+				extensions.Id(extensionsv1alpha1.BackupEntryResource, backupProvider),
+				extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
+				extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.NetworkResource, networkingType),
+				extensions.Id(extensionsv1alpha1.WorkerResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType1),
+				extensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
+				extensions.Id(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
+				extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType1),
+				extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType2),
+				extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType3),
 			)))
 		})
 	})

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -18,13 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gardener/gardener/pkg/api"
-	"github.com/gardener/gardener/pkg/apis/core"
-	"github.com/gardener/gardener/pkg/apis/core/helper"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/apis/core/validation"
-	"github.com/gardener/gardener/pkg/operation/common"
-
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -34,6 +27,12 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
+
+	"github.com/gardener/gardener/pkg/api"
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/helper"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/apis/core/validation"
 )
 
 type shootStrategy struct {
@@ -85,16 +84,16 @@ func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
 		switch lastOperation.State {
 		case core.LastOperationStateFailed:
 			// The shoot state is failed and the retry annotation is set.
-			if val, ok := newShoot.Annotations[v1beta1constants.GardenerOperation]; ok && val == common.ShootOperationRetry {
+			if val, ok := newShoot.Annotations[v1beta1constants.GardenerOperation]; ok && val == v1beta1constants.ShootOperationRetry {
 				mustIncrease = true
 			}
 		default:
 			// The shoot state is not failed and the reconcile or rotate-credentials annotation is set.
 			if val, ok := newShoot.Annotations[v1beta1constants.GardenerOperation]; ok {
-				if val == common.ShootOperationReconcile {
+				if val == v1beta1constants.GardenerOperationReconcile {
 					mustIncrease = true
 				}
-				if val == common.ShootOperationRotateKubeconfigCredentials {
+				if val == v1beta1constants.ShootOperationRotateKubeconfigCredentials {
 					// We don't want to remove the annotation so that the controller-manager can pick it up and rotate
 					// the credentials. It has to remove the annotation after it is done.
 					return true

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/operation/common"
 	shootregistry "github.com/gardener/gardener/pkg/registry/core/shoot"
 
 	. "github.com/onsi/ginkgo"
@@ -293,7 +292,7 @@ var _ = Describe("Strategy", func() {
 					},
 				}
 				newShoot := oldShoot.DeepCopy()
-				newShoot.Annotations = map[string]string{v1beta1constants.GardenerOperation: common.ShootOperationRetry}
+				newShoot.Annotations = map[string]string{v1beta1constants.GardenerOperation: v1beta1constants.ShootOperationRetry}
 
 				shootregistry.Strategy.PrepareForUpdate(context.TODO(), newShoot, oldShoot)
 				Expect(newShoot.Generation).To(Equal(oldShoot.Generation + 1))
@@ -308,7 +307,7 @@ var _ = Describe("Strategy", func() {
 					},
 				}
 				newShoot := oldShoot.DeepCopy()
-				newShoot.Annotations = map[string]string{v1beta1constants.GardenerOperation: common.ShootOperationRetry}
+				newShoot.Annotations = map[string]string{v1beta1constants.GardenerOperation: v1beta1constants.ShootOperationRetry}
 
 				shootregistry.Strategy.PrepareForUpdate(context.TODO(), newShoot, oldShoot)
 				Expect(newShoot.Generation).To(Equal(oldShoot.Generation))
@@ -317,7 +316,7 @@ var _ = Describe("Strategy", func() {
 			It("should increase when the reconcile annotation gets set but no last operation", func() {
 				oldShoot := &core.Shoot{}
 				newShoot := oldShoot.DeepCopy()
-				newShoot.Annotations = map[string]string{v1beta1constants.GardenerOperation: common.ShootOperationReconcile}
+				newShoot.Annotations = map[string]string{v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile}
 
 				shootregistry.Strategy.PrepareForUpdate(context.TODO(), newShoot, oldShoot)
 				Expect(newShoot.Generation).To(Equal(oldShoot.Generation))
@@ -330,7 +329,7 @@ var _ = Describe("Strategy", func() {
 					},
 				}
 				newShoot := oldShoot.DeepCopy()
-				newShoot.Annotations = map[string]string{v1beta1constants.GardenerOperation: common.ShootOperationReconcile}
+				newShoot.Annotations = map[string]string{v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile}
 
 				shootregistry.Strategy.PrepareForUpdate(context.TODO(), newShoot, oldShoot)
 				Expect(newShoot.Generation).To(Equal(oldShoot.Generation + 1))
@@ -343,7 +342,7 @@ var _ = Describe("Strategy", func() {
 					},
 				}
 				newShoot := oldShoot.DeepCopy()
-				newShoot.Annotations = map[string]string{v1beta1constants.GardenerOperation: common.ShootOperationRotateKubeconfigCredentials}
+				newShoot.Annotations = map[string]string{v1beta1constants.GardenerOperation: v1beta1constants.ShootOperationRotateKubeconfigCredentials}
 
 				shootregistry.Strategy.PrepareForUpdate(context.TODO(), newShoot, oldShoot)
 				Expect(newShoot.Generation).To(Equal(oldShoot.Generation + 1))

--- a/pkg/utils/gardener/dns.go
+++ b/pkg/utils/gardener/dns.go
@@ -83,3 +83,17 @@ func GetDomainInfoFromAnnotations(annotations map[string]string) (provider strin
 func GetAPIServerDomain(domain string) string {
 	return fmt.Sprintf("%s.%s", APIServerFQDNPrefix, domain)
 }
+
+// GenerateDNSProviderName creates a name for the dns provider out of the passed `secretName` and `providerType`.
+func GenerateDNSProviderName(secretName, providerType string) string {
+	switch {
+	case secretName != "" && providerType != "":
+		return fmt.Sprintf("%s-%s", providerType, secretName)
+	case secretName != "":
+		return secretName
+	case providerType != "":
+		return providerType
+	default:
+		return ""
+	}
+}

--- a/pkg/utils/gardener/dns_test.go
+++ b/pkg/utils/gardener/dns_test.go
@@ -48,4 +48,15 @@ var _ = Describe("Dns", func() {
 			DNSExcludeZones: "d,e,f",
 		}, Equal("bar"), Equal("foo"), Equal([]string{"a", "b", "c"}), Equal([]string{"d", "e", "f"}), Not(HaveOccurred())),
 	)
+
+	DescribeTable("#GenerateDNSProviderName",
+		func(secretName, providerType, expectedName string) {
+			Expect(GenerateDNSProviderName(secretName, providerType)).To(Equal(expectedName))
+		},
+
+		Entry("both empty", "", "", ""),
+		Entry("secretName empty", "", "provider-type", "provider-type"),
+		Entry("providerType empty", "secret-name", "", "secret-name"),
+		Entry("both set", "secret-name", "provider-type", "provider-type-secret-name"),
+	)
 })

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -26,11 +26,11 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	corelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
 	clientkubernetes "github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/plugin/pkg/utils"
 
 	"github.com/hashicorp/go-multierror"
@@ -266,7 +266,7 @@ func (r *ReferenceManager) Admit(ctx context.Context, a admission.Attributes, o 
 			if annotations == nil {
 				annotations = map[string]string{}
 			}
-			annotations[common.GardenCreatedBy] = a.GetUserInfo().GetName()
+			annotations[v1beta1constants.GardenCreatedBy] = a.GetUserInfo().GetName()
 			shoot.Annotations = annotations
 		case admission.Update:
 			// skip verification if spec wasn't changed

--- a/plugin/pkg/global/resourcereferencemanager/admission_test.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission_test.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 
 	"github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
-	"github.com/gardener/gardener/pkg/operation/common"
 	. "github.com/gardener/gardener/plugin/pkg/global/resourcereferencemanager"
 
 	. "github.com/onsi/ginkgo"
@@ -495,12 +495,12 @@ var _ = Describe("resourcereferencemanager", func() {
 				user := &user.DefaultInfo{Name: allowedUser}
 				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, user)
 
-				Expect(shoot.Annotations).NotTo(HaveKeyWithValue(common.GardenCreatedBy, user.Name))
+				Expect(shoot.Annotations).NotTo(HaveKeyWithValue(v1beta1constants.GardenCreatedBy, user.Name))
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 				Expect(err).NotTo(HaveOccurred())
-				Expect(shoot.Annotations).To(HaveKeyWithValue(common.GardenCreatedBy, user.Name))
+				Expect(shoot.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenCreatedBy, user.Name))
 			})
 
 			It("should accept because all referenced objects have been found", func() {

--- a/plugin/pkg/plant/admission.go
+++ b/plugin/pkg/plant/admission.go
@@ -21,10 +21,10 @@ import (
 	"io"
 
 	"github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
-	"github.com/gardener/gardener/pkg/operation/common"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
 
@@ -134,7 +134,7 @@ func (a *Handler) Admit(ctx context.Context, attrs admission.Attributes, o admis
 	}
 
 	if attrs.GetOperation() == admission.Create {
-		metav1.SetMetaDataAnnotation(&plant.ObjectMeta, common.GardenCreatedBy, attrs.GetUserInfo().GetName())
+		metav1.SetMetaDataAnnotation(&plant.ObjectMeta, v1beta1constants.GardenCreatedBy, attrs.GetUserInfo().GetName())
 	}
 
 	return nil

--- a/plugin/pkg/plant/admission_test.go
+++ b/plugin/pkg/plant/admission_test.go
@@ -18,8 +18,8 @@ import (
 	"context"
 
 	"github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
-	"github.com/gardener/gardener/pkg/operation/common"
 	. "github.com/gardener/gardener/plugin/pkg/plant"
 
 	. "github.com/onsi/ginkgo"
@@ -81,12 +81,12 @@ var _ = Describe("Admission", func() {
 
 			attrs := admission.NewAttributesRecord(&plant, nil, core.Kind("Plant").WithVersion("version"), plant.Namespace, plant.Name, core.Resource("plants").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, defaultUserInfo)
 
-			Expect(plant.Annotations).NotTo(HaveKeyWithValue(common.GardenCreatedBy, defaultUserName))
+			Expect(plant.Annotations).NotTo(HaveKeyWithValue(v1beta1constants.GardenCreatedBy, defaultUserName))
 
 			err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(plant.Annotations).To(HaveKeyWithValue(common.GardenCreatedBy, defaultUserName))
+			Expect(plant.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenCreatedBy, defaultUserName))
 		})
 
 		It("should reject Plant resources referencing same kubeconfig secret", func() {

--- a/plugin/pkg/shoot/quotavalidator/admission.go
+++ b/plugin/pkg/shoot/quotavalidator/admission.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/helper"
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
@@ -452,11 +451,11 @@ func getShootWorkerResources(shoot *core.Shoot, cloudProfile *core.CloudProfile)
 }
 
 func lifetimeVerificationNeeded(new, old core.Shoot) bool {
-	oldLifetime, ok := old.Annotations[constants.ShootExpirationTimestamp]
+	oldLifetime, ok := old.Annotations[v1beta1constants.ShootExpirationTimestamp]
 	if !ok {
 		oldLifetime = old.CreationTimestamp.String()
 	}
-	newLifetime := new.Annotations[constants.ShootExpirationTimestamp]
+	newLifetime := new.Annotations[v1beta1constants.ShootExpirationTimestamp]
 	return oldLifetime != newLifetime
 }
 

--- a/plugin/pkg/shoot/quotavalidator/admission.go
+++ b/plugin/pkg/shoot/quotavalidator/admission.go
@@ -23,10 +23,11 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/helper"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	corelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
-	"github.com/gardener/gardener/pkg/operation/common"
 	utiltime "github.com/gardener/gardener/pkg/utils/time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -220,7 +221,7 @@ func (q *QuotaValidator) Validate(ctx context.Context, a admission.Attributes, o
 	}
 
 	// Admit Shoot lifetime changes
-	if lifetime, exists := shoot.Annotations[common.ShootExpirationTimestamp]; checkLifetime && exists && maxShootLifetime != nil {
+	if lifetime, exists := shoot.Annotations[v1beta1constants.ShootExpirationTimestamp]; checkLifetime && exists && maxShootLifetime != nil {
 		var (
 			plannedExpirationTime     time.Time
 			maxPossibleExpirationTime time.Time
@@ -451,11 +452,11 @@ func getShootWorkerResources(shoot *core.Shoot, cloudProfile *core.CloudProfile)
 }
 
 func lifetimeVerificationNeeded(new, old core.Shoot) bool {
-	oldLifetime, ok := old.Annotations[common.ShootExpirationTimestamp]
+	oldLifetime, ok := old.Annotations[constants.ShootExpirationTimestamp]
 	if !ok {
 		oldLifetime = old.CreationTimestamp.String()
 	}
-	newLifetime := new.Annotations[common.ShootExpirationTimestamp]
+	newLifetime := new.Annotations[constants.ShootExpirationTimestamp]
 	return oldLifetime != newLifetime
 }
 

--- a/plugin/pkg/shoot/quotavalidator/admission_test.go
+++ b/plugin/pkg/shoot/quotavalidator/admission_test.go
@@ -19,9 +19,9 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	"github.com/gardener/gardener/pkg/logger"
-	"github.com/gardener/gardener/pkg/operation/common"
 	mocktime "github.com/gardener/gardener/pkg/utils/time/mock"
 	. "github.com/gardener/gardener/plugin/pkg/shoot/quotavalidator"
 
@@ -387,7 +387,7 @@ var _ = Describe("quotavalidator", func() {
 			})
 
 			It("should pass as shoot expiration time can be extended", func() {
-				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, common.ShootExpirationTimestamp, "2018-01-02T00:00:00+00:00") // plus 1 day compared to time.Now()
+				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, v1beta1constants.ShootExpirationTimestamp, "2018-01-02T00:00:00+00:00") // plus 1 day compared to time.Now()
 				attrs := admission.NewAttributesRecord(&shoot, &oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
 				now, err := time.Parse(time.RFC3339, "2018-01-01T00:00:00+00:00")
@@ -399,7 +399,7 @@ var _ = Describe("quotavalidator", func() {
 			})
 
 			It("should fail as shoots expiration time can’t be extended, because requested time higher then the minimum .spec.clusterLifetimeDays among the quotas", func() {
-				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, common.ShootExpirationTimestamp, "2018-01-05T00:00:00+00:00") // plus 4 days compared to time.Now()
+				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, v1beta1constants.ShootExpirationTimestamp, "2018-01-05T00:00:00+00:00") // plus 4 days compared to time.Now()
 				attrs := admission.NewAttributesRecord(&shoot, &oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
 				now, err := time.Parse(time.RFC3339, "2018-01-01T00:00:00+00:00")
@@ -411,7 +411,7 @@ var _ = Describe("quotavalidator", func() {
 			})
 
 			It("should fail as shoots expiration time can’t be extended, because requested time higher then the maximum .spec.clusterLifetimeDays among the quotas", func() {
-				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, common.ShootExpirationTimestamp, "2018-01-09T00:00:00+00:00") // plus 8 days compared to time.Now()
+				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, v1beta1constants.ShootExpirationTimestamp, "2018-01-09T00:00:00+00:00") // plus 8 days compared to time.Now()
 				attrs := admission.NewAttributesRecord(&shoot, &oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
 				now, err := time.Parse(time.RFC3339, "2018-01-01T00:00:00+00:00")

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -30,7 +30,6 @@ import (
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	corelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
@@ -347,7 +346,7 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 	if shoot.Spec.Maintenance != nil && utils.IsTrue(shoot.Spec.Maintenance.ConfineSpecUpdateRollout) &&
 		!apiequality.Semantic.DeepEqual(oldShoot.Spec, shoot.Spec) &&
 		shoot.Status.LastOperation != nil && shoot.Status.LastOperation.State == core.LastOperationStateFailed {
-		metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, common.FailedShootNeedsRetryOperation, "true")
+		metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, v1beta1constants.FailedShootNeedsRetryOperation, "true")
 	}
 
 	if shoot.DeletionTimestamp == nil {
@@ -945,5 +944,5 @@ func addInfrastructureDeploymentTask(shoot *core.Shoot) {
 	if shoot.ObjectMeta.Annotations == nil {
 		shoot.ObjectMeta.Annotations = make(map[string]string)
 	}
-	controllerutils.AddTasks(shoot.ObjectMeta.Annotations, common.ShootTaskDeployInfrastructure)
+	controllerutils.AddTasks(shoot.ObjectMeta.Annotations, v1beta1constants.ShootTaskDeployInfrastructure)
 }

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -32,10 +32,10 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/operation/common"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	. "github.com/gardener/gardener/plugin/pkg/shoot/validator"
@@ -748,27 +748,27 @@ var _ = Describe("validator", func() {
 				Entry(
 					"should add annotation for failed shoot",
 					specUpdate, confineEnabled, confineEnabled, operationFaild, operationFaild,
-					HaveKeyWithValue(common.FailedShootNeedsRetryOperation, "true"),
+					HaveKeyWithValue(v1beta1constants.FailedShootNeedsRetryOperation, "true"),
 				),
 				Entry(
 					"should not add annotation for failed shoot because of missing spec change",
 					!specUpdate, confineEnabled, confineEnabled, operationFaild, operationFaild,
-					Not(HaveKey(common.FailedShootNeedsRetryOperation)),
+					Not(HaveKey(v1beta1constants.FailedShootNeedsRetryOperation)),
 				),
 				Entry(
 					"should not add annotation for succeeded shoot",
 					specUpdate, confineEnabled, confineEnabled, operationFaild, operationSucceeded,
-					Not(HaveKey(common.FailedShootNeedsRetryOperation)),
+					Not(HaveKey(v1beta1constants.FailedShootNeedsRetryOperation)),
 				),
 				Entry(
 					"should not add annotation for shoot w/o confine spec roll-out enabled",
 					specUpdate, confineEnabled, !confineEnabled, operationFaild, operationFaild,
-					Not(HaveKey(common.FailedShootNeedsRetryOperation)),
+					Not(HaveKey(v1beta1constants.FailedShootNeedsRetryOperation)),
 				),
 				Entry(
 					"should not add annotation for shoot w/o last operation",
 					specUpdate, confineEnabled, confineEnabled, nil, nil,
-					Not(HaveKey(common.FailedShootNeedsRetryOperation)),
+					Not(HaveKey(v1beta1constants.FailedShootNeedsRetryOperation)),
 				),
 			)
 		})
@@ -917,7 +917,7 @@ var _ = Describe("validator", func() {
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 				Expect(err).To(Not(HaveOccurred()))
-				Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, common.ShootTaskDeployInfrastructure)).To(BeTrue())
+				Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, v1beta1constants.ShootTaskDeployInfrastructure)).To(BeTrue())
 			})
 
 			It("should add deploy infrastructure task because shoot is waking up from hibernation", func() {
@@ -932,7 +932,7 @@ var _ = Describe("validator", func() {
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 				Expect(err).To(Not(HaveOccurred()))
-				Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, common.ShootTaskDeployInfrastructure)).To(BeTrue())
+				Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, v1beta1constants.ShootTaskDeployInfrastructure)).To(BeTrue())
 			})
 
 			It("should add deploy infrastructure task because spec has changed", func() {
@@ -944,7 +944,7 @@ var _ = Describe("validator", func() {
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 				Expect(err).To(Not(HaveOccurred()))
-				Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, common.ShootTaskDeployInfrastructure)).To(BeTrue())
+				Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, v1beta1constants.ShootTaskDeployInfrastructure)).To(BeTrue())
 			})
 
 			It("should not add deploy infrastructure task because spec has not changed", func() {
@@ -952,7 +952,7 @@ var _ = Describe("validator", func() {
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 				Expect(err).To(Not(HaveOccurred()))
-				Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, common.ShootTaskDeployInfrastructure)).ToNot(BeTrue())
+				Expect(controllerutils.HasTask(shoot.ObjectMeta.Annotations, v1beta1constants.ShootTaskDeployInfrastructure)).ToNot(BeTrue())
 			})
 		})
 

--- a/test/integration/shoots/maintenance/maintenance_operations.go
+++ b/test/integration/shoots/maintenance/maintenance_operations.go
@@ -25,7 +25,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/logger"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
@@ -168,7 +167,7 @@ func TryUpdateShootForMachineImageMaintenance(ctx context.Context, gardenClient 
 func StartShootMaintenance(ctx context.Context, gardenClient client.Client, shootToUpdate *gardencorev1beta1.Shoot) error {
 	shoot := &gardencorev1beta1.Shoot{ObjectMeta: shootToUpdate.ObjectMeta}
 	return kutil.TryUpdate(ctx, retry.DefaultBackoff, gardenClient, shoot, func() error {
-		shoot.Annotations[v1beta1constants.GardenerOperation] = common.ShootOperationMaintain
+		shoot.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.ShootOperationMaintain
 		return nil
 	})
 }

--- a/test/integration/shoots/operations/operations.go
+++ b/test/integration/shoots/operations/operations.go
@@ -50,7 +50,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/framework/applications"
 
@@ -95,14 +94,14 @@ var _ = ginkgo.Describe("Shoot operation testing", func() {
 	f.Default().Serial().CIt("should fully maintain and reconcile a shoot cluster", func(ctx context.Context) {
 		ginkgo.By("maintain shoot")
 		err := f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
-			shoot.Annotations[v1beta1constants.GardenerOperation] = common.ShootOperationMaintain
+			shoot.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.ShootOperationMaintain
 			return nil
 		})
 		framework.ExpectNoError(err)
 
 		ginkgo.By("reconcile shoot")
 		err = f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
-			shoot.Annotations[v1beta1constants.GardenerOperation] = common.ShootOperationReconcile
+			shoot.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationReconcile
 			return nil
 		})
 		framework.ExpectNoError(err)
@@ -123,7 +122,7 @@ var _ = ginkgo.Describe("Shoot operation testing", func() {
 		framework.ExpectNoError(err)
 
 		err = f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
-			shoot.Annotations[v1beta1constants.GardenerOperation] = common.ShootOperationRotateKubeconfigCredentials
+			shoot.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.ShootOperationRotateKubeconfigCredentials
 			return nil
 		})
 		framework.ExpectNoError(err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR decouples the `gardener-apiserver` from the `pkg/operation/*` packages by moving some utility functions and constants to more appropriate packages.

/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
