### PR TITLE
Add ShootExtensionStatus controllers

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/clusterrole-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrole-admission-controller.yaml
@@ -21,6 +21,7 @@ rules:
   - seeds
   - shoots
   - shootstates
+  - shootextensionstatuses
   - projects
   verbs:
   - get

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -308,6 +308,7 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 			&gardencorev1beta1.ControllerDeployment{},
 			&gardencorev1beta1.Project{},
 			&gardencorev1alpha1.ShootState{},
+			&gardencorev1alpha1.ShootExtensionStatus{},
 		)
 
 	if seedConfig := cfg.SeedConfig; seedConfig != nil {

--- a/hack/local-development/dev-setup-register-gardener
+++ b/hack/local-development/dev-setup-register-gardener
@@ -374,6 +374,7 @@ $ADMISSION_CONTROLLER_PORT_STRING
     - backupbuckets
     - backupentries
     - shootstates
+    - shootextensionstatuses
   - apiGroups:
     - operations.gardener.cloud
     apiVersions:

--- a/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission.go
+++ b/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission.go
@@ -50,13 +50,14 @@ const (
 var (
 	// Only take v1beta1 for the core.gardener.cloud API group because the Authorize function only checks the resource
 	// group and the resource (but it ignores the version).
-	backupBucketResource         = gardencorev1beta1.Resource("backupbuckets")
-	backupEntryResource          = gardencorev1beta1.Resource("backupentries")
+	backupBucketResource              = gardencorev1beta1.Resource("backupbuckets")
+	backupEntryResource               = gardencorev1beta1.Resource("backupentries")
 	bastionResource                   = gardenoperationsv1alpha1.Resource("bastions")
-	certificateSigningRequestResource = certificatesv1beta1.Resource("certificatesigningrequests")leaseResource                = coordinationv1.Resource("leases")
-	seedResource                 = gardencorev1beta1.Resource("seeds")
-	shootStateResource           = gardencorev1beta1.Resource("shootstates")
-	shootExtensionStatusResource = gardencorev1beta1.Resource("shootextensionstatuses")
+	certificateSigningRequestResource = certificatesv1beta1.Resource("certificatesigningrequests")
+	leaseResource                     = coordinationv1.Resource("leases")
+	seedResource                      = gardencorev1beta1.Resource("seeds")
+	shootStateResource                = gardencorev1beta1.Resource("shootstates")
+	shootExtensionStatusResource      = gardencorev1beta1.Resource("shootextensionstatuses")
 )
 
 // New creates a new webhook handler restricting requests by gardenlets. It allows all requests.

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
@@ -77,6 +77,7 @@ var (
 	seedResource                      = gardencorev1beta1.Resource("seeds")
 	shootResource                     = gardencorev1beta1.Resource("shoots")
 	shootStateResource                = gardencorev1alpha1.Resource("shootstates")
+	shootExtensionStatusResource   = gardencorev1alpha1.Resource("shootextensionstatuses")
 )
 
 // TODO: Revisit all `DecisionNoOpinion` later. Today we cannot deny the request for backwards compatibility
@@ -164,6 +165,12 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			)
 		case shootStateResource:
 			return a.authorize(seedName, graph.VertexTypeShootState, attrs,
+				[]string{"get", "update", "patch"},
+				[]string{"create"},
+				nil,
+			)
+		case shootExtensionStatusResource:
+			return a.authorize(seedName, graph.VertexTypeShootExtensionStatus, attrs,
 				[]string{"get", "update", "patch"},
 				[]string{"create"},
 				nil,

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
@@ -77,7 +77,7 @@ var (
 	seedResource                      = gardencorev1beta1.Resource("seeds")
 	shootResource                     = gardencorev1beta1.Resource("shoots")
 	shootStateResource                = gardencorev1alpha1.Resource("shootstates")
-	shootExtensionStatusResource   = gardencorev1alpha1.Resource("shootextensionstatuses")
+	shootExtensionStatusResource      = gardencorev1alpha1.Resource("shootextensionstatuses")
 )
 
 // TODO: Revisit all `DecisionNoOpinion` later. Today we cannot deny the request for backwards compatibility

--- a/pkg/admissioncontroller/webhooks/auth/seed/graph/eventhandler_shootextensionstatus.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/graph/eventhandler_shootextensionstatus.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"time"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	toolscache "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+)
+
+func (g *graph) setupShootExtensionStatusWatch(informer cache.Informer) {
+	informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			status, ok := obj.(*gardencorev1alpha1.ShootExtensionStatus)
+			if !ok {
+				return
+			}
+			g.handleShootExtensionStatusCreate(status)
+		},
+
+		DeleteFunc: func(obj interface{}) {
+			if tombstone, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
+				obj = tombstone.Obj
+			}
+			status, ok := obj.(*gardencorev1alpha1.ShootExtensionStatus)
+			if !ok {
+				return
+			}
+			g.handleShootExtensionStatusDelete(status)
+		},
+	})
+}
+
+func (g *graph) handleShootExtensionStatusCreate(status *gardencorev1alpha1.ShootExtensionStatus) {
+	start := time.Now()
+	defer func() {
+		metricUpdateDuration.WithLabelValues("ShootExtensionStatus", "CreateOrUpdate").Observe(time.Since(start).Seconds())
+	}()
+	g.lock.Lock()
+	defer g.lock.Unlock()
+
+	var (
+		shootExtensionStatusVertex = g.getOrCreateVertex(VertexTypeShootExtensionStatus, status.Namespace, status.Name)
+		shootVertex                = g.getOrCreateVertex(VertexTypeShoot, status.Namespace, status.Name)
+	)
+
+	g.addEdge(shootExtensionStatusVertex, shootVertex)
+}
+
+func (g *graph) handleShootExtensionStatusDelete(status *gardencorev1alpha1.ShootExtensionStatus) {
+	start := time.Now()
+	defer func() {
+		metricUpdateDuration.WithLabelValues("ShootExtensionStatus", "Delete").Observe(time.Since(start).Seconds())
+	}()
+	g.lock.Lock()
+	defer g.lock.Unlock()
+
+	g.deleteVertex(VertexTypeShootExtensionStatus, status.Namespace, status.Name)
+}

