### PR TITLE
First steps towards removal of duplication in extension controllers

### DIFF
--- a/extensions/pkg/controller/backupbucket/controller.go
+++ b/extensions/pkg/controller/backupbucket/controller.go
@@ -75,7 +75,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 // Add creates a new BackupBucket Controller and adds it to the Manager.
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
-	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
+	args.ControllerOptions.Reconciler = NewReconciler(args.Actuator)
 	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
 	return add(mgr, args, predicates)
 }

--- a/extensions/pkg/controller/backupbucket/reconciler.go
+++ b/extensions/pkg/controller/backupbucket/reconciler.go
@@ -20,16 +20,13 @@ import (
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -40,18 +37,22 @@ type reconciler struct {
 	logger   logr.Logger
 	actuator Actuator
 
-	client client.Client
-	reader client.Reader
+	client        client.Client
+	reader        client.Reader
+	statusUpdater extensionscontroller.StatusUpdater
 }
 
 // NewReconciler creates a new reconcile.Reconciler that reconciles
 // BackupBucket resources of Gardener's `extensions.gardener.cloud` API group.
-func NewReconciler(mgr manager.Manager, actuator Actuator) reconcile.Reconciler {
+func NewReconciler(actuator Actuator) reconcile.Reconciler {
+	logger := log.Log.WithName(ControllerName)
+
 	return extensionscontroller.OperationAnnotationWrapper(
 		func() client.Object { return &extensionsv1alpha1.BackupBucket{} },
 		&reconciler{
-			logger:   log.Log.WithName(ControllerName),
-			actuator: actuator,
+			logger:        logger,
+			actuator:      actuator,
+			statusUpdater: extensionscontroller.NewStatusUpdater(logger),
 		},
 	)
 }
@@ -62,6 +63,7 @@ func (r *reconciler) InjectFunc(f inject.Func) error {
 
 func (r *reconciler) InjectClient(client client.Client) error {
 	r.client = client
+	r.statusUpdater.InjectClient(client)
 	return nil
 }
 
@@ -92,7 +94,7 @@ func (r *reconciler) reconcile(ctx context.Context, bb *extensionsv1alpha1.Backu
 	}
 
 	operationType := gardencorev1beta1helper.ComputeOperationType(bb.ObjectMeta, bb.Status.LastOperation)
-	if err := r.updateStatusProcessing(ctx, bb, operationType, "Reconciling the backupbucket"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, bb, operationType, "Reconciling the backupbucket"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -106,14 +108,11 @@ func (r *reconciler) reconcile(ctx context.Context, bb *extensionsv1alpha1.Backu
 
 	r.logger.Info("Starting the reconciliation of backupbucket", "backupbucket", bb.Name)
 	if err := r.actuator.Reconcile(ctx, bb); err != nil {
-		msg := "Error reconciling backupbucket"
-		_ = r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), bb, operationType, msg)
+		_ = r.statusUpdater.Error(ctx, bb, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling backupbucket")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	msg := "Successfully reconciled backupbucket"
-	r.logger.Info(msg, "backupbucket", bb.Name)
-	if err := r.updateStatusSuccess(ctx, bb, operationType, msg); err != nil {
+	if err := r.statusUpdater.Success(ctx, bb, operationType, "Successfully reconciled backupbucket"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -127,20 +126,17 @@ func (r *reconciler) delete(ctx context.Context, bb *extensionsv1alpha1.BackupBu
 	}
 
 	operationType := gardencorev1beta1helper.ComputeOperationType(bb.ObjectMeta, bb.Status.LastOperation)
-	if err := r.updateStatusProcessing(ctx, bb, operationType, "Deleting the backupbucket"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, bb, operationType, "Deleting the backupbucket"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	r.logger.Info("Starting the deletion of backupbucket", "backupbucket", bb.Name)
 	if err := r.actuator.Delete(ctx, bb); err != nil {
-		msg := "Error deleting backupbucket"
-		_ = r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), bb, operationType, msg)
+		_ = r.statusUpdater.Error(ctx, bb, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error deleting backupbucket")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	msg := "Successfully deleted backupbucket"
-	r.logger.Info(msg, "backupbucket", bb.Name)
-	if err := r.updateStatusSuccess(ctx, bb, operationType, msg); err != nil {
+	if err := r.statusUpdater.Success(ctx, bb, operationType, "Successfully deleted backupbucket"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -158,27 +154,4 @@ func (r *reconciler) delete(ctx context.Context, bb *extensionsv1alpha1.BackupBu
 	}
 
 	return reconcile.Result{}, nil
-}
-
-func (r *reconciler) updateStatusProcessing(ctx context.Context, bb *extensionsv1alpha1.BackupBucket, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, bb, func() error {
-		bb.Status.LastOperation = extensionscontroller.LastOperation(lastOperationType, gardencorev1beta1.LastOperationStateProcessing, 1, description)
-		return nil
-	})
-}
-
-func (r *reconciler) updateStatusError(ctx context.Context, err error, bb *extensionsv1alpha1.BackupBucket, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, bb, func() error {
-		bb.Status.ObservedGeneration = bb.Generation
-		bb.Status.LastOperation, bb.Status.LastError = extensionscontroller.ReconcileError(lastOperationType, gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, err)), 50, gardencorev1beta1helper.ExtractErrorCodes(gardencorev1beta1helper.DetermineError(err, err.Error()))...)
-		return nil
-	})
-}
-
-func (r *reconciler) updateStatusSuccess(ctx context.Context, bb *extensionsv1alpha1.BackupBucket, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, bb, func() error {
-		bb.Status.ObservedGeneration = bb.Generation
-		bb.Status.LastOperation, bb.Status.LastError = extensionscontroller.ReconcileSucceeded(lastOperationType, description)
-		return nil
-	})
 }

--- a/extensions/pkg/controller/backupentry/controller.go
+++ b/extensions/pkg/controller/backupentry/controller.go
@@ -73,7 +73,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 // Add creates a new BackupEntry Controller and adds it to the Manager.
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
-	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
+	args.ControllerOptions.Reconciler = NewReconciler(args.Actuator)
 	predicates := extensionspredicate.AddTypePredicate(args.Predicates, args.Type)
 	return add(mgr, args, predicates)
 }

--- a/extensions/pkg/controller/containerruntime/controller.go
+++ b/extensions/pkg/controller/containerruntime/controller.go
@@ -59,7 +59,7 @@ type AddArgs struct {
 
 // Add adds an ContainerRuntime controller to the given manager using the given AddArgs.
 func Add(mgr manager.Manager, args AddArgs) error {
-	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
+	args.ControllerOptions.Reconciler = NewReconciler(args.Actuator)
 	return add(mgr, args)
 }
 

--- a/extensions/pkg/controller/containerruntime/reconciler.go
+++ b/extensions/pkg/controller/containerruntime/reconciler.go
@@ -20,12 +20,9 @@ import (
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 
@@ -43,18 +40,22 @@ type reconciler struct {
 	logger   logr.Logger
 	actuator Actuator
 
-	client client.Client
-	reader client.Reader
+	client        client.Client
+	reader        client.Reader
+	statusUpdater extensionscontroller.StatusUpdater
 }
 
 // NewReconciler creates a new reconcile.Reconciler that reconciles
 // ContainerRuntime resources of Gardener's `extensions.gardener.cloud` API group.
-func NewReconciler(mgr manager.Manager, actuator Actuator) reconcile.Reconciler {
+func NewReconciler(actuator Actuator) reconcile.Reconciler {
+	logger := log.Log.WithName(ControllerName)
+
 	return extensionscontroller.OperationAnnotationWrapper(
 		func() client.Object { return &extensionsv1alpha1.ContainerRuntime{} },
 		&reconciler{
-			logger:   log.Log.WithName(ControllerName),
-			actuator: actuator,
+			logger:        logger,
+			actuator:      actuator,
+			statusUpdater: extensionscontroller.NewStatusUpdater(logger),
 		},
 	)
 }
@@ -67,6 +68,7 @@ func (r *reconciler) InjectFunc(f inject.Func) error {
 // InjectClient injects the controller runtime client into the reconciler.
 func (r *reconciler) InjectClient(client client.Client) error {
 	r.client = client
+	r.statusUpdater.InjectClient(client)
 	return nil
 }
 
@@ -115,18 +117,19 @@ func (r *reconciler) reconcile(ctx context.Context, cr *extensionsv1alpha1.Conta
 		return reconcile.Result{}, err
 	}
 
-	if err := r.updateStatusProcessing(ctx, cr, operationType, "Reconciling the container runtime"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, cr, operationType, "Reconciling the container runtime"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Reconcile(ctx, cr, cluster); err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), cr, operationType, "Error reconciling container runtime"))
+		_ = r.statusUpdater.Error(ctx, cr, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling container runtime")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, cr, operationType, "Successfully reconciled container runtime"); err != nil {
+	if err := r.statusUpdater.Success(ctx, cr, operationType, "Successfully reconciled container runtime"); err != nil {
 		return reconcile.Result{}, err
 	}
+
 	return reconcile.Result{}, nil
 }
 
@@ -135,24 +138,23 @@ func (r *reconciler) restore(ctx context.Context, cr *extensionsv1alpha1.Contain
 		return reconcile.Result{}, err
 	}
 
-	if err := r.updateStatusProcessing(ctx, cr, gardencorev1beta1.LastOperationTypeRestore, "Restoring the container runtime"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, cr, gardencorev1beta1.LastOperationTypeRestore, "Restoring the container runtime"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Restore(ctx, cr, cluster); err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), cr, gardencorev1beta1.LastOperationTypeRestore, "Error restoring container runtime"))
+		_ = r.statusUpdater.Error(ctx, cr, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring container runtime")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, cr, gardencorev1beta1.LastOperationTypeRestore, "Successfully restored container runtime"); err != nil {
+	if err := r.statusUpdater.Success(ctx, cr, gardencorev1beta1.LastOperationTypeRestore, "Successfully restored container runtime"); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	// remove operation annotation 'restore'
 	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, cr, v1beta1constants.GardenerOperation); err != nil {
-		msg := "Error removing annotation from ContainerRuntime"
-		return reconcile.Result{}, fmt.Errorf("%s: %+v", msg, err)
+		return reconcile.Result{}, fmt.Errorf("error removing annotation from ContainerRuntime: %+v", err)
 	}
+
 	return reconcile.Result{}, nil
 }
 
@@ -162,16 +164,16 @@ func (r *reconciler) delete(ctx context.Context, cr *extensionsv1alpha1.Containe
 		return reconcile.Result{}, nil
 	}
 
-	if err := r.updateStatusProcessing(ctx, cr, gardencorev1beta1.LastOperationTypeDelete, "Deleting the container runtime"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, cr, gardencorev1beta1.LastOperationTypeDelete, "Deleting the container runtime"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Delete(ctx, cr, cluster); err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), cr, gardencorev1beta1.LastOperationTypeDelete, "Error deleting container runtime"))
+		_ = r.statusUpdater.Error(ctx, cr, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeDelete, "Error deleting container runtime")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, cr, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted container runtime"); err != nil {
+	if err := r.statusUpdater.Success(ctx, cr, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted container runtime"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -184,16 +186,16 @@ func (r *reconciler) delete(ctx context.Context, cr *extensionsv1alpha1.Containe
 }
 
 func (r *reconciler) migrate(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
-	if err := r.updateStatusProcessing(ctx, cr, gardencorev1beta1.LastOperationTypeMigrate, "Migrating the container runtime"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, cr, gardencorev1beta1.LastOperationTypeMigrate, "Migrating the container runtime"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Migrate(ctx, cr, cluster); err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), cr, gardencorev1beta1.LastOperationTypeMigrate, "Error migrating container runtime"))
+		_ = r.statusUpdater.Error(ctx, cr, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating container runtime")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, cr, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated container runtime"); err != nil {
+	if err := r.statusUpdater.Success(ctx, cr, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated container runtime"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -202,36 +204,9 @@ func (r *reconciler) migrate(ctx context.Context, cr *extensionsv1alpha1.Contain
 		return reconcile.Result{}, fmt.Errorf("error removing finalizers from the container runtime resource: %+v", err)
 	}
 
-	// remove operation annotation 'migrate'
 	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, cr, v1beta1constants.GardenerOperation); err != nil {
-		msg := "Error removing annotation from ContainerRuntime"
-		return reconcile.Result{}, fmt.Errorf("%s: %+v", msg, err)
+		return reconcile.Result{}, fmt.Errorf("error removing annotation from ContainerRuntime: %+v", err)
 	}
 
 	return reconcile.Result{}, nil
