### PR TITLE
Allow GAC user to list/watch namespaces

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-system.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-system.yaml
@@ -127,13 +127,13 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - namespaces
   - configmaps
   verbs:
   - get
 - apiGroups:
   - ""
   resources:
+  - namespaces
   - secrets
   verbs:
   - get


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind regression

**What this PR does / why we need it**:
Due to a change to the Namespace Deletion admission in #3774, the Gardener-Admission-Controller now needs permissions to list and watch `Namespaces`. 

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
