### PR TITLE
Remove ginkgo flags from g-apiserver

### DIFF
--- a/pkg/utils/kubernetes/client/client.go
+++ b/pkg/utils/kubernetes/client/client.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/onsi/ginkgo"
-
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	utiltime "github.com/gardener/gardener/pkg/utils/time"
@@ -88,7 +86,6 @@ var defaultFinalizer = NewFinalizer()
 
 // Finalize removes the finalizers (.meta.finalizers) of given resource.
 func (f *finalizer) Finalize(ctx context.Context, c client.Client, obj client.Object) error {
-	defer ginkgo.GinkgoRecover()
 	withFinalizers := obj.DeepCopyObject()
 	obj.SetFinalizers(nil)
 	return c.Patch(ctx, obj, client.MergeFrom(withFinalizers))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**Which issue(s) this PR fixes**:
```
$ docker run eu.gcr.io/gardener-project/gardener/apiserver:v1.19.0 -h | grep ginkgo
      --ginkgo.debug                                            If set, ginkgo will emit node output to files when running in parallel.
      --ginkgo.dryRun                                           If set, ginkgo will walk the test hierarchy without actually running anything.  Best paired with -v.
      --ginkgo.failFast                                         If set, ginkgo will stop running a test suite after a failure occurs.
      --ginkgo.failOnPending                                    If set, ginkgo will mark the test suite as failed if any specs are pending.
      --ginkgo.flakeAttempts int                                Make up to this many attempts to run each spec. Please note that if any of the attempts succeed, the suite will not be failed. But any failures will still be recorded. (default 1)
      --ginkgo.focus string                                     If set, ginkgo will only run specs that match this regular expression.
      --ginkgo.noColor                                          If set, suppress color output in default reporter.
      --ginkgo.noisyPendings                                    If set, default reporter will shout about pending tests. (default true)
      --ginkgo.noisySkippings                                   If set, default reporter will shout about skipping tests. (default true)
      --ginkgo.parallel.node int                                This worker node's (one-indexed) node number.  For running specs in parallel. (default 1)
      --ginkgo.parallel.streamhost string                       The address for the server that the running nodes should stream data to.
      --ginkgo.parallel.synchost string                         The address for the server that will synchronize the running nodes.
      --ginkgo.parallel.total int                               The total number of worker nodes.  For running specs in parallel. (default 1)
      --ginkgo.progress                                         If set, ginkgo will emit progress information as each spec runs to the GinkgoWriter.
      --ginkgo.randomizeAllSpecs                                If set, ginkgo will randomize all specs together.  By default, ginkgo only randomizes the top level Describe, Context and When groups.
      --ginkgo.regexScansFilePath                               If set, ginkgo regex matching also will look at the file path (code location).
      --ginkgo.reportFile string                                Override the default reporter output file path.
      --ginkgo.reportPassed                                     If set, default reporter prints out captured output of passed tests.
      --ginkgo.seed int                                         The seed used to randomize the spec suite. (default 1619019225)
      --ginkgo.skip string                                      If set, ginkgo will only run specs that do not match this regular expression.
      --ginkgo.skipMeasurements                                 If set, ginkgo will skip any measurement specs.
      --ginkgo.slowSpecThreshold float                          (in seconds) Specs that take longer to run than this threshold are flagged as slow by the default reporter. (default 5)
      --ginkgo.succinct                                         If set, default reporter prints out a very succinct report
      --ginkgo.trace                                            If set, default reporter prints out the full stack trace when a failure occurs
      --ginkgo.v                                                If set, default reporter print out all specs as they begin.
```

**Special notes for your reviewer**:

Introduced by https://github.com/gardener/gardener/pull/3651/files#diff-ad8de4730729b4ae98e18f701b189c68b8716acb8a47b8b1285fe0151b661230R91

Kindly 
/invite @rfranzke 
😉 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