-}
-
-func (r *reconciler) updateStatusProcessing(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	r.logger.Info(description, "containerruntime", cr.Name)
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, cr, func() error {
-		cr.Status.LastOperation = extensionscontroller.LastOperation(lastOperationType, gardencorev1beta1.LastOperationStateProcessing, 1, description)
-		return nil
-	})
-}
-
-func (r *reconciler) updateStatusError(ctx context.Context, err error, cr *extensionsv1alpha1.ContainerRuntime, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, cr, func() error {
-		cr.Status.ObservedGeneration = cr.Generation
-		cr.Status.LastOperation, cr.Status.LastError = extensionscontroller.ReconcileError(lastOperationType, gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, err)), 50, gardencorev1beta1helper.ExtractErrorCodes(gardencorev1beta1helper.DetermineError(err, err.Error()))...)
-		return nil
-	})
-}
-
-func (r *reconciler) updateStatusSuccess(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	r.logger.Info(description, "containerruntime", cr.Name)
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, cr, func() error {
-		cr.Status.ObservedGeneration = cr.Generation
-		cr.Status.LastOperation, cr.Status.LastError = extensionscontroller.ReconcileSucceeded(lastOperationType, description)
-		return nil
-	})
 }

--- a/extensions/pkg/controller/controlplane/controller.go
+++ b/extensions/pkg/controller/controlplane/controller.go
@@ -73,7 +73,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 // Add creates a new ControlPlane Controller and adds it to the Manager.
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
-	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
+	args.ControllerOptions.Reconciler = NewReconciler(args.Actuator)
 
 	ctrl, err := controller.New(ControllerName, mgr, args.ControllerOptions)
 	if err != nil {

--- a/extensions/pkg/controller/controlplane/reconciler.go
+++ b/extensions/pkg/controller/controlplane/reconciler.go
@@ -21,11 +21,9 @@ import (
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 
@@ -44,18 +42,22 @@ type reconciler struct {
 	logger   logr.Logger
 	actuator Actuator
 
-	client client.Client
-	reader client.Reader
+	client        client.Client
+	reader        client.Reader
+	statusUpdater extensionscontroller.StatusUpdater
 }
 
 // NewReconciler creates a new reconcile.Reconciler that reconciles
 // controlplane resources of Gardener's `extensions.gardener.cloud` API group.
-func NewReconciler(mgr manager.Manager, actuator Actuator) reconcile.Reconciler {
+func NewReconciler(actuator Actuator) reconcile.Reconciler {
+	logger := log.Log.WithName(ControllerName)
+
 	return extensionscontroller.OperationAnnotationWrapper(
 		func() client.Object { return &extensionsv1alpha1.ControlPlane{} },
 		&reconciler{
-			logger:   log.Log.WithName(ControllerName),
-			actuator: actuator,
+			logger:        logger,
+			actuator:      actuator,
+			statusUpdater: extensionscontroller.NewStatusUpdater(logger),
 		},
 	)
 }
@@ -66,6 +68,7 @@ func (r *reconciler) InjectFunc(f inject.Func) error {
 
 func (r *reconciler) InjectClient(client client.Client) error {
 	r.client = client
+	r.statusUpdater.InjectClient(client)
 	return nil
 }
 
@@ -114,21 +117,18 @@ func (r *reconciler) reconcile(ctx context.Context, cp *extensionsv1alpha1.Contr
 		return reconcile.Result{}, err
 	}
 
-	if err := r.updateStatusProcessing(ctx, cp, operationType, "Reconciling the controlplane"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, cp, operationType, "Reconciling the controlplane"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	r.logger.Info("Starting the reconciliation of controlplane", "controlplane", cp.Name)
 	requeue, err := r.actuator.Reconcile(ctx, cp, cluster)
 	if err != nil {
-		msg := "Error reconciling controlplane"
-		_ = r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), cp, operationType, msg)
+		_ = r.statusUpdater.Error(ctx, cp, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling controlplane")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	msg := "Successfully reconciled controlplane"
-	r.logger.Info(msg, "controlplane", cp.Name)
-	if err := r.updateStatusSuccess(ctx, cp, operationType, msg); err != nil {
+	if err := r.statusUpdater.Success(ctx, cp, operationType, "Successfully reconciled controlplane"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -143,21 +143,18 @@ func (r *reconciler) restore(ctx context.Context, cp *extensionsv1alpha1.Control
 		return reconcile.Result{}, err
 	}
 
-	if err := r.updateStatusProcessing(ctx, cp, gardencorev1beta1.LastOperationTypeRestore, "Restoring the controlplane"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, cp, gardencorev1beta1.LastOperationTypeRestore, "Restoring the controlplane"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	r.logger.Info("Starting the restoration of controlplane", "controlplane", cp.Name)
 	requeue, err := r.actuator.Restore(ctx, cp, cluster)
 	if err != nil {
-		msg := "Error restoring controlplane"
-		_ = r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), cp, gardencorev1beta1.LastOperationTypeRestore, msg)
+		_ = r.statusUpdater.Error(ctx, cp, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring controlplane")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	msg := "Successfully restored controlplane"
-	r.logger.Info(msg, "controlplane", cp.Name)
-	if err := r.updateStatusSuccess(ctx, cp, gardencorev1beta1.LastOperationTypeRestore, msg); err != nil {
+	if err := r.statusUpdater.Success(ctx, cp, gardencorev1beta1.LastOperationTypeRestore, "Successfully restored controlplane"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -165,30 +162,25 @@ func (r *reconciler) restore(ctx context.Context, cp *extensionsv1alpha1.Control
 		return reconcile.Result{RequeueAfter: RequeueAfter}, nil
 	}
 
-	// remove operation annotation 'restore'
 	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, cp, v1beta1constants.GardenerOperation); err != nil {
-		msg := "Error removing annotation from ControlPlane"
-		return reconcile.Result{}, fmt.Errorf("%s: %+v", msg, err)
+		return reconcile.Result{}, fmt.Errorf("error removing annotation from ControlPlane: %+v", err)
 	}
 
 	return reconcile.Result{}, nil
 }
 
 func (r *reconciler) migrate(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
-	if err := r.updateStatusProcessing(ctx, cp, gardencorev1beta1.LastOperationTypeMigrate, "Migrating the controlplane"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, cp, gardencorev1beta1.LastOperationTypeMigrate, "Migrating the controlplane"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	r.logger.Info("Starting the migration of controlplane", "controlplane", cp.Name)
 	if err := r.actuator.Migrate(ctx, cp, cluster); err != nil {
-		msg := "Error migrating controlplane"
-		_ = r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), cp, gardencorev1beta1.LastOperationTypeMigrate, msg)
+		_ = r.statusUpdater.Error(ctx, cp, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating controlplane")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	msg := "Successfully migrated controlplane"
-	r.logger.Info(msg, "controlplane", cp.Name)
-	if err := r.updateStatusSuccess(ctx, cp, gardencorev1beta1.LastOperationTypeMigrate, msg); err != nil {
+	if err := r.statusUpdater.Success(ctx, cp, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated controlplane"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -197,10 +189,8 @@ func (r *reconciler) migrate(ctx context.Context, cp *extensionsv1alpha1.Control
 		return reconcile.Result{}, fmt.Errorf("error removing finalizers from ControlPlane: %+v", err)
 	}
 
-	// remove operation annotation 'migrate'
 	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, cp, v1beta1constants.GardenerOperation); err != nil {
-		msg := "Error removing annotation from ControlPlane"
-		return reconcile.Result{}, fmt.Errorf("%s: %+v", msg, err)
+		return reconcile.Result{}, fmt.Errorf("error removing annotation from ControlPlane: %+v", err)
 	}
 
 	return reconcile.Result{}, nil
@@ -213,20 +203,17 @@ func (r *reconciler) delete(ctx context.Context, cp *extensionsv1alpha1.ControlP
 	}
 
 	operationType := gardencorev1beta1helper.ComputeOperationType(cp.ObjectMeta, cp.Status.LastOperation)
-	if err := r.updateStatusProcessing(ctx, cp, operationType, "Deleting the controlplane"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, cp, operationType, "Deleting the controlplane"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	r.logger.Info("Starting the deletion of controlplane", "controlplane", cp.Name)
 	if err := r.actuator.Delete(ctx, cp, cluster); err != nil {
-		msg := "Error deleting controlplane"
-		_ = r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), cp, operationType, msg)
+		_ = r.statusUpdater.Error(ctx, cp, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error deleting controlplane")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	msg := "Successfully deleted controlplane"
-	r.logger.Info(msg, "controlplane", cp.Name)
-	if err := r.updateStatusSuccess(ctx, cp, operationType, msg); err != nil {
+	if err := r.statusUpdater.Success(ctx, cp, operationType, "Successfully deleted controlplane"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -236,27 +223,4 @@ func (r *reconciler) delete(ctx context.Context, cp *extensionsv1alpha1.ControlP
 	}
 
 	return reconcile.Result{}, nil
-}
-
-func (r *reconciler) updateStatusProcessing(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, cp, func() error {
-		cp.Status.LastOperation = extensionscontroller.LastOperation(lastOperationType, gardencorev1beta1.LastOperationStateProcessing, 1, description)
-		return nil
-	})
-}
-
-func (r *reconciler) updateStatusError(ctx context.Context, err error, cp *extensionsv1alpha1.ControlPlane, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, cp, func() error {
-		cp.Status.ObservedGeneration = cp.Generation
-		cp.Status.LastOperation, cp.Status.LastError = extensionscontroller.ReconcileError(lastOperationType, gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, err)), 50, gardencorev1beta1helper.ExtractErrorCodes(gardencorev1beta1helper.DetermineError(err, err.Error()))...)
-		return nil
-	})
-}
-
-func (r *reconciler) updateStatusSuccess(ctx context.Context, cp *extensionsv1alpha1.ControlPlane, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, cp, func() error {
-		cp.Status.ObservedGeneration = cp.Generation
-		cp.Status.LastOperation, cp.Status.LastError = extensionscontroller.ReconcileSucceeded(lastOperationType, description)
-		return nil
-	})
 }

--- a/extensions/pkg/controller/extension/reconciler.go
+++ b/extensions/pkg/controller/extension/reconciler.go
@@ -118,14 +118,14 @@ func add(mgr manager.Manager, args AddArgs) error {
 // reconciler reconciles Extension resources of Gardener's
 // `extensions.gardener.cloud` API group.
 type reconciler struct {
-	logger        logr.Logger
-	actuator      Actuator
-	finalizerName string
+	logger   logr.Logger
+	actuator Actuator
 
 	client client.Client
 	reader client.Reader
 
-	resync time.Duration
+	resync        time.Duration
+	finalizerName string
 }
 
 // NewReconciler creates a new reconcile.Reconciler that reconciles

--- a/extensions/pkg/controller/extension/reconciler.go
+++ b/extensions/pkg/controller/extension/reconciler.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -121,8 +120,9 @@ type reconciler struct {
 	logger   logr.Logger
 	actuator Actuator
 
-	client client.Client
-	reader client.Reader
+	client        client.Client
+	reader        client.Reader
+	statusUpdater extensionscontroller.StatusUpdater
 
 	resync        time.Duration
 	finalizerName string
@@ -132,15 +132,17 @@ type reconciler struct {
 // Extension resources of Gardener's `extensions.gardener.cloud` API group.
 func NewReconciler(args AddArgs) reconcile.Reconciler {
 	logger := log.Log.WithName(args.Name)
-	finalizer := fmt.Sprintf("%s/%s", FinalizerPrefix, args.FinalizerSuffix)
+
 	return extensionscontroller.OperationAnnotationWrapper(
 		func() client.Object { return &extensionsv1alpha1.Extension{} },
 		&reconciler{
 			logger:        logger,
 			actuator:      args.Actuator,
-			finalizerName: finalizer,
+			statusUpdater: extensionscontroller.NewStatusUpdater(logger),
+			finalizerName: fmt.Sprintf("%s/%s", FinalizerPrefix, args.FinalizerSuffix),
 			resync:        args.Resync,
-		})
+		},
+	)
 }
 
 // InjectFunc enables dependency injection into the actuator.
@@ -151,6 +153,7 @@ func (r *reconciler) InjectFunc(f inject.Func) error {
 // InjectClient injects the controller runtime client into the reconciler.
 func (r *reconciler) InjectClient(client client.Client) error {
 	r.client = client
+	r.statusUpdater.InjectClient(client)
 	return nil
 }
 
@@ -205,18 +208,19 @@ func (r *reconciler) reconcile(ctx context.Context, ex *extensionsv1alpha1.Exten
 		return reconcile.Result{}, err
 	}
 
-	if err := r.updateStatusProcessing(ctx, ex, operationType, "Reconciling Extension resource"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, ex, operationType, "Reconciling Extension resource"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Reconcile(ctx, ex); err != nil {
-		_ = r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), ex, operationType, "Unable to reconcile Extension resource")
+		_ = r.statusUpdater.Error(ctx, ex, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Unable to reconcile Extension resource")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, ex, operationType, "Successfully reconciled Extension resource"); err != nil {
+	if err := r.statusUpdater.Success(ctx, ex, operationType, "Successfully reconciled Extension resource"); err != nil {
 		return reconcile.Result{}, err
 	}
+
 	return reconcile.Result{}, nil
 }
 
@@ -226,22 +230,23 @@ func (r *reconciler) delete(ctx context.Context, ex *extensionsv1alpha1.Extensio
 		return reconcile.Result{}, nil
 	}
 
-	if err := r.updateStatusProcessing(ctx, ex, gardencorev1beta1.LastOperationTypeDelete, "Deleting Extension resource."); err != nil {
+	if err := r.statusUpdater.Processing(ctx, ex, gardencorev1beta1.LastOperationTypeDelete, "Deleting Extension resource."); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Delete(ctx, ex); err != nil {
-		_ = r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), ex, gardencorev1beta1.LastOperationTypeDelete, "Error deleting Extension resource")
+		_ = r.statusUpdater.Error(ctx, ex, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeDelete, "Error deleting Extension resource")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, ex, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted Extension resource"); err != nil {
+	if err := r.statusUpdater.Success(ctx, ex, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted Extension resource"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := controllerutils.RemoveFinalizer(ctx, r.reader, r.client, ex, r.finalizerName); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error removing finalizer from Extension resource: %+v", err)
 	}
+
 	return reconcile.Result{}, nil
 }
 
@@ -250,20 +255,19 @@ func (r *reconciler) restore(ctx context.Context, ex *extensionsv1alpha1.Extensi
 		return reconcile.Result{}, err
 	}
 
-	if err := r.updateStatusProcessing(ctx, ex, operationType, "Restoring Extension resource"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, ex, operationType, "Restoring Extension resource"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Restore(ctx, ex); err != nil {
-		_ = r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), ex, operationType, "Unable to restore Extension resource")
+		_ = r.statusUpdater.Error(ctx, ex, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Unable to restore Extension resource")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, ex, operationType, "Successfully restored Extension resource"); err != nil {
+	if err := r.statusUpdater.Success(ctx, ex, operationType, "Successfully restored Extension resource"); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	// remove operation annotation 'restore'
 	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, ex, v1beta1constants.GardenerOperation); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error removing annotation from Extension resource: %+v", err)
 	}
@@ -272,16 +276,16 @@ func (r *reconciler) restore(ctx context.Context, ex *extensionsv1alpha1.Extensi
 }
 
 func (r *reconciler) migrate(ctx context.Context, ex *extensionsv1alpha1.Extension) (reconcile.Result, error) {
-	if err := r.updateStatusProcessing(ctx, ex, gardencorev1beta1.LastOperationTypeMigrate, "Migrate Extension resource."); err != nil {
+	if err := r.statusUpdater.Processing(ctx, ex, gardencorev1beta1.LastOperationTypeMigrate, "Migrate Extension resource."); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Migrate(ctx, ex); err != nil {
-		_ = r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), ex, gardencorev1beta1.LastOperationTypeMigrate, "Error migrating Extension resource")
+		_ = r.statusUpdater.Error(ctx, ex, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating Extension resource")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, ex, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated Extension resource"); err != nil {
+	if err := r.statusUpdater.Success(ctx, ex, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated Extension resource"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -289,35 +293,9 @@ func (r *reconciler) migrate(ctx context.Context, ex *extensionsv1alpha1.Extensi
 		return reconcile.Result{}, fmt.Errorf("error removing all finalizers from Extension resource: %+v", err)
 	}
 
-	// remove operation annotation 'migrate'
 	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, ex, v1beta1constants.GardenerOperation); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error removing annotation from Extension resource: %+v", err)
 	}
 
 	return reconcile.Result{}, nil
-}
-
-func (r *reconciler) updateStatusProcessing(ctx context.Context, ex *extensionsv1alpha1.Extension, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	r.logger.Info(description, "extension", ex.Name, "namespace", ex.Namespace)
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, ex, func() error {
-		ex.Status.LastOperation = extensionscontroller.LastOperation(lastOperationType, gardencorev1beta1.LastOperationStateProcessing, 1, description)
-		return nil
-	})
-}
-
-func (r *reconciler) updateStatusError(ctx context.Context, err error, ex *extensionsv1alpha1.Extension, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, ex, func() error {
-		ex.Status.ObservedGeneration = ex.Generation
-		ex.Status.LastOperation, ex.Status.LastError = extensionscontroller.ReconcileError(lastOperationType, gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, err)), 50, gardencorev1beta1helper.ExtractErrorCodes(gardencorev1beta1helper.DetermineError(err, err.Error()))...)
-		return nil
-	})
-}
-
-func (r *reconciler) updateStatusSuccess(ctx context.Context, ex *extensionsv1alpha1.Extension, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	r.logger.Info(description, "extension", ex.Name, "namespace", ex.Namespace)
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, ex, func() error {
-		ex.Status.ObservedGeneration = ex.Generation
-		ex.Status.LastOperation, ex.Status.LastError = extensionscontroller.ReconcileSucceeded(lastOperationType, description)
-		return nil
-	})
 }

