### PR TITLE
[release-v1.20] Automated cherry pick of #3831: VPA minAllowed for dependency-watchdog

### DIFF
--- a/charts/seed-bootstrap/charts/dependency-watchdog/templates/endpoint-deployment.yaml
+++ b/charts/seed-bootstrap/charts/dependency-watchdog/templates/endpoint-deployment.yaml
@@ -57,6 +57,12 @@ metadata:
   name: dependency-watchdog-endpoint-vpa
   namespace: {{ .Release.Namespace }}
 spec:
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        minAllowed:
+          cpu: 25m
+          memory: 25Mi
   targetRef:
     apiVersion: {{ include "deploymentversion" . }}
     kind: Deployment

--- a/charts/seed-bootstrap/charts/dependency-watchdog/templates/probe-deployment.yaml
+++ b/charts/seed-bootstrap/charts/dependency-watchdog/templates/probe-deployment.yaml
@@ -67,6 +67,12 @@ metadata:
   name: dependency-watchdog-probe-vpa
   namespace: {{ .Release.Namespace }}
 spec:
+  resourcePolicy:
+    containerPolicies:
+      - containerName: '*'
+        minAllowed:
+          cpu: 25m
+          memory: 50Mi
   targetRef:
     apiVersion: {{ include "deploymentversion" . }}
     kind: Deployment


### PR DESCRIPTION
Cherry pick of #3831 on release-v1.20.

#3831: VPA minAllowed for dependency-watchdog

**Release Notes:**
```other operator
Configure VPA `minAllowed` for dependency-watchdog.
```