### PR TITLE
Add hvpa for Prometheus deployed by seed-bootstrap

### DIFF
--- a/charts/seed-bootstrap/templates/aggregate-prometheus/hvpa.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/hvpa.yaml
@@ -1,0 +1,82 @@
+{{ if .Values.hvpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1alpha1
+kind: Hvpa
+metadata:
+  name: aggregate-prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ toYaml .Values.aggregatePrometheus.labels | indent 4 }}
+spec:
+  replicas: 1
+{{- if .Values.aggregatePrometheus.hvpa.maintenanceTimeWindow }}
+  maintenanceTimeWindow:
+{{ toYaml .Values.aggregatePrometheus.hvpa.maintenanceTimeWindow | indent 4 }}
+{{- end }}
+  hpa:
+    selector:
+      matchLabels:
+        role: aggregate-prometheus-hpa
+    deploy: false
+    template:
+      metadata:
+        labels:
+          role: aggregate-prometheus-hpa
+      spec:
+        maxReplicas: 1
+        minReplicas: 1
+        metrics:
+        - resource:
+            name: memory
+            targetAverageUtilization: {{ .Values.aggregatePrometheus.hvpa.targetAverageUtilizationMemory }}
+          type: Resource
+        - resource:
+            name: cpu
+            targetAverageUtilization: {{ .Values.aggregatePrometheus.hvpa.targetAverageUtilizationCpu }}
+          type: Resource
+  vpa:
+    selector:
+      matchLabels:
+        role: aggregate-prometheus-vpa
+    deploy: true
+    scaleUp:
+      updatePolicy:
+        updateMode: "Auto"
+{{- if .Values.aggregatePrometheus.hvpa.scaleUpStabilization }}
+{{ toYaml .Values.aggregatePrometheus.hvpa.scaleUpStabilization | indent 6 }}
+{{- end }}
+    scaleDown:
+      updatePolicy:
+{{- if .Values.aggregatePrometheus.hvpa.maintenanceTimeWindow }}
+        updateMode: "MaintenanceWindow"
+{{- else }}
+        updateMode: "Auto"
+{{- end }}
+{{- if .Values.aggregatePrometheus.hvpa.scaleDownStabilization }}
+{{ toYaml .Values.aggregatePrometheus.hvpa.scaleDownStabilization | indent 6 }}
+{{- end }}
+{{- if .Values.aggregatePrometheus.hvpa.limitsRequestsGapScaleParams }}
+    limitsRequestsGapScaleParams:
+{{ toYaml .Values.aggregatePrometheus.hvpa.limitsRequestsGapScaleParams | indent 6 }}
+{{- end }}
+    template:
+      metadata:
+        labels:
+          role: aggregate-prometheus-vpa
+      spec:
+        resourcePolicy:
+          containerPolicies:
+            - containerName: prometheus
+              minAllowed:
+                memory: {{ .Values.aggregatePrometheus.hvpa.minAllowed.memory }}
+                cpu: "{{ .Values.aggregatePrometheus.hvpa.minAllowed.cpu }}"
+            - containerName: prometheus-config-reloader
+              mode: "Off"
+  weightBasedScalingIntervals:
+    - vpaWeight: 100
+      startReplicaCount: 1
+      lastReplicaCount: 1
+  targetRef:
+    apiVersion:  {{ include "statefulsetversion" . }}
+    kind: StatefulSet
+    name: aggregate-prometheus
+{{ end }}

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/statefulset.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/statefulset.yaml
@@ -58,9 +58,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 3
         resources:
-          requests:
-            cpu: 30m
-            memory: 500Mi
+          {{- toYaml .Values.prometheus.resources.prometheus | nindent 10 }}
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config
@@ -79,12 +77,7 @@ spec:
         - -volume-dir=/etc/prometheus/config
         - -volume-dir=/etc/prometheus/rules
         resources:
-          requests:
-            cpu: 5m
-            memory: 10Mi
-          limits:
-            cpu: 10m
-            memory: 20Mi
+          {{- index .Values.prometheus.resources "prometheus-config-reloader" | toYaml | nindent 10 }}
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/vpa.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/vpa.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.hvpa.enabled }}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
@@ -10,3 +11,4 @@ spec:
     name: aggregate-prometheus
   updatePolicy:
     updateMode: "Auto"
+{{ end }}