--- a/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/extensions/pkg/controller/healthcheck/reconciler.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -40,10 +39,11 @@ import (
 )
 
 type reconciler struct {
-	logger              logr.Logger
-	actuator            HealthCheckActuator
-	client              client.Client
-	recorder            record.EventRecorder
+	logger   logr.Logger
+	actuator HealthCheckActuator
+
+	client client.Client
+
 	registeredExtension RegisteredExtension
 	syncPeriod          metav1.Duration
 }
@@ -63,7 +63,6 @@ func NewReconciler(mgr manager.Manager, actuator HealthCheckActuator, registered
 	return &reconciler{
 		logger:              log.Log.WithName(ControllerName),
 		actuator:            actuator,
-		recorder:            mgr.GetEventRecorderFor(ControllerName),
 		registeredExtension: registeredExtension,
 		syncPeriod:          syncPeriod,
 	}

--- a/extensions/pkg/controller/infrastructure/controller.go
+++ b/extensions/pkg/controller/infrastructure/controller.go
@@ -77,7 +77,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 // Add creates a new Infrastructure Controller and adds it to the Manager.
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
-	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
+	args.ControllerOptions.Reconciler = NewReconciler(args.Actuator)
 	return add(mgr, args)
 }
 

--- a/extensions/pkg/controller/infrastructure/reconciler.go
+++ b/extensions/pkg/controller/infrastructure/reconciler.go
@@ -20,12 +20,9 @@ import (
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 
@@ -41,18 +38,22 @@ type reconciler struct {
 	logger   logr.Logger
 	actuator Actuator
 
-	client client.Client
-	reader client.Reader
+	client        client.Client
+	reader        client.Reader
+	statusUpdater extensionscontroller.StatusUpdater
 }
 
 // NewReconciler creates a new reconcile.Reconciler that reconciles
 // infrastructure resources of Gardener's `extensions.gardener.cloud` API group.
-func NewReconciler(mgr manager.Manager, actuator Actuator) reconcile.Reconciler {
+func NewReconciler(actuator Actuator) reconcile.Reconciler {
+	logger := log.Log.WithName(ControllerName)
+
 	return extensionscontroller.OperationAnnotationWrapper(
 		func() client.Object { return &extensionsv1alpha1.Infrastructure{} },
 		&reconciler{
-			logger:   log.Log.WithName(ControllerName),
-			actuator: actuator,
+			logger:        logger,
+			actuator:      actuator,
+			statusUpdater: extensionscontroller.NewStatusUpdater(logger),
 		},
 	)
 }
@@ -63,6 +64,7 @@ func (r *reconciler) InjectFunc(f inject.Func) error {
 
 func (r *reconciler) InjectClient(client client.Client) error {
 	r.client = client
+	r.statusUpdater.InjectClient(client)
 	return nil
 }
 
@@ -113,16 +115,16 @@ func (r *reconciler) reconcile(ctx context.Context, logger logr.Logger, infrastr
 		return reconcile.Result{}, err
 	}
 
-	if err := r.updateStatusProcessing(ctx, logger, infrastructure, operationType, "Reconciling the infrastructure"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, infrastructure, operationType, "Reconciling the infrastructure"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Reconcile(ctx, infrastructure, cluster); err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), infrastructure, operationType, "Error reconciling infrastructure"))
+		_ = r.statusUpdater.Error(ctx, infrastructure, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling infrastructure")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, logger, infrastructure, operationType, "Successfully reconciled infrastructure"); err != nil {
+	if err := r.statusUpdater.Success(ctx, infrastructure, operationType, "Successfully reconciled infrastructure"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -135,16 +137,16 @@ func (r *reconciler) delete(ctx context.Context, logger logr.Logger, infrastruct
 		return reconcile.Result{}, nil
 	}
 
-	if err := r.updateStatusProcessing(ctx, logger, infrastructure, gardencorev1beta1.LastOperationTypeDelete, "Deleting the infrastructure"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, infrastructure, gardencorev1beta1.LastOperationTypeDelete, "Deleting the infrastructure"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Delete(ctx, infrastructure, cluster); err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), infrastructure, gardencorev1beta1.LastOperationTypeDelete, "Error deleting infrastructure"))
+		_ = r.statusUpdater.Error(ctx, infrastructure, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeDelete, "Error deleting infrastructure")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, logger, infrastructure, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted infrastructure"); err != nil {
+	if err := r.statusUpdater.Success(ctx, infrastructure, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted infrastructure"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -153,16 +155,16 @@ func (r *reconciler) delete(ctx context.Context, logger logr.Logger, infrastruct
 }
 
 func (r *reconciler) migrate(ctx context.Context, logger logr.Logger, infrastructure *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
-	if err := r.updateStatusProcessing(ctx, logger, infrastructure, gardencorev1beta1.LastOperationTypeMigrate, "Starting Migration of the Infrastructure"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, infrastructure, gardencorev1beta1.LastOperationTypeMigrate, "Starting Migration of the Infrastructure"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Migrate(ctx, infrastructure, cluster); err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), infrastructure, gardencorev1beta1.LastOperationTypeMigrate, "Error migrating infrastructure"))
+		_ = r.statusUpdater.Error(ctx, infrastructure, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating infrastructure")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, logger, infrastructure, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated Infrastructure"); err != nil {
+	if err := r.statusUpdater.Success(ctx, infrastructure, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated Infrastructure"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -170,7 +172,6 @@ func (r *reconciler) migrate(ctx context.Context, logger logr.Logger, infrastruc
 		return reconcile.Result{}, err
 	}
 
-	// remove operation annotation 'migrate'
 	if err := r.removeAnnotation(ctx, logger, infrastructure); err != nil {
 		return reconcile.Result{}, err
 	}
@@ -184,54 +185,27 @@ func (r *reconciler) restore(ctx context.Context, logger logr.Logger, infrastruc
 		return reconcile.Result{}, err
 	}
 
-	if err := r.updateStatusProcessing(ctx, logger, infrastructure, gardencorev1beta1.LastOperationTypeRestore, "Restoring the infrastructure"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, infrastructure, gardencorev1beta1.LastOperationTypeRestore, "Restoring the infrastructure"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Restore(ctx, infrastructure, cluster); err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), infrastructure, gardencorev1beta1.LastOperationTypeRestore, "Error restoring infrastructure"))
+		_ = r.statusUpdater.Error(ctx, infrastructure, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring infrastructure")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	// remove operation annotation 'restore'
 	if err := r.removeAnnotation(ctx, logger, infrastructure); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	err := r.updateStatusSuccess(ctx, logger, infrastructure, gardencorev1beta1.LastOperationTypeRestore, "Successfully restored infrastructure")
+	err := r.statusUpdater.Success(ctx, infrastructure, gardencorev1beta1.LastOperationTypeRestore, "Successfully restored infrastructure")
 	return reconcile.Result{}, err
-}
-
-func (r *reconciler) updateStatusProcessing(ctx context.Context, logger logr.Logger, infrastructure *extensionsv1alpha1.Infrastructure, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	logger.Info(description)
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, infrastructure, func() error {
-		infrastructure.Status.LastOperation = extensionscontroller.LastOperation(lastOperationType, gardencorev1beta1.LastOperationStateProcessing, 1, description)
-		return nil
-	})
-}
-
-func (r *reconciler) updateStatusError(ctx context.Context, err error, infrastructure *extensionsv1alpha1.Infrastructure, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, infrastructure, func() error {
-		infrastructure.Status.ObservedGeneration = infrastructure.Generation
-		infrastructure.Status.LastOperation, infrastructure.Status.LastError = extensionscontroller.ReconcileError(lastOperationType, gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, err)), 50, gardencorev1beta1helper.ExtractErrorCodes(gardencorev1beta1helper.DetermineError(err, err.Error()))...)
-		return nil
-	})
-}
-
-func (r *reconciler) updateStatusSuccess(ctx context.Context, logger logr.Logger, infrastructure *extensionsv1alpha1.Infrastructure, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	logger.Info(description)
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, infrastructure, func() error {
-		infrastructure.Status.ObservedGeneration = infrastructure.Generation
-		infrastructure.Status.LastOperation, infrastructure.Status.LastError = extensionscontroller.ReconcileSucceeded(lastOperationType, description)
-		return nil
-	})
 }
 
 func (r *reconciler) removeFinalizerFromInfrastructure(ctx context.Context, logger logr.Logger, infrastructure *extensionsv1alpha1.Infrastructure) error {
 	logger.Info("Removing finalizer")
 	if err := controllerutils.RemoveFinalizer(ctx, r.reader, r.client, infrastructure, FinalizerName); err != nil {
-		msg := fmt.Sprintf("error removing finalizer from Infrastructure: %+v", err)
-		return fmt.Errorf(msg)
+		return fmt.Errorf("error removing finalizer from Infrastructure: %+v", err)
 	}
 	return nil
 }