--- a/pkg/admissioncontroller/webhooks/auth/seed/graph/graph.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/graph/graph.go
@@ -82,6 +82,7 @@ func (g *graph) Setup(ctx context.Context, c cache.Cache) error {
 		{&gardencorev1beta1.Seed{}, g.setupSeedWatch},
 		{&gardencorev1beta1.Shoot{}, g.setupShootWatch},
 		{shootStates, g.setupShootStateWatch},
+		{&gardencorev1alpha1.ShootExtensionStatus{}, g.setupShootExtensionStatusWatch},
 	} {
 		informer, err := c.GetInformer(ctx, resource.obj)
 		if err != nil {

--- a/pkg/admissioncontroller/webhooks/auth/seed/graph/graph_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/graph/graph_test.go
@@ -58,7 +58,7 @@ var _ = Describe("graph", func() {
 		fakeInformerControllerInstallation    *controllertest.FakeInformer
 		fakeInformerManagedSeed               *controllertest.FakeInformer
 		fakeInformerShootState                *controllertest.FakeInformer
-		fakeInformerShootExtensionStatus   *controllertest.FakeInformer
+		fakeInformerShootExtensionStatus      *controllertest.FakeInformer
 		fakeInformerLease                     *controllertest.FakeInformer
 		fakeInformerCertificateSigningRequest *controllertest.FakeInformer
 		fakeInformers                         *informertest.FakeInformers
@@ -134,7 +134,7 @@ var _ = Describe("graph", func() {
 				gardencorev1beta1.SchemeGroupVersion.WithKind("ControllerInstallation"):      fakeInformerControllerInstallation,
 				seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeed"):            fakeInformerManagedSeed,
 				metav1.SchemeGroupVersion.WithKind("PartialObjectMetadata"):                  fakeInformerShootState,
-				gardencorev1alpha1.SchemeGroupVersion.WithKind("ShootExtensionStatus"):  fakeInformerShootExtensionStatus,
+				gardencorev1alpha1.SchemeGroupVersion.WithKind("ShootExtensionStatus"):       fakeInformerShootExtensionStatus,
 				coordinationv1.SchemeGroupVersion.WithKind("Lease"):                          fakeInformerLease,
 				certificatesv1beta1.SchemeGroupVersion.WithKind("CertificateSigningRequest"): fakeInformerCertificateSigningRequest,
 			},

--- a/pkg/admissioncontroller/webhooks/auth/seed/graph/vertices.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/graph/vertices.go
@@ -76,7 +76,7 @@ var vertexTypes = map[VertexType]string{
 	VertexTypeSeed:                      "Seed",
 	VertexTypeShoot:                     "Shoot",
 	VertexTypeShootState:                "ShootState",
-	VertexTypeShootExtensionStatus:   "ShootExtensionStatus",
+	VertexTypeShootExtensionStatus:      "ShootExtensionStatus",
 }
 
 type vertex struct {

--- a/pkg/admissioncontroller/webhooks/auth/seed/graph/vertices.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/graph/vertices.go
@@ -54,6 +54,8 @@ const (
 	VertexTypeShoot
 	// VertexTypeShootState is a constant for a 'ShootState' vertex.
 	VertexTypeShootState
+	// VertexTypeShootExtensionStatus is a constant for a 'ShootExtensionStatus' vertex.
+	VertexTypeShootExtensionStatus
 )
 
 var vertexTypes = map[VertexType]string{
@@ -74,6 +76,7 @@ var vertexTypes = map[VertexType]string{
 	VertexTypeSeed:                      "Seed",
 	VertexTypeShoot:                     "Shoot",
 	VertexTypeShootState:                "ShootState",
+	VertexTypeShootExtensionStatus:   "ShootExtensionStatus",
 }
 
 type vertex struct {

--- a/pkg/gardenlet/controller/federatedseed/extensions/common.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/common.go
@@ -12,23 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package extensions_test
+package extensions
 
 import (
-	"encoding/json"
-	"testing"
+	"context"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/runtime"
+	apiextensions "github.com/gardener/gardener/pkg/api/extensions"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TestExtensionControllers(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Gardenlet Federated Extension Controller Suite")
-}
-
-func encode(obj runtime.Object) []byte {
-	out, _ := json.Marshal(obj)
-	return out
+// GetExtensionObject is a helper to get the extension object for a key and objectCreator function
+func GetExtensionObject(ctx context.Context, seedClient client.Client, key types.NamespacedName, objectCreator func() client.Object) (extensionsv1alpha1.Object, error) {
+	obj := objectCreator()
+	if err := seedClient.Get(ctx, key, obj); err != nil {
+		return nil, err
+	}
+	return apiextensions.Accessor(obj)
 }

--- a/pkg/gardenlet/controller/federatedseed/extensions/shootextensionstatus_control.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/shootextensionstatus_control.go
@@ -1,0 +1,234 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	"context"
+	"fmt"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/sirupsen/logrus"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/extensions"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+// ShootExtensionStatusControl is used to sync the `providerStatus` field from extension
+// resources in the Seed to the ShootExtensionStatus resource in the Garden cluster.
+type ShootExtensionStatusControl struct {
+	gardenClient client.Client
+	seedClient   client.Client
+	log          *logrus.Entry
+	recorder     record.EventRecorder
+	decoder      runtime.Decoder
+}
+
+// NewShootExtensionStatusControl creates a new instance of ShootExtensionStatusControl.
+func NewShootExtensionStatusControl(k8sGardenClient, seedClient client.Client, log *logrus.Entry, recorder record.EventRecorder) *ShootExtensionStatusControl {
+	return &ShootExtensionStatusControl{
+		gardenClient: k8sGardenClient,
+		seedClient:   seedClient,
+		log:          log,
+		recorder:     recorder,
+		decoder:      extensions.NewGardenDecoder(),
+	}
+}
+
+// CreateShootExtensionStatusSyncReconcileFunc creates a function which can be used by the reconciliation loop to sync
+// the extension status to the ShootExtensionStatus resource in the Garden cluster
+func (s *ShootExtensionStatusControl) CreateShootExtensionStatusSyncReconcileFunc(kind string, objectCreator func() client.Object) reconcile.Func {
+	return func(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+		extensionObj, err := GetExtensionObject(ctx, s.seedClient, req.NamespacedName, objectCreator)
+		if apierrors.IsNotFound(err) {
+			// the extension has been deleted from the Seed cluster
+			// we an be sure that there are no more cloud provider resources left.
+			// Delete the provider status from the ShootExtensionStatus resource in the Garden cluster
+			s.log.Debugf("Extension resource (%s/%s) of kind %q has been deleted. Synchonrizing with ShootExtensionStatus in the Garden cluster", req.NamespacedName.Namespace, req.NamespacedName.Name, kind)
+
+			shoot, err := s.getShootForRequest(ctx, req)
+			if err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to delete the provider status of the %q extension (%s/%s) from the ShootExtensionStatus: %w",
+					kind,
+					req.NamespacedName.Namespace,
+					req.NamespacedName.Name,
+					err)
+			}
+
+			shootExtensionStatus := &gardencorev1alpha1.ShootExtensionStatus{}
+			if err := s.gardenClient.Get(ctx, kutil.Key(shoot.Namespace, shoot.Name), shootExtensionStatus); err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to delete the provider status of the %q extension (%s/%s) from the ShootExtensionStatus for Shoot %q in namespace %q: %w",
+					kind,
+					req.NamespacedName.Namespace,
+					req.NamespacedName.Name,
+					shoot.Name,
+					shoot.Namespace,
+					err)
+			}
+			shootExtensionStatusCopy := shootExtensionStatus.DeepCopy()
+			shootExtensionStatus.Statuses = removeExtensionStatus(shootExtensionStatus.Statuses, kind)
+			return s.patchShootExtensionStatus(ctx, shootExtensionStatus, shootExtensionStatusCopy, kind)
+		}
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		if shouldSkipExtensionStatusSync(extensionObj) {
+			return reconcile.Result{}, nil
+		}
+
+		extensionType := extensionObj.GetExtensionSpec().GetExtensionType()
+		purpose := extensionObj.GetExtensionSpec().GetExtensionPurpose()
+		currentProviderStatus := extensionObj.GetExtensionStatus().GetProviderStatus()
+
+		shoot, err := s.getShootForRequest(ctx, req)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// ShootExtensionStatus resource must already exist in the project namespace
+		shootExtensionStatus := &gardencorev1alpha1.ShootExtensionStatus{}
+		if err := s.gardenClient.Get(ctx, kutil.Key(shoot.Namespace, shoot.Name), shootExtensionStatus); err != nil {
+			return reconcile.Result{}, fmt.Errorf("shoot extension status sync failed: %w", err)
+		}
+
+		shootExtensionStatusCopy := shootExtensionStatus.DeepCopy()
+		currentExtensionStatus, indexOldStatus := getExtensionStatusForKind(shootExtensionStatus.Statuses, kind)
+
+		if currentProviderStatus == nil {
+			if currentExtensionStatus == nil {
+				s.log.Infof("Skipping ShootExtensionStatus for the %q extension of Shoot %q. The resource is up-to-date.", kind, shoot.Name)
+				return reconcile.Result{}, nil
+			} else {
+				// Usually, the provider status of an extension resource should not be removed without the extension having a deletion timestamp
+				// so we should not get to this point.
+				// But if we do (e.g manual status update), we also delete the status from the ShootExtensionStatus resource
+				s.log.Debugf(fmt.Sprintf("Deleting the provider status for the %q extension from the ShootExtensionStatus for Shoot %q", kind, shoot.Name))
+				shootExtensionStatus.Statuses = removeExtensionStatus(shootExtensionStatus.Statuses, kind)
+				return s.patchShootExtensionStatus(ctx, shootExtensionStatus, shootExtensionStatusCopy, kind)
+			}
+		}
+
+		newEntry := gardencorev1alpha1.ExtensionStatus{
+			Kind:    kind,
+			Type:    extensionType,
+			Purpose: purpose,
+			Status:  *currentProviderStatus,
+		}
+
+		// new provider status that has not yet been synced
+		// add the new ExtensionStatus entry
+		if currentExtensionStatus == nil {
+			shootExtensionStatus.Statuses = append(shootExtensionStatus.Statuses, newEntry)
+			return s.patchShootExtensionStatus(ctx, shootExtensionStatus, shootExtensionStatusCopy, kind)
+		}
+
+		// at this point we know that we have a provider status that also exists in the ShootExtensionStatus in the Garden cluster
+		// we need to check if the status is up to date by checking for equality
+		if apiequality.Semantic.DeepEqual(*currentExtensionStatus, newEntry) {
+			s.log.Debugf("Skipping sync of the ShootExtensionStatus for the %q extension of Shoot %q. The resource is up-to-date", kind, shoot.Name)
+			return reconcile.Result{}, nil
+		}
+
+		// patch the existing ExtensionStatus entry and patch the ShootExtensionStatus resource
+		shootExtensionStatus.Statuses[indexOldStatus] = newEntry
+		return s.patchShootExtensionStatus(ctx, shootExtensionStatus, shootExtensionStatusCopy, kind)
+	}
+}
+
+// getShootForRequest returns the Shoot resource for a reconcile.Request parsed from the Cluster resource in the Seed
+func (s *ShootExtensionStatusControl) getShootForRequest(ctx context.Context, req reconcile.Request) (*gardencorev1beta1.Shoot, error) {
+	cluster, err := extensions.ClusterFromRequest(ctx, s.seedClient, req)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("could not get cluster with name %s : %w", cluster.Name, err)
+	}
+
+	shoot, err := extensions.ShootFromCluster(s.decoder, cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	if shoot == nil {
+		return nil, fmt.Errorf("cluster resource %s doesn't contain shoot resource", cluster.Name)
+	}
+	return shoot, nil
+}
+
+func (s *ShootExtensionStatusControl) patchShootExtensionStatus(ctx context.Context, shootExtensionStatus *gardencorev1alpha1.ShootExtensionStatus, shootExtensionStatusCopy *gardencorev1alpha1.ShootExtensionStatus, kind string) (reconcile.Result, error) {
+	if err := s.gardenClient.Patch(ctx, shootExtensionStatus, client.MergeFromWithOptions(shootExtensionStatusCopy, client.MergeFromWithOptimisticLock{})); err != nil {
+		message := fmt.Sprintf("The %q extension status for Shoot %q was NOT successfully synced: %v", shootExtensionStatus.Name, kind, err)
+		s.log.Error(message)
+		return reconcile.Result{}, err
+	}
+
+	message := fmt.Sprintf("The provider status of the %q extension of Shoot %q was successfully synced to the Garden cluster", kind, shootExtensionStatus.Name)
+	s.log.Info(message)
+	return reconcile.Result{}, nil
+}
+
+// getExtensionStatusForKind given an []ExtensionStatus and kind, returns the matching ExtensionStatus and index in the array
+func getExtensionStatusForKind(status []gardencorev1alpha1.ExtensionStatus, kind string) (*gardencorev1alpha1.ExtensionStatus, int) {
+	for i, entry := range status {
+		if entry.Kind == kind {
+			return &entry, i
+		}
+	}
+	return nil, 0
+}
+
+// removeExtensionStatus given an []ExtensionStatus and kind, returns the []ExtensionStatus without the ExtensionStatus
+// identified by kind
+func removeExtensionStatus(status []gardencorev1alpha1.ExtensionStatus, kind string) []gardencorev1alpha1.ExtensionStatus {
+	var entries []gardencorev1alpha1.ExtensionStatus
+	for _, entry := range status {
+		if entry.Kind == kind {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+// shouldSkipExtensionStatusSync returns true if the ShootExtensionStatus sync should be skipped.
+// Skip when
+//  - a control plane migration is ongoing to avoid concurrent updates from both source
+//    and destination Seed gardenlets.
+//  - the extension resource already has a deletion timestamp.
+//    The cloud provider resources might still exist.
+func shouldSkipExtensionStatusSync(extensionObject extensionsv1alpha1.Object) bool {
+	if extensionObject.GetDeletionTimestamp() != nil {
+		return true
+	}
+
+	annotations := extensionObject.GetAnnotations()
+	if annotations != nil {
+		operationAnnotation := annotations[v1beta1constants.GardenerOperation]
+		return operationAnnotation == v1beta1constants.GardenerOperationWaitForState ||
+			operationAnnotation == v1beta1constants.GardenerOperationRestore ||
+			operationAnnotation == v1beta1constants.GardenerOperationMigrate
+	}
+	return false
+}

--- a/pkg/gardenlet/controller/federatedseed/extensions/shootextensionstatus_control.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/shootextensionstatus_control.go
@@ -117,7 +117,7 @@ func (s *ShootExtensionStatusControl) CreateShootExtensionStatusSyncReconcileFun
 
 		if currentProviderStatus == nil {
 			if currentExtensionStatus == nil {
-				s.log.Infof("Skipping ShootExtensionStatus for the %q extension of Shoot %q. The resource is up-to-date.", kind, shoot.Name)
+				s.log.Debugf("Skipping ShootExtensionStatus for the %q extension of Shoot %q. The resource is up-to-date.", kind, shoot.Name)
 				return reconcile.Result{}, nil
 			} else {
 				// Usually, the provider status of an extension resource should not be removed without the extension having a deletion timestamp
@@ -185,7 +185,7 @@ func (s *ShootExtensionStatusControl) patchShootExtensionStatus(ctx context.Cont
 	}
 
 	message := fmt.Sprintf("The provider status of the %q extension of Shoot %q was successfully synced to the Garden cluster", kind, shootExtensionStatus.Name)
-	s.log.Info(message)
+	s.log.Debug(message)
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/gardenlet/controller/federatedseed/extensions/shootextensionstatus_control_test.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/shootextensionstatus_control_test.go
@@ -1,0 +1,324 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions_test
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/gardener/gardener/charts"
+	gardencoreinstall "github.com/gardener/gardener/pkg/apis/core/install"
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
+	extensionsutil "github.com/gardener/gardener/pkg/extensions"
+	"github.com/gardener/gardener/pkg/gardenlet/controller/federatedseed/extensions"
+	"github.com/gardener/gardener/pkg/logger"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"github.com/gardener/gardener/test/framework"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var gardenScheme *runtime.Scheme
+
+func init() {
+	gardenScheme = runtime.NewScheme()
+	gardencoreinstall.Install(gardenScheme)
+}
+
+var (
+	ctx        = context.Background()
+	err        error
+	restConfig *rest.Config
+	decoder    = extensionsutil.NewGardenDecoder()
+
+	gardenEnv    *gardenerenvtest.GardenerTestEnvironment
+	gardenClient client.Client
+
+	seedClient client.Client
+	seedEnv    *envtest.Environment
+
+	shootName           = "aws-clone"
+	workerName          = "worker-1"
+	shootControlPlaneNs = "shoot--dev--aws-clone"
+	shootProjectNs      = "garden-dev"
+	clusterName         = shootControlPlaneNs
+
+	recorder         = record.NewFakeRecorder(64)
+	log              = logger.NewNopLogger().WithField("seed", "test")
+	reconcileRequest = reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: shootControlPlaneNs,
+			Name:      workerName,
+		},
+	}
+
+	cluster              *extensionsv1alpha1.Cluster
+	worker               *extensionsv1alpha1.Worker
+	shootExtensionStatus *gardencorev1alpha1.ShootExtensionStatus
+	workerProviderStatus = &gardencorev1beta1.Shoot{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+			Kind:       "Shoot",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: shootProjectNs,
+			Name:      shootName,
+		},
+		Spec: gardencorev1beta1.ShootSpec{
+			CloudProfileName: "differentiating-attribute",
+		},
+	}
+)
+
+var _ = Describe("Shoot extension status tests", func() {
+	BeforeSuite(func() {
+		logf.SetLogger(logzap.New(logzap.UseDevMode(true), logzap.WriteTo(GinkgoWriter)))
+
+		Context("starting Seed cluster", func() {
+			seedEnv = &envtest.Environment{}
+
+			pathExtensionCRDs := filepath.Join("..", "..", "..", "..", "..", charts.Path, "seed-bootstrap", "charts", "extensions", "templates")
+			seedEnv.CRDDirectoryPaths = []string{
+				pathExtensionCRDs,
+			}
+			seedEnv.ErrorIfCRDPathMissing = true
+
+			restConfig, err = seedEnv.Start()
+			Expect(err).ToNot(HaveOccurred())
+
+			seedClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.SeedScheme})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("starting Garden cluster", func() {
+			gardenEnv = &gardenerenvtest.GardenerTestEnvironment{}
+			restConfig, err = gardenEnv.Start()
+			Expect(err).ToNot(HaveOccurred())
+
+			gardenClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.GardenScheme})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Expect(seedClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: shootControlPlaneNs}})).
+			To(Or(Succeed(), BeAlreadyExistsError()))
+
+		Expect(gardenClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: shootProjectNs}})).
+			To(Or(Succeed(), BeAlreadyExistsError()))
+	})
+
+	BeforeEach(func() {
+		cluster = &extensionsv1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterName,
+			},
+			Spec: extensionsv1alpha1.ClusterSpec{
+				Shoot: runtime.RawExtension{
+					Raw: encode(&gardencorev1beta1.Shoot{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+							Kind:       "Shoot",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: shootProjectNs,
+							Name:      shootName,
+						},
+					}),
+				},
+				CloudProfile: runtime.RawExtension{
+					Raw: encode(&gardencorev1beta1.CloudProfile{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+							Kind:       "CloudProfile",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "aws",
+						},
+					}),
+				},
+				Seed: runtime.RawExtension{
+					Raw: encode(&gardencorev1beta1.Seed{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+							Kind:       "Seed",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "my-seed",
+						},
+					}),
+				},
+			},
+		}
+		Expect(seedClient.Create(ctx, cluster)).ToNot(HaveOccurred())
+
+		worker = &extensionsv1alpha1.Worker{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      workerName,
+				Namespace: shootControlPlaneNs,
+			},
+			Spec: extensionsv1alpha1.WorkerSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type: "aws",
+				},
+				Pools: []extensionsv1alpha1.WorkerPool{
+					{
+						Name:        "superworker",
+						MachineType: "m5.large",
+						MachineImage: extensionsv1alpha1.MachineImage{
+							Name:    "gardenlinux",
+							Version: "184.0.0",
+						},
+						UserData: []byte("test"),
+					},
+				},
+			},
+			Status: extensionsv1alpha1.WorkerStatus{
+				DefaultStatus: extensionsv1alpha1.DefaultStatus{
+					ProviderStatus: &runtime.RawExtension{
+						Raw: encode(workerProviderStatus),
+					},
+				},
+			},
+		}
+
+		Expect(seedClient.Create(ctx, worker)).ToNot(HaveOccurred())
+		Expect(seedClient.Status().Update(ctx, worker)).ToNot(HaveOccurred())
+
+		shootExtensionStatus = &gardencorev1alpha1.ShootExtensionStatus{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shootName,
+				Namespace: shootProjectNs,
+			},
+		}
+		Expect(gardenClient.Create(ctx, shootExtensionStatus)).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(seedClient.Delete(ctx, worker)).To(Or(Succeed(), BeNotFoundError()))
+		Expect(seedClient.Delete(ctx, cluster)).ToNot(HaveOccurred())
+		Expect(gardenClient.Delete(ctx, shootExtensionStatus)).ToNot(HaveOccurred())
+	})
+
+	Describe("#CreateShootExtensionStatusSyncReconcileFunc", func() {
+		It("should create the entry in the ShootExtensionStatus", func() {
+			executeStatusSyncReconciler()
+
+			shootExtensionStatus := &gardencorev1alpha1.ShootExtensionStatus{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      shootName,
+					Namespace: shootProjectNs,
+				},
+			}
+			Expect(gardenClient.Get(ctx, kutil.Key(shootExtensionStatus.Namespace, shootExtensionStatus.Name), shootExtensionStatus)).ToNot(HaveOccurred())
+			Expect(shootExtensionStatus.Statuses).To(HaveLen(1))
+
+			syncedWorkerStatus := &gardencorev1beta1.Shoot{}
+			_, _, err = decoder.Decode(shootExtensionStatus.Statuses[0].Status.Raw, nil, syncedWorkerStatus)
+			Expect(err).ToNot(HaveOccurred())
+			// pick any differentiating attribute to check if the content has actually been synced
+			Expect(syncedWorkerStatus.Spec.CloudProfileName).To(Equal(workerProviderStatus.Spec.CloudProfileName))
+		})
+
+		It("should update the entry in the ShootExtensionStatus", func() {
+			// simulate existing entry in the ShootExtensionStatus
+			shootExtensionStatus.Statuses = append(shootExtensionStatus.Statuses, gardencorev1alpha1.ExtensionStatus{
+				Kind:    "Worker",
+				Type:    "aws",
+				Purpose: nil,
+				Status:  runtime.RawExtension{},
+			})
+			Expect(gardenClient.Update(ctx, shootExtensionStatus)).ToNot(HaveOccurred())
+
+			executeStatusSyncReconciler()
+
+			shootExtensionStatus := &gardencorev1alpha1.ShootExtensionStatus{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      shootName,
+					Namespace: shootProjectNs,
+				},
+			}
+			Expect(gardenClient.Get(ctx, kutil.Key(shootExtensionStatus.Namespace, shootExtensionStatus.Name), shootExtensionStatus)).ToNot(HaveOccurred())
+			Expect(shootExtensionStatus.Statuses).To(HaveLen(1))
+
+			syncedWorkerStatus := &gardencorev1beta1.Shoot{}
+			_, _, err = decoder.Decode(shootExtensionStatus.Statuses[0].Status.Raw, nil, syncedWorkerStatus)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(syncedWorkerStatus.Spec.CloudProfileName).To(Equal(workerProviderStatus.Spec.CloudProfileName))
+		})
+
+		It("should delete existing provider status from the ShootExtensionStatus when an extension resource has been deleted", func() {
+			// simulate existing entry in the ShootExtensionStatus
+			shootExtensionStatus.Statuses = append(shootExtensionStatus.Statuses, gardencorev1alpha1.ExtensionStatus{
+				Kind:    "Worker",
+				Type:    "aws",
+				Purpose: nil,
+				Status:  runtime.RawExtension{},
+			})
+			Expect(gardenClient.Update(ctx, shootExtensionStatus)).ToNot(HaveOccurred())
+
+			// simulate the worker resource has been deleted
+			// the reconcile function below is triggered after the resource has already been deleted
+			Expect(seedClient.Delete(ctx, worker)).ToNot(HaveOccurred())
+
+			executeStatusSyncReconciler()
+
+			shootExtensionStatus := &gardencorev1alpha1.ShootExtensionStatus{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      shootName,
+					Namespace: shootProjectNs,
+				},
+			}
+			Expect(gardenClient.Get(ctx, kutil.Key(shootExtensionStatus.Namespace, shootExtensionStatus.Name), shootExtensionStatus)).ToNot(HaveOccurred())
+			Expect(shootExtensionStatus.Statuses).To(HaveLen(0))
+		})
+	})
+
+	AfterSuite(func() {
+		By("running cleanup actions")
+		framework.RunCleanupActions()
+
+		By("stopping Seed test environment")
+		Expect(seedEnv.Stop()).To(Succeed())
+		Expect(gardenEnv.Stop()).To(Succeed())
+	})
+})
+
+func executeStatusSyncReconciler() {
+	control := extensions.NewShootExtensionStatusControl(
+		gardenClient,
+		seedClient,
+		log,
+		recorder)
+
+	reconcileFunc := control.CreateShootExtensionStatusSyncReconcileFunc(extensionsv1alpha1.WorkerResource, func() client.Object { return &extensionsv1alpha1.Worker{} })
+	_, err := reconcileFunc.Reconcile(ctx, reconcileRequest)
+	Expect(err).ToNot(HaveOccurred())
+}

