### PR TITLE
Aggregate container label for seed:images:count

### DIFF
--- a/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
+++ b/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
@@ -303,7 +303,7 @@ groups:
 
   # Recording rules for images running on seed
   - record: seed:images:count
-    expr: count(kube_pod_container_info) by (image, image_id)
+    expr: count(kube_pod_container_info) by (image, image_id, container)
 
   # Recording rules for container count for the entire seed
   - record: seed:kube_pod_container_info:count


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

The container label should also be part of the recording rule for the metric `seed:images:count`.

Often `image` and `image_id` are not human readable, so to identify what the image is it can be helpful to have the container name included in the metric.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