@@ -239,8 +213,7 @@ func (r *reconciler) removeFinalizerFromInfrastructure(ctx context.Context, logg
 func (r *reconciler) removeAnnotation(ctx context.Context, logger logr.Logger, infrastructure *extensionsv1alpha1.Infrastructure) error {
 	logger.Info("Removing operation annotation")
 	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, infrastructure, v1beta1constants.GardenerOperation); err != nil {
-		msg := fmt.Sprintf("error removing annotation from Infrastructure: %+v", err)
-		return fmt.Errorf(msg)
+		return fmt.Errorf("error removing annotation from Infrastructure: %+v", err)
 	}
 	return nil
 }

--- a/extensions/pkg/controller/network/controller.go
+++ b/extensions/pkg/controller/network/controller.go
@@ -73,7 +73,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 // Add creates a new network Controller and adds it to the Manager.
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
-	args.ControllerOptions.Reconciler = NewReconciler(mgr, args.Actuator)
+	args.ControllerOptions.Reconciler = NewReconciler(args.Actuator)
 	return add(mgr, args)
 }
 

--- a/extensions/pkg/controller/network/reconciler.go
+++ b/extensions/pkg/controller/network/reconciler.go
@@ -20,12 +20,9 @@ import (
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 
@@ -41,18 +38,22 @@ type reconciler struct {
 	logger   logr.Logger
 	actuator Actuator
 
-	client client.Client
-	reader client.Reader
+	client        client.Client
+	reader        client.Reader
+	statusUpdater extensionscontroller.StatusUpdater
 }
 
 // NewReconciler creates a new reconcile.Reconciler that reconciles
 // Network resources of Gardener's `extensions.gardener.cloud` API group.
-func NewReconciler(mgr manager.Manager, actuator Actuator) reconcile.Reconciler {
+func NewReconciler(actuator Actuator) reconcile.Reconciler {
+	logger := log.Log.WithName(ControllerName)
+
 	return extensionscontroller.OperationAnnotationWrapper(
 		func() client.Object { return &extensionsv1alpha1.Network{} },
 		&reconciler{
-			logger:   log.Log.WithName(ControllerName),
-			actuator: actuator,
+			logger:        logger,
+			actuator:      actuator,
+			statusUpdater: extensionscontroller.NewStatusUpdater(logger),
 		},
 	)
 }
@@ -63,6 +64,7 @@ func (r *reconciler) InjectFunc(f inject.Func) error {
 
 func (r *reconciler) InjectClient(client client.Client) error {
 	r.client = client
+	r.statusUpdater.InjectClient(client)
 	return nil
 }
 
@@ -111,16 +113,16 @@ func (r *reconciler) reconcile(ctx context.Context, network *extensionsv1alpha1.
 		return reconcile.Result{}, err
 	}
 
-	if err := r.updateStatusProcessing(ctx, network, operationType, "Reconciling the network"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, network, operationType, "Reconciling the network"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Reconcile(ctx, network, cluster); err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), network, operationType, "Error reconciling network"))
+		_ = r.statusUpdater.Error(ctx, network, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling network")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, network, operationType, "Successfully reconciled network"); err != nil {
+	if err := r.statusUpdater.Success(ctx, network, operationType, "Successfully reconciled network"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -132,23 +134,21 @@ func (r *reconciler) restore(ctx context.Context, network *extensionsv1alpha1.Ne
 		return reconcile.Result{}, err
 	}
 
-	if err := r.updateStatusProcessing(ctx, network, gardencorev1beta1.LastOperationTypeRestore, "Restoring the network"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, network, gardencorev1beta1.LastOperationTypeRestore, "Restoring the network"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Restore(ctx, network, cluster); err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), network, gardencorev1beta1.LastOperationTypeRestore, "Error restoring network"))
+		_ = r.statusUpdater.Error(ctx, network, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring network")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, network, gardencorev1beta1.LastOperationTypeRestore, "Successfully restored network"); err != nil {
+	if err := r.statusUpdater.Success(ctx, network, gardencorev1beta1.LastOperationTypeRestore, "Successfully restored network"); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	// remove operation annotation 'restore'
 	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, network, v1beta1constants.GardenerOperation); err != nil {
-		msg := "Error removing annotation from Network"
-		return reconcile.Result{}, fmt.Errorf("%s: %+v", msg, err)
+		return reconcile.Result{}, fmt.Errorf("error removing annotation from Network: %+v", err)
 	}
 
 	return reconcile.Result{}, nil
@@ -160,17 +160,17 @@ func (r *reconciler) delete(ctx context.Context, network *extensionsv1alpha1.Net
 		return reconcile.Result{}, nil
 	}
 
-	if err := r.updateStatusProcessing(ctx, network, gardencorev1beta1.LastOperationTypeDelete, "Deleting the network"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, network, gardencorev1beta1.LastOperationTypeDelete, "Deleting the network"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	r.logger.Info("Starting the deletion of network", "network", network.Name)
 	if err := r.actuator.Delete(ctx, network, cluster); err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), network, gardencorev1beta1.LastOperationTypeDelete, "Error deleting network"))
