### PR TITLE
Fix broken docs link

### DIFF
--- a/docs/deployment/deploy_gardenlet_automatically.md
+++ b/docs/deployment/deploy_gardenlet_automatically.md
@@ -11,7 +11,7 @@ The only prerequisite is to register an initial cluster as a seed cluster that h
 * This gardenlet was either deployed as part of a Gardener installation using a setup tool (for example, `gardener/garden-setup`) or
 * the gardenlet was deployed manually 
   - for a step-by-step manual installation Guide see: [Deploy a Gardenlet Manually](deploy_gardenlet_manually.md))
-  - for a Gardenlet deployment using an installation tool see: [Gardenlet landscaper component](../../landscaper/gardenlet/README.md).
+  - for a Gardenlet deployment using an installation tool see: [Gardenlet landscaper component](../../landscaper/pkg/gardenlet/README.md).
 
 > The initial cluster can be the garden cluster itself.
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality


**What this PR does / why we need it**:

Fixes a broken doc link in the gardenlet installation manual.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
