### PR TITLE
Add envtest suite for Seed

### DIFF
--- a/pkg/envtest/garden/apiserver.go
+++ b/pkg/envtest/garden/apiserver.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envtest
+package envtest_garden
 
 import (
 	"context"

--- a/pkg/envtest/garden/environment.go
+++ b/pkg/envtest/garden/environment.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envtest
+package envtest_garden
 
 import (
 	"fmt"

--- a/pkg/envtest/garden/environment_test.go
+++ b/pkg/envtest/garden/environment_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envtest_test
+package envtest_garden_test
 
 import (
 	. "github.com/onsi/ginkgo"

--- a/pkg/envtest/garden/envtest_suite_test.go
+++ b/pkg/envtest/garden/envtest_suite_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envtest_garden_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/gardener/gardener/pkg/envtest/garden"
+	"github.com/gardener/gardener/test/framework"
+)
+
+func TestEnvtest(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gardener Envtest Suite")
+}
+
+var (
+	ctx        = context.Background()
+	err        error
+	testEnv    *GardenerTestEnvironment
+	restConfig *rest.Config
+
+	testClient client.Client
+)
+
+var _ = Describe("Envtest experiment", func() {
+	BeforeSuite(func() {
+		logf.SetLogger(logzap.New(logzap.UseDevMode(true), logzap.WriteTo(GinkgoWriter)))
+
+		By("starting test environment")
+		testEnv = &GardenerTestEnvironment{}
+		restConfig, err = testEnv.Start()
+		Expect(err).ToNot(HaveOccurred())
+
+		testClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.GardenScheme})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterSuite(func() {
+		By("running cleanup actions")
+		framework.RunCleanupActions()
+
+		By("stopping test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+	})
+})

--- a/pkg/envtest/garden/port.go
+++ b/pkg/envtest/garden/port.go
@@ -17,7 +17,7 @@
 //
 // Modifications Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved.
 
-package envtest
+package envtest_garden
 
 import (
 	"fmt"

--- a/pkg/envtest/seed/environment.go
+++ b/pkg/envtest/seed/environment.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envtestseed
+
+import (
+	"path/filepath"
+
+	"github.com/gardener/gardener/charts"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var log = logf.Log.WithName("seed.test-env")
+
+// SeedTestEnvironment wraps envtest.Environment and registers CRDs typically deployed during
+// Seed bootstrap
+type SeedTestEnvironment struct {
+	*envtest.Environment
+	chartPath string
+}
+
+// Start starts the underlying envtest.Environment
+func (e *SeedTestEnvironment) Start() (*rest.Config, error) {
+	if e.Environment == nil {
+		e.Environment = &envtest.Environment{}
+	}
+
+	if e.chartPath == "" {
+		e.chartPath = filepath.Join("..", "..", "..", charts.Path)
+	}
+
+	pathExtensionCRDs := filepath.Join(e.chartPath, "seed-bootstrap", "charts", "extensions", "templates")
+	pathVPA := filepath.Join("resources", "crd-verticalpodautoscalers.yaml")
+	pathVPACheckpoints := filepath.Join("resources", "crd-verticalpodautoscalercheckpoints.yaml")
+	pathHVPA := filepath.Join("resources", "hvpa-crd.yaml")
+	pathIstio := filepath.Join(e.chartPath, "istio", "istio-crds", "templates", "crd-all.gen.yaml")
+
+	e.Environment.CRDDirectoryPaths = []string{
+		pathExtensionCRDs,
+		pathVPA,
+		pathVPACheckpoints,
+		pathHVPA,
+		pathIstio,
+	}
+	e.Environment.ErrorIfCRDPathMissing = true
+
+	log.V(1).Info("starting Seed's envtest control plane")
+	restConfig, err := e.Environment.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	return restConfig, nil
+}
+
+// Stop stops the underlying envtest.Environment.
+func (e *SeedTestEnvironment) Stop() error {
+	return e.Environment.Stop()
+}

--- a/pkg/envtest/seed/environment_test.go
+++ b/pkg/envtest/seed/environment_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envtestseed_test
+
+import (
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("SeedTestEnvironment", func() {
+	BeforeEach(func() {
+		By("ensuring that garden namespace exists")
+		Expect(testClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "garden"}})).
+			To(Or(Succeed(), BeAlreadyExistsError()))
+	})
+
+	It("should be able to manipulate Gardener Extension resources", func() {
+		infrastructure := &extensionsv1alpha1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "garden"}}
+		Expect(testClient.Create(ctx, infrastructure)).To(Succeed())
+		Expect(testClient.Get(ctx, client.ObjectKeyFromObject(infrastructure), infrastructure)).To(Succeed())
+		Expect(testClient.Delete(ctx, infrastructure)).To(Succeed())
+	})
+})

--- a/pkg/envtest/seed/resources/crd-verticalpodautoscalercheckpoints.yaml
+++ b/pkg/envtest/seed/resources/crd-verticalpodautoscalercheckpoints.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
+  annotations:
+    "api-approved.kubernetes.io": "https://github.com/kubernetes/kubernetes/pull/63797"
+    resources.gardener.cloud/keep-object: "true"
+spec:
+  group: autoscaling.k8s.io
+  scope: Namespaced
+  preserveUnknownFields: true
+  names:
+    plural: verticalpodautoscalercheckpoints
+    singular: verticalpodautoscalercheckpoint
+    kind: VerticalPodAutoscalerCheckpoint
+    shortNames:
+      - vpacheckpoint
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: false
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true
+  - name: v1
+    served: true
+    storage: false

--- a/pkg/envtest/seed/resources/crd-verticalpodautoscalers.yaml
+++ b/pkg/envtest/seed/resources/crd-verticalpodautoscalers.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: verticalpodautoscalers.autoscaling.k8s.io
+  annotations:
+    "api-approved.kubernetes.io": "https://github.com/kubernetes/kubernetes/pull/63797"
+    resources.gardener.cloud/keep-object: "true"
+spec:
+  group: autoscaling.k8s.io
+  scope: Namespaced
+  preserveUnknownFields: true
+  names:
+    plural: verticalpodautoscalers
+    singular: verticalpodautoscaler
+    kind: VerticalPodAutoscaler
+    shortNames:
+      - vpa
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: false
+    storage: false
+  - name: v1beta2
+    served: true
+    storage: true
+  - name: v1
+    served: true
+    storage: false
+  validation:
+    # openAPIV3Schema is the schema for validating custom objects.
+    openAPIV3Schema:
+      type: object
+      properties:
+        spec:
+          type: object
+          required: []
+          properties:
+            targetRef:
+              type: object
+            updatePolicy:
+              type: object
+              properties:
+                updateMode:
+                  type: string
+            resourcePolicy:
+              type: object
+              properties:
+                containerPolicies:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      containerName:
+                        type: string
+                      mode:
+                        type: string
+                        enum: ["Auto", "Off"]
+                      minAllowed:
+                        type: object
+                      maxAllowed:
+                        type: object
+                      controlledResources:
+                        type: array
+                        items:
+                          type: string
+                          enum: ["cpu", "memory"]

--- a/pkg/envtest/seed/resources/hvpa-crd.yaml
+++ b/pkg/envtest/seed/resources/hvpa-crd.yaml
@@ -1,0 +1,1204 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hvpas.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  names:
+    kind: Hvpa
+    plural: hvpas
+  scope: ""
+  preserveUnknownFields: false
+  subresources:
+    scale:
+      labelSelectorPath: .status.targetSelector
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Hvpa is the Schema for the hvpas API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: HvpaSpec defines the desired state of Hvpa
+          properties:
+            hpa:
+              description: Hpa defines the spec of HPA
+              properties:
+                deploy:
+                  description: Deploy defines whether the HPA is deployed or not
+                  type: boolean
+                scaleDown:
+                  description: ScaleDown defines the parameters for scale down
+                  properties:
+                    minChange:
+                      description: MinChange is the minimum change in the resource
+                        on which HVPA acts HVPA uses minimum of the Value and Percentage
+                        value
+                      properties:
+                        cpu:
+                          description: Scale parameters for CPU
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                        memory:
+                          description: Scale parameters for memory
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                        replicas:
+                          description: Scale patameters for replicas
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                      type: object
+                    stabilizationDuration:
+                      description: StabilizationDuration defines the minimum delay
+                        in minutes between 2 consecutive scale operations Valid time
+                        units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                      type: string
+                    updatePolicy:
+                      description: Describes the rules on when changes are applied.
+                        If not specified, all fields in the `UpdatePolicy` are set
+                        to their default values.
+                      properties:
+                        updateMode:
+                          description: Controls when autoscaler applies changes to
+                            the resources. The default is 'Auto'.
+                          type: string
+                      type: object
+                  type: object
+                scaleUp:
+                  description: ScaleUp defines the parameters for scale up
+                  properties:
+                    minChange:
+                      description: MinChange is the minimum change in the resource
+                        on which HVPA acts HVPA uses minimum of the Value and Percentage
+                        value
+                      properties:
+                        cpu:
+                          description: Scale parameters for CPU
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                        memory:
+                          description: Scale parameters for memory
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                        replicas:
+                          description: Scale patameters for replicas
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                      type: object
+                    stabilizationDuration:
+                      description: StabilizationDuration defines the minimum delay
+                        in minutes between 2 consecutive scale operations Valid time
+                        units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                      type: string
+                    updatePolicy:
+                      description: Describes the rules on when changes are applied.
+                        If not specified, all fields in the `UpdatePolicy` are set
+                        to their default values.
+                      properties:
+                        updateMode:
+                          description: Controls when autoscaler applies changes to
+                            the resources. The default is 'Auto'.
+                          type: string
+                      type: object
+                  type: object
+                selector:
+                  description: 'Selector is a label query that should match HPA. Must
+                    match in order to be controlled. If empty, defaulted to labels
+                    on HPA template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                template:
+                  description: Template is the object that describes the HPA that
+                    will be created.
+                  properties:
+                    metadata:
+                      description: Metadata of the pods created from this template.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true # To be replaced by proper OpenAPI spec
+                    spec:
+                      description: Spec defines the behavior of a HPA.
+                      properties:
+                        maxReplicas:
+                          description: maxReplicas is the upper limit for the number
+                            of replicas to which the autoscaler can scale up. It cannot
+                            be less that minReplicas.
+                          format: int32
+                          type: integer
+                        metrics:
+                          description: metrics contains the specifications for which
+                            to use to calculate the desired replica count (the maximum
+                            replica count across all metrics will be used).  The desired
+                            replica count is calculated multiplying the ratio between
+                            the target value and the current value by the current
+                            number of pods.  Ergo, metrics used must decrease as the
+                            pod count is increased, and vice-versa.  See the individual
+                            metric source types for more information about how each
+                            type of metric must respond. If not set, the default metric
+                            will be set to 80% average CPU utilization.
+                          items:
+                            description: MetricSpec specifies how to scale based on
+                              a single metric (only `type` and one other matching
+                              field should be set at once).
+                            properties:
+                              external:
+                                description: external refers to a global metric that
+                                  is not associated with any Kubernetes object. It
+                                  allows autoscaling based on information coming from
+                                  components running outside of cluster (for example
+                                  length of queue in cloud messaging service, or QPS
+                                  from loadbalancer running outside of cluster).
+                                properties:
+                                  metricName:
+                                    description: metricName is the name of the metric
+                                      in question.
+                                    type: string
+                                  metricSelector:
+                                    description: metricSelector is used to identify
+                                      a specific time series within a given metric.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  targetAverageValue:
+                                    description: targetAverageValue is the target
+                                      per-pod value of global metric (as a quantity).
+                                      Mutually exclusive with TargetValue.
+                                    type: string
+                                  targetValue:
+                                    description: targetValue is the target value of
+                                      the metric (as a quantity). Mutually exclusive
+                                      with TargetAverageValue.
+                                    type: string
+                                required:
+                                - metricName
+                                type: object
+                              object:
+                                description: object refers to a metric describing
+                                  a single kubernetes object (for example, hits-per-second
+                                  on an Ingress object).
+                                properties:
+                                  averageValue:
+                                    description: averageValue is the target value
+                                      of the average of the metric across all relevant
+                                      pods (as a quantity)
+                                    type: string
+                                  metricName:
+                                    description: metricName is the name of the metric
+                                      in question.
+                                    type: string
+                                  selector:
+                                    description: selector is the string-encoded form
+                                      of a standard kubernetes label selector for
+                                      the given metric When set, it is passed as an
+                                      additional parameter to the metrics server for
+                                      more specific metrics scoping When unset, just
+                                      the metricName will be used to gather metrics.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  target:
+                                    description: target is the described Kubernetes
+                                      object.
+                                    properties:
+                                      apiVersion:
+                                        description: API version of the referent
+                                        type: string
+                                      kind:
+                                        description: 'Kind of the referent; More info:
+                                          https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"'
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent; More info:
+                                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                  targetValue:
+                                    description: targetValue is the target value of
+                                      the metric (as a quantity).
+                                    type: string
+                                required:
+                                - metricName
+                                - target
+                                - targetValue
+                                type: object
+                              pods:
+                                description: pods refers to a metric describing each
+                                  pod in the current scale target (for example, transactions-processed-per-second).  The
+                                  values will be averaged together before being compared
+                                  to the target value.
+                                properties:
+                                  metricName:
+                                    description: metricName is the name of the metric
+                                      in question
+                                    type: string
+                                  selector:
+                                    description: selector is the string-encoded form
+                                      of a standard kubernetes label selector for
+                                      the given metric When set, it is passed as an
+                                      additional parameter to the metrics server for
+                                      more specific metrics scoping When unset, just
+                                      the metricName will be used to gather metrics.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  targetAverageValue:
+                                    description: targetAverageValue is the target
+                                      value of the average of the metric across all
+                                      relevant pods (as a quantity)
+                                    type: string
+                                required:
+                                - metricName
+                                - targetAverageValue
+                                type: object
+                              resource:
+                                description: resource refers to a resource metric
+                                  (such as those specified in requests and limits)
+                                  known to Kubernetes describing each pod in the current
+                                  scale target (e.g. CPU or memory). Such metrics
+                                  are built in to Kubernetes, and have special scaling
+                                  options on top of those available to normal per-pod
+                                  metrics using the "pods" source.
+                                properties:
+                                  name:
+                                    description: name is the name of the resource
+                                      in question.
+                                    type: string
+                                  targetAverageUtilization:
+                                    description: targetAverageUtilization is the target
+                                      value of the average of the resource metric
+                                      across all relevant pods, represented as a percentage
+                                      of the requested value of the resource for the
+                                      pods.
+                                    format: int32
+                                    type: integer
+                                  targetAverageValue:
+                                    description: targetAverageValue is the target
+                                      value of the average of the resource metric
+                                      across all relevant pods, as a raw value (instead
+                                      of as a percentage of the request), similar
+                                      to the "pods" metric source type.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type:
+                                description: type is the type of metric source.  It
+                                  should be one of "Object", "Pods" or "Resource",
+                                  each mapping to a matching field in the object.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          type: array
+                        minReplicas:
+                          description: minReplicas is the lower limit for the number
+                            of replicas to which the autoscaler can scale down. It
+                            defaults to 1 pod.
+                          format: int32
+                          type: integer
+                      required:
+                      - maxReplicas
+                      type: object
+                  type: object
+              type: object
+            maintenanceTimeWindow:
+              description: MaintenanceTimeWindow contains information about the time
+                window for maintenance operations.
+              properties:
+                begin:
+                  description: Begin is the beginning of the time window in the format
+                    HHMMSS+ZONE, e.g. "220000+0100".
+                  type: string
+                end:
+                  description: End is the end of the time window in the format HHMMSS+ZONE,
+                    e.g. "220000+0100".
+                  type: string
+              required:
+              - begin
+              - end
+              type: object
+            replicas:
+              description: Replicas is the number of replicas of target resource
+              format: int32
+              type: integer
+            targetRef:
+              description: TargetRef points to the controller managing the set of
+                pods for the autoscaler to control
+              properties:
+                apiVersion:
+                  description: API version of the referent
+                  type: string
+                kind:
+                  description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"'
+                  type: string
+                name:
+                  description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                  type: string
+              required:
+              - kind
+              - name
+              type: object
+            vpa:
+              description: Vpa defines the spec of VPA
+              properties:
+                deploy:
+                  description: Deploy defines whether the VPA is deployed or not
+                  type: boolean
+                limitsRequestsGapScaleParams:
+                  description: LimitsRequestsGapScaleParams is the scaling thresholds
+                    for limits
+                  properties:
+                    cpu:
+                      description: Scale parameters for CPU
+                      properties:
+                        percentage:
+                          description: Percentage is the percentage of currently allocated
+                            value to be used for scaling
+                          format: int32
+                          type: integer
+                        value:
+                          description: Value is the absolute value of the scaling
+                          type: string
+                      type: object
+                    memory:
+                      description: Scale parameters for memory
+                      properties:
+                        percentage:
+                          description: Percentage is the percentage of currently allocated
+                            value to be used for scaling
+                          format: int32
+                          type: integer
+                        value:
+                          description: Value is the absolute value of the scaling
+                          type: string
+                      type: object
+                    replicas:
+                      description: Scale patameters for replicas
+                      properties:
+                        percentage:
+                          description: Percentage is the percentage of currently allocated
+                            value to be used for scaling
+                          format: int32
+                          type: integer
+                        value:
+                          description: Value is the absolute value of the scaling
+                          type: string
+                      type: object
+                  type: object
+                scaleDown:
+                  description: ScaleDown defines the parameters for scale down
+                  properties:
+                    minChange:
+                      description: MinChange is the minimum change in the resource
+                        on which HVPA acts HVPA uses minimum of the Value and Percentage
+                        value
+                      properties:
+                        cpu:
+                          description: Scale parameters for CPU
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                        memory:
+                          description: Scale parameters for memory
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                        replicas:
+                          description: Scale patameters for replicas
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                      type: object
+                    stabilizationDuration:
+                      description: StabilizationDuration defines the minimum delay
+                        in minutes between 2 consecutive scale operations Valid time
+                        units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                      type: string
+                    updatePolicy:
+                      description: Describes the rules on when changes are applied.
+                        If not specified, all fields in the `UpdatePolicy` are set
+                        to their default values.
+                      properties:
+                        updateMode:
+                          description: Controls when autoscaler applies changes to
+                            the resources. The default is 'Auto'.
+                          type: string
+                      type: object
+                  type: object
+                scaleUp:
+                  description: ScaleUp defines the parameters for scale up
+                  properties:
+                    minChange:
+                      description: MinChange is the minimum change in the resource
+                        on which HVPA acts HVPA uses minimum of the Value and Percentage
+                        value
+                      properties:
+                        cpu:
+                          description: Scale parameters for CPU
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                        memory:
+                          description: Scale parameters for memory
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                        replicas:
+                          description: Scale patameters for replicas
+                          properties:
+                            percentage:
+                              description: Percentage is the percentage of currently
+                                allocated value to be used for scaling
+                              format: int32
+                              type: integer
+                            value:
+                              description: Value is the absolute value of the scaling
+                              type: string
+                          type: object
+                      type: object
+                    stabilizationDuration:
+                      description: StabilizationDuration defines the minimum delay
+                        in minutes between 2 consecutive scale operations Valid time
+                        units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                      type: string
+                    updatePolicy:
+                      description: Describes the rules on when changes are applied.
+                        If not specified, all fields in the `UpdatePolicy` are set
+                        to their default values.
+                      properties:
+                        updateMode:
+                          description: Controls when autoscaler applies changes to
+                            the resources. The default is 'Auto'.
+                          type: string
+                      type: object
+                  type: object
+                selector:
+                  description: 'Selector is a label query that should match VPA. Must
+                    match in order to be controlled. If empty, defaulted to labels
+                    on VPA template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                template:
+                  description: Template is the object that describes the VPA that
+                    will be created.
+                  properties:
+                    metadata:
+                      description: Metadata of the pods created from this template.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true # To be replaced by proper OpenAPI spec
+                    spec:
+                      description: Spec defines the behavior of a VPA.
+                      properties:
+                        resourcePolicy:
+                          description: Controls how the autoscaler computes recommended
+                            resources. The resource policy may be used to set constraints
+                            on the recommendations for individual containers. If not
+                            specified, the autoscaler computes recommended resources
+                            for all containers in the pod, without additional constraints.
+                          properties:
+                            containerPolicies:
+                              description: Per-container resource policies.
+                              items:
+                                description: ContainerResourcePolicy controls how
+                                  autoscaler computes the recommended resources for
+                                  a specific container.
+                                properties:
+                                  containerName:
+                                    description: Name of the container or DefaultContainerResourcePolicy,
+                                      in which case the policy is used by the containers
+                                      that don't have their own policy specified.
+                                    type: string
+                                  maxAllowed:
+                                    additionalProperties:
+                                      type: string
+                                    description: Specifies the maximum amount of resources
+                                      that will be recommended for the container.
+                                      The default is no maximum.
+                                    type: object
+                                  minAllowed:
+                                    additionalProperties:
+                                      type: string
+                                    description: Specifies the minimal amount of resources
+                                      that will be recommended for the container.
+                                      The default is no minimum.
+                                    type: object
+                                  mode:
+                                    description: Whether autoscaler is enabled for
+                                      the container. The default is "Auto".
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                  type: object
+              type: object
+            weightBasedScalingIntervals:
+              description: WeightBasedScalingIntervals defines the intervals of replica
+                counts, and the weights for scaling a deployment vertically If there
+                are overlapping intervals, then the vpaWeight will be taken from the
+                first matching interval
+              items:
+                description: WeightBasedScalingInterval defines the interval of replica
+                  counts in which VpaWeight is applied to VPA scaling
+                properties:
+                  lastReplicaCount:
+                    description: LastReplicaCount is the number of replicas till which
+                      VpaWeight is applied to VPA scaling If this field is not provided,
+                      it will default to maxReplicas of HPA
+                    format: int32
+                    type: integer
+                  startReplicaCount:
+                    description: StartReplicaCount is the number of replicas from
+                      which VpaWeight is applied to VPA scaling If this field is not
+                      provided, it will default to minReplicas of HPA
+                    format: int32
+                    type: integer
+                  vpaWeight:
+                    description: VpaWeight defines the weight (in percentage) to be
+                      given to VPA's recommendationd for the interval of number of
+                      replicas provided
+                    format: int32
+                    type: integer
+                type: object
+              type: array
+          required:
+          - targetRef
+          type: object
+        status:
+          description: HvpaStatus defines the observed state of Hvpa
+          properties:
+            hpaScaleDownUpdatePolicy:
+              description: Current HPA UpdatePolicy set in the spec
+              properties:
+                updateMode:
+                  description: Controls when autoscaler applies changes to the resources.
+                    The default is 'Auto'.
+                  type: string
+              type: object
+            hpaScaleUpUpdatePolicy:
+              description: Current HPA UpdatePolicy set in the spec
+              properties:
+                updateMode:
+                  description: Controls when autoscaler applies changes to the resources.
+                    The default is 'Auto'.
+                  type: string
+              type: object
+            hpaWeight:
+              description: VpaWeight - weight to provide to VPA scaling
+              format: int32
+              type: integer
+            lastBlockedScaling:
+              items:
+                description: BlockedScaling defines the details for blocked scaling
+                properties:
+                  reason:
+                    description: BlockingReason defines the reason for blocking.
+                    type: string
+                  scalingStatus:
+                    description: ScalingStatus defines the status of scaling
+                    properties:
+                      hpaStatus:
+                        description: HpaStatus defines the status of HPA
+                        properties:
+                          currentReplicas:
+                            format: int32
+                            type: integer
+                          desiredReplicas:
+                            format: int32
+                            type: integer
+                        type: object
+                      lastScaleTime:
+                        format: date-time
+                        type: string
+                      vpaStatus:
+                        description: VerticalPodAutoscalerStatus describes the runtime
+                          state of the autoscaler.
+                        properties:
+                          conditions:
+                            description: Conditions is the set of conditions required
+                              for this autoscaler to scale its target, and indicates
+                              whether or not those conditions are met.
+                            items:
+                              description: VerticalPodAutoscalerCondition describes
+                                the state of a VerticalPodAutoscaler at a certain
+                                point.
+                              properties:
+                                lastTransitionTime:
+                                  description: lastTransitionTime is the last time
+                                    the condition transitioned from one status to
+                                    another
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: message is a human-readable explanation
+                                    containing details about the transition
+                                  type: string
+                                reason:
+                                  description: reason is the reason for the condition's
+                                    last transition.
+                                  type: string
+                                status:
+                                  description: status is the status of the condition
+                                    (True, False, Unknown)
+                                  type: string
+                                type:
+                                  description: type describes the current condition
+                                  type: string
+                              required:
+                              - status
+                              - type
+                              type: object
+                            type: array
+                          recommendation:
+                            description: The most recently computed amount of resources
+                              recommended by the autoscaler for the controlled pods.
+                            properties:
+                              containerRecommendations:
+                                description: Resources recommended by the autoscaler
+                                  for each container.
+                                items:
+                                  description: RecommendedContainerResources is the
+                                    recommendation of resources computed by autoscaler
+                                    for a specific container. Respects the container
+                                    resource policy if present in the spec. In particular
+                                    the recommendation is not produced for containers
+                                    with `ContainerScalingMode` set to 'Off'.
+                                  properties:
+                                    containerName:
+                                      description: Name of the container.
+                                      type: string
+                                    lowerBound:
+                                      additionalProperties:
+                                        type: string
+                                      description: Minimum recommended amount of resources.
+                                        Observes ContainerResourcePolicy. This amount
+                                        is not guaranteed to be sufficient for the
+                                        application to operate in a stable way, however
+                                        running with less resources is likely to have
+                                        significant impact on performance/availability.
+                                      type: object
+                                    target:
+                                      additionalProperties:
+                                        type: string
+                                      description: Recommended amount of resources.
+                                        Observes ContainerResourcePolicy.
+                                      type: object
+                                    uncappedTarget:
+                                      additionalProperties:
+                                        type: string
+                                      description: The most recent recommended resources
+                                        target computed by the autoscaler for the
+                                        controlled pods, based only on actual resource
+                                        usage, not taking into account the ContainerResourcePolicy.
+                                        May differ from the Recommendation if the
+                                        actual resource usage causes the target to
+                                        violate the ContainerResourcePolicy (lower
+                                        than MinAllowed or higher that MaxAllowed).
+                                        Used only as status indication, will not affect
+                                        actual resource assignment.
+                                      type: object
+                                    upperBound:
+                                      additionalProperties:
+                                        type: string
+                                      description: Maximum recommended amount of resources.
+                                        Observes ContainerResourcePolicy. Any resources
+                                        allocated beyond this value are likely wasted.
+                                        This value may be larger than the maximum
+                                        amount of application is actually capable
+                                        of consuming.
+                                      type: object
+                                  required:
+                                  - target
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              type: array
+            lastError:
+              description: LastError has details of any errors that occured
+              properties:
+                description:
+                  description: Description of the error
+                  type: string
+                lastOperation:
+                  description: LastOperation is the type of operation for which error
+                    occurred
+                  type: string
+                lastUpdateTime:
+                  description: Time at which the error occurred
+                  format: date-time
+                  type: string
+              type: object
+            lastScaling:
+              description: ScalingStatus defines the status of scaling
+              properties:
+                hpaStatus:
+                  description: HpaStatus defines the status of HPA
+                  properties:
+                    currentReplicas:
+                      format: int32
+                      type: integer
+                    desiredReplicas:
+                      format: int32
+                      type: integer
+                  type: object
+                lastScaleTime:
+                  format: date-time
+                  type: string
+                vpaStatus:
+                  description: VerticalPodAutoscalerStatus describes the runtime state
+                    of the autoscaler.
+                  properties:
+                    conditions:
+                      description: Conditions is the set of conditions required for
+                        this autoscaler to scale its target, and indicates whether
+                        or not those conditions are met.
+                      items:
+                        description: VerticalPodAutoscalerCondition describes the
+                          state of a VerticalPodAutoscaler at a certain point.
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the last time the condition
+                              transitioned from one status to another
+                            format: date-time
+                            type: string
+                          message:
+                            description: message is a human-readable explanation containing
+                              details about the transition
+                            type: string
+                          reason:
+                            description: reason is the reason for the condition's
+                              last transition.
+                            type: string
+                          status:
+                            description: status is the status of the condition (True,
+                              False, Unknown)
+                            type: string
+                          type:
+                            description: type describes the current condition
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                    recommendation:
+                      description: The most recently computed amount of resources
+                        recommended by the autoscaler for the controlled pods.
+                      properties:
+                        containerRecommendations:
+                          description: Resources recommended by the autoscaler for
+                            each container.
+                          items:
+                            description: RecommendedContainerResources is the recommendation
+                              of resources computed by autoscaler for a specific container.
+                              Respects the container resource policy if present in
+                              the spec. In particular the recommendation is not produced
+                              for containers with `ContainerScalingMode` set to 'Off'.
+                            properties:
+                              containerName:
+                                description: Name of the container.
+                                type: string
+                              lowerBound:
+                                additionalProperties:
+                                  type: string
+                                description: Minimum recommended amount of resources.
+                                  Observes ContainerResourcePolicy. This amount is
+                                  not guaranteed to be sufficient for the application
+                                  to operate in a stable way, however running with
+                                  less resources is likely to have significant impact
+                                  on performance/availability.
+                                type: object
+                              target:
+                                additionalProperties:
+                                  type: string
+                                description: Recommended amount of resources. Observes
+                                  ContainerResourcePolicy.
+                                type: object
+                              uncappedTarget:
+                                additionalProperties:
+                                  type: string
+                                description: The most recent recommended resources
+                                  target computed by the autoscaler for the controlled
+                                  pods, based only on actual resource usage, not taking
+                                  into account the ContainerResourcePolicy. May differ
+                                  from the Recommendation if the actual resource usage
+                                  causes the target to violate the ContainerResourcePolicy
+                                  (lower than MinAllowed or higher that MaxAllowed).
+                                  Used only as status indication, will not affect
+                                  actual resource assignment.
+                                type: object
+                              upperBound:
+                                additionalProperties:
+                                  type: string
+                                description: Maximum recommended amount of resources.
+                                  Observes ContainerResourcePolicy. Any resources
+                                  allocated beyond this value are likely wasted. This
+                                  value may be larger than the maximum amount of application
+                                  is actually capable of consuming.
+                                type: object
+                            required:
+                            - target
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+              type: object
+            overrideScaleUpStabilization:
+              description: Override scale up stabilization window
+              type: boolean
+            replicas:
+              description: Replicas is the number of replicas of the target resource.
+              format: int32
+              type: integer
+            targetSelector:
+              description: TargetSelector is the string form of the label selector
+                of HPA. This is required for HPA to work with scale subresource.
+              type: string
+            vpaScaleDownUpdatePolicy:
+              description: Current VPA UpdatePolicy set in the spec
+              properties:
+                updateMode:
+                  description: Controls when autoscaler applies changes to the resources.
+                    The default is 'Auto'.
+                  type: string
+              type: object
+            vpaScaleUpUpdatePolicy:
+              description: Current VPA UpdatePolicy set in the spec
+              properties:
+                updateMode:
+                  description: Controls when autoscaler applies changes to the resources.
+                    The default is 'Auto'.
+                  type: string
+              type: object
+            vpaWeight:
+              description: VpaWeight - weight to provide to VPA scaling
+              format: int32
+              type: integer
+          type: object
+      type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/envtest/seed/seed_envtest_suite_test.go
+++ b/pkg/envtest/seed/seed_envtest_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package envtest_test
+package envtestseed_test
 
 import (
 	"context"
@@ -26,34 +26,34 @@ import (
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/envtest"
+	seedenvtest "github.com/gardener/gardener/pkg/envtest/seed"
 	"github.com/gardener/gardener/test/framework"
 )
 
 func TestEnvtest(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Gardener Envtest Suite")
+	RunSpecs(t, "Seed Envtest Suite")
 }
 
 var (
 	ctx        = context.Background()
 	err        error
-	testEnv    *envtest.GardenerTestEnvironment
+	testEnv    *seedenvtest.SeedTestEnvironment
 	restConfig *rest.Config
 
 	testClient client.Client
 )
 
-var _ = Describe("Envtest experiment", func() {
+var _ = Describe("Seed Envtest experiment", func() {
 	BeforeSuite(func() {
 		logf.SetLogger(logzap.New(logzap.UseDevMode(true), logzap.WriteTo(GinkgoWriter)))
 
 		By("starting test environment")
-		testEnv = &envtest.GardenerTestEnvironment{}
+		testEnv = &seedenvtest.SeedTestEnvironment{}
 		restConfig, err = testEnv.Start()
 		Expect(err).ToNot(HaveOccurred())
 
-		testClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.GardenScheme})
+		testClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.SeedScheme})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -61,7 +61,7 @@ var _ = Describe("Envtest experiment", func() {
 		By("running cleanup actions")
 		framework.RunCleanupActions()
 
-		By("stopping test environment")
+		By("stopping Seed test environment")
 		Expect(testEnv.Stop()).To(Succeed())
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:

Add an envtest setup for the Seed cluster, similar to the existing Garden cluster envtest suite.

Adds CRD's typically deployed during the SeedBootstrap
 - Gardener Extension CRDs (Worker, Infrastructure, ...)
 - Istio CRDs
 - VPA CRDs
 - HVPA CRD

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Includes copied of the HVPA & VPA CRDs in the `resources` sub-directory as they contain helm-specific templating instructions in the `chart` folder.
Alternatively, these resources could also be rendered to a `temp` directory and then applied.


I wanted to use this functionality with PR #3893 to test the federated seed controller.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
