### PR TITLE
Stop running logging integration test on chost nodes

### DIFF
--- a/test/integration/shoots/logging/seed_logging_stack.go
+++ b/test/integration/shoots/logging/seed_logging_stack.go
@@ -17,6 +17,7 @@ package logging
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -80,6 +81,12 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 	lokiPriorityClass := &schedulingv1.PriorityClass{}
 
 	framework.CBeforeEach(func(ctx context.Context) {
+		for _, worker := range f.Shoot.Spec.Provider.Workers {
+			if strings.Contains(worker.Machine.Image.Name, "chost") {
+				ginkgo.Skip("Skipping logging integration test for chost nodes")
+			}
+		}
+
 		checkRequiredResources(ctx, f.SeedClient)
 		framework.ExpectNoError(f.SeedClient.Client().Get(ctx, types.NamespacedName{Namespace: v1beta1constants.GardenNamespace, Name: fluentBitName}, fluentBit))
 		framework.ExpectNoError(f.SeedClient.Client().Get(ctx, types.NamespacedName{Namespace: v1beta1constants.GardenNamespace, Name: fluentBitConfigMapName}, fluentBitConfMap))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug

**What this PR does / why we need it**:
Fluent-bit reads from `/var/log/journal` the systemd logs.
Chost nodes are using different directory by default: `/run/log/journal` so the logging stack does not work on `chost` nodes and this test is not relevant for them.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@vlvasilev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