+		_ = r.statusUpdater.Error(ctx, network, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeDelete, "Error deleting network")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, network, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted network"); err != nil {
+	if err := r.statusUpdater.Success(ctx, network, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted network"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -183,16 +183,16 @@ func (r *reconciler) delete(ctx context.Context, network *extensionsv1alpha1.Net
 }
 
 func (r *reconciler) migrate(ctx context.Context, network *extensionsv1alpha1.Network, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
-	if err := r.updateStatusProcessing(ctx, network, gardencorev1beta1.LastOperationTypeMigrate, "Migrating the network"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, network, gardencorev1beta1.LastOperationTypeMigrate, "Migrating the network"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Migrate(ctx, network, cluster); err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), network, gardencorev1beta1.LastOperationTypeMigrate, "Error migrating network"))
+		_ = r.statusUpdater.Error(ctx, network, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating network")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, network, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated network"); err != nil {
+	if err := r.statusUpdater.Success(ctx, network, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated network"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -201,35 +201,9 @@ func (r *reconciler) migrate(ctx context.Context, network *extensionsv1alpha1.Ne
 		return reconcile.Result{}, fmt.Errorf("error removing finalizers from the Network resource: %+v", err)
 	}
 
-	// remove operation annotation 'migrate'
 	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, network, v1beta1constants.GardenerOperation); err != nil {
-		msg := "Error removing annotation from Network"
-		return reconcile.Result{}, fmt.Errorf("%s: %+v", msg, err)
+		return reconcile.Result{}, fmt.Errorf("error removing annotation from Network: %+v", err)
 	}
+
 	return reconcile.Result{}, nil
-}
-
-func (r *reconciler) updateStatusProcessing(ctx context.Context, network *extensionsv1alpha1.Network, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	r.logger.Info(description, "network", network.Name)
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, network, func() error {
-		network.Status.LastOperation = extensionscontroller.LastOperation(lastOperationType, gardencorev1beta1.LastOperationStateProcessing, 1, description)
-		return nil
-	})
-}
-
-func (r *reconciler) updateStatusError(ctx context.Context, err error, network *extensionsv1alpha1.Network, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, network, func() error {
-		network.Status.ObservedGeneration = network.Generation
-		network.Status.LastOperation, network.Status.LastError = extensionscontroller.ReconcileError(lastOperationType, gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, err)), 50, gardencorev1beta1helper.ExtractErrorCodes(gardencorev1beta1helper.DetermineError(err, err.Error()))...)
-		return nil
-	})
-}
-
-func (r *reconciler) updateStatusSuccess(ctx context.Context, network *extensionsv1alpha1.Network, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	r.logger.Info(description, "network", network.Name)
-	return extensionscontroller.TryUpdateStatus(ctx, retry.DefaultBackoff, r.client, network, func() error {
-		network.Status.ObservedGeneration = network.Generation
-		network.Status.LastOperation, network.Status.LastError = extensionscontroller.ReconcileSucceeded(lastOperationType, description)
-		return nil
-	})
 }

--- a/extensions/pkg/controller/operatingsystemconfig/controller.go
+++ b/extensions/pkg/controller/operatingsystemconfig/controller.go
@@ -31,8 +31,6 @@ const (
 
 	// ControllerName is the name of the operating system configuration controller.
 	ControllerName = "operatingsystemconfig_controller"
-
-	name = "operatingsystemconfig-controller"
 )
 
 // AddArgs are arguments for adding an operatingsystemconfig controller to a manager.

--- a/extensions/pkg/controller/operatingsystemconfig/reconciler.go
+++ b/extensions/pkg/controller/operatingsystemconfig/reconciler.go
@@ -22,7 +22,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -43,20 +42,23 @@ type reconciler struct {
 	logger   logr.Logger
 	actuator Actuator
 
-	client client.Client
-	reader client.Reader
-	scheme *runtime.Scheme
+	client        client.Client
+	reader        client.Reader
+	scheme        *runtime.Scheme
+	statusUpdater extensionscontroller.StatusUpdater
 }
 
 // NewReconciler creates a new reconcile.Reconciler that reconciles
 // OperatingSystemConfig resources of Gardener's `extensions.gardener.cloud` API group.
 func NewReconciler(actuator Actuator) reconcile.Reconciler {
-	logger := log.Log.WithName(name)
+	logger := log.Log.WithName(ControllerName)
+
 	return extensionscontroller.OperationAnnotationWrapper(
 		func() client.Object { return &extensionsv1alpha1.OperatingSystemConfig{} },
 		&reconciler{
-			logger:   logger,
-			actuator: actuator,
+			logger:        logger,
+			actuator:      actuator,
+			statusUpdater: extensionscontroller.NewStatusUpdater(logger),
 		},
 	)
 }