--- a/charts/seed-bootstrap/templates/prometheus/hvpa.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/hvpa.yaml
@@ -1,0 +1,82 @@
+{{ if .Values.hvpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1alpha1
+kind: Hvpa
+metadata:
+  name: prometheus
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ toYaml .Values.prometheus.labels | indent 4 }}
+spec:
+  replicas: 1
+{{- if .Values.prometheus.hvpa.maintenanceTimeWindow }}
+  maintenanceTimeWindow:
+{{ toYaml .Values.prometheus.hvpa.maintenanceTimeWindow | indent 4 }}
+{{- end }}
+  hpa:
+    selector:
+      matchLabels:
+        role: prometheus-hpa
+    deploy: false
+    template:
+      metadata:
+        labels:
+          role: prometheus-hpa
+      spec:
+        maxReplicas: 1
+        minReplicas: 1
+        metrics:
+        - resource:
+            name: memory
+            targetAverageUtilization: {{ .Values.prometheus.hvpa.targetAverageUtilizationMemory }}
+          type: Resource
+        - resource:
+            name: cpu
+            targetAverageUtilization: {{ .Values.prometheus.hvpa.targetAverageUtilizationCpu }}
+          type: Resource
+  vpa:
+    selector:
+      matchLabels:
+        role: prometheus-vpa
+    deploy: true
+    scaleUp:
+      updatePolicy:
+        updateMode: "Auto"
+{{- if .Values.prometheus.hvpa.scaleUpStabilization }}
+{{ toYaml .Values.prometheus.hvpa.scaleUpStabilization | indent 6 }}
+{{- end }}
+    scaleDown:
+      updatePolicy:
+{{- if .Values.prometheus.hvpa.maintenanceTimeWindow }}
+        updateMode: "MaintenanceWindow"
+{{- else }}
+        updateMode: "Auto"
+{{- end }}
+{{- if .Values.prometheus.hvpa.scaleDownStabilization }}
+{{ toYaml .Values.prometheus.hvpa.scaleDownStabilization | indent 6 }}
+{{- end }}
+{{- if .Values.prometheus.hvpa.limitsRequestsGapScaleParams }}
+    limitsRequestsGapScaleParams:
+{{ toYaml .Values.prometheus.hvpa.limitsRequestsGapScaleParams | indent 6 }}
+{{- end }}
+    template:
+      metadata:
+        labels:
+          role: prometheus-vpa
+      spec:
+        resourcePolicy:
+          containerPolicies:
+            - containerName: prometheus
+              minAllowed:
+                memory: {{ .Values.prometheus.hvpa.minAllowed.memory }}
+                cpu: "{{ .Values.prometheus.hvpa.minAllowed.cpu }}"
+            - containerName: prometheus-config-reloader
+              mode: "Off"
+  weightBasedScalingIntervals:
+    - vpaWeight: 100
+      startReplicaCount: 1
+      lastReplicaCount: 1
+  targetRef:
+    apiVersion:  {{ include "statefulsetversion" . }}
+    kind: StatefulSet
+    name: prometheus
+{{ end }}

--- a/charts/seed-bootstrap/templates/prometheus/prometheus-vpa.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/prometheus-vpa.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.hvpa.enabled }}
 apiVersion: "autoscaling.k8s.io/v1beta2"
 kind: VerticalPodAutoscaler
 metadata:
@@ -10,3 +11,4 @@ spec:
     name: prometheus
   updatePolicy:
     updateMode: "Auto"
+{{ end }}

--- a/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
@@ -60,9 +60,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 3
         resources:
-          requests:
-            cpu: 30m
-            memory: 500Mi
+          {{- toYaml .Values.prometheus.resources.prometheus | nindent 10 }}
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config
@@ -81,12 +79,7 @@ spec:
         - -volume-dir=/etc/prometheus/config
         - -volume-dir=/etc/prometheus/rules
         resources:
-          requests:
-            cpu: 5m
-            memory: 10Mi
-          limits:
-            cpu: 10m
-            memory: 20Mi
+          {{- index .Values.prometheus.resources "prometheus-config-reloader" | toYaml | nindent 10 }}
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -1,17 +1,111 @@
 priorityClassName: foo
 
 prometheus:
+  resources:
+    prometheus:
+      limits:
+        cpu: 500m
+        memory: 2000Mi
+      requests:
+        cpu: 300m
+        memory: 1000Mi
+    prometheus-config-reloader:
+      limits:
+        cpu: 20m
+        memory: 50Mi
+      requests:
+        cpu: 10m
+        memory: 25Mi
   port: 9090
   storage: 10Gi
   additionalScrapeConfigs: ""
   additionalCAdvisorScrapeConfigMetricRelabelConfigs: ""
+  hvpa:
+    enabled: false
+    minAllowed:
+      cpu: 100m
+      memory: 1000M
+    targetAverageUtilizationCpu: 80
+    targetAverageUtilizationMemory: 80
+    scaleUpStabilization:
+      stabilizationDuration: "5m"
+      minChange:
+        cpu:
+          value: "100m"
+          percentage: 80
+        memory:
+          value: 300M
+          percentage: 80
+    scaleDownStabilization:
+      stabilizationDuration: "24h"
+      minChange:
+        cpu:
+          value: "200m"
+          percentage: 80
+        memory:
+          value: 500M
+          percentage: 80
+    limitsRequestsGapScaleParams:
+      cpu:
+        value: "300m"
+        percentage: 40
+      memory:
+        value: "1000M"
+        percentage: 40
 
 aggregatePrometheus:
+  resources:
+    prometheus:
+      limits:
+        cpu: 500m
+        memory: 2000Mi
+      requests:
+        cpu: 300m
+        memory: 1000Mi
+    prometheus-config-reloader:
+      limits:
+        cpu: 20m
+        memory: 20Mi
+      requests:
+        cpu: 10m
+        memory: 10Mi
   port: 9090
   storage: 20Gi
   seed: seed
   hostName: p.seed-1.example.com
   secretName: prometheus-tls
+  hvpa:
+    enabled: false
+    minAllowed:
+      cpu: 100m
+      memory: 1000M
+    targetAverageUtilizationCpu: 80
+    targetAverageUtilizationMemory: 80
+    scaleUpStabilization:
+      stabilizationDuration: "5m"
+      minChange:
+        cpu:
+          value: "100m"
+          percentage: 80
+        memory:
+          value: 300M
+          percentage: 80
+    scaleDownStabilization:
+      stabilizationDuration: "24h"
+      minChange:
+        cpu:
+          value: "200m"
+          percentage: 80
+        memory:
+          value: 500M
+          percentage: 80
+    limitsRequestsGapScaleParams:
+      cpu:
+        value: "300m"
+        percentage: 40
+      memory:
+        value: "1000M"
+        percentage: 40
 
 grafana:
   hostName: p.seed-1.example.com

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -350,6 +350,16 @@ func RunReconcileSeedFlow(
 		if err := common.DeleteHvpa(ctx, k8sSeedClient, v1beta1constants.GardenNamespace); client.IgnoreNotFound(err) != nil {
 			return err
 		}
+	} else {
+		// Clean up stale vpa objects
+		resources := []client.Object{
+			&autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "prometheus-vpa", Namespace: v1beta1constants.GardenNamespace}},
+			&autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "aggregate-prometheus-vpa", Namespace: v1beta1constants.GardenNamespace}},
+		}
+
+		if err := kutil.DeleteObjects(ctx, k8sSeedClient.Client(), resources...); err != nil {
+			return err
+		}
 	}
 
 	// Fetch component-specific dependency-watchdog configuration
@@ -537,6 +547,26 @@ func RunReconcileSeedFlow(
 	} else {
 		if err := common.DeleteSeedLoggingStack(ctx, k8sSeedClient.Client()); err != nil {
 			return err
+		}
+	}
+
+	// Monitoring resource values
+	monitoringResources := map[string]interface{}{
+		"prometheus":           map[string]interface{}{},
+		"aggregate-prometheus": map[string]interface{}{},
+	}
+
+	if hvpaEnabled {
+		for resource := range monitoringResources {
+			currentResources, err := kutil.GetContainerResourcesInStatefulSet(ctx, k8sSeedClient.Client(), kutil.Key(v1beta1constants.GardenNamespace, resource))
+			if err != nil {
+				return err
+			}
+			if len(currentResources) != 0 && currentResources[resource] != nil {
+				monitoringResources[resource] = map[string]interface{}{
+					resource: currentResources[resource],
+				}
+			}
 		}
 	}
 
@@ -754,11 +784,13 @@ func RunReconcileSeedFlow(
 			"reserve-excess-capacity": desiredExcessCapacity(),
 		},
 		"prometheus": map[string]interface{}{
+			"resources":               monitoringResources["prometheus"],
 			"storage":                 seed.GetValidVolumeSize("10Gi"),
 			"additionalScrapeConfigs": centralScrapeConfigs.String(),
 			"additionalCAdvisorScrapeConfigMetricRelabelConfigs": centralCAdvisorScrapeConfigMetricRelabelConfigs.String(),
 		},
 		"aggregatePrometheus": map[string]interface{}{
+			"resources":  monitoringResources["aggregate-prometheus"],
 			"storage":    seed.GetValidVolumeSize("20Gi"),
 			"seed":       seed.Info.Name,
 			"hostName":   prometheusHost,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Add HVPA for all prometheus instances managed by `seed-bootstrap`

**Which issue(s) this PR fixes**:
Partial fix for #3889

Once hvpa is rolled out for the Prometheus in the shoot control plane the above issue will be fixed.

**Special notes for your reviewer**:

I kept the original vpa objects in case hvpa is disabled.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add HVPA for all prometheus instances managed by `seed-bootstrap`
```