--- a/pkg/gardenlet/controller/federatedseed/extensions/shootstate_control_test.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/shootstate_control_test.go
@@ -309,8 +309,3 @@ var _ = Describe("ShootState Control", func() {
 		})
 	})
 })
-
-func encode(obj runtime.Object) []byte {
-	out, _ := json.Marshal(obj)
-	return out
-}

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -93,6 +93,10 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Name: "Ensuring that ShootState exists",
 			Fn:   flow.TaskFn(botanist.EnsureShootStateExists).RetryUntilTimeout(defaultInterval, defaultTimeout),
 		})
+		ensureShootExtensionStatus = g.Add(flow.Task{
+			Name: "Ensuring that ShootExtensionStatus resource exists in the project namespace",
+			Fn:   flow.TaskFn(botanist.Shoot.Components.ShootExtensionStatus.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
+		})
 		deployNamespace = g.Add(flow.Task{
 			Name: "Deploying Shoot namespace in Seed",
 			Fn:   flow.TaskFn(botanist.DeploySeedNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
@@ -165,7 +169,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployInfrastructure = g.Add(flow.Task{
 			Name:         "Deploying Shoot infrastructure",
 			Fn:           flow.TaskFn(botanist.DeployInfrastructure).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(deploySecrets, deployCloudProviderSecret, deployReferencedResources),
+			Dependencies: flow.NewTaskIDs(deploySecrets, deployCloudProviderSecret, deployReferencedResources, ensureShootExtensionStatus),
 		})
 		waitUntilInfrastructureReady = g.Add(flow.Task{
 			Name: "Waiting until shoot infrastructure has been reconciled",

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/clusteridentity"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/shootextensionstatus"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -148,7 +149,22 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 
 	// other components
 	o.Shoot.Components.BackupEntry = b.DefaultCoreBackupEntry(b.K8sGardenClient.DirectClient())
-	o.Shoot.Components.ClusterIdentity = clusteridentity.New(o.Shoot.Info.Status.ClusterIdentity, o.GardenClusterIdentity, o.Shoot.Info.Name, o.Shoot.Info.Namespace, o.Shoot.SeedNamespace, string(o.Shoot.Info.Status.UID), b.K8sGardenClient.DirectClient(), b.K8sSeedClient.DirectClient(), b.Logger)
+	o.Shoot.Components.ClusterIdentity = clusteridentity.New(
+		o.Shoot.Info.Status.ClusterIdentity,
+		o.GardenClusterIdentity,
+		o.Shoot.Info.Name,
+		o.Shoot.Info.Namespace,
+		o.Shoot.SeedNamespace,
+		string(o.Shoot.Info.Status.UID),
+		b.K8sGardenClient.DirectClient(),
+		b.K8sSeedClient.DirectClient(),
+		b.Logger,
+	)
+
+	o.Shoot.Components.ShootExtensionStatus = shootextensionstatus.New(
+		b.K8sGardenClient.Client(),
+		b.Shoot.Info,
+	)
 	o.Shoot.Components.NetworkPolicies, err = b.DefaultNetworkPolicies(sniPhase)
 	if err != nil {
 		return nil, err

--- a/pkg/operation/botanist/component/shootextensionstatus/shoot_extension_status.go
+++ b/pkg/operation/botanist/component/shootextensionstatus/shoot_extension_status.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shootextensionstatus
+
+import (
+	"context"
+	"fmt"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ShootExtensionStatus contains functions for a ShootExtensionStatus deployer.
+type ShootExtensionStatus interface {
+	component.Deployer
+}
+
+// New creates a new instance of DeployWaiter for the ShootExtensionStatus.
+func New(
+	client client.Client,
+	shoot *gardencorev1beta1.Shoot,
+) ShootExtensionStatus {
+	return &shootExtensionStatus{
+		gardenClient: client,
+		shoot:        shoot,
+	}
+}
+
+type shootExtensionStatus struct {
+	gardenClient client.Client
+	shoot        *gardencorev1beta1.Shoot
+}
+
+func (m *shootExtensionStatus) Deploy(ctx context.Context) error {
+	if m.shoot == nil {
+		return fmt.Errorf("failed to deploy the ShootExtensionStatus as the Shoot is not set")
+	}
+
+	status := &gardencorev1alpha1.ShootExtensionStatus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      m.shoot.Name,
+			Namespace: m.shoot.Namespace,
+		},
+	}
+	ownerReference := metav1.NewControllerRef(m.shoot, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"))
+	blockOwnerDeletion := false
+	ownerReference.BlockOwnerDeletion = &blockOwnerDeletion
+
+	_, err := controllerutils.StrategicMergePatchOrCreate(ctx, m.gardenClient, status, func() error {
+		status.OwnerReferences = []metav1.OwnerReference{*ownerReference}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Destroy is done automatically via OwnerReference from the ShootExtensionStatus to the Shoot resource
+func (m *shootExtensionStatus) Destroy(ctx context.Context) error {
+	return nil
+}

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -85,12 +85,13 @@ type Shoot struct {
 
 // Components contains different components deployed in the Shoot cluster.
 type Components struct {
-	BackupEntry      component.DeployMigrateWaiter
-	ClusterIdentity  component.Deployer
-	ControlPlane     *ControlPlane
-	Extensions       *Extensions
-	NetworkPolicies  component.Deployer
-	SystemComponents *SystemComponents
+	BackupEntry          component.DeployMigrateWaiter
+	ClusterIdentity      component.Deployer
+	ControlPlane         *ControlPlane
+	ShootExtensionStatus component.Deployer
+	Extensions           *Extensions
+	NetworkPolicies      component.Deployer
+	SystemComponents     *SystemComponents
 }
 
 // ControlPlane contains references to K8S control plane components.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:

Contains 3 commits
- Add ShootExtensionStatus to SeedRestriction Admission Webhook
- Add ShootExtensionStatus to SeedAuthorizer Authorization Webhook
- Add federated seed controllers for the ShootExtensionStatus resource.


Part of #3873 

 - Creation of the `ShootExtensionStatus` is done via ShootReconciliation flow. Deletion is implicit via owner reference on the particular Shoot resource.
- Adds the reconciliation of the `ShootExtensionStatus` to the federated seed controller in the Gardenlet

Only enables the sync for the `Infrastructure` and `Worker` extension resources for now.
 - This is to avoid unnecessary network traffic. The mentioned resources are the only ones that currently write a `providerStatus`  in their status. 
 - Also, the Gardenlet is unable to detect and therefore `not` sync an "empty" `providerStatus` that only contains `apiVersion` and `kind` such as:
 ```
  providerStatus:
      apiVersion: calico.networking.extensions.gardener.cloud/v1alpha1
      kind: NetworkStatus
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
THe Gardenlet exposes the provider status of extension resources from the Seed cluster in the Garden cluster via the "ShootExtensionStatus" resource.
```
