### PR TITLE
Add scale subresource for ManagedSeedSets

### DIFF
--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -19,10 +19,12 @@ import (
 	seedmanagementinstall "github.com/gardener/gardener/pkg/apis/seedmanagement/install"
 	settingsinstall "github.com/gardener/gardener/pkg/apis/settings/install"
 
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var (
@@ -36,6 +38,8 @@ func init() {
 	coreinstall.Install(Scheme)
 	seedmanagementinstall.Install(Scheme)
 	settingsinstall.Install(Scheme)
+
+	utilruntime.Must(autoscalingv1.AddToScheme(Scheme))
 
 	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
 

--- a/pkg/registry/seedmanagement/rest/storage_seedmanagement.go
+++ b/pkg/registry/seedmanagement/rest/storage_seedmanagement.go
@@ -52,6 +52,7 @@ func (p StorageProvider) v1alpha1Storage(restOptionsGetter generic.RESTOptionsGe
 	storage["managedseeds/status"] = managedSeedStorage.Status
 	storage["managedseedsets"] = managedSeedSetStorage.ManagedSeedSet
 	storage["managedseedsets/status"] = managedSeedSetStorage.Status
+	storage["managedseedsets/scale"] = managedSeedSetStorage.Scale
 
 	return storage
 }


### PR DESCRIPTION
**How to categorize this PR?**

/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Adds a scale subresource for ManagedSeedSets in order to allow operators to scale them via a simple `kubectl` command, e.g. `kubectl scale mss/my-seeds --replicas 3`

**Which issue(s) this PR fixes**:
Fixes #3907

**Special notes for your reviewer**:

**Release note**:

```other operator
ManagedSeedSets can now be scaled via the `scale` command, e.g. `kubectl scale mss/my-seeds --replicas 3`
```
