### PR TITLE
[release-v1.20] Automated cherry pick of #3876: Increase limits for etcd to avoid potential long down time during maintenance window.

### DIFF
--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -434,11 +434,11 @@ func (e *etcd) Deploy(ctx context.Context) error {
 				},
 				LimitsRequestsGapScaleParams: hvpav1alpha1.ScaleParams{
 					CPU: hvpav1alpha1.ChangeParams{
-						Value:      pointer.StringPtr("1"),
+						Value:      pointer.StringPtr("2"),
 						Percentage: pointer.Int32Ptr(40),
 					},
 					Memory: hvpav1alpha1.ChangeParams{
-						Value:      pointer.StringPtr("1G"),
+						Value:      pointer.StringPtr("5G"),
 						Percentage: pointer.Int32Ptr(40),
 					},
 				},
@@ -599,8 +599,8 @@ func (e *etcd) computeContainerResources(foundSts bool, existingSts *appsv1.Stat
 				corev1.ResourceMemory: resource.MustParse("1G"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("900m"),
-				corev1.ResourceMemory: resource.MustParse("3G"),
+				corev1.ResourceCPU:    resource.MustParse("2300m"),
+				corev1.ResourceMemory: resource.MustParse("6G"),
 			},
 		}
 		resourcesBackupRestore = &corev1.ResourceRequirements{

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -183,8 +183,8 @@ var _ = Describe("Etcd", func() {
 					corev1.ResourceMemory: resource.MustParse("1G"),
 				},
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("900m"),
-					corev1.ResourceMemory: resource.MustParse("3G"),
+					corev1.ResourceCPU:    resource.MustParse("2300m"),
+					corev1.ResourceMemory: resource.MustParse("6G"),
 				},
 			}
 			if existingResourcesContainerEtcd != nil {
@@ -396,11 +396,11 @@ var _ = Describe("Etcd", func() {
 						},
 						LimitsRequestsGapScaleParams: hvpav1alpha1.ScaleParams{
 							CPU: hvpav1alpha1.ChangeParams{
-								Value:      pointer.StringPtr("1"),
+								Value:      pointer.StringPtr("2"),
 								Percentage: pointer.Int32Ptr(40),
 							},
 							Memory: hvpav1alpha1.ChangeParams{
-								Value:      pointer.StringPtr("1G"),
+								Value:      pointer.StringPtr("5G"),
 								Percentage: pointer.Int32Ptr(40),
 							},
 						},


### PR DESCRIPTION
Cherry pick of #3876 on release-v1.20.

#3876: Increase limits for etcd to avoid potential long down time during maintenance window.

**Release Notes:**
```other operator
Increase limits for etcd to avoid potential long down time during maintenance window.
```