### PR TITLE
Increase limits for etcd to avoid potential long down time during maintenance window.

### DIFF
--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -434,11 +434,11 @@ func (e *etcd) Deploy(ctx context.Context) error {
 				},
 				LimitsRequestsGapScaleParams: hvpav1alpha1.ScaleParams{
 					CPU: hvpav1alpha1.ChangeParams{
-						Value:      pointer.StringPtr("1"),
+						Value:      pointer.StringPtr("2"),
 						Percentage: pointer.Int32Ptr(40),
 					},
 					Memory: hvpav1alpha1.ChangeParams{
-						Value:      pointer.StringPtr("1G"),
+						Value:      pointer.StringPtr("5G"),
 						Percentage: pointer.Int32Ptr(40),
 					},
 				},
@@ -599,8 +599,8 @@ func (e *etcd) computeContainerResources(foundSts bool, existingSts *appsv1.Stat
 				corev1.ResourceMemory: resource.MustParse("1G"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("900m"),
-				corev1.ResourceMemory: resource.MustParse("3G"),
+				corev1.ResourceCPU:    resource.MustParse("2300m"),
+				corev1.ResourceMemory: resource.MustParse("6G"),
 			},
 		}
 		resourcesBackupRestore = &corev1.ResourceRequirements{

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -183,8 +183,8 @@ var _ = Describe("Etcd", func() {
 					corev1.ResourceMemory: resource.MustParse("1G"),
 				},
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("900m"),
-					corev1.ResourceMemory: resource.MustParse("3G"),
+					corev1.ResourceCPU:    resource.MustParse("2300m"),
+					corev1.ResourceMemory: resource.MustParse("6G"),
 				},
 			}
 			if existingResourcesContainerEtcd != nil {
@@ -396,11 +396,11 @@ var _ = Describe("Etcd", func() {
 						},
 						LimitsRequestsGapScaleParams: hvpav1alpha1.ScaleParams{
 							CPU: hvpav1alpha1.ChangeParams{
-								Value:      pointer.StringPtr("1"),
+								Value:      pointer.StringPtr("2"),
 								Percentage: pointer.Int32Ptr(40),
 							},
 							Memory: hvpav1alpha1.ChangeParams{
-								Value:      pointer.StringPtr("1G"),
+								Value:      pointer.StringPtr("5G"),
 								Percentage: pointer.Int32Ptr(40),
 							},
 						},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane auto-scaling high-availability cost
/kind post-mortem

**What this PR does / why we need it**:
Increase limits for etcd.

**Which issue(s) this PR fixes**:
Fixes https://github.tools.sap/kubernetes-live/issues-live/issues/250

**Special notes for your reviewer**:
Replacement for #3835 after out-of-band discussion.

There is a risk of longer downtime (also, possibly corrupted WAL files) during maintenance window in bigger clusters (if they have large fluctuations in usage pattern during 24h period) which is triggered by too drastic a scale down during maintenance window followed by sub-optimal subsequent scale ups.

The increased limit values are based on the spikes in CPU and memory usage in some of the largest shoot clusters in the landscapes including the one mentioned in the linked issue.

Please see here for more details -> https://github.tools.sap/kubernetes-live/issues-live/issues/250#issuecomment-202646

cc @mvladev  @vlerenc @istvanballok @mliepold @ialidzhikov @rfranzke @dguendisch

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Increase limits for etcd to avoid potential long down time during maintenance window.
```