@@ -69,6 +71,7 @@ func (r *reconciler) InjectFunc(f inject.Func) error {
 // InjectClient injects the controller runtime client into the reconciler.
 func (r *reconciler) InjectClient(client client.Client) error {
 	r.client = client
+	r.statusUpdater.InjectClient(client)
 	return nil
 }
 
@@ -124,25 +127,25 @@ func (r *reconciler) reconcile(ctx context.Context, osc *extensionsv1alpha1.Oper
 		return reconcile.Result{}, err
 	}
 
-	if err := r.updateStatusProcessing(ctx, osc, operationType, "Reconciling the operating system config"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, osc, operationType, "Reconciling the operating system config"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	userData, command, units, err := r.actuator.Reconcile(ctx, osc)
 	if err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), osc, operationType, "Error reconciling operating system config"))
+		_ = r.statusUpdater.Error(ctx, osc, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling operating system config")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
 	secret, err := r.createOrUpdateOSCResultSecret(ctx, osc, userData)
 	if err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), osc, operationType, "Could not apply secret for generated cloud config"))
+		_ = r.statusUpdater.Error(ctx, osc, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Could not apply secret for generated cloud config")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
 	setOSCStatus(osc, secret, command, units)
 
-	if err := r.updateStatusSuccess(ctx, osc, operationType, "Successfully reconciled operating system config"); err != nil {
+	if err := r.statusUpdater.Success(ctx, osc, operationType, "Successfully reconciled operating system config"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -154,25 +157,25 @@ func (r *reconciler) restore(ctx context.Context, osc *extensionsv1alpha1.Operat
 		return reconcile.Result{}, err
 	}
 
-	if err := r.updateStatusProcessing(ctx, osc, gardencorev1beta1.LastOperationTypeRestore, "Restoring the operating system config"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, osc, gardencorev1beta1.LastOperationTypeRestore, "Restoring the operating system config"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	userData, command, units, err := r.actuator.Restore(ctx, osc)
 	if err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), osc, gardencorev1beta1.LastOperationTypeRestore, "Error restoring operating system config"))
+		_ = r.statusUpdater.Error(ctx, osc, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring operating system config")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
 	secret, err := r.createOrUpdateOSCResultSecret(ctx, osc, userData)
 	if err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), osc, gardencorev1beta1.LastOperationTypeRestore, "Could not apply secret for generated cloud config"))
