### PR TITLE
[release-v1.20] Automated cherry pick of #3868: VPA minAllowed configuration for node-exporter.

### DIFF
--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/vpa.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/vpa.yaml
@@ -5,6 +5,12 @@ metadata:
   name: node-exporter
   namespace: {{ .Release.Namespace }}
 spec:
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        minAllowed:
+          cpu: 50m
+          memory: 50Mi
   targetRef:
     apiVersion: {{ include "daemonsetversion" . }}
     kind: DaemonSet


### PR DESCRIPTION
Cherry pick of #3868 on release-v1.20.

#3868: VPA minAllowed configuration for node-exporter.

**Release Notes:**
```other operator
VPA minAllowed configuration for node-exporter.
```