### PR TITLE
[release-v1.20] Cherry pick of #3895: [ci:component:github.com/gardener/autoscaler:v0.14.0->v0.15.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -75,7 +75,7 @@ images:
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
-  tag: "v0.14.0"
+  tag: "v0.15.0"
   targetVersion: ">= 1.16"
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler


### PR DESCRIPTION
/area quality
/kind bug

Cherry pick of https://github.com/gardener/gardener/pull/3895 on release-v1.20

https://github.com/gardener/gardener/pull/3895: [ci:component:github.com/gardener/autoscaler:v0.14.0->v0.15.0]

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator github.com/gardener/autoscaler #73 @prashanth26 
Switch to using cached informers to fetch cloud provider details more optimally. 
```
```feature user github.com/gardener/autoscaler #73 @prashanth26 
Enable configuraiton of flags such as `control-apiserver-burst`, `control-apiserver-qps`, `target-apiserver-burst`, `target-apiserver-qps` and `min-resync-period` for kubernetes client configurations while fetching objects for MCM cloud provider.
```