+		_ = r.statusUpdater.Error(ctx, osc, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Could not apply secret for generated cloud config")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
 	setOSCStatus(osc, secret, command, units)
 
-	if err := r.updateStatusSuccess(ctx, osc, gardencorev1beta1.LastOperationTypeRestore, "Successfully restored operating system config"); err != nil {
+	if err := r.statusUpdater.Success(ctx, osc, gardencorev1beta1.LastOperationTypeRestore, "Successfully restored operating system config"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -189,16 +192,16 @@ func (r *reconciler) delete(ctx context.Context, osc *extensionsv1alpha1.Operati
 		return reconcile.Result{}, nil
 	}
 
-	if err := r.updateStatusProcessing(ctx, osc, gardencorev1beta1.LastOperationTypeDelete, "Deleting the operating system config"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, osc, gardencorev1beta1.LastOperationTypeDelete, "Deleting the operating system config"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Delete(ctx, osc); err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), osc, gardencorev1beta1.LastOperationTypeDelete, "Error deleting operating system config"))
+		_ = r.statusUpdater.Error(ctx, osc, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeDelete, "Error deleting operating system config")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, osc, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted operating system config"); err != nil {
+	if err := r.statusUpdater.Success(ctx, osc, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted operating system config"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -216,16 +219,16 @@ func (r *reconciler) migrate(ctx context.Context, osc *extensionsv1alpha1.Operat
 		return reconcile.Result{}, nil
 	}
 
-	if err := r.updateStatusProcessing(ctx, osc, gardencorev1beta1.LastOperationTypeMigrate, "Migrating the operating system config"); err != nil {
+	if err := r.statusUpdater.Processing(ctx, osc, gardencorev1beta1.LastOperationTypeMigrate, "Migrating the operating system config"); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if err := r.actuator.Migrate(ctx, osc); err != nil {
-		utilruntime.HandleError(r.updateStatusError(ctx, extensionscontroller.ReconcileErrCauseOrErr(err), osc, gardencorev1beta1.LastOperationTypeMigrate, "Error migrating operating system config"))
+		_ = r.statusUpdater.Error(ctx, osc, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating operating system config")
 		return extensionscontroller.ReconcileErr(err)
 	}
 
-	if err := r.updateStatusSuccess(ctx, osc, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated operating system config"); err != nil {
+	if err := r.statusUpdater.Success(ctx, osc, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated operating system config"); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -239,25 +242,6 @@ func (r *reconciler) migrate(ctx context.Context, osc *extensionsv1alpha1.Operat
 	}
 
 	return reconcile.Result{}, nil
-}
-
-func (r *reconciler) updateStatusProcessing(ctx context.Context, osc *extensionsv1alpha1.OperatingSystemConfig, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	r.logger.Info(description, "osc", osc.Name)
-	osc.Status.LastOperation = extensionscontroller.LastOperation(lastOperationType, gardencorev1beta1.LastOperationStateProcessing, 1, description)
-	return r.client.Status().Update(ctx, osc)
-}
-
-func (r *reconciler) updateStatusError(ctx context.Context, err error, osc *extensionsv1alpha1.OperatingSystemConfig, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	osc.Status.ObservedGeneration = osc.Generation
-	osc.Status.LastOperation, osc.Status.LastError = extensionscontroller.ReconcileError(lastOperationType, gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, err)), 50, gardencorev1beta1helper.ExtractErrorCodes(gardencorev1beta1helper.DetermineError(err, err.Error()))...)
-	return r.client.Status().Update(ctx, osc)
-}
-
-func (r *reconciler) updateStatusSuccess(ctx context.Context, osc *extensionsv1alpha1.OperatingSystemConfig, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
-	r.logger.Info(description, "osc", osc.Name)
-	osc.Status.ObservedGeneration = osc.Generation
-	osc.Status.LastOperation, osc.Status.LastError = extensionscontroller.ReconcileSucceeded(lastOperationType, description)
-	return r.client.Status().Update(ctx, osc)
 }
 
 func (r *reconciler) createOrUpdateOSCResultSecret(ctx context.Context, osc *extensionsv1alpha1.OperatingSystemConfig, userData []byte) (*corev1.Secret, error) {

--- a/extensions/pkg/controller/status.go
+++ b/extensions/pkg/controller/status.go
@@ -89,6 +89,10 @@ func (s *statusUpdater) InjectClient(c client.Client) {
 }
 
 func (s *statusUpdater) Processing(ctx context.Context, obj extensionsv1alpha1.Object, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+	if s.client == nil {
+		return fmt.Errorf("client is not set. Call InjectClient() first")
+	}
+
 	s.logger.Info(description, s.logKeysAndValues(obj)...)
 
 	return TryUpdateStatus(ctx, retry.DefaultBackoff, s.client, obj, func() error {
@@ -100,6 +104,10 @@ func (s *statusUpdater) Processing(ctx context.Context, obj extensionsv1alpha1.O
 }
 
 func (s *statusUpdater) Error(ctx context.Context, obj extensionsv1alpha1.Object, err error, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+	if s.client == nil {
+		return fmt.Errorf("client is not set. Call InjectClient() first")
+	}
+
 	errDescription := gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, err))
 	s.logger.Error(fmt.Errorf(errDescription), "error", s.logKeysAndValues(obj)...)
 
@@ -114,6 +122,10 @@ func (s *statusUpdater) Error(ctx context.Context, obj extensionsv1alpha1.Object
 }
 
 func (s *statusUpdater) Success(ctx context.Context, obj extensionsv1alpha1.Object, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+	if s.client == nil {
+		return fmt.Errorf("client is not set. Call InjectClient() first")
+	}
+
 	s.logger.Info(description, s.logKeysAndValues(obj)...)
 
 	return TryUpdateStatus(ctx, retry.DefaultBackoff, s.client, obj, func() error {

--- a/extensions/pkg/controller/status.go
+++ b/extensions/pkg/controller/status.go
@@ -15,9 +15,17 @@
 package controller
 
 import (
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"context"
+	"fmt"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+
+	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // LastOperation creates a new LastOperation from the given parameters.
@@ -50,4 +58,79 @@ func ReconcileSucceeded(t gardencorev1beta1.LastOperationType, description strin
 // ReconcileError returns a LastOperation with state error and a LastError with the given description and codes.
 func ReconcileError(t gardencorev1beta1.LastOperationType, description string, progress int32, codes ...gardencorev1beta1.ErrorCode) (*gardencorev1beta1.LastOperation, *gardencorev1beta1.LastError) {
 	return LastOperation(t, gardencorev1beta1.LastOperationStateError, progress, description), LastError(description, codes...)
+}
+
+// StatusUpdater contains functions for updating statuses of extension resources after a controller operation.
+type StatusUpdater interface {
+	//  InjectClient injects the client into the status updater.
+	InjectClient(client.Client)
+	// Processing updates the last operation of an extension resource when an operation is started.
+	Processing(context.Context, extensionsv1alpha1.Object, gardencorev1beta1.LastOperationType, string) error
+	// Error updates the last operation of an extension resource when an operation was erroneous.
+	Error(context.Context, extensionsv1alpha1.Object, error, gardencorev1beta1.LastOperationType, string) error
+	// Success updates the last operation of an extension resource when an operation was successful.
+	Success(context.Context, extensionsv1alpha1.Object, gardencorev1beta1.LastOperationType, string) error
+}
+
+// NewStatusUpdater returns a new status updater.
+func NewStatusUpdater(logger logr.Logger) *statusUpdater {
+	return &statusUpdater{logger: logger}
+}
+
+type statusUpdater struct {
+	logger logr.Logger
+	client client.Client
+}
+
+var _ = StatusUpdater(&statusUpdater{})
+
+func (s *statusUpdater) InjectClient(c client.Client) {
+	s.client = c
+}
+
+func (s *statusUpdater) Processing(ctx context.Context, obj extensionsv1alpha1.Object, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+	s.logger.Info(description, s.logKeysAndValues(obj)...)
+
+	return TryUpdateStatus(ctx, retry.DefaultBackoff, s.client, obj, func() error {
+		lastOp := LastOperation(lastOperationType, gardencorev1beta1.LastOperationStateProcessing, 1, description)
+
+		obj.GetExtensionStatus().SetLastOperation(lastOp)
+		return nil
+	})
+}
+
+func (s *statusUpdater) Error(ctx context.Context, obj extensionsv1alpha1.Object, err error, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+	errDescription := gardencorev1beta1helper.FormatLastErrDescription(fmt.Errorf("%s: %v", description, err))
+	s.logger.Error(fmt.Errorf(errDescription), "error", s.logKeysAndValues(obj)...)
+
+	return TryUpdateStatus(ctx, retry.DefaultBackoff, s.client, obj, func() error {
+		lastOp, lastErr := ReconcileError(lastOperationType, errDescription, 50, gardencorev1beta1helper.ExtractErrorCodes(gardencorev1beta1helper.DetermineError(err, err.Error()))...)
+
+		obj.GetExtensionStatus().SetObservedGeneration(obj.GetGeneration())
+		obj.GetExtensionStatus().SetLastOperation(lastOp)
+		obj.GetExtensionStatus().SetLastError(lastErr)
+		return nil
+	})
+}
+
+func (s *statusUpdater) Success(ctx context.Context, obj extensionsv1alpha1.Object, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+	s.logger.Info(description, s.logKeysAndValues(obj)...)
+
+	return TryUpdateStatus(ctx, retry.DefaultBackoff, s.client, obj, func() error {
+		lastOp, lastErr := ReconcileSucceeded(lastOperationType, description)
+
+		obj.GetExtensionStatus().SetObservedGeneration(obj.GetGeneration())
+		obj.GetExtensionStatus().SetLastOperation(lastOp)
+		obj.GetExtensionStatus().SetLastError(lastErr)
+		return nil
+	})
+}
+
+func (s *statusUpdater) logKeysAndValues(obj metav1.Object) []interface{} {
+	var keysAndValues []interface{}
+	if ns := obj.GetNamespace(); ns != "" {
+		keysAndValues = append(keysAndValues, "namespace", ns)
+	}
+	keysAndValues = append(keysAndValues, "name", obj.GetName())
+	return keysAndValues
 }

--- a/extensions/pkg/controller/status_test.go
+++ b/extensions/pkg/controller/status_test.go
@@ -1,0 +1,237 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	. "github.com/gardener/gardener/extensions/pkg/controller"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var _ = Describe("Status", func() {
+	var (
+		ctx     = context.TODO()
+		fakeErr = fmt.Errorf("fake")
+
+		generation int64 = 1337
+		lastOpType       = gardencorev1beta1.LastOperationTypeCreate
+		lastOpDesc       = "foo"
+
+		ctrl   *gomock.Controller
+		logger logr.Logger
+		c      *mockclient.MockClient
+
+		statusUpdater StatusUpdater
+		obj           extensionsv1alpha1.Object
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		logger = logzap.New(logzap.WriteTo(GinkgoWriter))
+		c = mockclient.NewMockClient(ctrl)
+
+		statusUpdater = NewStatusUpdater(logger)
+		statusUpdater.InjectClient(c)
+
+		obj = &extensionsv1alpha1.Infrastructure{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: generation,
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#Processing", func() {
+		It("should return an error if the Get() call fails", func() {
+			gomock.InOrder(
+				c.EXPECT().Status().Return(c),
+				c.EXPECT().Get(ctx, kutil.Key(obj.GetNamespace(), obj.GetName()), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).Return(fakeErr),
+			)
+
+			Expect(statusUpdater.Processing(ctx, obj, lastOpType, lastOpDesc)).To(MatchError(fakeErr))
+		})
+
+		It("should return an error if the Update() call fails", func() {
+			gomock.InOrder(
+				c.EXPECT().Status().Return(c),
+				c.EXPECT().Get(ctx, kutil.Key(obj.GetNamespace(), obj.GetName()), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})),
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).Return(fakeErr),
+			)
+
+			Expect(statusUpdater.Processing(ctx, obj, lastOpType, lastOpDesc)).To(MatchError(fakeErr))
+		})
+
+		It("should update the last operation as expected", func() {
+			gomock.InOrder(
+				c.EXPECT().Status().Return(c),
+				c.EXPECT().Get(ctx, kutil.Key(obj.GetNamespace(), obj.GetName()), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})),
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).Do(func(ctx context.Context, obj extensionsv1alpha1.Object, opts ...client.UpdateOption) {
+					lastOperation := obj.GetExtensionStatus().GetLastOperation()
+
+					Expect(lastOperation.Type).To(Equal(lastOpType))
+					Expect(lastOperation.State).To(Equal(gardencorev1beta1.LastOperationStateProcessing))
+					Expect(lastOperation.Progress).To(Equal(int32(1)))
+					Expect(lastOperation.Description).To(Equal(lastOpDesc))
+				}),
+			)
+
+			Expect(statusUpdater.Processing(ctx, obj, lastOpType, lastOpDesc)).To(Succeed())
+		})
+	})
+
+	Describe("#Error", func() {
+		It("should return an error if the Get() call fails", func() {
+			gomock.InOrder(
+				c.EXPECT().Status().Return(c),
+				c.EXPECT().Get(ctx, kutil.Key(obj.GetNamespace(), obj.GetName()), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).Return(fakeErr),
+			)
+
+			Expect(statusUpdater.Error(ctx, obj, fakeErr, lastOpType, lastOpDesc)).To(MatchError(fakeErr))
+		})
+
+		It("should return an error if the Update() call fails", func() {
+			gomock.InOrder(
+				c.EXPECT().Status().Return(c),
+				c.EXPECT().Get(ctx, kutil.Key(obj.GetNamespace(), obj.GetName()), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})),
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).Return(fakeErr),
+			)
+
+			Expect(statusUpdater.Error(ctx, obj, fakeErr, lastOpType, lastOpDesc)).To(MatchError(fakeErr))
+		})
+
+		It("should update the last operation as expected (w/o error codes)", func() {
+			gomock.InOrder(
+				c.EXPECT().Status().Return(c),
+				c.EXPECT().Get(ctx, kutil.Key(obj.GetNamespace(), obj.GetName()), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})),
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).Do(func(ctx context.Context, obj extensionsv1alpha1.Object, opts ...client.UpdateOption) {
+					var (
+						description = strings.Title(lastOpDesc) + ": " + fakeErr.Error()
+
+						lastOperation      = obj.GetExtensionStatus().GetLastOperation()
+						lastError          = obj.GetExtensionStatus().GetLastError()
+						observedGeneration = obj.GetExtensionStatus().GetObservedGeneration()
+					)
+
+					Expect(observedGeneration).To(Equal(generation))
+
+					Expect(lastOperation.Type).To(Equal(lastOpType))
+					Expect(lastOperation.State).To(Equal(gardencorev1beta1.LastOperationStateError))
+					Expect(lastOperation.Progress).To(Equal(int32(50)))
+					Expect(lastOperation.Description).To(Equal(description))
+
+					Expect(lastError.Description).To(Equal(description))
+					Expect(lastError.TaskID).To(BeNil())
+					Expect(lastError.Codes).To(BeEmpty())
+				}),
+			)
+
+			Expect(statusUpdater.Error(ctx, obj, fakeErr, lastOpType, lastOpDesc)).To(Succeed())
+		})
+
+		It("should update the last operation as expected (w/ error codes)", func() {
+			err := fmt.Errorf("foo unauthorized foo")
+
+			gomock.InOrder(
+				c.EXPECT().Status().Return(c),
+				c.EXPECT().Get(ctx, kutil.Key(obj.GetNamespace(), obj.GetName()), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})),
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).Do(func(ctx context.Context, obj extensionsv1alpha1.Object, opts ...client.UpdateOption) {
+					var (
+						description = strings.Title(lastOpDesc) + ": " + err.Error()
+
+						lastOperation      = obj.GetExtensionStatus().GetLastOperation()
+						lastError          = obj.GetExtensionStatus().GetLastError()
+						observedGeneration = obj.GetExtensionStatus().GetObservedGeneration()
+					)
+
+					Expect(observedGeneration).To(Equal(generation))
+
+					Expect(lastOperation.Type).To(Equal(lastOpType))
+					Expect(lastOperation.State).To(Equal(gardencorev1beta1.LastOperationStateError))
+					Expect(lastOperation.Progress).To(Equal(int32(50)))
+					Expect(lastOperation.Description).To(Equal(description))
+
+					Expect(lastError.Description).To(Equal(description))
+					Expect(lastError.TaskID).To(BeNil())
+					Expect(lastError.Codes).To(ConsistOf(gardencorev1beta1.ErrorCode("ERR_INFRA_UNAUTHORIZED")))
+				}),
+			)
+
+			Expect(statusUpdater.Error(ctx, obj, err, lastOpType, lastOpDesc)).To(Succeed())
+		})
+	})
+
+	Describe("#Success", func() {
+		It("should return an error if the Get() call fails", func() {
+			gomock.InOrder(
+				c.EXPECT().Status().Return(c),
+				c.EXPECT().Get(ctx, kutil.Key(obj.GetNamespace(), obj.GetName()), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).Return(fakeErr),
+			)
+
+			Expect(statusUpdater.Success(ctx, obj, lastOpType, lastOpDesc)).To(MatchError(fakeErr))
+		})
+
+		It("should return an error if the Update() call fails", func() {
+			gomock.InOrder(
+				c.EXPECT().Status().Return(c),
+				c.EXPECT().Get(ctx, kutil.Key(obj.GetNamespace(), obj.GetName()), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})),
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).Return(fakeErr),
+			)
+
+			Expect(statusUpdater.Success(ctx, obj, lastOpType, lastOpDesc)).To(MatchError(fakeErr))
+		})
+
+		It("should update the last operation as expected", func() {
+			gomock.InOrder(
+				c.EXPECT().Status().Return(c),
+				c.EXPECT().Get(ctx, kutil.Key(obj.GetNamespace(), obj.GetName()), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})),
+				c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).Do(func(ctx context.Context, obj extensionsv1alpha1.Object, opts ...client.UpdateOption) {
+					var (
+						lastOperation      = obj.GetExtensionStatus().GetLastOperation()
+						lastError          = obj.GetExtensionStatus().GetLastError()
+						observedGeneration = obj.GetExtensionStatus().GetObservedGeneration()
+					)
+
+					Expect(observedGeneration).To(Equal(generation))
+
+					Expect(lastOperation.Type).To(Equal(lastOpType))
+					Expect(lastOperation.State).To(Equal(gardencorev1beta1.LastOperationStateSucceeded))
+					Expect(lastOperation.Progress).To(Equal(int32(100)))
+					Expect(lastOperation.Description).To(Equal(lastOpDesc))
+
+					Expect(lastError).To(BeNil())
+				}),
+			)
+
+			Expect(statusUpdater.Success(ctx, obj, lastOpType, lastOpDesc)).To(Succeed())
+		})
+	})
+})

