### PR TITLE
Fix logging for suse

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
@@ -37,49 +37,49 @@
     [INPUT]
         Name            systemd
         Tag             journald.docker
-        Path            /var/log/journal/
+        Path            %%JOURNALD_PATH%%
         Read_From_Tail  True
         Systemd_Filter  _SYSTEMD_UNIT=docker.service
 
     [INPUT]
         Name            systemd
         Tag             journald.kubelet
-        Path            /var/log/journal/
+        Path            %%JOURNALD_PATH%%
         Read_From_Tail  True
         Systemd_Filter  _SYSTEMD_UNIT=kubelet.service
 
     [INPUT]
         Name            systemd
         Tag             journald.containerd
-        Path            /var/log/journal/
+        Path            %%JOURNALD_PATH%%
         Read_From_Tail  True
         Systemd_Filter  _SYSTEMD_UNIT=containerd.service
 
     [INPUT]
         Name            systemd
         Tag             journald.cloud-config-downloader
-        Path            /var/log/journal/
+        Path            %%JOURNALD_PATH%%
         Read_From_Tail  True
         Systemd_Filter  _SYSTEMD_UNIT=cloud-config-downloader.service
 
     [INPUT]
         Name            systemd
         Tag             journald.docker-monitor
-        Path            /var/log/journal/
+        Path            %%JOURNALD_PATH%%
         Read_From_Tail  True
         Systemd_Filter  _SYSTEMD_UNIT=docker-monitor.service
 
     [INPUT]
         Name            systemd
         Tag             journald.containerd-monitor
-        Path            /var/log/journal/
+        Path            %%JOURNALD_PATH%%
         Read_From_Tail  True
         Systemd_Filter  _SYSTEMD_UNIT=containerd-monitor.service
 
     [INPUT]
         Name            systemd
         Tag             journald.kubelet-monitor
-        Path            /var/log/journal/
+        Path            %%JOURNALD_PATH%%
         Read_From_Tail  True
         Systemd_Filter  _SYSTEMD_UNIT=kubelet-monitor.service
 {{ end }}

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
@@ -30,6 +30,25 @@ spec:
         volumeMounts:
         - name: plugins
           mountPath: "/plugins"
+      - name: journald-config
+        image: {{ index .Values.global.images "alpine" }}
+        command:
+        - sh
+        - "-c"
+        - |
+          JOURNALD_PATH="/var/log/journal"
+          if [ ! -d ${JOURNALD_PATH} ]; then
+              JOURNALD_PATH="/run/log/journal"
+          fi
+          cp -rL /template-config/* /fluent-bit-config/
+          sed -i "s|%%JOURNALD_PATH%%|${JOURNALD_PATH}|g" /fluent-bit-config/input.conf
+        volumeMounts:
+        - name: template-config
+          mountPath: /template-config
+        - name: config-dir
+          mountPath: /fluent-bit-config
+        - name: varlog
+          mountPath: /var/log
       priorityClassName: fluent-bit
       containers:
       - name: fluent-bit
@@ -71,10 +90,12 @@ spec:
           initialDelaySeconds: 90
           periodSeconds: 10
         volumeMounts:
-        - name: config
+        - name: config-dir
           mountPath: /fluent-bit/etc
         - name: varlog
           mountPath: /var/log
+        - name: runlogjournal
+          mountPath: /run/log/journal
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
@@ -90,12 +111,17 @@ spec:
       - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
       volumes:
-      - name: config
+      - name: template-config
         configMap:
           name: fluent-bit-config
+      - name: config-dir
+        emptyDir: {}
       - name: varlog
         hostPath:
           path: /var/log
+      - name: runlogjournal
+        hostPath:
+          path: /run/log/journal
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers

--- a/test/integration/shoots/logging/seed_logging_stack.go
+++ b/test/integration/shoots/logging/seed_logging_stack.go
@@ -17,7 +17,6 @@ package logging
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -81,12 +80,6 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 	lokiPriorityClass := &schedulingv1.PriorityClass{}
 
 	framework.CBeforeEach(func(ctx context.Context) {
-		for _, worker := range f.Shoot.Spec.Provider.Workers {
-			if strings.Contains(worker.Machine.Image.Name, "chost") {
-				ginkgo.Skip("Skipping logging integration test for chost nodes")
-			}
-		}
-
 		checkRequiredResources(ctx, f.SeedClient)
 		framework.ExpectNoError(f.SeedClient.Client().Get(ctx, types.NamespacedName{Namespace: v1beta1constants.GardenNamespace, Name: fluentBitName}, fluentBit))
 		framework.ExpectNoError(f.SeedClient.Client().Get(ctx, types.NamespacedName{Namespace: v1beta1constants.GardenNamespace, Name: fluentBitConfigMapName}, fluentBitConfMap))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug

**What this PR does / why we need it**:
1.  Add init container which will determine the right path for the journald logs
2.  Revert https://github.com/gardener/gardener/pull/3900

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@vlvasilev @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