--- a/extensions/pkg/controller/worker/state_reconciler.go
+++ b/extensions/pkg/controller/worker/state_reconciler.go
@@ -23,9 +23,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -33,21 +31,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
 
-const (
-	// StartToSyncState is used as part of the Event 'reason' when a Worker state starts to synchronize
-	StartToSyncState = "SynchronizingState"
-	// SuccessSynced is used as part of the Event 'reason' when a Worker state is synced
-	SuccessSynced = "StateSynced"
-	// ErrorStateSync is used as part of the Event 'reason' when a Worker state fail to sync
-	ErrorStateSync = "ErrorSynchronizingState"
-	// StateSyncControllerName is the name of the controller which synchronize the Worker state
-	StateSyncControllerName = "worker-state-controller"
-)
-
 type stateReconciler struct {
 	logger   logr.Logger
 	actuator StateActuator
-	recorder record.EventRecorder
 
 	client client.Client
 }
@@ -58,7 +44,6 @@ func NewStateReconciler(mgr manager.Manager, actuator StateActuator) reconcile.R
 	return &stateReconciler{
 		logger:   log.Log.WithName(StateUpdatingControllerName),
 		actuator: actuator,
-		recorder: mgr.GetEventRecorderFor(StateSyncControllerName),
 	}
 }
 
@@ -97,18 +82,14 @@ func (r *stateReconciler) Reconcile(ctx context.Context, request reconcile.Reque
 		return reconcile.Result{}, nil
 	}
 
-	r.recorder.Event(worker, corev1.EventTypeNormal, StartToSyncState, "Updating the worker state")
-
 	if err := r.actuator.Reconcile(ctx, worker); err != nil {
 		msg := "Error updating worker state"
 		logger.Error(err, msg)
-		r.recorder.Event(worker, corev1.EventTypeWarning, ErrorStateSync, msg)
 		return extensionscontroller.ReconcileErr(err)
 	}
 
 	msg := "Successfully updated worker state"
 	logger.Info(msg)
-	r.recorder.Event(worker, corev1.EventTypeNormal, SuccessSynced, msg)
 
 	return reconcile.Result{}, nil
 }

--- a/pkg/api/extensions/accessor.go
+++ b/pkg/api/extensions/accessor.go
@@ -147,6 +147,18 @@ func (u unstructuredStatusAccessor) GetLastOperation() *gardencorev1beta1.LastOp
 	return lastOperation
 }
 
+// SetLastOperation implements Status.
+func (u unstructuredStatusAccessor) SetLastOperation(lastOp *gardencorev1beta1.LastOperation) {
+	unstrc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(lastOp)
+	if err != nil {
+		return
+	}
+
+	if err := unstructured.SetNestedField(u.UnstructuredContent(), unstrc, "status", "lastOperation"); err != nil {
+		return
+	}
+}
+
 // GetLastError implements Status.
 func (u unstructuredStatusAccessor) GetLastError() *gardencorev1beta1.LastError {
 	val, ok, err := unstructured.NestedFieldNoCopy(u.UnstructuredContent(), "status", "lastError")
@@ -161,9 +173,28 @@ func (u unstructuredStatusAccessor) GetLastError() *gardencorev1beta1.LastError 
 	return lastError
 }
 
+// SetLastError implements Status.
+func (u unstructuredStatusAccessor) SetLastError(lastErr *gardencorev1beta1.LastError) {
+	unstrc, err := runtime.DefaultUnstructuredConverter.ToUnstructured(lastErr)
+	if err != nil {
+		return
+	}
+
+	if err := unstructured.SetNestedField(u.UnstructuredContent(), unstrc, "status", "lastError"); err != nil {
+		return
+	}
+}
+
 // GetObservedGeneration implements Status.
 func (u unstructuredStatusAccessor) GetObservedGeneration() int64 {
 	return nestedInt64(u.Object, "status", "observedGeneration")
+}
+
+// SetObservedGeneration implements Status.
+func (u unstructuredStatusAccessor) SetObservedGeneration(generation int64) {
+	if err := unstructured.SetNestedField(u.UnstructuredContent(), generation, "status", "observedGeneration"); err != nil {
+		return
+	}
 }
 
 // GetState implements Status.

--- a/pkg/api/extensions/accessor_test.go
+++ b/pkg/api/extensions/accessor_test.go
@@ -146,6 +146,15 @@ var _ = Describe("Accessor", func() {
 				})
 			})
 
+			Describe("#SetLastOperation()", func() {
+				It("should set the last operation", func() {
+					lastOp := &gardencorev1beta1.LastOperation{Description: "foo"}
+					acc := mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{})
+					acc.SetLastOperation(lastOp)
+					Expect(acc.GetLastOperation()).To(Equal(lastOp))
+				})
+			})
+
 			Describe("#GetLastError", func() {
 				It("should get the last error", func() {
 					var (
@@ -154,6 +163,15 @@ var _ = Describe("Accessor", func() {
 					)
 
 					Expect(acc.GetLastError()).To(Equal(&gardencorev1beta1.LastError{Description: desc}))
+				})
+			})
+
+			Describe("#SetLastError()", func() {
+				It("should set the last error", func() {
+					lastErr := &gardencorev1beta1.LastError{Description: "bar"}
+					acc := mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{})
+					acc.SetLastError(lastErr)
+					Expect(acc.GetLastError()).To(Equal(lastErr))
 				})
 			})
 
@@ -191,6 +209,23 @@ var _ = Describe("Accessor", func() {
 					acc.SetState(state)
 					actualState := acc.GetState()
 					Expect(actualState).To(Equal(state))
+				})
+			})
+
+			Describe("#GetObservedGeneration", func() {
+				It("should get the observed generation", func() {
+					var generation int64 = 1337
+					acc := mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{ObservedGeneration: generation})
+					Expect(acc.GetObservedGeneration()).To(Equal(generation))
+				})
+			})
+
+			Describe("#SetObservedGeneration", func() {
+				It("should set the observed generation", func() {
+					var generation int64 = 1337
+					acc := mkUnstructuredAccessorWithStatus(extensionsv1alpha1.DefaultStatus{})
+					acc.SetObservedGeneration(generation)
+					Expect(acc.GetObservedGeneration()).To(Equal(generation))
 				})
 			})
 

--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -35,11 +35,17 @@ type Status interface {
 	// GetLastOperation retrieves the LastOperation of a status.
 	// LastOperation may be nil.
 	GetLastOperation() *gardencorev1beta1.LastOperation
+	// SetLastOperation sets the LastOperation of a status.
+	SetLastOperation(*gardencorev1beta1.LastOperation)
 	// GetObservedGeneration retrieves the last generation observed by the extension controller.
 	GetObservedGeneration() int64
+	// SetObservedGeneration sets the ObservedGeneration of a status.
+	SetObservedGeneration(int64)
 	// GetLastError retrieves the LastError of a status.
 	// LastError may be nil.
 	GetLastError() *gardencorev1beta1.LastError
+	// SetLastError sets the LastError of a status.
+	SetLastError(*gardencorev1beta1.LastError)
 	// GetState retrieves the State of the extension
 	GetState() *runtime.RawExtension
 	// SetState sets the State of the extension

--- a/pkg/apis/extensions/v1alpha1/types_defaults.go
+++ b/pkg/apis/extensions/v1alpha1/types_defaults.go
@@ -93,14 +93,29 @@ func (d *DefaultStatus) GetLastOperation() *gardencorev1beta1.LastOperation {
 	return d.LastOperation
 }
 
+// SetLastOperation implements Status.
+func (d *DefaultStatus) SetLastOperation(lastOp *gardencorev1beta1.LastOperation) {
+	d.LastOperation = lastOp
+}
+
 // GetLastError implements Status.
 func (d *DefaultStatus) GetLastError() *gardencorev1beta1.LastError {
 	return d.LastError
 }
 
+// SetLastError implements Status.
+func (d *DefaultStatus) SetLastError(lastErr *gardencorev1beta1.LastError) {
+	d.LastError = lastErr
+}
+
 // GetObservedGeneration implements Status.
 func (d *DefaultStatus) GetObservedGeneration() int64 {
 	return d.ObservedGeneration
+}
+
+// SetObservedGeneration implements Status.
+func (d *DefaultStatus) SetObservedGeneration(generation int64) {
+	d.ObservedGeneration = generation
 }
 
 // GetState implements Status.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
There is a lot of duplication in the `extensions/controllers/*` package, and this PR is the first step to eliminate it. 
The goal of the PR is the removal of the duplicated `updateStatus{Processing,Error,Success}` functions in the `reconciler`s in of the various controllers. They were all kind of similar, but still different and inconsistent (which changes with this PR).

Along the way, I removed all events emitted from the extension controllers. They were never evaluated and not used at all. In large seed clusters they might even be harmful because they unnecessarily pollute the seed cluster's etcd. They were also not consistently used across the various extension controllers.

/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
